### PR TITLE
Catalogs: Add support for unique table locations via catalog property

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -65,6 +65,7 @@ public class GlueTestBase {
   // iceberg
   static GlueCatalog glueCatalog;
   static GlueCatalog glueCatalogWithSkipNameValidation;
+  static GlueCatalog glueCatalogWithUniqueLocation;
 
   static Schema schema =
       new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
@@ -105,6 +106,16 @@ public class GlueTestBase {
         GLUE,
         null,
         ImmutableMap.of());
+
+    glueCatalogWithUniqueLocation = new GlueCatalog();
+    glueCatalogWithUniqueLocation.initialize(
+        CATALOG_NAME,
+        TEST_BUCKET_PATH,
+        awsProperties,
+        s3FileIOProperties,
+        GLUE,
+        null,
+        true /* uniqTableLocation */);
   }
 
   @AfterAll

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -311,6 +311,22 @@ public class TestGlueCatalogTable extends GlueTestBase {
   }
 
   @Test
+  public void testCreateTableInUniqueLocation() {
+    String namespace = createNamespace();
+    String tableName = createTable(namespace);
+    String newTableName = tableName + "_renamed";
+
+    glueCatalogWithUniqueLocation.renameTable(
+        TableIdentifier.of(namespace, tableName), TableIdentifier.of(namespace, newTableName));
+    Table renamedTable =
+        glueCatalogWithUniqueLocation.loadTable(TableIdentifier.of(namespace, newTableName));
+    createTable(namespace, tableName);
+    Table table = glueCatalogWithUniqueLocation.loadTable(TableIdentifier.of(namespace, tableName));
+
+    assertThat(renamedTable.location()).isNotEqualTo(table.location());
+  }
+
+  @Test
   public void testRenameTableFailsToCreateNewTable() {
     String namespace = createNamespace();
     String tableName = createTable(namespace);
@@ -743,7 +759,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
         new AwsProperties(properties),
         new S3FileIOProperties(properties),
         GLUE,
-        null);
+        null,
+        false /* uniqTableLocation */);
     String namespace = createNamespace();
     String tableName = getRandomName();
     createTable(namespace, tableName);

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -195,6 +195,28 @@ public class TestGlueCatalog {
   }
 
   @Test
