### PR TITLE
Migrate Spark 3.4 ExtensionsTestBase-related tests  for Partition, Schema and Branch/Tag

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -20,6 +20,9 @@ package org.apache.iceberg.spark.extensions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -29,39 +32,45 @@ import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestAlterTablePartitionFields extends ExtensionsTestBase {
 
-  @Parameterized.Parameters(name = "catalogConfig = {0}, formatVersion = {1}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, formatVersion = {3}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {SparkCatalogConfig.HIVE, 1},
-      {SparkCatalogConfig.SPARK, 2}
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties(),
+        1
+      },
+      {
+        SparkCatalogConfig.SPARK.catalogName(),
+        SparkCatalogConfig.SPARK.implementation(),
+        SparkCatalogConfig.SPARK.properties(),
+        2
+      }
     };
   }
 
-  private final int formatVersion;
+  @Parameter(index = 3)
+  private int formatVersion;
 
-  public TestAlterTablePartitionFields(SparkCatalogConfig catalogConfig, int formatVersion) {
-    super(catalogConfig.catalogName(), catalogConfig.implementation(), catalogConfig.properties());
-    this.formatVersion = formatVersion;
-  }
-
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testAddIdentityPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD category", tableName);
 
@@ -70,15 +79,15 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).identity("category").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddBucketPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id)", tableName);
 
@@ -90,15 +99,15 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
             .bucket("id", 16, "id_bucket_16")
             .build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddTruncatePartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD truncate(data, 4)", tableName);
 
@@ -110,15 +119,15 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
             .truncate("data", 4, "data_trunc_4")
             .build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddYearsPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD years(ts)", tableName);
 
@@ -127,15 +136,15 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddMonthsPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD months(ts)", tableName);
 
@@ -144,15 +153,15 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddDaysPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD days(ts)", tableName);
 
@@ -161,15 +170,15 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddHoursPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD hours(ts)", tableName);
 
@@ -178,10 +187,10 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddYearPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
@@ -198,7 +207,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddMonthPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
@@ -215,7 +224,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddDayPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
@@ -232,7 +241,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddHourPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
@@ -249,12 +258,12 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testAddNamedPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id) AS shard", tableName);
 
@@ -263,16 +272,15 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).bucket("id", 16, "shard").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testDropIdentityPartition() {
     createTable("id bigint NOT NULL, category string, data string", "category");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertEquals(
-        "Table should start with 1 partition field", 1, table.spec().fields().size());
+    assertThat(table.spec().fields()).as("Table should start with 1 partition field").hasSize(1);
 
     sql("ALTER TABLE %s DROP PARTITION FIELD category", tableName);
 
@@ -284,19 +292,18 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
               .withSpecId(1)
               .alwaysNull("category", "category")
               .build();
-      Assert.assertEquals("Should have new spec field", expected, table.spec());
+      assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
     } else {
-      Assert.assertTrue("New spec must be unpartitioned", table.spec().isUnpartitioned());
+      assertThat(table.spec().isUnpartitioned()).as("New spec must be unpartitioned").isTrue();
     }
   }
 
-  @Test
+  @TestTemplate
   public void testDropDaysPartition() {
     createTable("id bigint NOT NULL, ts timestamp, data string", "days(ts)");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertEquals(
-        "Table should start with 1 partition field", 1, table.spec().fields().size());
+    assertThat(table.spec().fields()).as("Table should start with 1 partition field").hasSize(1);
 
     sql("ALTER TABLE %s DROP PARTITION FIELD days(ts)", tableName);
 
@@ -305,19 +312,18 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     if (formatVersion == 1) {
       PartitionSpec expected =
           PartitionSpec.builderFor(table.schema()).withSpecId(1).alwaysNull("ts", "ts_day").build();
-      Assert.assertEquals("Should have new spec field", expected, table.spec());
+      assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
     } else {
-      Assert.assertTrue("New spec must be unpartitioned", table.spec().isUnpartitioned());
+      assertThat(table.spec().isUnpartitioned()).as("New spec must be unpartitioned").isTrue();
     }
   }
 
-  @Test
+  @TestTemplate
   public void testDropBucketPartition() {
     createTable("id bigint NOT NULL, data string", "bucket(16, id)");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertEquals(
-        "Table should start with 1 partition field", 1, table.spec().fields().size());
+    assertThat(table.spec().fields()).as("Table should start with 1 partition field").hasSize(1);
 
     sql("ALTER TABLE %s DROP PARTITION FIELD bucket(16, id)", tableName);
 
@@ -329,24 +335,24 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
               .withSpecId(1)
               .alwaysNull("id", "id_bucket")
               .build();
-      Assert.assertEquals("Should have new spec field", expected, table.spec());
+      assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
     } else {
-      Assert.assertTrue("New spec must be unpartitioned", table.spec().isUnpartitioned());
+      assertThat(table.spec().isUnpartitioned()).as("New spec must be unpartitioned").isTrue();
     }
   }
 
-  @Test
+  @TestTemplate
   public void testDropPartitionByName() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id) AS shard", tableName);
 
     table.refresh();
 
-    Assert.assertEquals("Table should have 1 partition field", 1, table.spec().fields().size());
+    assertThat(table.spec().fields()).as("Table should have 1 partition field").hasSize(1);
 
     // Should be recognized as iceberg command even with extra white spaces
     sql("ALTER TABLE %s DROP  PARTITION \n FIELD shard", tableName);
@@ -356,23 +362,23 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     if (formatVersion == 1) {
       PartitionSpec expected =
           PartitionSpec.builderFor(table.schema()).withSpecId(2).alwaysNull("id", "shard").build();
-      Assert.assertEquals("Should have new spec field", expected, table.spec());
+      assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
     } else {
-      Assert.assertTrue("New spec must be unpartitioned", table.spec().isUnpartitioned());
+      assertThat(table.spec().isUnpartitioned()).as("New spec must be unpartitioned").isTrue();
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReplacePartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD days(ts)", tableName);
     table.refresh();
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
 
     sql("ALTER TABLE %s REPLACE PARTITION FIELD days(ts) WITH hours(ts)", tableName);
     table.refresh();
@@ -391,21 +397,22 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
               .addField("hour", 3, 1001, "ts_hour")
               .build();
     }
-    Assert.assertEquals(
-        "Should changed from daily to hourly partitioned field", expected, table.spec());
+    assertThat(table.spec())
+        .as("Should changed from daily to hourly partitioned field")
+        .isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testReplacePartitionAndRename() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD days(ts)", tableName);
     table.refresh();
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
 
     sql("ALTER TABLE %s REPLACE PARTITION FIELD days(ts) WITH hours(ts) AS hour_col", tableName);
     table.refresh();
@@ -424,21 +431,22 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
               .addField("hour", 3, 1001, "hour_col")
               .build();
     }
-    Assert.assertEquals(
-        "Should changed from daily to hourly partitioned field", expected, table.spec());
+    assertThat(table.spec())
+        .as("Should changed from daily to hourly partitioned field")
+        .isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceNamedPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD days(ts) AS day_col", tableName);
     table.refresh();
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts", "day_col").build();
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
 
     sql("ALTER TABLE %s REPLACE PARTITION FIELD day_col WITH hours(ts)", tableName);
     table.refresh();
@@ -457,21 +465,22 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
               .addField("hour", 3, 1001, "ts_hour")
               .build();
     }
-    Assert.assertEquals(
-        "Should changed from daily to hourly partitioned field", expected, table.spec());
+    assertThat(table.spec())
+        .as("Should changed from daily to hourly partitioned field")
+        .isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceNamedPartitionAndRenameDifferently() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    assertThat(table.spec().isUnpartitioned()).as("Table should start unpartitioned").isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD days(ts) AS day_col", tableName);
     table.refresh();
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts", "day_col").build();
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
 
     sql("ALTER TABLE %s REPLACE PARTITION FIELD day_col WITH hours(ts) AS hour_col", tableName);
     table.refresh();
@@ -490,15 +499,15 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
               .addField("hour", 3, 1001, "hour_col")
               .build();
     }
-    Assert.assertEquals(
-        "Should changed from daily to hourly partitioned field", expected, table.spec());
+    assertThat(table.spec())
+        .as("Should changed from daily to hourly partitioned field")
+        .isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSparkTableAddDropPartitions() throws Exception {
     createTable("id bigint NOT NULL, ts timestamp, data string");
-    Assert.assertEquals(
-        "spark table partition should be empty", 0, sparkTable().partitioning().length);
+    assertThat(sparkTable().partitioning()).as("spark table partition should be empty").isEmpty();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id) AS shard", tableName);
     assertPartitioningEquals(sparkTable(), 1, "bucket(16, id)");
