### PR TITLE
Flink: fix parameters for test recovery

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -576,7 +576,7 @@ class TestTriggerManager extends OperatorTestBase {
 
   private static Stream<Arguments> parametersForTestRecovery() {
     return Stream.of(
-        Arguments.of(true, false),
+        Arguments.of(true, true),
         Arguments.of(true, false),
         Arguments.of(false, true),
         Arguments.of(false, false));

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -576,7 +576,7 @@ class TestTriggerManager extends OperatorTestBase {
 
   private static Stream<Arguments> parametersForTestRecovery() {
     return Stream.of(
-        Arguments.of(true, false),
+        Arguments.of(true, true),
         Arguments.of(true, false),
         Arguments.of(false, true),
         Arguments.of(false, false));


### PR DESCRIPTION
This pr aim to fix paramters for test recovery . It's a trivial change so I put changes in all Flink versions.