### PR TITLE
Flink: backport fix TriggerManager to unlock task execution when previous job left an orphaned lock for Flink 1.19

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TriggerManager.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TriggerManager.java
@@ -189,6 +189,9 @@ public class TriggerManager extends KeyedProcessFunction<Boolean, TableChange, T
     this.recoveryLock = lockFactory.createRecoveryLock();
     if (context.isRestored()) {
       shouldRestoreTasks = true;
+    } else {
+      lock.unlock();
+      recoveryLock.unlock();
     }
   }
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTriggerManager.java
@@ -292,6 +292,24 @@ class TestTriggerManager extends OperatorTestBase {
   }
 
   @Test
+  void testNewJobReleasesExistingLock() throws Exception {
+    // Lock first to mock previous job orphaned lock
+    lock.tryLock();
+    recoveringLock.tryLock();
+
+    TableLoader tableLoader = tableLoader();
+    TriggerManager manager = manager(tableLoader);
+    try (KeyedOneInputStreamOperatorTestHarness<Boolean, TableChange, Trigger> testHarness =
+        harness(manager)) {
+      testHarness.open();
+
+      // Check the new job weather remove the orphaned lock
+      assertThat(lock.isHeld()).isFalse();
+      assertThat(recoveringLock.isHeld()).isFalse();
+    }
+  }
+
+  @Test
   void testMinFireDelay() throws Exception {
     TableLoader tableLoader = tableLoader();
     TriggerManager manager = manager(tableLoader, DELAY, 1);


### PR DESCRIPTION
This pr is aim to backport https://github.com/apache/iceberg/pull/12794 for Flink 1.19