### PR TITLE
CatalogTests: Fix listNamespaces Check, Avoid Reserved Keyword, Allow Configurable Location

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2010,7 +2010,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2088,7 +2088,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
     }
     assertFiles(table, FILE_A, anotherFile);
     assertFilePartitionSpec(table, FILE_A, initialSpecId);
@@ -2111,7 +2111,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2154,7 +2154,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
     }
 
     assertFiles(table, FILE_A);
@@ -2243,7 +2243,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2280,7 +2280,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
     }
 
     assertFiles(table, FILE_A);
@@ -2355,7 +2355,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2403,7 +2403,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
     }
 
     assertUUIDsMatch(original, loaded);
@@ -2519,7 +2519,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction replace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2569,7 +2569,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
     }
 
     assertUUIDsMatch(original, loaded);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2010,7 +2010,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2088,7 +2088,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
     }
     assertFiles(table, FILE_A, anotherFile);
     assertFilePartitionSpec(table, FILE_A, initialSpecId);
@@ -2111,7 +2111,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2154,7 +2154,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
     }
 
     assertFiles(table, FILE_A);
@@ -2243,7 +2243,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2280,7 +2280,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
     }
 
     assertFiles(table, FILE_A);
@@ -2355,7 +2355,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2403,7 +2403,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
     }
 
     assertUUIDsMatch(original, loaded);
@@ -2519,7 +2519,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction replace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2569,7 +2569,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" + TABLE.name());
     }
 
     assertUUIDsMatch(original, loaded);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -1230,8 +1230,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   @Test
   public void listNamespacesWithEmptyNamespace() {
     assumeThat(supportsEmptyNamespace())
-            .as("Only valid for catalogs that support empty namespaces")
-            .isTrue();
+        .as("Only valid for catalogs that support empty namespaces")
+        .isTrue();
     catalog().createNamespace(NS);
 
     assertThat(catalog().namespaceExists(Namespace.empty())).isFalse();

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -85,8 +85,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
+  private static final String DEFAULT_TABLE_LOCATION = "file:/tmp";
   protected static final Namespace NS = Namespace.of("newdb");
-  protected static final TableIdentifier TABLE = TableIdentifier.of(NS, "table");
+  protected static final TableIdentifier TABLE = TableIdentifier.of(NS, "newtable");
   protected static final TableIdentifier RENAMED_TABLE = TableIdentifier.of(NS, "table_renamed");
 
   // Schema passed to create tables
@@ -189,6 +190,10 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   protected boolean supportsEmptyNamespace() {
     return false;
+  }
+
+  protected String testTableBaseLocation() {
+    return DEFAULT_TABLE_LOCATION;
   }
 
   @Test
@@ -538,7 +543,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testBasicCreateTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
@@ -620,7 +625,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testBasicCreateTableThatAlreadyExists() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -633,7 +638,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     assertThatThrownBy(() -> catalog.buildTable(ident, OTHER_SCHEMA).create())
         .isInstanceOf(AlreadyExistsException.class)
-        .hasMessageStartingWith("Table already exists: ns.table");
+        .hasMessageStartingWith("Table already exists: ns.nstable");
 
     Table table = catalog.loadTable(ident);
     assertThat(table.schema().asStruct())
@@ -645,7 +650,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testCompleteCreateTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -658,7 +663,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table table =
         catalog
             .buildTable(ident, SCHEMA)
-            .withLocation("file:/tmp/ns/table")
+            .withLocation(testTableBaseLocation() + "/ns/nstable")
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -688,7 +693,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testDefaultTableProperties() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -714,7 +719,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testDefaultTablePropertiesCreateTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -743,7 +748,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testDefaultTablePropertiesReplaceTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -773,7 +778,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testOverrideTableProperties() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -801,7 +806,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testOverrideTablePropertiesCreateTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -832,7 +837,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testOverrideTablePropertiesReplaceTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -864,7 +869,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testCreateTableWithDefaultColumnValue() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -884,7 +889,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     catalog
         .buildTable(ident, schemaWithDefault)
-        .withLocation("file:/tmp/ns/table")
+        .withLocation(testTableBaseLocation() + "/ns/nstable")
         .withProperty(TableProperties.FORMAT_VERSION, "3")
         .create();
     assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
@@ -896,7 +901,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testLoadTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -908,7 +913,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
     catalog
         .buildTable(ident, SCHEMA)
-        .withLocation("file:/tmp/ns/table")
+        .withLocation(testTableBaseLocation() + "/ns/nstable")
         .withPartitionSpec(SPEC)
         .withSortOrder(WRITE_ORDER)
         .withProperties(properties)
@@ -938,8 +943,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testLoadMetadataTable() {
     C catalog = catalog();
 
-    TableIdentifier tableIdent = TableIdentifier.of("ns", "table");
-    TableIdentifier metaIdent = TableIdentifier.of("ns", "table", "files");
+    TableIdentifier tableIdent = TableIdentifier.of("ns", "nstable");
+    TableIdentifier metaIdent = TableIdentifier.of("ns", "nstable", "files");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(tableIdent.namespace());
@@ -961,12 +966,12 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testLoadMissingTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
 
     assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
     assertThatThrownBy(() -> catalog.loadTable(ident))
         .isInstanceOf(NoSuchTableException.class)
-        .hasMessageStartingWith("Table does not exist: ns.table");
+        .hasMessageStartingWith("Table does not exist: ns.nstable");
   }
 
   @Test
@@ -1022,7 +1027,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void renameTableNamespaceMissing() {
-    TableIdentifier from = TableIdentifier.of("ns", "table");
+    TableIdentifier from = TableIdentifier.of("ns", "nstable");
     TableIdentifier to = TableIdentifier.of("non_existing", "renamedTable");
 
     if (requiresNamespaceCreate()) {
@@ -1224,6 +1229,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void listNamespacesWithEmptyNamespace() {
+    assumeThat(supportsEmptyNamespace())
+            .as("Only valid for catalogs that support empty namespaces")
+            .isTrue();
     catalog().createNamespace(NS);
 
     assertThat(catalog().namespaceExists(Namespace.empty())).isFalse();
@@ -2002,7 +2010,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation("file:/tmp/ns/table")
+            .withLocation(testTableBaseLocation() + "/ns/newtable")
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2080,7 +2088,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo("file:/tmp/ns/table");
+          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
     }
     assertFiles(table, FILE_A, anotherFile);
     assertFilePartitionSpec(table, FILE_A, initialSpecId);
@@ -2103,7 +2111,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation("file:/tmp/ns/table")
+            .withLocation(testTableBaseLocation() + "/ns/newtable")
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2146,7 +2154,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo("file:/tmp/ns/table");
+          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
     }
 
     assertFiles(table, FILE_A);
@@ -2235,7 +2243,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation("file:/tmp/ns/table")
+            .withLocation(testTableBaseLocation() + "/ns/newtable")
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2272,7 +2280,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo("file:/tmp/ns/table");
+          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
     }
 
     assertFiles(table, FILE_A);
@@ -2347,7 +2355,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation("file:/tmp/ns/table")
+            .withLocation(testTableBaseLocation() + "/ns/newtable")
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2395,7 +2403,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo("file:/tmp/ns/table");
+          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
     }
 
     assertUUIDsMatch(original, loaded);
