### PR TITLE
Spark: Add 'skip_file_list' option to RewriteTablePathProcedure for optional file-list generation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
@@ -92,7 +92,7 @@ public interface RewriteTablePath extends Action<RewriteTablePath, RewriteTableP
    * @param skipFileList true to skip saving the file list, false to include it
    * @return this instance for method chaining
    */
-  default RewriteTablePath skipFileList(boolean skipFileList) {
+  default RewriteTablePath saveFileList(boolean skipFileList) {
     return this;
   }
 

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
@@ -86,6 +86,16 @@ public interface RewriteTablePath extends Action<RewriteTablePath, RewriteTableP
    */
   RewriteTablePath stagingLocation(String stagingLocation);
 
+  /**
+   * Whether to skip saving the file list location.
+   *
+   * @param skipFileList true to skip saving the file list, false to include it
+   * @return this instance for method chaining
+   */
+  default RewriteTablePath skipFileList(boolean skipFileList) {
+    return this;
+  }
+
   /** The action result that contains a summary of the execution. */
   interface Result {
     /** Staging location of rewritten files */
@@ -112,5 +122,15 @@ public interface RewriteTablePath extends Action<RewriteTablePath, RewriteTableP
 
     /** Name of latest metadata file version */
     String latestVersion();
+
+    /** count of rewrite delete files, default value is 0 */
+    default int deleteFilesCount() {
+      return 0;
+    }
+
+    /** count of rewrite metadata files involved, default value is 0 */
+    default int metadataFilesCount() {
+      return 0;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteTablePath.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteTablePath.java
@@ -29,5 +29,17 @@ import org.immutables.value.Value;
 interface BaseRewriteTablePath extends RewriteTablePath {
 
   @Value.Immutable
-  interface Result extends RewriteTablePath.Result {}
+  interface Result extends RewriteTablePath.Result {
+    @Override
+    @Value.Default
+    default int deleteFilesCount() {
+      return RewriteTablePath.Result.super.deleteFilesCount();
+    }
+
+    @Override
+    @Value.Default
+    default int metadataFilesCount() {
+      return RewriteTablePath.Result.super.metadataFilesCount();
+    }
+  }
 }

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteTablePathProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteTablePathProcedure.java
@@ -169,6 +169,23 @@ public class TestRewriteTablePathProcedure extends ExtensionsTestBase {
             "Cannot find provided version file %s in metadata log.", "v11.metadata.json");
   }
 
+  @TestTemplate
+  public void testRewriteTablePathWithSkipFileList() {
+    String location = targetTableDir.toFile().toURI().toString();
+    Table table = validationCatalog.loadTable(tableIdent);
+    String metadataJson = TableUtil.metadataFileLocation(table);
+
+    List<Object[]> result =
+        sql(
+            "CALL %s.system.rewrite_table_path(table => '%s', source_prefix => '%s', target_prefix => '%s', skip_file_list => true)",
+            catalogName, tableIdent, table.location(), location);
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0)[0])
+        .as("Should return correct latest version")
+        .isEqualTo(RewriteTablePathUtil.fileName(metadataJson));
+    assertThat(result.get(0)[1]).as("Should return empty").asString().isEqualTo("");
+  }
+
   private void checkFileListLocationCount(String fileListLocation, long expectedFileCount) {
     long fileCount = spark.read().format("text").load(fileListLocation).count();
     assertThat(fileCount).isEqualTo(expectedFileCount);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -150,7 +150,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   @Override
-  public RewriteTablePath skipFileList(boolean pSkipFileList) {
+  public RewriteTablePath saveFileList(boolean pSkipFileList) {
     this.skipFileList = pSkipFileList;
     return this;
   }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteTablePathProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteTablePathProcedure.java
@@ -118,7 +118,7 @@ public class RewriteTablePathProcedure extends BaseProcedure {
           if (stagingLocation != null) {
             action.stagingLocation(stagingLocation);
           }
-          action.skipFileList(skipFileList);
+          action.saveFileList(skipFileList);
 
           return toOutputRows(action.rewriteLocationPrefix(sourcePrefix, targetPrefix).execute());
         });

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteTablePathProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteTablePathProcedure.java
@@ -45,6 +45,8 @@ public class RewriteTablePathProcedure extends BaseProcedure {
       ProcedureParameter.optional("end_version", DataTypes.StringType);
   private static final ProcedureParameter STAGING_LOCATION_PARAM =
       ProcedureParameter.optional("staging_location", DataTypes.StringType);
+  private static final ProcedureParameter SKIP_FILE_LIST_PARAM =
+      ProcedureParameter.optional("skip_file_list", DataTypes.BooleanType);
 
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
@@ -53,14 +55,19 @@ public class RewriteTablePathProcedure extends BaseProcedure {
         TARGET_PREFIX_PARAM,
         START_VERSION_PARAM,
         END_VERSION_PARM,
-        STAGING_LOCATION_PARAM
+        STAGING_LOCATION_PARAM,
+        SKIP_FILE_LIST_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
       new StructType(
           new StructField[] {
             new StructField("latest_version", DataTypes.StringType, true, Metadata.empty()),
-            new StructField("file_list_location", DataTypes.StringType, true, Metadata.empty())
+            new StructField("file_list_location", DataTypes.StringType, true, Metadata.empty()),
+            new StructField(
+                "rewrite_metadata_files_count", DataTypes.IntegerType, true, Metadata.empty()),
+            new StructField(
+                "rewrite_delete_files_count", DataTypes.IntegerType, true, Metadata.empty())
           });
 
   public static SparkProcedures.ProcedureBuilder builder() {
@@ -95,6 +102,7 @@ public class RewriteTablePathProcedure extends BaseProcedure {
     String startVersion = input.asString(START_VERSION_PARAM, null);
     String endVersion = input.asString(END_VERSION_PARM, null);
     String stagingLocation = input.asString(STAGING_LOCATION_PARAM, null);
+    boolean skipFileList = input.asBoolean(SKIP_FILE_LIST_PARAM, false);
 
     return withIcebergTable(
         tableIdent,
@@ -110,6 +118,7 @@ public class RewriteTablePathProcedure extends BaseProcedure {
           if (stagingLocation != null) {
             action.stagingLocation(stagingLocation);
           }
+          action.skipFileList(skipFileList);
 
           return toOutputRows(action.rewriteLocationPrefix(sourcePrefix, targetPrefix).execute());
         });
@@ -119,7 +128,9 @@ public class RewriteTablePathProcedure extends BaseProcedure {
     return new InternalRow[] {
       newInternalRow(
           UTF8String.fromString(result.latestVersion()),
-          UTF8String.fromString(result.fileListLocation()))
+          UTF8String.fromString(result.fileListLocation()),
+          result.metadataFilesCount(),
+          result.deleteFilesCount())
     };
   }
 


### PR DESCRIPTION
This is a minor feature improvement. The background is that we are using `RewriteTablePathProcedure` to convert Hive tables to Iceberg tables, as detailed in #12762. `RewriteTablePathProcedure` generates a `file-list` file, and I need to manually clean up this file after each conversion. I understand that the `file-list` is mainly used to check data integrity, but since it is not essential for metadata, I believe allowing users to decide whether to generate this file would offer greater flexibility.