### PR TITLE
Core: Return this instead of null in enableRowLineage()

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1012,7 +1012,7 @@ public class TableMetadata implements Serializable {
       }
 
       // otherwise this is a no-op
-      return null;
+      return this;
     }
 
     public Builder withMetadataLocation(String newMetadataLocation) {


### PR DESCRIPTION
See my other comment on this in https://github.com/apache/iceberg/pull/12593#pullrequestreview-2742015722 where we should be returning `this` instead of `null`. 
@rdblue I'm not sure if https://github.com/apache/iceberg/pull/12672 makes it into 1.9.0, so we should probably just fix this separately so that we can do a 1.9.0 RC