### PR TITLE
API: Use normalized JSON path to identify Variant fields

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundExtract.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundExtract.java
@@ -19,19 +19,16 @@
 package org.apache.iceberg.expressions;
 
 import org.apache.iceberg.StructLike;
-import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.types.Type;
 
 public class BoundExtract<T> implements BoundTerm<T> {
   private final BoundReference<?> ref;
   private final String path;
-  private final String fullFieldName;
   private final Type type;
 
   BoundExtract(BoundReference<?> ref, String path, Type type) {
     this.ref = ref;
-    this.path = path;
-    this.fullFieldName = Joiner.on(".").join(PathUtil.parse(path));
+    this.path = PathUtil.toNormalizedPath(PathUtil.parse(path));
     this.type = type;
   }
 
@@ -42,10 +39,6 @@ public class BoundExtract<T> implements BoundTerm<T> {
 
   public String path() {
     return path;
-  }
-
-  String fullFieldName() {
-    return fullFieldName;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -556,8 +556,7 @@ public class InclusiveMetricsEvaluator {
       Integer id = bound.ref().fieldId();
       if (lowerBounds != null && lowerBounds.containsKey(id)) {
         VariantObject fieldLowerBounds = parseBounds(lowerBounds.get(id));
-        return VariantExpressionUtil.castTo(
-            fieldLowerBounds.get(bound.fullFieldName()), bound.type());
+        return VariantExpressionUtil.castTo(fieldLowerBounds.get(bound.path()), bound.type());
       }
 
       return null;
@@ -567,8 +566,7 @@ public class InclusiveMetricsEvaluator {
       Integer id = bound.ref().fieldId();
       if (upperBounds != null && upperBounds.containsKey(id)) {
         VariantObject fieldUpperBounds = parseBounds(upperBounds.get(id));
-        return VariantExpressionUtil.castTo(
-            fieldUpperBounds.get(bound.fullFieldName()), bound.type());
+        return VariantExpressionUtil.castTo(fieldUpperBounds.get(bound.path()), bound.type());
       }
 
       return null;

--- a/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
@@ -19,12 +19,19 @@
 package org.apache.iceberg.expressions;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 
-class PathUtil {
+public class PathUtil {
   private PathUtil() {}
 
   private static final String RFC9535_NAME_FIRST =
@@ -33,6 +40,12 @@ class PathUtil {
       "[0-9A-Za-z_\\x{0080}-\\x{D7FF}\\x{E000}-\\x{10FFFF}]*";
   private static final Predicate<String> RFC9535_MEMBER_NAME_SHORTHAND =
       Pattern.compile(RFC9535_NAME_FIRST + RFC9535_NAME_CHARS).asMatchPredicate();
+
+  private static final Pattern RFC9535_REQUIRES_ESCAPE =
+      Pattern.compile(
+          "[^\\x{0020}-\\x{0026}\\x{0028}-\\x{005B}\\x{005D}-\\x{D7FF}\\x{E000}-\\x{10FFFF}]");
+
+  private static final Map<Character, String> RFC9535_ESCAPE_REPLACEMENTS = buildReplacementMap();
 
   private static final Splitter DOT = Splitter.on(".");
   private static final String ROOT = "$";
@@ -60,5 +73,60 @@ class PathUtil {
     }
 
     return names;
+  }
+
+  public static String toNormalizedPath(Iterable<String> fields) {
+    return ROOT
+        + Streams.stream(fields)
+            .map(PathUtil::rfc9535escape)
+            .map(name -> "['" + name + "']")
+            .collect(Collectors.joining(""));
+  }
+
+  @VisibleForTesting
+  static String rfc9535escape(String name) {
+    StringBuilder builder = new StringBuilder();
+    Matcher matcher = RFC9535_REQUIRES_ESCAPE.matcher(name);
+    while (matcher.find()) {
+      matcher.appendReplacement(builder, replacement(matcher.group()));
+    }
+
+    matcher.appendTail(builder);
+
+    return builder.toString();
+  }
+
+  private static String replacement(String esc) {
+    String replacement = RFC9535_ESCAPE_REPLACEMENTS.get(esc.charAt(0));
+    if (replacement != null) {
+      return replacement;
+    }
+
+    throw new IllegalArgumentException("Cannot escape for normalized path: " + esc);
+  }
+
+  @SuppressWarnings("DefaultLocale")
+  private static Map<Character, String> buildReplacementMap() {
+    ImmutableMap.Builder<Character, String> builder = ImmutableMap.builder();
+
+    // replacements are double-escaped to pass correctly through appendReplacement
+    builder.put('\b', "\\\\b");
+    builder.put('\t', "\\\\t");
+    builder.put('\f', "\\\\f");
+    builder.put('\n', "\\\\n");
+    builder.put('\r', "\\\\r");
+    builder.put('\'', "\\\\'");
+    builder.put('\\', "\\\\\\\\");
+
+    // RFC9535 normal-hexchar: add control chars that are escaped as hex
+    Set<Character> specialEscapeChars = Set.of('\b', '\t', '\f', '\n', '\r');
+    for (char ch = 0; ch <= 0x1F; ch = (char) (ch + 1)) {
+      // add all escaped chars to the map
+      if (!specialEscapeChars.contains(ch)) {
+        builder.put(ch, String.format("\\\\u%04x", (int) ch));
+      }
+    }
+
+    return builder.build();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -339,7 +339,7 @@ public class TestExpressionBinding {
     assertThat(pred.term()).as("Should use a BoundExtract").isInstanceOf(BoundExtract.class);
     BoundExtract<?> boundExtract = (BoundExtract<?>) pred.term();
     assertThat(boundExtract.ref().fieldId()).isEqualTo(4);
-    assertThat(boundExtract.fullFieldName()).isEqualTo("event_id");
+    assertThat(boundExtract.path()).isEqualTo("$['event_id']");
     assertThat(boundExtract.type()).isEqualTo(Types.LongType.get());
   }
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
@@ -27,7 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
-public class TestPathParsing {
+@SuppressWarnings({"AvoidEscapedUnicodeCharacters", "IllegalTokenText"})
+public class TestPathUtil {
 
   @Test
   public void testSimplePath() {
@@ -69,5 +70,57 @@ public class TestPathParsing {
     assertThatThrownBy(() -> PathUtil.parse(path))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageMatching("(Unsupported|Invalid) path.*");
+  }
+
+  private static final String[][] NORMALIZED_PATHS =
+      new String[][] {
+        new String[] {"$", "$"},
+        new String[] {"$.a", "$['a']"}, // RFC 9535 example
+        new String[] {"$.a.b.c", "$['a']['b']['c']"},
+        new String[] {"$.\u2603", "$['☃']"},
+        new String[] {"$.a\uD834\uDD1Eb.x", "$['a\uD834\uDD1Eb']['x']"},
+      };
+
+  @ParameterizedTest
+  @FieldSource("NORMALIZED_PATHS")
+  public void testNormalizedPath(String shortPath, String normalizedPath) {
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse(shortPath))).isEqualTo(normalizedPath);
+  }
+
+  private static final Object[][] NORMALIZED_FIELD_LISTS =
+      new Object[][] {
+        new Object[] {List.of(), "$"},
+        new Object[] {List.of("a.b", "c"), "$['a.b']['c']"},
+        new Object[] {List.of("a", "b", "c"), "$['a']['b']['c']"},
+        new Object[] {List.of("a", "\u2603", "c"), "$['a']['\u2603']['c']"},
+        new Object[] {List.of("a\uD834\uDD1Eb", "c"), "$['a\uD834\uDD1Eb']['c']"},
+        new Object[] {List.of("a'b\n", "\u000Cc"), "$['a\\'b\\n']['\\fc']"},
+        new Object[] {List.of("a'b\u000B\n", "\u000Cc"), "$['a\\'b\\u000b\\n']['\\fc']"},
+      };
+
+  @ParameterizedTest
+  @FieldSource("NORMALIZED_FIELD_LISTS")
+  public void testNormalizedFieldLists(List<String> fields, String normalizedPath) {
+    assertThat(PathUtil.toNormalizedPath(fields)).isEqualTo(normalizedPath);
+  }
+
+  private static final String[][] ESCAPE_CASES =
+      new String[][] {
+        new String[] {"\u000B", "\\u000b"}, // RFC 9535 example
+        new String[] {"\b", "\\b"},
+        new String[] {"\t", "\\t"},
+        new String[] {"\f", "\\f"},
+        new String[] {"\n", "\\n"},
+        new String[] {"\r", "\\r"},
+        new String[] {"'", "\\'"},
+        new String[] {"\\", "\\\\"},
+        new String[] {"a\\b", "a\\\\b"},
+        new String[] {"a\\b'", "a\\\\b\\'"},
+      };
+
+  @ParameterizedTest
+  @FieldSource("ESCAPE_CASES")
+  public void testPathEscaping(String name, String escaped) {
+    assertThat(PathUtil.rfc9535escape(name)).isEqualTo(escaped);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluatorWithExtract.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluatorWithExtract.java
@@ -87,12 +87,20 @@ public class TestInclusiveMetricsEvaluatorWithExtract {
           ImmutableMap.of(
               2,
               VariantTestUtil.variantBuffer(
-                  Map.of("event_id", Variants.of(INT_MIN_VALUE), "str", Variants.of("abc")))),
+                  Map.of(
+                      "$['event_id']",
+                      Variants.of(INT_MIN_VALUE),
+                      "$['str']",
+                      Variants.of("abc")))),
           // upper bounds
           ImmutableMap.of(
               2,
               VariantTestUtil.variantBuffer(
-                  Map.of("event_id", Variants.of(INT_MAX_VALUE), "str", Variants.of("abe")))));
+                  Map.of(
+                      "$['event_id']",
+                      Variants.of(INT_MAX_VALUE),
+                      "$['str']",
+                      Variants.of("abe")))));
 
   private boolean shouldRead(Expression expr) {
     return shouldRead(expr, FILE);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import org.apache.iceberg.expressions.PathUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Comparators;
@@ -287,7 +288,7 @@ class ParquetVariantUtil {
 
     public String fieldName() {
       if (null == lazyFieldName) {
-        this.lazyFieldName = String.join(".", fieldNames);
+        this.lazyFieldName = PathUtil.toNormalizedPath(fieldNames);
       }
 
       return lazyFieldName;

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
@@ -62,7 +62,7 @@ public class TestVariantMetrics {
 
   private static final VariantMetadata EMPTY = Variants.emptyMetadata();
 
-  private static final String ROOT_FIELD = "";
+  private static final String ROOT_FIELD = "$";
 
   private static final VariantValue[] PRIMITIVES =
       new VariantValue[] {
@@ -304,12 +304,12 @@ public class TestVariantMetrics {
     assertThat(metrics.nullValueCounts()).isEqualTo(Map.of(1, 0L, 2, 1L));
     assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
 
-    VariantMetadata boundMetadata = Variants.metadata("a", "b", "c", "d.e");
+    VariantMetadata boundMetadata = Variants.metadata("$['a']", "$['b']", "$['c']", "$['d']['e']");
     ShreddedObject expectedBounds = Variants.object(boundMetadata);
-    expectedBounds.put("a", date);
-    expectedBounds.put("b", num);
-    expectedBounds.put("c", str);
-    expectedBounds.put("d.e", dec);
+    expectedBounds.put("$['a']", date);
+    expectedBounds.put("$['b']", num);
+    expectedBounds.put("$['c']", str);
+    expectedBounds.put("$['d']['e']", dec);
 
     assertThat(metrics.lowerBounds().size()).isEqualTo(2);
     assertThat(metrics.lowerBounds().get(1))
@@ -362,10 +362,10 @@ public class TestVariantMetrics {
     assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
 
     // only a and b were shredded so the other fields are not present
-    VariantMetadata boundMetadata = Variants.metadata("a", "b");
+    VariantMetadata boundMetadata = Variants.metadata("$['a']", "$['b']");
     ShreddedObject expectedBounds = Variants.object(boundMetadata);
-    expectedBounds.put("a", date);
-    expectedBounds.put("b", num);
+    expectedBounds.put("$['a']", date);
+    expectedBounds.put("$['b']", num);
 
     assertThat(metrics.lowerBounds().size()).isEqualTo(2);
     assertThat(metrics.lowerBounds().get(1))
@@ -420,10 +420,10 @@ public class TestVariantMetrics {
     assertThat(metrics.nanValueCounts()).isEqualTo(Map.of());
 
     // only a and b were shredded so the other fields are not present
-    VariantMetadata boundMetadata = Variants.metadata("a", "d.e");
+    VariantMetadata boundMetadata = Variants.metadata("$['a']", "$['d']['e']");
     ShreddedObject expectedBounds = Variants.object(boundMetadata);
-    expectedBounds.put("a", date);
-    expectedBounds.put("d.e", dec);
+    expectedBounds.put("$['a']", date);
+    expectedBounds.put("$['d']['e']", dec);
 
     assertThat(metrics.lowerBounds().size()).isEqualTo(2);
     assertThat(metrics.lowerBounds().get(1))


### PR DESCRIPTION
This updates the Parquet metrics conversion to use normalized JSON paths instead of joining field names using `.`. A normalized path is a more reliable representation that preserves the distinction between `[a.b][c]`, `[a][b][c]` and `[a.b.c]`.

This implements the changes from #12658. Currently, the spec does not cover how bounds should be stored for variants, but I think we are in agreement about using normalized paths, so I would like to get this in to avoid writing incorrect bounds in the 1.9.0 release.