### PR TITLE
Core: Enhance remove snapshots efficiency by executing them in bulk

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1178,6 +1178,11 @@ acceptedBreaks:
       new: "class org.apache.iceberg.Metrics"
       justification: "Java serialization across versions is not guaranteed"
     org.apache.iceberg:iceberg-core:
+    - code: "java.class.removed"
+      old: "class org.apache.iceberg.MetadataUpdate.RemoveSnapshot"
+      justification: "Changing the RemoveSnapshot class to receive a list of snapshots\
+      \ IDs instead of a single snapshot ID. This will make the remove snapshots\
+      \ more efficient."
     - code: "java.method.removed"
       old: "method java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(org.apache.iceberg.CombinedScanTask,\
         \ org.apache.hadoop.conf.Configuration)"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1178,11 +1178,6 @@ acceptedBreaks:
       new: "class org.apache.iceberg.Metrics"
       justification: "Java serialization across versions is not guaranteed"
     org.apache.iceberg:iceberg-core:
-    - code: "java.class.removed"
-      old: "class org.apache.iceberg.MetadataUpdate.RemoveSnapshot"
-      justification: "Changing the RemoveSnapshot class to receive a list of snapshots\
-      \ IDs instead of a single snapshot ID. This will make the remove snapshots\
-      \ more efficient."
     - code: "java.method.removed"
       old: "method java.lang.String[] org.apache.iceberg.hadoop.Util::blockLocations(org.apache.iceberg.CombinedScanTask,\
         \ org.apache.hadoop.conf.Configuration)"

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -329,7 +329,7 @@ public interface MetadataUpdate extends Serializable {
   }
 
   /**
-   * @deprecated since 1.8.1, will be removed in 2.0.0; Use {@link MetadataUpdate.RemoveSnapshots}
+   * @deprecated since 1.10.0, will be removed in 2.0.0; Use {@link MetadataUpdate.RemoveSnapshots}
    *     instead.
    */
   @Deprecated

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.iceberg.view.ViewVersion;
 
@@ -328,20 +327,20 @@ public interface MetadataUpdate extends Serializable {
     }
   }
 