@@ -2511,7 +2519,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction replace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation("file:/tmp/ns/table")
+            .withLocation(testTableBaseLocation() + "/ns/newtable")
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2561,7 +2569,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo("file:/tmp/ns/table");
+          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
     }
 
     assertUUIDsMatch(original, loaded);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -85,7 +85,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
-  private static final String DEFAULT_TABLE_LOCATION = "file:/tmp";
+  private static final String BASE_TABLE_LOCATION = "file:/tmp";
   protected static final Namespace NS = Namespace.of("newdb");
   protected static final TableIdentifier TABLE = TableIdentifier.of(NS, "newtable");
   protected static final TableIdentifier RENAMED_TABLE = TableIdentifier.of(NS, "table_renamed");
@@ -192,8 +192,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     return false;
   }
 
-  protected String testTableBaseLocation() {
-    return DEFAULT_TABLE_LOCATION;
+  protected String baseTableLocation() {
+    return BASE_TABLE_LOCATION;
   }
 
   @Test
@@ -543,7 +543,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testBasicCreateTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
@@ -625,7 +625,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testBasicCreateTableThatAlreadyExists() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -638,7 +638,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     assertThatThrownBy(() -> catalog.buildTable(ident, OTHER_SCHEMA).create())
         .isInstanceOf(AlreadyExistsException.class)
-        .hasMessageStartingWith("Table already exists: ns.nstable");
+        .hasMessageStartingWith("Table already exists: ns.tbl");
 
     Table table = catalog.loadTable(ident);
     assertThat(table.schema().asStruct())
@@ -650,7 +650,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testCompleteCreateTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -663,7 +663,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table table =
         catalog
             .buildTable(ident, SCHEMA)
-            .withLocation(testTableBaseLocation() + "/ns/nstable")
+            .withLocation(baseTableLocation() + "/ns/tbl")
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -693,7 +693,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testDefaultTableProperties() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -719,7 +719,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testDefaultTablePropertiesCreateTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -748,7 +748,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testDefaultTablePropertiesReplaceTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -778,7 +778,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testOverrideTableProperties() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -806,7 +806,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testOverrideTablePropertiesCreateTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -837,7 +837,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testOverrideTablePropertiesReplaceTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -869,7 +869,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testCreateTableWithDefaultColumnValue() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -889,7 +889,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     catalog
         .buildTable(ident, schemaWithDefault)
-        .withLocation(testTableBaseLocation() + "/ns/nstable")
+        .withLocation(baseTableLocation() + "/ns/tbl")
         .withProperty(TableProperties.FORMAT_VERSION, "3")
         .create();
     assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
@@ -901,7 +901,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testLoadTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
@@ -913,7 +913,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
     catalog
         .buildTable(ident, SCHEMA)
-        .withLocation(testTableBaseLocation() + "/ns/nstable")
+        .withLocation(baseTableLocation() + "/ns/tbl")
         .withPartitionSpec(SPEC)
         .withSortOrder(WRITE_ORDER)
         .withProperties(properties)
@@ -943,8 +943,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testLoadMetadataTable() {
     C catalog = catalog();
 
-    TableIdentifier tableIdent = TableIdentifier.of("ns", "nstable");
-    TableIdentifier metaIdent = TableIdentifier.of("ns", "nstable", "files");
+    TableIdentifier tableIdent = TableIdentifier.of("ns", "tbl");
+    TableIdentifier metaIdent = TableIdentifier.of("ns", "tbl", "files");
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(tableIdent.namespace());
@@ -966,12 +966,12 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testLoadMissingTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "nstable");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
 
     assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
     assertThatThrownBy(() -> catalog.loadTable(ident))
         .isInstanceOf(NoSuchTableException.class)
-        .hasMessageStartingWith("Table does not exist: ns.nstable");
+        .hasMessageStartingWith("Table does not exist: ns.tbl");
   }
 
   @Test
