### PR TITLE
API: Don't check underlying error msg on AIOOBE

### DIFF
--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
@@ -34,14 +34,14 @@ public class TestSerializedMetadata {
   private final Random random = new Random(872591);
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testEmptyVariantMetadata() {
     SerializedMetadata metadata = SerializedMetadata.EMPTY_V1_METADATA;
 
     assertThat(metadata.isSorted()).isFalse();
     assertThat(metadata.dictionarySize()).isEqualTo(0);
-    assertThatThrownBy(() -> metadata.get(0))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> metadata.get(0)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test
@@ -99,6 +99,7 @@ public class TestSerializedMetadata {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testReadString() {
     SerializedMetadata metadata =
         SerializedMetadata.from(
@@ -111,12 +112,12 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("c");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testMultibyteString() {
     SerializedMetadata metadata =
         SerializedMetadata.from(
@@ -129,12 +130,12 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("xyz");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void testTwoByteOffsets() {
     SerializedMetadata metadata =
         SerializedMetadata.from(
@@ -148,9 +149,8 @@ public class TestSerializedMetadata {
     assertThat(metadata.get(2)).isEqualTo("xyz");
     assertThat(metadata.get(3)).isEqualTo("d");
     assertThat(metadata.get(4)).isEqualTo("e");
-    assertThatThrownBy(() -> metadata.get(5))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("out of bounds");
+    // no check on the underlying error msg as it might be missing based on the JDK version
+    assertThatThrownBy(() -> metadata.get(5)).isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test


### PR DESCRIPTION
The error msg might be missing when the tests are executed with different JDK versions, so it's better to skip checking the underlying error msg to avoid flakiness in test executions