@@ -517,11 +526,10 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
     sql("ALTER TABLE %s DROP PARTITION FIELD shard", tableName);
     sql("DESCRIBE %s", tableName);
-    Assert.assertEquals(
-        "spark table partition should be empty", 0, sparkTable().partitioning().length);
+    assertThat(sparkTable().partitioning()).as("spark table partition should be empty").isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testDropColumnOfOldPartitionFieldV1() {
     // default table created in v1 format
     sql(
@@ -533,7 +541,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s DROP COLUMN day_of_ts", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testDropColumnOfOldPartitionFieldV2() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, ts timestamp, day_of_ts date) USING iceberg PARTITIONED BY (day_of_ts) TBLPROPERTIES('format-version' = '2')",
@@ -545,11 +553,10 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
   }
 
   private void assertPartitioningEquals(SparkTable table, int len, String transform) {
-    Assert.assertEquals("spark table partition should be " + len, len, table.partitioning().length);
-    Assert.assertEquals(
-        "latest spark table partition transform should match",
-        transform,
-        table.partitioning()[len - 1].toString());
+    assertThat(table.partitioning()[len - 1])
+        .asString()
+        .as("latest spark table partition transform should match")
+        .isEqualTo(transform);
   }
 
   private SparkTable sparkTable() throws Exception {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTableSchema.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTableSchema.java
@@ -18,66 +18,61 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestAlterTableSchema extends SparkExtensionsTestBase {
-  public TestAlterTableSchema(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestAlterTableSchema extends ExtensionsTestBase {
 
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testSetIdentifierFields() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, "
             + "location struct<lon:bigint NOT NULL,lat:bigint NOT NULL> NOT NULL) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue(
-        "Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
+    assertThat(table.schema().identifierFieldIds())
+        .as("Table should start without identifier")
+        .isEmpty();
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id", tableName);
     table.refresh();
-    Assert.assertEquals(
-        "Should have new identifier field",
-        Sets.newHashSet(table.schema().findField("id").fieldId()),
-        table.schema().identifierFieldIds());
+    assertThat(table.schema().identifierFieldIds())
+        .containsExactly(table.schema().findField("id").fieldId());
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id, location.lon", tableName);
     table.refresh();
-    Assert.assertEquals(
-        "Should have new identifier field",
-        Sets.newHashSet(
+    assertThat(table.schema().identifierFieldIds())
+        .as("Should have new identifier field")
+        .containsExactlyInAnyOrder(
             table.schema().findField("id").fieldId(),
-            table.schema().findField("location.lon").fieldId()),
-        table.schema().identifierFieldIds());
+            table.schema().findField("location.lon").fieldId());
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS location.lon", tableName);
     table.refresh();
-    Assert.assertEquals(
-        "Should have new identifier field",
-        Sets.newHashSet(table.schema().findField("location.lon").fieldId()),
-        table.schema().identifierFieldIds());
+    assertThat(table.schema().identifierFieldIds())
+        .as("Should have new identifier field")
+        .containsExactly(table.schema().findField("location.lon").fieldId());
   }
 
-  @Test
+  @TestTemplate
   public void testSetInvalidIdentifierFields() {
     sql("CREATE TABLE %s (id bigint NOT NULL, id2 bigint) USING iceberg", tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue(
-        "Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
+    assertThat(table.schema().identifierFieldIds())
+        .as("Table should start without identifier")
+        .isEmpty();
     assertThatThrownBy(() -> sql("ALTER TABLE %s SET IDENTIFIER FIELDS unknown", tableName))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith("not found in current schema or added columns");
@@ -87,56 +82,54 @@ public class TestAlterTableSchema extends SparkExtensionsTestBase {
         .hasMessageEndingWith("not a required field");
   }
 
-  @Test
+  @TestTemplate
   public void testDropIdentifierFields() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, "
             + "location struct<lon:bigint NOT NULL,lat:bigint NOT NULL> NOT NULL) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue(
-        "Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
+    assertThat(table.schema().identifierFieldIds())
+        .as("Table should start without identifier")
+        .isEmpty();
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id, location.lon", tableName);
     table.refresh();
-    Assert.assertEquals(
-        "Should have new identifier fields",
-        Sets.newHashSet(
+    assertThat(table.schema().identifierFieldIds())
+        .as("Should have new identifier fields")
+        .containsExactlyInAnyOrder(
             table.schema().findField("id").fieldId(),
-            table.schema().findField("location.lon").fieldId()),
-        table.schema().identifierFieldIds());
+            table.schema().findField("location.lon").fieldId());
 
     sql("ALTER TABLE %s DROP IDENTIFIER FIELDS id", tableName);
     table.refresh();
-    Assert.assertEquals(
-        "Should removed identifier field",
-        Sets.newHashSet(table.schema().findField("location.lon").fieldId()),
-        table.schema().identifierFieldIds());
+    assertThat(table.schema().identifierFieldIds())
+        .as("Should removed identifier field")
+        .containsExactly(table.schema().findField("location.lon").fieldId());
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id, location.lon", tableName);
     table.refresh();
-    Assert.assertEquals(
-        "Should have new identifier fields",
-        Sets.newHashSet(
+    assertThat(table.schema().identifierFieldIds())
+        .as("Should have new identifier fields")
+        .containsExactlyInAnyOrder(
             table.schema().findField("id").fieldId(),
-            table.schema().findField("location.lon").fieldId()),
-        table.schema().identifierFieldIds());
+            table.schema().findField("location.lon").fieldId());
 
     sql("ALTER TABLE %s DROP IDENTIFIER FIELDS id, location.lon", tableName);
     table.refresh();
-    Assert.assertEquals(
-        "Should have no identifier field", Sets.newHashSet(), table.schema().identifierFieldIds());
+    assertThat(table.schema().identifierFieldIds()).as("Should have no identifier field").isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testDropInvalidIdentifierFields() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string NOT NULL, "
             + "location struct<lon:bigint NOT NULL,lat:bigint NOT NULL> NOT NULL) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue(
-        "Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
+    assertThat(table.schema().identifierFieldIds())
+        .as("Table should start without identifier")
+        .isEmpty();
     assertThatThrownBy(() -> sql("ALTER TABLE %s DROP IDENTIFIER FIELDS unknown", tableName))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot complete drop identifier fields operation: field unknown not found");

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
@@ -22,8 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
@@ -34,25 +35,25 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestBranchDDL extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestBranchDDL extends ExtensionsTestBase {
 
-  @Before
-  public void before() {
+  @BeforeEach
+  public void createTable() {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
   }
 
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -63,11 +64,7 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
     };
   }
 
-  public TestBranchDDL(String catalog, String implementation, Map<String, String> properties) {
-    super(catalog, implementation, properties);
-  }
-
-  @Test
+  @TestTemplate
   public void testCreateBranch() throws NoSuchTableException {
     Table table = insertRows();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -79,54 +76,64 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
         "ALTER TABLE %s CREATE BRANCH %s AS OF VERSION %d RETAIN %d DAYS WITH SNAPSHOT RETENTION %d SNAPSHOTS %d days",
         tableName, branchName, snapshotId, maxRefAge, minSnapshotsToKeep, maxSnapshotAge);
     table.refresh();
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), ref.snapshotId());
-    Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
-    Assert.assertEquals(TimeUnit.DAYS.toMillis(maxSnapshotAge), ref.maxSnapshotAgeMs().longValue());
-    Assert.assertEquals(TimeUnit.DAYS.toMillis(maxRefAge), ref.maxRefAgeMs().longValue());
-
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
+              assertThat(ref.minSnapshotsToKeep()).isEqualTo(minSnapshotsToKeep);
+              assertThat(ref.maxSnapshotAgeMs().longValue())
+                  .isEqualTo(TimeUnit.DAYS.toMillis(maxSnapshotAge));
+              assertThat(ref.maxRefAgeMs().longValue())
+                  .isEqualTo(TimeUnit.DAYS.toMillis(maxRefAge));
+            });
     assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Ref b1 already exists");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchOnEmptyTable() {
     String branchName = "b1";
     sql("ALTER TABLE %s CREATE BRANCH %s", tableName, "b1");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    SnapshotRef mainRef = table.refs().get(SnapshotRef.MAIN_BRANCH);
-    assertThat(mainRef).isNull();
+    assertThat(table.refs())
+        .doesNotContainKey(SnapshotRef.MAIN_BRANCH)
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.minSnapshotsToKeep()).isNull();
+              assertThat(ref.maxSnapshotAgeMs()).isNull();
+              assertThat(ref.maxRefAgeMs()).isNull();
 
-    SnapshotRef ref = table.refs().get(branchName);
-    assertThat(ref).isNotNull();
-    assertThat(ref.minSnapshotsToKeep()).isNull();
-    assertThat(ref.maxSnapshotAgeMs()).isNull();
-    assertThat(ref.maxRefAgeMs()).isNull();
-
-    Snapshot snapshot = table.snapshot(ref.snapshotId());
-    assertThat(snapshot.parentId()).isNull();
-    assertThat(snapshot.addedDataFiles(table.io())).isEmpty();
-    assertThat(snapshot.removedDataFiles(table.io())).isEmpty();
-    assertThat(snapshot.addedDeleteFiles(table.io())).isEmpty();
-    assertThat(snapshot.removedDeleteFiles(table.io())).isEmpty();
+              Snapshot snapshot = table.snapshot(ref.snapshotId());
+              assertThat(snapshot.parentId()).isNull();
+              assertThat(snapshot.addedDataFiles(table.io())).isEmpty();
+              assertThat(snapshot.removedDataFiles(table.io())).isEmpty();
+              assertThat(snapshot.addedDeleteFiles(table.io())).isEmpty();
+              assertThat(snapshot.removedDeleteFiles(table.io())).isEmpty();
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchUseDefaultConfig() throws NoSuchTableException {
     Table table = insertRows();
     String branchName = "b1";
     sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName);
     table.refresh();
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), ref.snapshotId());
-    Assert.assertNull(ref.minSnapshotsToKeep());
-    Assert.assertNull(ref.maxSnapshotAgeMs());
-    Assert.assertNull(ref.maxRefAgeMs());
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
+              assertThat(ref.minSnapshotsToKeep()).isNull();
+              assertThat(ref.maxSnapshotAgeMs()).isNull();
+              assertThat(ref.maxRefAgeMs()).isNull();
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchUseCustomMinSnapshotsToKeep() throws NoSuchTableException {
     Integer minSnapshotsToKeep = 2;
     Table table = insertRows();
@@ -135,14 +142,18 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
         "ALTER TABLE %s CREATE BRANCH %s WITH SNAPSHOT RETENTION %d SNAPSHOTS",
         tableName, branchName, minSnapshotsToKeep);
     table.refresh();
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), ref.snapshotId());
-    Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
-    Assert.assertNull(ref.maxSnapshotAgeMs());
-    Assert.assertNull(ref.maxRefAgeMs());
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
+              assertThat(ref.minSnapshotsToKeep()).isEqualTo(minSnapshotsToKeep);
+              assertThat(ref.maxSnapshotAgeMs()).isNull();
+              assertThat(ref.maxRefAgeMs()).isNull();
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchUseCustomMaxSnapshotAge() throws NoSuchTableException {
     long maxSnapshotAge = 2L;
     Table table = insertRows();
@@ -151,14 +162,19 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
         "ALTER TABLE %s CREATE BRANCH %s WITH SNAPSHOT RETENTION %d DAYS",
         tableName, branchName, maxSnapshotAge);
     table.refresh();
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertNotNull(ref);
-    Assert.assertNull(ref.minSnapshotsToKeep());
-    Assert.assertEquals(TimeUnit.DAYS.toMillis(maxSnapshotAge), ref.maxSnapshotAgeMs().longValue());
-    Assert.assertNull(ref.maxRefAgeMs());
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref).isNotNull();
+              assertThat(ref.minSnapshotsToKeep()).isNull();
+              assertThat(ref.maxSnapshotAgeMs().longValue())
+                  .isEqualTo(TimeUnit.DAYS.toMillis(maxSnapshotAge));
+              assertThat(ref.maxRefAgeMs()).isNull();
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchIfNotExists() throws NoSuchTableException {
     long maxSnapshotAge = 2L;
     Table table = insertRows();
@@ -169,14 +185,19 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s CREATE BRANCH IF NOT EXISTS %s", tableName, branchName);
 
     table.refresh();
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), ref.snapshotId());
-    Assert.assertNull(ref.minSnapshotsToKeep());
-    Assert.assertEquals(TimeUnit.DAYS.toMillis(maxSnapshotAge), ref.maxSnapshotAgeMs().longValue());
-    Assert.assertNull(ref.maxRefAgeMs());
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
+              assertThat(ref.minSnapshotsToKeep()).isNull();
+              assertThat(ref.maxSnapshotAgeMs().longValue())
+                  .isEqualTo(TimeUnit.DAYS.toMillis(maxSnapshotAge));
+              assertThat(ref.maxRefAgeMs()).isNull();
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchUseCustomMinSnapshotsToKeepAndMaxSnapshotAge()
       throws NoSuchTableException {
     Integer minSnapshotsToKeep = 2;
@@ -187,11 +208,16 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
         "ALTER TABLE %s CREATE BRANCH %s WITH SNAPSHOT RETENTION %d SNAPSHOTS %d DAYS",
         tableName, branchName, minSnapshotsToKeep, maxSnapshotAge);
     table.refresh();
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), ref.snapshotId());
-    Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
-    Assert.assertEquals(TimeUnit.DAYS.toMillis(maxSnapshotAge), ref.maxSnapshotAgeMs().longValue());
-    Assert.assertNull(ref.maxRefAgeMs());
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
+              assertThat(ref.minSnapshotsToKeep()).isEqualTo(minSnapshotsToKeep);
+              assertThat(ref.maxSnapshotAgeMs().longValue())
+                  .isEqualTo(TimeUnit.DAYS.toMillis(maxSnapshotAge));
+              assertThat(ref.maxRefAgeMs()).isNull();
+            });
 
     assertThatThrownBy(
             () ->
@@ -202,18 +228,23 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
         .hasMessageContaining("no viable alternative at input 'WITH SNAPSHOT RETENTION'");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateBranchUseCustomMaxRefAge() throws NoSuchTableException {
     long maxRefAge = 10L;
     Table table = insertRows();
     String branchName = "b1";
     sql("ALTER TABLE %s CREATE BRANCH %s RETAIN %d DAYS", tableName, branchName, maxRefAge);
     table.refresh();
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), ref.snapshotId());
-    Assert.assertNull(ref.minSnapshotsToKeep());
-    Assert.assertNull(ref.maxSnapshotAgeMs());
-    Assert.assertEquals(TimeUnit.DAYS.toMillis(maxRefAge), ref.maxRefAgeMs().longValue());
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
+              assertThat(ref.minSnapshotsToKeep()).isNull();
+              assertThat(ref.maxSnapshotAgeMs()).isNull();
+              assertThat(ref.maxRefAgeMs().longValue())
+                  .isEqualTo(TimeUnit.DAYS.toMillis(maxRefAge));
+            });
 
     assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE BRANCH %s RETAIN", tableName, branchName))
         .isInstanceOf(IcebergParseException.class)