@@ -1027,7 +1027,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void renameTableNamespaceMissing() {
-    TableIdentifier from = TableIdentifier.of("ns", "nstable");
+    TableIdentifier from = TableIdentifier.of("ns", "tbl");
     TableIdentifier to = TableIdentifier.of("non_existing", "renamedTable");
 
     if (requiresNamespaceCreate()) {
@@ -2010,7 +2010,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(testTableBaseLocation() + "/ns/newtable")
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2088,7 +2088,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
     }
     assertFiles(table, FILE_A, anotherFile);
     assertFilePartitionSpec(table, FILE_A, initialSpecId);
@@ -2111,7 +2111,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(testTableBaseLocation() + "/ns/newtable")
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2154,7 +2154,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
     }
 
     assertFiles(table, FILE_A);
@@ -2243,7 +2243,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(testTableBaseLocation() + "/ns/newtable")
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2280,7 +2280,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
     }
 
     assertFiles(table, FILE_A);
@@ -2355,7 +2355,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(testTableBaseLocation() + "/ns/newtable")
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2403,7 +2403,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
     }
 
     assertUUIDsMatch(original, loaded);
@@ -2519,7 +2519,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction replace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(testTableBaseLocation() + "/ns/newtable")
+            .withLocation(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name())
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2569,7 +2569,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo(testTableBaseLocation() + "/ns/newtable");
+          .isEqualTo(baseTableLocation() + TABLE.namespace() + "/" +TABLE.name());
     }
 
     assertUUIDsMatch(original, loaded);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -544,21 +544,19 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testBasicCreateTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    Table table = catalog.buildTable(ident, SCHEMA).create();
-    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+    Table table = catalog.buildTable(TBL, SCHEMA).create();
+    assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
 
     // validate table settings
     assertThat(table.name())
         .as("Table name should report its full name")
-        .isEqualTo(catalog.name() + "." + ident);
+        .isEqualTo(catalog.name() + "." + TBL);
     assertThat(table.schema().asStruct())
         .as("Schema should match expected ID assignment")
         .isEqualTo(TABLE_SCHEMA.asStruct());
@@ -626,22 +624,20 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testBasicCreateTableThatAlreadyExists() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
-    catalog.buildTable(ident, SCHEMA).create();
-    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+    catalog.buildTable(TBL, SCHEMA).create();
+    assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
 
-    assertThatThrownBy(() -> catalog.buildTable(ident, OTHER_SCHEMA).create())
+    assertThatThrownBy(() -> catalog.buildTable(TBL, OTHER_SCHEMA).create())
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageStartingWith("Table already exists: ns.tbl");
 
-    Table table = catalog.loadTable(ident);
+    Table table = catalog.loadTable(TBL);
     assertThat(table.schema().asStruct())
         .as("Schema should match original table schema")
         .isEqualTo(TABLE_SCHEMA.asStruct());
@@ -651,19 +647,17 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testCompleteCreateTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
     Map<String, String> properties =
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
     Table table =
         catalog
-            .buildTable(ident, SCHEMA)
+            .buildTable(TBL, SCHEMA)
             .withLocation(baseTableLocation(TBL))
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
@@ -673,8 +667,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     // validate table settings
     assertThat(table.name())
         .as("Table name should report its full name")
-        .isEqualTo(catalog.name() + "." + ident);
-    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+        .isEqualTo(catalog.name() + "." + TBL);
+    assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
     assertThat(table.schema().asStruct())
         .as("Schema should match expected ID assignment")
         .isEqualTo(TABLE_SCHEMA.asStruct());
@@ -694,17 +688,15 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testDefaultTableProperties() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
     Table table =
         catalog()
-            .buildTable(ident, SCHEMA)
+            .buildTable(TBL, SCHEMA)
             .withProperty("default-key2", "catalog-overridden-key2")
             .withProperty("prop1", "val1")
             .create();
@@ -713,83 +705,77 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .containsEntry("default-key2", "catalog-overridden-key2")
         .containsEntry("prop1", "val1");
 
-    assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+    assertThat(catalog.dropTable(TBL)).as("Should successfully drop table").isTrue();
   }
 
   @Test
   public void testDefaultTablePropertiesCreateTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
     catalog()
