### PR TITLE
Spark 3.5: Disable executor cache for delete files in RewriteDataFilesSparkAction

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkExecutorCache.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkExecutorCache.java
@@ -70,10 +70,10 @@ public class SparkExecutorCache {
    *
    * <p>Note this method returns null if caching is disabled.
    */
-  public static SparkExecutorCache getOrCreate() {
+  public static SparkExecutorCache getOrCreate(boolean forDeletes) {
     if (instance == null) {
       Conf conf = new Conf();
-      if (conf.cacheEnabled()) {
+      if (conf.cacheEnabled(forDeletes)) {
         synchronized (SparkExecutorCache.class) {
           if (instance == null) {
             SparkExecutorCache.instance = new SparkExecutorCache(conf);
@@ -193,11 +193,26 @@ public class SparkExecutorCache {
   static class Conf {
     private final SparkConfParser confParser = new SparkConfParser();
 
-    public boolean cacheEnabled() {
+    public boolean cacheEnabled(boolean forDeletes) {
+      if (forDeletes) {
+        return executorCacheEnabledForDeletes() && executorCacheEnabled();
+      }
+      return executorCacheEnabled();
+    }
+
+    public boolean executorCacheEnabled() {
       return confParser
           .booleanConf()
           .sessionConf(SparkSQLProperties.EXECUTOR_CACHE_ENABLED)
           .defaultValue(SparkSQLProperties.EXECUTOR_CACHE_ENABLED_DEFAULT)
+          .parse();
+    }
+
+    public boolean executorCacheEnabledForDeletes() {
+      return confParser
+          .booleanConf()
+          .sessionConf(SparkSQLProperties.EXECUTOR_CACHE_DELETES_ENABLED)
+          .defaultValue(SparkSQLProperties.EXECUTOR_CACHE_DELETES_ENABLED_DEFAULT)
           .parse();
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -79,6 +79,11 @@ public class SparkSQLProperties {
   public static final String EXECUTOR_CACHE_ENABLED = "spark.sql.iceberg.executor-cache.enabled";
   public static final boolean EXECUTOR_CACHE_ENABLED_DEFAULT = true;
 
+  // Controls whether to enable executor cache for delete files
+  public static final String EXECUTOR_CACHE_DELETES_ENABLED =
+      "spark.sql.iceberg.executor-cache.deletes.enabled";
+  public static final boolean EXECUTOR_CACHE_DELETES_ENABLED_DEFAULT = true;
+
   public static final String EXECUTOR_CACHE_TIMEOUT = "spark.sql.iceberg.executor-cache.timeout";
   public static final Duration EXECUTOR_CACHE_TIMEOUT_DEFAULT = Duration.ofMinutes(10);
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -62,6 +62,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.math.IntMath;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.PropertyUtil;
@@ -109,6 +110,7 @@ public class RewriteDataFilesSparkAction
     super(spark.cloneSession());
     // Disable Adaptive Query Execution as this may change the output partitioning of our write
     spark().conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
+    spark().conf().set(SparkSQLProperties.EXECUTOR_CACHE_DELETES_ENABLED, false);
     this.caseSensitive = SparkUtil.caseSensitive(spark);
     this.table = table;
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -229,7 +229,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
 
       CachingDeleteLoader(Function<DeleteFile, InputFile> loadInputFile) {
         super(loadInputFile);
-        this.cache = SparkExecutorCache.getOrCreate();
+        this.cache = SparkExecutorCache.getOrCreate(true);
       }
 
       @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -133,14 +133,37 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
         ImmutableMap.of(SparkSQLProperties.EXECUTOR_CACHE_ENABLED, "true"),
         () -> {
           Conf conf = new Conf();
-          assertThat(conf.cacheEnabled()).isTrue();
+          assertThat(conf.cacheEnabled(true)).isTrue();
+          assertThat(conf.cacheEnabled(false)).isTrue();
         });
 
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.EXECUTOR_CACHE_ENABLED, "false"),
         () -> {
           Conf conf = new Conf();
-          assertThat(conf.cacheEnabled()).isFalse();
+          assertThat(conf.cacheEnabled(true)).isFalse();
+          assertThat(conf.cacheEnabled(false)).isFalse();
+        });
+
+    withSQLConf(
+        ImmutableMap.of(
+            SparkSQLProperties.EXECUTOR_CACHE_ENABLED, "true",
+            SparkSQLProperties.EXECUTOR_CACHE_DELETES_ENABLED, "false"),
+        () -> {
+          Conf conf = new Conf();
+          assertThat(conf.cacheEnabled(false)).isTrue();
+          assertThat(conf.cacheEnabled(true)).isFalse(); // delete caching disabled
+        });
+
+    withSQLConf(
+        ImmutableMap.of(
+            SparkSQLProperties.EXECUTOR_CACHE_ENABLED, "false",
+            SparkSQLProperties.EXECUTOR_CACHE_DELETES_ENABLED, "true"),
+        () -> {
+          Conf conf = new Conf();
+          assertThat(conf.cacheEnabled(false)).isFalse();
+          assertThat(conf.cacheEnabled(true))
+              .isFalse(); // cache is disabled, so ignore delete cache
         });
   }
 
@@ -183,7 +206,7 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
 
   @TestTemplate
   public void testConcurrentAccess() throws InterruptedException {
-    SparkExecutorCache cache = SparkExecutorCache.getOrCreate();
+    SparkExecutorCache cache = SparkExecutorCache.getOrCreate(false);
 
     String table1 = "table1";
     String table2 = "table2";


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg/issues/11648

This PR introduces a new Spark conf `spark.sql.iceberg.executor-cache.deletes.enabled` to control whether executor cache should be enabled for delete files. 

Further, it disables executor caching for deletes in `RewriteDataFilesSparkAction`.