### PR TITLE
Update Spark Parquet vectorized read tests to uses Iceberg Record instead of Avro GenericRecord

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -35,6 +35,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -49,6 +50,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
 import scala.collection.Seq;
 
@@ -67,6 +69,32 @@ public class GenericsHelpers {
       Object actualValue = actual.get(i);
 
       assertEqualsSafe(fieldType, expectedValue, actualValue);
+    }
+  }
+
+  public static void assertEqualsBatch(
+      Types.StructType struct, Iterator<Record> expectedRecords, ColumnarBatch batch) {
+    for (int rowId = 0; rowId < batch.numRows(); rowId++) {
+      InternalRow row = batch.getRow(rowId);
+      Record expectedRecord = expectedRecords.next();
+      Types.StructType expectedRecordType = expectedRecord.struct();
+      List<Types.NestedField> fields = struct.fields();
+
+      for (int readPos = 0; readPos < fields.size(); readPos += 1) {
+        Types.NestedField field = fields.get(readPos);
+        Types.NestedField expectedField = expectedRecordType.field(field.fieldId());
+        Object expectedValue;
+        Object actualValue = row.isNullAt(readPos) ? null : row.get(readPos, convert(field.type()));
+        if (expectedField != null) {
+          expectedValue = expectedRecord.getField(expectedField.name());
+          assertEqualsUnsafe(field.type(), expectedValue, actualValue);
+        } else {
+          assertEqualsUnsafe(
+              field.type(),
+              GenericDataUtil.internalToGeneric(field.type(), field.initialDefault()),
+              actualValue);
+        }
+      }
     }
   }
 
@@ -289,11 +317,27 @@ public class GenericsHelpers {
     }
 
     switch (type.typeId()) {
+      case LONG:
+        assertThat(actual).as("Should be a long").isInstanceOf(Long.class);
+        if (expected instanceof Integer) {
+          assertThat(actual).as("Values didn't match").isEqualTo(((Number) expected).longValue());
+        } else {
+          assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
+        }
+        break;
+      case DOUBLE:
+        assertThat(actual).as("Should be a double").isInstanceOf(Double.class);
+        if (expected instanceof Float) {
+          assertThat(Double.doubleToLongBits((double) actual))
+              .as("Values didn't match")
+              .isEqualTo(Double.doubleToLongBits(((Number) expected).doubleValue()));
+        } else {
+          assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
+        }
+        break;
       case BOOLEAN:
       case INTEGER:
-      case LONG:
       case FLOAT:
-      case DOUBLE:
         assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case DATE:

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -29,9 +29,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
-import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
@@ -71,14 +73,15 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
   }
 
   @Override
