### PR TITLE
Spark 3.5: Add Parallelism Parameter Validation to AddFilesProcedure.

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -1111,7 +1111,7 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
-  public void testMigrateWithInvalidParallelism() throws IOException {
+  public void testAddFilesWithInvalidParallelism() {
     createUnpartitionedHiveTable();
 
     createIcebergTable(

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -1120,8 +1120,8 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
     assertThatThrownBy(
             () ->
                 sql(
-                    "CALL %s.system.add_files(table => '%s', source_table => '%s', parallelism => %d)",
-                    catalogName, tableName, sourceTableName, -1))
+                    "CALL %s.system.add_files(table => '%s', source_table => '%s', parallelism => -1)",
+                    catalogName, tableName, sourceTableName))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Parallelism should be larger than 0");
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -118,6 +118,7 @@ class AddFilesProcedure extends BaseProcedure {
     boolean checkDuplicateFiles = input.asBoolean(CHECK_DUPLICATE_FILES_PARAM, true);
 
     int parallelism = input.asInt(PARALLELISM, 1);
+    Preconditions.checkArgument(parallelism > 0, "Parallelism should be larger than 0");
 
     return importToIceberg(
         tableIdent, sourceIdent, partitionFilter, checkDuplicateFiles, parallelism);


### PR DESCRIPTION
Spark 3.5: Add Parallelism Parameter Validation to AddFilesProcedure.