### PR TITLE
Spark: Avoid closing deserialized copies of shared resources like FileIO

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -22,7 +22,6 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -103,7 +102,7 @@ public class TestTableSerialization {
       ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
       verify(spyIO, never()).close();
-      verify(spyFileIOCopy, times(1)).close();
+      verify(spyFileIOCopy, never()).close();
     }
   }
 
@@ -124,7 +123,7 @@ public class TestTableSerialization {
       ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
       verify(spyIO, never()).close();
-      verify(spyFileIOCopy, times(1)).close();
+      verify(spyFileIOCopy, never()).close();
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -23,7 +23,6 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -100,7 +99,7 @@ public class TestTableSerialization {
       ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
       verify(spyIO, never()).close();
-      verify(spyFileIOCopy, times(1)).close();
+      verify(spyFileIOCopy, never()).close();
     }
   }
 
@@ -121,7 +120,7 @@ public class TestTableSerialization {
       ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
       verify(spyIO, never()).close();
-      verify(spyFileIOCopy, times(1)).close();
+      verify(spyFileIOCopy, never()).close();
     }
   }
 


### PR DESCRIPTION
This change prevents calling `close()` on `FileIO` during the cleanup of Spark's broadcast variable when `memoryStore.remove(blockId)` is called. Closing `FileIO` can unintentionally shut down shared resources—such as a shared connection pool—when `S3FileIO` is backed by the Apache HTTPClient. Calling `close()` will trigger the shutdown of the [HttpClientConnectionManager](https://github.com/aws/aws-sdk-java-v2/blob/master/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ApacheHttpClient.java#L252), leading to request failures if other instances are still in use.
Fixes: [#12858](https://github.com/apache/iceberg/issues/12858), [#12046](https://github.com/apache/iceberg/issues/12046)