-        .buildTable(ident, SCHEMA)
+        .buildTable(TBL, SCHEMA)
         .withProperty("default-key2", "catalog-overridden-key2")
         .withProperty("prop1", "val1")
         .createTransaction()
         .commitTransaction();
 
-    Table table = catalog.loadTable(ident);
+    Table table = catalog.loadTable(TBL);
 
     assertThat(table.properties())
         .containsEntry("default-key1", "catalog-default-key1")
         .containsEntry("default-key2", "catalog-overridden-key2")
         .containsEntry("prop1", "val1");
 
-    assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+    assertThat(catalog.dropTable(TBL)).as("Should successfully drop table").isTrue();
   }
 
   @Test
   public void testDefaultTablePropertiesReplaceTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    catalog.createTable(ident, SCHEMA);
-    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+    catalog.createTable(TBL, SCHEMA);
+    assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
 
     catalog()
-        .buildTable(ident, OTHER_SCHEMA)
+        .buildTable(TBL, OTHER_SCHEMA)
         .withProperty("default-key2", "catalog-overridden-key2")
         .withProperty("prop1", "val1")
         .replaceTransaction()
         .commitTransaction();
 
-    Table table = catalog.loadTable(ident);
+    Table table = catalog.loadTable(TBL);
 
     assertThat(table.properties())
         .containsEntry("default-key1", "catalog-default-key1")
         .containsEntry("default-key2", "catalog-overridden-key2")
         .containsEntry("prop1", "val1");
 
-    assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+    assertThat(catalog.dropTable(TBL)).as("Should successfully drop table").isTrue();
   }
 
   @Test
   public void testOverrideTableProperties() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
     Table table =
         catalog()
-            .buildTable(ident, SCHEMA)
+            .buildTable(TBL, SCHEMA)
             .withProperty("override-key4", "catalog-overridden-key4")
             .withProperty("prop1", "val1")
             .create();
@@ -800,29 +786,27 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .containsEntry("override-key4", "catalog-override-key4")
         .containsEntry("prop1", "val1");
 
-    assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+    assertThat(catalog.dropTable(TBL)).as("Should successfully drop table").isTrue();
   }
 
   @Test
   public void testOverrideTablePropertiesCreateTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
     catalog()
-        .buildTable(ident, SCHEMA)
+        .buildTable(TBL, SCHEMA)
         .withProperty("override-key4", "catalog-overridden-key4")
         .withProperty("prop1", "val1")
         .createTransaction()
         .commitTransaction();
 
-    Table table = catalog.loadTable(ident);
+    Table table = catalog.loadTable(TBL);
 
     assertThat(table.properties())
         .containsEntry("default-key1", "catalog-default-key1")
@@ -831,30 +815,28 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .containsEntry("override-key4", "catalog-override-key4")
         .containsEntry("prop1", "val1");
 
-    assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+    assertThat(catalog.dropTable(TBL)).as("Should successfully drop table").isTrue();
   }
 
   @Test
   public void testOverrideTablePropertiesReplaceTransaction() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    catalog.createTable(ident, SCHEMA);
-    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+    catalog.createTable(TBL, SCHEMA);
+    assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
 
     catalog()
-        .buildTable(ident, OTHER_SCHEMA)
+        .buildTable(TBL, OTHER_SCHEMA)
         .withProperty("override-key4", "catalog-overridden-key4")
         .withProperty("prop1", "val1")
         .replaceTransaction()
         .commitTransaction();
 
-    Table table = catalog.loadTable(ident);
+    Table table = catalog.loadTable(TBL);
 
     assertThat(table.properties())
         .containsEntry("default-key1", "catalog-default-key1")
@@ -863,25 +845,23 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .containsEntry("override-key4", "catalog-override-key4")
         .containsEntry("prop1", "val1");
 
-    assertThat(catalog.dropTable(ident)).as("Should successfully drop table").isTrue();
+    assertThat(catalog.dropTable(TBL)).as("Should successfully drop table").isTrue();
   }
 
   @Test
   public void testCreateTableWithDefaultColumnValue() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
     Schema schemaWithDefault =
         new Schema(
             List.of(
-                Types.NestedField.required("colWithDefault")
+                required("colWithDefault")
                     .withId(1)
                     .ofType(Types.IntegerType.get())
                     .withWriteDefault(Literal.of(10))
@@ -889,44 +869,41 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
                     .build()));
 
     catalog
-        .buildTable(ident, schemaWithDefault)
+        .buildTable(TBL, schemaWithDefault)
         .withLocation(baseTableLocation(TBL))
         .withProperty(TableProperties.FORMAT_VERSION, "3")
         .create();
-    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
-    assertThat(schemaWithDefault.asStruct())
-        .isEqualTo(catalog.loadTable(ident).schema().asStruct());
+    assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
+    assertThat(schemaWithDefault.asStruct()).isEqualTo(catalog.loadTable(TBL).schema().asStruct());
   }
 
   @Test
   public void testLoadTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
 
     Map<String, String> properties =
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
     catalog
