### PR TITLE
Flink: Fix npe in SketchUtil when numPartitions bigger than length of samples

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchUtil.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchUtil.java
@@ -23,7 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import org.apache.hadoop.util.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.SortKey;
 import org.apache.iceberg.StructLike;
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchUtil.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchUtil.java
@@ -23,9 +23,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.SortKey;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class SketchUtil {
   static final int COORDINATOR_MIN_RESERVOIR_SIZE = 10_000;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchUtil.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/SketchUtil.java
@@ -20,8 +20,10 @@ package org.apache.iceberg.flink.sink.shuffle;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import org.apache.hadoop.util.Lists;
 import org.apache.iceberg.SortKey;
 import org.apache.iceberg.StructLike;
 
@@ -109,23 +111,23 @@ class SketchUtil {
     // sort the keys first
     Arrays.sort(samples, comparator);
     int numCandidates = numPartitions - 1;
-    SortKey[] candidates = new SortKey[numCandidates];
+    List<SortKey> candidatesList = Lists.newLinkedList();
     int step = (int) Math.ceil((double) samples.length / numPartitions);
     int position = step - 1;
     int numChosen = 0;
     while (position < samples.length && numChosen < numCandidates) {
       SortKey candidate = samples[position];
       // skip duplicate values
-      if (numChosen > 0 && candidate.equals(candidates[numChosen - 1])) {
+      if (numChosen > 0 && candidate.equals(candidatesList.get(candidatesList.size() - 1))) {
         // linear probe for the next distinct value
         position += 1;
       } else {
-        candidates[numChosen] = candidate;
+        candidatesList.add(candidate);
         position += step;
         numChosen += 1;
       }
     }
-
+    SortKey[] candidates = candidatesList.toArray(new SortKey[0]);
     return candidates;
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSketchUtil.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSketchUtil.java
@@ -134,6 +134,17 @@ public class TestSketchUtil {
         .containsExactly(CHAR_KEYS.get("c"), CHAR_KEYS.get("g"), CHAR_KEYS.get("j"));
   }
 
+  @Test
+  public void testRangeBoundsNumPartitionsBigThanSortKeyCount() {
+    assertThat(
+            SketchUtil.rangeBounds(
+                5,
+                SORT_ORDER_COMPARTOR,
+                new SortKey[] {CHAR_KEYS.get("a"), CHAR_KEYS.get("b"), CHAR_KEYS.get("c")}))
+        .containsExactly(CHAR_KEYS.get("a"), CHAR_KEYS.get("b"), CHAR_KEYS.get("c"))
+        .doesNotContainNull();
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {4, 6})
   public void testPartitioningAndScaleUp(int numPartitions) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSketchUtil.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSketchUtil.java
@@ -135,7 +135,7 @@ public class TestSketchUtil {
   }
 
   @Test
-  public void testRangeBoundsNumPartitionsBigThanSortKeyCount() {
+  public void testRangeBoundsNumPartitionsBiggerThanSortKeyCount() {
     assertThat(
             SketchUtil.rangeBounds(
                 5,


### PR DESCRIPTION
When we enable range mode and set range-distribution-statistics-type=Sketch, a NullPointerException occurs if the number of sort keys is less than the downstream parallelism. In the SketchUtil.rangeBounds method, the SortKey[] array is initialized with null values. If the number of sort keys during a checkpoint duration is less than the downstream parallelism, this method will pass a SortKey[] array containing null values, which leads to a NullPointerException during serialization.



the error log like this:

```
org.apache.flink.util.FlinkException: Global failure triggered by OperatorCoordinator for 'Source: source -> flat -> deliver -> *anonymous_datastream_source$1*[1] -> Calc[2] -> range-shuffle' (operator 7016fb5b1ab54e21d55257a88ab9a39e).
  at org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder$LazyInitializedCoordinatorContext.failJob(OperatorCoordinatorHolder.java:651) ~[flink-dist-1.19.1.jar:1.19.1]
  at org.apache.flink.runtime.operators.coordination.RecreateOnResetOperatorCoordinator$QuiesceableContext.failJob(RecreateOnResetOperatorCoordinator.java:248) ~[flink-dist-1.19.1.jar:1.19.1]
  at org.apache.iceberg.flink.sink.shuffle.DataStatisticsCoordinator.lambda$runInCoordinatorThread$2(DataStatisticsCoordinator.java:192) ~[flink-onejar-4.0.3.jar:?]
  at org.apache.flink.util.ThrowableCatchingRunnable.run(ThrowableCatchingRunnable.java:40) ~[flink-dist-1.19.1.jar:1.19.1]
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
  at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: java.lang.NullPointerException
  at org.apache.iceberg.flink.sink.shuffle.SortKeySerializer.serialize(SortKeySerializer.java:146) ~[flink-onejar-4.0.3.jar:?]
  at org.apache.iceberg.flink.sink.shuffle.SortKeySerializer.serialize(SortKeySerializer.java:52) ~[flink-onejar-4.0.3.jar:?]
  at org.apache.flink.api.common.typeutils.base.ListSerializer.serialize(ListSerializer.java:126) ~[flink-dist-1.19.1.jar:1.19.1]
  at org.apache.iceberg.flink.sink.shuffle.GlobalStatisticsSerializer.serialize(GlobalStatisticsSerializer.java:106) ~[flink-onejar-4.0.3.jar:?]
  at org.apache.iceberg.flink.sink.shuffle.GlobalStatisticsSerializer.serialize(GlobalStatisticsSerializer.java:40) ~[flink-onejar-4.0.3.jar:?]
  at org.apache.iceberg.flink.sink.shuffle.StatisticsUtil.serializeGlobalStatistics(StatisticsUtil.java:106) ~[flink-onejar-4.0.3.jar:?]
  at org.apache.iceberg.flink.sink.shuffle.StatisticsEvent.createGlobalStatisticsEvent(StatisticsEvent.java:61) ~[flink-onejar-4.0.3.jar:?]
  at org.apache.iceberg.flink.sink.shuffle.DataStatisticsCoordinator.lambda$sendGlobalStatisticsToSubtasks$3(DataStatisticsCoordinator.java:259) ~[flink-onejar-4.0.3.jar:?]
  at org.apache.iceberg.flink.sink.shuffle.DataStatisticsCoordinator.lambda$runInCoordinatorThread$2(DataStatisticsCoordinator.java:184) ~[flink-onejar-4.0.3.jar:?]
  ... 4 more

```

This PR primarily modifies the rangeBounds method to create a SortKey[] array without null values.