### PR TITLE
Core: Use OutputFile.location(), InputFile.location() in Error Messages

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -99,7 +99,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
             .build();
 
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file);
+        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file.location());
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -134,7 +134,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
             .build();
 
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file);
+        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file.location());
       }
     }
   }
@@ -170,7 +170,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
             .build();
 
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file);
+        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file.location());
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -99,7 +99,8 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
             .build();
 
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create snapshot list writer for path: %s", file.location());
       }
     }
   }
@@ -134,7 +135,8 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
             .build();
 
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create snapshot list writer for path: %s", file.location());
       }
     }
   }
@@ -170,7 +172,8 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
             .build();
 
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create snapshot list writer for path: %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create snapshot list writer for path: %s", file.location());
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -254,7 +254,8 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
 
   private CloseableIterable<ManifestEntry<F>> open(Schema projection) {
     FileFormat format = FileFormat.fromFileName(file.location());
-    Preconditions.checkArgument(format != null, "Unable to determine format of manifest: %s", file.location());
+    Preconditions.checkArgument(
+        format != null, "Unable to determine format of manifest: %s", file.location());
 
     List<Types.NestedField> fields = Lists.newArrayList();
     fields.addAll(projection.asStruct().fields());

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -254,7 +254,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
 
   private CloseableIterable<ManifestEntry<F>> open(Schema projection) {
     FileFormat format = FileFormat.fromFileName(file.location());
-    Preconditions.checkArgument(format != null, "Unable to determine format of manifest: %s", file);
+    Preconditions.checkArgument(format != null, "Unable to determine format of manifest: %s", file.location());
 
     List<Types.NestedField> fields = Lists.newArrayList();
     fields.addAll(projection.asStruct().fields());

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -246,7 +246,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file);
+        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
   }
@@ -280,7 +280,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file);
+        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -246,7 +246,8 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
   }
@@ -280,7 +281,8 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
 
@@ -319,7 +321,8 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
   }
@@ -353,7 +356,8 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
 
@@ -391,7 +395,8 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -319,7 +319,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file);
+        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
   }
@@ -353,7 +353,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file);
+        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
 
@@ -391,7 +391,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
             .overwrite()
             .build();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file);
+        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", file.location());
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -131,7 +131,7 @@ public class TableMetadataParser {
       toJson(metadata, generator);
       generator.flush();
     } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile);
+      throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile.location());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -290,7 +290,7 @@ public class TableMetadataParser {
         codec == Codec.GZIP ? new GZIPInputStream(file.newStream()) : file.newStream()) {
       return fromJson(file, JsonUtil.mapper().readValue(is, JsonNode.class));
     } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to read file: %s", file);
+      throw new RuntimeIOException(e, "Failed to read file: %s", file.location());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -66,7 +66,7 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
       try (DataFileReader<D> reader = newFileReader()) {
         initMetadata(reader);
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to read metadata for file: %s", file);
+        throw new RuntimeIOException(e, "Failed to read metadata for file: %s", file.location());
       }
     }
     return metadata;
@@ -101,7 +101,7 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
       return (DataFileReader<D>)
           DataFileReader.openReader(AvroIO.stream(file.newStream(), file.getLength()), reader);
     } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to open file: %s", file);