-        .buildTable(ident, SCHEMA)
+        .buildTable(TBL, SCHEMA)
         .withLocation(baseTableLocation(TBL))
         .withPartitionSpec(SPEC)
         .withSortOrder(WRITE_ORDER)
         .withProperties(properties)
         .create();
-    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+    assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
 
-    Table table = catalog.loadTable(ident);
+    Table table = catalog.loadTable(TBL);
     // validate table settings
     assertThat(table.name())
         .as("Table name should report its full name")
-        .isEqualTo(catalog.name() + "." + ident);
-    assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+        .isEqualTo(catalog.name() + "." + TBL);
+    assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
     assertThat(table.schema().asStruct())
         .as("Schema should match expected ID assignment")
         .isEqualTo(TABLE_SCHEMA.asStruct());
@@ -967,10 +944,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testLoadMissingTable() {
     C catalog = catalog();
 
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
-
-    assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
-    assertThatThrownBy(() -> catalog.loadTable(ident))
+    assertThat(catalog.tableExists(TBL)).as("Table should not exist").isFalse();
+    assertThatThrownBy(() -> catalog.loadTable(TBL))
         .isInstanceOf(NoSuchTableException.class)
         .hasMessageStartingWith("Table does not exist: ns.tbl");
   }

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -89,6 +89,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   protected static final Namespace NS = Namespace.of("newdb");
   protected static final TableIdentifier TABLE = TableIdentifier.of(NS, "newtable");
   protected static final TableIdentifier RENAMED_TABLE = TableIdentifier.of(NS, "table_renamed");
+  protected static final TableIdentifier TBL = TableIdentifier.of("ns", "tbl");
 
   // Schema passed to create tables
   protected static final Schema SCHEMA =
@@ -192,8 +193,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     return false;
   }
 
-  protected String baseTableLocation() {
-    return BASE_TABLE_LOCATION;
+  protected String baseTableLocation(TableIdentifier identifier) {
+    return BASE_TABLE_LOCATION + "/" + identifier.namespace() + "/" + identifier.name();
   }
 
   @Test
@@ -663,7 +664,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table table =
         catalog
             .buildTable(ident, SCHEMA)
-            .withLocation(baseTableLocation() + "/ns/tbl")
+            .withLocation(baseTableLocation(TBL))
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -889,7 +890,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     catalog
         .buildTable(ident, schemaWithDefault)
-        .withLocation(baseTableLocation() + "/ns/tbl")
+        .withLocation(baseTableLocation(TBL))
         .withProperty(TableProperties.FORMAT_VERSION, "3")
         .create();
     assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
@@ -913,7 +914,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
     catalog
         .buildTable(ident, SCHEMA)
-        .withLocation(baseTableLocation() + "/ns/tbl")
+        .withLocation(baseTableLocation(TBL))
         .withPartitionSpec(SPEC)
         .withSortOrder(WRITE_ORDER)
         .withProperties(properties)
@@ -2010,7 +2011,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation(TABLE))
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2088,7 +2089,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation(TABLE));
     }
     assertFiles(table, FILE_A, anotherFile);
     assertFilePartitionSpec(table, FILE_A, initialSpecId);
@@ -2111,7 +2112,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction create =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation(TABLE))
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2154,7 +2155,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation(TABLE));
     }
 
     assertFiles(table, FILE_A);
@@ -2243,7 +2244,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation(TABLE))
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2280,7 +2281,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should match requested")
-          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation(TABLE));
     }
 
     assertFiles(table, FILE_A);
@@ -2355,7 +2356,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction createOrReplace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation(TABLE))
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2403,7 +2404,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation(TABLE));
     }
 
     assertUUIDsMatch(original, loaded);
@@ -2519,7 +2520,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Transaction replace =
         catalog
             .buildTable(TABLE, SCHEMA)
-            .withLocation(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name())
+            .withLocation(baseTableLocation(TABLE))
             .withPartitionSpec(SPEC)
             .withSortOrder(WRITE_ORDER)
             .withProperties(properties)
@@ -2569,7 +2570,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     if (!overridesRequestedLocation()) {
       assertThat(table.location())
           .as("Table location should be replaced")
-          .isEqualTo(baseTableLocation() + "/" + TABLE.namespace() + "/" + TABLE.name());
+          .isEqualTo(baseTableLocation(TABLE));
     }
 
     assertUUIDsMatch(original, loaded);

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1255,29 +1255,29 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             required(2, "data", Types.StringType.get()));
 
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    Table table = catalog.createTable(ident, expectedSchema);
+    Table table = catalog.createTable(TBL, expectedSchema);
     assertThat(table.schema().asStruct())
         .as("Schema should match")
         .isEqualTo(expectedSchema.asStruct());
 
-    Table loaded = catalog.loadTable(ident); // the first load will send the token
+    Table loaded = catalog.loadTable(TBL); // the first load will send the token
     assertThat(loaded.schema().asStruct())
         .as("Schema should match")
         .isEqualTo(expectedSchema.asStruct());
 
     loaded.refresh(); // refresh to force reload
 
-    Mockito.verify(adapter)
+    verify(adapter)
         .execute(
             reqMatcher(HTTPMethod.GET, "v1/config", catalogHeaders),
             eq(ConfigResponse.class),
             any(),
             any());
     // session client credentials flow
