### PR TITLE
Spark 3.4: Fix RewriteDataFiles with partial progress enabled and max-failed-commits larger than total-file-group

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -377,7 +377,8 @@ public class RewriteDataFilesSparkAction
     // stop commit service
     commitService.close();
 
-    int failedCommits = maxCommits - commitService.succeededCommits();
+    int totalCommits = Math.min(ctx.totalGroupCount(), maxCommits);
+    int failedCommits = totalCommits - commitService.succeededCommits();
     if (failedCommits > 0 && failedCommits <= maxFailedCommits) {
       LOG.warn(
           "{} is true but {} rewrite commits failed. Check the logs to determine why the individual "


### PR DESCRIPTION
Back-port of #12120