### PR TITLE
allow dashes in glue database and table names

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -59,8 +59,8 @@ class IcebergToGlueConverter {
 
   private IcebergToGlueConverter() {}
 
-  private static final Pattern GLUE_DB_PATTERN = Pattern.compile("^[a-z0-9_]{1,252}$");
-  private static final Pattern GLUE_TABLE_PATTERN = Pattern.compile("^[a-z0-9_]{1,255}$");
+  private static final Pattern GLUE_DB_PATTERN = Pattern.compile("^[-a-z0-9_]{1,252}$");
+  private static final Pattern GLUE_TABLE_PATTERN = Pattern.compile("^[-a-z0-9_]{1,255}$");
   public static final String GLUE_DB_LOCATION_KEY = "location";
   // Utilized for defining descriptions at both the Glue database and table levels.
   public static final String GLUE_DESCRIPTION_KEY = "comment";

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -60,7 +60,7 @@ public class TestIcebergToGlueConverter {
     List<Namespace> badNames =
         Lists.newArrayList(
             Namespace.of("db", "a"),
-            Namespace.of("db-1"),
+            Namespace.of("db^1"),
             Namespace.empty(),
             Namespace.of(""),
             Namespace.of(new String(new char[600]).replace("\0", "a")));
@@ -78,7 +78,7 @@ public class TestIcebergToGlueConverter {
   @Test
   public void testSkipNamespaceValidation() {
     List<Namespace> acceptableNames =
-        Lists.newArrayList(Namespace.of("db-1"), Namespace.of("db-1-1-1"));
+        Lists.newArrayList(Namespace.of("db^1"), Namespace.of("db-1-1-1"));
     for (Namespace name : acceptableNames) {
       assertThat(IcebergToGlueConverter.toDatabaseName(name, true)).isEqualTo(name.toString());
     }


### PR DESCRIPTION
AWS Glue allows dashes in database and table names. AWS _Athena_ does not. ([citation](https://docs.aws.amazon.com/glue/latest/dg/define-database.html))

Glue can be used as an Iceberg data catalog exclusively, without Athena support.

If a Glue table is created with a dash in the name (e.g. `d-b`, which is entirely legal) it will cause `spark.catalog.listDatabases()` to fail due to validation presumably intended for Athena compatibility.