-    Mockito.verify(adapter)
+    verify(adapter)
         .execute(
             reqMatcher(HTTPMethod.POST, oauth2ServerUri, catalogHeaders),
             eq(OAuthTokenResponse.class),
@@ -1285,7 +1285,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
 
     // create table request
-    Mockito.verify(adapter)
+    verify(adapter)
         .execute(
             reqMatcher(HTTPMethod.POST, "v1/namespaces/ns/tables", expectedContextHeaders),
             eq(LoadTableResponse.class),
@@ -1295,7 +1295,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // if the table returned a bearer token or a credential, there will be no token request
     if (!tableConfig.containsKey("token") && !tableConfig.containsKey("credential")) {
       // token exchange to get a table token
-      Mockito.verify(adapter, times(1))
+      verify(adapter, times(1))
           .execute(
               reqMatcher(HTTPMethod.POST, oauth2ServerUri, expectedContextHeaders),
               eq(OAuthTokenResponse.class),
@@ -1305,25 +1305,25 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     if (expectedContextHeaders.equals(expectedTableHeaders)) {
       // load table from catalog + refresh loaded table
-      Mockito.verify(adapter, times(2))
+      verify(adapter, times(2))
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedTableHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedTableHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
     } else {
       // load table from catalog
-      Mockito.verify(adapter)
+      verify(adapter)
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedContextHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedContextHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
 
       // refresh loaded table
-      Mockito.verify(adapter)
+      verify(adapter)
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedTableHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedTableHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1255,29 +1255,29 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             required(2, "data", Types.StringType.get()));
 
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TBL.namespace());
+      catalog.createNamespace(ident.namespace());
     }
 
-    Table table = catalog.createTable(TBL, expectedSchema);
+    Table table = catalog.createTable(ident, expectedSchema);
     assertThat(table.schema().asStruct())
         .as("Schema should match")
         .isEqualTo(expectedSchema.asStruct());
 
-    Table loaded = catalog.loadTable(TBL); // the first load will send the token
+    Table loaded = catalog.loadTable(ident); // the first load will send the token
     assertThat(loaded.schema().asStruct())
         .as("Schema should match")
         .isEqualTo(expectedSchema.asStruct());
 
     loaded.refresh(); // refresh to force reload
 
-    verify(adapter)
+    Mockito.verify(adapter)
         .execute(
             reqMatcher(HTTPMethod.GET, "v1/config", catalogHeaders),
             eq(ConfigResponse.class),
             any(),
             any());
     // session client credentials flow
-    verify(adapter)
+    Mockito.verify(adapter)
         .execute(
             reqMatcher(HTTPMethod.POST, oauth2ServerUri, catalogHeaders),
             eq(OAuthTokenResponse.class),
@@ -1285,7 +1285,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
 
     // create table request
-    verify(adapter)
+    Mockito.verify(adapter)
         .execute(
             reqMatcher(HTTPMethod.POST, "v1/namespaces/ns/tables", expectedContextHeaders),
             eq(LoadTableResponse.class),
@@ -1295,7 +1295,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // if the table returned a bearer token or a credential, there will be no token request
     if (!tableConfig.containsKey("token") && !tableConfig.containsKey("credential")) {
       // token exchange to get a table token
-      verify(adapter, times(1))
+      Mockito.verify(adapter, times(1))
           .execute(
               reqMatcher(HTTPMethod.POST, oauth2ServerUri, expectedContextHeaders),
               eq(OAuthTokenResponse.class),
@@ -1305,25 +1305,25 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     if (expectedContextHeaders.equals(expectedTableHeaders)) {
       // load table from catalog + refresh loaded table
-      verify(adapter, times(2))
+      Mockito.verify(adapter, times(2))
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedTableHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedTableHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
     } else {
       // load table from catalog
-      verify(adapter)
+      Mockito.verify(adapter)
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedContextHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedContextHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
 
       // refresh loaded table
-      verify(adapter)
+      Mockito.verify(adapter)
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedTableHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedTableHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2636,11 +2636,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(
-                HTTPMethod.HEAD,
-                "v1/namespaces/" + TABLE.namespace() + "/tables/" + TABLE.name(),
-                Map.of(),
-                Map.of()),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of()),
             any(),
             any(),
             any());
@@ -2689,10 +2685,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Mockito.verify(adapter)
         .execute(
             reqMatcher(
-                HTTPMethod.GET,
-                "v1/namespaces/" + TABLE.namespace() + "/tables/" + TABLE.name(),
-                Map.of(),
-                Map.of("snapshots", "all")),
+                HTTPMethod.GET, RESOURCE_PATHS.table(TABLE), Map.of(), Map.of("snapshots", "all")),
             any(),
             any(),
             any());

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -106,6 +106,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   private static final ResourcePaths RESOURCE_PATHS =
       ResourcePaths.forCatalogProperties(Maps.newHashMap());
 
+  private static final TableIdentifier TBL = TableIdentifier.of("ns", "tbl");
+
   @TempDir public Path temp;
 
   private RESTCatalog restCatalog;
@@ -380,7 +382,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     catalog.initialize(
         "prod", ImmutableMap.of(CatalogProperties.URI, "ignored", "token", "bearer-token"));
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     // the bearer token should be used for all interactions
     Mockito.verify(adapter)
@@ -391,7 +393,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", catalogHeaders),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), catalogHeaders),
             any(),
             any(),
             any());
@@ -410,7 +412,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     catalog.initialize(
         "prod", ImmutableMap.of(CatalogProperties.URI, "ignored", "credential", "catalog:secret"));
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     // no token or credential for catalog token exchange
     Mockito.verify(adapter)
@@ -429,7 +431,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the catalog token for all interactions
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", catalogHeaders),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), catalogHeaders),
             any(),
             any(),
             any());
@@ -456,7 +458,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             OAuth2Properties.OAUTH2_SERVER_URI,
             oauth2ServerUri));
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     // no token or credential for catalog token exchange
     Mockito.verify(adapter)
