### PR TITLE
AWS: Use custom Execution interceptor to support multiple storage credentials

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -66,7 +66,6 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileIOParser;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.IOUtil;
-import org.apache.iceberg.io.ImmutableStorageCredential;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.ResolvingFileIO;
@@ -639,89 +638,6 @@ public class TestS3FileIO {
     s3FileIOProperties
         .extracting(S3FileIOProperties::sessionToken)
         .isEqualTo("sessionTokenFromProperties");
-  }
-
-  @Test
-  public void singleStorageCredentialConfigured() {
-    StorageCredential s3Credential =
-        ImmutableStorageCredential.builder()
-            .prefix("s3://custom-uri")
-            .config(
-                ImmutableMap.of(
-                    "s3.access-key-id",
-                    "keyIdFromCredential",
-                    "s3.secret-access-key",
-                    "accessKeyFromCredential",
-                    "s3.session-token",
-                    "sessionTokenFromCredential"))
-            .build();
-
-    S3FileIO fileIO = new S3FileIO();
-    fileIO.setCredentials(ImmutableList.of(s3Credential));
-    fileIO.initialize(
-        ImmutableMap.of(
-            "s3.access-key-id",
-            "keyIdFromProperties",
-            "s3.secret-access-key",
-            "accessKeyFromProperties",
-            "s3.session-token",
-            "sessionTokenFromProperties"));
-
-    ObjectAssert<S3FileIOProperties> s3FileIOProperties =
-        assertThat(fileIO)
-            .extracting("s3FileIOProperties")
-            .asInstanceOf(InstanceOfAssertFactories.type(S3FileIOProperties.class));
-    s3FileIOProperties.extracting(S3FileIOProperties::accessKeyId).isEqualTo("keyIdFromCredential");
-    s3FileIOProperties
-        .extracting(S3FileIOProperties::secretAccessKey)
-        .isEqualTo("accessKeyFromCredential");
-    s3FileIOProperties
-        .extracting(S3FileIOProperties::sessionToken)
-        .isEqualTo("sessionTokenFromCredential");
-  }
-
-  @Test
-  public void multipleStorageCredentialsConfigured() {
-    StorageCredential s3Credential1 =
-        ImmutableStorageCredential.builder()
-            .prefix("s3://custom-uri/1")
-            .config(
-                ImmutableMap.of(
-                    "s3.access-key-id",
-                    "keyIdFromCredential1",
-                    "s3.secret-access-key",
-                    "accessKeyFromCredential1",
-                    "s3.session-token",
-                    "sessionTokenFromCredential1"))
-            .build();
-
-    StorageCredential s3Credential2 =
-        ImmutableStorageCredential.builder()
-            .prefix("s3://custom-uri/2")
-            .config(
-                ImmutableMap.of(
-                    "s3.access-key-id",
-                    "keyIdFromCredential2",
-                    "s3.secret-access-key",
-                    "accessKeyFromCredential2",
-                    "s3.session-token",
-                    "sessionTokenFromCredential2"))
-            .build();
-
-    S3FileIO fileIO = new S3FileIO();
-    fileIO.setCredentials(ImmutableList.of(s3Credential1, s3Credential2));
-    assertThatThrownBy(
-            () ->
-                fileIO.initialize(
-                    ImmutableMap.of(
-                        "s3.access-key-id",
-                        "keyIdFromProperties",
-                        "s3.secret-access-key",
-                        "accessKeyFromProperties",
-                        "s3.session-token",
-                        "sessionTokenFromProperties")))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Invalid S3 Credentials: only one S3 credential should exist");
   }
 
   private void createRandomObjects(String prefix, int count) {

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -52,6 +52,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)
         .applyMutation(s3FileIOProperties::applySignerConfiguration)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
+        .applyMutation(s3FileIOProperties::applyStorageCredentialsInterceptor)
         .build();
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -116,6 +116,7 @@ public class AwsClientFactories {
           .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
           .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
           .applyMutation(s3FileIOProperties::applyRetryConfigurations)
+          .applyMutation(s3FileIOProperties::applyStorageCredentialsInterceptor)
           .build();
     }
 
@@ -133,6 +134,7 @@ public class AwsClientFactories {
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyStorageCredentialsInterceptor)
           .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3ExecutionInterceptor.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3ExecutionInterceptor.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+public class S3ExecutionInterceptor implements ExecutionInterceptor {
+  private final List<StorageCredential> storageCredentials;
+
+  public S3ExecutionInterceptor(List<StorageCredential> storageCredentials) {
+    Preconditions.checkArgument(null != storageCredentials, "Invalid storage credentials: null");
+    this.storageCredentials = storageCredentials;
+  }
+
+  @Override
+  public SdkHttpRequest modifyHttpRequest(
+      Context.ModifyHttpRequest context, ExecutionAttributes executionAttributes) {
+    if (!storageCredentials.isEmpty()) {
+      SdkHttpRequest.Builder builder = context.httpRequest().toBuilder();
+      String requestPath = context.httpRequest().encodedPath();
+      StorageCredential credentialToUse = storageCredentials.get(0);
+      Map<String, String> configToUse = null;
+
+      for (StorageCredential storageCredential : storageCredentials) {
+        if (requestPath.startsWith(storageCredential.prefix())
+            && storageCredential.prefix().length() >= credentialToUse.prefix().length()) {
+          configToUse = storageCredential.config();
+        }
+      }
+
+      if (null != configToUse) {
+        String accessKeyId = configToUse.get(S3FileIOProperties.ACCESS_KEY_ID);
+        String secretAccessKey = configToUse.get(S3FileIOProperties.SECRET_ACCESS_KEY);
+        String sessionToken = configToUse.get(S3FileIOProperties.SESSION_TOKEN);
+        String tokenExpiresAtMillis =
+            configToUse.get(S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS);
+
+        if (null != accessKeyId && null != secretAccessKey) {
+          builder.putHeader("X-Amz-Access-Key", accessKeyId);
+          builder.putHeader("X-Amz-Secret-Key", secretAccessKey);
+          if (null != sessionToken) {
+            builder.putHeader("X-Amz-Security-Token", sessionToken);
+          }
+
+          if (null != tokenExpiresAtMillis) {
+            Instant expiresAt = Instant.ofEpochMilli(Long.parseLong(tokenExpiresAtMillis));
+            long expiresInSeconds =
+                Math.max(1, expiresAt.minusMillis(Instant.now().toEpochMilli()).getEpochSecond());
+            builder.putHeader("X-Amz-Expires", Long.toString(expiresInSeconds));
+          }
+        }
+
+        return builder.build();
+      }
+    }
+
+    return ExecutionInterceptor.super.modifyHttpRequest(context, executionAttributes);
+  }
+}


### PR DESCRIPTION
This uses a custom `ExecutionInterceptor` to set the correct headers when storage credentials are configured for `S3FileIO`. This is an alternative approach to #12799 and is currently WIP (I haven't actually tested this yet to see whether it works properly and some additional tests are missing)