### PR TITLE
Spark: Use newArrayListWithExpectedSize instead of newArrayList for NDVSketchUtil

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/NDVSketchUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/NDVSketchUtil.java
@@ -50,7 +50,8 @@ public class NDVSketchUtil {
       SparkSession spark, Table table, Snapshot snapshot, List<String> columns) {
     Row sketches = computeNDVSketches(spark, table, snapshot, columns);
     Schema schema = table.schemas().get(snapshot.schemaId());
-    List<Blob> blobs = Lists.newArrayList();
+    List<Blob> blobs = Lists.newArrayListWithExpectedSize(columns.size());
+
     for (int i = 0; i < columns.size(); i++) {
       Types.NestedField field = schema.findField(columns.get(i));
       Sketch sketch = CompactSketch.wrap(Memory.wrap((byte[]) sketches.get(i)));

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/NDVSketchUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/NDVSketchUtil.java
@@ -50,7 +50,8 @@ public class NDVSketchUtil {
       SparkSession spark, Table table, Snapshot snapshot, List<String> columns) {
     Row sketches = computeNDVSketches(spark, table, snapshot, columns);
     Schema schema = table.schemas().get(snapshot.schemaId());
-    List<Blob> blobs = Lists.newArrayList();
+    List<Blob> blobs = Lists.newArrayListWithExpectedSize(columns.size());
+
     for (int i = 0; i < columns.size(); i++) {
       Types.NestedField field = schema.findField(columns.get(i));
       Sketch sketch = CompactSketch.wrap(Memory.wrap((byte[]) sketches.get(i)));


### PR DESCRIPTION
We renamed the method from `newArrayList` to `newArrayListWithExpectedSize` because some user tables may contain hundreds or even thousands of columns. If the expected capacity (size) of the collection is not specified in advance, dynamic resizing operations will trigger multiple memory copy operations.