+      throw new RuntimeIOException(e, "Failed to open file: %s", file.location());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
@@ -175,7 +175,7 @@ public class ViewMetadataParser {
         codec == Codec.GZIP ? new GZIPInputStream(file.newStream()) : file.newStream()) {
       return fromJson(file.location(), JsonUtil.mapper().readValue(is, JsonNode.class));
     } catch (IOException e) {
-      throw new UncheckedIOException(String.format("Failed to read json file: %s", file), e);
+      throw new UncheckedIOException(String.format("Failed to read json file: %s", file.location()), e);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
@@ -175,7 +175,8 @@ public class ViewMetadataParser {
         codec == Codec.GZIP ? new GZIPInputStream(file.newStream()) : file.newStream()) {
       return fromJson(file.location(), JsonUtil.mapper().readValue(is, JsonNode.class));
     } catch (IOException e) {
-      throw new UncheckedIOException(String.format("Failed to read json file: %s", file.location()), e);
+      throw new UncheckedIOException(
+          String.format("Failed to read json file: %s", file.location()), e);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java
@@ -191,7 +191,7 @@ public class ViewMetadataParser {
       generator.flush();
     } catch (IOException e) {
       throw new UncheckedIOException(
-          String.format("Failed to write json to file: %s", outputFile), e);
+          String.format("Failed to write json to file: %s", outputFile.location()), e);
     }
   }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -136,7 +136,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
       return new VectorizedRowBatchIterator(
           file.location(), readerSchema, orcFileReader.rows(options), recordsPerBatch);
     } catch (IOException ioe) {
-      throw new RuntimeIOException(ioe, "Failed to get ORC rows for file: %s", file);
+      throw new RuntimeIOException(ioe, "Failed to get ORC rows for file: %s", file.location());
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -50,7 +50,7 @@ class ParquetIO {
         return org.apache.parquet.hadoop.util.HadoopInputFile.fromStatus(
             hfile.getStat(), hfile.getConf());
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create Parquet input file for %s", file);
+        throw new RuntimeIOException(e, "Failed to create Parquet input file for %s", file.location());
       }
     }
     return new ParquetInputFile(file);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -63,7 +63,7 @@ class ParquetIO {
         return org.apache.parquet.hadoop.util.HadoopOutputFile.fromPath(
             hfile.getPath(), hfile.getConf());
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create Parquet output file for %s", file);
+        throw new RuntimeIOException(e, "Failed to create Parquet output file for %s", file.location());
       }
     }
     return new ParquetOutputFile(file);
@@ -75,7 +75,7 @@ class ParquetIO {
       try {
         return org.apache.parquet.hadoop.util.HadoopOutputFile.fromPath(hfile.getPath(), conf);
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create Parquet output file for %s", file);
+        throw new RuntimeIOException(e, "Failed to create Parquet output file for %s", file.location());
       }
     }
     return new ParquetOutputFile(file);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -50,7 +50,8 @@ class ParquetIO {
         return org.apache.parquet.hadoop.util.HadoopInputFile.fromStatus(
             hfile.getStat(), hfile.getConf());
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create Parquet input file for %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create Parquet input file for %s", file.location());
       }
     }
     return new ParquetInputFile(file);
@@ -63,7 +64,8 @@ class ParquetIO {
         return org.apache.parquet.hadoop.util.HadoopOutputFile.fromPath(
             hfile.getPath(), hfile.getConf());
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create Parquet output file for %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create Parquet output file for %s", file.location());
       }
     }
     return new ParquetOutputFile(file);
@@ -75,7 +77,8 @@ class ParquetIO {
       try {
         return org.apache.parquet.hadoop.util.HadoopOutputFile.fromPath(hfile.getPath(), conf);
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create Parquet output file for %s", file.location());
+        throw new RuntimeIOException(
+            e, "Failed to create Parquet output file for %s", file.location());
       }
     }
     return new ParquetOutputFile(file);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -64,7 +64,7 @@ public class ParquetUtil {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(file))) {
       return footerMetrics(reader.getFooter(), Stream.empty(), metricsConfig, nameMapping);
     } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to read footer of file: %s", file);
+      throw new RuntimeIOException(e, "Failed to read footer of file: %s", file.location());
     }
   }
 


### PR DESCRIPTION
Object Instances of the OutputFile & InputFile Interface are occasionally referenced directly in error messages. [Example](https://github.com/apache/iceberg/blob/0152075268851d397b60bcb66e5a7c346271dfd9/core/src/main/java/org/apache/iceberg/view/ViewMetadataParser.java#L194).

In order for the error message to print the path of the OutputFile/ InputFile, each implementation must have a toString() method overridden (typically with .location()).

However, if the Implementation does not override the toString, the result is:
`Failed to open file: com.random.folder.exec.store.iceberg.RandomOutputFileImplementation@5e3d9f12`

instead of leaving it up to the implementation to properly override the toString() method, it would be best to print the OutputFile.location() & InputFile.location(). There are many [examples](https://github.com/apache/iceberg/blob/main/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java#L106) in the Iceberg Codebase where we already print the .location instead of the Object's reference ID. This pattern should be followed.