### PR TITLE
Flink: Support zookeeper lock in TableMaintenance

### DIFF
--- a/.baseline/checkstyle/checkstyle-suppressions.xml
+++ b/.baseline/checkstyle/checkstyle-suppressions.xml
@@ -49,6 +49,9 @@
     <!-- Referencing guava classes should be allowed in classes within bundled-guava module -->
     <suppress files="org.apache.iceberg.GuavaClasses" id="BanUnrelocatedGuavaClasses"/>
 
+    <!-- Allow using Flink's shaded Curator dependency -->
+    <suppress files="org.apache.iceberg.flink.maintenance.api.ZkLockFactory" id="BanShadedClasses"/>
+
     <!-- Suppress checks for CometColumnReader -->
     <suppress files="org.apache.iceberg.spark.data.vectorized.CometColumnReader" checks="IllegalImport"/>
 </suppressions>

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
@@ -137,14 +137,14 @@ public class ZkLockFactory implements TriggerLockFactory {
     @Override
     public boolean tryLock() {
       if (isHeld()) {
-        LOG.info("Lock is already held for {}", this);
+        LOG.debug("Lock is already held for {}", this);
         return false;
       }
 
       try {
         return sharedCount.trySetCount(sharedCount.getVersionedValue(), 1);
       } catch (Exception e) {
-        LOG.info("Failed to acquire Zookeeper lock ", e);
+        LOG.debug("Failed to acquire Zookeeper lock ", e);
         return false;
       }
     }
@@ -163,7 +163,6 @@ public class ZkLockFactory implements TriggerLockFactory {
       try {
         sharedCount.setCount(0);
       } catch (Exception e) {
-        LOG.info("Failed to release Zookeeper lock ", e);
         throw new RuntimeException("Failed to release lock", e);
       }
     }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
@@ -142,7 +142,7 @@ public class ZkLockFactory implements TriggerLockFactory {
       }
 
       try {
-        return sharedCount.trySetCount(1);
+        return sharedCount.trySetCount(sharedCount.getVersionedValue(), 1);
       } catch (Exception e) {
         LOG.info("Failed to acquire Zookeeper lock ", e);
         return false;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
@@ -20,10 +20,10 @@ package org.apache.iceberg.flink.maintenance.api;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.recipes.shared.SharedCount;
-import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
+import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.flink.shaded.curator5.org.apache.curator.framework.recipes.shared.SharedCount;
+import org.apache.flink.shaded.curator5.org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
@@ -158,7 +158,7 @@ public class ZkLockFactory implements TriggerLockFactory {
       return isHeld(sharedCount.getVersionedValue());
     }
 
-    private boolean isHeld(VersionedValue<Integer> versionedValue) {
+    private static boolean isHeld(VersionedValue<Integer> versionedValue) {
       try {
         return versionedValue.getValue() == LOCKED;
       } catch (Exception e) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
@@ -20,7 +20,7 @@ package org.apache.iceberg.flink.maintenance.api;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.curator.framework.CuratorFramework;
@@ -128,7 +128,7 @@ public class ZkLockFactory implements TriggerLockFactory {
         client
             .create()
             .creatingParentsIfNeeded()
-            .forPath(lockPath, newInstanceId.getBytes(Charset.defaultCharset()));
+            .forPath(lockPath, newInstanceId.getBytes(StandardCharsets.UTF_8));
         return true;
       } catch (KeeperException.NodeExistsException e) {
         // Check if the lock creation was successful behind the scenes.
@@ -170,7 +170,7 @@ public class ZkLockFactory implements TriggerLockFactory {
     public String instanceId() {
       try {
         byte[] data = client.getData().forPath(lockPath);
-        return new String(data, Charset.defaultCharset());
+        return new String(data, StandardCharsets.UTF_8);
       } catch (Exception e) {
         LOG.info("Failed to get lock value: {}", lockPath, e);
         return null;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZkLockFactory.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.iceberg.jdbc.UncheckedSQLException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Zookeeper backed implementation of the {@link TriggerLockFactory}. */
+public class ZkLockFactory implements TriggerLockFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(ZkLockFactory.class);
+
+  private static final String LOCK_BASE_PATH = "/iceberg/flink/maintenance/locks";
+
+  private final String connectString;
+  private final String lockId;
+  private final int sessionTimeoutMs;
+  private final int connectionTimeoutMs;
+  private final ExponentialBackoffRetryWrapper retryWrapper;
+  private transient CuratorFramework client;
+
+  /**
+   * Create Zookeeper lock factory
+   *
+   * @param connectString Zookeeper connection string
+   * @param lockId Lock ID to distinguish different jobs
+   * @param sessionTimeoutMs Session timeout in milliseconds
+   * @param connectionTimeoutMs Connection timeout in milliseconds
+   */
+  public ZkLockFactory(
+      String connectString,
+      String lockId,
+      int sessionTimeoutMs,
+      int connectionTimeoutMs,
+      ExponentialBackoffRetryWrapper retryWrapper) {
+    Preconditions.checkNotNull(connectString, "Zookeeper connection string cannot be null");
+    Preconditions.checkNotNull(lockId, "Lock ID cannot be null");
+    this.connectString = connectString;
+    this.lockId = lockId;
+    this.sessionTimeoutMs = sessionTimeoutMs;
+    this.connectionTimeoutMs = connectionTimeoutMs;
+    this.retryWrapper = retryWrapper;
+  }
+
+  @Override
+  public void open() {
+    this.client =
+        CuratorFrameworkFactory.builder()
+            .connectString(connectString)
+            .sessionTimeoutMs(sessionTimeoutMs)
+            .connectionTimeoutMs(connectionTimeoutMs)
+            .retryPolicy(retryWrapper.getRetryPolicy())
+            .build();
+    client.start();
+
+    try {
+      if (!client.blockUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)) {
+        throw new IllegalStateException("Connection to Zookeeper timed out");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while connecting to Zookeeper", e);
+    }
+  }
+
+  @Override
+  public Lock createLock() {
+    return new ZkLock(client, LOCK_BASE_PATH + "/maintenance/" + lockId);
+  }
+
+  @Override
+  public Lock createRecoveryLock() {
+    return new ZkLock(client, LOCK_BASE_PATH + "/recovery/" + lockId);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  /** Zookeeper lock implementation */
+  private static class ZkLock implements Lock {
+    private final String lockPath;
+    private final CuratorFramework client;
+
+    private ZkLock(CuratorFramework client, String lockPath) {
+      this.client = client;
+      this.lockPath = lockPath;
+    }
+
+    @Override
+    public boolean tryLock() {
+      if (isHeld()) {
+        LOG.info("Lock is already held for {}", this);
+        return false;
+      }
+
+      String newInstanceId = UUID.randomUUID().toString();
+      try {
+        client
+            .create()
+            .creatingParentsIfNeeded()
+            .forPath(lockPath, newInstanceId.getBytes(Charset.defaultCharset()));
+        return true;
+      } catch (KeeperException.NodeExistsException e) {
+        // Check if the lock creation was successful behind the scenes.
+        if (newInstanceId.equals(instanceId())) {
+          return true;
+        } else {
+          throw new UncheckedSQLException(e, "Failed to create %s lock", this);
+        }
+      } catch (Exception e) {
+        LOG.info("Failed to acquire Zookeeper lock: {}", lockPath, e);
+        return false;
+      }
+    }
+
+    @Override
+    public boolean isHeld() {
+      try {
+        return client.checkExists().forPath(lockPath) != null;
+      } catch (Exception e) {
+        LOG.info("Failed to check Zookeeper lock status: {}", lockPath, e);
+        return false;
+      }
+    }
+
+    @Override
+    public void unlock() {
+      // If the path is not exists, delete will fail.
+      if (!isHeld()) {
+        return;
+      }
+      try {
+        client.delete().forPath(lockPath);
+      } catch (Exception e) {
+        LOG.info("Failed to release Zookeeper lock: {}", lockPath, e);
+        throw new RuntimeException("Failed to release lock", e);
+      }
+    }
+
+    public String instanceId() {
+      try {
+        byte[] data = client.getData().forPath(lockPath);
+        return new String(data, Charset.defaultCharset());
+      } catch (Exception e) {
+        LOG.info("Failed to get lock value: {}", lockPath, e);
+        return null;
+      }
+    }
+  }
+
+  // Since ExponentialBackoffRetry contains non-serializable fields, it needs to be wrapped and
+  // lazily initialized.
+  public static class ExponentialBackoffRetryWrapper implements Serializable {
+    private transient ExponentialBackoffRetry retryPolicy;
+
+    public ExponentialBackoffRetryWrapper(int baseSleepTimeMs, int maxRetries) {
+      this.retryPolicy = new ExponentialBackoffRetry(baseSleepTimeMs, maxRetries);
+    }
+
+    public ExponentialBackoffRetry getRetryPolicy() {
+      if (retryPolicy == null) {
+        retryPolicy = new ExponentialBackoffRetry(1000, 3);
+      }
+      return retryPolicy;
+    }
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestZkLockFactory.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestZkLockFactory.java
@@ -21,20 +21,26 @@ package org.apache.iceberg.flink.maintenance.api;
 import java.io.IOException;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TestZkLockFactory extends TestLockFactoryBase {
   private final String testLockId = "tableName";
   private TestingServer zkTestServer;
 
+  @BeforeEach
   @Override
-  TriggerLockFactory lockFactory() {
-
+  void before() {
     try {
       zkTestServer = new TestingServer();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
 
+    super.before();
+  }
+
+  @Override
+  TriggerLockFactory lockFactory() {
     return new ZkLockFactory(zkTestServer.getConnectString(), testLockId, 5000, 3000, 1000, 3);
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestZkLockFactory.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestZkLockFactory.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestZkLockFactory {
+  private TestingServer zkTestServer;
+  private ZkLockFactory lockFactory;
+  private final String testLockId = "tableName";
+
+  @Before
+  public void setUp() throws Exception {
+    // Start test Zookeeper server
+    zkTestServer = new TestingServer();
+    // Create lock factory instance
+    lockFactory =
+        new ZkLockFactory(
+            zkTestServer.getConnectString(),
+            testLockId,
+            5000,
+            3000,
+            new ZkLockFactory.ExponentialBackoffRetryWrapper(1000, 3));
+    lockFactory.open();
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (lockFactory != null) {
+      lockFactory.close();
+    }
+    if (zkTestServer != null) {
+      zkTestServer.close();
+    }
+  }
+
+  @Test
+  public void testCreateLock() {
+    // Test creating normal lock
+    TriggerLockFactory.Lock lock = lockFactory.createLock();
+    assertNotNull("Lock object should not be null", lock);
+
+    // Test basic lock functionality
+    assertTrue("First lock attempt should succeed", lock.tryLock());
+    assertTrue("Lock should be held after acquisition", lock.isHeld());
+    lock.unlock();
+    assertFalse("Lock should not be held after release", lock.isHeld());
+  }
+
+  @Test
+  public void testCreateRecoveryLock() {
+    // Test creating recovery lock
+    TriggerLockFactory.Lock recoveryLock = lockFactory.createRecoveryLock();
+    assertNotNull("Recovery lock object should not be null", recoveryLock);
+
+    // Test basic recovery lock functionality
+    assertTrue("First recovery lock attempt should succeed", recoveryLock.tryLock());
+    assertTrue("Recovery lock should be held after acquisition", recoveryLock.isHeld());
+    recoveryLock.unlock();
+    assertFalse("Recovery lock should not be held after release", recoveryLock.isHeld());
+  }
+
+  @Test
+  public void testLockExclusivity() {
+    TriggerLockFactory.Lock lock1 = lockFactory.createLock();
+    TriggerLockFactory.Lock lock2 = lockFactory.createLock();
+
+    // First lock acquisition should succeed
+    assertTrue(lock1.tryLock());
+    // Second lock acquisition should fail
+    assertFalse(lock2.tryLock());
+
+    // After releasing first lock, second can be acquired
+    lock1.unlock();
+    assertTrue(lock2.tryLock());
+    lock2.unlock();
+  }
+
+  @Test
+  public void testDifferentLockTypes() {
+    TriggerLockFactory.Lock normalLock = lockFactory.createLock();
+    TriggerLockFactory.Lock recoveryLock = lockFactory.createRecoveryLock();
+
+    assertTrue(normalLock.tryLock());
+    assertTrue(recoveryLock.tryLock());
+
+    normalLock.unlock();
+    recoveryLock.unlock();
+  }
+
+  @Test
+  public void testReopenFactory() throws IOException {
+    lockFactory.close();
+    lockFactory.open();
+
+    TriggerLockFactory.Lock lock = lockFactory.createLock();
+    assertTrue(lock.tryLock());
+    lock.unlock();
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestZkLockFactory.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestZkLockFactory.java
@@ -34,7 +34,7 @@ public class TestZkLockFactory {
   private final String testLockId = "tableName";
 
   @Before
-  public void setUp() throws Exception {
+  public void before() throws Exception {
     // Start test Zookeeper server
     zkTestServer = new TestingServer();
     // Create lock factory instance
@@ -49,7 +49,7 @@ public class TestZkLockFactory {
   }
 
   @After
-  public void tearDown() throws IOException {
+  public void after() throws IOException {
     if (lockFactory != null) {
       lockFactory.close();
     }


### PR DESCRIPTION
In TableMaintenance, we have already implemented JdbcLock. I believe we will have a need for ZookeeperLock. This PR aims to support ZkLockFactory to implement ZkLock.