### PR TITLE
Core: Fix a cast that is too narrow

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ClientPoolImpl.java
+++ b/core/src/main/java/org/apache/iceberg/ClientPoolImpl.java
@@ -82,7 +82,7 @@ public abstract class ClientPoolImpl<C, E extends Exception>
               retryAttempts++;
               Thread.sleep(CONNECTION_RETRY_WAIT_PERIOD_MS);
             } else {
-              throw reconnectExc.cast(exc);
+              throw (E) exc;
             }
           }
         }

--- a/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
+++ b/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
@@ -58,9 +58,7 @@ public class TestClientPoolImpl {
 
       int actions =
           mockClientPool.run(
-              client ->
-                  client.succeedAfter(
-                      succeedAfterAttempts, () -> new CustomException(true)));
+              client -> client.succeedAfter(succeedAfterAttempts, () -> new CustomException(true)));
       assertThat(actions)
           .as("There should be exactly one successful action invocation")
           .isEqualTo(1);
@@ -118,8 +116,7 @@ public class TestClientPoolImpl {
     try (MockClientPoolImpl mockClientPool =
         new MockClientPoolImpl(2, RetryableException.class, true, 3)) {
       assertThatThrownBy(
-              () ->
-                  mockClientPool.run(MockClient::throwCustomNonRetryableException, true))
+              () -> mockClientPool.run(MockClient::throwCustomNonRetryableException, true))
           .isInstanceOf(NonRetryableException.class)
           .hasMessage(null);
       assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(0);
@@ -237,8 +234,7 @@ public class TestClientPoolImpl {
     @Override
     protected boolean isConnectionException(Exception exc) {
       return super.isConnectionException(exc)
-          || (exc instanceof CustomException
-              && ((CustomException) exc).isRetryable());
+          || (exc instanceof CustomException && ((CustomException) exc).isRetryable());
     }
 
     int reconnectionAttempts() {

--- a/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
+++ b/core/src/test/java/org/apache/iceberg/TestClientPoolImpl.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
@@ -56,7 +55,11 @@ public class TestClientPoolImpl {
       MockClient firstClient = mockClientPool.newClient();
       mockClientPool.clients().add(firstClient);
 
-      int actions = mockClientPool.run(client -> client.succeedAfter(succeedAfterAttempts, () -> new ImplementationSpecificException(true)));
+      int actions =
+          mockClientPool.run(
+              client ->
+                  client.succeedAfter(
+                      succeedAfterAttempts, () -> new ImplementationSpecificException(true)));
       assertThat(actions)
           .as("There should be exactly one successful action invocation")
           .isEqualTo(1);
@@ -94,7 +97,9 @@ public class TestClientPoolImpl {
   public void testNoRetryingNonRetryableImplementationSpecificException() {
     try (MockClientPoolImpl mockClientPool =
         new MockClientPoolImpl(2, RetryableException.class, true, 3)) {
-      assertThatThrownBy(() -> mockClientPool.run(MockClient::failWithNonRetryableImplementationSpecific, true))
+      assertThatThrownBy(
+              () ->
+                  mockClientPool.run(MockClient::failWithNonRetryableImplementationSpecific, true))
           .isInstanceOf(NonRetryableException.class)
           .hasMessage(null);
       assertThat(mockClientPool.reconnectionAttempts()).isEqualTo(0);
@@ -200,8 +205,9 @@ public class TestClientPoolImpl {
 
     @Override
     protected boolean isConnectionException(Exception exc) {
-      return super.isConnectionException(exc) ||
-              (exc instanceof ImplementationSpecificException && ((ImplementationSpecificException) exc).isRetryable());
+      return super.isConnectionException(exc)
+          || (exc instanceof ImplementationSpecificException
+              && ((ImplementationSpecificException) exc).isRetryable());
     }
 
     int reconnectionAttempts() {


### PR DESCRIPTION
The current cast assumes that the type of the exception matches the type of reconnectExc, in the JdbcClientPool the isConnectionException method can return true for any SQLException with the correct sql status. The exception is always a subclass of the parameterized type though.

Closes #11176