### PR TITLE
Flink: Move unlock from MemoryLock open to TestCase Before

### DIFF
--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -94,6 +94,8 @@ public class OperatorTestBase {
   @BeforeEach
   void before() {
     LOCK_FACTORY.open();
+    LOCK_FACTORY.createLock().unlock();
+    LOCK_FACTORY.createRecoveryLock().unlock();
     MetricsReporterFactoryForTests.reset();
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -242,8 +242,7 @@ public class OperatorTestBase {
 
     @Override
     public void open() {
-      MAINTENANCE_LOCK.unlock();
-      RECOVERY_LOCK.unlock();
+      // do nothing
     }
 
     @Override

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -62,8 +62,8 @@ class TestTriggerManager extends OperatorTestBase {
     Table table = createTable();
     this.lock = LOCK_FACTORY.createLock();
     this.recoveringLock = LOCK_FACTORY.createRecoveryLock();
-    this.lock.unlock();
-    this.recoveringLock.unlock();
+    lock.unlock();
+    recoveringLock.unlock();
     this.tableName = table.name();
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -62,6 +62,8 @@ class TestTriggerManager extends OperatorTestBase {
     Table table = createTable();
     this.lock = LOCK_FACTORY.createLock();
     this.recoveringLock = LOCK_FACTORY.createRecoveryLock();
+    this.lock.unlock();
+    this.recoveringLock.unlock();
     this.tableName = table.name();
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -59,11 +59,10 @@ class TestTriggerManager extends OperatorTestBase {
 
   @BeforeEach
   void before() {
+    super.before();
     Table table = createTable();
     this.lock = LOCK_FACTORY.createLock();
     this.recoveringLock = LOCK_FACTORY.createRecoveryLock();
-    lock.unlock();
-    recoveringLock.unlock();
     this.tableName = table.name();
   }
 


### PR DESCRIPTION
Since OperatorTestBase.MemoryLockFactory.open cleans the lock automatically, so it doesn't test when there is an existing lock.

This pr is aim to move the unlock to the TestCase before