### PR TITLE
Add `format/` to site-ci

### DIFF
--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -24,6 +24,7 @@ on:
     paths:
       - docs/**
       - site/**
+      - format/**
   workflow_dispatch:
 jobs:
   deploy:


### PR DESCRIPTION
I merged a [spec-change earlier today](https://github.com/apache/iceberg/pull/12644), but noticed that it was not live on the website. I think it would be good to get these changes out right away.