### PR TITLE
Remove usage of Map.containsKey(null)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
@@ -82,7 +82,7 @@ public class CreateNamespaceRequest implements RESTRequest {
 
     public Builder setProperties(Map<String, String> props) {
       Preconditions.checkNotNull(props, "Invalid collection of properties: null");
-      Preconditions.checkArgument(!props.containsKey(null), "Invalid property: null");
+      Preconditions.checkArgument(!props.keySet().contains(null), "Invalid property: null");
       Preconditions.checkArgument(
           !props.containsValue(null),
           "Invalid value for properties %s: null",

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
@@ -150,7 +150,7 @@ public class CreateTableRequest implements RESTRequest {
 
     public Builder setProperties(Map<String, String> props) {
       Preconditions.checkNotNull(props, "Invalid collection of properties: null");
-      Preconditions.checkArgument(!props.containsKey(null), "Invalid property: null");
+      Preconditions.checkArgument(!props.keySet().contains(null), "Invalid property: null");
       Preconditions.checkArgument(
           !props.containsValue(null),
           "Invalid value for properties %s: null",

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateNamespacePropertiesRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateNamespacePropertiesRequest.java
@@ -107,7 +107,7 @@ public class UpdateNamespacePropertiesRequest implements RESTRequest {
 
     public Builder updateAll(Map<String, String> updates) {
       Preconditions.checkNotNull(updates, "Invalid collection of properties to update: null");
-      Preconditions.checkArgument(!updates.containsKey(null), "Invalid property to update: null");
+      Preconditions.checkArgument(!updates.keySet().contains(null), "Invalid property to update: null");
       Preconditions.checkArgument(
           !updates.containsValue(null),
           "Invalid value to update for properties %s: null. Use remove instead",

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponse.java
@@ -159,7 +159,7 @@ public class ConfigResponse implements RESTResponse {
     public Builder withDefaults(Map<String, String> defaultsToAdd) {
       Preconditions.checkNotNull(defaultsToAdd, "Invalid default properties map: null");
       Preconditions.checkArgument(
-          !defaultsToAdd.containsKey(null), "Invalid default property: null");
+          !defaultsToAdd.keySet().contains(null), "Invalid default property: null");
       defaults.putAll(defaultsToAdd);
       return this;
     }
@@ -168,7 +168,7 @@ public class ConfigResponse implements RESTResponse {
     public Builder withOverrides(Map<String, String> overridesToAdd) {
       Preconditions.checkNotNull(overridesToAdd, "Invalid override properties map: null");
       Preconditions.checkArgument(
-          !overridesToAdd.containsKey(null), "Invalid override property: null");
+          !overridesToAdd.keySet().contains(null), "Invalid override property: null");
       overrides.putAll(overridesToAdd);
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
@@ -82,7 +82,7 @@ public class CreateNamespaceResponse implements RESTResponse {
 
     public Builder setProperties(Map<String, String> props) {
       Preconditions.checkNotNull(props, "Invalid collection of properties: null");
-      Preconditions.checkArgument(!props.containsKey(null), "Invalid property to set: null");
+      Preconditions.checkArgument(!props.keySet().contains(null), "Invalid property to set: null");
       Preconditions.checkArgument(
           !props.containsValue(null),
           "Invalid value to set for properties %s: null",

--- a/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
@@ -82,7 +82,7 @@ public class GetNamespaceResponse implements RESTResponse {
 
     public Builder setProperties(Map<String, String> props) {
       Preconditions.checkNotNull(props, "Invalid properties map: null");
-      Preconditions.checkArgument(!props.containsKey(null), "Invalid property: null");
+      Preconditions.checkArgument(!props.keySet().contains(null), "Invalid property: null");
       Preconditions.checkArgument(
           !props.containsValue(null),
           "Invalid value for properties %s: null",


### PR DESCRIPTION
When working on a change for Apache Polaris, I hit an error of the following form:

```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.ImmutableCollections$MapN.containsKey(ImmutableCollections.java:1207)
	at org.apache.iceberg.rest.requests.CreateNamespaceRequest$Builder.setProperties(CreateNamespaceRequest.java:85)
	at org.apache.iceberg.rest.RESTSessionCatalog.createNamespace(RESTSessionCatalog.java:626)
	at org.apache.iceberg.catalog.BaseSessionCatalog$AsCatalog.createNamespace(BaseSessionCatalog.java:128)
	at org.apache.iceberg.rest.RESTCatalog.createNamespace(RESTCatalog.java:223)
	at org.apache.polaris.service.it.test.PolarisRestCatalogIntegrationTest.testCreateNamespaceWithReservedProperty(PolarisRestCatalogIntegrationTest.java:1376)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

Looking closer, I see that in `java.util.ImmutableCollections.MapN`, the `containsKey` method looks like:
```
        @Override
        public boolean containsKey(Object o) {
            Objects.requireNonNull(o);
            return size > 0 && probe(o) >= 0;
        }
```

This suggests to me that `containsKey(null)` should probably be avoided; to keep the same semantics I suggest that we can use `keySet().contains(null)`.