@@ -475,7 +477,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the catalog token for all interactions
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", catalogHeaders),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), catalogHeaders),
             any(),
             any(),
             any());
@@ -508,7 +510,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             OAuth2Properties.OAUTH2_SERVER_URI,
             oauth2ServerUri));
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     // use the bearer token for config
     Mockito.verify(adapter)
@@ -527,7 +529,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the context token for table existence check
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", contextHeaders),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), contextHeaders),
             any(),
             any(),
             any());
@@ -562,7 +564,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             OAuth2Properties.OAUTH2_SERVER_URI,
             oauth2ServerUri));
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     // call client credentials with no initial auth
     Mockito.verify(adapter)
@@ -588,7 +590,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the context token for table existence check
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", contextHeaders),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), contextHeaders),
             any(),
             any(),
             any());
@@ -625,7 +627,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             OAuth2Properties.OAUTH2_SERVER_URI,
             oauth2ServerUri));
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     // use the bearer token for client credentials
     Mockito.verify(adapter)
@@ -651,7 +653,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // use the context token for table existence check
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", contextHeaders),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), contextHeaders),
             any(),
             any(),
             any());
@@ -809,7 +811,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             .build();
     catalog.initialize("prod", initializationProperties);
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     Mockito.verify(adapter)
         .execute(
@@ -830,7 +832,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     }
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", expectedHeaders),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), expectedHeaders),
             any(),
             any(),
             any());
@@ -1203,7 +1205,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       Map<String, String> expectedContextHeaders,
       Map<String, String> expectedTableHeaders,
       String oauth2ServerUri) {
-    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
     Map<String, String> catalogHeaders = ImmutableMap.of("Authorization", "Bearer " + catalogToken);
 
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
@@ -1230,7 +1232,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Mockito.doAnswer(addTableConfig)
         .when(adapter)
         .execute(
-            reqMatcher(HTTPMethod.GET, "v1/namespaces/ns/tables/table", expectedContextHeaders),
+            reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedContextHeaders),
             eq(LoadTableResponse.class),
             any(),
             any());
