### PR TITLE
Update the docs for working with Flink and REST catalog

### DIFF
--- a/docs/docs/flink-connector.md
+++ b/docs/docs/flink-connector.md
@@ -24,7 +24,7 @@ Apache Flink supports creating Iceberg table directly without creating the expli
 In Flink, the SQL `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)` will create a Flink table in current Flink catalog (use [GenericInMemoryCatalog](https://ci.apache.org/projects/flink/flink-docs-release-{{ flinkVersionMajor }}/docs/dev/table/catalogs/#genericinmemorycatalog) by default),
 which is just mapping to the underlying iceberg table instead of maintaining iceberg table directly in current Flink catalog.
 
-To create the table in Flink SQL by using SQL syntax `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)`,  Flink iceberg connector allows setting the catalog properties through table properties. The valid property values are described on the [Flink Configuration](flink-configuration.md#catalog-configuration) page in detail. Here are some examples below:
+To create the table in Flink SQL by using SQL syntax `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)`,  Flink iceberg connector allows setting the catalog properties through table properties. The valid property values are described on the [Flink Configuration](flink-configuration.md#catalog-configuration) page in detail.
 
 ## Table managed in Hive catalog.
 

--- a/docs/docs/flink-connector.md
+++ b/docs/docs/flink-connector.md
@@ -28,7 +28,7 @@ To create the table in Flink SQL by using SQL syntax `CREATE TABLE test (..) WIT
 
 * `connector`: Use the constant `iceberg`.
 * `catalog-name`: User-specified catalog name. It's required because the connector don't have any default value.
-* `catalog-type`: `hive` or `hadoop` for built-in catalogs (defaults to `hive`), or left unset for custom catalog implementations using `catalog-impl`.
+* `catalog-type`: `hive`, `rest` or `hadoop` for built-in catalogs (defaults to `hive`), or left unset for custom catalog implementations using `catalog-impl`.
 * `catalog-impl`: The fully-qualified class name of a custom catalog implementation. Must be set if `catalog-type` is unset. See also [custom catalog](flink.md#adding-catalogs) for more details.
 * `catalog-database`: The iceberg database name in the backend catalog, use the current flink database name by default.
 * `catalog-table`: The iceberg table name in the backend catalog. Default to use the table name in the flink `CREATE TABLE` sentence.
@@ -87,6 +87,27 @@ CREATE TABLE flink_table (
 );
 ```
 
+## Table managed in REST catalog
+
+The following SQL will create a Flink table in current Flink catalog, which maps to the iceberg table `default_database.flink_table` managed in rest catalog
+
+```sql
+CREATE TABLE flink_table (
+    id   BIGINT,
+    data STRING
+) WITH (
+    'connector'='iceberg',
+    'catalog-name'='rest_prod',
+    'catalog-type'='rest',
+    'uri'='https://localhost/'
+    'credential'='xxxx' -- Optional
+    'token'='xxxx' -- Optional
+    'scope'='xxxx' -- Optional
+     ...
+);
+```
+
+
 ## Table managed in custom catalog
 
 The following SQL will create a Flink table in current Flink catalog, which maps to the iceberg table `default_database.flink_table` managed in
@@ -105,7 +126,6 @@ CREATE TABLE flink_table (
      ...
 );
 ```
-
 Please check sections under the Integrations tab for all custom catalogs.
 
 ## A complete example.

--- a/docs/docs/flink-connector.md
+++ b/docs/docs/flink-connector.md
@@ -24,7 +24,7 @@ Apache Flink supports creating Iceberg table directly without creating the expli
 In Flink, the SQL `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)` will create a Flink table in current Flink catalog (use [GenericInMemoryCatalog](https://ci.apache.org/projects/flink/flink-docs-release-{{ flinkVersionMajor }}/docs/dev/table/catalogs/#genericinmemorycatalog) by default),
 which is just mapping to the underlying iceberg table instead of maintaining iceberg table directly in current Flink catalog.
 
-To create the table in Flink SQL by using SQL syntax `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)`,  Flink iceberg connector provides some table properties. The valid property values are described on the [Flink Configuration](flink-configuration.md) page in detail. Here are some examples below:
+To create the table in Flink SQL by using SQL syntax `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)`,  Flink iceberg connector allows setting the catalog properties through table properties. The valid property values are described on the [Flink Configuration](flink-configuration.md#catalog-configuration) page in detail. Here are some examples below:
 
 ## Table managed in Hive catalog.
 

--- a/docs/docs/flink-connector.md
+++ b/docs/docs/flink-connector.md
@@ -89,7 +89,7 @@ CREATE TABLE flink_table (
 
 ## Table managed in REST catalog
 
-The following SQL will create a Flink table in current Flink catalog, which maps to the iceberg table `default_database.flink_table` managed in rest catalog
+The following SQL will create a Flink table in current Flink catalog, which maps to the iceberg table `default_database.flink_table` managed in REST catalog
 
 ```sql
 CREATE TABLE flink_table (
@@ -106,6 +106,7 @@ CREATE TABLE flink_table (
      ...
 );
 ```
+
 
 
 ## Table managed in custom catalog

--- a/docs/docs/flink-connector.md
+++ b/docs/docs/flink-connector.md
@@ -107,8 +107,6 @@ CREATE TABLE flink_table (
 );
 ```
 
-
-
 ## Table managed in custom catalog
 
 The following SQL will create a Flink table in current Flink catalog, which maps to the iceberg table `default_database.flink_table` managed in

--- a/docs/docs/flink-connector.md
+++ b/docs/docs/flink-connector.md
@@ -24,14 +24,7 @@ Apache Flink supports creating Iceberg table directly without creating the expli
 In Flink, the SQL `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)` will create a Flink table in current Flink catalog (use [GenericInMemoryCatalog](https://ci.apache.org/projects/flink/flink-docs-release-{{ flinkVersionMajor }}/docs/dev/table/catalogs/#genericinmemorycatalog) by default),
 which is just mapping to the underlying iceberg table instead of maintaining iceberg table directly in current Flink catalog.
 
-To create the table in Flink SQL by using SQL syntax `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)`,  Flink iceberg connector provides the following table properties:
-
-* `connector`: Use the constant `iceberg`.
-* `catalog-name`: User-specified catalog name. It's required because the connector don't have any default value.
-* `catalog-type`: `hive`, `rest` or `hadoop` for built-in catalogs (defaults to `hive`), or left unset for custom catalog implementations using `catalog-impl`.
-* `catalog-impl`: The fully-qualified class name of a custom catalog implementation. Must be set if `catalog-type` is unset. See also [custom catalog](flink.md#adding-catalogs) for more details.
-* `catalog-database`: The iceberg database name in the backend catalog, use the current flink database name by default.
-* `catalog-table`: The iceberg table name in the backend catalog. Default to use the table name in the flink `CREATE TABLE` sentence.
+To create the table in Flink SQL by using SQL syntax `CREATE TABLE test (..) WITH ('connector'='iceberg', ...)`,  Flink iceberg connector provides some table properties. The valid property values are described on the [Flink Configuration](flink-configuration.md) page in detail. Here are some examples below:
 
 ## Table managed in Hive catalog.
 
@@ -125,6 +118,7 @@ CREATE TABLE flink_table (
      ...
 );
 ```
+
 Please check sections under the Integrations tab for all custom catalogs.
 
 ## A complete example.

--- a/docs/docs/flink.md
+++ b/docs/docs/flink.md
@@ -223,6 +223,25 @@ The following properties can be set if using the Hive catalog:
 * `hive-conf-dir`: Path to a directory containing a `hive-site.xml` configuration file which will be used to provide custom Hive configuration values. The value of `hive.metastore.warehouse.dir` from `<hive-conf-dir>/hive-site.xml` (or hive configure file from classpath) will be overwritten with the `warehouse` value if setting both `hive-conf-dir` and `warehouse` when creating iceberg catalog.
 * `hadoop-conf-dir`: Path to a directory containing `core-site.xml` and `hdfs-site.xml` configuration files which will be used to provide custom Hadoop configuration values.
 
+### REST catalog
+
+This creates an iceberg catalog named `rest_catalog` that can be configured using `'catalog-type'='rest'`, which loads tables from a REST catalog:
+
+```sql
+CREATE CATALOG rest_catalog WITH (
+  'type'='iceberg',
+  'catalog-type'='rest',
+  'uri'='https://localhost/'
+);
+```
+
+The following properties can be set if using the REST catalog:
+
+* `uri`: The URL to the REST Catalog (Required)
+* `credential`: A credential to exchange for a token in the OAuth2 client credentials flow (Optional)
+* `token`: A token which will be used to interact with the server (Optional)
+
+
 ##  Creating a table
 
 ```sql

--- a/docs/docs/flink.md
+++ b/docs/docs/flink.md
@@ -215,14 +215,6 @@ CREATE CATALOG hive_catalog WITH (
 );
 ```
 
-The following properties can be set if using the Hive catalog:
-
-* `uri`: The Hive metastore's thrift URI. (Required)
-* `clients`: The Hive metastore client pool size, default value is 2. (Optional)
-* `warehouse`: The Hive warehouse location, users should specify this path if neither set the `hive-conf-dir` to specify a location containing a `hive-site.xml` configuration file nor add a correct `hive-site.xml` to classpath.
-* `hive-conf-dir`: Path to a directory containing a `hive-site.xml` configuration file which will be used to provide custom Hive configuration values. The value of `hive.metastore.warehouse.dir` from `<hive-conf-dir>/hive-site.xml` (or hive configure file from classpath) will be overwritten with the `warehouse` value if setting both `hive-conf-dir` and `warehouse` when creating iceberg catalog.
-* `hadoop-conf-dir`: Path to a directory containing `core-site.xml` and `hdfs-site.xml` configuration files which will be used to provide custom Hadoop configuration values.
-
 ### REST catalog
 
 This creates an iceberg catalog named `rest_catalog` that can be configured using `'catalog-type'='rest'`, which loads tables from a REST catalog:
@@ -234,13 +226,6 @@ CREATE CATALOG rest_catalog WITH (
   'uri'='https://localhost/'
 );
 ```
-
-The following properties can be set if using the REST catalog:
-
-* `uri`: The URL to the REST Catalog (Required)
-* `credential`: A credential to exchange for a token in the OAuth2 client credentials flow (Optional)
-* `token`: A token which will be used to interact with the server (Optional)
-
 
 ##  Creating a table
 


### PR DESCRIPTION
Updating the doc as REST catalog type was introduced a while ago in https://github.com/apache/iceberg/pull/7044