-  class RemoveSnapshot implements MetadataUpdate {
-    private final long snapshotId;
+  class RemoveSnapshots implements MetadataUpdate {
+    private final Set<Long> snapshotIds;
 
-    public RemoveSnapshot(long snapshotId) {
-      this.snapshotId = snapshotId;
+    public RemoveSnapshots(Set<Long> snapshotIds) {
+      this.snapshotIds = snapshotIds;
     }
 
-    public long snapshotId() {
-      return snapshotId;
+    public Set<Long> snapshotIds() {
+      return snapshotIds;
     }
 
     @Override
     public void applyTo(TableMetadata.Builder metadataBuilder) {
-      metadataBuilder.removeSnapshots(ImmutableSet.of(snapshotId));
+      metadataBuilder.removeSnapshots(snapshotIds);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.iceberg.view.ViewVersion;
 
@@ -324,6 +325,28 @@ public interface MetadataUpdate extends Serializable {
     @Override
     public void applyTo(TableMetadata.Builder metadataBuilder) {
       metadataBuilder.addSnapshot(snapshot);
+    }
+  }
+
+  /**
+   * @deprecated since 1.8.1, will be removed in 2.0.0; Use {@link MetadataUpdate.RemoveSnapshots}
+   *     instead.
+   */
+  @Deprecated
+  class RemoveSnapshot implements MetadataUpdate {
+    private final long snapshotId;
+
+    public RemoveSnapshot(long snapshotId) {
+      this.snapshotId = snapshotId;
+    }
+
+    public long snapshotId() {
+      return snapshotId;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.removeSnapshots(ImmutableSet.of(snapshotId));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -329,7 +329,7 @@ public interface MetadataUpdate extends Serializable {
   }
 
   /**
-   * @deprecated since 1.10.0, will be removed in 2.0.0; Use {@link MetadataUpdate.RemoveSnapshots}
+   * @deprecated since 1.9.0, will be removed in 2.0.0; Use {@link MetadataUpdate.RemoveSnapshots}
    *     instead.
    */
   @Deprecated

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -26,8 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.util.JsonUtil;
 import org.apache.iceberg.view.ViewVersionParser;
 
@@ -97,7 +95,7 @@ public class MetadataUpdateParser {
   // AddSnapshot
   private static final String SNAPSHOT = "snapshot";
 
-  // RemoveSnapshot
+  // RemoveSnapshots
   private static final String SNAPSHOT_IDS = "snapshot-ids";
 
   // SetSnapshotRef
@@ -150,7 +148,7 @@ public class MetadataUpdateParser {
           .put(MetadataUpdate.SetPartitionStatistics.class, SET_PARTITION_STATISTICS)
           .put(MetadataUpdate.RemovePartitionStatistics.class, REMOVE_PARTITION_STATISTICS)
           .put(MetadataUpdate.AddSnapshot.class, ADD_SNAPSHOT)
-          .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOTS)
+          .put(MetadataUpdate.RemoveSnapshots.class, REMOVE_SNAPSHOTS)
           .put(MetadataUpdate.RemoveSnapshotRef.class, REMOVE_SNAPSHOT_REF)
           .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
           .put(MetadataUpdate.SetProperties.class, SET_PROPERTIES)
@@ -229,7 +227,7 @@ public class MetadataUpdateParser {
         writeAddSnapshot((MetadataUpdate.AddSnapshot) metadataUpdate, generator);
         break;
       case REMOVE_SNAPSHOTS:
-        writeRemoveSnapshots((MetadataUpdate.RemoveSnapshot) metadataUpdate, generator);
+        writeRemoveSnapshots((MetadataUpdate.RemoveSnapshots) metadataUpdate, generator);
         break;
       case REMOVE_SNAPSHOT_REF:
         writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
@@ -419,9 +417,9 @@ public class MetadataUpdateParser {
 
   // TODO - Reconcile the spec's set-based removal with the current class implementation that only
   // handles one value.
-  private static void writeRemoveSnapshots(MetadataUpdate.RemoveSnapshot update, JsonGenerator gen)
+  private static void writeRemoveSnapshots(MetadataUpdate.RemoveSnapshots update, JsonGenerator gen)
       throws IOException {
-    JsonUtil.writeLongArray(SNAPSHOT_IDS, ImmutableSet.of(update.snapshotId()), gen);
+    JsonUtil.writeLongArray(SNAPSHOT_IDS, update.snapshotIds(), gen);
   }
 
   private static void writeSetSnapshotRef(MetadataUpdate.SetSnapshotRef update, JsonGenerator gen)
@@ -557,11 +555,10 @@ public class MetadataUpdateParser {
   private static MetadataUpdate readRemoveSnapshots(JsonNode node) {
     Set<Long> snapshotIds = JsonUtil.getLongSetOrNull(SNAPSHOT_IDS, node);
     Preconditions.checkArgument(
-        snapshotIds != null && snapshotIds.size() == 1,
+        snapshotIds != null,
         "Invalid set of snapshot ids to remove. Expected one value but received: %s",
         snapshotIds);
-    Long snapshotId = Iterables.getOnlyElement(snapshotIds);
-    return new MetadataUpdate.RemoveSnapshot(snapshotId);
+    return new MetadataUpdate.RemoveSnapshots(snapshotIds);
   }
 
   private static MetadataUpdate readSetSnapshotRef(JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -150,7 +150,7 @@ public class MetadataUpdateParser {
           .put(MetadataUpdate.SetPartitionStatistics.class, SET_PARTITION_STATISTICS)
           .put(MetadataUpdate.RemovePartitionStatistics.class, REMOVE_PARTITION_STATISTICS)
           .put(MetadataUpdate.AddSnapshot.class, ADD_SNAPSHOT)
-          .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOTS) // TODO: Deprecate
+          .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOTS)
           .put(MetadataUpdate.RemoveSnapshots.class, REMOVE_SNAPSHOTS)
           .put(MetadataUpdate.RemoveSnapshotRef.class, REMOVE_SNAPSHOT_REF)
           .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
@@ -230,7 +230,6 @@ public class MetadataUpdateParser {
         writeAddSnapshot((MetadataUpdate.AddSnapshot) metadataUpdate, generator);
         break;
       case REMOVE_SNAPSHOTS:
-        // TODO: Remove condition once RemoveSnapshot is deprecated and removed
         MetadataUpdate.RemoveSnapshots removeSnapshots;
         if (metadataUpdate instanceof MetadataUpdate.RemoveSnapshot) {
           Long snapshotId = ((MetadataUpdate.RemoveSnapshot) metadataUpdate).snapshotId();
@@ -238,7 +237,7 @@ public class MetadataUpdateParser {
         } else {
           removeSnapshots = (MetadataUpdate.RemoveSnapshots) metadataUpdate;
         }
-        writeRemoveSnapshot(removeSnapshots, generator);
+        writeRemoveSnapshots(removeSnapshots, generator);
         break;
       case REMOVE_SNAPSHOT_REF:
         writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
@@ -426,7 +425,7 @@ public class MetadataUpdateParser {
     SnapshotParser.toJson(update.snapshot(), gen);
   }
 
-  private static void writeRemoveSnapshot(MetadataUpdate.RemoveSnapshots update, JsonGenerator gen)
+  private static void writeRemoveSnapshots(MetadataUpdate.RemoveSnapshots update, JsonGenerator gen)
       throws IOException {
     JsonUtil.writeLongArray(SNAPSHOT_IDS, update.snapshotIds(), gen);
   }
@@ -565,9 +564,8 @@ public class MetadataUpdateParser {
     Set<Long> snapshotIds = JsonUtil.getLongSetOrNull(SNAPSHOT_IDS, node);
     Preconditions.checkArgument(
         snapshotIds != null,
-        "Invalid set of snapshot ids to remove. Expected at least 1 value but received: %s",
+        "Invalid set of snapshot ids to remove: must be non-null",
         snapshotIds);
-    // TODO: Remove condition once RemoveSnapshot is deprecated and removed
     MetadataUpdate metadataUpdate;
     if (snapshotIds.size() == 1) {
       Long snapshotId = Iterables.getOnlyElement(snapshotIds);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1436,14 +1436,14 @@ public class TableMetadata implements Serializable {
     private Builder rewriteSnapshotsInternal(Collection<Long> idsToRemove, boolean suppress) {
       List<Snapshot> retainedSnapshots =
           Lists.newArrayListWithExpectedSize(snapshots.size() - idsToRemove.size());
-      Set<Long> removedSnapshotIds = Sets.newHashSet();
+      Set<Long> snapshotIdsToRemove = Sets.newHashSet();
 
       for (Snapshot snapshot : snapshots) {
         long snapshotId = snapshot.snapshotId();
         if (idsToRemove.contains(snapshotId)) {
           snapshotsById.remove(snapshotId);
           if (!suppress) {
-            removedSnapshotIds.add(snapshotId);
+            snapshotIdsToRemove.add(snapshotId);
           }
           removeStatistics(snapshotId);
           removePartitionStatistics(snapshotId);
@@ -1452,8 +1452,8 @@ public class TableMetadata implements Serializable {
         }
       }
 
-      if (!removedSnapshotIds.isEmpty()) {
-        changes.add(new MetadataUpdate.RemoveSnapshots(removedSnapshotIds));
+      if (!snapshotIdsToRemove.isEmpty()) {
+        changes.add(new MetadataUpdate.RemoveSnapshots(snapshotIdsToRemove));
       }
 
       this.snapshots = retainedSnapshots;
@@ -1870,7 +1870,6 @@ public class TableMetadata implements Serializable {
         List<MetadataUpdate> changes) {
       Set<Long> intermediateSnapshotIds = intermediateSnapshotIdSet(changes, currentSnapshotId);
       boolean hasIntermediateSnapshots = !intermediateSnapshotIds.isEmpty();
-      // TODO: Remove extra condition once RemoveSnapshot is deprecated and removed
       boolean hasRemovedSnapshots =
           changes.stream()
               .anyMatch(

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
@@ -419,18 +420,18 @@ public class TestMetadataUpdateParser {
   @Test
   public void testRemoveSnapshotsFromJson() {
     String action = MetadataUpdateParser.REMOVE_SNAPSHOTS;
-    long snapshotId = 2L;
-    String json = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
-    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshot(snapshotId);
+    Set<Long> snapshotIds = Sets.newHashSet(2L, 3L);
+    String json = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2,3]}", action);
+    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshots(snapshotIds);
     assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
   }
 
   @Test
   public void testRemoveSnapshotsToJson() {
     String action = MetadataUpdateParser.REMOVE_SNAPSHOTS;
-    long snapshotId = 2L;
-    String expected = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
-    MetadataUpdate update = new MetadataUpdate.RemoveSnapshot(snapshotId);
+    Set<Long> snapshotIds = Sets.newHashSet(2L, 3L);
+    String expected = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2,3]}", action);
+    MetadataUpdate update = new MetadataUpdate.RemoveSnapshots(snapshotIds);
     String actual = MetadataUpdateParser.toJson(update);
     assertThat(actual)
         .as("Remove snapshots should serialize to the correct JSON value")
@@ -1019,8 +1020,8 @@ public class TestMetadataUpdateParser {
         break;
       case MetadataUpdateParser.REMOVE_SNAPSHOTS:
         assertEqualsRemoveSnapshots(
-            (MetadataUpdate.RemoveSnapshot) expectedUpdate,
-            (MetadataUpdate.RemoveSnapshot) actualUpdate);
+            (MetadataUpdate.RemoveSnapshots) expectedUpdate,
+            (MetadataUpdate.RemoveSnapshots) actualUpdate);
         break;
       case MetadataUpdateParser.REMOVE_SNAPSHOT_REF:
         assertEqualsRemoveSnapshotRef(
@@ -1225,10 +1226,10 @@ public class TestMetadataUpdateParser {
   }
 
   private static void assertEqualsRemoveSnapshots(
-      MetadataUpdate.RemoveSnapshot expected, MetadataUpdate.RemoveSnapshot actual) {
-    assertThat(actual.snapshotId())
+      MetadataUpdate.RemoveSnapshots expected, MetadataUpdate.RemoveSnapshots actual) {
+    assertThat(actual.snapshotIds())
         .as("Snapshots to remove should be the same")
-        .isEqualTo(expected.snapshotId());
+        .isEqualTo(expected.snapshotIds());
   }
 
   private static void assertEqualsSetSnapshotRef(

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -416,6 +416,28 @@ public class TestMetadataUpdateParser {
     assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
   }
 
+  /** RemoveSnapshot * */
+  @Test
+  public void testRemoveSnapshotFromJson() {
+    String action = MetadataUpdateParser.REMOVE_SNAPSHOTS;
+    long snapshotId = 2L;
+    String json = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
+    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshot(snapshotId);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testRemoveSnapshotToJson() {
+    String action = MetadataUpdateParser.REMOVE_SNAPSHOTS;
+    long snapshotId = 2L;
+    String expected = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
+    MetadataUpdate update = new MetadataUpdate.RemoveSnapshot(snapshotId);
+    String actual = MetadataUpdateParser.toJson(update);
+    assertThat(actual)
+        .as("Remove snapshots should serialize to the correct JSON value")
+        .isEqualTo(expected);
+  }
+
   /** RemoveSnapshots * */
   @Test
   public void testRemoveSnapshotsFromJson() {
@@ -1019,9 +1041,16 @@ public class TestMetadataUpdateParser {
             (MetadataUpdate.AddSnapshot) expectedUpdate, (MetadataUpdate.AddSnapshot) actualUpdate);
         break;
       case MetadataUpdateParser.REMOVE_SNAPSHOTS:
-        assertEqualsRemoveSnapshots(
-            (MetadataUpdate.RemoveSnapshots) expectedUpdate,
-            (MetadataUpdate.RemoveSnapshots) actualUpdate);
+        // TODO: Remove condition once RemoveSnapshot is deprecated and removed
+        if (actualUpdate instanceof MetadataUpdate.RemoveSnapshot) {
+          assertEqualsRemoveSnapshot(
+              (MetadataUpdate.RemoveSnapshot) expectedUpdate,
+              (MetadataUpdate.RemoveSnapshot) actualUpdate);
+        } else {
+          assertEqualsRemoveSnapshots(
+              (MetadataUpdate.RemoveSnapshots) expectedUpdate,
+              (MetadataUpdate.RemoveSnapshots) actualUpdate);
+        }
         break;
       case MetadataUpdateParser.REMOVE_SNAPSHOT_REF:
         assertEqualsRemoveSnapshotRef(
@@ -1223,6 +1252,13 @@ public class TestMetadataUpdateParser {
     assertThat(actual.snapshot().timestampMillis())
         .isEqualTo(expected.snapshot().timestampMillis());
     assertThat(actual.snapshot().schemaId()).isEqualTo(expected.snapshot().schemaId());
+  }
+
+  private static void assertEqualsRemoveSnapshot(
+      MetadataUpdate.RemoveSnapshot expected, MetadataUpdate.RemoveSnapshot actual) {
+    assertThat(actual.snapshotId())
+        .as("Snapshot to remove should be the same")
+        .isEqualTo(expected.snapshotId());
   }
 
   private static void assertEqualsRemoveSnapshots(

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -1041,7 +1041,6 @@ public class TestMetadataUpdateParser {
             (MetadataUpdate.AddSnapshot) expectedUpdate, (MetadataUpdate.AddSnapshot) actualUpdate);
         break;
       case MetadataUpdateParser.REMOVE_SNAPSHOTS:
-        // TODO: Remove condition once RemoveSnapshot is deprecated and removed
         if (actualUpdate instanceof MetadataUpdate.RemoveSnapshot) {
           assertEqualsRemoveSnapshot(
               (MetadataUpdate.RemoveSnapshot) expectedUpdate,

--- a/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
@@ -691,6 +691,30 @@ public class TestUpdateRequirements {
   }
 
   @Test
+  public void addAndRemoveSnapshot() {
+    List<UpdateRequirement> requirements =
+        UpdateRequirements.forUpdateTable(
+            metadata, ImmutableList.of(new MetadataUpdate.AddSnapshot(mock(Snapshot.class))));
+    requirements.forEach(req -> req.validate(metadata));
+
+    assertThat(requirements)
+        .hasSize(1)
+        .hasOnlyElementsOfTypes(UpdateRequirement.AssertTableUUID.class);
+
+    assertTableUUID(requirements);
+
+    requirements =
+        UpdateRequirements.forUpdateTable(
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshot(0L)));
+
+    assertThat(requirements)
+        .hasSize(1)
+        .hasOnlyElementsOfTypes(UpdateRequirement.AssertTableUUID.class);
+
+    assertTableUUID(requirements);
+  }
+
+  @Test
   public void addAndRemoveSnapshots() {
     List<UpdateRequirement> requirements =
         UpdateRequirements.forUpdateTable(

--- a/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -690,7 +691,7 @@ public class TestUpdateRequirements {
   }
 
   @Test
-  public void addAndRemoveSnapshot() {
+  public void addAndRemoveSnapshots() {
     List<UpdateRequirement> requirements =
         UpdateRequirements.forUpdateTable(
             metadata, ImmutableList.of(new MetadataUpdate.AddSnapshot(mock(Snapshot.class))));
@@ -704,7 +705,7 @@ public class TestUpdateRequirements {
 
     requirements =
         UpdateRequirements.forUpdateTable(
-            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshot(0L)));
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshots(Set.of(0L))));
 
     assertThat(requirements)
         .hasSize(1)
@@ -747,7 +748,7 @@ public class TestUpdateRequirements {
 
     requirements =
         UpdateRequirements.forUpdateTable(
-            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshot(0L)));
+            metadata, ImmutableList.of(new MetadataUpdate.RemoveSnapshots(Set.of(0L))));
     requirements.forEach(req -> req.validate(metadata));
 
     assertThat(requirements)

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCommitTransactionRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCommitTransactionRequestParser.java
@@ -22,11 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.Set;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
 public class TestCommitTransactionRequestParser {
@@ -97,8 +97,7 @@ public class TestCommitTransactionRequestParser {
                 new UpdateRequirement.AssertDefaultSpecID(4),
                 new UpdateRequirement.AssertCurrentSchemaID(24)),
             ImmutableList.of(
-                new MetadataUpdate.RemoveSnapshots(Set.of(101L)),
-                new MetadataUpdate.SetCurrentSchema(25)));
+                new MetadataUpdate.RemoveSnapshot(101L), new MetadataUpdate.SetCurrentSchema(25)));
 
     CommitTransactionRequest request =
         new CommitTransactionRequest(
@@ -139,6 +138,85 @@ public class TestCommitTransactionRequestParser {
             + "    \"updates\" : [ {\n"
             + "      \"action\" : \"remove-snapshots\",\n"
             + "      \"snapshot-ids\" : [ 101 ]\n"
+            + "    }, {\n"
+            + "      \"action\" : \"set-current-schema\",\n"
+            + "      \"schema-id\" : 25\n"
+            + "    } ]\n"
+            + "  } ]\n"
+            + "}";
+
+    String json = CommitTransactionRequestParser.toJson(request, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    // can't do an equality comparison on CommitTransactionRequest because updates/requirements
+    // don't implement equals/hashcode
+    assertThat(
+            CommitTransactionRequestParser.toJson(
+                CommitTransactionRequestParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void roundTripSerdeWithMultipleSnapshots() {
+    String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
+    UpdateTableRequest commitTableRequestOne =
+        UpdateTableRequest.create(
+            TableIdentifier.of("ns1", "table1"),
+            ImmutableList.of(
+                new UpdateRequirement.AssertTableUUID(uuid),
+                new UpdateRequirement.AssertTableDoesNotExist()),
+            ImmutableList.of(
+                new MetadataUpdate.AssignUUID(uuid), new MetadataUpdate.SetCurrentSchema(23)));
+
+    UpdateTableRequest commitTableRequestTwo =
+        UpdateTableRequest.create(
+            TableIdentifier.of("ns1", "table2"),
+            ImmutableList.of(
+                new UpdateRequirement.AssertDefaultSpecID(4),
+                new UpdateRequirement.AssertCurrentSchemaID(24)),
+            ImmutableList.of(
+                new MetadataUpdate.RemoveSnapshots(Sets.newHashSet(101L, 102L)),
+                new MetadataUpdate.SetCurrentSchema(25)));
+
+    CommitTransactionRequest request =
+        new CommitTransactionRequest(
+            ImmutableList.of(commitTableRequestOne, commitTableRequestTwo));
+
+    String expectedJson =
+        "{\n"
+            + "  \"table-changes\" : [ {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns1\" ],\n"
+            + "      \"name\" : \"table1\"\n"
+            + "    },\n"
+            + "    \"requirements\" : [ {\n"
+            + "      \"type\" : \"assert-table-uuid\",\n"
+            + "      \"uuid\" : \"2cc52516-5e73-41f2-b139-545d41a4e151\"\n"
+            + "    }, {\n"
+            + "      \"type\" : \"assert-create\"\n"
+            + "    } ],\n"
+            + "    \"updates\" : [ {\n"
+            + "      \"action\" : \"assign-uuid\",\n"
+            + "      \"uuid\" : \"2cc52516-5e73-41f2-b139-545d41a4e151\"\n"
+            + "    }, {\n"
+            + "      \"action\" : \"set-current-schema\",\n"
+            + "      \"schema-id\" : 23\n"
+            + "    } ]\n"
+            + "  }, {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns1\" ],\n"
+            + "      \"name\" : \"table2\"\n"
+            + "    },\n"
+            + "    \"requirements\" : [ {\n"
+            + "      \"type\" : \"assert-default-spec-id\",\n"
+            + "      \"default-spec-id\" : 4\n"
+            + "    }, {\n"
+            + "      \"type\" : \"assert-current-schema-id\",\n"
+            + "      \"current-schema-id\" : 24\n"
+            + "    } ],\n"
+            + "    \"updates\" : [ {\n"
+            + "      \"action\" : \"remove-snapshots\",\n"
+            + "      \"snapshot-ids\" : [ 101, 102 ]\n"
             + "    }, {\n"
             + "      \"action\" : \"set-current-schema\",\n"
             + "      \"schema-id\" : 25\n"

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCommitTransactionRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCommitTransactionRequestParser.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Set;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -96,7 +97,8 @@ public class TestCommitTransactionRequestParser {
                 new UpdateRequirement.AssertDefaultSpecID(4),
                 new UpdateRequirement.AssertCurrentSchemaID(24)),
             ImmutableList.of(
-                new MetadataUpdate.RemoveSnapshot(101L), new MetadataUpdate.SetCurrentSchema(25)));
+                new MetadataUpdate.RemoveSnapshots(Set.of(101L)),
+                new MetadataUpdate.SetCurrentSchema(25)));
 
     CommitTransactionRequest request =
         new CommitTransactionRequest(


### PR DESCRIPTION
This PR changes the `remove-snapshots` operation to run in bulk instead of single operations on the Rest Catalog server.

The remove-snapshots operation signature already accepts a list of snapshots IDs. However, each snapshot ID is stored in a dedicated `Metadata` object. This makes the operations not very efficient, causing performance issues, mentioned on: https://github.com/apache/iceberg/issues/12642.

The PR changes:
- Rename `MetadataUpdate` class `RemoveSnapshot` to `RemoveSnapshots`.
- Compute the entire snapshots IDs list and store them on the `RemoveSnapshots` instead of an individual snapshot ID.