### PR TITLE
Spark3.4: Migrate tests in spark, extensions and functions

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -96,9 +96,6 @@ public final class TaskCheckHelper {
     assertThat(actual.splitOffsets())
         .as("Should match the serialized record offsets")
         .isEqualTo(expected.splitOffsets());
-    assertThat(actual.keyMetadata())
-        .as("Should match the serialized record offsets")
-        .isEqualTo(expected.keyMetadata());
   }
 
   private static List<FileScanTask> getFileScanTasksInFilePathOrder(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -18,10 +18,11 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Assert;
 
 public final class TaskCheckHelper {
   private TaskCheckHelper() {}
@@ -31,8 +32,9 @@ public final class TaskCheckHelper {
     List<FileScanTask> expectedTasks = getFileScanTasksInFilePathOrder(expected);
     List<FileScanTask> actualTasks = getFileScanTasksInFilePathOrder(actual);
 
-    Assert.assertEquals(
-        "The number of file scan tasks should match", expectedTasks.size(), actualTasks.size());
+    assertThat(actualTasks)
+        .as("The number of file scan tasks should match")
+        .hasSameSizeAs(expectedTasks);
 
     for (int i = 0; i < expectedTasks.size(); i++) {
       FileScanTask expectedTask = expectedTasks.get(i);
@@ -45,61 +47,58 @@ public final class TaskCheckHelper {
     assertEquals(expected.file(), actual.file());
 
     // PartitionSpec implements its own equals method
-    Assert.assertEquals("PartitionSpec doesn't match", expected.spec(), actual.spec());
+    assertThat(actual.spec()).as("PartitionSpec doesn't match").isEqualTo(expected.spec());
 
-    Assert.assertEquals("starting position doesn't match", expected.start(), actual.start());
+    assertThat(actual.start()).as("starting position doesn't match").isEqualTo(expected.start());
 
-    Assert.assertEquals(
-        "the number of bytes to scan doesn't match", expected.start(), actual.start());
+    assertThat(actual.start())
+        .as("the number of bytes to scan doesn't match")
+        .isEqualTo(expected.start());
 
     // simplify comparison on residual expression via comparing toString
-    Assert.assertEquals(
-        "Residual expression doesn't match",
-        expected.residual().toString(),
-        actual.residual().toString());
+    assertThat(actual.residual())
+        .asString()
+        .as("Residual expression doesn't match")
+        .isEqualTo(expected.residual().toString());
   }
 
   public static void assertEquals(DataFile expected, DataFile actual) {
-    Assert.assertEquals(
-        "Should match the serialized record path", expected.location(), actual.location());
-    Assert.assertEquals(
-        "Should match the serialized record format", expected.format(), actual.format());
-    Assert.assertEquals(
-        "Should match the serialized record partition",
-        expected.partition().get(0, Object.class),
-        actual.partition().get(0, Object.class));
-    Assert.assertEquals(
-        "Should match the serialized record count", expected.recordCount(), actual.recordCount());
-    Assert.assertEquals(
-        "Should match the serialized record size",
-        expected.fileSizeInBytes(),
-        actual.fileSizeInBytes());
-    Assert.assertEquals(
-        "Should match the serialized record value counts",
-        expected.valueCounts(),
-        actual.valueCounts());
-    Assert.assertEquals(
-        "Should match the serialized record null value counts",
-        expected.nullValueCounts(),
-        actual.nullValueCounts());
-    Assert.assertEquals(
-        "Should match the serialized record lower bounds",
-        expected.lowerBounds(),
-        actual.lowerBounds());
-    Assert.assertEquals(
-        "Should match the serialized record upper bounds",
-        expected.upperBounds(),
-        actual.upperBounds());
-    Assert.assertEquals(
-        "Should match the serialized record key metadata",
-        expected.keyMetadata(),
-        actual.keyMetadata());
-    Assert.assertEquals(
-        "Should match the serialized record offsets",
-        expected.splitOffsets(),
-        actual.splitOffsets());
-    Assert.assertEquals(
-        "Should match the serialized record offsets", expected.keyMetadata(), actual.keyMetadata());
+    assertThat(actual.location())
+        .as("Should match the serialized record path")
+        .isEqualTo(expected.location());
+    assertThat(actual.format())
+        .as("Should match the serialized record format")
+        .isEqualTo(expected.format());
+    assertThat(actual.partition().get(0, Object.class))
+        .as("Should match the serialized record partition")
+        .isEqualTo(expected.partition().get(0, Object.class));
+    assertThat(actual.recordCount())
+        .as("Should match the serialized record count")
+        .isEqualTo(expected.recordCount());
+    assertThat(actual.fileSizeInBytes())
+        .as("Should match the serialized record size")
+        .isEqualTo(expected.fileSizeInBytes());
+    assertThat(actual.valueCounts())
+        .as("Should match the serialized record value counts")
+        .isEqualTo(expected.valueCounts());
+    assertThat(actual.nullValueCounts())
+        .as("Should match the serialized record null value counts")
+        .isEqualTo(expected.nullValueCounts());
+    assertThat(actual.lowerBounds())
+        .as("Should match the serialized record lower bounds")
+        .isEqualTo(expected.lowerBounds());
+    assertThat(actual.upperBounds())
+        .as("Should match the serialized record upper bounds")
+        .isEqualTo(expected.upperBounds());
+    assertThat(actual.keyMetadata())
+        .as("Should match the serialized record key metadata")
+        .isEqualTo(expected.keyMetadata());
+    assertThat(actual.splitOffsets())
+        .as("Should match the serialized record offsets")
+        .isEqualTo(expected.splitOffsets());
+    assertThat(actual.keyMetadata())
+        .as("Should match the serialized record offsets")
+        .isEqualTo(expected.keyMetadata());
   }
 
   private static List<FileScanTask> getFileScanTasksInFilePathOrder(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -20,9 +20,12 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopFileIO;
@@ -32,11 +35,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestFileIOSerialization {
 
@@ -60,15 +61,15 @@ public class TestFileIOSerialization {
     CONF.set("k2", "v2");
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
   private Table table;
 
-  @Before
+  @BeforeEach
   public void initTable() throws IOException {
     Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
 
-    File tableLocation = temp.newFolder();
-    Assert.assertTrue(tableLocation.delete());
+    File tableLocation = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableLocation.delete()).isTrue();
 
     this.table = TABLES.create(SCHEMA, SPEC, SORT_ORDER, props, tableLocation.toString());
   }
@@ -82,9 +83,7 @@ public class TestFileIOSerialization {
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 
-    Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
-    Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));
-    Assert.assertEquals("Conf values must be present", "v2", actualConf.get("k2"));
+    assertThat(actualConf).containsExactlyInAnyOrderElementsOf(expectedConf);
   }
 
   @Test
@@ -96,9 +95,7 @@ public class TestFileIOSerialization {
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 
-    Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
-    Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));
-    Assert.assertEquals("Conf values must be present", "v2", actualConf.get("k2"));
+    assertThat(actualConf).containsExactlyInAnyOrderElementsOf(expectedConf);
   }
 
   private Map<String, String> toMap(Configuration conf) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.hadoop.HadoopMetricsContext;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestHadoopMetricsContextSerialization {
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
@@ -201,7 +201,6 @@ public class TestManifestFileSerialization {
   private ManifestFile writeManifest(DataFile... files) throws IOException {
     File manifestFile = File.createTempFile("input.m0", ".avro", temp.toFile());
     assertThat(manifestFile.delete()).isTrue();
-    ;
     OutputFile outputFile = FILE_IO.newOutputFile(manifestFile.getCanonicalPath());
 
     ManifestWriter<DataFile> writer = ManifestFiles.write(SPEC, outputFile);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
@@ -35,6 +35,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.file.Path;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.ManifestFile.PartitionFieldSummary;
 import org.apache.iceberg.hadoop.HadoopFileIO;
@@ -44,10 +45,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestManifestFileSerialization {
 
@@ -99,12 +98,12 @@ public class TestManifestFileSerialization {
 
   private static final FileIO FILE_IO = new HadoopFileIO(new Configuration());
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   @Test
   public void testManifestFileKryoSerialization() throws IOException {
-    File data = temp.newFile();
-    Assert.assertTrue(data.delete());
+    File data = File.createTempFile("junit", null, temp.toFile());
+    assertThat(data.delete()).isTrue();
 
     Kryo kryo = new KryoSerializer(new SparkConf()).newKryo();
 
@@ -148,55 +147,61 @@ public class TestManifestFileSerialization {
   }
 
   private void checkManifestFile(ManifestFile expected, ManifestFile actual) {
-    Assert.assertEquals("Path must match", expected.path(), actual.path());
-    Assert.assertEquals("Length must match", expected.length(), actual.length());
-    Assert.assertEquals("Spec id must match", expected.partitionSpecId(), actual.partitionSpecId());
-    Assert.assertEquals("Snapshot id must match", expected.snapshotId(), actual.snapshotId());
-    Assert.assertEquals(
-        "Added files flag must match", expected.hasAddedFiles(), actual.hasAddedFiles());
-    Assert.assertEquals(
-        "Added files count must match", expected.addedFilesCount(), actual.addedFilesCount());
-    Assert.assertEquals(
-        "Added rows count must match", expected.addedRowsCount(), actual.addedRowsCount());
-    Assert.assertEquals(
-        "Existing files flag must match", expected.hasExistingFiles(), actual.hasExistingFiles());
-    Assert.assertEquals(
-        "Existing files count must match",
-        expected.existingFilesCount(),
-        actual.existingFilesCount());
-    Assert.assertEquals(
-        "Existing rows count must match", expected.existingRowsCount(), actual.existingRowsCount());
-    Assert.assertEquals(
-        "Deleted files flag must match", expected.hasDeletedFiles(), actual.hasDeletedFiles());
-    Assert.assertEquals(
-        "Deleted files count must match", expected.deletedFilesCount(), actual.deletedFilesCount());
-    Assert.assertEquals(
-        "Deleted rows count must match", expected.deletedRowsCount(), actual.deletedRowsCount());
+    assertThat(actual.path()).as("Path must match").isEqualTo(expected.path());
+    assertThat(actual.length()).as("Length must match").isEqualTo(expected.length());
+    assertThat(actual.partitionSpecId())
+        .as("Spec id must match")
+        .isEqualTo(expected.partitionSpecId());
+    assertThat(actual.snapshotId()).as("Snapshot id must match").isEqualTo(expected.snapshotId());
+    assertThat(actual.hasAddedFiles())
+        .as("Added files flag must match")
+        .isEqualTo(expected.hasAddedFiles());
+    assertThat(actual.addedFilesCount())
+        .as("Added files count must match")
+        .isEqualTo(expected.addedFilesCount());
+    assertThat(actual.addedRowsCount())
+        .as("Added rows count must match")
+        .isEqualTo(expected.addedRowsCount());
+    assertThat(actual.hasExistingFiles())
+        .as("Existing files flag must match")
+        .isEqualTo(expected.hasExistingFiles());
+    assertThat(actual.existingFilesCount())
+        .as("Existing files count must match")
+        .isEqualTo(expected.existingFilesCount());
+    assertThat(actual.existingRowsCount())
+        .as("Existing rows count must match")
+        .isEqualTo(expected.existingRowsCount());
+    assertThat(actual.hasDeletedFiles())
+        .as("Deleted files flag must match")
+        .isEqualTo(expected.hasDeletedFiles());
+    assertThat(actual.deletedFilesCount())
+        .as("Deleted files count must match")
+        .isEqualTo(expected.deletedFilesCount());
+    assertThat(actual.deletedRowsCount())
+        .as("Deleted rows count must match")
+        .isEqualTo(expected.deletedRowsCount());
 
     PartitionFieldSummary expectedPartition = expected.partitions().get(0);
     PartitionFieldSummary actualPartition = actual.partitions().get(0);
 
-    Assert.assertEquals(
-        "Null flag in partition must match",
-        expectedPartition.containsNull(),
-        actualPartition.containsNull());
-    Assert.assertEquals(
-        "NaN flag in partition must match",
-        expectedPartition.containsNaN(),
-        actualPartition.containsNaN());
-    Assert.assertEquals(
-        "Lower bounds in partition must match",
-        expectedPartition.lowerBound(),
-        actualPartition.lowerBound());
-    Assert.assertEquals(
-        "Upper bounds in partition must match",
-        expectedPartition.upperBound(),
-        actualPartition.upperBound());
+    assertThat(actualPartition.containsNull())
+        .as("Null flag in partition must match")
+        .isEqualTo(expectedPartition.containsNull());
+    assertThat(actualPartition.containsNaN())
+        .as("NaN flag in partition must match")
+        .isEqualTo(expectedPartition.containsNaN());
+    assertThat(actualPartition.lowerBound())
+        .as("Lower bounds in partition must match")
+        .isEqualTo(expectedPartition.lowerBound());
+    assertThat(actualPartition.upperBound())
+        .as("Upper bounds in partition must match")
+        .isEqualTo(expectedPartition.upperBound());
   }
 
   private ManifestFile writeManifest(DataFile... files) throws IOException {
-    File manifestFile = temp.newFile("input.m0.avro");
-    Assert.assertTrue(manifestFile.delete());
+    File manifestFile = File.createTempFile("input.m0", ".avro", temp.toFile());
+    assertThat(manifestFile.delete()).isTrue();
+    ;
     OutputFile outputFile = FILE_IO.newOutputFile(manifestFile.getCanonicalPath());
 
     ManifestWriter<DataFile> writer = ManifestFiles.write(SPEC, outputFile);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -32,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -40,20 +41,18 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestScanTaskSerialization extends SparkTestBase {
+public class TestScanTaskSerialization extends TestBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
@@ -62,13 +61,13 @@ public class TestScanTaskSerialization extends SparkTestBase {
           optional(2, "c2", Types.StringType.get()),
           optional(3, "c3", Types.StringType.get()));
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
+  @TempDir private File tableDir;
 
   private String tableLocation = null;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
     this.tableLocation = tableDir.toURI().toString();
   }
 
@@ -76,8 +75,8 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseCombinedScanTaskKryoSerialization() throws Exception {
     BaseCombinedScanTask scanTask = prepareBaseCombinedScanTaskForSerDeTest();
 
-    File data = temp.newFile();
-    Assert.assertTrue(data.delete());
+    File data = File.createTempFile("junit", null, temp.toFile());
+    assertThat(data.delete()).isTrue();
     Kryo kryo = new KryoSerializer(new SparkConf()).newKryo();
 
     try (Output out = new Output(new FileOutputStream(data))) {
@@ -117,10 +116,10 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupKryoSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertFalse("Task group can't be empty", taskGroup.tasks().isEmpty());
+    assertThat(taskGroup.tasks()).as("Task group can't be empty").isNotEmpty();
 
-    File data = temp.newFile();
-    Assert.assertTrue(data.delete());
+    File data = File.createTempFile("junit", null, temp.toFile());
+    assertThat(data.delete()).isTrue();
     Kryo kryo = new KryoSerializer(new SparkConf()).newKryo();
 
     try (Output out = new Output(Files.newOutputStream(data.toPath()))) {
@@ -139,7 +138,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupJavaSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertFalse("Task group can't be empty", taskGroup.tasks().isEmpty());
+    assertThat(taskGroup.tasks()).as("Task group can't be empty").isNotEmpty();
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -28,6 +29,9 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
@@ -36,29 +40,22 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestTableSerialization {
 
-  public TestTableSerialization(String isObjectStoreEnabled) {
-    this.isObjectStoreEnabled = isObjectStoreEnabled;
-  }
-
-  @Parameterized.Parameters(name = "isObjectStoreEnabled = {0}")
-  public static Object[] parameters() {
-    return new Object[] {"true", "false"};
+  @Parameters(name = "isObjectStoreEnabled = {0}")
+  public static List<String> parameters() {
+    return Arrays.asList("true", "false");
   }
 
   private static final HadoopTables TABLES = new HadoopTables();
 
-  private final String isObjectStoreEnabled;
+  @Parameter private String isObjectStoreEnabled;
 
   private static final Schema SCHEMA =
       new Schema(
@@ -72,21 +69,21 @@ public class TestTableSerialization {
 
   private static final SortOrder SORT_ORDER = SortOrder.builderFor(SCHEMA).asc("id").build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
   private Table table;
 
-  @Before
+  @BeforeEach
   public void initTable() throws IOException {
     Map<String, String> props =
         ImmutableMap.of("k1", "v1", TableProperties.OBJECT_STORE_ENABLED, isObjectStoreEnabled);
 
-    File tableLocation = temp.newFolder();
-    Assert.assertTrue(tableLocation.delete());
+    File tableLocation = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableLocation.delete()).isTrue();
 
     this.table = TABLES.create(SCHEMA, SPEC, SORT_ORDER, props, tableLocation.toString());
   }
 
-  @Test
+  @TestTemplate
   public void testCloseSerializableTableKryoSerialization() throws Exception {
     for (Table tbl : tables()) {
       Table spyTable = spy(tbl);
@@ -107,7 +104,7 @@ public class TestTableSerialization {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testCloseSerializableTableJavaSerialization() throws Exception {
     for (Table tbl : tables()) {
       Table spyTable = spy(tbl);
@@ -128,14 +125,14 @@ public class TestTableSerialization {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testSerializableTableKryoSerialization() throws IOException {
     Table serializableTable = SerializableTableWithSize.copyOf(table);
     TestHelpers.assertSerializedAndLoadedMetadata(
         table, KryoHelpers.roundTripSerialize(serializableTable));
   }
 
-  @Test
+  @TestTemplate
   public void testSerializableMetadataTableKryoSerialization() throws IOException {
     for (MetadataTableType type : MetadataTableType.values()) {
       TableOperations ops = ((HasTableOperations) table).operations();
@@ -148,7 +145,7 @@ public class TestTableSerialization {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testSerializableTransactionTableKryoSerialization() throws IOException {
     Transaction txn = table.newTransaction();
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
@@ -175,7 +175,6 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
                       blobMetadata -> {
                         assertThat(blobMetadata.properties())
                             .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
-                        ;
                       });
             });
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
@@ -27,10 +27,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import org.apache.iceberg.BlobMetadata;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StatisticsFile;
@@ -41,8 +40,8 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.Spark3Util;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.data.RandomData;
@@ -56,10 +55,12 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.types.StructType;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestComputeTableStatsAction extends SparkCatalogTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestComputeTableStatsAction extends CatalogTestBase {
 
   private static final Types.StructType LEAF_STRUCT_TYPE =
       Types.StructType.of(
@@ -77,12 +78,12 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
           required(4, "nestedStructCol", NESTED_STRUCT_TYPE),
           required(5, "stringCol", Types.StringType.get()));
 
-  public TestComputeTableStatsAction(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
+  @AfterEach
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testLoadingTableDirectly() {
     sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
     sql("INSERT into %s values(1, 'abcd')", tableName);
@@ -92,11 +93,11 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
     SparkActions actions = SparkActions.get();
     ComputeTableStats.Result results = actions.computeTableStats(table).execute();
     StatisticsFile statisticsFile = results.statisticsFile();
-    assertThat(statisticsFile.fileSizeInBytes()).isNotEqualTo(0);
-    assertThat(statisticsFile.blobMetadata().size()).isEqualTo(2);
+    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+    assertThat(statisticsFile.blobMetadata()).hasSize(2);
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsAction() throws NoSuchTableException, ParseException {
     sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
@@ -122,18 +123,23 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
     assertThat(results).isNotNull();
 
     List<StatisticsFile> statisticsFiles = table.statisticsFiles();
-    assertThat(statisticsFiles.size()).isEqualTo(1);
-
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isNotEqualTo(0);
-    assertThat(statisticsFile.blobMetadata().size()).isEqualTo(2);
-
-    BlobMetadata blobMetadata = statisticsFile.blobMetadata().get(0);
-    assertThat(blobMetadata.properties().get(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY))
-        .isEqualTo(String.valueOf(4));
+    assertThat(statisticsFiles)
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .hasSize(2)
+                  .element(0)
+                  .satisfies(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+                      });
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsActionWithoutExplicitColumns()
       throws NoSuchTableException, ParseException {
     sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
@@ -154,29 +160,27 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
     ComputeTableStats.Result results = actions.computeTableStats(table).execute();
     assertThat(results).isNotNull();
 
-    assertThat(table.statisticsFiles().size()).isEqualTo(1);
-    StatisticsFile statisticsFile = table.statisticsFiles().get(0);
-    assertThat(statisticsFile.blobMetadata().size()).isEqualTo(2);
-    assertThat(statisticsFile.fileSizeInBytes()).isNotEqualTo(0);
-    assertThat(
-            Long.parseLong(
-                statisticsFile
-                    .blobMetadata()
-                    .get(0)
-                    .properties()
-                    .get(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY)))
-        .isEqualTo(4);
-    assertThat(
-            Long.parseLong(
-                statisticsFile
-                    .blobMetadata()
-                    .get(1)
-                    .properties()
-                    .get(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY)))
-        .isEqualTo(4);
+    assertThat(table.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .hasSize(2)
+                  .satisfiesExactly(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+                      },
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+                        ;
+                      });
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsForInvalidColumns() throws NoSuchTableException, ParseException {
     sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
     // Append data to create snapshot
@@ -188,7 +192,7 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
         .hasMessageContaining("Can't find column id1 in table");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsWithNoSnapshots() throws NoSuchTableException, ParseException {
     sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
@@ -197,7 +201,7 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
     assertThat(result.statisticsFile()).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsWithNullValues() throws NoSuchTableException, ParseException {
     sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
     List<SimpleRecord> records =
@@ -217,19 +221,22 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
     ComputeTableStats.Result results = actions.computeTableStats(table).columns("data").execute();
     assertThat(results).isNotNull();
 
-    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
-    assertThat(statisticsFiles.size()).isEqualTo(1);
-
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isNotEqualTo(0);
-    assertThat(statisticsFile.blobMetadata().size()).isEqualTo(1);
-
-    BlobMetadata blobMetadata = statisticsFile.blobMetadata().get(0);
-    assertThat(blobMetadata.properties().get(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY))
-        .isEqualTo(String.valueOf(4));
+    assertThat(table.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .singleElement()
+                  .satisfies(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+                      });
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsWithSnapshotHavingDifferentSchemas()
       throws NoSuchTableException, ParseException {
     SparkActions actions = SparkActions.get();
@@ -260,7 +267,7 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
         .hasMessageContaining("Can't find column data in table");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsWhenSnapshotIdNotSpecified()
       throws NoSuchTableException, ParseException {
     sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
@@ -272,19 +279,22 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
 
     assertThat(results).isNotNull();
 
-    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
-    assertThat(statisticsFiles.size()).isEqualTo(1);
-
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isNotEqualTo(0);
-    assertThat(statisticsFile.blobMetadata().size()).isEqualTo(1);
-
-    BlobMetadata blobMetadata = statisticsFile.blobMetadata().get(0);
-    assertThat(blobMetadata.properties().get(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY))
-        .isEqualTo(String.valueOf(1));
+    assertThat(table.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .singleElement()
+                  .satisfies(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "1");
+                      });
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsWithNestedSchema()
       throws NoSuchTableException, ParseException, IOException {
     List<Record> records = Lists.newArrayList(createNestedRecord());
@@ -294,8 +304,7 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
             SCHEMA_WITH_NESTED_COLUMN,
             PartitionSpec.unpartitioned(),
             ImmutableMap.of());
-    DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
     table.newAppend().appendFile(dataFile).commit();
 
     Table tbl = Spark3Util.loadIcebergTable(spark, tableName);
@@ -303,21 +312,22 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
     actions.computeTableStats(tbl).execute();
 
     tbl.refresh();
-    List<StatisticsFile> statisticsFiles = tbl.statisticsFiles();
-    assertThat(statisticsFiles.size()).isEqualTo(1);
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isNotEqualTo(0);
-    assertThat(statisticsFile.blobMetadata().size()).isEqualTo(1);
+    assertThat(tbl.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata()).hasSize(1);
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsWithNoComputableColumns() throws IOException {
     List<Record> records = Lists.newArrayList(createNestedRecord());
     Table table =
         validationCatalog.createTable(
             tableIdent, NESTED_SCHEMA, PartitionSpec.unpartitioned(), ImmutableMap.of());
-    DataFile dataFile =
-        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
     table.newAppend().appendFile(dataFile).commit();
 
     table.refresh();
@@ -327,48 +337,48 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
         .hasMessageContaining("No columns found to compute stats");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnByteColumn() throws NoSuchTableException, ParseException {
     testComputeTableStats("byte_col", "TINYINT");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnShortColumn() throws NoSuchTableException, ParseException {
     testComputeTableStats("short_col", "SMALLINT");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnIntColumn() throws NoSuchTableException, ParseException {
     testComputeTableStats("int_col", "INT");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnLongColumn() throws NoSuchTableException, ParseException {
     testComputeTableStats("long_col", "BIGINT");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnTimestampColumn() throws NoSuchTableException, ParseException {
     testComputeTableStats("timestamp_col", "TIMESTAMP");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnTimestampNtzColumn()
       throws NoSuchTableException, ParseException {
     testComputeTableStats("timestamp_col", "TIMESTAMP_NTZ");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnDateColumn() throws NoSuchTableException, ParseException {
     testComputeTableStats("date_col", "DATE");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnDecimalColumn() throws NoSuchTableException, ParseException {
     testComputeTableStats("decimal_col", "DECIMAL(20, 2)");
   }
 
-  @Test
+  @TestTemplate
   public void testComputeTableStatsOnBinaryColumn() throws NoSuchTableException, ParseException {
     testComputeTableStats("binary_col", "BINARY");
   }
@@ -387,16 +397,19 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
         actions.computeTableStats(table).columns(columnName).execute();
     assertThat(results).isNotNull();
 
-    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
-    assertThat(statisticsFiles.size()).isEqualTo(1);
-
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isNotEqualTo(0);
-    assertThat(statisticsFile.blobMetadata().size()).isEqualTo(1);
-
-    BlobMetadata blobMetadata = statisticsFile.blobMetadata().get(0);
-    assertThat(blobMetadata.properties().get(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY))
-        .isNotNull();
+    assertThat(table.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .singleElement()
+                  .satisfies(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsKey(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY);
+                      });
+            });
   }
 
   private GenericRecord createNestedRecord() {
@@ -421,10 +434,5 @@ public class TestComputeTableStatsAction extends SparkCatalogTestBase {
   private void append(String table, Dataset<Row> df) throws NoSuchTableException {
     // fanout writes are enabled as write-time clustering is not supported without Spark extensions
     df.coalesce(1).writeTo(table).option(SparkWriteOptions.FANOUT_ENABLED, "true").append();
-  }
-
-  @After
-  public void removeTable() {
-    sql("DROP TABLE IF EXISTS %s", tableName);
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -534,11 +534,7 @@ public class TestCreateActions extends CatalogTestBase {
     expectedProps.putAll(props);
     expectedProps.put("dogs", "sundance");
 
-    for (Map.Entry<String, String> entry : expectedProps.entrySet()) {
-      assertThat(table.properties())
-          .as("Property value is not the expected value")
-          .containsEntry(entry.getKey(), entry.getValue());
-    }
+    assertThat(table.properties()).containsAllEntriesOf(expectedProps);
   }
 
   @TestTemplate
@@ -556,11 +552,9 @@ public class TestCreateActions extends CatalogTestBase {
 
     String[] keys = {"provider", "format", "current-snapshot-id", "location", "sort-order"};
 
-    for (String entry : keys) {
-      assertThat(table.properties())
-          .as("Created table missing reserved property " + entry)
-          .containsKey(entry);
-    }
+    assertThat(table.properties())
+        .as("Created table missing reserved properties")
+        .containsKeys(keys);
 
     assertThat(table.properties())
         .containsEntry("provider", "iceberg")

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -18,10 +18,14 @@
  */
 package org.apache.iceberg.spark.actions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,6 +35,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -40,9 +47,9 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalog;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.iceberg.spark.source.SparkTable;
@@ -68,20 +75,18 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import scala.Option;
 import scala.Some;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
-public class TestCreateActions extends SparkCatalogTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestCreateActions extends CatalogTestBase {
   private static final String CREATE_PARTITIONED_PARQUET =
       "CREATE TABLE %s (id INT, data STRING) " + "using parquet PARTITIONED BY (id) LOCATION '%s'";
   private static final String CREATE_PARQUET =
@@ -94,70 +99,72 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
   private static final String NAMESPACE = "default";
 
-  @Parameterized.Parameters(name = "Catalog Name {0} - Options {2}")
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, type = {3}")
   public static Object[][] parameters() {
     return new Object[][] {
       new Object[] {
         "spark_catalog",
         SparkSessionCatalog.class.getName(),
         ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default",
-            "parquet-enabled", "true",
+            "type",
+            "hive",
+            "default-namespace",
+            "default",
+            "parquet-enabled",
+            "true",
             "cache-enabled",
-                "false" // Spark will delete tables using v1, leaving the cache out of sync
-            )
+            "false" // Spark will delete tables using v1, leaving the cache out of sync
+            ),
+        "hive"
       },
       new Object[] {
         "spark_catalog",
         SparkSessionCatalog.class.getName(),
         ImmutableMap.of(
-            "type", "hadoop",
-            "default-namespace", "default",
-            "parquet-enabled", "true",
+            "type",
+            "hadoop",
+            "default-namespace",
+            "default",
+            "parquet-enabled",
+            "true",
             "cache-enabled",
-                "false" // Spark will delete tables using v1, leaving the cache out of sync
-            )
+            "false" // Spark will delete tables using v1, leaving the cache out of sync
+            ),
+        "hadoop"
       },
       new Object[] {
         "testhive",
         SparkCatalog.class.getName(),
         ImmutableMap.of(
             "type", "hive",
-            "default-namespace", "default")
+            "default-namespace", "default"),
+        "hive"
       },
       new Object[] {
         "testhadoop",
         SparkCatalog.class.getName(),
         ImmutableMap.of(
             "type", "hadoop",
-            "default-namespace", "default")
+            "default-namespace", "default"),
+        "hadoop"
       }
     };
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
-
   private final String baseTableName = "baseTable";
-  private File tableDir;
+  @TempDir private File tableDir;
   private String tableLocation;
-  private final String type;
-  private final TableCatalog catalog;
 
-  public TestCreateActions(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-    this.catalog = (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
-    this.type = config.get("type");
-  }
+  @Parameter(index = 3)
+  private String type;
 
-  @Before
+  private TableCatalog catalog;
+
+  @BeforeEach
   public void before() {
-    try {
-      this.tableDir = temp.newFolder();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    super.before();
     this.tableLocation = tableDir.toURI().toString();
+    this.catalog = (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
 
     spark.conf().set("hive.exec.dynamic.partition", "true");
     spark.conf().set("hive.exec.dynamic.partition.mode", "nonstrict");
@@ -179,7 +186,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
         .saveAsTable(baseTableName);
   }
 
-  @After
+  @AfterEach
   public void after() throws IOException {
     // Drop the hive table.
     spark.sql(String.format("DROP TABLE IF EXISTS %s", baseTableName));
@@ -190,25 +197,27 @@ public class TestCreateActions extends SparkCatalogTestBase {
     spark.conf().unset("spark.sql.catalog.spark_catalog.cache-enabled");
   }
 
-  @Test
+  @TestTemplate
   public void testMigratePartitioned() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_migrate_partitioned_table");
     String dest = source;
     createSourceTable(CREATE_PARTITIONED_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTableWithUnRecoveredPartitions() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_unrecovered_partitions");
     String dest = source;
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(CREATE_PARTITIONED_PARQUET, source, location);
 
     // Data generation and partition addition
@@ -224,15 +233,16 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedTableWithCustomPartitions() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_custom_parts");
     String dest = source;
-    File tblLocation = temp.newFolder();
-    File partitionDataLoc = temp.newFolder();
+    File tblLocation = Files.createTempDirectory(temp, "junit").toFile();
+    File partitionDataLoc = Files.createTempDirectory(temp, "junit").toFile();
 
     // Data generation and partition addition
     spark.sql(String.format(CREATE_PARTITIONED_PARQUET, source, tblLocation));
@@ -248,11 +258,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testAddColumnOnMigratedTableAtEnd() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_add_column_migrated_table");
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
@@ -269,30 +280,31 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String newCol1 = "newCol1";
     sparkTable.table().updateSchema().addColumn(newCol1, Types.IntegerType.get()).commit();
     Schema afterSchema = table.schema();
-    Assert.assertNull(beforeSchema.findField(newCol1));
-    Assert.assertNotNull(afterSchema.findField(newCol1));
+    assertThat(beforeSchema.findField(newCol1)).isNull();
+    assertThat(afterSchema.findField(newCol1)).isNotNull();
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results1.isEmpty());
+    assertThat(results1).isNotEmpty();
     assertEquals("Output must match", results1, expected1);
 
     String newCol2 = "newCol2";
     sql("ALTER TABLE %s ADD COLUMN %s INT", dest, newCol2);
     StructType schema = spark.table(dest).schema();
-    Assert.assertTrue(Arrays.asList(schema.fieldNames()).contains(newCol2));
+    assertThat(schema.fieldNames()).contains(newCol2);
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results2.isEmpty());
+    assertThat(results2).isNotEmpty();
     assertEquals("Output must match", results2, expected2);
   }
 
-  @Test
+  @TestTemplate
   public void testAddColumnOnMigratedTableAtMiddle() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_add_column_migrated_table_middle");
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
@@ -313,26 +325,26 @@ public class TestCreateActions extends SparkCatalogTestBase {
         .moveAfter(newCol1, "id")
         .commit();
     Schema afterSchema = table.schema();
-    Assert.assertNull(beforeSchema.findField(newCol1));
-    Assert.assertNotNull(afterSchema.findField(newCol1));
+    assertThat(beforeSchema.findField(newCol1)).isNull();
+    assertThat(afterSchema.findField(newCol1)).isNotNull();
 
     // reads should succeed
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", results, expected);
   }
 
-  @Test
+  @TestTemplate
   public void removeColumnsAtEnd() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_remove_column_migrated_table");
     String dest = source;
 
     String colName1 = "newCol1";
     String colName2 = "newCol2";
-    File location = temp.newFolder();
     spark
         .range(10)
         .selectExpr("cast(id as INT)", "CAST(id as INT) " + colName1, "CAST(id as INT) " + colName2)
@@ -351,29 +363,30 @@ public class TestCreateActions extends SparkCatalogTestBase {
     Schema beforeSchema = table.schema();
     sparkTable.table().updateSchema().deleteColumn(colName1).commit();
     Schema afterSchema = table.schema();
-    Assert.assertNotNull(beforeSchema.findField(colName1));
-    Assert.assertNull(afterSchema.findField(colName1));
+    assertThat(beforeSchema.findField(colName1)).isNotNull();
+    assertThat(afterSchema.findField(colName1)).isNull();
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results1.isEmpty());
+    assertThat(results1).isNotEmpty();
     assertEquals("Output must match", expected1, results1);
 
     sql("ALTER TABLE %s DROP COLUMN %s", dest, colName2);
     StructType schema = spark.table(dest).schema();
-    Assert.assertFalse(Arrays.asList(schema.fieldNames()).contains(colName2));
+    assertThat(schema.fieldNames()).doesNotContain(colName2);
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results2.isEmpty());
+    assertThat(results2).isNotEmpty();
     assertEquals("Output must match", expected2, results2);
   }
 
-  @Test
+  @TestTemplate
   public void removeColumnFromMiddle() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_remove_column_migrated_table_from_middle");
     String dest = source;
     String dropColumnName = "col1";
@@ -393,31 +406,32 @@ public class TestCreateActions extends SparkCatalogTestBase {
     // drop column
     sql("ALTER TABLE %s DROP COLUMN %s", dest, "col1");
     StructType schema = spark.table(dest).schema();
-    Assert.assertFalse(Arrays.asList(schema.fieldNames()).contains(dropColumnName));
+    assertThat(schema.fieldNames()).doesNotContain(dropColumnName);
 
     // reads should return same output as that of non-iceberg table
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
-  @Test
+  @TestTemplate
   public void testMigrateUnpartitioned() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String source = sourceName("test_migrate_unpartitioned_table");
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotPartitioned() throws Exception {
-    Assume.assumeTrue(
-        "Cannot snapshot with arbitrary location in a hadoop based catalog",
-        !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type)
+        .as("Cannot snapshot with arbitrary location in a hadoop based catalog")
+        .isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("test_snapshot_partitioned_table");
     String dest = destName("iceberg_snapshot_partitioned");
     createSourceTable(CREATE_PARTITIONED_PARQUET, source);
@@ -428,12 +442,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotUnpartitioned() throws Exception {
-    Assume.assumeTrue(
-        "Cannot snapshot with arbitrary location in a hadoop based catalog",
-        !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type)
+        .as("Cannot snapshot with arbitrary location in a hadoop based catalog")
+        .isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("test_snapshot_unpartitioned_table");
     String dest = destName("iceberg_snapshot_unpartitioned");
     createSourceTable(CREATE_PARQUET, source);
@@ -444,12 +458,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotHiveTable() throws Exception {
-    Assume.assumeTrue(
-        "Cannot snapshot with arbitrary location in a hadoop based catalog",
-        !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type)
+        .as("Cannot snapshot with arbitrary location in a hadoop based catalog")
+        .isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("snapshot_hive_table");
     String dest = destName("iceberg_snapshot_hive_table");
     createSourceTable(CREATE_HIVE_EXTERNAL_PARQUET, source);
@@ -460,19 +474,19 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testMigrateHiveTable() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
     String source = sourceName("migrate_hive_table");
     String dest = source;
     createSourceTable(CREATE_HIVE_EXTERNAL_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotManagedHiveTable() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("snapshot_managed_hive_table");
     String dest = destName("iceberg_snapshot_managed_hive_table");
     createSourceTable(CREATE_HIVE_PARQUET, source);
@@ -483,10 +497,10 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void testMigrateManagedHiveTable() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    File location = temp.newFolder();
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String source = sourceName("migrate_managed_hive_table");
     String dest = destName("iceberg_migrate_managed_hive_table");
     createSourceTable(CREATE_HIVE_PARQUET, source);
@@ -496,7 +510,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
         dest);
   }
 
-  @Test
+  @TestTemplate
   public void testProperties() throws Exception {
     String source = sourceName("test_properties_table");
     String dest = destName("iceberg_properties");
@@ -521,17 +535,13 @@ public class TestCreateActions extends SparkCatalogTestBase {
     expectedProps.put("dogs", "sundance");
 
     for (Map.Entry<String, String> entry : expectedProps.entrySet()) {
-      Assert.assertTrue(
-          "Created table missing property " + entry.getKey(),
-          table.properties().containsKey(entry.getKey()));
-      Assert.assertEquals(
-          "Property value is not the expected value",
-          entry.getValue(),
-          table.properties().get(entry.getKey()));
+      assertThat(table.properties())
+          .as("Property value is not the expected value")
+          .containsEntry(entry.getKey(), entry.getValue());
     }
   }
 
-  @Test
+  @TestTemplate
   public void testSparkTableReservedProperties() throws Exception {
     String destTableName = "iceberg_reserved_properties";
     String source = sourceName("test_reserved_properties_table");
@@ -547,28 +557,24 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String[] keys = {"provider", "format", "current-snapshot-id", "location", "sort-order"};
 
     for (String entry : keys) {
-      Assert.assertTrue(
-          "Created table missing reserved property " + entry,
-          table.properties().containsKey(entry));
+      assertThat(table.properties())
+          .as("Created table missing reserved property " + entry)
+          .containsKey(entry);
     }
 
-    Assert.assertEquals("Unexpected provider", "iceberg", table.properties().get("provider"));
-    Assert.assertEquals("Unexpected format", "iceberg/parquet", table.properties().get("format"));
-    Assert.assertNotEquals(
-        "No current-snapshot-id found", "none", table.properties().get("current-snapshot-id"));
-    Assert.assertTrue(
-        "Location isn't correct", table.properties().get("location").endsWith(destTableName));
+    assertThat(table.properties())
+        .containsEntry("provider", "iceberg")
+        .containsEntry("format", "iceberg/parquet")
+        .hasEntrySatisfying("current-snapshot-id", id -> assertThat(id).isNotEqualTo("none"))
+        .hasEntrySatisfying("location", loc -> assertThat(loc).endsWith(destTableName));
 
-    Assert.assertEquals("Unexpected format-version", "1", table.properties().get("format-version"));
+    assertThat(table.properties()).containsEntry("format-version", "1");
     table.table().updateProperties().set("format-version", "2").commit();
-    Assert.assertEquals("Unexpected format-version", "2", table.properties().get("format-version"));
+    assertThat(table.properties()).containsEntry("format-version", "2");
 
-    Assert.assertEquals(
-        "Sort-order isn't correct",
-        "id ASC NULLS FIRST, data DESC NULLS LAST",
-        table.properties().get("sort-order"));
-    Assert.assertNull(
-        "Identifier fields should be null", table.properties().get("identifier-fields"));
+    assertThat(table.properties())
+        .containsEntry("sort-order", "id ASC NULLS FIRST, data DESC NULLS LAST")
+        .doesNotContainKey("identifier-fields");
 
     table
         .table()
@@ -577,11 +583,10 @@ public class TestCreateActions extends SparkCatalogTestBase {
         .requireColumn("id")
         .setIdentifierFields("id")
         .commit();
-    Assert.assertEquals(
-        "Identifier fields aren't correct", "[id]", table.properties().get("identifier-fields"));
+    assertThat(table.properties()).containsEntry("identifier-fields", "[id]");
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotDefaultLocation() throws Exception {
     String source = sourceName("test_snapshot_default");
     String dest = destName("iceberg_snapshot_default");
@@ -590,13 +595,14 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertIsolatedSnapshot(source, dest);
   }
 
-  @Test
+  @TestTemplate
   public void schemaEvolutionTestWithSparkAPI() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
 
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     String tblName = sourceName("schema_evolution_test");
 
     // Data generation and partition addition
@@ -644,11 +650,12 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertEquals("Output must match", expectedAfterAddColumn, afterMigarteAfterAddResults);
   }
 
-  @Test
+  @TestTemplate
   public void schemaEvolutionTestWithSparkSQL() throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
-    Assume.assumeTrue(
-        "Can only migrate from Spark Session Catalog", catalog.name().equals("spark_catalog"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
+    assumeThat(catalog.name())
+        .as("Can only migrate from Spark Session Catalog")
+        .isEqualTo("spark_catalog");
     String tblName = sourceName("schema_evolution_test_sql");
 
     // Data generation and partition addition
@@ -691,54 +698,54 @@ public class TestCreateActions extends SparkCatalogTestBase {
     assertEquals("Output must match", expectedAfterAddColumn, afterMigarteAfterAddResults);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveStyleThreeLevelList() throws Exception {
     threeLevelList(true);
   }
 
-  @Test
+  @TestTemplate
   public void testThreeLevelList() throws Exception {
     threeLevelList(false);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveStyleThreeLevelListWithNestedStruct() throws Exception {
     threeLevelListWithNestedStruct(true);
   }
 
-  @Test
+  @TestTemplate
   public void testThreeLevelListWithNestedStruct() throws Exception {
     threeLevelListWithNestedStruct(false);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveStyleThreeLevelLists() throws Exception {
     threeLevelLists(true);
   }
 
-  @Test
+  @TestTemplate
   public void testThreeLevelLists() throws Exception {
     threeLevelLists(false);
   }
 
-  @Test
+  @TestTemplate
   public void testHiveStyleStructOfThreeLevelLists() throws Exception {
     structOfThreeLevelLists(true);
   }
 
-  @Test
+  @TestTemplate
   public void testStructOfThreeLevelLists() throws Exception {
     structOfThreeLevelLists(false);
   }
 
-  @Test
+  @TestTemplate
   public void testTwoLevelList() throws IOException {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
 
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", true);
 
     String tableName = sourceName("testTwoLevelList");
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
 
     StructType sparkSchema =
         new StructType(
@@ -798,7 +805,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
             HadoopInputFile.fromPath(
                 new Path(parquetFile.getPath()), spark.sessionState().newHadoopConf()));
     MessageType schema = pqReader.getFooter().getFileMetaData().getSchema();
-    Assert.assertEquals(MessageTypeParser.parseMessageType(expectedParquetSchema), schema);
+    assertThat(schema).isEqualTo(MessageTypeParser.parseMessageType(expectedParquetSchema));
 
     // create sql table on top of it
     sql(
@@ -813,17 +820,17 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
   private void threeLevelList(boolean useLegacyMode) throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
 
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", useLegacyMode);
 
     String tableName = sourceName(String.format("threeLevelList_%s", useLegacyMode));
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(
         "CREATE TABLE %s (col1 ARRAY<STRUCT<col2 INT>>)" + " STORED AS parquet" + " LOCATION '%s'",
         tableName, location);
@@ -837,18 +844,18 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
   private void threeLevelListWithNestedStruct(boolean useLegacyMode) throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
 
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", useLegacyMode);
 
     String tableName =
         sourceName(String.format("threeLevelListWithNestedStruct_%s", useLegacyMode));
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(
         "CREATE TABLE %s (col1 ARRAY<STRUCT<col2 STRUCT<col3 INT>>>)"
             + " STORED AS parquet"
@@ -864,17 +871,17 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
   private void threeLevelLists(boolean useLegacyMode) throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
 
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", useLegacyMode);
 
     String tableName = sourceName(String.format("threeLevelLists_%s", useLegacyMode));
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(
         "CREATE TABLE %s (col1 ARRAY<STRUCT<col2 INT>>, col3 ARRAY<STRUCT<col4 INT>>)"
             + " STORED AS parquet"
@@ -893,17 +900,17 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
   private void structOfThreeLevelLists(boolean useLegacyMode) throws Exception {
-    Assume.assumeTrue("Cannot migrate to a hadoop based catalog", !type.equals("hadoop"));
+    assumeThat(type).as("Cannot migrate to a hadoop based catalog").isNotEqualTo("hadoop");
 
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", useLegacyMode);
 
     String tableName = sourceName(String.format("structOfThreeLevelLists_%s", useLegacyMode));
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     sql(
         "CREATE TABLE %s (col1 STRUCT<col2 ARRAY<STRUCT<col3 INT>>>)"
             + " STORED AS parquet"
@@ -919,7 +926,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertFalse(results.isEmpty());
+    assertThat(results).isNotEmpty();
     assertEquals("Output must match", expected, results);
   }
 
@@ -940,7 +947,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
   private void createSourceTable(String createStatement, String tableName)
       throws IOException, NoSuchTableException, NoSuchDatabaseException, ParseException {
-    File location = temp.newFolder();
+    File location = Files.createTempDirectory(temp, "junit").toFile();
     spark.sql(String.format(createStatement, tableName, location));
     CatalogTable table = loadSessionTable(tableName);
     Seq<String> partitionColumns = table.partitionColumnNames();
@@ -961,8 +968,9 @@ public class TestCreateActions extends SparkCatalogTestBase {
     long expectedFiles = expectedFilesCount(source);
     MigrateTable.Result migratedFiles = migrateAction.execute();
     validateTables(source, dest);
-    Assert.assertEquals(
-        "Expected number of migrated files", expectedFiles, migratedFiles.migratedDataFilesCount());
+    assertThat(migratedFiles.migratedDataFilesCount())
+        .as("Expected number of migrated files")
+        .isEqualTo(expectedFiles);
   }
 
   // Counts the number of files in the source table, makes sure the same files exist in the
@@ -972,33 +980,38 @@ public class TestCreateActions extends SparkCatalogTestBase {
     long expectedFiles = expectedFilesCount(source);
     SnapshotTable.Result snapshotTableResult = snapshotTable.execute();
     validateTables(source, dest);
-    Assert.assertEquals(
-        "Expected number of imported snapshot files",
-        expectedFiles,
-        snapshotTableResult.importedDataFilesCount());
+    assertThat(snapshotTableResult.importedDataFilesCount())
+        .as("Expected number of imported snapshot files")
+        .isEqualTo(expectedFiles);
   }
 
   private void validateTables(String source, String dest)
       throws NoSuchTableException, ParseException {
     List<Row> expected = spark.table(source).collectAsList();
     SparkTable destTable = loadTable(dest);
-    Assert.assertEquals(
-        "Provider should be iceberg",
-        "iceberg",
-        destTable.properties().get(TableCatalog.PROP_PROVIDER));
+    assertThat(destTable.properties().get(TableCatalog.PROP_PROVIDER))
+        .as("Provider should be iceberg")
+        .isEqualTo("iceberg");
     List<Row> actual = spark.table(dest).collectAsList();
-    Assert.assertTrue(
-        String.format(
-            "Rows in migrated table did not match\nExpected :%s rows \nFound    :%s",
-            expected, actual),
-        expected.containsAll(actual) && actual.containsAll(expected));
+    assertThat(actual)
+        .as(
+            String.format(
+                "Rows in migrated table did not match\nExpected :%s rows \nFound    :%s",
+                expected, actual))
+        .containsAll(expected);
+    assertThat(expected)
+        .as(
+            String.format(
+                "Rows in migrated table did not match\nExpected :%s rows \nFound    :%s",
+                expected, actual))
+        .containsAll(actual);
   }
 
   private long expectedFilesCount(String source)
       throws NoSuchDatabaseException, NoSuchTableException, ParseException {
     CatalogTable sourceTable = loadSessionTable(source);
     List<URI> uris;
-    if (sourceTable.partitionColumnNames().size() == 0) {
+    if (sourceTable.partitionColumnNames().isEmpty()) {
       uris = Lists.newArrayList();
       uris.add(sourceTable.location());
     } else {
@@ -1032,14 +1045,15 @@ public class TestCreateActions extends SparkCatalogTestBase {
     df.write().format("iceberg").mode("append").saveAsTable(dest);
 
     List<Row> result = spark.sql(String.format("SELECT * FROM %s", source)).collectAsList();
-    Assert.assertEquals(
-        "No additional rows should be added to the original table", expected.size(), result.size());
+    assertThat(result)
+        .as("No additional rows should be added to the original table")
+        .hasSameSizeAs(expected);
 
     List<Row> snapshot =
         spark
             .sql(String.format("SELECT * FROM %s WHERE id = 4 AND data = 'd'", dest))
             .collectAsList();
-    Assert.assertEquals("Added row not found in snapshot", 1, snapshot.size());
+    assertThat(snapshot).as("Added row not found in snapshot").hasSize(1);
   }
 
   private String sourceName(String source) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -983,9 +983,7 @@ public class TestCreateActions extends CatalogTestBase {
       throws NoSuchTableException, ParseException {
     List<Row> expected = spark.table(source).collectAsList();
     SparkTable destTable = loadTable(dest);
-    assertThat(destTable.properties().get(TableCatalog.PROP_PROVIDER))
-        .as("Provider should be iceberg")
-        .isEqualTo("iceberg");
+    assertThat(destTable.properties()).containsEntry(TableCatalog.PROP_PROVIDER, "iceberg");
     List<Row> actual = spark.table(dest).collectAsList();
     assertThat(actual)
         .as(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/functions/TestSparkFunctions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/functions/TestSparkFunctions.java
@@ -24,7 +24,7 @@ import org.apache.spark.sql.connector.catalog.functions.ScalarFunction;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.DecimalType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkFunctions {
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -56,7 +56,8 @@ public final class TaskCheckHelper {
         .isEqualTo(expected.start());
 
     // simplify comparison on residual expression via comparing toString
-    assertThat(actual.residual().toString())
+    assertThat(actual.residual())
+        .asString()
         .as("Residual expression doesn't match")
         .isEqualTo(expected.residual().toString());
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -96,9 +96,6 @@ public final class TaskCheckHelper {
     assertThat(actual.splitOffsets())
         .as("Should match the serialized record offsets")
         .isEqualTo(expected.splitOffsets());
-    assertThat(actual.keyMetadata())
-        .as("Should match the serialized record offsets")
-        .isEqualTo(expected.keyMetadata());
   }
 
   private static List<FileScanTask> getFileScanTasksInFilePathOrder(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -83,9 +83,7 @@ public class TestFileIOSerialization {
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 
-    assertThat(toMap(actualConf)).as("Conf pairs must match").isEqualTo(toMap(expectedConf));
-    assertThat(actualConf.get("k1")).as("Conf values must be present").isEqualTo("v1");
-    assertThat(actualConf.get("k2")).as("Conf values must be present").isEqualTo("v2");
+    assertThat(actualConf).containsExactlyInAnyOrderElementsOf(expectedConf);
   }
 
   @Test
@@ -97,9 +95,7 @@ public class TestFileIOSerialization {
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 
-    assertThat(toMap(actualConf)).as("Conf pairs must match").isEqualTo(toMap(expectedConf));
-    assertThat(actualConf.get("k1")).as("Conf values must be present").isEqualTo("v1");
-    assertThat(actualConf.get("k2")).as("Conf values must be present").isEqualTo("v2");
+    assertThat(actualConf).containsExactlyInAnyOrderElementsOf(expectedConf);
   }
 
   private Map<String, String> toMap(Configuration conf) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -67,7 +67,7 @@ public class TestScanTaskSerialization extends TestBase {
   private String tableLocation = null;
 
   @BeforeEach
-  public void setupTableLocation() throws Exception {
+  public void setupTableLocation() {
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
@@ -174,7 +174,6 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
                       blobMetadata -> {
                         assertThat(blobMetadata.properties())
                             .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
-                        ;
                       });
             });
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableStatsAction.java
@@ -27,9 +27,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
-import org.apache.iceberg.BlobMetadata;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StatisticsFile;
@@ -57,9 +57,10 @@ import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestComputeTableStatsAction extends CatalogTestBase {
-
   private static final Types.StructType LEAF_STRUCT_TYPE =
       Types.StructType.of(
           optional(1, "leafLongCol", Types.LongType.get()),
@@ -75,6 +76,11 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
       new Schema(
           required(4, "nestedStructCol", NESTED_STRUCT_TYPE),
           required(5, "stringCol", Types.StringType.get()));
+
+  @AfterEach
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
 
   @TestTemplate
   public void testLoadingTableDirectly() {
@@ -116,15 +122,20 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
     assertThat(results).isNotNull();
 
     List<StatisticsFile> statisticsFiles = table.statisticsFiles();
-    assertThat(statisticsFiles).hasSize(1);
-
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
-    assertThat(statisticsFile.blobMetadata()).hasSize(2);
-
-    BlobMetadata blobMetadata = statisticsFile.blobMetadata().get(0);
-    assertThat(blobMetadata.properties())
-        .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+    assertThat(statisticsFiles)
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .hasSize(2)
+                  .element(0)
+                  .satisfies(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+                      });
+            });
   }
 
   @TestTemplate
@@ -148,14 +159,24 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
     ComputeTableStats.Result results = actions.computeTableStats(table).execute();
     assertThat(results).isNotNull();
 
-    assertThat(table.statisticsFiles()).hasSize(1);
-    StatisticsFile statisticsFile = table.statisticsFiles().get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
-    assertThat(statisticsFile.blobMetadata()).hasSize(2);
-    assertThat(statisticsFile.blobMetadata().get(0).properties())
-        .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
-    assertThat(statisticsFile.blobMetadata().get(1).properties())
-        .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+    assertThat(table.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .hasSize(2)
+                  .satisfiesExactly(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+                      },
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+                        ;
+                      });
+            });
   }
 
   @TestTemplate
@@ -199,15 +220,19 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
     ComputeTableStats.Result results = actions.computeTableStats(table).columns("data").execute();
     assertThat(results).isNotNull();
 
-    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
-    assertThat(statisticsFiles).hasSize(1);
-
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
-    assertThat(statisticsFile.blobMetadata()).hasSize(1);
-
-    assertThat(statisticsFile.blobMetadata().get(0).properties())
-        .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+    assertThat(table.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .singleElement()
+                  .satisfies(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "4");
+                      });
+            });
   }
 
   @TestTemplate
@@ -253,15 +278,19 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
 
     assertThat(results).isNotNull();
 
-    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
-    assertThat(statisticsFiles).hasSize(1);
-
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
-    assertThat(statisticsFile.blobMetadata()).hasSize(1);
-
-    assertThat(statisticsFile.blobMetadata().get(0).properties())
-        .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "1");
+    assertThat(table.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .singleElement()
+                  .satisfies(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsEntry(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY, "1");
+                      });
+            });
   }
 
   @TestTemplate
@@ -282,11 +311,13 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
     actions.computeTableStats(tbl).execute();
 
     tbl.refresh();
-    List<StatisticsFile> statisticsFiles = tbl.statisticsFiles();
-    assertThat(statisticsFiles).hasSize(1);
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
-    assertThat(statisticsFile.blobMetadata()).hasSize(1);
+    assertThat(tbl.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata()).hasSize(1);
+            });
   }
 
   @TestTemplate
@@ -365,15 +396,19 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
         actions.computeTableStats(table).columns(columnName).execute();
     assertThat(results).isNotNull();
 
-    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
-    assertThat(statisticsFiles).hasSize(1);
-
-    StatisticsFile statisticsFile = statisticsFiles.get(0);
-    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
-    assertThat(statisticsFile.blobMetadata()).hasSize(1);
-
-    assertThat(statisticsFile.blobMetadata().get(0).properties())
-        .containsKey(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY);
+    assertThat(table.statisticsFiles())
+        .singleElement()
+        .satisfies(
+            statisticsFile -> {
+              assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+              assertThat(statisticsFile.blobMetadata())
+                  .singleElement()
+                  .satisfies(
+                      blobMetadata -> {
+                        assertThat(blobMetadata.properties())
+                            .containsKey(APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY);
+                      });
+            });
   }
 
   private GenericRecord createNestedRecord() {
@@ -398,10 +433,5 @@ public class TestComputeTableStatsAction extends CatalogTestBase {
   private void append(String table, Dataset<Row> df) throws NoSuchTableException {
     // fanout writes are enabled as write-time clustering is not supported without Spark extensions
     df.coalesce(1).writeTo(table).option(SparkWriteOptions.FANOUT_ENABLED, "true").append();
-  }
-
-  @AfterEach
-  public void removeTable() {
-    sql("DROP TABLE IF EXISTS %s", tableName);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -36,6 +36,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -77,12 +78,14 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import scala.Option;
 import scala.Some;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestCreateActions extends CatalogTestBase {
   private static final String CREATE_PARTITIONED_PARQUET =
       "CREATE TABLE %s (id INT, data STRING) " + "using parquet PARTITIONED BY (id) LOCATION '%s'";
@@ -337,7 +340,6 @@ public class TestCreateActions extends CatalogTestBase {
 
     String colName1 = "newCol1";
     String colName2 = "newCol2";
-    File location = Files.createTempDirectory(temp, "junit").toFile();
     spark
         .range(10)
         .selectExpr("cast(id as INT)", "CAST(id as INT) " + colName1, "CAST(id as INT) " + colName2)
@@ -555,31 +557,19 @@ public class TestCreateActions extends CatalogTestBase {
           .containsKey(entry);
     }
 
-    assertThat(table.properties().get("provider")).as("Unexpected provider").isEqualTo("iceberg");
-    assertThat(table.properties().get("format"))
-        .as("Unexpected provider")
-        .isEqualTo("iceberg/parquet");
-    assertThat(table.properties().get("current-snapshot-id"))
-        .as("No current-snapshot-id found")
-        .isNotEqualTo("none");
-    assertThat(table.properties().get("location"))
-        .as("Location isn't correct")
-        .endsWith(destTableName);
+    assertThat(table.properties())
+        .containsEntry("provider", "iceberg")
+        .containsEntry("format", "iceberg/parquet")
+        .hasEntrySatisfying("current-snapshot-id", id -> assertThat(id).isNotEqualTo("none"))
+        .hasEntrySatisfying("location", loc -> assertThat(loc).endsWith(destTableName));
 
-    assertThat(table.properties().get("format-version"))
-        .as("Unexpected format-version")
-        .isEqualTo("1");
+    assertThat(table.properties()).containsEntry("format-version", "1");
     table.table().updateProperties().set("format-version", "2").commit();
-    assertThat(table.properties().get("format-version"))
-        .as("Unexpected format-version")
-        .isEqualTo("2");
+    assertThat(table.properties()).containsEntry("format-version", "2");
 
-    assertThat(table.properties().get("sort-order"))
-        .as("Sort-order isn't correct")
-        .isEqualTo("id ASC NULLS FIRST, data DESC NULLS LAST");
-    assertThat(table.properties().get("identifier-fields"))
-        .as("Identifier fields should be null")
-        .isNull();
+    assertThat(table.properties())
+        .containsEntry("sort-order", "id ASC NULLS FIRST, data DESC NULLS LAST")
+        .doesNotContainKey("identifier-fields");
 
     table
         .table()
@@ -588,9 +578,7 @@ public class TestCreateActions extends CatalogTestBase {
         .requireColumn("id")
         .setIdentifierFields("id")
         .commit();
-    assertThat(table.properties().get("identifier-fields"))
-        .as("Identifier fields aren't correct")
-        .isEqualTo("[id]");
+    assertThat(table.properties()).containsEntry("identifier-fields", "[id]");
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -977,9 +977,7 @@ public class TestCreateActions extends CatalogTestBase {
       throws NoSuchTableException, ParseException {
     List<Row> expected = spark.table(source).collectAsList();
     SparkTable destTable = loadTable(dest);
-    assertThat(destTable.properties().get(TableCatalog.PROP_PROVIDER))
-        .as("Provider should be iceberg")
-        .isEqualTo("iceberg");
+    assertThat(destTable.properties()).containsEntry(TableCatalog.PROP_PROVIDER, "iceberg");
     List<Row> actual = spark.table(dest).collectAsList();
     assertThat(actual)
         .as(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -529,11 +529,7 @@ public class TestCreateActions extends CatalogTestBase {
     expectedProps.putAll(props);
     expectedProps.put("dogs", "sundance");
 
-    for (Map.Entry<String, String> entry : expectedProps.entrySet()) {
-      assertThat(table.properties())
-          .as("Property value is not the expected value")
-          .containsEntry(entry.getKey(), entry.getValue());
-    }
+    assertThat(table.properties()).containsAllEntriesOf(expectedProps);
   }
 
   @TestTemplate
@@ -551,11 +547,9 @@ public class TestCreateActions extends CatalogTestBase {
 
     String[] keys = {"provider", "format", "current-snapshot-id", "location", "sort-order"};
 
-    for (String entry : keys) {
-      assertThat(table.properties())
-          .as("Created table missing reserved property " + entry)
-          .containsKey(entry);
-    }
+    assertThat(table.properties())
+        .as("Created table missing reserved properties")
+        .containsKeys(keys);
 
     assertThat(table.properties())
         .containsEntry("provider", "iceberg")


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates the following Spark 3.4 tests to JUnit 5 with AssertJ:

* In the`extensions` package:
  * `TestComputeTableStatsAction` including refactoring
  * `TestCreateActions` including refactoring
  * `TestSnapshotTableAction`
* In the `functions` package: `TestFunctions`
* Under the `spark`:
  * `TestTableSerialization`
  * `TestScanTaskSerialization`
  * `TestManifestFileSerialization`
  * `TestFileIOSerialization`
  * `TestDataFileSerialization`
  * `TaskCheckHelper`