### PR TITLE
AWS: Support StaticCredentialsProvider in DefaultAwsClientFactory

### DIFF
--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -137,6 +137,35 @@ public class TestAwsClientFactories {
   }
 
   @Test
+  public void testStaticCredentialsProviderVerification() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(
+        AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER,
+        "software.amazon.awssdk.auth.credentials.StaticCredentialsProvider");
+    properties.put(
+        AwsClientProperties.CLIENT_CREDENTIAL_PROVIDER_PREFIX + AwsClientProperties.ACCESS_KEY_ID,
+        "key");
+    properties.put(
+        AwsClientProperties.CLIENT_CREDENTIAL_PROVIDER_PREFIX + AwsClientProperties.SESSION_TOKEN,
+        "token");
+
+    assertThatThrownBy(() -> AwsClientFactories.from(properties).s3().listBuckets())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Both access key ID and secret access key must be provided.");
+
+    properties.remove(
+        AwsClientProperties.CLIENT_CREDENTIAL_PROVIDER_PREFIX + AwsClientProperties.ACCESS_KEY_ID);
+    properties.put(
+        AwsClientProperties.CLIENT_CREDENTIAL_PROVIDER_PREFIX
+            + AwsClientProperties.SECRET_ACCESS_KEY,
+        "secret");
+
+    assertThatThrownBy(() -> AwsClientFactories.from(properties).s3().listBuckets())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Both access key ID and secret access key must be provided.");
+  }
+
+  @Test
   public void testWithDummyValidCredentialsProvider() {
     AwsClientFactory defaultAwsClientFactory =
         getAwsClientFactoryByCredentialsProvider(DummyValidProvider.class.getName());


### PR DESCRIPTION
This change adds support for `StaticCredentialsProvider` in `DefaultAwsClientFactory`. Fixes #10614. 
Using the following properties to use `StaticCredentialsProvider`:

```
AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER -> "software.amazon.awssdk.auth.credentials.StaticCredentialsProvider"
AwsClientProperties.CLIENT_CREDENTIAL_PROVIDER_PREFIX + AwsClientProperties.ACCESS_KEY_ID -> "your-access-key-id"
AwsClientProperties.CLIENT_CREDENTIAL_PROVIDER_PREFIX + AwsClientProperties.SECRET_ACCESS_KEY -> "your-secret-access-key"
AwsClientProperties.CLIENT_CREDENTIAL_PROVIDER_PREFIX + AwsClientProperties.SESSION_TOKEN -> "your-session-token" // optional
```