-  Iterable<GenericData.Record> generateData(
+  Iterable<Record> generateData(
       Schema schema,
       int numRecords,
       long seed,
       float nullPercentage,
-      Function<GenericData.Record, GenericData.Record> transform) {
+      Function<Record, Record> transform) {
     Iterable data =
-        RandomData.generateDictionaryEncodableData(schema, numRecords, seed, nullPercentage);
+        RandomGenericData.generateDictionaryEncodableRecords(
+            schema, numRecords, seed, nullPercentage);
     return transform == IDENTITY ? data : Iterables.transform(data, transform);
   }
 
@@ -92,19 +95,18 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
     File dictionaryEncodedFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(dictionaryEncodedFile.delete()).as("Delete should succeed").isTrue();
-    Iterable<GenericData.Record> dictionaryEncodableData =
-        RandomData.generateDictionaryEncodableData(
+    Iterable<Record> dictionaryEncodableData =
+        RandomGenericData.generateDictionaryEncodableRecords(
             schema, 10000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE);
-    try (FileAppender<GenericData.Record> writer =
-        getParquetWriter(schema, dictionaryEncodedFile)) {
+    try (FileAppender<Record> writer = getParquetWriter(schema, dictionaryEncodedFile)) {
       writer.addAll(dictionaryEncodableData);
     }
 
     File plainEncodingFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(plainEncodingFile.delete()).as("Delete should succeed").isTrue();
-    Iterable<GenericData.Record> nonDictionaryData =
-        RandomData.generate(schema, 10000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE);
-    try (FileAppender<GenericData.Record> writer = getParquetWriter(schema, plainEncodingFile)) {
+    Iterable<Record> nonDictionaryData =
+        RandomGenericData.generate(schema, 10000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE);
+    try (FileAppender<Record> writer = getParquetWriter(schema, plainEncodingFile)) {
       writer.addAll(nonDictionaryData);
     }
 
@@ -132,12 +134,13 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
     File parquetFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(parquetFile.delete()).as("Delete should succeed").isTrue();
 
-    Iterable<GenericData.Record> records = RandomData.generateFallbackData(schema, 500, 0L, 100);
-    try (FileAppender<GenericData.Record> writer =
+    Iterable<Record> records = RandomGenericData.generateFallbackRecords(schema, 500, 0L, 100);
+    try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(parquetFile))
             .schema(schema)
             .set(PARQUET_DICT_SIZE_BYTES, "4096")
             .set(PARQUET_PAGE_ROW_LIMIT, "100")
+            .createWriterFunc(GenericParquetWriter::create)
             .build()) {
       writer.addAll(records);
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryFallbackToPlainEncodingVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryFallbackToPlainEncodingVectorizedReads.java
@@ -20,15 +20,16 @@ package org.apache.iceberg.spark.data.parquet.vectorized;
 
 import java.io.File;
 import java.io.IOException;
-import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Function;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.spark.data.RandomData;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -42,24 +43,25 @@ public class TestParquetDictionaryFallbackToPlainEncodingVectorizedReads
   }
 
   @Override
-  Iterable<GenericData.Record> generateData(
+  Iterable<Record> generateData(
       Schema schema,
       int numRecords,
       long seed,
       float nullPercentage,
-      Function<GenericData.Record, GenericData.Record> transform) {
+      Function<Record, Record> transform) {
     // TODO: take into account nullPercentage when generating fallback encoding data
-    Iterable data = RandomData.generateFallbackData(schema, numRecords, seed, numRecords / 20);
+    Iterable data =
+        RandomGenericData.generateFallbackRecords(schema, numRecords, seed, numRecords / 20);
     return transform == IDENTITY ? data : Iterables.transform(data, transform);
   }
 
   @Override
-  FileAppender<GenericData.Record> getParquetWriter(Schema schema, File testFile)
-      throws IOException {
+  FileAppender<Record> getParquetWriter(Schema schema, File testFile) throws IOException {
     return Parquet.write(Files.localOutput(testFile))
         .schema(schema)
         .named("test")
         .set(TableProperties.PARQUET_DICT_SIZE_BYTES, "512000")
+        .createWriterFunc(GenericParquetWriter::create)
         .build();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -27,9 +27,11 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
-import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
@@ -39,8 +41,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.data.AvroDataTest;
+import org.apache.iceberg.spark.data.GenericsHelpers;
 import org.apache.iceberg.spark.data.RandomData;
-import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -55,7 +57,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
   private static final int NUM_ROWS = 200_000;
   static final int BATCH_SIZE = 10_000;
 
-  static final Function<GenericData.Record, GenericData.Record> IDENTITY = record -> record;
+  static final Function<Record, Record> IDENTITY = record -> record;
 
   @Override
   protected void writeAndValidate(Schema schema) throws IOException {
@@ -100,7 +102,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       float nullPercentage,
       boolean reuseContainers,
       int batchSize,
-      Function<GenericData.Record, GenericData.Record> transform)
+      Function<Record, Record> transform)
       throws IOException {
     // Write test data
     assumeThat(
@@ -110,14 +112,14 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         .as("Parquet Avro cannot write non-string map keys")
         .isNull();
 
-    Iterable<GenericData.Record> expected =
+    Iterable<Record> expected =
         generateData(writeSchema, numRecords, seed, nullPercentage, transform);
 
     // write a test parquet file using iceberg writer
     File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
-    try (FileAppender<GenericData.Record> writer = getParquetWriter(writeSchema, testFile)) {
+    try (FileAppender<Record> writer = getParquetWriter(writeSchema, testFile)) {
       writer.addAll(expected);
     }
 
@@ -128,35 +130,37 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     return NUM_ROWS;
   }
 
-  Iterable<GenericData.Record> generateData(
+  Iterable<Record> generateData(
       Schema schema,
       int numRecords,
       long seed,
       float nullPercentage,
-      Function<GenericData.Record, GenericData.Record> transform) {
-    Iterable<GenericData.Record> data =
-        RandomData.generate(schema, numRecords, seed, nullPercentage);
+      Function<Record, Record> transform) {
+    Iterable<Record> data = RandomGenericData.generate(schema, numRecords, seed);
     return transform == IDENTITY ? data : Iterables.transform(data, transform);
   }
 
-  FileAppender<GenericData.Record> getParquetWriter(Schema schema, File testFile)
-      throws IOException {
-    return Parquet.write(Files.localOutput(testFile)).schema(schema).named("test").build();
+  FileAppender<Record> getParquetWriter(Schema schema, File testFile) throws IOException {
+    return Parquet.write(Files.localOutput(testFile))
+        .schema(schema)
+        .named("test")
+        .createWriterFunc(GenericParquetWriter::create)
+        .build();
   }
 
-  FileAppender<GenericData.Record> getParquetV2Writer(Schema schema, File testFile)
-      throws IOException {
+  FileAppender<Record> getParquetV2Writer(Schema schema, File testFile) throws IOException {
     return Parquet.write(Files.localOutput(testFile))
         .schema(schema)
         .named("test")
         .writerVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
+        .createWriterFunc(GenericParquetWriter::create)
         .build();
   }
 
   void assertRecordsMatch(
       Schema schema,
       int expectedSize,
-      Iterable<GenericData.Record> expected,
+      Iterable<Record> expected,
       File testFile,
       boolean reuseContainers,
       int batchSize)
@@ -173,13 +177,13 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       readBuilder.reuseContainers();
     }
     try (CloseableIterable<ColumnarBatch> batchReader = readBuilder.build()) {
-      Iterator<GenericData.Record> expectedIter = expected.iterator();
+      Iterator<Record> expectedIter = expected.iterator();
       Iterator<ColumnarBatch> batches = batchReader.iterator();
       int numRowsRead = 0;
       while (batches.hasNext()) {
         ColumnarBatch batch = batches.next();
         numRowsRead += batch.numRows();
-        TestHelpers.assertEqualsBatch(schema.asStruct(), expectedIter, batch);
+        GenericsHelpers.assertEqualsBatch(schema.asStruct(), expectedIter, batch);
       }
       assertThat(numRowsRead).isEqualTo(expectedSize);
     }
@@ -239,6 +243,8 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         new Schema(
             Lists.newArrayList(
                 SUPPORTED_PRIMITIVES.field("id"), SUPPORTED_PRIMITIVES.field("data")));
+    int dataOrdinal = 1;
+
     writeAndValidate(
         schema,
         schema,
@@ -248,10 +254,11 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         true,
         2,
         record -> {
-          if (record.get("data") != null) {
-            record.put("data", Strings.padEnd((String) record.get("data"), 512, 'a'));
+          if (record.get(dataOrdinal, String.class) != null) {
+            record.set(
+                dataOrdinal, Strings.padEnd(record.get(dataOrdinal, String.class), 512, 'a'));
           } else {
-            record.put("data", Strings.padEnd("", 512, 'a'));
+            record.set(dataOrdinal, Strings.padEnd("", 512, 'a'));
           }
           return record;
         });
@@ -268,9 +275,9 @@ public class TestParquetVectorizedReads extends AvroDataTest {
 
     File dataFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
-    Iterable<GenericData.Record> data =
+    Iterable<Record> data =
         generateData(writeSchema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
-    try (FileAppender<GenericData.Record> writer = getParquetWriter(writeSchema, dataFile)) {
+    try (FileAppender<Record> writer = getParquetWriter(writeSchema, dataFile)) {
       writer.addAll(data);
     }
 
@@ -297,9 +304,9 @@ public class TestParquetVectorizedReads extends AvroDataTest {
 
     File dataFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
-    Iterable<GenericData.Record> data =
+    Iterable<Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
-    try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
+    try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);
     }
     assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE);
@@ -312,9 +319,9 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
     File dataFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(dataFile.delete()).as("Delete should succeed").isTrue();
-    Iterable<GenericData.Record> data =
+    Iterable<Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
-    try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
+    try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);
     }
     assertThatThrownBy(() -> assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE))


### PR DESCRIPTION
This change updates the Spark Parquet Vectorized read tests to write and validate against Iceberg Records instead of Avro generic records. Iceberg generic record is the interface that we should be testing against since it avoids the intricacies around Avro data types, which end up bubbling through when we build expectations currently. Refer to https://github.com/apache/iceberg/commit/ab92d6e66b61195a8e9845d3eb592f3e67ae67e1#diff-e649f357cf9965d322086f95bc78451fa1e61e4612f3d8af2114d93a1bd657aa for similar changes made for the non-vectorized Parquet reader.

This refactoring is done to prepare for the row lineage changes required for the vectorized reader. Since there are a bit more changes involved here, I've separated out the test part first so the row lineage changes are easier to review.