### PR TITLE
Flink: Backport add StreamingStartingStrategy.INCREMENTAL_FROM_LATEST_SNAPSHOT_EXCLUSIVE to Flink 1.19

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/StreamingStartingStrategy.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/StreamingStartingStrategy.java
@@ -30,14 +30,21 @@ public enum StreamingStartingStrategy {
   /**
    * Start incremental mode from the latest snapshot inclusive.
    *
-   * <p>If it is an empty map, all future append snapshots should be discovered.
+   * <p>If it is an empty table, all future append snapshots should be discovered.
    */
   INCREMENTAL_FROM_LATEST_SNAPSHOT,
 
   /**
+   * Start incremental mode from the latest snapshot exclusive.
+   *
+   * <p>If it is an empty table, all future append snapshots should be discovered.
+   */
+  INCREMENTAL_FROM_LATEST_SNAPSHOT_EXCLUSIVE,
+
+  /**
    * Start incremental mode from the earliest snapshot inclusive.
    *
-   * <p>If it is an empty map, all future append snapshots should be discovered.
+   * <p>If it is an empty table, all future append snapshots should be discovered.
    */
   INCREMENTAL_FROM_EARLIEST_SNAPSHOT,
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class TestContinuousSplitPlannerImplStartStrategy {
   private static final FileFormat FILE_FORMAT = FileFormat.PARQUET;
@@ -88,18 +90,35 @@ public class TestContinuousSplitPlannerImplStartStrategy {
     assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot3.snapshotId());
   }
 
-  @Test
-  public void testForLatestSnapshotStrategy() throws IOException {
+  @ParameterizedTest
+  @EnumSource(
+      value = StreamingStartingStrategy.class,
+      names = {"INCREMENTAL_FROM_LATEST_SNAPSHOT", "INCREMENTAL_FROM_LATEST_SNAPSHOT_EXCLUSIVE"})
+  public void testForLatestSnapshotStrategyWithEmptyTable(
+      StreamingStartingStrategy startingStrategy) throws IOException {
     ScanContext scanContext =
-        ScanContext.builder()
-            .streaming(true)
-            .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_LATEST_SNAPSHOT)
-            .build();
+        ScanContext.builder().streaming(true).startingStrategy(startingStrategy).build();
 
     assertThat(ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext))
         .isNotPresent();
 
     appendThreeSnapshots();
+    Snapshot startSnapshot =
+        ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext).get();
+    assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot3.snapshotId());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = StreamingStartingStrategy.class,
+      names = {"INCREMENTAL_FROM_LATEST_SNAPSHOT", "INCREMENTAL_FROM_LATEST_SNAPSHOT_EXCLUSIVE"})
+  public void testForLatestSnapshotStrategyWithNonEmptyTable(
+      StreamingStartingStrategy startingStrategy) throws IOException {
+    appendThreeSnapshots();
+
+    ScanContext scanContext =
+        ScanContext.builder().streaming(true).startingStrategy(startingStrategy).build();
+
     Snapshot startSnapshot =
         ContinuousSplitPlannerImpl.startSnapshot(TABLE_RESOURCE.table(), scanContext).get();
     assertThat(startSnapshot.snapshotId()).isEqualTo(snapshot3.snapshotId());


### PR DESCRIPTION
backports [#12839](https://github.com/apache/iceberg/pull/12839)