### PR TITLE
Flink:Backport fix npe in SketchUtil to Flink 1.19 and 1.18

### DIFF
--- a/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSketchUtil.java
+++ b/flink/v1.18/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSketchUtil.java
@@ -134,6 +134,17 @@ public class TestSketchUtil {
         .containsExactly(CHAR_KEYS.get("c"), CHAR_KEYS.get("g"), CHAR_KEYS.get("j"));
   }
 
+  @Test
+  public void testRangeBoundsNumPartitionsBiggerThanSortKeyCount() {
+    assertThat(
+            SketchUtil.rangeBounds(
+                5,
+                SORT_ORDER_COMPARTOR,
+                new SortKey[] {CHAR_KEYS.get("a"), CHAR_KEYS.get("b"), CHAR_KEYS.get("c")}))
+        .containsExactly(CHAR_KEYS.get("a"), CHAR_KEYS.get("b"), CHAR_KEYS.get("c"))
+        .doesNotContainNull();
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {4, 6})
   public void testPartitioningAndScaleUp(int numPartitions) {

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSketchUtil.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestSketchUtil.java
@@ -134,6 +134,17 @@ public class TestSketchUtil {
         .containsExactly(CHAR_KEYS.get("c"), CHAR_KEYS.get("g"), CHAR_KEYS.get("j"));
   }
 
+  @Test
+  public void testRangeBoundsNumPartitionsBiggerThanSortKeyCount() {
+    assertThat(
+            SketchUtil.rangeBounds(
+                5,
+                SORT_ORDER_COMPARTOR,
+                new SortKey[] {CHAR_KEYS.get("a"), CHAR_KEYS.get("b"), CHAR_KEYS.get("c")}))
+        .containsExactly(CHAR_KEYS.get("a"), CHAR_KEYS.get("b"), CHAR_KEYS.get("c"))
+        .doesNotContainNull();
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {4, 6})
   public void testPartitioningAndScaleUp(int numPartitions) {


### PR DESCRIPTION
This PR backports https://github.com/apache/iceberg/pull/12703