@@ -234,31 +265,34 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
         .hasMessageContaining("mismatched input 'SECONDS' expecting {'DAYS', 'HOURS', 'MINUTES'}");
   }
 
-  @Test
+  @TestTemplate
   public void testDropBranch() throws NoSuchTableException {
     insertRows();
 
     Table table = validationCatalog.loadTable(tableIdent);
     String branchName = "b1";
     table.manageSnapshots().createBranch(branchName, table.currentSnapshot().snapshotId()).commit();
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertEquals(table.currentSnapshot().snapshotId(), ref.snapshotId());
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
+            });
 
     sql("ALTER TABLE %s DROP BRANCH %s", tableName, branchName);
     table.refresh();
 
-    ref = table.refs().get(branchName);
-    Assert.assertNull(ref);
+    assertThat(table.refs()).doesNotContainKey(branchName);
   }
 
-  @Test
+  @TestTemplate
   public void testDropBranchDoesNotExist() {
     assertThatThrownBy(() -> sql("ALTER TABLE %s DROP BRANCH %s", tableName, "nonExistingBranch"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Branch does not exist: nonExistingBranch");
   }
 
-  @Test
+  @TestTemplate
   public void testDropBranchFailsForTag() throws NoSuchTableException {
     String tagName = "b1";
     Table table = insertRows();
@@ -269,31 +303,29 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
         .hasMessage("Ref b1 is a tag not a branch");
   }
 
-  @Test
+  @TestTemplate
   public void testDropBranchNonConformingName() {
     assertThatThrownBy(() -> sql("ALTER TABLE %s DROP BRANCH %s", tableName, "123"))
         .isInstanceOf(IcebergParseException.class)
         .hasMessageContaining("no viable alternative at input '123'");
   }
 
-  @Test
+  @TestTemplate
   public void testDropMainBranchFails() {
     assertThatThrownBy(() -> sql("ALTER TABLE %s DROP BRANCH main", tableName))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot remove main branch");
   }
 
-  @Test
+  @TestTemplate
   public void testDropBranchIfExists() {
     String branchName = "nonExistingBranch";
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertNull(table.refs().get(branchName));
+    assertThat(table.refs()).doesNotContainKey(branchName);
 
     sql("ALTER TABLE %s DROP BRANCH IF EXISTS %s", tableName, branchName);
     table.refresh();
-
-    SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertNull(ref);
+    assertThat(table.refs()).doesNotContainKey(branchName);
   }
 
   private Table insertRows() throws NoSuchTableException {
@@ -304,7 +336,7 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
     return validationCatalog.loadTable(tableIdent);
   }
 
-  @Test
+  @TestTemplate
   public void createOrReplace() throws NoSuchTableException {
     Table table = insertRows();
     long first = table.currentSnapshot().snapshotId();
@@ -320,30 +352,32 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
     assertThat(table.refs().get(branchName).snapshotId()).isEqualTo(second);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateOrReplaceBranchOnEmptyTable() {
     String branchName = "b1";
     sql("ALTER TABLE %s CREATE OR REPLACE BRANCH %s", tableName, "b1");
     Table table = validationCatalog.loadTable(tableIdent);
 
-    SnapshotRef mainRef = table.refs().get(SnapshotRef.MAIN_BRANCH);
-    assertThat(mainRef).isNull();
+    assertThat(table.refs())
+        .doesNotContainKey(SnapshotRef.MAIN_BRANCH)
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref).isNotNull();
+              assertThat(ref.minSnapshotsToKeep()).isNull();
+              assertThat(ref.maxSnapshotAgeMs()).isNull();
+              assertThat(ref.maxRefAgeMs()).isNull();
 
-    SnapshotRef ref = table.refs().get(branchName);
-    assertThat(ref).isNotNull();
-    assertThat(ref.minSnapshotsToKeep()).isNull();
-    assertThat(ref.maxSnapshotAgeMs()).isNull();
-    assertThat(ref.maxRefAgeMs()).isNull();
-
-    Snapshot snapshot = table.snapshot(ref.snapshotId());
-    assertThat(snapshot.parentId()).isNull();
-    assertThat(snapshot.addedDataFiles(table.io())).isEmpty();
-    assertThat(snapshot.removedDataFiles(table.io())).isEmpty();
-    assertThat(snapshot.addedDeleteFiles(table.io())).isEmpty();
-    assertThat(snapshot.removedDeleteFiles(table.io())).isEmpty();
+              Snapshot snapshot = table.snapshot(ref.snapshotId());
+              assertThat(snapshot.parentId()).isNull();
+              assertThat(snapshot.addedDataFiles(table.io())).isEmpty();
+              assertThat(snapshot.removedDataFiles(table.io())).isEmpty();
+              assertThat(snapshot.addedDeleteFiles(table.io())).isEmpty();
+              assertThat(snapshot.removedDeleteFiles(table.io())).isEmpty();
+            });
   }
 
