### PR TITLE
Core: Ensure reactivated view version uses correct timestamp

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
@@ -251,21 +251,15 @@ public interface ViewMetadata extends Serializable {
 
       // Use the timestamp from the view version if it was added in current set of changes;
       // otherwise, use the current system time. This handles cases where the view version
-      // was created in a past commit and is being re-activated.
+      // was set as current in the past and is being re-activated.
       boolean versionAddedInThisChange =
-          changes.stream()
-              .anyMatch(
-                  change ->
-                      change instanceof MetadataUpdate.AddViewVersion
-                          && ((MetadataUpdate.AddViewVersion) change).viewVersion().versionId()
-                              == newVersionId);
-
-      long timestamp =
-          versionAddedInThisChange ? version.timestampMillis() : System.currentTimeMillis();
+          changes(MetadataUpdate.AddViewVersion.class)
+              .anyMatch(added -> added.viewVersion().versionId() == newVersionId);
 
       this.historyEntry =
           ImmutableViewHistoryEntry.builder()
-              .timestampMillis(timestamp)
+              .timestampMillis(
+                  versionAddedInThisChange ? version.timestampMillis() : System.currentTimeMillis())
               .versionId(version.versionId())
               .build();
 

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
@@ -249,8 +249,8 @@ public interface ViewMetadata extends Serializable {
         changes.add(new MetadataUpdate.SetCurrentViewVersion(newVersionId));
       }
 
-      // Use the timestamp from the view version if it was added in current set of changes;
-      // otherwise, use the current system time. This handles cases where the view version
+      // Use the timestamp from the view version if it was added in current set of changes.
+      // Otherwise, use the current system time. This handles cases where the view version
       // was set as current in the past and is being re-activated.
       boolean versionAddedInThisChange =
           changes(MetadataUpdate.AddViewVersion.class)

--- a/core/src/test/java/org/apache/iceberg/view/TestViewMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewMetadata.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
@@ -394,6 +395,47 @@ public class TestViewMetadata {
     assertThatThrownBy(() -> ViewMetadata.buildFrom(view).setCurrentVersionId(1).build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot set current version to unknown version: 1");
+  }
+
+  @Test
+  public void versionHistoryEntryMaintainCorrectTimeline() {
+    ViewVersion viewVersionOne = newViewVersion(1, "select * from ns.tbl");
+    ViewVersion viewVersionTwo = newViewVersion(2, "select count(*) from ns.tbl");
+    ViewVersion viewVersionThree = newViewVersion(3, "select count(*) as count from ns.tbl");
+
+    long ts1 = viewVersionOne.timestampMillis();
+    long ts2 = viewVersionTwo.timestampMillis();
+    long ts3 = viewVersionThree.timestampMillis();
+
+    // Create initial view metadata
+    ViewMetadata viewMetadata =
+        ViewMetadata.builder()
+            .setLocation("location")
+            .addSchema(new Schema(Types.NestedField.required(1, "x", Types.LongType.get())))
+            .addVersion(viewVersionOne)
+            .setCurrentVersionId(1)
+            .build();
+
+    // Update view metadata with multiple view versions in the same builder
+    ViewMetadata updated =
+        ViewMetadata.buildFrom(viewMetadata)
+            .addVersion(viewVersionTwo)
+            .addVersion(viewVersionThree)
+            .setCurrentVersionId(3)
+            .build();
+
+    // Reactivate an old view version as current version
+    ViewMetadata reactiveOldView = ViewMetadata.buildFrom(updated).setCurrentVersionId(1).build();
+    List<ViewHistoryEntry> history = reactiveOldView.history();
+
+    List<Integer> versionIds =
+        history.stream().map(ViewHistoryEntry::versionId).collect(Collectors.toList());
+    assertThat(versionIds).containsExactly(1, 3, 1);
+
+    // Verify timestamps in the history entries
+    assertThat(history.get(0).timestampMillis()).isEqualTo(ts1).isLessThanOrEqualTo(ts2);
+    assertThat(history.get(1).timestampMillis()).isEqualTo(ts3).isGreaterThanOrEqualTo(ts2);
+    assertThat(history.get(2).timestampMillis()).isGreaterThanOrEqualTo(ts3);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/view/TestViewMetadataParser.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewMetadataParser.java
@@ -106,7 +106,6 @@ public class TestViewMetadataParser {
                     .assignUUID("fa6506c3-7681-40c8-86dc-e36561f83385")
                     .addSchema(TEST_SCHEMA)
                     .addVersion(version1)
-                    .addVersion(version2)
                     .setLocation("s3://bucket/test/location")
                     .setProperties(
                         ImmutableMap.of(
@@ -114,6 +113,7 @@ public class TestViewMetadataParser {
                     .setCurrentVersionId(1)
                     .upgradeFormatVersion(1)
                     .build())
+            .addVersion(version2)
             .setCurrentVersionId(2)
             .build();
 
@@ -222,7 +222,6 @@ public class TestViewMetadataParser {
                             .assignUUID("fa6506c3-7681-40c8-86dc-e36561f83385")
                             .addSchema(TEST_SCHEMA)
                             .addVersion(version1)
-                            .addVersion(version2)
                             .setLocation("s3://bucket/test/location")
                             .setProperties(
                                 ImmutableMap.of(
@@ -233,6 +232,7 @@ public class TestViewMetadataParser {
                             .setCurrentVersionId(1)
                             .upgradeFormatVersion(1)
                             .build())
+                    .addVersion(version2)
                     .setCurrentVersionId(2)
                     .build())
             .setMetadataLocation(metadataLocation)


### PR DESCRIPTION
### Description
* Fixes #12809
* Apply the fixes from https://github.com/apache/iceberg-rust/pull/1218 by @c-thiel 