### PR TITLE
Core: Use InputFile.location() Instead of Direct Object Reference in Error Messages

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -254,7 +254,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
 
   private CloseableIterable<ManifestEntry<F>> open(Schema projection) {
     FileFormat format = FileFormat.fromFileName(file.location());
-    Preconditions.checkArgument(format != null, "Unable to determine format of manifest: %s", file);
+    Preconditions.checkArgument(format != null, "Unable to determine format of manifest: %s", file.location());
 
     List<Types.NestedField> fields = Lists.newArrayList();
     fields.addAll(projection.asStruct().fields());

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -290,7 +290,7 @@ public class TableMetadataParser {
         codec == Codec.GZIP ? new GZIPInputStream(file.newStream()) : file.newStream()) {
       return fromJson(file, JsonUtil.mapper().readValue(is, JsonNode.class));
     } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to read file: %s", file);
+      throw new RuntimeIOException(e, "Failed to read file: %s", file.location());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -66,7 +66,7 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
       try (DataFileReader<D> reader = newFileReader()) {
         initMetadata(reader);
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to read metadata for file: %s", file);
+        throw new RuntimeIOException(e, "Failed to read metadata for file: %s", file.location());
       }
     }
     return metadata;
@@ -101,7 +101,7 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
       return (DataFileReader<D>)
           DataFileReader.openReader(AvroIO.stream(file.newStream(), file.getLength()), reader);
     } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to open file: %s", file);
+      throw new RuntimeIOException(e, "Failed to open file: %s", file.location());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
@@ -175,7 +175,7 @@ public class ViewMetadataParser {
         codec == Codec.GZIP ? new GZIPInputStream(file.newStream()) : file.newStream()) {
       return fromJson(file.location(), JsonUtil.mapper().readValue(is, JsonNode.class));
     } catch (IOException e) {
-      throw new UncheckedIOException(String.format("Failed to read json file: %s", file), e);
+      throw new UncheckedIOException(String.format("Failed to read json file: %s", file.location()), e);
     }
   }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -136,7 +136,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
       return new VectorizedRowBatchIterator(
           file.location(), readerSchema, orcFileReader.rows(options), recordsPerBatch);
     } catch (IOException ioe) {
-      throw new RuntimeIOException(ioe, "Failed to get ORC rows for file: %s", file);
+      throw new RuntimeIOException(ioe, "Failed to get ORC rows for file: %s", file.location());
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -50,7 +50,7 @@ class ParquetIO {
         return org.apache.parquet.hadoop.util.HadoopInputFile.fromStatus(
             hfile.getStat(), hfile.getConf());
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create Parquet input file for %s", file);
+        throw new RuntimeIOException(e, "Failed to create Parquet input file for %s", file.location());
       }
     }
     return new ParquetInputFile(file);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -64,7 +64,7 @@ public class ParquetUtil {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(file))) {
       return footerMetrics(reader.getFooter(), Stream.empty(), metricsConfig, nameMapping);
     } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to read footer of file: %s", file);
+      throw new RuntimeIOException(e, "Failed to read footer of file: %s", file.location());
     }
   }
 


### PR DESCRIPTION
Object Instances of the InputFile Interface are occasionally referenced directly in error messages. [Example](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java#L104).
 

In order for the error message to print the path of the InputFile, each implementation must have a toString() method overridden (typically with .location()).

However, if the Implementation does not override the toString, the result is: 
`Failed to open file: com.random.folder.exec.store.iceberg.RandomInputFileImplementation@5e3d9f12`

instead of leaving it up to the implementation to properly override the toString() method, it would be best to print the InputFile.location(). There are many [examples](https://github.com/apache/iceberg/blob/main/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java#L101) in the Iceberg Codebase where we already print the .location instead of the Object's reference ID. This pattern should be followed.

Note: We address a similar issue with the 'OutputFile' Interface in the following PR: https://github.com/apache/iceberg/pull/12755

Change-Id: Ib81ac94c7c6c110a4108f590ad0ba3149a6a0a05