### PR TITLE
Validate Members in case two iceberg sink jobs use same consumer group id

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -238,6 +238,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private final Map<String, TableSinkConfig> tableConfigMap = Maps.newHashMap();
   private final JsonConverter jsonConverter;
   private final Set<String> sourceTopics;
+  private final String sourceTopicRegex;
 
   public IcebergSinkConfig(Map<String, String> originalProps) {
     super(CONFIG_DEF, originalProps);
@@ -248,6 +249,7 @@ public class IcebergSinkConfig extends AbstractConfig {
             .map(String::trim)
             .filter(s -> !s.isEmpty())
             .collect(Collectors.toSet());
+    this.sourceTopicRegex = originalProps.getOrDefault("topics.regex", "");
 
     this.catalogProps = PropertyUtil.propertiesWithPrefix(originalProps, CATALOG_PROP_PREFIX);
     this.hadoopProps = PropertyUtil.propertiesWithPrefix(originalProps, HADOOP_PROP_PREFIX);
@@ -299,6 +301,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public Set<String> sourceTopics() {
     return sourceTopics;
+  }
+
+  public String sourceTopicRegex() {
+    return sourceTopicRegex;
   }
 
   public Map<String, String> catalogProps() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.iceberg.IcebergBuild;
@@ -237,19 +236,10 @@ public class IcebergSinkConfig extends AbstractConfig {
   private final Map<String, String> writeProps;
   private final Map<String, TableSinkConfig> tableConfigMap = Maps.newHashMap();
   private final JsonConverter jsonConverter;
-  private final Set<String> sourceTopics;
-  private final String sourceTopicRegex;
 
   public IcebergSinkConfig(Map<String, String> originalProps) {
     super(CONFIG_DEF, originalProps);
     this.originalProps = originalProps;
-
-    this.sourceTopics =
-        Arrays.stream(originalProps.get("topics").split(","))
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .collect(Collectors.toSet());
-    this.sourceTopicRegex = originalProps.getOrDefault("topics.regex", "");
 
     this.catalogProps = PropertyUtil.propertiesWithPrefix(originalProps, CATALOG_PROP_PREFIX);
     this.hadoopProps = PropertyUtil.propertiesWithPrefix(originalProps, HADOOP_PROP_PREFIX);
@@ -297,14 +287,6 @@ public class IcebergSinkConfig extends AbstractConfig {
   public String transactionalSuffix() {
     // this is for internal use and is not part of the config definition...
     return originalProps.get(INTERNAL_TRANSACTIONAL_SUFFIX_PROP);
-  }
-
-  public Set<String> sourceTopics() {
-    return sourceTopics;
-  }
-
-  public String sourceTopicRegex() {
-    return sourceTopicRegex;
   }
 
   public Map<String, String> catalogProps() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -236,10 +236,13 @@ public class IcebergSinkConfig extends AbstractConfig {
   private final Map<String, String> writeProps;
   private final Map<String, TableSinkConfig> tableConfigMap = Maps.newHashMap();
   private final JsonConverter jsonConverter;
+  private final int maxTasks;
 
   public IcebergSinkConfig(Map<String, String> originalProps) {
     super(CONFIG_DEF, originalProps);
     this.originalProps = originalProps;
+
+    this.maxTasks = Integer.parseInt(originalProps.get("tasks.max"));
 
     this.catalogProps = PropertyUtil.propertiesWithPrefix(originalProps, CATALOG_PROP_PREFIX);
     this.hadoopProps = PropertyUtil.propertiesWithPrefix(originalProps, HADOOP_PROP_PREFIX);
@@ -287,6 +290,10 @@ public class IcebergSinkConfig extends AbstractConfig {
   public String transactionalSuffix() {
     // this is for internal use and is not part of the config definition...
     return originalProps.get(INTERNAL_TRANSACTIONAL_SUFFIX_PROP);
+  }
+
+  public int taskCount() {
+    return maxTasks;
   }
 
   public Map<String, String> catalogProps() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.iceberg.IcebergBuild;
@@ -236,13 +237,17 @@ public class IcebergSinkConfig extends AbstractConfig {
   private final Map<String, String> writeProps;
   private final Map<String, TableSinkConfig> tableConfigMap = Maps.newHashMap();
   private final JsonConverter jsonConverter;
-  private final int maxTasks;
+  private final Set<String> sourceTopics;
 
   public IcebergSinkConfig(Map<String, String> originalProps) {
     super(CONFIG_DEF, originalProps);
     this.originalProps = originalProps;
 
-    this.maxTasks = Integer.parseInt(originalProps.get("tasks.max"));
+    this.sourceTopics =
+        Arrays.stream(originalProps.get("topics").split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .collect(Collectors.toSet());
 
     this.catalogProps = PropertyUtil.propertiesWithPrefix(originalProps, CATALOG_PROP_PREFIX);
     this.hadoopProps = PropertyUtil.propertiesWithPrefix(originalProps, HADOOP_PROP_PREFIX);
@@ -292,8 +297,8 @@ public class IcebergSinkConfig extends AbstractConfig {
     return originalProps.get(INTERNAL_TRANSACTIONAL_SUFFIX_PROP);
   }
 
-  public int taskCount() {
-    return maxTasks;
+  public Set<String> sourceTopics() {
+    return sourceTopics;
   }
 
   public Map<String, String> catalogProps() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConnector.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConnector.java
@@ -54,7 +54,8 @@ public class IcebergSinkConnector extends SinkConnector {
     String txnSuffix = "-txn-" + UUID.randomUUID() + "-";
 
     return IntStream.range(0, maxTasks)
-            .mapToObj(i -> {
+        .mapToObj(
+            i -> {
               Map<String, String> taskProps = Maps.newHashMap(props);
               taskProps.put(IcebergSinkConfig.INTERNAL_TRANSACTIONAL_SUFFIX_PROP, txnSuffix + i);
 
@@ -64,7 +65,7 @@ public class IcebergSinkConnector extends SinkConnector {
 
               return taskProps;
             })
-            .collect(Collectors.toList());
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -55,13 +55,6 @@ public class CommitterImpl implements Committer {
   private Collection<MemberDescription> membersWhenWorkerIsCoordinator;
   private final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
-  public CommitterImpl() {}
-
-  @VisibleForTesting
-  CommitterImpl(IcebergSinkConfig config) {
-    this.config = config;
-  }
-
   private void initialize(
       Catalog icebergCatalog,
       IcebergSinkConfig icebergSinkConfig,
@@ -105,7 +98,6 @@ public class CommitterImpl implements Committer {
   boolean containsFirstPartition(
       Collection<MemberDescription> members, Collection<TopicPartition> partitions) {
     Set<Integer> clientSuffixes = Sets.newHashSet();
-
     // Filter members that are assigned partitions from source topics
     TopicPartition firstTopicPartition =
         members.stream()

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -81,6 +81,12 @@ public class CommitterImpl implements Committer {
     }
     if (groupDesc.state() == ConsumerGroupState.STABLE) {
       Collection<MemberDescription> members = groupDesc.members();
+      if (members.size() != config.taskCount()) {
+        throw new IllegalStateException(
+            String.format(
+                "Consumer group = {%s} is in illegal state. Can't have members more than number of workers",
+                config.connectGroupId()));
+      }
       if (containsFirstPartition(members, currentAssignedPartitions)) {
         membersWhenWorkerIsCoordinator = members;
         return true;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -98,7 +98,10 @@ public class CommitterImpl implements Committer {
   boolean containsFirstPartition(
       Collection<MemberDescription> members, Collection<TopicPartition> partitions) {
     Set<Integer> clientSuffixes = Sets.newHashSet();
-    // Filter members that are assigned partitions from source topics
+    // there should only be one task assigned partition 0 of the first topic,
+    // so elect that one the leader
+    // Also it might be possible that mistakenly two jobs have shared the same consumer group id, we
+    // need to fail the job in that scenario rather than simply not electing the coordinator.
     TopicPartition firstTopicPartition =
         members.stream()
             .filter(member -> isUniqueClientSuffix(member, clientSuffixes))

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -18,14 +18,19 @@
  */
 package org.apache.iceberg.connect.channel;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.connect.Committer;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.data.SinkWriter;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.MemberDescription;
@@ -92,17 +97,57 @@ public class CommitterImpl implements Committer {
   @VisibleForTesting
   boolean containsFirstPartition(
       Collection<MemberDescription> members, Collection<TopicPartition> partitions) {
-    // there should only be one task assigned partition 0 of the first topic,
-    // so elect that one the leader
+    Set<Integer> clientSuffixes = Sets.newHashSet();
+
+    // Filter members that are assigned partitions from source topics
     TopicPartition firstTopicPartition =
         members.stream()
+            .filter(this::hasSourceTopicPartition)
+            .filter(member -> isUniqueClientSuffix(member, clientSuffixes))
             .flatMap(member -> member.assignment().topicPartitions().stream())
-            .filter(topicPartition -> config.sourceTopics().contains(topicPartition.topic()))
+            .filter(tp -> config.sourceTopics().contains(tp.topic()))
             .min(new TopicPartitionComparator())
             .orElseThrow(
                 () -> new ConnectException("No partitions assigned, cannot determine leader"));
 
     return partitions.contains(firstTopicPartition);
+  }
+
+  private boolean hasSourceTopicPartition(MemberDescription member) {
+    return member.assignment().topicPartitions().stream()
+        .map(TopicPartition::topic)
+        .anyMatch(config.sourceTopics()::contains);
+  }
+
+  private boolean isUniqueClientSuffix(MemberDescription member, Set<Integer> seenSuffixes) {
+    String clientId = member.clientId();
+    List<String> parts =
+        Arrays.stream(clientId.split("-"))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .collect(Collectors.toList());
+
+    if (parts.isEmpty()) {
+      throw new ConnectException("Invalid client ID: " + clientId);
+    }
+
+    String suffixStr = parts.get(parts.size() - 1);
+
+    int suffix;
+    try {
+      suffix = Integer.parseInt(suffixStr);
+    } catch (NumberFormatException e) {
+      throw new ConnectException("Client ID suffix is not an integer: " + clientId);
+    }
+
+    if (!seenSuffixes.add(suffix)) {
+      throw new ConnectException(
+          "Duplicate client ID suffix '"
+              + suffix
+              + "' found in group. Possibly more than one jobs are sharing the same consumer group.");
+    }
+
+    return true;
   }
 
   @Override

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -56,8 +56,7 @@ public class CommitterImpl implements Committer {
   private Collection<MemberDescription> membersWhenWorkerIsCoordinator;
   private final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
-  public CommitterImpl() {
-  }
+  public CommitterImpl() {}
 
   @VisibleForTesting
   CommitterImpl(IcebergSinkConfig config) {
@@ -114,7 +113,6 @@ public class CommitterImpl implements Committer {
             .filter(this::hasSourceTopicPartition)
             .filter(member -> isUniqueClientSuffix(member, clientSuffixes))
             .flatMap(member -> member.assignment().topicPartitions().stream())
-            .filter(tp -> config.sourceTopics().contains(tp.topic()))
             .min(new TopicPartitionComparator())
             .orElseThrow(
                 () -> new ConnectException("No partitions assigned, cannot determine leader"));
@@ -126,16 +124,15 @@ public class CommitterImpl implements Committer {
     if (!config.sourceTopics().isEmpty()) {
       // Exact match using topic names
       return member.assignment().topicPartitions().stream()
-              .map(TopicPartition::topic)
-              .anyMatch(config.sourceTopics()::contains);
+          .map(TopicPartition::topic)
+          .anyMatch(config.sourceTopics()::contains);
     } else {
       // Pattern match using topics.regex
       return member.assignment().topicPartitions().stream()
-              .map(TopicPartition::topic)
-              .anyMatch(topic -> Pattern.compile(config.sourceTopicRegex()).matcher(topic).matches());
+          .map(TopicPartition::topic)
+          .anyMatch(topic -> Pattern.compile(config.sourceTopicRegex()).matcher(topic).matches());
     }
   }
-
 
   private boolean isUniqueClientSuffix(MemberDescription member, Set<Integer> seenSuffixes) {
     String clientId = member.clientId();

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -81,12 +81,6 @@ public class CommitterImpl implements Committer {
     }
     if (groupDesc.state() == ConsumerGroupState.STABLE) {
       Collection<MemberDescription> members = groupDesc.members();
-      if (members.size() != config.taskCount()) {
-        throw new IllegalStateException(
-            String.format(
-                "Consumer group = {%s} is in illegal state. Can't have members more than number of workers",
-                config.connectGroupId()));
-      }
       if (containsFirstPartition(members, currentAssignedPartitions)) {
         membersWhenWorkerIsCoordinator = members;
         return true;
@@ -103,6 +97,7 @@ public class CommitterImpl implements Committer {
     TopicPartition firstTopicPartition =
         members.stream()
             .flatMap(member -> member.assignment().topicPartitions().stream())
+            .filter(topicPartition -> config.sourceTopics().contains(topicPartition.topic()))
             .min(new TopicPartitionComparator())
             .orElseThrow(
                 () -> new ConnectException("No partitions assigned, cannot determine leader"));

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -56,6 +56,14 @@ public class CommitterImpl implements Committer {
   private Collection<MemberDescription> membersWhenWorkerIsCoordinator;
   private final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
+  public CommitterImpl() {
+  }
+
+  @VisibleForTesting
+  CommitterImpl(IcebergSinkConfig config) {
+    this.config = config;
+  }
+
   private void initialize(
       Catalog icebergCatalog,
       IcebergSinkConfig icebergSinkConfig,

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/CommitterImplTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/CommitterImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -39,19 +40,21 @@ public class CommitterImplTest {
 
   @Test
   public void testIsLeader() {
-    CommitterImpl committer = new CommitterImpl();
+    IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
+    CommitterImpl committer = new CommitterImpl(icebergSinkConfig);
+    when(icebergSinkConfig.sourceTopics()).thenReturn(Set.of("topic1", "topic2"));
 
     MemberAssignment assignment1 =
         new MemberAssignment(
             ImmutableSet.of(new TopicPartition("topic1", 0), new TopicPartition("topic2", 1)));
     MemberDescription member1 =
-        new MemberDescription(null, Optional.empty(), null, null, assignment1);
+        new MemberDescription(null, Optional.empty(), "connector1-consumer-0", null, assignment1);
 
     MemberAssignment assignment2 =
         new MemberAssignment(
             ImmutableSet.of(new TopicPartition("topic2", 0), new TopicPartition("topic1", 1)));
     MemberDescription member2 =
-        new MemberDescription(null, Optional.empty(), null, null, assignment2);
+        new MemberDescription(null, Optional.empty(), "connector1-consumer-1", null, assignment2);
 
     List<MemberDescription> members = ImmutableList.of(member1, member2);
 
@@ -65,7 +68,8 @@ public class CommitterImplTest {
   }
 
   @Test
-  public void testCoordinatorElectionWhenTwoJobsHaveSameConsumerGroupButSubscribedToMutuallyExclusiveTopics() {
+  public void
+      testCoordinatorElectionWhenTwoJobsHaveSameConsumerGroupButSubscribedToMutuallyExclusiveTopics() {
 
     IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
 
@@ -73,54 +77,60 @@ public class CommitterImplTest {
     when(icebergSinkConfig.sourceTopics()).thenReturn(Sets.newHashSet("topic1"));
 
     MemberAssignment assignment1 =
-            new MemberAssignment(
-                    ImmutableSet.of(new TopicPartition("topic1", 0)));
+        new MemberAssignment(ImmutableSet.of(new TopicPartition("topic1", 0)));
     MemberDescription member1 =
-            new MemberDescription("connector1-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment1);
+        new MemberDescription(
+            "connector1-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment1);
 
     MemberAssignment assignment2 =
-            new MemberAssignment(
-                    ImmutableSet.of(new TopicPartition("topic2", 0)));
+        new MemberAssignment(ImmutableSet.of(new TopicPartition("topic2", 0)));
     MemberDescription member2 =
-            new MemberDescription("connector2-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment2);
+        new MemberDescription(
+            "connector2-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment2);
 
     List<MemberDescription> members = ImmutableList.of(member1, member2);
 
-    List<TopicPartition> assignments =
-            ImmutableList.of(new TopicPartition("topic1", 0));
+    List<TopicPartition> assignments = ImmutableList.of(new TopicPartition("topic1", 0));
     assertThat(committer.containsFirstPartition(members, assignments)).isTrue();
     List<TopicPartition> assignmentsNotContaining0thPartition =
-            ImmutableList.of(new TopicPartition("topic1", 1));
-    assertThat(committer.containsFirstPartition(members, assignments)).isFalse();
+        ImmutableList.of(new TopicPartition("topic1", 1));
+    assertThat(committer.containsFirstPartition(members, assignmentsNotContaining0thPartition))
+        .isFalse();
   }
 
   @Test
-  public void testCoordinatorElectionWhenTwoJobsHaveSameConsumerGroupButSubscribedToMutuallyInclusiveTopics() {
+  public void
+      testCoordinatorElectionWhenTwoJobsHaveSameConsumerGroupButSubscribedToMutuallyInclusiveTopics() {
     IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
     when(icebergSinkConfig.sourceTopics()).thenReturn(Sets.newHashSet("topic1"));
 
     CommitterImpl committer = new CommitterImpl(icebergSinkConfig);
 
     MemberAssignment assignment1 =
-            new MemberAssignment(
-                    ImmutableSet.of(new TopicPartition("topic1", 0), new TopicPartition("topic3", 0)));
+        new MemberAssignment(
+            ImmutableSet.of(new TopicPartition("topic1", 0), new TopicPartition("topic3", 0)));
     MemberDescription member1 =
-            new MemberDescription("connector1-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment1);
+        new MemberDescription(
+            "connector1-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment1);
 
     MemberAssignment assignment2 =
-            new MemberAssignment(
-                    ImmutableSet.of(new TopicPartition("topic2", 0), new TopicPartition("topic1", 1)));
+        new MemberAssignment(
+            ImmutableSet.of(new TopicPartition("topic2", 0), new TopicPartition("topic1", 1)));
     MemberDescription member2 =
-            new MemberDescription("connector2-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment2); // same client ID
+        new MemberDescription(
+            "connector2-consumer-0",
+            Optional.empty(),
+            "connector1-consumer-0",
+            null,
+            assignment2); // same client ID
 
     List<MemberDescription> members = ImmutableList.of(member1, member2);
 
     List<TopicPartition> assignments =
-            ImmutableList.of(new TopicPartition("topic1", 0), new TopicPartition("topic3", 0));
+        ImmutableList.of(new TopicPartition("topic1", 0), new TopicPartition("topic3", 0));
 
     assertThatThrownBy(() -> committer.containsFirstPartition(members, assignments))
-            .isInstanceOf(ConnectException.class)
-            .hasMessageContaining("Possibly more than one jobs are sharing the same consumer group.");
+        .isInstanceOf(ConnectException.class)
+        .hasMessageContaining("Possibly more than one jobs are sharing the same consumer group.");
   }
-
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/CommitterImplTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/CommitterImplTest.java
@@ -68,8 +68,7 @@ public class CommitterImplTest {
   }
 
   @Test
-  public void
-      testCoordinatorElectionWhenTwoJobsHaveSameConsumerGroupButSubscribedToMutuallyExclusiveTopics() {
+  public void testCoordinatorElectionShouldFailWhenMultipleJobsShareConsumerGroupId() {
 
     IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
 
@@ -91,44 +90,6 @@ public class CommitterImplTest {
     List<MemberDescription> members = ImmutableList.of(member1, member2);
 
     List<TopicPartition> assignments = ImmutableList.of(new TopicPartition("topic1", 0));
-    assertThat(committer.containsFirstPartition(members, assignments)).isTrue();
-    List<TopicPartition> assignmentsNotContaining0thPartition =
-        ImmutableList.of(new TopicPartition("topic1", 1));
-    assertThat(committer.containsFirstPartition(members, assignmentsNotContaining0thPartition))
-        .isFalse();
-  }
-
-  @Test
-  public void
-      testCoordinatorElectionWhenTwoJobsHaveSameConsumerGroupButSubscribedToMutuallyInclusiveTopics() {
-    IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
-    when(icebergSinkConfig.sourceTopics()).thenReturn(Sets.newHashSet("topic1"));
-
-    CommitterImpl committer = new CommitterImpl(icebergSinkConfig);
-
-    MemberAssignment assignment1 =
-        new MemberAssignment(
-            ImmutableSet.of(new TopicPartition("topic1", 0), new TopicPartition("topic3", 0)));
-    MemberDescription member1 =
-        new MemberDescription(
-            "connector1-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment1);
-
-    MemberAssignment assignment2 =
-        new MemberAssignment(
-            ImmutableSet.of(new TopicPartition("topic2", 0), new TopicPartition("topic1", 1)));
-    MemberDescription member2 =
-        new MemberDescription(
-            "connector2-consumer-0",
-            Optional.empty(),
-            "connector1-consumer-0",
-            null,
-            assignment2); // same client ID
-
-    List<MemberDescription> members = ImmutableList.of(member1, member2);
-
-    List<TopicPartition> assignments =
-        ImmutableList.of(new TopicPartition("topic1", 0), new TopicPartition("topic3", 0));
-
     assertThatThrownBy(() -> committer.containsFirstPartition(members, assignments))
         .isInstanceOf(ConnectException.class)
         .hasMessageContaining("Possibly more than one jobs are sharing the same consumer group.");

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/CommitterImplTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/CommitterImplTest.java
@@ -20,29 +20,22 @@ package org.apache.iceberg.connect.channel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.kafka.clients.admin.MemberAssignment;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class CommitterImplTest {
 
   @Test
   public void testIsLeader() {
-    IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
-    CommitterImpl committer = new CommitterImpl(icebergSinkConfig);
-    when(icebergSinkConfig.sourceTopics()).thenReturn(Set.of("topic1", "topic2"));
+    CommitterImpl committer = new CommitterImpl();
 
     MemberAssignment assignment1 =
         new MemberAssignment(
@@ -69,11 +62,7 @@ public class CommitterImplTest {
 
   @Test
   public void testCoordinatorElectionShouldFailWhenMultipleJobsShareConsumerGroupId() {
-
-    IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
-
-    CommitterImpl committer = new CommitterImpl(icebergSinkConfig);
-    when(icebergSinkConfig.sourceTopics()).thenReturn(Sets.newHashSet("topic1"));
+    CommitterImpl committer = new CommitterImpl();
 
     MemberAssignment assignment1 =
         new MemberAssignment(ImmutableSet.of(new TopicPartition("topic1", 0)));
@@ -85,7 +74,7 @@ public class CommitterImplTest {
         new MemberAssignment(ImmutableSet.of(new TopicPartition("topic2", 0)));
     MemberDescription member2 =
         new MemberDescription(
-            "connector2-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment2);
+            "connector2-consumer-0", Optional.empty(), "connector2-consumer-0", null, assignment2);
 
     List<MemberDescription> members = ImmutableList.of(member1, member2);
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/CommitterImplTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/CommitterImplTest.java
@@ -19,15 +19,21 @@
 package org.apache.iceberg.connect.channel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.kafka.clients.admin.MemberAssignment;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class CommitterImplTest {
 
@@ -57,4 +63,64 @@ public class CommitterImplTest {
         ImmutableList.of(new TopicPartition("topic2", 0), new TopicPartition("topic1", 1));
     assertThat(committer.containsFirstPartition(members, assignments)).isFalse();
   }
+
+  @Test
+  public void testCoordinatorElectionWhenTwoJobsHaveSameConsumerGroupButSubscribedToMutuallyExclusiveTopics() {
+
+    IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
+
+    CommitterImpl committer = new CommitterImpl(icebergSinkConfig);
+    when(icebergSinkConfig.sourceTopics()).thenReturn(Sets.newHashSet("topic1"));
+
+    MemberAssignment assignment1 =
+            new MemberAssignment(
+                    ImmutableSet.of(new TopicPartition("topic1", 0)));
+    MemberDescription member1 =
+            new MemberDescription("connector1-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment1);
+
+    MemberAssignment assignment2 =
+            new MemberAssignment(
+                    ImmutableSet.of(new TopicPartition("topic2", 0)));
+    MemberDescription member2 =
+            new MemberDescription("connector2-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment2);
+
+    List<MemberDescription> members = ImmutableList.of(member1, member2);
+
+    List<TopicPartition> assignments =
+            ImmutableList.of(new TopicPartition("topic1", 0));
+    assertThat(committer.containsFirstPartition(members, assignments)).isTrue();
+    List<TopicPartition> assignmentsNotContaining0thPartition =
+            ImmutableList.of(new TopicPartition("topic1", 1));
+    assertThat(committer.containsFirstPartition(members, assignments)).isFalse();
+  }
+
+  @Test
+  public void testCoordinatorElectionWhenTwoJobsHaveSameConsumerGroupButSubscribedToMutuallyInclusiveTopics() {
+    IcebergSinkConfig icebergSinkConfig = Mockito.mock(IcebergSinkConfig.class);
+    when(icebergSinkConfig.sourceTopics()).thenReturn(Sets.newHashSet("topic1"));
+
+    CommitterImpl committer = new CommitterImpl(icebergSinkConfig);
+
+    MemberAssignment assignment1 =
+            new MemberAssignment(
+                    ImmutableSet.of(new TopicPartition("topic1", 0), new TopicPartition("topic3", 0)));
+    MemberDescription member1 =
+            new MemberDescription("connector1-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment1);
+
+    MemberAssignment assignment2 =
+            new MemberAssignment(
+                    ImmutableSet.of(new TopicPartition("topic2", 0), new TopicPartition("topic1", 1)));
+    MemberDescription member2 =
+            new MemberDescription("connector2-consumer-0", Optional.empty(), "connector1-consumer-0", null, assignment2); // same client ID
+
+    List<MemberDescription> members = ImmutableList.of(member1, member2);
+
+    List<TopicPartition> assignments =
+            ImmutableList.of(new TopicPartition("topic1", 0), new TopicPartition("topic3", 0));
+
+    assertThatThrownBy(() -> committer.containsFirstPartition(members, assignments))
+            .isInstanceOf(ConnectException.class)
+            .hasMessageContaining("Possibly more than one jobs are sharing the same consumer group.");
+  }
+
 }


### PR DESCRIPTION
**Issue**
In rare scenarios, two Kafka Connect jobs may unintentionally be configured with the same consumer group ID. When this happens, one of the jobs may silently hang — even though the consumer group appears stable — because it cannot find any member consuming from its assigned source topics (i.e., the member with the lexicographically smallest partition) to elect itself as coordinator.

**Root Cause**
1. The connector logic assumes each job is isolated by group ID.
2. If two jobs share a group ID but operate on disjoint sets of topics, only one job gets assigned partitions, while the other finds none and cannot proceed.
3. Because no error is thrown and the group is technically "stable", the idle job just waits indefinitely.

**Solution**
This PR introduces validation and safeguards to detect and prevent this silent failure:

- Client ID Collision Detection

To catch potential overlaps between jobs sharing the same group ID, the PR also checks for duplicate consumer.override.client.id values within the filtered members.
If a collision is detected, the job fails early with a clear error message.

**Behavior After This Change**
If two jobs accidentally share a consumer group but have overlapping client IDs, one will fail fast with an informative exception.