### PR TITLE
Flink: Backport support source watermark for flink sql windows

### DIFF
--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestSqlBase.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/source/TestSqlBase.java
@@ -63,6 +63,8 @@ public abstract class TestSqlBase {
 
   private volatile TableEnvironment tEnv;
 
+  private volatile TableEnvironment streamingTEnv;
+
   protected TableEnvironment getTableEnv() {
     if (tEnv == null) {
       synchronized (this) {
@@ -73,6 +75,19 @@ public abstract class TestSqlBase {
       }
     }
     return tEnv;
+  }
+
+  protected TableEnvironment getStreamingTableEnv() {
+    if (streamingTEnv == null) {
+      synchronized (this) {
+        if (streamingTEnv == null) {
+          this.streamingTEnv =
+              TableEnvironment.create(EnvironmentSettings.newInstance().inStreamingMode().build());
+        }
+      }
+    }
+
+    return streamingTEnv;
   }
 
   @BeforeEach

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -227,6 +227,6 @@ public class IcebergTableSource
 
   @Override
   public String asSummaryString() {
-    return "Iceberg table source";
+    return "Iceberg table source.";
   }
 }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -227,6 +227,6 @@ public class IcebergTableSource
 
   @Override
   public String asSummaryString() {
-    return "Iceberg table source.";
+    return "Iceberg table source";
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestSqlBase.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/TestSqlBase.java
@@ -63,6 +63,8 @@ public abstract class TestSqlBase {
 
   private volatile TableEnvironment tEnv;
 
+  private volatile TableEnvironment streamingTEnv;
+
   protected TableEnvironment getTableEnv() {
     if (tEnv == null) {
       synchronized (this) {
@@ -73,6 +75,19 @@ public abstract class TestSqlBase {
       }
     }
     return tEnv;
+  }
+
+  protected TableEnvironment getStreamingTableEnv() {
+    if (streamingTEnv == null) {
+      synchronized (this) {
+        if (streamingTEnv == null) {
+          this.streamingTEnv =
+              TableEnvironment.create(EnvironmentSettings.newInstance().inStreamingMode().build());
+        }
+      }
+    }
+
+    return streamingTEnv;
   }
 
   @BeforeEach


### PR DESCRIPTION
Backport changes in https://github.com/apache/iceberg/pull/12191 to 1.18,1.19 

 Iceberg Source to support Source Watermark, so it can be used in Flink WINDOW functions. https://github.com/apache/flink/blob/release-1.18/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsSourceWatermark.java enables Flink to rely on the watermark strategy provided by the ScanTableSource itself.

```
CREATE TABLE table_wm (
      eventTS AS CAST(t1 AS TIMESTAMP(3)),
      WATERMARK FOR eventTS AS SOURCE_WATERMARK()
) WITH (
  'watermark-column'='t1'
) LIKE iceberg_catalog.db.table;
```

**Reference:**
https://github.com/apache/iceberg/issues/10219
https://github.com/apache/iceberg/pull/9346