-  @Test
+  @TestTemplate
   public void createOrReplaceWithNonExistingBranch() throws NoSuchTableException {
     Table table = insertRows();
     String branchName = "b1";
@@ -357,7 +391,7 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
     assertThat(table.refs().get(branchName).snapshotId()).isEqualTo(snapshotId);
   }
 
-  @Test
+  @TestTemplate
   public void replaceBranch() throws NoSuchTableException {
     Table table = insertRows();
     long first = table.currentSnapshot().snapshotId();
@@ -374,12 +408,16 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
 
     sql("ALTER TABLE %s REPLACE BRANCH %s AS OF VERSION %d", tableName, branchName, second);
     table.refresh();
-    SnapshotRef ref = table.refs().get(branchName);
-    assertThat(ref.snapshotId()).isEqualTo(second);
-    assertThat(ref.maxRefAgeMs()).isEqualTo(expectedMaxRefAgeMs);
+    assertThat(table.refs())
+        .hasEntrySatisfying(
+            branchName,
+            ref -> {
+              assertThat(ref.snapshotId()).isEqualTo(second);
+              assertThat(ref.maxRefAgeMs()).isEqualTo(expectedMaxRefAgeMs);
+            });
   }
 
-  @Test
+  @TestTemplate
   public void replaceBranchDoesNotExist() throws NoSuchTableException {
     Table table = insertRows();
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestComputeTableStatsProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestComputeTableStatsProcedure.java
@@ -22,8 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.iceberg.BlobMetadata;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
@@ -33,22 +33,19 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.actions.NDVSketchUtil;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.parser.ParseException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestComputeTableStatsProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestComputeTableStatsProcedure extends ExtensionsTestBase {
 
-  public TestComputeTableStatsProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testProcedureOnEmptyTable() throws NoSuchTableException, ParseException {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     List<Object[]> result =
@@ -56,7 +53,7 @@ public class TestComputeTableStatsProcedure extends SparkExtensionsTestBase {
     assertThat(result).isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testProcedureWithNamedArgs() throws NoSuchTableException, ParseException {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
@@ -72,7 +69,7 @@ public class TestComputeTableStatsProcedure extends SparkExtensionsTestBase {
     verifyTableStats(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testProcedureWithPositionalArgs() throws NoSuchTableException, ParseException {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
@@ -90,7 +87,7 @@ public class TestComputeTableStatsProcedure extends SparkExtensionsTestBase {
     verifyTableStats(tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testProcedureWithInvalidColumns() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
@@ -105,7 +102,7 @@ public class TestComputeTableStatsProcedure extends SparkExtensionsTestBase {
         .hasMessageContaining("Can't find column id1");
   }
 
-  @Test
+  @TestTemplate
   public void testProcedureWithInvalidSnapshot() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
@@ -119,7 +116,7 @@ public class TestComputeTableStatsProcedure extends SparkExtensionsTestBase {
         .hasMessageContaining("Snapshot not found");
   }
 
-  @Test
+  @TestTemplate
   public void testProcedureWithInvalidTable() {
     assertThatThrownBy(
             () ->

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
@@ -23,30 +23,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.catalyst.parser.ParseException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
-  public TestFastForwardBranchProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestFastForwardBranchProcedure extends ExtensionsTestBase {
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testFastForwardBranchUsingPositionalArgs() {
     sql("CREATE TABLE %s (id int NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -97,7 +94,7 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s order by id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testFastForwardBranchUsingNamedArgs() {
     sql("CREATE TABLE %s (id int NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -130,7 +127,7 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s order by id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testFastForwardWhenTargetIsNotAncestorFails() {
     sql("CREATE TABLE %s (id int NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -164,7 +161,7 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
         .hasMessage("Cannot fast-forward: main is not an ancestor of testBranch");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidFastForwardBranchCases() {
     assertThatThrownBy(
             () ->
@@ -182,8 +179,8 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;
-              Assert.assertEquals("PARSE_SYNTAX_ERROR", parseException.getErrorClass());
-              Assert.assertEquals("'CALL'", parseException.getMessageParameters().get("error"));
+              assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.fast_forward('test_table', 'main')", catalogName))
@@ -194,5 +191,74 @@ public class TestFastForwardBranchProcedure extends SparkExtensionsTestBase {
             () -> sql("CALL %s.system.fast_forward('', 'main', 'newBranch')", catalogName))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot handle an empty identifier for argument table");
+  }
+
+  @TestTemplate
+  public void testFastForwardNonExistingToRefFails() {
+    sql("CREATE TABLE %s (id int NOT NULL, data string) USING iceberg", tableName);
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.fast_forward(table => '%s', branch => '%s', to => '%s')",
+                    catalogName, tableIdent, SnapshotRef.MAIN_BRANCH, "non_existing_branch"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Ref does not exist: non_existing_branch");
+  }
+
+  @TestTemplate
+  public void testFastForwardNonMain() {
+    sql("CREATE TABLE %s (id int NOT NULL, data string) USING iceberg", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.refresh();
+
+    String branch1 = "branch1";
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branch1);
+    String tableNameWithBranch1 = String.format("%s.branch_%s", tableName, branch1);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableNameWithBranch1);
+    table.refresh();
+    Snapshot branch1Snapshot = table.snapshot(branch1);
+
+    // Create branch2 from branch1
+    String branch2 = "branch2";
+    sql(
+        "ALTER TABLE %s CREATE BRANCH %s AS OF VERSION %d",
+        tableName, branch2, branch1Snapshot.snapshotId());
+    String tableNameWithBranch2 = String.format("%s.branch_%s", tableName, branch2);
+    sql("INSERT INTO TABLE %s VALUES (3, 'c')", tableNameWithBranch2);
+    table.refresh();
+    Snapshot branch2Snapshot = table.snapshot(branch2);
+    assertThat(
+            sql(
+                "CALL %s.system.fast_forward('%s', '%s', '%s')",
+                catalogName, tableIdent, branch1, branch2))
+        .containsExactly(row(branch1, branch1Snapshot.snapshotId(), branch2Snapshot.snapshotId()));
+  }
+
+  @TestTemplate
+  public void testFastForwardNonExistingFromMainCreatesBranch() {
+    sql("CREATE TABLE %s (id int NOT NULL, data string) USING iceberg", tableName);
+    String branch1 = "branch1";
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branch1);
+    String branchIdentifier = String.format("%s.branch_%s", tableName, branch1);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", branchIdentifier);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", branchIdentifier);
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.refresh();
+    Snapshot branch1Snapshot = table.snapshot(branch1);
+
+    assertThat(
+            sql(
+                "CALL %s.system.fast_forward('%s', '%s', '%s')",
+                catalogName, tableIdent, SnapshotRef.MAIN_BRANCH, branch1))
+        .containsExactly(row(SnapshotRef.MAIN_BRANCH, null, branch1Snapshot.snapshotId()));
+
+    // Ensure the same behavior for non-main branches
+    String branch2 = "branch2";
+    assertThat(
+            sql(
+                "CALL %s.system.fast_forward('%s', '%s', '%s')",
+                catalogName, tableIdent, branch2, branch1))
+        .containsExactly(row(branch2, null, branch1Snapshot.snapshotId()));
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
@@ -19,10 +19,11 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.WRITE_AUDIT_PUBLISH_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -32,23 +33,19 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestPublishChangesProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestPublishChangesProcedure extends ExtensionsTestBase {
 
-  public TestPublishChangesProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testApplyWapChangesUsingPositionalArgs() {
     String wapId = "wap_id_1";
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
@@ -84,7 +81,7 @@ public class TestPublishChangesProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testApplyWapChangesUsingNamedArgs() {
     String wapId = "wap_id_1";
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
@@ -122,7 +119,7 @@ public class TestPublishChangesProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testApplyWapChangesRefreshesRelationCache() {
     String wapId = "wap_id_1";
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
@@ -154,7 +151,7 @@ public class TestPublishChangesProcedure extends SparkExtensionsTestBase {
     sql("UNCACHE TABLE tmp");
   }
 
-  @Test
+  @TestTemplate
   public void testApplyInvalidWapId() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
@@ -164,7 +161,7 @@ public class TestPublishChangesProcedure extends SparkExtensionsTestBase {
         .hasMessage("Cannot apply unknown WAP ID 'not_valid'");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidApplyWapChangesCases() {
     assertThatThrownBy(
             () ->
@@ -179,8 +176,8 @@ public class TestPublishChangesProcedure extends SparkExtensionsTestBase {
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;
-              Assert.assertEquals("PARSE_SYNTAX_ERROR", parseException.getErrorClass());
-              Assert.assertEquals("'CALL'", parseException.getMessageParameters().get("error"));
+              assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.publish_changes('t')", catalogName))

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRegisterTableProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRegisterTableProcedure.java
@@ -18,8 +18,11 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.atIndex;
+
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.spark.Spark3Util;
@@ -27,31 +30,28 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.DataTypes;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestRegisterTableProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRegisterTableProcedure extends ExtensionsTestBase {
 
-  private final String targetName;
+  private String targetName;
 
-  public TestRegisterTableProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
+  @BeforeEach
+  public void setTargetName() {
     targetName = tableName("register_table");
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
-
-  @After
+  @AfterEach
   public void dropTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS %s", targetName);
   }
 
-  @Test
+  @TestTemplate
   public void testRegisterTable() throws NoSuchTableException, ParseException {
     long numRows = 1000;
 
@@ -69,16 +69,17 @@ public class TestRegisterTableProcedure extends SparkExtensionsTestBase {
 
     List<Object[]> result =
         sql("CALL %s.system.register_table('%s', '%s')", catalogName, targetName, metadataJson);
-    Assert.assertEquals("Current Snapshot is not correct", currentSnapshotId, result.get(0)[0]);
+    assertThat(result.get(0))
+        .as("Current Snapshot is not correct")
+        .contains(currentSnapshotId, atIndex(0));
 
     List<Object[]> original = sql("SELECT * FROM %s", tableName);
     List<Object[]> registered = sql("SELECT * FROM %s", targetName);
     assertEquals("Registered table rows should match original table rows", original, registered);
-    Assert.assertEquals(
-        "Should have the right row count in the procedure result", numRows, result.get(0)[1]);
-    Assert.assertEquals(
-        "Should have the right datafile count in the procedure result",
-        originalFileCount,
-        result.get(0)[2]);
+    assertThat(result.get(0))
+        .as("Should have the right row count in the procedure result")
+        .contains(numRows, atIndex(1))
+        .as("Should have the right datafile count in the procedure result")
+        .contains(originalFileCount, atIndex(2));
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceBranch.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceBranch.java
@@ -18,11 +18,13 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -31,16 +33,16 @@ import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestReplaceBranch extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestReplaceBranch extends ExtensionsTestBase {
 
   private static final String[] TIME_UNITS = {"DAYS", "HOURS", "MINUTES"};
 
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -51,16 +53,12 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
     };
   }
 
-  public TestReplaceBranch(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranchFailsForTag() throws NoSuchTableException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
     String tagName = "tag1";
@@ -84,7 +82,7 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
         .hasMessage("Ref tag1 is a tag not a branch");
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranch() throws NoSuchTableException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
     List<SimpleRecord> records =
@@ -113,14 +111,14 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
 
     table.refresh();
     SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertNotNull(ref);
-    Assert.assertEquals(second, ref.snapshotId());
-    Assert.assertEquals(expectedMinSnapshotsToKeep, ref.minSnapshotsToKeep().intValue());
-    Assert.assertEquals(expectedMaxSnapshotAgeMs, ref.maxSnapshotAgeMs().longValue());
-    Assert.assertEquals(expectedMaxRefAgeMs, ref.maxRefAgeMs().longValue());
+    assertThat(ref).isNotNull();
+    assertThat(ref.snapshotId()).isEqualTo(second);
+    assertThat(ref.minSnapshotsToKeep().intValue()).isEqualTo(expectedMinSnapshotsToKeep);
+    assertThat(ref.maxSnapshotAgeMs().longValue()).isEqualTo(expectedMaxSnapshotAgeMs);
+    assertThat(ref.maxRefAgeMs().longValue()).isEqualTo(expectedMaxRefAgeMs);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranchDoesNotExist() throws NoSuchTableException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
     List<SimpleRecord> records =
@@ -138,7 +136,7 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
         .hasMessage("Branch does not exist: someBranch");
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranchWithRetain() throws NoSuchTableException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
     List<SimpleRecord> records =
@@ -164,16 +162,16 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
 
       table.refresh();
       SnapshotRef ref = table.refs().get(branchName);
-      Assert.assertNotNull(ref);
-      Assert.assertEquals(second, ref.snapshotId());
-      Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
-      Assert.assertEquals(maxSnapshotAgeMs, ref.maxSnapshotAgeMs());
-      Assert.assertEquals(
-          TimeUnit.valueOf(timeUnit).toMillis(maxRefAge), ref.maxRefAgeMs().longValue());
+      assertThat(ref).isNotNull();
+      assertThat(ref.snapshotId()).isEqualTo(second);
+      assertThat(ref.minSnapshotsToKeep()).isNull();
+      assertThat(ref.maxSnapshotAgeMs()).isNull();
+      assertThat(ref.maxRefAgeMs().longValue())
+          .isEqualTo(TimeUnit.valueOf(timeUnit).toMillis(maxRefAge));
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranchWithSnapshotRetention() throws NoSuchTableException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
     List<SimpleRecord> records =
@@ -197,16 +195,16 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
 
       table.refresh();
       SnapshotRef ref = table.refs().get(branchName);
-      Assert.assertNotNull(ref);
-      Assert.assertEquals(second, ref.snapshotId());
-      Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
-      Assert.assertEquals(
-          TimeUnit.valueOf(timeUnit).toMillis(maxSnapshotAge), ref.maxSnapshotAgeMs().longValue());
-      Assert.assertEquals(maxRefAgeMs, ref.maxRefAgeMs());
+      assertThat(ref).isNotNull();
+      assertThat(ref.snapshotId()).isEqualTo(second);
+      assertThat(ref.minSnapshotsToKeep()).isEqualTo(minSnapshotsToKeep);
+      assertThat(ref.maxSnapshotAgeMs().longValue())
+          .isEqualTo(TimeUnit.valueOf(timeUnit).toMillis(maxSnapshotAge));
+      assertThat(ref.maxRefAgeMs()).isEqualTo(maxRefAgeMs);
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceBranchWithRetainAndSnapshotRetention() throws NoSuchTableException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
     List<SimpleRecord> records =
@@ -238,17 +236,17 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
 
       table.refresh();
       SnapshotRef ref = table.refs().get(branchName);
-      Assert.assertNotNull(ref);
-      Assert.assertEquals(second, ref.snapshotId());
-      Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
-      Assert.assertEquals(
-          TimeUnit.valueOf(timeUnit).toMillis(maxSnapshotAge), ref.maxSnapshotAgeMs().longValue());
-      Assert.assertEquals(
-          TimeUnit.valueOf(timeUnit).toMillis(maxRefAge), ref.maxRefAgeMs().longValue());
+      assertThat(ref).isNotNull();
+      assertThat(ref.snapshotId()).isEqualTo(second);
+      assertThat(ref.minSnapshotsToKeep()).isEqualTo(minSnapshotsToKeep);
+      assertThat(ref.maxSnapshotAgeMs().longValue())
+          .isEqualTo(TimeUnit.valueOf(timeUnit).toMillis(maxSnapshotAge));
+      assertThat(ref.maxRefAgeMs().longValue())
+          .isEqualTo(TimeUnit.valueOf(timeUnit).toMillis(maxRefAge));
     }
   }
 
-  @Test
+  @TestTemplate
   public void testCreateOrReplace() throws NoSuchTableException {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
     List<SimpleRecord> records =
@@ -269,7 +267,7 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
 
     table.refresh();
     SnapshotRef ref = table.refs().get(branchName);
-    Assert.assertNotNull(ref);
-    Assert.assertEquals(first, ref.snapshotId());
+    assertThat(ref).isNotNull();
+    assertThat(ref.snapshotId()).isEqualTo(first);
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -23,8 +23,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -35,16 +36,16 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestTagDDL extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestTagDDL extends ExtensionsTestBase {
   private static final String[] TIME_UNITS = {"DAYS", "HOURS", "MINUTES"};
 
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -55,21 +56,17 @@ public class TestTagDDL extends SparkExtensionsTestBase {
     };
   }
 
-  public TestTagDDL(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @Before
-  public void before() {
+  @BeforeEach
+  public void createTable() {
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
   }
 
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTagWithRetain() throws NoSuchTableException {
     Table table = insertRows();
     long firstSnapshotId = table.currentSnapshot().snapshotId();
@@ -87,12 +84,12 @@ public class TestTagDDL extends SparkExtensionsTestBase {
           tableName, tagName, firstSnapshotId, maxRefAge, timeUnit);
       table.refresh();
       SnapshotRef ref = table.refs().get(tagName);
-      Assert.assertEquals(
-          "The tag needs to point to a specific snapshot id.", firstSnapshotId, ref.snapshotId());
-      Assert.assertEquals(
-          "The tag needs to have the correct max ref age.",
-          TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ENGLISH)).toMillis(maxRefAge),
-          ref.maxRefAgeMs().longValue());
+      assertThat(ref.snapshotId())
+          .as("The tag needs to point to a specific snapshot id.")
+          .isEqualTo(firstSnapshotId);
+      assertThat(ref.maxRefAgeMs().longValue())
+          .as("The tag needs to have the correct max ref age.")
+          .isEqualTo(TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ENGLISH)).toMillis(maxRefAge));
     }
 
     String tagName = "t1";
@@ -118,7 +115,7 @@ public class TestTagDDL extends SparkExtensionsTestBase {
         .hasMessageContaining("mismatched input 'SECONDS' expecting {'DAYS', 'HOURS', 'MINUTES'}");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTagOnEmptyTable() {
     assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE TAG %s", tableName, "abc"))
         .isInstanceOf(IllegalArgumentException.class)
@@ -127,7 +124,7 @@ public class TestTagDDL extends SparkExtensionsTestBase {
             tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTagUseDefaultConfig() throws NoSuchTableException {
     Table table = insertRows();
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -141,10 +138,12 @@ public class TestTagDDL extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s CREATE TAG %s", tableName, tagName);
     table.refresh();
     SnapshotRef ref = table.refs().get(tagName);
-    Assert.assertEquals(
-        "The tag needs to point to a specific snapshot id.", snapshotId, ref.snapshotId());
-    Assert.assertNull(
-        "The tag needs to have the default max ref age, which is null.", ref.maxRefAgeMs());
+    assertThat(ref.snapshotId())
+        .as("The tag needs to point to a specific snapshot id.")
+        .isEqualTo(snapshotId);
+    assertThat(ref.maxRefAgeMs())
+        .as("The tag needs to have the default max ref age, which is null.")
+        .isNull();
 
     assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE TAG %s", tableName, tagName))
         .isInstanceOf(IllegalArgumentException.class)
@@ -163,13 +162,15 @@ public class TestTagDDL extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d", tableName, tagName, snapshotId);
     table.refresh();
     ref = table.refs().get(tagName);
-    Assert.assertEquals(
-        "The tag needs to point to a specific snapshot id.", snapshotId, ref.snapshotId());
-    Assert.assertNull(
-        "The tag needs to have the default max ref age, which is null.", ref.maxRefAgeMs());
+    assertThat(ref.snapshotId())
+        .as("The tag needs to point to a specific snapshot id.")
+        .isEqualTo(snapshotId);
+    assertThat(ref.maxRefAgeMs())
+        .as("The tag needs to have the default max ref age, which is null.")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTagIfNotExists() throws NoSuchTableException {
     long maxSnapshotAge = 2L;
     Table table = insertRows();
@@ -179,17 +180,15 @@ public class TestTagDDL extends SparkExtensionsTestBase {
 
     table.refresh();
     SnapshotRef ref = table.refs().get(tagName);
-    Assert.assertEquals(
-        "The tag needs to point to a specific snapshot id.",
-        table.currentSnapshot().snapshotId(),
-        ref.snapshotId());
-    Assert.assertEquals(
-        "The tag needs to have the correct max ref age.",
-        TimeUnit.DAYS.toMillis(maxSnapshotAge),
-        ref.maxRefAgeMs().longValue());
+    assertThat(ref.snapshotId())
+        .as("The tag needs to point to a specific snapshot id.")
+        .isEqualTo(table.currentSnapshot().snapshotId());
+    assertThat(ref.maxRefAgeMs().longValue())
+        .as("The tag needs to have the correct max ref age.")
+        .isEqualTo(TimeUnit.DAYS.toMillis(maxSnapshotAge));
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTagFailsForBranch() throws NoSuchTableException {
     String branchName = "branch1";
     Table table = insertRows();
@@ -203,7 +202,7 @@ public class TestTagDDL extends SparkExtensionsTestBase {
         .hasMessageContaining("Ref branch1 is a branch not a tag");
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTag() throws NoSuchTableException {
     Table table = insertRows();
     long first = table.currentSnapshot().snapshotId();
@@ -221,15 +220,15 @@ public class TestTagDDL extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s REPLACE Tag %s AS OF VERSION %d", tableName, tagName, second);
     table.refresh();
     SnapshotRef ref = table.refs().get(tagName);
-    Assert.assertEquals(
-        "The tag needs to point to a specific snapshot id.", second, ref.snapshotId());
-    Assert.assertEquals(
-        "The tag needs to have the correct max ref age.",
-        expectedMaxRefAgeMs,
-        ref.maxRefAgeMs().longValue());
+    assertThat(ref.snapshotId())
+        .as("The tag needs to point to a specific snapshot id.")
+        .isEqualTo(second);
+    assertThat(ref.maxRefAgeMs().longValue())
+        .as("The tag needs to have the correct max ref age.")
+        .isEqualTo(expectedMaxRefAgeMs);
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTagDoesNotExist() throws NoSuchTableException {
     Table table = insertRows();
 
@@ -242,7 +241,7 @@ public class TestTagDDL extends SparkExtensionsTestBase {
         .hasMessageContaining("Tag does not exist");
   }
 
-  @Test
+  @TestTemplate
   public void testReplaceTagWithRetain() throws NoSuchTableException {
     Table table = insertRows();
     long first = table.currentSnapshot().snapshotId();
@@ -259,16 +258,16 @@ public class TestTagDDL extends SparkExtensionsTestBase {
 
       table.refresh();
       SnapshotRef ref = table.refs().get(tagName);
-      Assert.assertEquals(
-          "The tag needs to point to a specific snapshot id.", second, ref.snapshotId());
-      Assert.assertEquals(
-          "The tag needs to have the correct max ref age.",
-          TimeUnit.valueOf(timeUnit).toMillis(maxRefAge),
-          ref.maxRefAgeMs().longValue());
+      assertThat(ref.snapshotId())
+          .as("The tag needs to point to a specific snapshot id.")
+          .isEqualTo(second);
+      assertThat(ref.maxRefAgeMs().longValue())
+          .as("The tag needs to have the correct max ref age.")
+          .isEqualTo(TimeUnit.valueOf(timeUnit).toMillis(maxRefAge));
     }
   }
 
-  @Test
+  @TestTemplate
   public void testCreateOrReplace() throws NoSuchTableException {
     Table table = insertRows();
     long first = table.currentSnapshot().snapshotId();
@@ -280,43 +279,40 @@ public class TestTagDDL extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s CREATE OR REPLACE TAG %s AS OF VERSION %d", tableName, tagName, first);
     table.refresh();
     SnapshotRef ref = table.refs().get(tagName);
-    Assert.assertEquals(
-        "The tag needs to point to a specific snapshot id.", first, ref.snapshotId());
+    assertThat(ref.snapshotId())
+        .as("The tag needs to point to a specific snapshot id.")
+        .isEqualTo(first);
   }
 
-  @Test
+  @TestTemplate
   public void testDropTag() throws NoSuchTableException {
     insertRows();
     Table table = validationCatalog.loadTable(tableIdent);
     String tagName = "t1";
     table.manageSnapshots().createTag(tagName, table.currentSnapshot().snapshotId()).commit();
     SnapshotRef ref = table.refs().get(tagName);
-    Assert.assertEquals(
-        "The tag needs to point to a specific snapshot id.",
-        table.currentSnapshot().snapshotId(),
-        ref.snapshotId());
+    assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
 
     sql("ALTER TABLE %s DROP TAG %s", tableName, tagName);
     table.refresh();
-    ref = table.refs().get(tagName);
-    Assert.assertNull("The tag needs to be dropped.", ref);
+    assertThat(table.refs()).doesNotContainKey(tagName);
   }
 
-  @Test
+  @TestTemplate
   public void testDropTagNonConformingName() {
     assertThatThrownBy(() -> sql("ALTER TABLE %s DROP TAG %s", tableName, "123"))
         .isInstanceOf(IcebergParseException.class)
         .hasMessageContaining("no viable alternative at input '123'");
   }
 
-  @Test
+  @TestTemplate
   public void testDropTagDoesNotExist() {
     assertThatThrownBy(() -> sql("ALTER TABLE %s DROP TAG %s", tableName, "nonExistingTag"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Tag does not exist: nonExistingTag");
   }
 
-  @Test
+  @TestTemplate
   public void testDropTagFailesForBranch() throws NoSuchTableException {
     String branchName = "b1";
     Table table = insertRows();
@@ -327,28 +323,27 @@ public class TestTagDDL extends SparkExtensionsTestBase {
         .hasMessageContaining("Ref b1 is a branch not a tag");
   }
 
-  @Test
+  @TestTemplate
   public void testDropTagIfExists() throws NoSuchTableException {
     String tagName = "nonExistingTag";
     Table table = insertRows();
-    Assert.assertNull("The tag does not exists.", table.refs().get(tagName));
+    assertThat(table.refs()).doesNotContainKey(tagName);
 
     sql("ALTER TABLE %s DROP TAG IF EXISTS %s", tableName, tagName);
     table.refresh();
-    Assert.assertNull("The tag still does not exist.", table.refs().get(tagName));
+    assertThat(table.refs()).doesNotContainKey(tagName);
 
     table.manageSnapshots().createTag(tagName, table.currentSnapshot().snapshotId()).commit();
-    Assert.assertEquals(
-        "The tag has been created successfully.",
-        table.currentSnapshot().snapshotId(),
-        table.refs().get(tagName).snapshotId());
+    assertThat(table.refs().get(tagName).snapshotId())
+        .as("The tag has been created successfully.")
+        .isEqualTo(table.currentSnapshot().snapshotId());
 
     sql("ALTER TABLE %s DROP TAG IF EXISTS %s", tableName, tagName);
     table.refresh();
-    Assert.assertNull("The tag needs to be dropped.", table.refs().get(tagName));
+    assertThat(table.refs()).doesNotContainKey(tagName);
   }
 
-  @Test
+  @TestTemplate
   public void createOrReplaceWithNonExistingTag() throws NoSuchTableException {
     Table table = insertRows();
     String tagName = "t1";

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
@@ -71,18 +71,18 @@ public class FastForwardBranchProcedure extends BaseProcedure {
   @Override
   public InternalRow[] call(InternalRow args) {
     Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    String source = args.getString(1);
-    String target = args.getString(2);
+    String from = args.getString(1);
+    String to = args.getString(2);
 
     return modifyIcebergTable(
         tableIdent,
         table -> {
-          long currentRef = table.currentSnapshot().snapshotId();
-          table.manageSnapshots().fastForwardBranch(source, target).commit();
-          long updatedRef = table.currentSnapshot().snapshotId();
-
+          Long snapshotBefore =
+              table.snapshot(from) != null ? table.snapshot(from).snapshotId() : null;
+          table.manageSnapshots().fastForwardBranch(from, to).commit();
+          long snapshotAfter = table.snapshot(from).snapshotId();
           InternalRow outputRow =
-              newInternalRow(UTF8String.fromString(source), currentRef, updatedRef);
+              newInternalRow(UTF8String.fromString(from), snapshotBefore, snapshotAfter);
           return new InternalRow[] {outputRow};
         });
   }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -507,7 +507,7 @@ public class TestAlterTablePartitionFields extends ExtensionsTestBase {
   @TestTemplate
   public void testSparkTableAddDropPartitions() throws Exception {
     createTable("id bigint NOT NULL, ts timestamp, data string");
-    assertThat(sparkTable().partitioning()).as("spark table partition should be empty").hasSize(0);
+    assertThat(sparkTable().partitioning()).as("spark table partition should be empty").isEmpty();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id) AS shard", tableName);
     assertPartitioningEquals(sparkTable(), 1, "bucket(16, id)");
@@ -526,7 +526,7 @@ public class TestAlterTablePartitionFields extends ExtensionsTestBase {
 
     sql("ALTER TABLE %s DROP PARTITION FIELD shard", tableName);
     sql("DESCRIBE %s", tableName);
-    assertThat(sparkTable().partitioning()).as("spark table partition should be empty").hasSize(0);
+    assertThat(sparkTable().partitioning()).as("spark table partition should be empty").isEmpty();
   }
 
   @TestTemplate
@@ -554,7 +554,8 @@ public class TestAlterTablePartitionFields extends ExtensionsTestBase {
 
   private void assertPartitioningEquals(SparkTable table, int len, String transform) {
     assertThat(table.partitioning()).as("spark table partition should be " + len).hasSize(len);
-    assertThat(table.partitioning()[len - 1].toString())
+    assertThat(table.partitioning()[len - 1])
+        .asString()
         .as("latest spark table partition transform should match")
         .isEqualTo(transform);
   }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTableSchema.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTableSchema.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,23 +49,21 @@ public class TestAlterTableSchema extends ExtensionsTestBase {
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id", tableName);
     table.refresh();
     assertThat(table.schema().identifierFieldIds())
-        .as("Should have new identifier field")
-        .isEqualTo(Sets.newHashSet(table.schema().findField("id").fieldId()));
+        .containsExactly(table.schema().findField("id").fieldId());
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id, location.lon", tableName);
     table.refresh();
     assertThat(table.schema().identifierFieldIds())
         .as("Should have new identifier field")
-        .isEqualTo(
-            Sets.newHashSet(
-                table.schema().findField("id").fieldId(),
-                table.schema().findField("location.lon").fieldId()));
+        .containsExactlyInAnyOrder(
+            table.schema().findField("id").fieldId(),
+            table.schema().findField("location.lon").fieldId());
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS location.lon", tableName);
     table.refresh();
     assertThat(table.schema().identifierFieldIds())
         .as("Should have new identifier field")
-        .isEqualTo(Sets.newHashSet(table.schema().findField("location.lon").fieldId()));
+        .containsExactly(table.schema().findField("location.lon").fieldId());
   }
 
   @TestTemplate
@@ -100,31 +97,27 @@ public class TestAlterTableSchema extends ExtensionsTestBase {
     table.refresh();
     assertThat(table.schema().identifierFieldIds())
         .as("Should have new identifier fields")
-        .isEqualTo(
-            Sets.newHashSet(
-                table.schema().findField("id").fieldId(),
-                table.schema().findField("location.lon").fieldId()));
+        .containsExactlyInAnyOrder(
+            table.schema().findField("id").fieldId(),
+            table.schema().findField("location.lon").fieldId());
 
     sql("ALTER TABLE %s DROP IDENTIFIER FIELDS id", tableName);
     table.refresh();
     assertThat(table.schema().identifierFieldIds())
         .as("Should removed identifier field")
-        .isEqualTo(Sets.newHashSet(table.schema().findField("location.lon").fieldId()));
+        .containsExactly(table.schema().findField("location.lon").fieldId());
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id, location.lon", tableName);
     table.refresh();
     assertThat(table.schema().identifierFieldIds())
         .as("Should have new identifier fields")
-        .isEqualTo(
-            Sets.newHashSet(
-                table.schema().findField("id").fieldId(),
-                table.schema().findField("location.lon").fieldId()));
+        .containsExactlyInAnyOrder(
+            table.schema().findField("id").fieldId(),
+            table.schema().findField("location.lon").fieldId());
 
     sql("ALTER TABLE %s DROP IDENTIFIER FIELDS id, location.lon", tableName);
     table.refresh();
-    assertThat(table.schema().identifierFieldIds())
-        .as("Should have no identifier field")
-        .isEqualTo(Sets.newHashSet());
+    assertThat(table.schema().identifierFieldIds()).as("Should have no identifier field").isEmpty();
   }
 
   @TestTemplate

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestFastForwardBranchProcedure.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
@@ -32,7 +33,9 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestFastForwardBranchProcedure extends ExtensionsTestBase {
 
   @AfterEach
@@ -177,7 +180,7 @@ public class TestFastForwardBranchProcedure extends ExtensionsTestBase {
             exception -> {
               ParseException parseException = (ParseException) exception;
               assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
-              assertThat(parseException.getMessageParameters().get("error")).isEqualTo("'CALL'");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.fast_forward('test_table', 'main')", catalogName))

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestPublishChangesProcedure.java
@@ -19,10 +19,11 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.WRITE_AUDIT_PUBLISH_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.util.List;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -34,7 +35,9 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestPublishChangesProcedure extends ExtensionsTestBase {
 
   @AfterEach
@@ -174,7 +177,7 @@ public class TestPublishChangesProcedure extends ExtensionsTestBase {
             exception -> {
               ParseException parseException = (ParseException) exception;
               assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
-              assertThat(parseException.getMessageParameters().get("error")).isEqualTo("'CALL'");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.publish_changes('t')", catalogName))

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRegisterTableProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRegisterTableProcedure.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.atIndex;
 
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -68,16 +69,17 @@ public class TestRegisterTableProcedure extends ExtensionsTestBase {
 
     List<Object[]> result =
         sql("CALL %s.system.register_table('%s', '%s')", catalogName, targetName, metadataJson);
-    assertThat(result.get(0)[0]).as("Current Snapshot is not correct").isEqualTo(currentSnapshotId);
+    assertThat(result.get(0))
+        .as("Current Snapshot is not correct")
+        .contains(currentSnapshotId, atIndex(0));
 
     List<Object[]> original = sql("SELECT * FROM %s", tableName);
     List<Object[]> registered = sql("SELECT * FROM %s", targetName);
     assertEquals("Registered table rows should match original table rows", original, registered);
-    assertThat(result.get(0)[1])
+    assertThat(result.get(0))
         .as("Should have the right row count in the procedure result")
-        .isEqualTo(numRows);
-    assertThat(result.get(0)[2])
+        .contains(numRows, atIndex(1))
         .as("Should have the right datafile count in the procedure result")
-        .isEqualTo(originalFileCount);
+        .contains(originalFileCount, atIndex(2));
   }
 }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteTablePathProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteTablePathProcedure.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.RewriteTablePathUtil;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableUtil;
@@ -31,8 +32,10 @@ import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestRewriteTablePathProcedure extends ExtensionsTestBase {
   @TempDir private Path staging;
   @TempDir private Path targetTableDir;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -291,12 +291,11 @@ public class TestTagDDL extends ExtensionsTestBase {
     String tagName = "t1";
     table.manageSnapshots().createTag(tagName, table.currentSnapshot().snapshotId()).commit();
     SnapshotRef ref = table.refs().get(tagName);
-    assertThat(ref.snapshotId()).as("").isEqualTo(table.currentSnapshot().snapshotId());
+    assertThat(ref.snapshotId()).isEqualTo(table.currentSnapshot().snapshotId());
 
     sql("ALTER TABLE %s DROP TAG %s", tableName, tagName);
     table.refresh();
-    ref = table.refs().get(tagName);
-    assertThat(ref).as("The tag needs to be dropped.").isNull();
+    assertThat(table.refs()).doesNotContainKey(tagName);
   }
 
   @TestTemplate
@@ -328,11 +327,11 @@ public class TestTagDDL extends ExtensionsTestBase {
   public void testDropTagIfExists() throws NoSuchTableException {
     String tagName = "nonExistingTag";
     Table table = insertRows();
-    assertThat(table.refs().get(tagName)).as("The tag does not exists.").isNull();
+    assertThat(table.refs()).doesNotContainKey(tagName);
 
     sql("ALTER TABLE %s DROP TAG IF EXISTS %s", tableName, tagName);
     table.refresh();
-    assertThat(table.refs().get(tagName)).as("The tag still does not exist.").isNull();
+    assertThat(table.refs()).doesNotContainKey(tagName);
 
     table.manageSnapshots().createTag(tagName, table.currentSnapshot().snapshotId()).commit();
     assertThat(table.refs().get(tagName).snapshotId())
@@ -341,7 +340,7 @@ public class TestTagDDL extends ExtensionsTestBase {
 
     sql("ALTER TABLE %s DROP TAG IF EXISTS %s", tableName, tagName);
     table.refresh();
-    assertThat(table.refs().get(tagName)).as("The tag needs to be dropped.").isNull();
+    assertThat(table.refs()).doesNotContainKey(tagName);
   }
 
   @TestTemplate


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates the below tests, which are related to extensions test base in Spark 3.4, into JUnit 5 with AssertJ. The following classes are included in this PR:

* Partition and schema changes:
  * `TestAlterTablePartitionFields`
  * `TestAlterTableSchema`
* Branching and Tagging:
  * `TestBranchDDL` including refactoring
  * `TestFastForwardBranchProcedure` (including the backport from https://github.com/apache/iceberg/pull/9196)
  * `TestReplaceBranch`
  * `TestPublishChangesProcedure` 
    * `org.assertj.core.api.AssertionsForClassTypes.assertThat;` was used, but this is only for Java 8 which has been deprecated in recent Iceberg verions. So replace it with `Assertions.assertThat`
  * `TestTagDDL` 

Additional tests:
  * `TestComputeTableStatsProcedure`
  * `TestRegisterTableProcedure`