### PR TITLE
Flink: backport #12793 to Flink 1.19

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -94,6 +94,8 @@ public class OperatorTestBase {
   @BeforeEach
   void before() {
     LOCK_FACTORY.open();
+    LOCK_FACTORY.createLock().unlock();
+    LOCK_FACTORY.createRecoveryLock().unlock();
     MetricsReporterFactoryForTests.reset();
   }
 
@@ -242,8 +244,7 @@ public class OperatorTestBase {
 
     @Override
     public void open() {
-      MAINTENANCE_LOCK.unlock();
-      RECOVERY_LOCK.unlock();
+      // do nothing
     }
 
     @Override

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -59,6 +59,7 @@ class TestTriggerManager extends OperatorTestBase {
 
   @BeforeEach
   void before() {
+    super.before();
     Table table = createTable();
     this.lock = LOCK_FACTORY.createLock();
     this.recoveringLock = LOCK_FACTORY.createRecoveryLock();


### PR DESCRIPTION
This pr is backport https://github.com/apache/iceberg/pull/12793 to Flink 1.19