### PR TITLE
Flink: Add lockFactory open in LockRemover

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/LockRemover.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/LockRemover.java
@@ -125,6 +125,7 @@ public class LockRemover extends AbstractStreamOperator<Void>
           .gauge(TableMaintenanceMetrics.LAST_RUN_DURATION_MS, duration::get);
     }
 
+    lockFactory.open();
     this.lock = lockFactory.createLock();
     this.recoveryLock = lockFactory.createRecoveryLock();
   }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
@@ -307,6 +307,7 @@ class TestLockRemover extends OperatorTestBase {
       if (!open) {
         throw new IllegalStateException("Lock factory not open");
       }
+
       return LOCK;
     }
 
@@ -315,6 +316,7 @@ class TestLockRemover extends OperatorTestBase {
       if (!open) {
         throw new IllegalStateException("Lock factory not open");
       }
+
       return RECOVERY_LOCK;
     }
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
@@ -294,18 +294,27 @@ class TestLockRemover extends OperatorTestBase {
   }
 
   private static class TestingLockFactory implements TriggerLockFactory {
+
+    private boolean open = false;
+
     @Override
     public void open() {
-      // Do nothing
+      open = true;
     }
 
     @Override
     public Lock createLock() {
+      if (!open) {
+        throw new IllegalStateException("Lock factory not open");
+      }
       return LOCK;
     }
 
     @Override
     public Lock createRecoveryLock() {
+      if (!open) {
+        throw new IllegalStateException("Lock factory not open");
+      }
       return RECOVERY_LOCK;
     }
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
@@ -320,7 +320,7 @@ class TestLockRemover extends OperatorTestBase {
 
     @Override
     public void close() {
-      // Do nothing
+      open = false;
     }
   }
 


### PR DESCRIPTION
In LockRemover, I noticed we missed `lockFactory.open()` before `this.lock = lockFactory.createLock()`. This could lead to an NPE since the factory isn't initialized and we have to close lock after (similar to the pool in jdbcFactory).

This pr is aim to add the init of lockFactory when LockRemover init.