### PR TITLE
Spark: Add _row_id and _last_updated_sequence_number readers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -278,6 +278,9 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
     if (projection.findField(DataFile.RECORD_COUNT.fieldId()) == null) {
       fields.add(DataFile.RECORD_COUNT);
     }
+    if (projection.findField(DataFile.FIRST_ROW_ID.fieldId()) == null) {
+      fields.add(DataFile.FIRST_ROW_ID);
+    }
     fields.add(MetadataColumns.ROW_POSITION);
 
     CloseableIterable<ManifestEntry<F>> reader =

--- a/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
@@ -53,6 +53,13 @@ public class PartitionUtil {
     // use java.util.HashMap because partition data may contain null values
     Map<Integer, Object> idToConstant = Maps.newHashMap();
 
+    // add first_row_id as _row_id
+    if (task.file().firstRowId() != null) {
+      idToConstant.put(
+          MetadataColumns.ROW_ID.fieldId(),
+          convertConstant.apply(Types.LongType.get(), task.file().firstRowId()));
+    }
+
     // add _file
     idToConstant.put(
         MetadataColumns.FILE_PATH.fieldId(),

--- a/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
@@ -60,6 +60,10 @@ public class PartitionUtil {
           convertConstant.apply(Types.LongType.get(), task.file().firstRowId()));
     }
 
+    idToConstant.put(
+        MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId(),
+        convertConstant.apply(Types.LongType.get(), task.file().fileSequenceNumber()));
+
     // add _file
     idToConstant.put(
         MetadataColumns.FILE_PATH.fieldId(),

--- a/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
@@ -685,6 +685,9 @@ public class TestRowLineageAssignment {
     try (ManifestReader<DataFile> reader =
         ManifestFiles.read(manifest, table.io(), table.specs())) {
 
+      // test that the first_row_id column is always scanned, even if not requested
+      reader.select(BaseScan.SCAN_COLUMNS);
+
       for (DataFile file : reader) {
         assertThat(file.content()).isEqualTo(FileContent.DATA);
         if (index < firstRowIds.length) {

--- a/core/src/test/java/org/apache/iceberg/data/DataTest.java
+++ b/core/src/test/java/org/apache/iceberg/data/DataTest.java
@@ -55,9 +55,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class DataTest {
 
-  protected static final long FIRST_ROW_ID = 2_000L;
+  private static final long FIRST_ROW_ID = 2_000L;
   protected static final Map<Integer, Object> ID_TO_CONSTANT =
-      Map.of(MetadataColumns.ROW_ID.fieldId(), FIRST_ROW_ID);
+      Map.of(
+          MetadataColumns.ROW_ID.fieldId(),
+          FIRST_ROW_ID,
+          MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId(),
+          34L);
 
   protected abstract void writeAndValidate(Schema schema) throws IOException;
 
@@ -145,7 +149,7 @@ public abstract class DataTest {
     return false;
   }
 
-  protected boolean supportsRowIds() {
+  protected boolean supportsRowLineage() {
     return false;
   }
 
@@ -611,13 +615,17 @@ public abstract class DataTest {
   }
 
   @Test
-  public void testRowIds() throws Exception {
-    Assumptions.assumeThat(supportsRowIds()).as("_row_id support is not implemented").isTrue();
+  public void testRowLineage() throws Exception {
+    Assumptions.assumeThat(supportsRowLineage())
+        .as("Row Lineage support is not implemented")
+        .isTrue();
+
     Schema schema =
         new Schema(
             required(1, "id", LongType.get()),
             required(2, "data", Types.StringType.get()),
-            MetadataColumns.ROW_ID);
+            MetadataColumns.ROW_ID,
+            MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER);
 
     GenericRecord record = GenericRecord.create(schema);
 
@@ -626,7 +634,16 @@ public abstract class DataTest {
         List.of(
             record.copy(Map.of("id", 1L, "data", "a")),
             record.copy(Map.of("id", 2L, "data", "b")),
-            record.copy(Map.of("id", 3L, "data", "c", "_row_id", 1_000L)),
+            record.copy(
+                Map.of(
+                    "id",
+                    3L,
+                    "data",
+                    "c",
+                    "_row_id",
+                    1_000L,
+                    "_last_updated_sequence_number",
+                    33L)),
             record.copy(Map.of("id", 4L, "data", "d", "_row_id", 1_001L)),
             record.copy(Map.of("id", 5L, "data", "e"))));
   }

--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
@@ -64,7 +64,7 @@ public class TestGenericData extends DataTest {
   }
 
   @Override
-  protected boolean supportsRowIds() {
+  protected boolean supportsRowLineage() {
     return true;
   }
 
@@ -110,7 +110,7 @@ public class TestGenericData extends DataTest {
 
     for (int pos = 0; pos < expected.size(); pos += 1) {
       DataTestHelpers.assertEquals(
-          expectedSchema.asStruct(), expected.get(pos), rows.get(pos), FIRST_ROW_ID + pos);
+          expectedSchema.asStruct(), expected.get(pos), rows.get(pos), ID_TO_CONSTANT, pos);
     }
 
     // test reuseContainers
@@ -125,7 +125,7 @@ public class TestGenericData extends DataTest {
       int pos = 0;
       for (Record actualRecord : reader) {
         DataTestHelpers.assertEquals(
-            expectedSchema.asStruct(), expected.get(pos), actualRecord, FIRST_ROW_ID + pos);
+            expectedSchema.asStruct(), expected.get(pos), actualRecord, ID_TO_CONSTANT, pos);
         pos += 1;
       }
     }

--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
@@ -36,8 +36,10 @@ import org.apache.iceberg.data.DataTest;
 import org.apache.iceberg.data.DataTestHelpers;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
@@ -62,6 +64,11 @@ public class TestGenericData extends DataTest {
   }
 
   @Override
+  protected boolean supportsRowIds() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     writeAndValidate(schema, schema);
   }
@@ -80,11 +87,10 @@ public class TestGenericData extends DataTest {
   private void writeAndValidate(Schema writeSchema, Schema expectedSchema, List<Record> expected)
       throws IOException {
 
-    File testFile = File.createTempFile("junit", null, temp.toFile());
-    assertThat(testFile.delete()).isTrue();
+    OutputFile output = new InMemoryOutputFile();
 
     try (FileAppender<Record> appender =
-        Parquet.write(Files.localOutput(testFile))
+        Parquet.write(output)
             .schema(writeSchema)
             .createWriterFunc(GenericParquetWriter::create)
             .build()) {
@@ -93,30 +99,34 @@ public class TestGenericData extends DataTest {
 
     List<Record> rows;
     try (CloseableIterable<Record> reader =
-        Parquet.read(Files.localInput(testFile))
+        Parquet.read(output.toInputFile())
             .project(expectedSchema)
             .createReaderFunc(
-                fileSchema -> GenericParquetReaders.buildReader(expectedSchema, fileSchema))
+                fileSchema ->
+                    GenericParquetReaders.buildReader(expectedSchema, fileSchema, ID_TO_CONSTANT))
             .build()) {
       rows = Lists.newArrayList(reader);
     }
 
-    for (int i = 0; i < expected.size(); i += 1) {
-      DataTestHelpers.assertEquals(expectedSchema.asStruct(), expected.get(i), rows.get(i));
+    for (int pos = 0; pos < expected.size(); pos += 1) {
+      DataTestHelpers.assertEquals(
+          expectedSchema.asStruct(), expected.get(pos), rows.get(pos), FIRST_ROW_ID + pos);
     }
 
     // test reuseContainers
     try (CloseableIterable<Record> reader =
-        Parquet.read(Files.localInput(testFile))
+        Parquet.read(output.toInputFile())
             .project(expectedSchema)
             .reuseContainers()
             .createReaderFunc(
-                fileSchema -> GenericParquetReaders.buildReader(expectedSchema, fileSchema))
+                fileSchema ->
+                    GenericParquetReaders.buildReader(expectedSchema, fileSchema, ID_TO_CONSTANT))
             .build()) {
-      int index = 0;
+      int pos = 0;
       for (Record actualRecord : reader) {
-        DataTestHelpers.assertEquals(expectedSchema.asStruct(), expected.get(index), actualRecord);
-        index += 1;
+        DataTestHelpers.assertEquals(
+            expectedSchema.asStruct(), expected.get(pos), actualRecord, FIRST_ROW_ID + pos);
+        pos += 1;
       }
     }
   }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.parquet.ParquetValueReader;
@@ -77,7 +76,7 @@ abstract class BaseParquetReaders<T> {
   }
 
   protected abstract ParquetValueReader<T> createStructReader(
-      List<Type> types, List<ParquetValueReader<?>> fieldReaders, Types.StructType structType);
+      List<ParquetValueReader<?>> fieldReaders, Types.StructType structType);
 
   protected abstract ParquetValueReader<?> fixedReader(ColumnDescriptor desc);
 
@@ -110,7 +109,6 @@ abstract class BaseParquetReaders<T> {
       // the expected struct is ignored because nested fields are never found when the
       List<ParquetValueReader<?>> newFields =
           Lists.newArrayListWithExpectedSize(fieldReaders.size());
-      List<Type> types = Lists.newArrayListWithExpectedSize(fieldReaders.size());
       List<Type> fields = struct.getFields();
       for (int i = 0; i < fields.size(); i += 1) {
         ParquetValueReader<?> fieldReader = fieldReaders.get(i);
@@ -118,11 +116,10 @@ abstract class BaseParquetReaders<T> {
           Type fieldType = fields.get(i);
           int fieldD = type().getMaxDefinitionLevel(path(fieldType.getName())) - 1;
           newFields.add(ParquetValueReaders.option(fieldType, fieldD, fieldReader));
-          types.add(fieldType);
         }
       }
 
-      return createStructReader(types, newFields, expected);
+      return createStructReader(newFields, expected);
     }
   }
 
@@ -225,9 +222,12 @@ abstract class BaseParquetReaders<T> {
     @Override
     public ParquetValueReader<?> struct(
         Types.StructType expected, GroupType struct, List<ParquetValueReader<?>> fieldReaders) {
+      if (null == expected) {
+        return createStructReader(ImmutableList.of(), null);
+      }
+
       // match the expected struct's order
       Map<Integer, ParquetValueReader<?>> readersById = Maps.newHashMap();
-      Map<Integer, Type> typesById = Maps.newHashMap();
       List<Type> fields = struct.getFields();
       for (int i = 0; i < fields.size(); i += 1) {
         ParquetValueReader<?> fieldReader = fieldReaders.get(i);
@@ -236,64 +236,37 @@ abstract class BaseParquetReaders<T> {
           int fieldD = type.getMaxDefinitionLevel(path(fieldType.getName())) - 1;
           int id = fieldType.getId().intValue();
           readersById.put(id, ParquetValueReaders.option(fieldType, fieldD, fieldReader));
-          typesById.put(id, fieldType);
         }
       }
 
-      List<Types.NestedField> expectedFields =
-          expected != null ? expected.fields() : ImmutableList.of();
+      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
+      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
           Lists.newArrayListWithExpectedSize(expectedFields.size());
-      List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
-      // use the struct's DL for constants that are always non-null if the struct is non-null
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
+
       for (Types.NestedField field : expectedFields) {
         int id = field.fieldId();
-        ParquetValueReader<?> reader = readersById.get(id);
-        if (id == MetadataColumns.ROW_ID.fieldId()) {
-          Long baseRowId = (Long) idToConstant.get(id);
-          if (baseRowId != null) {
-            reorderedFields.add(ParquetValueReaders.rowIds(baseRowId, reader));
-          } else {
-            reorderedFields.add(ParquetValueReaders.nulls());
-          }
-        } else if (id == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
-          Long baseRowId = (Long) idToConstant.get(id);
-          Long fileSeqNumber = (Long) idToConstant.get(id);
-          if (fileSeqNumber != null && baseRowId != null) {
-            reorderedFields.add(ParquetValueReaders.lastUpdated(fileSeqNumber, reader));
-          } else {
-            reorderedFields.add(ParquetValueReaders.nulls());
-          }
-        } else if (idToConstant.containsKey(id)) {
-          // containsKey is used because the constant may be null
-          reorderedFields.add(
-              ParquetValueReaders.constant(idToConstant.get(id), constantDefinitionLevel));
-          types.add(null);
-        } else if (id == MetadataColumns.ROW_POSITION.fieldId()) {
-          reorderedFields.add(ParquetValueReaders.position());
-          types.add(null);
-        } else if (id == MetadataColumns.IS_DELETED.fieldId()) {
-          reorderedFields.add(ParquetValueReaders.constant(false));
-          types.add(null);
-        } else if (reader != null) {
-          reorderedFields.add(reader);
-          types.add(typesById.get(id));
-        } else if (field.initialDefault() != null) {
-          reorderedFields.add(
-              ParquetValueReaders.constant(
-                  convertConstant(field.type(), field.initialDefault()), constantDefinitionLevel));
-          types.add(typesById.get(id));
-        } else if (field.isOptional()) {
-          reorderedFields.add(ParquetValueReaders.nulls());
-          types.add(null);
-        } else {
-          throw new IllegalArgumentException(
-              String.format("Missing required field: %s", field.name()));
-        }
+        ParquetValueReader<?> reader =
+            ParquetValueReaders.replaceWithMetadataReader(
+                id, readersById.get(id), idToConstant, constantDefinitionLevel);
+        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
       }
 
-      return createStructReader(types, reorderedFields, expected);
+      return createStructReader(reorderedFields, expected);
+    }
+
+    private ParquetValueReader<?> defaultReader(
+        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
+      if (reader != null) {
+        return reader;
+      } else if (field.initialDefault() != null) {
+        return ParquetValueReaders.constant(
+            convertConstant(field.type(), field.initialDefault()), constantDL);
+      } else if (field.isOptional()) {
+        return ParquetValueReaders.nulls();
+      }
+
+      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -254,7 +254,14 @@ abstract class BaseParquetReaders<T> {
       for (Types.NestedField field : expectedFields) {
         int id = field.fieldId();
         ParquetValueReader<?> reader = readersById.get(id);
-        if (idToConstant.containsKey(id)) {
+        if (id == MetadataColumns.ROW_ID.fieldId()) {
+          Long baseRowId = (Long) idToConstant.get(id);
+          if (baseRowId != null) {
+            reorderedFields.add(ParquetValueReaders.rowIds(baseRowId, reader));
+          } else {
+            reorderedFields.add(ParquetValueReaders.nulls());
+          }
+        } else if (idToConstant.containsKey(id)) {
           // containsKey is used because the constant may be null
           int fieldMaxDefinitionLevel =
               maxDefinitionLevelsById.getOrDefault(id, defaultMaxDefinitionLevel);

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -261,6 +261,14 @@ abstract class BaseParquetReaders<T> {
           } else {
             reorderedFields.add(ParquetValueReaders.nulls());
           }
+        } else if (id == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
+          Long baseRowId = (Long) idToConstant.get(id);
+          Long fileSeqNumber = (Long) idToConstant.get(id);
+          if (fileSeqNumber != null && baseRowId != null) {
+            reorderedFields.add(ParquetValueReaders.lastUpdated(fileSeqNumber, reader));
+          } else {
+            reorderedFields.add(ParquetValueReaders.nulls());
+          }
         } else if (idToConstant.containsKey(id)) {
           // containsKey is used because the constant may be null
           int fieldMaxDefinitionLevel =

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
@@ -41,7 +41,6 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
 
 public class GenericParquetReaders extends BaseParquetReaders<Record> {
 
@@ -61,7 +60,7 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
 
   @Override
   protected ParquetValueReader<Record> createStructReader(
-      List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
+      List<ParquetValueReader<?>> fieldReaders, StructType structType) {
     return ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
@@ -36,12 +36,12 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
 
 public class GenericParquetReaders extends BaseParquetReaders<Record> {
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/GenericParquetReaders.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -56,6 +57,18 @@ public class GenericParquetReaders extends BaseParquetReaders<Record> {
   public static ParquetValueReader<Record> buildReader(
       Schema expectedSchema, MessageType fileSchema, Map<Integer, ?> idToConstant) {
     return INSTANCE.createReader(expectedSchema, fileSchema, idToConstant);
+  }
+
+  /**
+   * Create a struct reader.
+   *
+   * @deprecated will be removed in 1.10.0; use {@link #createStructReader(List, StructType)}
+   *     instead.
+   */
+  @Deprecated
+  protected ParquetValueReader<Record> createStructReader(
+      List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
+    return ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 
 public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> {
 
@@ -50,7 +49,7 @@ public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> 
   @Override
   @SuppressWarnings("unchecked")
   protected ParquetValueReader<T> createStructReader(
-      List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
+      List<ParquetValueReader<?>> fieldReaders, StructType structType) {
     return (ParquetValueReader<T>) ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
@@ -24,10 +24,10 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetValueReaders;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
 
 public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> {
 

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/InternalReader.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetValueReaders;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.MessageType;
@@ -44,6 +45,19 @@ public class InternalReader<T extends StructLike> extends BaseParquetReaders<T> 
   public static <T extends StructLike> ParquetValueReader<T> create(
       Schema expectedSchema, MessageType fileSchema, Map<Integer, ?> idToConstant) {
     return (ParquetValueReader<T>) INSTANCE.createReader(expectedSchema, fileSchema, idToConstant);
+  }
+
+  /**
+   * Create a struct reader.
+   *
+   * @deprecated will be removed in 1.10.0; use {@link #createStructReader(List, StructType)}
+   *     instead.
+   */
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  protected ParquetValueReader<T> createStructReader(
+      List<Type> types, List<ParquetValueReader<?>> fieldReaders, StructType structType) {
+    return (ParquetValueReader<T>) ParquetValueReaders.recordReader(fieldReaders, structType);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -280,13 +280,8 @@ public class ParquetValueReaders {
 
     ConstantReader(C constantValue, int parentDl) {
       this.constantValue = constantValue;
-      if (constantValue != null) {
-        this.column = new ConstantDLColumn<>(parentDl);
-        this.children = ImmutableList.of(column);
-      } else {
-        this.column = NullReader.NULL_COLUMN;
-        this.children = NullReader.COLUMNS;
-      }
+      this.column = new ConstantDLColumn<>(parentDl);
+      this.children = ImmutableList.of(column);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -382,12 +382,14 @@ public class ParquetValueReaders {
 
     @Override
     public Long read(Long reuse) {
+      // always call the position reader to keep the position accurate
+      long pos = posReader.read(null);
       Long idFromFile = idReader.read(null);
       if (idFromFile != null) {
         return idFromFile;
       }
 
-      return firstRowId + posReader.read(null);
+      return firstRowId + pos;
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.parquet.ParquetValueReader;
@@ -135,9 +134,12 @@ public class SparkParquetReaders {
     @Override
     public ParquetValueReader<?> struct(
         Types.StructType expected, GroupType struct, List<ParquetValueReader<?>> fieldReaders) {
+      if (null == expected) {
+        return new InternalRowReader(ImmutableList.of());
+      }
+
       // match the expected struct's order
       Map<Integer, ParquetValueReader<?>> readersById = Maps.newHashMap();
-      Map<Integer, Type> typesById = Maps.newHashMap();
       List<Type> fields = struct.getFields();
       for (int i = 0; i < fields.size(); i += 1) {
         Type fieldType = fields.get(i);
@@ -145,58 +147,37 @@ public class SparkParquetReaders {
         if (fieldType.getId() != null) {
           int id = fieldType.getId().intValue();
           readersById.put(id, ParquetValueReaders.option(fieldType, fieldD, fieldReaders.get(i)));
-          typesById.put(id, fieldType);
         }
       }
 
-      List<Types.NestedField> expectedFields =
-          expected != null ? expected.fields() : ImmutableList.of();
+      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
+      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
           Lists.newArrayListWithExpectedSize(expectedFields.size());
-      // use the struct's DL for constants that are always non-null if the struct is non-null
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
+
       for (Types.NestedField field : expectedFields) {
         int id = field.fieldId();
-        ParquetValueReader<?> reader = readersById.get(id);
-        if (id == MetadataColumns.ROW_ID.fieldId()) {
-          Long baseRowId = (Long) idToConstant.get(id);
-          if (baseRowId != null) {
-            reorderedFields.add(ParquetValueReaders.rowIds(baseRowId, reader));
-          } else {
-            reorderedFields.add(ParquetValueReaders.nulls());
-          }
-        } else if (id == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
-          Long baseRowId = (Long) idToConstant.get(id);
-          Long fileSeqNumber = (Long) idToConstant.get(id);
-          if (fileSeqNumber != null && baseRowId != null) {
-            reorderedFields.add(ParquetValueReaders.lastUpdated(fileSeqNumber, reader));
-          } else {
-            reorderedFields.add(ParquetValueReaders.nulls());
-          }
-        } else if (idToConstant.containsKey(id)) {
-          // containsKey is used because the constant may be null
-          reorderedFields.add(
-              ParquetValueReaders.constant(idToConstant.get(id), constantDefinitionLevel));
-        } else if (id == MetadataColumns.ROW_POSITION.fieldId()) {
-          reorderedFields.add(ParquetValueReaders.position());
-        } else if (id == MetadataColumns.IS_DELETED.fieldId()) {
-          reorderedFields.add(ParquetValueReaders.constant(false));
-        } else if (reader != null) {
-          reorderedFields.add(reader);
-        } else if (field.initialDefault() != null) {
-          reorderedFields.add(
-              ParquetValueReaders.constant(
-                  SparkUtil.internalToSpark(field.type(), field.initialDefault()),
-                  constantDefinitionLevel));
-        } else if (field.isOptional()) {
-          reorderedFields.add(ParquetValueReaders.nulls());
-        } else {
-          throw new IllegalArgumentException(
-              String.format("Missing required field: %s", field.name()));
-        }
+        ParquetValueReader<?> reader =
+            ParquetValueReaders.replaceWithMetadataReader(
+                id, readersById.get(id), idToConstant, constantDefinitionLevel);
+        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
       }
 
       return new InternalRowReader(reorderedFields);
+    }
+
+    private ParquetValueReader<?> defaultReader(
+        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
+      if (reader != null) {
+        return reader;
+      } else if (field.initialDefault() != null) {
+        return ParquetValueReaders.constant(
+            SparkUtil.internalToSpark(field.type(), field.initialDefault()), constantDL);
+      } else if (field.isOptional()) {
+        return ParquetValueReaders.nulls();
+      }
+
+      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -162,7 +162,14 @@ public class SparkParquetReaders {
       for (Types.NestedField field : expectedFields) {
         int id = field.fieldId();
         ParquetValueReader<?> reader = readersById.get(id);
-        if (idToConstant.containsKey(id)) {
+        if (id == MetadataColumns.ROW_ID.fieldId()) {
+          Long baseRowId = (Long) idToConstant.get(id);
+          if (baseRowId != null) {
+            reorderedFields.add(ParquetValueReaders.rowIds(baseRowId, reader));
+          } else {
+            reorderedFields.add(ParquetValueReaders.nulls());
+          }
+        } else if (idToConstant.containsKey(id)) {
           // containsKey is used because the constant may be null
           int fieldMaxDefinitionLevel =
               maxDefinitionLevelsById.getOrDefault(id, defaultMaxDefinitionLevel);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -169,6 +169,14 @@ public class SparkParquetReaders {
           } else {
             reorderedFields.add(ParquetValueReaders.nulls());
           }
+        } else if (id == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
+          Long baseRowId = (Long) idToConstant.get(id);
+          Long fileSeqNumber = (Long) idToConstant.get(id);
+          if (fileSeqNumber != null && baseRowId != null) {
+            reorderedFields.add(ParquetValueReaders.lastUpdated(fileSeqNumber, reader));
+          } else {
+            reorderedFields.add(ParquetValueReaders.nulls());
+          }
         } else if (idToConstant.containsKey(id)) {
           // containsKey is used because the constant may be null
           int fieldMaxDefinitionLevel =

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -180,7 +180,10 @@ class SparkBatch implements Batch {
   }
 
   private boolean supportsCometBatchReads(Types.NestedField field) {
-    return field.type().isPrimitiveType() && !field.type().typeId().equals(Type.TypeID.UUID);
+    return field.type().isPrimitiveType()
+        && !field.type().typeId().equals(Type.TypeID.UUID)
+        && field.fieldId() != MetadataColumns.ROW_ID.fieldId()
+        && field.fieldId() != MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
   }
 
   // conditions for using ORC batch reads:

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
@@ -63,10 +63,7 @@ public class SparkTestHelperBase {
       Object[] expected = expectedRows.get(row);
       Object[] actual = actualRows.get(row);
       assertThat(actual).as("Number of columns should match").hasSameSizeAs(expected);
-      for (int col = 0; col < actualRows.get(row).length; col += 1) {
-        String newContext = String.format("%s: row %d col %d", context, row + 1, col + 1);
-        assertEquals(newContext, expected, actual);
-      }
+      assertEquals(context + ": row " + (row + 1), expected, actual);
     }
   }
 
@@ -83,7 +80,9 @@ public class SparkTestHelperBase {
           assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
         }
       } else if (expectedValue != ANY) {
-        assertThat(actualValue).as(context + " contents should match").isEqualTo(expectedValue);
+        assertThat(actualValue)
+            .as(context + " col " + (col + 1) + " contents should match")
+            .isEqualTo(expectedValue);
       }
     }
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -27,10 +27,15 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
@@ -51,11 +56,21 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class AvroDataTest {
 
+  protected static final long FIRST_ROW_ID = 2_000L;
+  protected static final Map<Integer, Object> ID_TO_CONSTANT =
+      Map.of(MetadataColumns.ROW_ID.fieldId(), FIRST_ROW_ID);
+
   protected abstract void writeAndValidate(Schema schema) throws IOException;
 
   protected void writeAndValidate(Schema writeSchema, Schema expectedSchema) throws IOException {
     throw new UnsupportedEncodingException(
         "Cannot run test, writeAndValidate(Schema, Schema) is not implemented");
+  }
+
+  protected void writeAndValidate(Schema writeSchema, Schema expectedSchema, List<Record> records)
+      throws IOException {
+    throw new UnsupportedEncodingException(
+        "Cannot run test, writeAndValidate(Schema, Schema, List<Record>) is not implemented");
   }
 
   protected boolean supportsDefaultValues() {
@@ -64,6 +79,10 @@ public abstract class AvroDataTest {
 
   protected boolean supportsNestedTypes() {
     return true;
+  }
+
+  protected boolean supportsRowIds() {
+    return false;
   }
 
   protected static final StructType SUPPORTED_PRIMITIVES =
@@ -546,5 +565,27 @@ public abstract class AvroDataTest {
                 .build());
 
     writeAndValidate(writeSchema, readSchema);
+  }
+
+  @Test
+  public void testRowIds() throws Exception {
+    Assumptions.assumeThat(supportsRowIds()).as("_row_id support is not implemented").isTrue();
+    Schema schema =
+        new Schema(
+            required(1, "id", LongType.get()),
+            required(2, "data", Types.StringType.get()),
+            MetadataColumns.ROW_ID);
+
+    GenericRecord record = GenericRecord.create(schema);
+
+    writeAndValidate(
+        schema,
+        schema,
+        List.of(
+            record.copy(Map.of("id", 1L, "data", "a")),
+            record.copy(Map.of("id", 2L, "data", "b")),
+            record.copy(Map.of("id", 3L, "data", "c", "_row_id", 1_000L)),
+            record.copy(Map.of("id", 4L, "data", "d", "_row_id", 1_001L)),
+            record.copy(Map.of("id", 5L, "data", "e"))));
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -18,18 +18,15 @@
  */
 package org.apache.iceberg.spark.data;
 
-import static org.apache.iceberg.spark.data.TestHelpers.assertEqualsUnsafe;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -39,11 +36,15 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.parquet.ParquetUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -69,6 +70,13 @@ public class TestSparkParquetReader extends AvroDataTest {
 
   @Override
   protected void writeAndValidate(Schema writeSchema, Schema expectedSchema) throws IOException {
+    List<Record> expected = RandomGenericData.generate(writeSchema, 100, 0L);
+    writeAndValidate(writeSchema, expectedSchema, expected);
+  }
+
+  @Override
+  protected void writeAndValidate(Schema writeSchema, Schema expectedSchema, List<Record> expected)
+      throws IOException {
     assumeThat(
             TypeUtil.find(
                 writeSchema,
@@ -76,28 +84,37 @@ public class TestSparkParquetReader extends AvroDataTest {
         .as("Parquet Avro cannot write non-string map keys")
         .isNull();
 
-    List<GenericData.Record> expected = RandomData.generateList(writeSchema, 100, 0L);
-
-    File testFile = File.createTempFile("junit", null, temp.toFile());
-    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
-
-    try (FileAppender<GenericData.Record> writer =
-        Parquet.write(Files.localOutput(testFile)).schema(writeSchema).named("test").build()) {
+    OutputFile output = new InMemoryOutputFile();
+    try (FileAppender<Record> writer =
+        Parquet.write(output)
+            .schema(writeSchema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .named("test")
+            .build()) {
       writer.addAll(expected);
     }
 
     try (CloseableIterable<InternalRow> reader =
-        Parquet.read(Files.localInput(testFile))
+        Parquet.read(output.toInputFile())
             .project(expectedSchema)
-            .createReaderFunc(type -> SparkParquetReaders.buildReader(expectedSchema, type))
+            .createReaderFunc(
+                type -> SparkParquetReaders.buildReader(expectedSchema, type, ID_TO_CONSTANT))
             .build()) {
       Iterator<InternalRow> rows = reader.iterator();
-      for (GenericData.Record record : expected) {
+      int pos = 0;
+      for (Record record : expected) {
         assertThat(rows).as("Should have expected number of rows").hasNext();
-        assertEqualsUnsafe(expectedSchema.asStruct(), record, rows.next());
+        GenericsHelpers.assertEqualsUnsafe(
+            expectedSchema.asStruct(), record, rows.next(), FIRST_ROW_ID + pos);
+        pos += 1;
       }
       assertThat(rows).as("Should not have extra rows").isExhausted();
     }
+  }
+
+  @Override
+  protected boolean supportsRowIds() {
+    return true;
   }
 
   @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -105,7 +105,7 @@ public class TestSparkParquetReader extends AvroDataTest {
       for (Record record : expected) {
         assertThat(rows).as("Should have expected number of rows").hasNext();
         GenericsHelpers.assertEqualsUnsafe(
-            expectedSchema.asStruct(), record, rows.next(), FIRST_ROW_ID + pos);
+            expectedSchema.asStruct(), record, rows.next(), ID_TO_CONSTANT, pos);
         pos += 1;
       }
       assertThat(rows).as("Should not have extra rows").isExhausted();
@@ -113,7 +113,7 @@ public class TestSparkParquetReader extends AvroDataTest {
   }
 
   @Override
-  protected boolean supportsRowIds() {
+  protected boolean supportsRowLineage() {
     return true;
   }
 


### PR DESCRIPTION
This adds readers for `_row_id` and `_last_updated_sequence_number` in Spark and the generic data model.