### PR TITLE
Migrate Spark 3.4 ExtensionsTestBase-related tests for Snapshot manipulation, ChangeLogView and Distribution/Ordering

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -226,11 +226,13 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
     }
 
     val distributionMode = if (distributionSpec != null) {
-      DistributionMode.HASH
-    } else if (orderingSpec.UNORDERED != null || orderingSpec.LOCALLY != null) {
-      DistributionMode.NONE
+      Some(DistributionMode.HASH)
+    } else if (orderingSpec.UNORDERED != null) {
+      Some(DistributionMode.NONE)
+    } else if (orderingSpec.LOCALLY() != null) {
+      None
     } else {
-      DistributionMode.RANGE
+      Some(DistributionMode.RANGE)
     }
 
     val ordering = if (orderingSpec != null && orderingSpec.order != null) {

--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetWriteDistributionAndOrderingExec.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetWriteDistributionAndOrderingExec.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.connector.catalog.TableCatalog
 case class SetWriteDistributionAndOrderingExec(
     catalog: TableCatalog,
     ident: Identifier,
-    distributionMode: DistributionMode,
+    distributionMode: Option[DistributionMode],
     sortOrder: Seq[(Term, SortDirection, NullOrder)]) extends LeafV2CommandExec {
 
   import CatalogV2Implicits._
@@ -56,9 +56,11 @@ case class SetWriteDistributionAndOrderingExec(
         }
         orderBuilder.commit()
 
-        txn.updateProperties()
-          .set(WRITE_DISTRIBUTION_MODE, distributionMode.modeName())
-          .commit()
+        distributionMode.foreach { mode =>
+          txn.updateProperties()
+            .set(WRITE_DISTRIBUTION_MODE, mode.modeName())
+            .commit()
+        }
 
         txn.commitTransaction()
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAncestorsOfProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAncestorsOfProcedure.java
@@ -21,26 +21,23 @@ package org.apache.iceberg.spark.extensions;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.spark.sql.AnalysisException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestAncestorsOfProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestAncestorsOfProcedure extends ExtensionsTestBase {
 
-  public TestAncestorsOfProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testAncestorOfUsingEmptyArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -61,7 +58,7 @@ public class TestAncestorsOfProcedure extends SparkExtensionsTestBase {
         output);
   }
 
-  @Test
+  @TestTemplate
   public void testAncestorOfUsingSnapshotId() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -85,7 +82,7 @@ public class TestAncestorsOfProcedure extends SparkExtensionsTestBase {
         sql("CALL %s.system.ancestors_of('%s', %dL)", catalogName, tableIdent, preSnapshotId));
   }
 
-  @Test
+  @TestTemplate
   public void testAncestorOfWithRollBack() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     Table table = validationCatalog.loadTable(tableIdent);
@@ -129,7 +126,7 @@ public class TestAncestorsOfProcedure extends SparkExtensionsTestBase {
         sql("CALL %s.system.ancestors_of('%s', %dL)", catalogName, tableIdent, thirdSnapshotId));
   }
 
