### PR TITLE
Flink: fix unlock when previous job orphaned lock

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TriggerManager.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TriggerManager.java
@@ -189,6 +189,9 @@ public class TriggerManager extends KeyedProcessFunction<Boolean, TableChange, T
     this.recoveryLock = lockFactory.createRecoveryLock();
     if (context.isRestored()) {
       shouldRestoreTasks = true;
+    } else {
+      lock.unlock();
+      recoveryLock.unlock();
     }
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -292,7 +292,7 @@ class TestTriggerManager extends OperatorTestBase {
   }
 
   @Test
-  void testNewJobReleasesPreviousJobHoldLock() throws Exception {
+  void testNewJobReleasesExistingLock() throws Exception {
     // Lock first to mock previous job orphaned lock
     lock.tryLock();
     recoveringLock.tryLock();

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -292,6 +292,24 @@ class TestTriggerManager extends OperatorTestBase {
   }
 
   @Test
+  void testNewJobReleasesPreviousJobHoldLock() throws Exception {
+    // Lock first to mock previous job orphaned lock
+    lock.tryLock();
+    recoveringLock.tryLock();
+
+    TableLoader tableLoader = tableLoader();
+    TriggerManager manager = manager(tableLoader);
+    try (KeyedOneInputStreamOperatorTestHarness<Boolean, TableChange, Trigger> testHarness =
+        harness(manager)) {
+      testHarness.open();
+
+      // Check the new job weather remove the orphaned lock
+      assertThat(lock.isHeld()).isFalse();
+      assertThat(recoveringLock.isHeld()).isFalse();
+    }
+  }
+
+  @Test
   void testMinFireDelay() throws Exception {
     TableLoader tableLoader = tableLoader();
     TriggerManager manager = manager(tableLoader, DELAY, 1);


### PR DESCRIPTION
In the following scenario, the performance of TableMaintenance may not meet expectations:

1. The previous job stopped but left a lock that was not released.
2. A new job starts directly instead of recovering from state (when there is an existing lock, but no state).
3. TableMaintenance keeps failing to try to acquire the lock and cannot execute new tasks.

This PR aims to release the lock when the job starts without state to avoid the issue of failing to acquire the lock indefinitely.