### PR TITLE
Core: Enhance remove snapshots efficiency by executing them in bulk

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1178,6 +1178,11 @@ acceptedBreaks:
       new: "class org.apache.iceberg.Metrics"
       justification: "Java serialization across versions is not guaranteed"
     org.apache.iceberg:iceberg-core:
+    - code: "java.class.removed"
+      old: "class org.apache.iceberg.MetadataUpdate.RemoveSnapshot"
+      justification: "Changing the RemoveSnapshot class to receive a list of snapshots\
+        \ IDs instead of a single snapshot ID. This will make the remove snapshots\
+        \ more efficient."
     - code: "java.method.removed"
       old: "method java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(org.apache.iceberg.CombinedScanTask,\
         \ org.apache.hadoop.conf.Configuration)"

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.iceberg.view.ViewVersion;
 
@@ -328,20 +327,20 @@ public interface MetadataUpdate extends Serializable {
     }
   }
 
-  class RemoveSnapshot implements MetadataUpdate {
-    private final long snapshotId;
+  class RemoveSnapshots implements MetadataUpdate {
+    private final Set<Long> snapshotIds;
 
-    public RemoveSnapshot(long snapshotId) {
-      this.snapshotId = snapshotId;
+    public RemoveSnapshots(Set<Long> snapshotIds) {
+      this.snapshotIds = snapshotIds;
     }
 
-    public long snapshotId() {
-      return snapshotId;
+    public Set<Long> snapshotIds() {
+      return snapshotIds;
     }
 
     @Override
     public void applyTo(TableMetadata.Builder metadataBuilder) {
-      metadataBuilder.removeSnapshots(ImmutableSet.of(snapshotId));
+      metadataBuilder.removeSnapshots(snapshotIds);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -97,7 +97,7 @@ public class MetadataUpdateParser {
   // AddSnapshot
   private static final String SNAPSHOT = "snapshot";
 
-  // RemoveSnapshot
+  // RemoveSnapshots
   private static final String SNAPSHOT_IDS = "snapshot-ids";
 
   // SetSnapshotRef
@@ -150,7 +150,7 @@ public class MetadataUpdateParser {
           .put(MetadataUpdate.SetPartitionStatistics.class, SET_PARTITION_STATISTICS)
           .put(MetadataUpdate.RemovePartitionStatistics.class, REMOVE_PARTITION_STATISTICS)
           .put(MetadataUpdate.AddSnapshot.class, ADD_SNAPSHOT)
-          .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOTS)
+          .put(MetadataUpdate.RemoveSnapshots.class, REMOVE_SNAPSHOTS)
           .put(MetadataUpdate.RemoveSnapshotRef.class, REMOVE_SNAPSHOT_REF)
           .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
           .put(MetadataUpdate.SetProperties.class, SET_PROPERTIES)
@@ -229,7 +229,7 @@ public class MetadataUpdateParser {
         writeAddSnapshot((MetadataUpdate.AddSnapshot) metadataUpdate, generator);
         break;
       case REMOVE_SNAPSHOTS:
-        writeRemoveSnapshots((MetadataUpdate.RemoveSnapshot) metadataUpdate, generator);
+        writeRemoveSnapshots((MetadataUpdate.RemoveSnapshots) metadataUpdate, generator);
         break;
       case REMOVE_SNAPSHOT_REF:
         writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
@@ -419,9 +419,9 @@ public class MetadataUpdateParser {
 
   // TODO - Reconcile the spec's set-based removal with the current class implementation that only
   // handles one value.
-  private static void writeRemoveSnapshots(MetadataUpdate.RemoveSnapshot update, JsonGenerator gen)
+  private static void writeRemoveSnapshots(MetadataUpdate.RemoveSnapshots update, JsonGenerator gen)
       throws IOException {
-    JsonUtil.writeLongArray(SNAPSHOT_IDS, ImmutableSet.of(update.snapshotId()), gen);
+    JsonUtil.writeLongArray(SNAPSHOT_IDS, update.snapshotIds(), gen);
   }
 
   private static void writeSetSnapshotRef(MetadataUpdate.SetSnapshotRef update, JsonGenerator gen)
@@ -557,11 +557,10 @@ public class MetadataUpdateParser {
   private static MetadataUpdate readRemoveSnapshots(JsonNode node) {
     Set<Long> snapshotIds = JsonUtil.getLongSetOrNull(SNAPSHOT_IDS, node);
     Preconditions.checkArgument(
-        snapshotIds != null && snapshotIds.size() == 1,
+        snapshotIds != null,
         "Invalid set of snapshot ids to remove. Expected one value but received: %s",
         snapshotIds);
-    Long snapshotId = Iterables.getOnlyElement(snapshotIds);
-    return new MetadataUpdate.RemoveSnapshot(snapshotId);
+    return new MetadataUpdate.RemoveSnapshots(snapshotIds);
   }
 
   private static MetadataUpdate readSetSnapshotRef(JsonNode node) {

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
+import org.apache.hadoop.util.Sets;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -419,18 +420,18 @@ public class TestMetadataUpdateParser {
   @Test
   public void testRemoveSnapshotsFromJson() {
     String action = MetadataUpdateParser.REMOVE_SNAPSHOTS;
-    long snapshotId = 2L;
-    String json = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
-    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshot(snapshotId);
+    Set<Long> snapshotIds = Sets.newHashSet(2L, 3L);
+    String json = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2,3]}", action);
+    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshots(snapshotIds);
     assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
   }
 
   @Test
   public void testRemoveSnapshotsToJson() {
     String action = MetadataUpdateParser.REMOVE_SNAPSHOTS;
-    long snapshotId = 2L;
-    String expected = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
-    MetadataUpdate update = new MetadataUpdate.RemoveSnapshot(snapshotId);
+    Set<Long> snapshotIds = Sets.newHashSet(2L, 3L);
+    String expected = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2,3]}", action);
+    MetadataUpdate update = new MetadataUpdate.RemoveSnapshots(snapshotIds);
     String actual = MetadataUpdateParser.toJson(update);
     assertThat(actual)
         .as("Remove snapshots should serialize to the correct JSON value")
@@ -1019,8 +1020,8 @@ public class TestMetadataUpdateParser {
         break;
       case MetadataUpdateParser.REMOVE_SNAPSHOTS:
         assertEqualsRemoveSnapshots(
-            (MetadataUpdate.RemoveSnapshot) expectedUpdate,
-            (MetadataUpdate.RemoveSnapshot) actualUpdate);
+            (MetadataUpdate.RemoveSnapshots) expectedUpdate,
+            (MetadataUpdate.RemoveSnapshots) actualUpdate);
         break;
       case MetadataUpdateParser.REMOVE_SNAPSHOT_REF:
         assertEqualsRemoveSnapshotRef(
@@ -1225,10 +1226,10 @@ public class TestMetadataUpdateParser {
   }
 
   private static void assertEqualsRemoveSnapshots(
-      MetadataUpdate.RemoveSnapshot expected, MetadataUpdate.RemoveSnapshot actual) {
-    assertThat(actual.snapshotId())
+      MetadataUpdate.RemoveSnapshots expected, MetadataUpdate.RemoveSnapshots actual) {
+    assertThat(actual.snapshotIds())
         .as("Snapshots to remove should be the same")
-        .isEqualTo(expected.snapshotId());
+        .isEqualTo(expected.snapshotIds());
   }
 
   private static void assertEqualsSetSnapshotRef(

--- a/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -690,7 +691,7 @@ public class TestUpdateRequirements {
   }
 
   @Test
-  public void addAndRemoveSnapshot() {
+  public void addAndRemoveSnapshots() {
     List<UpdateRequirement> requirements =
         UpdateRequirements.forUpdateTable(
             metadata, ImmutableList.of(new MetadataUpdate.AddSnapshot(mock(Snapshot.class))));
@@ -704,7 +705,7 @@ public class TestUpdateRequirements {
 
     requirements =
         UpdateRequirements.forUpdateTable(
-            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshot(0L)));
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshots(Set.of(0L))));
 
     assertThat(requirements)
         .hasSize(1)
@@ -747,7 +748,7 @@ public class TestUpdateRequirements {
 
     requirements =
         UpdateRequirements.forUpdateTable(
-            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshot(0L)));
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshots(Set.of(0L))));
     requirements.forEach(req -> req.validate(metadata));
 
     assertThat(requirements)

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCommitTransactionRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCommitTransactionRequestParser.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Set;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -96,7 +97,8 @@ public class TestCommitTransactionRequestParser {
                 new UpdateRequirement.AssertDefaultSpecID(4),
                 new UpdateRequirement.AssertCurrentSchemaID(24)),
             ImmutableList.of(
-                new MetadataUpdate.RemoveSnapshot(101L), new MetadataUpdate.SetCurrentSchema(25)));
+                new MetadataUpdate.RemoveSnapshots(Set.of(101L)),
+                new MetadataUpdate.SetCurrentSchema(25)));
 
     CommitTransactionRequest request =
         new CommitTransactionRequest(


### PR DESCRIPTION
This PR changes the `remove-snapshots` operation to run in bulk instead of single operations on the Rest Catalog server.

The `remove-snapshots` operation signature already accepts a list of snapshots IDs. However, each snapshot ID is stored in a dedicated `Metadata` object. This makes the operations not very efficient, causing performance issues, mentioned on: https://github.com/apache/iceberg/issues/12642.

The PR changes: 
- Rename `MetadataUpdate` class `RemoveSnapshot` to `RemoveSnapshots`.
- Compute the entire snapshots IDs list and store them on the `RemoveSnapshots` instead of an individual snapshot ID.