### PR TITLE
Doc: Remove Warning for resolved issue #11147.

### DIFF
--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -595,9 +595,6 @@ See [`migrate`](#migrate) to replace an existing table with an Iceberg table.
 | `properties`  | ️   | map<string, string> | Properties to add to the newly created table |
 | `parallelism` |    | int | Number of threads to use for file reading (defaults to 1) |
 
-!!! warning
-    There's a [known issue with `parallelism > 1`](https://github.com/apache/iceberg/issues/11147) that is scheduled to be fixed in the next release.
-
 #### Output
 
 | Output Name | Type | Description |
@@ -640,9 +637,6 @@ By default, the original table is retained with the name `table_BACKUP_`.
 | `drop_backup` |   | boolean | When true, the original table will not be retained as backup (defaults to false) |
 | `backup_table_name` |  | string | Name of the table that will be retained as backup (defaults to `table_BACKUP_`) |
 | `parallelism` |   | int | Number of threads to use for file reading (defaults to 1) |
-
-!!! warning
-    There's a [known issue with `parallelism > 1`](https://github.com/apache/iceberg/issues/11147) that is scheduled to be fixed in the next release.
 
 #### Output
 
@@ -689,9 +683,6 @@ will then treat these files as if they are part of the set of files  owned by Ic
 Warning : Schema is not validated, adding files with different schema to the Iceberg table will cause issues.
 
 Warning : Files added by this method can be physically deleted by Iceberg operations
-
-!!! warning
-    There's a [known issue with `parallelism > 1`](https://github.com/apache/iceberg/issues/11147) that is scheduled to be fixed in the next release.
 
 #### Output
 


### PR DESCRIPTION
Doc: Remove Warning for resolved issue #11147 .

Reference: Spark 3.5: Fix NotSerializableException when migrating Spark tables #11157.