### PR TITLE
Spark: SnapShotAction add validation for non-overlapping source/dest table paths.

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -124,10 +124,12 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
     StagedSparkTable stagedTable = stageDestTable();
     Table icebergTable = stagedTable.table();
 
-    // TODO: Check the dest table location does not overlap with the source table location
-
     boolean threw = true;
     try {
+      Preconditions.checkArgument(
+          !sourceTableLocation().equals(icebergTable.location()),
+          "The destination table location overlaps with the source table location.");
+
       LOG.info("Ensuring {} has a valid name mapping", destTableIdent());
       ensureNameMappingPresent(icebergTable);
 


### PR DESCRIPTION
I am currently working on migrating some Hive tables to Iceberg, with a particular focus on SnapShot and Migrate functionalities. I noticed a TODO in the SnapShot process that needs improvement. In this PR, I will enhance this by adding a validation to ensure non-overlapping source and destination table paths, along with corresponding unit tests.