-  @Test
+  @TestTemplate
   public void testAncestorOfUsingNamedArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -146,7 +143,7 @@ public class TestAncestorsOfProcedure extends SparkExtensionsTestBase {
             catalogName, firstSnapshotId, tableIdent));
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidAncestorOfCases() {
     assertThatThrownBy(() -> sql("CALL %s.system.ancestors_of()", catalogName))
         .isInstanceOf(AnalysisException.class)

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -19,10 +19,11 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.WRITE_AUDIT_PUBLISH_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -32,23 +33,19 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestCherrypickSnapshotProcedure extends ExtensionsTestBase {
 
-  public TestCherrypickSnapshotProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testCherrypickSnapshotUsingPositionalArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("ALTER TABLE %s SET TBLPROPERTIES ('%s' 'true')", tableName, WRITE_AUDIT_PUBLISH_ENABLED);
@@ -85,7 +82,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testCherrypickSnapshotUsingNamedArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("ALTER TABLE %s SET TBLPROPERTIES ('%s' 'true')", tableName, WRITE_AUDIT_PUBLISH_ENABLED);
@@ -122,7 +119,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testCherrypickSnapshotRefreshesRelationCache() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("ALTER TABLE %s SET TBLPROPERTIES ('%s' 'true')", tableName, WRITE_AUDIT_PUBLISH_ENABLED);
@@ -158,7 +155,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
     sql("UNCACHE TABLE tmp");
   }
 
-  @Test
+  @TestTemplate
   public void testCherrypickInvalidSnapshot() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
@@ -168,7 +165,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
         .hasMessage("Cannot cherry-pick unknown snapshot ID: -1");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidCherrypickSnapshotCases() {
     assertThatThrownBy(
             () -> sql("CALL %s.system.cherrypick_snapshot('n', table => 't', 1L)", catalogName))
@@ -181,8 +178,8 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;
-              Assert.assertEquals("PARSE_SYNTAX_ERROR", parseException.getErrorClass());
-              Assert.assertEquals("'CALL'", parseException.getMessageParameters().get("error"));
+              assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.cherrypick_snapshot('t')", catalogName))

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestConflictValidation.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestConflictValidation.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.spark.extensions;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.iceberg.IsolationLevel;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -31,18 +31,15 @@ import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.functions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestConflictValidation extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestConflictValidation extends ExtensionsTestBase {
 
-  public TestConflictValidation(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @Before
+  @BeforeEach
   public void createTables() {
     sql(
         "CREATE TABLE %s (id int, data string) USING iceberg "
@@ -54,12 +51,12 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteFilterSerializableIsolation() throws Exception {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -91,7 +88,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwrite(functions.col("id").equalTo(1));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteFilterSerializableIsolation2() throws Exception {
     List<SimpleRecord> records =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(1, "b"));
@@ -128,7 +125,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwrite(functions.col("id").equalTo(1));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteFilterSerializableIsolation3() throws Exception {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -162,7 +159,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwrite(functions.col("id").equalTo(1));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteFilterNoSnapshotIdValidation() throws Exception {
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -193,7 +190,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwrite(functions.col("id").equalTo(1));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteFilterSnapshotIsolation() throws Exception {
     List<SimpleRecord> records =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(1, "b"));
@@ -230,7 +227,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwrite(functions.col("id").equalTo(1));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwriteFilterSnapshotIsolation2() throws Exception {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -247,7 +244,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwrite(functions.col("id").equalTo(1));
   }
 
-  @Test
+  @TestTemplate
   public void testOverwritePartitionSerializableIsolation() throws Exception {
     Table table = validationCatalog.loadTable(tableIdent);
     final long snapshotId = table.currentSnapshot().snapshotId();
@@ -279,7 +276,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwritePartitions();
   }
 
-  @Test
+  @TestTemplate
   public void testOverwritePartitionSnapshotIsolation() throws Exception {
     List<SimpleRecord> records =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(1, "b"));
@@ -314,7 +311,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwritePartitions();
   }
 
-  @Test
+  @TestTemplate
   public void testOverwritePartitionSnapshotIsolation2() throws Exception {
     Table table = validationCatalog.loadTable(tableIdent);
     final long snapshotId = table.currentSnapshot().snapshotId();
@@ -348,7 +345,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwritePartitions();
   }
 
-  @Test
+  @TestTemplate
   public void testOverwritePartitionSnapshotIsolation3() throws Exception {
     Table table = validationCatalog.loadTable(tableIdent);
     final long snapshotId = table.currentSnapshot().snapshotId();
@@ -365,7 +362,7 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
         .overwritePartitions();
   }
 
-  @Test
+  @TestTemplate
   public void testOverwritePartitionNoSnapshotIdValidation() throws Exception {
     Table table = validationCatalog.loadTable(tableIdent);
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
@@ -18,34 +18,31 @@
  */
 package org.apache.iceberg.spark.extensions;
 
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ChangelogOperation;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.spark.sql.types.StructField;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestCreateChangelogViewProcedure extends ExtensionsTestBase {
   private static final String DELETE = ChangelogOperation.DELETE.name();
   private static final String INSERT = ChangelogOperation.INSERT.name();
   private static final String UPDATE_BEFORE = ChangelogOperation.UPDATE_BEFORE.name();
   private static final String UPDATE_AFTER = ChangelogOperation.UPDATE_AFTER.name();
 
-  public TestCreateChangelogViewProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
@@ -65,7 +62,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testCustomizedViewName() {
     createTableWithTwoColumns();
     sql("INSERT INTO %s VALUES (1, 'a')", tableName);
@@ -95,10 +92,10 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         "cdc_view");
 
     long rowCount = sql("select * from %s", "cdc_view").stream().count();
-    Assert.assertEquals(2, rowCount);
+    assertThat(rowCount).isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testNonStandardColumnNames() {
     sql("CREATE TABLE %s (`the id` INT, `the.data` STRING) USING iceberg", tableName);
     sql("ALTER TABLE %s ADD PARTITION FIELD `the.data`", tableName);
@@ -133,14 +130,14 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
     var fieldNames =
         Arrays.stream(df.schema().fields()).map(StructField::name).collect(Collectors.toList());
 
-    Assert.assertEquals(
-        "Result Schema should match",
-        List.of("the id", "the.data", "_change_type", "_change_ordinal", "_commit_snapshot_id"),
-        fieldNames);
-    Assert.assertEquals("Result Row Count should match", 2, df.collectAsList().size());
+    assertThat(fieldNames)
+        .containsExactly(
+            "the id", "the.data", "_change_type", "_change_ordinal", "_commit_snapshot_id");
+
+    assertThat(df.collectAsList()).hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testNoSnapshotIdInput() {
     createTableWithTwoColumns();
     sql("INSERT INTO %s VALUES (1, 'a')", tableName);
@@ -171,7 +168,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id", viewName));
   }
 
-  @Test
+  @TestTemplate
   public void testOnlyStartSnapshotIdInput() {
     createTableWithTwoColumns();
     sql("INSERT INTO %s VALUES (1, 'a')", tableName);
@@ -200,7 +197,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
   }
 
-  @Test
+  @TestTemplate
   public void testOnlyEndTimestampIdInput() {
     createTableWithTwoColumns();
     sql("INSERT INTO %s VALUES (1, 'a')", tableName);
@@ -225,7 +222,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
   }
 
-  @Test
+  @TestTemplate
   public void testTimestampsBasedQuery() {
     createTableWithTwoColumns();
     long beginning = System.currentTimeMillis();
@@ -285,7 +282,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
   }
 
-  @Test
+  @TestTemplate
   public void testOnlyStartTimestampInput() {
     createTableWithTwoColumns();
     long beginning = System.currentTimeMillis();
@@ -331,7 +328,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
   }
 
-  @Test
+  @TestTemplate
   public void testOnlyEndTimestampInput() {
     createTableWithTwoColumns();
 
@@ -358,7 +355,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
   }
 
-  @Test
+  @TestTemplate
   public void testStartTimeStampEndSnapshotId() {
     createTableWithTwoColumns();
 
@@ -395,7 +392,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
   }
 
-  @Test
+  @TestTemplate
   public void testStartSnapshotIdEndTimestamp() {
     createTableWithTwoColumns();
 
@@ -428,7 +425,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdate() {
     createTableWithTwoColumns();
     sql("ALTER TABLE %s DROP PARTITION FIELD data", tableName);
@@ -459,7 +456,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id, data", viewName));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithIdentifierField() {
     createTableWithIdentifierField();
 
@@ -487,7 +484,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id, data", viewName));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithFilter() {
     createTableWithTwoColumns();
     sql("ALTER TABLE %s DROP PARTITION FIELD data", tableName);
@@ -519,7 +516,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s where id != 3 order by _change_ordinal, id, data", viewName));
   }
 
-  @Test
+  @TestTemplate
   public void testUpdateWithMultipleIdentifierColumns() {
     createTableWithThreeColumns();
 
@@ -551,7 +548,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id, data", viewName));
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveCarryOvers() {
     createTableWithThreeColumns();
 
@@ -585,7 +582,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id, data", viewName));
   }
 
-  @Test
+  @TestTemplate
   public void testRemoveCarryOversWithoutUpdatedRows() {
     createTableWithThreeColumns();
 
@@ -617,7 +614,7 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, id, data", viewName));
   }
 
-  @Test
+  @TestTemplate
   public void testNetChangesWithRemoveCarryOvers() {
     // partitioned by id
     createTableWithThreeColumns();
@@ -670,15 +667,15 @@ public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
         sql("select * from %s order by _change_ordinal, data", viewName));
   }
 
-  @Test
+  @TestTemplate
   public void testNetChangesWithComputeUpdates() {
     createTableWithTwoColumns();
-    assertThrows(
-        "Should fail because net_changes is not supported with computing updates",
-        IllegalArgumentException.class,
-        () ->
-            sql(
-                "CALL %s.system.create_changelog_view(table => '%s', identifier_columns => array('id'), net_changes => true)",
-                catalogName, tableName));
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.create_changelog_view(table => '%s', identifier_columns => array('id'), net_changes => true)",
+                    catalogName, tableName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Not support net changes with update images");
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetaColumnProjectionWithStageScan.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetaColumnProjectionWithStageScan.java
@@ -21,8 +21,9 @@ package org.apache.iceberg.spark.extensions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
@@ -36,18 +37,14 @@ import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestMetaColumnProjectionWithStageScan extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestMetaColumnProjectionWithStageScan extends ExtensionsTestBase {
 
-  public TestMetaColumnProjectionWithStageScan(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -58,7 +55,7 @@ public class TestMetaColumnProjectionWithStageScan extends SparkExtensionsTestBa
     };
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
@@ -69,7 +66,7 @@ public class TestMetaColumnProjectionWithStageScan extends SparkExtensionsTestBa
     taskSetManager.stageTasks(tab, fileSetID, Lists.newArrayList(tasks));
   }
 
-  @Test
+  @TestTemplate
   public void testReadStageTableMeta() throws Exception {
     sql(
         "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
@@ -104,7 +101,7 @@ public class TestMetaColumnProjectionWithStageScan extends SparkExtensionsTestBa
               .option(SparkReadOptions.SCAN_TASK_SET_ID, fileSetID)
               .load(tableLocation);
 
-      assertThat(scanDF2.columns().length).isEqualTo(2);
+      assertThat(scanDF2.columns()).hasSize(2);
     }
 
     try (CloseableIterable<ScanTask> tasks = table.newBatchScan().planFiles()) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRequiredDistributionAndOrdering.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRequiredDistributionAndOrdering.java
@@ -22,29 +22,26 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRequiredDistributionAndOrdering extends ExtensionsTestBase {
 
-  public TestRequiredDistributionAndOrdering(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void dropTestTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultLocalSortWithBucketTransforms() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (c1 INT, c2 STRING, c3 STRING) "
@@ -73,7 +70,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
         sql("SELECT count(*) FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionColumnsArePrependedForRangeDistribution() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (c1 INT, c2 STRING, c3 STRING) "
@@ -104,7 +101,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
         sql("SELECT count(*) FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testSortOrderIncludesPartitionColumns() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (c1 INT, c2 STRING, c3 STRING) "
@@ -135,7 +132,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
         sql("SELECT count(*) FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testHashDistributionOnBucketedColumn() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (c1 INT, c2 STRING, c3 STRING) "
@@ -166,7 +163,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
         sql("SELECT count(*) FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testDisabledDistributionAndOrdering() {
     sql(
         "CREATE TABLE %s (c1 INT, c2 STRING, c3 STRING) "
@@ -201,7 +198,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
                 + "and by partition within each spec. Either cluster the incoming records or switch to fanout writers.");
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultSortOnDecimalBucketedColumn() {
     sql(
         "CREATE TABLE %s (c1 INT, c2 DECIMAL(20, 2)) "
@@ -220,7 +217,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
     assertEquals("Rows must match", expected, sql("SELECT * FROM %s ORDER BY c1", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultSortOnStringBucketedColumn() {
     sql(
         "CREATE TABLE %s (c1 INT, c2 STRING) "
@@ -235,7 +232,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
     assertEquals("Rows must match", expected, sql("SELECT * FROM %s ORDER BY c1", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultSortOnBinaryBucketedColumn() {
     sql(
         "CREATE TABLE %s (c1 INT, c2 Binary) "
@@ -252,7 +249,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
     assertEquals("Rows must match", expected, sql("SELECT * FROM %s ORDER BY c1", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultSortOnDecimalTruncatedColumn() {
     sql(
         "CREATE TABLE %s (c1 INT, c2 DECIMAL(20, 2)) "
@@ -268,7 +265,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
     assertEquals("Rows must match", expected, sql("SELECT * FROM %s ORDER BY c1", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultSortOnLongTruncatedColumn() {
     sql(
         "CREATE TABLE %s (c1 INT, c2 BIGINT) "
@@ -283,7 +280,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
     assertEquals("Rows must match", expected, sql("SELECT * FROM %s ORDER BY c1", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRangeDistributionWithQuotedColumnNames() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (`c.1` INT, c2 STRING, c3 STRING) "

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -30,24 +32,19 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRollbackToSnapshotProcedure extends ExtensionsTestBase {
 
-  public TestRollbackToSnapshotProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToSnapshotUsingPositionalArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -82,7 +79,7 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToSnapshotUsingNamedArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -117,7 +114,7 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToSnapshotRefreshesRelationCache() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -157,7 +154,7 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
     sql("UNCACHE TABLE tmp");
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToSnapshotWithQuotedIdentifiers() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -202,9 +199,9 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToSnapshotWithoutExplicitCatalog() {
-    Assume.assumeTrue("Working only with the session catalog", "spark_catalog".equals(catalogName));
+    assumeThat(catalogName).as("Working only with the session catalog").isEqualTo("spark_catalog");
 
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -238,7 +235,7 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToInvalidSnapshot() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
@@ -248,7 +245,7 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
         .hasMessage("Cannot roll back to unknown snapshot id: -1");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidRollbackToSnapshotCases() {
     assertThatThrownBy(
             () ->
@@ -264,8 +261,8 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;
-              Assert.assertEquals("PARSE_SYNTAX_ERROR", parseException.getErrorClass());
-              Assert.assertEquals("'CALL'", parseException.getMessageParameters().get("error"));
+              assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.rollback_to_snapshot('t')", catalogName))

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
@@ -18,13 +18,15 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -32,24 +34,19 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRollbackToTimestampProcedure extends ExtensionsTestBase {
 
-  public TestRollbackToTimestampProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToTimestampUsingPositionalArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -87,7 +84,7 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToTimestampUsingNamedArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -125,7 +122,7 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToTimestampRefreshesRelationCache() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -168,7 +165,7 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
     sql("UNCACHE TABLE tmp");
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToTimestampWithQuotedIdentifiers() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -214,9 +211,9 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToTimestampWithoutExplicitCatalog() {
-    Assume.assumeTrue("Working only with the session catalog", "spark_catalog".equals(catalogName));
+    assumeThat(catalogName).as("Working only with the session catalog").isEqualTo("spark_catalog");
 
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -255,7 +252,7 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testRollbackToTimestampBeforeOrEqualToOldestSnapshot() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -288,7 +285,7 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
             exactFirstSnapshot.toInstant().toEpochMilli());
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidRollbackToTimestampCases() {
     String timestamp = "TIMESTAMP '2007-12-03T10:15:30'";
 
@@ -307,8 +304,8 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;
-              Assert.assertEquals("PARSE_SYNTAX_ERROR", parseException.getErrorClass());
-              Assert.assertEquals("'CALL'", parseException.getMessageParameters().get("error"));
+              assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.rollback_to_timestamp('t')", catalogName))

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
@@ -19,10 +19,12 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.WRITE_AUDIT_PUBLISH_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -30,24 +32,19 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.catalyst.parser.ParseException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSetCurrentSnapshotProcedure extends ExtensionsTestBase {
 
-  public TestSetCurrentSnapshotProcedure(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testSetCurrentSnapshotUsingPositionalArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -82,7 +79,7 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testSetCurrentSnapshotUsingNamedArgs() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -117,7 +114,7 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testSetCurrentSnapshotWap() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("ALTER TABLE %s SET TBLPROPERTIES ('%s' 'true')", tableName, WRITE_AUDIT_PUBLISH_ENABLED);
@@ -150,9 +147,9 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void tesSetCurrentSnapshotWithoutExplicitCatalog() {
-    Assume.assumeTrue("Working only with the session catalog", "spark_catalog".equals(catalogName));
+    assumeThat(catalogName).as("Working only with the session catalog").isEqualTo("spark_catalog");
 
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -186,7 +183,7 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testSetCurrentSnapshotToInvalidSnapshot() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
@@ -196,7 +193,7 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
         .hasMessage("Cannot roll back to unknown snapshot id: -1");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidRollbackToSnapshotCases() {
     assertThatThrownBy(
             () ->
@@ -212,8 +209,8 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
         .satisfies(
             exception -> {
               ParseException parseException = (ParseException) exception;
-              Assert.assertEquals("PARSE_SYNTAX_ERROR", parseException.getErrorClass());
-              Assert.assertEquals("'CALL'", parseException.getMessageParameters().get("error"));
+              assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.set_current_snapshot('t')", catalogName))
@@ -250,7 +247,7 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
         .hasMessage("Either snapshot_id or ref must be provided, not both");
   }
 
-  @Test
+  @TestTemplate
   public void testSetCurrentSnapshotToRef() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetWriteDistributionAndOrdering.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetWriteDistributionAndOrdering.java
@@ -19,44 +19,42 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.expressions.Expressions.bucket;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Map;
 import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSetWriteDistributionAndOrdering extends SparkExtensionsTestBase {
-  public TestSetWriteDistributionAndOrdering(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
-  @After
+  @AfterEach
   public void removeTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteOrderByColumn() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE ORDERED BY category, id", tableName);
 
     table.refresh();
 
     String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "range", distributionMode);
+    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("range");
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -64,16 +62,16 @@ public class TestSetWriteDistributionAndOrdering extends SparkExtensionsTestBase
             .asc("category", NullOrder.NULLS_FIRST)
             .asc("id", NullOrder.NULLS_FIRST)
             .build();
-    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Should have expected order").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteOrderWithCaseSensitiveColumnNames() {
     sql(
         "CREATE TABLE %s (Id bigint NOT NULL, Category string, ts timestamp, data string) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
     sql("SET %s=true", SQLConf.CASE_SENSITIVE().key());
     assertThatThrownBy(
             () -> {
@@ -87,23 +85,22 @@ public class TestSetWriteDistributionAndOrdering extends SparkExtensionsTestBase
     table = validationCatalog.loadTable(tableIdent);
     SortOrder expected =
         SortOrder.builderFor(table.schema()).withOrderId(1).asc("Category").asc("Id").build();
-    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Should have expected order").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteOrderByColumnWithDirection() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE ORDERED BY category ASC, id DESC", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "range", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "range");
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -111,23 +108,22 @@ public class TestSetWriteDistributionAndOrdering extends SparkExtensionsTestBase
             .asc("category", NullOrder.NULLS_FIRST)
             .desc("id", NullOrder.NULLS_LAST)
             .build();
-    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Should have expected order").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteOrderByColumnWithDirectionAndNullOrder() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE ORDERED BY category ASC NULLS LAST, id DESC NULLS FIRST", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "range", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "range");
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -135,23 +131,22 @@ public class TestSetWriteDistributionAndOrdering extends SparkExtensionsTestBase
             .asc("category", NullOrder.NULLS_LAST)
             .desc("id", NullOrder.NULLS_FIRST)
             .build();
-    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Should have expected order").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteOrderByTransform() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).isTrue();
 
     sql("ALTER TABLE %s WRITE ORDERED BY category DESC, bucket(16, id), id", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "range", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "range");
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -160,50 +155,47 @@ public class TestSetWriteDistributionAndOrdering extends SparkExtensionsTestBase
             .asc(bucket("id", 16))
             .asc("id")
             .build();
-    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Should have expected order").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteUnordered() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE ORDERED BY category DESC, bucket(16, id), id", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "range", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "range");
 
-    Assert.assertNotEquals("Table must be sorted", SortOrder.unsorted(), table.sortOrder());
+    assertThat(table.sortOrder()).as("Table must be sorted").isNotEqualTo(SortOrder.unsorted());
 
     sql("ALTER TABLE %s WRITE UNORDERED", tableName);
 
     table.refresh();
 
-    String newDistributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("New distribution mode must match", "none", newDistributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "none");
 
-    Assert.assertEquals("New sort order must match", SortOrder.unsorted(), table.sortOrder());
+    assertThat(table.sortOrder()).as("New sort order must match").isEqualTo(SortOrder.unsorted());
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteLocallyOrdered() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE LOCALLY ORDERED BY category DESC, bucket(16, id), id", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "none", distributionMode);
+    assertThat(table.properties()).doesNotContainKey(TableProperties.WRITE_DISTRIBUTION_MODE);
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -212,117 +204,136 @@ public class TestSetWriteDistributionAndOrdering extends SparkExtensionsTestBase
             .asc(bucket("id", 16))
             .asc("id")
             .build();
-    Assert.assertEquals("Sort order must match", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
+  public void testSetWriteLocallyOrderedToPartitionedTable() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string) USING iceberg PARTITIONED BY (id)",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
+
+    sql("ALTER TABLE %s WRITE LOCALLY ORDERED BY category DESC", tableName);
+
+    table.refresh();
+
+    assertThat(table.properties()).doesNotContainKey(TableProperties.WRITE_DISTRIBUTION_MODE);
+
+    SortOrder expected =
+        SortOrder.builderFor(table.schema()).withOrderId(1).desc("category").build();
+    assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(expected);
+  }
+
+  @TestTemplate
   public void testSetWriteDistributedByWithSort() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string) USING iceberg PARTITIONED BY (category)",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE DISTRIBUTED BY PARTITION ORDERED BY id", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "hash", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     SortOrder expected = SortOrder.builderFor(table.schema()).withOrderId(1).asc("id").build();
-    Assert.assertEquals("Sort order must match", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteDistributedByWithLocalSort() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string) USING iceberg PARTITIONED BY (category)",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE DISTRIBUTED BY PARTITION LOCALLY ORDERED BY id", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "hash", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     SortOrder expected = SortOrder.builderFor(table.schema()).withOrderId(1).asc("id").build();
-    Assert.assertEquals("Sort order must match", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(expected);
+
+    sql("ALTER TABLE %s WRITE LOCALLY ORDERED BY id", tableName);
+
+    table.refresh();
+
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteDistributedByAndUnordered() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string) USING iceberg PARTITIONED BY (category)",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE DISTRIBUTED BY PARTITION UNORDERED", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "hash", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
-    Assert.assertEquals("Sort order must match", SortOrder.unsorted(), table.sortOrder());
+    assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(SortOrder.unsorted());
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteDistributedByOnly() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string) USING iceberg PARTITIONED BY (category)",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE DISTRIBUTED BY PARTITION UNORDERED", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "hash", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
-    Assert.assertEquals("Sort order must match", SortOrder.unsorted(), table.sortOrder());
+    assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(SortOrder.unsorted());
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteDistributedAndUnorderedInverted() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string) USING iceberg PARTITIONED BY (category)",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE UNORDERED DISTRIBUTED BY PARTITION", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "hash", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
-    Assert.assertEquals("Sort order must match", SortOrder.unsorted(), table.sortOrder());
+    assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(SortOrder.unsorted());
   }
 
-  @Test
+  @TestTemplate
   public void testSetWriteDistributedAndLocallyOrderedInverted() {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, category string) USING iceberg PARTITIONED BY (category)",
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+    assertThat(table.sortOrder().isUnsorted()).as("Table should start unsorted").isTrue();
 
     sql("ALTER TABLE %s WRITE ORDERED BY id DISTRIBUTED BY PARTITION", tableName);
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    Assert.assertEquals("Distribution mode must match", "hash", distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     SortOrder expected = SortOrder.builderFor(table.schema()).withOrderId(1).asc("id").build();
-    Assert.assertEquals("Sort order must match", expected, table.sortOrder());
+    assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(expected);
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestStoragePartitionedJoinsInRowLevelOperations.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestStoragePartitionedJoinsInRowLevelOperations.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -32,12 +34,12 @@ import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestStoragePartitionedJoinsInRowLevelOperations extends ExtensionsTestBase {
 
   private static final String OTHER_TABLE_NAME = "other_table";
 
@@ -68,7 +70,7 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
           SparkSQLProperties.PRESERVE_DATA_GROUPING,
           "true");
 
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -79,23 +81,18 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
     };
   }
 
-  public TestStoragePartitionedJoinsInRowLevelOperations(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS %s", tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testCopyOnWriteDeleteWithoutShuffles() {
     checkDelete(COPY_ON_WRITE);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeOnReadDeleteWithoutShuffles() {
     checkDelete(MERGE_ON_READ);
   }
@@ -153,12 +150,12 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
         sql("SELECT * FROM %s ORDER BY id, salary", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testCopyOnWriteUpdateWithoutShuffles() {
     checkUpdate(COPY_ON_WRITE);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeOnReadUpdateWithoutShuffles() {
     checkUpdate(MERGE_ON_READ);
   }
@@ -217,22 +214,22 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
         sql("SELECT * FROM %s ORDER BY id, salary", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testCopyOnWriteMergeWithoutShuffles() {
     checkMerge(COPY_ON_WRITE, false /* with ON predicate */);
   }
 
-  @Test
+  @TestTemplate
   public void testCopyOnWriteMergeWithoutShufflesWithPredicate() {
     checkMerge(COPY_ON_WRITE, true /* with ON predicate */);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeOnReadMergeWithoutShuffles() {
     checkMerge(MERGE_ON_READ, false /* with ON predicate */);
   }
 
-  @Test
+  @TestTemplate
   public void testMergeOnReadMergeWithoutShufflesWithPredicate() {
     checkMerge(MERGE_ON_READ, true /* with ON predicate */);
   }
@@ -284,7 +281,7 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
           String planAsString = plan.toString();
           if (mode == COPY_ON_WRITE) {
             int actualNumShuffles = StringUtils.countMatches(planAsString, "Exchange");
-            Assert.assertEquals("Should be 1 shuffle with SPJ", 1, actualNumShuffles);
+            assertThat(actualNumShuffles).as("Should be 1 shuffle with SPJ").isEqualTo(1);
             assertThat(planAsString).contains("Exchange hashpartitioning(_file");
           } else {
             assertThat(planAsString).doesNotContain("Exchange");

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownDQL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSystemFunctionPushDownDQL.java
@@ -40,7 +40,8 @@ import static org.apache.iceberg.spark.SystemFunctionPushDownHelper.timestampStr
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.source.PlanUtils;
@@ -50,18 +51,15 @@ import org.apache.spark.sql.catalyst.expressions.ApplyFunctionExpression;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
-  public TestSystemFunctionPushDownDQL(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSystemFunctionPushDownDQL extends ExtensionsTestBase {
 
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -72,23 +70,24 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     };
   }
 
-  @Before
+  @BeforeEach
   public void before() {
+    super.before();
     sql("USE %s", catalogName);
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testYearsFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
     testYearsFunction(false);
   }
 
-  @Test
+  @TestTemplate
   public void testYearsFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "years(ts)");
     testYearsFunction(true);
@@ -107,16 +106,16 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     checkPushedFilters(optimizedPlan, equal(year("ts"), targetYears));
 
     List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual.size()).isEqualTo(5);
+    assertThat(actual).hasSize(5);
   }
 
-  @Test
+  @TestTemplate
   public void testMonthsFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
     testMonthsFunction(false);
   }
 
-  @Test
+  @TestTemplate
   public void testMonthsFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "months(ts)");
     testMonthsFunction(true);
@@ -135,16 +134,16 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     checkPushedFilters(optimizedPlan, greaterThan(month("ts"), targetMonths));
 
     List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual.size()).isEqualTo(5);
+    assertThat(actual).hasSize(5);
   }
 
-  @Test
+  @TestTemplate
   public void testDaysFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
     testDaysFunction(false);
   }
 
-  @Test
+  @TestTemplate
   public void testDaysFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "days(ts)");
     testDaysFunction(true);
@@ -165,16 +164,16 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     checkPushedFilters(optimizedPlan, lessThan(day("ts"), targetDays));
 
     List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual.size()).isEqualTo(5);
+    assertThat(actual).hasSize(5);
   }
 
-  @Test
+  @TestTemplate
   public void testHoursFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
     testHoursFunction(false);
   }
 
-  @Test
+  @TestTemplate
   public void testHoursFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "hours(ts)");
     testHoursFunction(true);
@@ -193,16 +192,16 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     checkPushedFilters(optimizedPlan, greaterThanOrEqual(hour("ts"), targetHours));
 
     List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual.size()).isEqualTo(8);
+    assertThat(actual).hasSize(8);
   }
 
-  @Test
+  @TestTemplate
   public void testBucketLongFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
     testBucketLongFunction(false);
   }
 
-  @Test
+  @TestTemplate
   public void testBucketLongFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "bucket(5, id)");
     testBucketLongFunction(true);
@@ -221,16 +220,16 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     checkPushedFilters(optimizedPlan, lessThanOrEqual(bucket("id", 5), target));
 
     List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual.size()).isEqualTo(5);
+    assertThat(actual).hasSize(5);
   }
 
-  @Test
+  @TestTemplate
   public void testBucketStringFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
     testBucketStringFunction(false);
   }
 
-  @Test
+  @TestTemplate
   public void testBucketStringFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "bucket(5, data)");
     testBucketStringFunction(true);
@@ -249,16 +248,16 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     checkPushedFilters(optimizedPlan, notEqual(bucket("data", 5), target));
 
     List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual.size()).isEqualTo(8);
+    assertThat(actual).hasSize(8);
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateFunctionOnUnpartitionedTable() {
     createUnpartitionedTable(spark, tableName);
     testTruncateFunction(false);
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateFunctionOnPartitionedTable() {
     createPartitionedTable(spark, tableName, "truncate(4, data)");
     testTruncateFunction(true);
@@ -278,7 +277,7 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     checkPushedFilters(optimizedPlan, equal(truncate("data", 4), target));
 
     List<Object[]> actual = rowsToJava(df.collectAsList());
-    assertThat(actual.size()).isEqualTo(5);
+    assertThat(actual).hasSize(5);
   }
 
   private void checkExpressions(
@@ -295,7 +294,7 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
     if (partitioned) {
       assertThat(applyExpressions).isEmpty();
     } else {
-      assertThat(applyExpressions.size()).isEqualTo(1);
+      assertThat(applyExpressions).hasSize(1);
       ApplyFunctionExpression expression = (ApplyFunctionExpression) applyExpressions.get(0);
       assertThat(expression.name()).isEqualTo(expectedFunctionName);
     }
@@ -305,7 +304,7 @@ public class TestSystemFunctionPushDownDQL extends SparkExtensionsTestBase {
       LogicalPlan optimizedPlan, org.apache.iceberg.expressions.Expression expected) {
     List<org.apache.iceberg.expressions.Expression> pushedFilters =
         PlanUtils.collectPushDownFilters(optimizedPlan);
-    assertThat(pushedFilters.size()).isEqualTo(1);
+    assertThat(pushedFilters).hasSize(1);
     org.apache.iceberg.expressions.Expression actual = pushedFilters.get(0);
     assertThat(ExpressionUtil.equivalent(expected, actual, STRUCT, true))
         .as("Pushed filter should match")

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
@@ -20,10 +20,13 @@ package org.apache.iceberg.spark.extensions;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -39,15 +42,14 @@ import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestWriteAborts extends SparkExtensionsTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestWriteAborts extends ExtensionsTestBase {
 
-  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
       {
@@ -75,20 +77,14 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
     };
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
-
-  public TestWriteAborts(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testBatchAppend() throws Exception {
-    String dataLocation = temp.newFolder().toString();
+    String dataLocation = Files.createTempDirectory(temp, "junit").toFile().toString();
 
     sql(
         "CREATE TABLE %s (id INT, data STRING) "

--- a/spark/v3.4/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SetWriteDistributionAndOrdering.scala
+++ b/spark/v3.4/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SetWriteDistributionAndOrdering.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits
 
 case class SetWriteDistributionAndOrdering(
     table: Seq[String],
-    distributionMode: DistributionMode,
+    distributionMode: Option[DistributionMode],
     sortOrder: Seq[(Term, SortDirection, NullOrder)]) extends LeafCommand {
 
   import CatalogV2Implicits._

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -77,7 +77,7 @@ public class TestCallStatementParser {
             exception -> {
               ParseException parseException = (ParseException) exception;
               assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
-              assertThat(parseException.getMessageParameters().get("error")).isEqualTo("'CALL'");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
   }
 
@@ -87,7 +87,7 @@ public class TestCallStatementParser {
         (CallStatement) parser.parsePlan("CALL cat.`system`.`rollback_to_snapshot`()");
     assertThat(seqAsJavaList(call.name())).containsExactly("cat", "system", "rollback_to_snapshot");
 
-    assertThat(seqAsJavaList(call.args())).hasSize(0);
+    assertThat(seqAsJavaList(call.args())).isEmpty();
   }
 
   @Test

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -417,12 +417,6 @@ public class TestChangelogTable extends ExtensionsTestBase {
     sql("INSERT INTO %s VALUES (3, 'c')", tableName);
     sql("INSERT INTO %s VALUES (4, 'd')", tableName);
 
-    Table table = validationCatalog.loadTable(tableIdent);
-    Snapshot insertSnapshot = table.currentSnapshot();
-
-    // Get timestamp after inserts but before our changelog window
-    long beforeWindowTime = System.currentTimeMillis();
-
     // Small delay to ensure our timestamps are different
     try {
       Thread.sleep(100);

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -19,10 +19,11 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.WRITE_AUDIT_PUBLISH_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.util.List;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -34,7 +35,9 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestCherrypickSnapshotProcedure extends ExtensionsTestBase {
 
   @AfterEach
@@ -176,7 +179,7 @@ public class TestCherrypickSnapshotProcedure extends ExtensionsTestBase {
             exception -> {
               ParseException parseException = (ParseException) exception;
               assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
-              assertThat(parseException.getMessageParameters().get("error")).isEqualTo("'CALL'");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.cherrypick_snapshot('t')", catalogName))

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
@@ -261,7 +261,7 @@ public class TestRollbackToSnapshotProcedure extends ExtensionsTestBase {
             exception -> {
               ParseException parseException = (ParseException) exception;
               assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
-              assertThat(parseException.getMessageParameters().get("error")).isEqualTo("'CALL'");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.rollback_to_snapshot('t')", catalogName))

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
@@ -18,14 +18,15 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -35,7 +36,9 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestRollbackToTimestampProcedure extends ExtensionsTestBase {
 
   @AfterEach
@@ -302,7 +305,7 @@ public class TestRollbackToTimestampProcedure extends ExtensionsTestBase {
             exception -> {
               ParseException parseException = (ParseException) exception;
               assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
-              assertThat(parseException.getMessageParameters().get("error")).isEqualTo("'CALL'");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.rollback_to_timestamp('t')", catalogName))

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
@@ -19,8 +19,8 @@
 package org.apache.iceberg.spark.extensions;
 
 import static org.apache.iceberg.TableProperties.WRITE_AUDIT_PUBLISH_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
@@ -210,7 +210,7 @@ public class TestSetCurrentSnapshotProcedure extends ExtensionsTestBase {
             exception -> {
               ParseException parseException = (ParseException) exception;
               assertThat(parseException.getErrorClass()).isEqualTo("PARSE_SYNTAX_ERROR");
-              assertThat(parseException.getMessageParameters().get("error")).isEqualTo("'CALL'");
+              assertThat(parseException.getMessageParameters()).containsEntry("error", "'CALL'");
             });
 
     assertThatThrownBy(() -> sql("CALL %s.system.set_current_snapshot('t')", catalogName))

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetWriteDistributionAndOrdering.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetWriteDistributionAndOrdering.java
@@ -100,8 +100,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("range");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "range");
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -124,8 +123,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("range");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "range");
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -148,8 +146,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("range");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "range");
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -173,8 +170,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("range");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "range");
 
     assertThat(table.sortOrder()).as("Table must be sorted").isNotEqualTo(SortOrder.unsorted());
 
@@ -182,8 +178,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String newDistributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(newDistributionMode).as("New distribution mode must match").isEqualTo("none");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "none");
 
     assertThat(table.sortOrder()).as("New sort order must match").isEqualTo(SortOrder.unsorted());
   }
@@ -200,7 +195,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    assertThat(table.properties().containsKey(TableProperties.WRITE_DISTRIBUTION_MODE)).isFalse();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.WRITE_DISTRIBUTION_MODE);
 
     SortOrder expected =
         SortOrder.builderFor(table.schema())
@@ -224,7 +219,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    assertThat(table.properties().containsKey(TableProperties.WRITE_DISTRIBUTION_MODE)).isFalse();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.WRITE_DISTRIBUTION_MODE);
 
     SortOrder expected =
         SortOrder.builderFor(table.schema()).withOrderId(1).desc("category").build();
@@ -243,8 +238,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("hash");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     SortOrder expected = SortOrder.builderFor(table.schema()).withOrderId(1).asc("id").build();
     assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(expected);
@@ -262,8 +256,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("hash");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     SortOrder expected = SortOrder.builderFor(table.schema()).withOrderId(1).asc("id").build();
     assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(expected);
@@ -272,8 +265,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String newDistributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(newDistributionMode).as("Distribution mode must match").isEqualTo(distributionMode);
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
   }
 
   @TestTemplate
@@ -288,8 +280,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("hash");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(SortOrder.unsorted());
   }
@@ -306,8 +297,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("hash");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(SortOrder.unsorted());
   }
@@ -324,8 +314,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("hash");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(SortOrder.unsorted());
   }
@@ -342,8 +331,7 @@ public class TestSetWriteDistributionAndOrdering extends ExtensionsTestBase {
 
     table.refresh();
 
-    String distributionMode = table.properties().get(TableProperties.WRITE_DISTRIBUTION_MODE);
-    assertThat(distributionMode).as("Distribution mode must match").isEqualTo("hash");
+    assertThat(table.properties()).containsEntry(TableProperties.WRITE_DISTRIBUTION_MODE, "hash");
 
     SortOrder expected = SortOrder.builderFor(table.schema()).withOrderId(1).asc("id").build();
     assertThat(table.sortOrder()).as("Sort order must match").isEqualTo(expected);


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates the below tests, which are related to extensions test base in Spark 3.4, into JUnit 5 with AssertJ. The following classes are included in this PR:

* Snapshot Manipulation: 
  * `TestAncestorsOfProcedure` 
  * `TestCherrypickSnapshotProcedure` (Replace `import static org.assertj.core.api.AssertionsForClassTypes.assertThat;` with `Assertions.assertThat` because the previous one is only for Java 8 which has been deprecated in recent Iceberg verions)
  * `TestSetCurrentSnapshotProcedure` (Replace `AssertionsForClassTypes.assertThat` with `Assertions.assertThat` as well)
  * `TestRollbackToSnapshotProcedure` (Replace `AssertionsForClassTypes.assertThat` with `Assertions.assertThat`)
  * `TestRollbackToTimestampProcedure` (Replace `AssertionsForClassTypes.assertThat` with `Assertions.assertThat`)
* Change log view
  * `TestChangelogTable` including the backport from 3.5 tests
  * `TestCreateChangelogViewProcedure`
* Distribution and ordering:
  * `TestRequiredDistributionAndOrdering` 
  * `TestSetWriteDistributionAndOrdering` including the backport from https://github.com/apache/iceberg/pull/10774
* Additional tests:
  * `TestCallStatementParser` 
  * `TestConflictValidation` 
  * `TestMetaColumnProjectionWithStageScan` 
  * `TestStoragePartitionedJoinsInRowLevelOperations` 
  * `TestSystemFunctionPushDownDQL`
  * `TestSystemFunctionPushDownInRowLevelOperations` 
  * `TestWriteAborts`