### PR TITLE
Upgrades Flink Version to 1.19.2 and 1.20.1

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -715,7 +715,8 @@ class TestIcebergCommitter extends TestBase {
       processElement(jobId, checkpointId, harness, 1, operatorId.toString(), dataFile);
 
       snapshot = harness.snapshot(++checkpointId, ++timestamp);
-      assertFlinkManifests(0);
+
+      assertFlinkManifests(1);
     }
 
     // Redeploying flink job from external checkpoint.
@@ -726,6 +727,11 @@ class TestIcebergCommitter extends TestBase {
       harness.getStreamConfig().setOperatorID(operatorId);
       harness.initializeState(snapshot);
       harness.open();
+
+      // test harness has a limitation wherein it is not able to commit pending commits when
+      // initializeState is called, when the checkpointId > 0
+      // so we have to call it explicitly
+      harness.notifyOfCompletedCheckpoint(checkpointId);
 
       // All flink manifests should be cleaned because it has committed the unfinished iceberg
       // transaction.

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/util/TestFlinkPackage.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/util/TestFlinkPackage.java
@@ -29,7 +29,7 @@ public class TestFlinkPackage {
   /** This unit test would need to be adjusted as new Flink version is supported. */
   @Test
   public void testVersion() {
-    assertThat(FlinkPackage.version()).isEqualTo("1.19.1");
+    assertThat(FlinkPackage.version()).isEqualTo("1.19.2");
   }
 
   @Test

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -715,7 +715,7 @@ class TestIcebergCommitter extends TestBase {
       processElement(jobId, checkpointId, harness, 1, operatorId.toString(), dataFile);
 
       snapshot = harness.snapshot(++checkpointId, ++timestamp);
-      assertFlinkManifests(0);
+      assertFlinkManifests(1);
     }
 
     // Redeploying flink job from external checkpoint.
@@ -726,6 +726,11 @@ class TestIcebergCommitter extends TestBase {
       harness.getStreamConfig().setOperatorID(operatorId);
       harness.initializeState(snapshot);
       harness.open();
+
+      // test harness has a limitation wherein it is not able to commit pending commits when
+      // initializeState is called, when the checkpointId > 0
+      // so we have to call it explicitly
+      harness.notifyOfCompletedCheckpoint(checkpointId);
 
       // All flink manifests should be cleaned because it has committed the unfinished iceberg
       // transaction.

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/util/TestFlinkPackage.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/util/TestFlinkPackage.java
@@ -29,7 +29,7 @@ public class TestFlinkPackage {
   /** This unit test would need to be adjusted as new Flink version is supported. */
   @Test
   public void testVersion() {
-    assertThat(FlinkPackage.version()).isEqualTo("1.20.0");
+    assertThat(FlinkPackage.version()).isEqualTo("1.20.1");
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,8 +44,8 @@ errorprone-annotations = "2.37.0"
 failsafe = "3.3.2"
 findbugs-jsr305 = "3.0.2"
 flink118 =  { strictly = "1.18.1"}
-flink119 =  { strictly = "1.19.1"}
-flink120 = { strictly = "1.20.0"}
+flink119 =  { strictly = "1.19.2"}
+flink120 = { strictly = "1.20.1"}
 google-libraries-bom = "26.58.0"
 guava = "33.4.6-jre"
 hadoop3 = "3.4.1"


### PR DESCRIPTION
This code also updates `testRecoveryFromSnapshotWithoutCompletedNotification` unit test, by removing the second assertion when we check that `harness.initializeState` is actually committing pending transactions. 

The reason we need to remove it, is because the flink test harness has a known limitation, where for recovery the lastCompleted checkpoint is always reset to 0, which makes it impossible to correctly commit the pending commits when the checkpointId > 0.
see: https://issues.apache.org/jira/browse/FLINK-36058
and: https://github.com/apache/flink/blob/master/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java#L184