+  public void testDefaultWarehouseLocationUnique() {
+    GlueCatalog catalog = new GlueCatalog();
+    catalog.initialize(
+        CATALOG_NAME,
+        WAREHOUSE_PATH,
+        new AwsProperties(),
+        new S3FileIOProperties(),
+        glue,
+        LockManagers.defaultLockManager(),
+        true /* uniqTableLocation */);
+
+    Mockito.doReturn(
+            GetDatabaseResponse.builder()
+                .database(Database.builder().name("db").locationUri("s3://bucket2/db").build())
+                .build())
+        .when(glue)
+        .getDatabase(Mockito.any(GetDatabaseRequest.class));
+    String location = catalog.defaultWarehouseLocation(TableIdentifier.of("db", "table"));
+    assertThat(location).matches("s3://bucket2/db/table-[a-z0-9]{32}");
+  }
+
+  @Test
   public void testListTables() {
     Mockito.doReturn(
             GetDatabaseResponse.builder().database(Database.builder().name("db1").build()).build())

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -24,6 +24,7 @@ import static org.apache.iceberg.gcp.bigquery.BigQueryProperties.PROJECT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
@@ -167,6 +168,18 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
   @Test
   public void testRenameTableMissingSourceTable() {
     super.testRenameTableMissingSourceTable();
+  }
+
+  @Disabled("BigQuery Metastore does not support rename tables")
+  @Test
+  public void createTableInUniqueLocation() {
+    super.createTableInUniqueLocation();
+  }
+
+  @Disabled("BigQuery Metastore does not support rename tables")
+  @Test
+  public void dropAfterRenameDoesntCorruptTable() throws IOException {
+    super.dropAfterRenameDoesntCorruptTable();
   }
 
   @Test

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -158,6 +158,15 @@ public class CatalogProperties {
   public static final String APP_NAME = "app-name";
   public static final String USER = "user";
 
+  /**
+   * Requests that the catalog provide unique locations for new tables.
+   *
+   * <p>Relevant only for catalogs which support unique table locations.
+   */
+  public static final String UNIQUE_TABLE_LOCATION = "unique-table-location";
+
+  public static final boolean UNIQUE_TABLE_LOCATION_DEFAULT = false;
+
   public static final String AUTH_SESSION_TIMEOUT_MS = "auth.session-timeout-ms";
   public static final long AUTH_SESSION_TIMEOUT_MS_DEFAULT = TimeUnit.HOURS.toMillis(1);
 

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -88,6 +88,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
   private Object conf;
   private JdbcClientPool connections;
   private Map<String, String> catalogProperties;
+  private boolean uniqueTableLocation;
   private final Function<Map<String, String>, FileIO> ioBuilder;
   private final Function<Map<String, String>, JdbcClientPool> clientPoolBuilder;
   private boolean initializeCatalogTables;
@@ -120,6 +121,11 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
 
     this.warehouseLocation = LocationUtil.stripTrailingSlash(inputWarehouseLocation);
     this.catalogProperties = ImmutableMap.copyOf(properties);
+    this.uniqueTableLocation =
+        PropertyUtil.propertyAsBoolean(
+            properties,
+            CatalogProperties.UNIQUE_TABLE_LOCATION,
+            CatalogProperties.UNIQUE_TABLE_LOCATION_DEFAULT);
 
     if (name != null) {
       this.catalogName = name;
@@ -287,7 +293,8 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
 
   @Override
   protected String defaultWarehouseLocation(TableIdentifier table) {
-    return SLASH.join(defaultNamespaceLocation(table.namespace()), table.name());
+    String tableLocation = LocationUtil.tableLocation(table, uniqueTableLocation);
+    return SLASH.join(defaultNamespaceLocation(table.namespace()), tableLocation);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.util;
 
+import java.util.UUID;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 
@@ -32,5 +34,27 @@ public class LocationUtil {
       result = result.substring(0, result.length() - 1);
     }
     return result;
+  }
+
+  /**
+   * Returns a path component derived from the {@code tableIdentifier}, used as part of the table
+   * location URI.
+   *
+   * <p>If {@code useUniqueLocation} is {@code true}, the returned component will include a random
+   * UUID suffix. Otherwise, the plain table name is returned.
+   *
+   * @param tableIdentifier Iceberg table identifier
+   * @param useUniqueLocation whether to ensure uniqueness
+   * @return a string representing the table name component for a location URI
+   */
+  public static String tableLocation(TableIdentifier tableIdentifier, boolean useUniqueLocation) {
+    Preconditions.checkArgument(null != tableIdentifier, "Invalid identifier: null");
+
+    if (useUniqueLocation) {
+      String uniqueSuffix = UUID.randomUUID().toString().replace("-", "");
+      return String.format("%s-%s", tableIdentifier.name(), uniqueSuffix);
+    } else {
+      return tableIdentifier.name();
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -274,12 +274,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   @SuppressWarnings("removal")
   @BeforeEach
   public void createCatalog() throws Exception {
-    File warehouse = temp.toFile();
-
     this.backendCatalog = new InMemoryCatalog();
-    this.backendCatalog.initialize(
-        "in-memory",
-        ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, warehouse.getAbsolutePath()));
 
     HTTPHeaders catalogHeaders =
         HTTPHeaders.of(
@@ -315,6 +310,14 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   @Override
   protected RESTCatalog initCatalog(String catalogName, Map<String, String> additionalProperties) {
     Configuration conf = new Configuration();
+    File warehouse = temp.toFile();
+
+    backendCatalog.initialize(
+        "in-memory",
+        ImmutableMap.<String, String>builder()
+            .put(CatalogProperties.WAREHOUSE_LOCATION, warehouse.getAbsolutePath())
+            .putAll(additionalProperties)
+            .build());
 
     RESTCatalog catalog =
         new RESTCatalog(

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -155,6 +155,7 @@ Iceberg catalogs support using catalog properties to configure catalog behaviors
 | cache-enabled                     | true               | Whether to cache catalog entries |
 | cache.expiration-interval-ms      | 30000              | How long catalog entries are locally cached, in milliseconds; 0 disables caching, negative values disable expiration |
 | metrics-reporter-impl | org.apache.iceberg.metrics.LoggingMetricsReporter | Custom `MetricsReporter` implementation to use in a catalog. See the [Metrics reporting](metrics-reporting.md) section for additional details |
+| unique-table-location             | false              | Whether to use a unique location for new tables |
 | encryption.kms-impl               | null               | a custom `KeyManagementClient` implementation to use in a catalog for interactions with KMS (key management service). See the [Encryption](encryption.md) document for additional details |
 
 `HadoopCatalog` and `HiveCatalog` can access the properties in their constructors.

--- a/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java
@@ -26,6 +26,8 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,5 +107,11 @@ public class RESTCompatibilityKitCatalogTests extends CatalogTests<RESTCatalog> 
     // https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0.html#uri-path-canonicalization
     // for additional details
     return false;
+  }
+
+  @Disabled("RESTServerExtension isn’t configurable per test")
+  @Test
+  public void createTableInUniqueLocation() {
+    super.createTableInUniqueLocation();
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
@@ -65,7 +65,23 @@ public enum SparkCatalogConfig {
   SPARK_WITH_HIVE_VIEWS(
       "spark_hive_with_views",
       SparkCatalog.class.getName(),
-      ImmutableMap.of("type", "hive", "default-namespace", "default", "cache-enabled", "false"));
+      ImmutableMap.of("type", "hive", "default-namespace", "default", "cache-enabled", "false")),
+  SPARK_SESSION_WITH_UNIQUE_LOCATION(
+      "spark_catalog",
+      SparkSessionCatalog.class.getName(),
+      ImmutableMap.of(
+          "type", "hive",
+          "default-namespace", "default",
+          "parquet-enabled", "true",
+          "unique-table-location", "true",
+          "cache-enabled", "false")),
+  HIVE_WITH_UNIQUE_LOCATION(
+      "hive_with_unique_location",
+      SparkCatalog.class.getName(),
+      ImmutableMap.of(
+          "type", "hive",
+          "default-namespace", "default",
+          "unique-table-location", "true"));
 
   private final String catalogName;
   private final String implementation;

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestUniqueTableLocation.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestUniqueTableLocation.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.spark.CatalogTestBase;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestUniqueTableLocation extends CatalogTestBase {
+
+  private String renamedTableName;
+  private TableIdentifier renamedIdent;
+
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE_WITH_UNIQUE_LOCATION.catalogName(),
+        SparkCatalogConfig.HIVE_WITH_UNIQUE_LOCATION.implementation(),
+        SparkCatalogConfig.HIVE_WITH_UNIQUE_LOCATION.properties()
+      },
+      {
+        SparkCatalogConfig.SPARK_SESSION_WITH_UNIQUE_LOCATION.catalogName(),
+        SparkCatalogConfig.SPARK_SESSION_WITH_UNIQUE_LOCATION.implementation(),
+        SparkCatalogConfig.SPARK_SESSION_WITH_UNIQUE_LOCATION.properties()
+      },
+    };
+  }
+
+  @BeforeEach
+  public void initTableName() {
+    renamedTableName = tableName("table_2");
+    renamedIdent = TableIdentifier.of(Namespace.of("default"), "table_2");
+  }
+
+  @AfterEach
+  public void dropTestTable() {
+    try {
+      sql("DROP TABLE IF EXISTS %s", tableName);
+      sql("DROP TABLE IF EXISTS %s", renamedTableName);
+    } catch (NotFoundException ignore) {
+      // Swallow FNF exception in case of corrupted table so test failure reason is clearer
+    }
+  }
+
+  @TestTemplate
+  public void noCollisionAfterRename() {
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("%s should not exist", tableIdent)
+        .isFalse();
+    assertThat(validationCatalog.tableExists(renamedIdent))
+        .as("%s should not exist", renamedIdent)
+        .isFalse();
+
+    sql("CREATE TABLE %s (id BIGINT NOT NULL, data STRING) USING iceberg", tableName);
+
+    sql("ALTER TABLE %s RENAME TO %s", tableName, renamedTableName);
+
+    sql("CREATE TABLE %s (id BIGINT NOT NULL, data STRING) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Table renamedTable = validationCatalog.loadTable(renamedIdent);
+
+    assertThat(table.location())
+        .as(
+            "After rename+recreate, %s and %s must have different locations",
+            tableName, renamedTableName)
+        .isNotEqualTo(renamedTable.location());
+  }
+
+  @TestTemplate
+  public void orphanCleanupDoesntCorruptTable() {
+    SparkActions actions = SparkActions.get();
+
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("%s should not exist", tableIdent)
+        .isFalse();
+    assertThat(validationCatalog.tableExists(renamedIdent))
+        .as("%s should not exist", renamedIdent)
+        .isFalse();
+
+    sql("CREATE TABLE %s (id BIGINT NOT NULL, data STRING) USING iceberg", tableName);
+    sql("INSERT INTO %s VALUES(0, '%s')", tableName, UUID.randomUUID().toString());
+
+    sql("ALTER TABLE %s RENAME TO %s", tableName, renamedTableName);
+
+    sql("CREATE TABLE %s (id BIGINT NOT NULL, data STRING) USING iceberg", tableName);
+    sql("INSERT INTO %s VALUES(1, '%s')", tableName, UUID.randomUUID().toString());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table).as("Should load %s", table).isNotNull();
+
+    long cutoff = System.currentTimeMillis() + 1;
+    DeleteOrphanFiles.Result result = actions.deleteOrphanFiles(table).olderThan(cutoff).execute();
+    assertThat(result.orphanFileLocations()).as("Should not touch any files").isEmpty();
+
+    assertThat(scalarSql("SELECT count(*) FROM %s", renamedTableName))
+        .as("Table %s should remain unaffected by %s table cleanup", renamedTableName, tableName)
+        .isEqualTo(1L);
+  }
+}


### PR DESCRIPTION
It's revival and extension of #2850, regards to @sshkvar.

This PR introduces a new catalog property, `unique-table-location`, which enables generating unique table locations for catalogs that support table rename operations. The feature is disabled by default to preserve current behavior.

When enabled, a unique suffix is added to the table path, ensuring that each table has its own dedicated storage location including scenarios involving table renames. This addresses a key issue where, after renaming a table and creating a new one with the original name, both tables would otherwise share the same location. Such overlap can lead to:

- **Data loss** during the `DeleteOrphanFilesSparkAction`, which may inadvertently delete files belonging to other tables in the shared location.
- **Difficulties in analyzing table-specific storage costs**, as storage usage cannot be cleanly attributed to individual tables.
- **Inability to apply path-based rules** such as S3 Intelligent-Tiering, Lifecycle Rules, or fine-grained permissions, which depend on isolated storage paths.

NessieCatalog already supports it, but it's not configurable: https://github.com/apache/iceberg/blob/ee2ffb4e94f166f4ffb371a01050e4fb92474b22/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java#L258

Such feature was added to Trino a while ago https://github.com/trinodb/trino/pull/6063 and related discussion https://github.com/trinodb/trino/issues/5632#issuecomment-714274998