@@ -1308,7 +1310,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       // load table from catalog + refresh loaded table
       Mockito.verify(adapter, times(2))
           .execute(
-              reqMatcher(HTTPMethod.GET, "v1/namespaces/ns/tables/table", expectedTableHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedTableHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
@@ -1316,7 +1318,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       // load table from catalog
       Mockito.verify(adapter)
           .execute(
-              reqMatcher(HTTPMethod.GET, "v1/namespaces/ns/tables/table", expectedContextHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedContextHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
@@ -1324,7 +1326,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       // refresh loaded table
       Mockito.verify(adapter)
           .execute(
-              reqMatcher(HTTPMethod.GET, "v1/namespaces/ns/tables/table", expectedTableHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedTableHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
@@ -1483,7 +1485,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .untilAsserted(
             () -> {
               // use the exchanged catalog token
-              assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+              assertThat(catalog.tableExists(TBL)).isFalse();
 
               // call client credentials with no initial auth
               Map<String, String> clientCredentialsRequest =
@@ -1539,7 +1541,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               Mockito.verify(adapter)
                   .execute(
                       reqMatcher(
-                          HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", refreshedCatalogHeader),
+                          HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), refreshedCatalogHeader),
                       any(),
                       any(),
                       any());
@@ -1594,7 +1596,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             OAuth2Properties.OAUTH2_SERVER_URI,
             oauth2ServerUri));
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     // call client credentials with no initial auth
     Map<String, String> clientCredentialsRequest =
@@ -1659,7 +1661,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .execute(
             reqMatcher(
                 HTTPMethod.HEAD,
-                "v1/namespaces/ns/tables/table",
+                RESOURCE_PATHS.table(TBL),
                 Map.of("Authorization", "Bearer token-exchange-token:sub=" + token)),
             any(),
             any(),
@@ -1685,7 +1687,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalog catalog = new RESTCatalog(context, (config) -> adapter);
     catalog.initialize("prod", ImmutableMap.of(CatalogProperties.URI, "ignored", "token", token));
 
-    assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+    assertThat(catalog.tableExists(TBL)).isFalse();
 
     Mockito.verify(adapter)
         .execute(
@@ -1696,8 +1698,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(
-                HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", OAuth2Util.authHeaders(token)),
+            reqMatcher(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), OAuth2Util.authHeaders(token)),
             any(),
             any(),
             any());
@@ -1772,7 +1773,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .untilAsserted(
             () -> {
               // use the exchanged catalog token
-              assertThat(catalog.tableExists(TableIdentifier.of("ns", "table"))).isFalse();
+              assertThat(catalog.tableExists(TBL)).isFalse();
 
               // call client credentials with no initial auth
               Map<String, String> clientCredentialsRequest =
@@ -1829,7 +1830,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               Mockito.verify(adapter)
                   .execute(
                       reqMatcher(
-                          HTTPMethod.HEAD, "v1/namespaces/ns/tables/table", refreshedCatalogHeader),
+                          HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), refreshedCatalogHeader),
                       any(),
                       any(),
                       any());

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1255,15 +1255,15 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             required(2, "data", Types.StringType.get()));
 
     if (requiresNamespaceCreate()) {
-      catalog.createNamespace(ident.namespace());
+      catalog.createNamespace(TBL.namespace());
     }
 
-    Table table = catalog.createTable(ident, expectedSchema);
+    Table table = catalog.createTable(TBL, expectedSchema);
     assertThat(table.schema().asStruct())
         .as("Schema should match")
         .isEqualTo(expectedSchema.asStruct());
 
-    Table loaded = catalog.loadTable(ident); // the first load will send the token
+    Table loaded = catalog.loadTable(TBL); // the first load will send the token
     assertThat(loaded.schema().asStruct())
         .as("Schema should match")
         .isEqualTo(expectedSchema.asStruct());
@@ -1307,7 +1307,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       // load table from catalog + refresh loaded table
       Mockito.verify(adapter, times(2))
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedTableHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedTableHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
@@ -1315,7 +1315,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       // load table from catalog
       Mockito.verify(adapter)
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedContextHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedContextHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());
@@ -1323,7 +1323,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       // refresh loaded table
       Mockito.verify(adapter)
           .execute(
-              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedTableHeaders),
+              reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedTableHeaders),
               eq(LoadTableResponse.class),
               any(),
               any());

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -106,8 +106,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   private static final ResourcePaths RESOURCE_PATHS =
       ResourcePaths.forCatalogProperties(Maps.newHashMap());
 
-  private static final TableIdentifier TBL = TableIdentifier.of("ns", "tbl");
-
   @TempDir public Path temp;
 
   private RESTCatalog restCatalog;

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1203,7 +1203,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       Map<String, String> expectedContextHeaders,
       Map<String, String> expectedTableHeaders,
       String oauth2ServerUri) {
-    TableIdentifier ident = TableIdentifier.of("ns", "tbl");
     Map<String, String> catalogHeaders = ImmutableMap.of("Authorization", "Bearer " + catalogToken);
 
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
@@ -1230,7 +1229,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Mockito.doAnswer(addTableConfig)
         .when(adapter)
         .execute(
-            reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(ident), expectedContextHeaders),
+            reqMatcher(HTTPMethod.GET, RESOURCE_PATHS.table(TBL), expectedContextHeaders),
             eq(LoadTableResponse.class),
             any(),
             any());

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2636,7 +2636,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any());
     Mockito.verify(adapter)
         .execute(
-            reqMatcher(HTTPMethod.HEAD, "v1/namespaces/newdb/tables/table", Map.of(), Map.of()),
+            reqMatcher(
+                HTTPMethod.HEAD,
+                "v1/namespaces/" + TABLE.namespace() + "/tables/" + TABLE.name(),
+                Map.of(),
+                Map.of()),
             any(),
             any(),
             any());
@@ -2686,7 +2690,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .execute(
             reqMatcher(
                 HTTPMethod.GET,
-                "v1/namespaces/newdb/tables/table",
+                "v1/namespaces/" + TABLE.namespace() + "/tables/" + TABLE.name(),
                 Map.of(),
                 Map.of("snapshots", "all")),
             any(),


### PR DESCRIPTION
Hi all,

This PR addresses several improvements to the `CatalogTests` class:

1.  **`listNamespacesWithEmptyNamespace` Fix:** It corrects a bug where the `listNamespacesWithEmptyNamespace` test doesn't properly check for `supportsEmptyNamespace` on catalogs. This ensures the test is only executed for catalogs that support empty namespaces, preventing potential errors or misleading test results.

2.  **Reserved Keyword Avoidance:** The tests were using `TABLE` as a table identifier, which is a reserved keyword in ANSI SQL and various database systems (e.g., [Spark](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-reserved-words)). This PR renames the identifier to `newtable` to avoid conflicts and improve compatibility with a wider range of catalogs. 

3.  **Configurable Table Location:** Currently, the `CatalogTests` class hardcodes table locations, preventing catalog implementations from easily overriding this behavior for their specific needs. This PR introduces a mechanism to configure the base table location via the `testTableBaseLocation() ` method, with a default value of `file:/tmp`. This allows sub-classes to adapt the tests to different storage systems and environments.

These changes enhance the robustness, compatibility, and flexibility of the `CatalogTests` suite, making it more effective for verifying catalog implementations.