### PR TITLE
Build: Specify -XX:-OmitStackTraceInFastThrow in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,8 @@ subprojects {
   }
 
   tasks.withType(Test).configureEach {
-    // Some tests verify the messages included in the stack traces
+    // JVM may stop outputting stack trace of the exception which often occurs.
+    // Disable the optimization because some tests depend on the stack trace.
     jvmArgs += '-XX:-OmitStackTraceInFastThrow'
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,11 @@ subprojects {
     testImplementation libs.assertj.core
   }
 
+  tasks.withType(Test).configureEach {
+    // Some tests verify the messages included in the stack traces
+    jvmArgs += '-XX:-OmitStackTraceInFastThrow'
+  }
+
   test {
     def logDir = "${rootDir}/build/testlogs"
     def logFile = "${logDir}/${project.name}.log"


### PR DESCRIPTION
Fixes #12676

I could reproduce the issue by adding `@RepeatedTest` to test methods in the class. This option fixes the flaky tests.  