### PR TITLE
Flink: fix rateLimit argument check in TableMaintenance

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
@@ -152,7 +152,9 @@ public class TableMaintenance {
      * @param newRateLimit firing frequency
      */
     public Builder rateLimit(Duration newRateLimit) {
-      Preconditions.checkNotNull(rateLimit.toMillis() > 0, "Rate limit should be greater than 0");
+      Preconditions.checkNotNull(newRateLimit, "Rate limit should not be null");
+      Preconditions.checkArgument(
+          newRateLimit.toMillis() > 0, "Rate limit should be greater than 0");
       this.rateLimit = newRateLimit;
       return this;
     }


### PR DESCRIPTION
This PR fixes two things:

1. Use checkArgument with `newRateLimit`, not rateLimit, as expected.
2. Add checkNotNull before checking `newRateLimit.toMillis() > 0`.