### PR TITLE
Spec: Avoid struct field conflicts in default values

### DIFF
--- a/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
@@ -61,7 +61,7 @@ public class ShreddedObject implements VariantObject {
   }
 
   private Set<String> nameSet() {
-    Set<String> names = Sets.newHashSet(shreddedFields.keySet());
+    Set<String> names = Sets.newTreeSet(shreddedFields.keySet());
 
     if (unshredded != null) {
       Iterables.addAll(names, unshredded.fieldNames());

--- a/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
@@ -61,7 +61,7 @@ public class ShreddedObject implements VariantObject {
   }
 
   private Set<String> nameSet() {
-    Set<String> names = Sets.newTreeSet(shreddedFields.keySet());
+    Set<String> names = Sets.newHashSet(shreddedFields.keySet());
 
     if (unshredded != null) {
       Iterables.addAll(names, unshredded.fieldNames());

--- a/format/spec.md
+++ b/format/spec.md
@@ -268,7 +268,9 @@ The `initial-default` and `write-default` produce SQL default value behavior, wi
 
 All columns of `unknown`, `variant`, `geometry`, and `geography` types must default to null. Non-null values for `initial-default` or `write-default` are invalid.
 
-Default values for struct fields must be either null or non-null to avoid conflicts between the struct-level default for a field and a field-level default. Default values for struct fields are tracked at the field level.
+Default values for the fields of a struct are tracked as `initial-default` and `write-default` at the field level. Default values for fields that are nested structs must not contain default values for the struct's fields (sub-fields). Sub-field defaults are tracked in sub-field's metadata. As a result, the default stored for a nested struct may be either null or a non-null struct with no field values. The actual default value is produced by setting each field default in a new struct.
+
+For example, a column `point` with fields `x` (default 0) and `y` (default 0) can be defaulted to `{"x": 0, "y": 0}` or `null`. The values stored for `initial-default` and `write-default` may be either `null` or an empty struct (`{}`) that indicates a non-null struct with field values set from each field's `initial-default` or `write-default`, respectively.
 
 Default values are attributes of fields in schemas and serialized with fields in the JSON format. See [Appendix C](#appendix-c-json-serialization).
 
@@ -317,7 +319,7 @@ Struct evolution requires the following rules for default values:
 * The `write-default` must be set when a field is added and may change
 * When a required field is added, both defaults must be set to a non-null value
 * When an optional field is added, the defaults may be null and should be explicitly set
-* When a field that is a struct type is added, its default may only be null or non-null. Default values for fields must be stored in field metadata.
+* When a field that is a struct type is added, its default may only be null or a non-null struct with no field values. Default values for fields must be stored in field metadata.
 * If a field value is missing from a struct's `initial-default`, the field's `initial-default` must be used for the field
 * If a field value is missing from a struct's `write-default`, the field's `write-default` must be used for the field
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -272,6 +272,13 @@ Default values for the fields of a struct are tracked as `initial-default` and `
 
 For example, a struct column `point` with fields `x` (default 0) and `y` (default 0) can be defaulted to `{"x": 0, "y": 0}` or `null`. A non-null default is stored by setting `initial-default` or `write-default` to an empty struct (`{}`) that will use field values set from each field's `initial-default` or `write-default`, respectively.
 
+| `point` default | `point.x` default | `point.y` default | Data value   | Result value |
+|-----------------|-------------------|-------------------|--------------|--------------|
+| `null`          | `0`               | `0`               | (missing)    | `null` |
+| `null`          | `0`               | `0`               | `{"x": 3}`   | `{"x": 3, "y": 0}` |
+| `{}`            | `0`               | `0`               | (missing)    | `{"x": 0, "y": 0}` |
+| `{}`            | `0`               | `0`               | `{"y": -1}`  | `{"x": 0, "y": -1}` |
+
 Default values are attributes of fields in schemas and serialized with fields in the JSON format. See [Appendix C](#appendix-c-json-serialization).
 
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -268,9 +268,9 @@ The `initial-default` and `write-default` produce SQL default value behavior, wi
 
 All columns of `unknown`, `variant`, `geometry`, and `geography` types must default to null. Non-null values for `initial-default` or `write-default` are invalid.
 
-Default values for the fields of a struct are tracked as `initial-default` and `write-default` at the field level. Default values for fields that are nested structs must not contain default values for the struct's fields (sub-fields). Sub-field defaults are tracked in sub-field's metadata. As a result, the default stored for a nested struct may be either null or a non-null struct with no field values. The actual default value is produced by setting each field default in a new struct.
+Default values for the fields of a struct are tracked as `initial-default` and `write-default` at the field level. Default values for fields that are nested structs must not contain default values for the struct's fields (sub-fields). Sub-field defaults are tracked in sub-field's metadata. As a result, the default stored for a nested struct may be either null or a non-null struct with no field values. The actual default value is produced by setting each fields' default in a new struct.
 
-For example, a column `point` with fields `x` (default 0) and `y` (default 0) can be defaulted to `{"x": 0, "y": 0}` or `null`. The values stored for `initial-default` and `write-default` may be either `null` or an empty struct (`{}`) that indicates a non-null struct with field values set from each field's `initial-default` or `write-default`, respectively.
+For example, a struct column `point` with fields `x` (default 0) and `y` (default 0) can be defaulted to `{"x": 0, "y": 0}` or `null`. A non-null default is stored by setting `initial-default` or `write-default` to an empty struct (`{}`) that will use field values set from each field's `initial-default` or `write-default`, respectively.
 
 Default values are attributes of fields in schemas and serialized with fields in the JSON format. See [Appendix C](#appendix-c-json-serialization).
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -268,7 +268,7 @@ The `initial-default` and `write-default` produce SQL default value behavior, wi
 
 All columns of `unknown`, `variant`, `geometry`, and `geography` types must default to null. Non-null values for `initial-default` or `write-default` are invalid.
 
-Default values for the fields of a struct are tracked as `initial-default` and `write-default` at the field level. Default values for fields that are nested structs must not contain default values for the struct's fields (sub-fields). Sub-field defaults are tracked in sub-field's metadata. As a result, the default stored for a nested struct may be either null or a non-null struct with no field values. The actual default value is produced by setting each fields' default in a new struct.
+Default values for the fields of a struct are tracked as `initial-default` and `write-default` at the field level. Default values for fields that are nested structs must not contain default values for the struct's fields (sub-fields). Sub-field defaults are tracked in sub-field's metadata. As a result, the default stored for a nested struct may be either null or a non-null struct with no field values. The effective default value is produced by setting each fields' default in a new struct.
 
 For example, a struct column `point` with fields `x` (default 0) and `y` (default 0) can be defaulted to `{"x": 0, "y": 0}` or `null`. A non-null default is stored by setting `initial-default` or `write-default` to an empty struct (`{}`) that will use field values set from each field's `initial-default` or `write-default`, respectively.
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -266,7 +266,9 @@ The `initial-default` is set only when a field is added to an existing schema. T
 
 The `initial-default` and `write-default` produce SQL default value behavior, without rewriting data files. SQL default value behavior when a field is added handles all existing rows as though the rows were written with the new field's default value. Default value changes may only affect future records and all known fields are written into data files. Omitting a known field when writing a data file is never allowed. The write default for a field must be written if a field is not supplied to a write. If the write default for a required field is not set, the writer must fail.
 
-All columns of `unknown`, `geometry`, and `geography` types must default to null. Non-null values for `initial-default` or `write-default` are invalid.
+All columns of `unknown`, `variant`, `geometry`, and `geography` types must default to null. Non-null values for `initial-default` or `write-default` are invalid.
+
+Default values for struct fields must be either null or non-null to avoid conflicts between the struct-level default for a field and a field-level default. Default values for struct fields are tracked at the field level.
 
 Default values are attributes of fields in schemas and serialized with fields in the JSON format. See [Appendix C](#appendix-c-json-serialization).
 
@@ -315,7 +317,7 @@ Struct evolution requires the following rules for default values:
 * The `write-default` must be set when a field is added and may change
 * When a required field is added, both defaults must be set to a non-null value
 * When an optional field is added, the defaults may be null and should be explicitly set
-* When a new field is added to a struct with a default value, updating the struct's default is optional
+* When a field that is a struct type is added, its default may only be null or non-null. Default values for fields must be stored in field metadata.
 * If a field value is missing from a struct's `initial-default`, the field's `initial-default` must be used for the field
 * If a field value is missing from a struct's `write-default`, the field's `write-default` must be used for the field
 
@@ -1171,7 +1173,7 @@ Values should be stored in Avro using the Avro types and logical type annotation
 
 Optional fields, array elements, and map values must be wrapped in an Avro `union` with `null`. This is the only union type allowed in Iceberg data files.
 
-Optional fields must always set the Avro field default value to null.
+Optional fields without an Iceberg default must set the Avro field default value to null. Fields with a non-null Iceberg default must convert the default to an equivalent Avro default.
 
 Maps with non-string keys must use an array representation with the `map` logical type. The array representation or Avro’s map type may be used for maps with string keys.
 


### PR DESCRIPTION
This makes a slight change to the spec for v3 default values.

Previously, the spec allowed default values for struct fields in the struct default and in fields. For example, this was valid:

```sql
ALTER TABLE t ADD COLUMN point struct<x int NOT NULL DEFAULT 0, y int NOT NULL DEFAULT 0> DEFAULT struct(-1, -1)
```

This would result in a different write default depending on whether a field (default to 0) or the struct itself (default fields to -1) was missing. This behavior is difficult to implement correctly and unnecessary. It is also confusing what will happen when attempting to modify the struct's default, which should not change field defaults, and what will be used for a field's initial default.

The proposed change is to always track field defaults in the struct fields. This results in a uniform way to handle a struct: either produce null, or create a non-null default struct from field defaults. Effectively, this means that structs can default to null or non-null (`struct()`).

Also note that this change does not prevent us from allowing struct-level and field-level defaults in the future. It simply states that for v3, there can be no field defaults from the struct level. We can add them later if there is a use case that requires them.