### PR TITLE
Flink: Backport Typeinfo in RowConverter to Flink 1.19 and 1.18

### DIFF
--- a/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowConverter.java
+++ b/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowConverter.java
@@ -18,12 +18,14 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import java.util.stream.Stream;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.runtime.typeutils.ExternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.types.Row;
@@ -42,8 +44,11 @@ public class RowConverter implements RowDataConverter<Row> {
   public static RowConverter fromIcebergSchema(org.apache.iceberg.Schema icebergSchema) {
     RowType rowType = FlinkSchemaUtil.convert(icebergSchema);
     TableSchema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema);
-    RowTypeInfo rowTypeInfo =
-        new RowTypeInfo(tableSchema.getFieldTypes(), tableSchema.getFieldNames());
+    TypeInformation[] typeInformations =
+        Stream.of(tableSchema.getFieldDataTypes())
+            .map(ExternalTypeInfo::of)
+            .toArray(TypeInformation[]::new);
+    RowTypeInfo rowTypeInfo = new RowTypeInfo(typeInformations, tableSchema.getFieldNames());
     return new RowConverter(rowType, rowTypeInfo);
   }
 

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowConverter.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowConverter.java
@@ -18,12 +18,14 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import java.util.stream.Stream;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.runtime.typeutils.ExternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.types.Row;
@@ -42,8 +44,11 @@ public class RowConverter implements RowDataConverter<Row> {
   public static RowConverter fromIcebergSchema(org.apache.iceberg.Schema icebergSchema) {
     RowType rowType = FlinkSchemaUtil.convert(icebergSchema);
     TableSchema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema);
-    RowTypeInfo rowTypeInfo =
-        new RowTypeInfo(tableSchema.getFieldTypes(), tableSchema.getFieldNames());
+    TypeInformation[] typeInformations =
+        Stream.of(tableSchema.getFieldDataTypes())
+            .map(ExternalTypeInfo::of)
+            .toArray(TypeInformation[]::new);
+    RowTypeInfo rowTypeInfo = new RowTypeInfo(typeInformations, tableSchema.getFieldNames());
     return new RowConverter(rowType, rowTypeInfo);
   }
 


### PR DESCRIPTION
This PR backports https://github.com/apache/iceberg/pull/11838