### PR TITLE
API, Core: Add table metadata keys for encryption

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Snapshot.java
+++ b/api/src/main/java/org/apache/iceberg/Snapshot.java
@@ -195,4 +195,13 @@ public interface Snapshot extends Serializable {
   default Long addedRows() {
     return null;
   }
+
+  /**
+   * ID of the encryption key used to encrypt this snapshot's manifest list.
+   *
+   * @return a string key ID
+   */
+  default String keyId() {
+    return null;
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptedKey.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptedKey.java
@@ -18,25 +18,15 @@
  */
 package org.apache.iceberg.encryption;
 
-import java.util.List;
+import java.nio.ByteBuffer;
 import java.util.Map;
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
-public class EncryptionTestHelpers {
+public interface EncryptedKey {
+  String keyId();
 
-  private EncryptionTestHelpers() {}
+  ByteBuffer encryptedKeyMetadata();
 
-  public static EncryptionManager createEncryptionManager() {
-    Map<String, String> catalogProperties = Maps.newHashMap();
-    catalogProperties.put(
-        CatalogProperties.ENCRYPTION_KMS_IMPL, UnitestKMS.class.getCanonicalName());
-    Map<String, String> tableProperties = Maps.newHashMap();
-    tableProperties.put(TableProperties.ENCRYPTION_TABLE_KEY, UnitestKMS.MASTER_KEY_NAME1);
-    tableProperties.put(TableProperties.FORMAT_VERSION, "2");
+  String encryptedById();
 
-    return EncryptionUtil.createEncryptionManager(
-        List.of(), tableProperties, EncryptionUtil.createKmsClient(catalogProperties));
-  }
+  Map<String, String> properties();
 }

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -45,6 +45,7 @@ class BaseSnapshot implements Snapshot {
   private final String[] v1ManifestLocations;
   private final Long firstRowId;
   private final Long addedRows;
+  private final String keyId;
 
   // lazily initialized
   private transient List<ManifestFile> allManifests = null;
@@ -65,7 +66,8 @@ class BaseSnapshot implements Snapshot {
       Integer schemaId,
       String manifestList,
       Long firstRowId,
-      Long addedRows) {
+      Long addedRows,
+      String keyId) {
     Preconditions.checkArgument(
         firstRowId == null || firstRowId >= 0,
         "Invalid first-row-id (cannot be negative): %s",
@@ -88,6 +90,7 @@ class BaseSnapshot implements Snapshot {
     this.v1ManifestLocations = null;
     this.firstRowId = firstRowId;
     this.addedRows = firstRowId != null ? addedRows : null;
+    this.keyId = keyId;
   }
 
   BaseSnapshot(
@@ -110,6 +113,7 @@ class BaseSnapshot implements Snapshot {
     this.v1ManifestLocations = v1ManifestLocations;
     this.firstRowId = null;
     this.addedRows = null;
+    this.keyId = null;
   }
 
   @Override
@@ -155,6 +159,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public Long addedRows() {
     return addedRows;
+  }
+
+  @Override
+  public String keyId() {
+    return keyId;
   }
 
   private void cacheManifests(FileIO fileIO) {

--- a/core/src/main/java/org/apache/iceberg/EncryptedKeyParser.java
+++ b/core/src/main/java/org/apache/iceberg/EncryptedKeyParser.java
@@ -30,6 +30,8 @@ import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.JsonUtil;
 
 public class EncryptedKeyParser {
+  private EncryptedKeyParser() {}
+
   private static final String KEY_ID = "key-id";
   private static final String KEY_METADATA = "encrypted-key-metadata";
   private static final String ENCRYPTED_BY_ID = "encrypted-by-id";

--- a/core/src/main/java/org/apache/iceberg/EncryptedKeyParser.java
+++ b/core/src/main/java/org/apache/iceberg/EncryptedKeyParser.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Map;
+import org.apache.iceberg.encryption.BaseEncryptedKey;
+import org.apache.iceberg.encryption.EncryptedKey;
+import org.apache.iceberg.util.ByteBuffers;
+import org.apache.iceberg.util.JsonUtil;
+
+public class EncryptedKeyParser {
+  private static final String KEY_ID = "key-id";
+  private static final String KEY_METADATA = "encrypted-key-metadata";
+  private static final String ENCRYPTED_BY_ID = "encrypted-by-id";
+  private static final String PROPERTIES = "properties";
+
+  public static String toJson(EncryptedKey key) {
+    return toJson(key, true);
+  }
+
+  public static String toJson(EncryptedKey key, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(key, gen), pretty);
+  }
+
+  static void toJson(EncryptedKey key, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+
+    generator.writeStringField(KEY_ID, key.keyId());
+    generator.writeStringField(
+        KEY_METADATA,
+        Base64.getEncoder().encodeToString(ByteBuffers.toByteArray(key.encryptedKeyMetadata())));
+    generator.writeStringField(ENCRYPTED_BY_ID, key.encryptedById());
+
+    if (key.properties() != null) {
+      JsonUtil.writeStringMap(PROPERTIES, key.properties(), generator);
+    }
+
+    generator.writeEndObject();
+  }
+
+  public static EncryptedKey fromJson(String json) {
+    return JsonUtil.parse(json, EncryptedKeyParser::fromJson);
+  }
+
+  static EncryptedKey fromJson(JsonNode node) {
+    String keyId = JsonUtil.getString(KEY_ID, node);
+    ByteBuffer keyMetadata =
+        ByteBuffer.wrap(Base64.getDecoder().decode(JsonUtil.getString(KEY_METADATA, node)));
+    String encryptedById = JsonUtil.getString(ENCRYPTED_BY_ID, node);
+    Map<String, String> properties = JsonUtil.getStringMapOrNull(PROPERTIES, node);
+
+    return new BaseEncryptedKey(keyId, keyMetadata, encryptedById, properties);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.iceberg.view.ViewVersion;
@@ -540,6 +541,40 @@ public interface MetadataUpdate extends Serializable {
     @Override
     public void applyTo(ViewMetadata.Builder viewMetadataBuilder) {
       viewMetadataBuilder.setCurrentVersionId(versionId);
+    }
+  }
+
+  class AddEncryptionKey implements MetadataUpdate {
+    private final EncryptedKey key;
+
+    public AddEncryptionKey(EncryptedKey key) {
+      this.key = key;
+    }
+
+    public EncryptedKey key() {
+      return key;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder builder) {
+      builder.addEncryptedKey(key);
+    }
+  }
+
+  class RemoveEncryptionKey implements MetadataUpdate {
+    private final String keyId;
+
+    public RemoveEncryptionKey(String keyId) {
+      this.keyId = keyId;
+    }
+
+    public String keyId() {
+      return keyId;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder builder) {
+      builder.removeEncryptedKey(keyId);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -557,7 +557,7 @@ public interface MetadataUpdate extends Serializable {
 
     @Override
     public void applyTo(TableMetadata.Builder builder) {
-      builder.addEncryptedKey(key);
+      builder.addEncryptionKey(key);
     }
   }
 
@@ -574,7 +574,7 @@ public interface MetadataUpdate extends Serializable {
 
     @Override
     public void applyTo(TableMetadata.Builder builder) {
-      builder.removeEncryptedKey(keyId);
+      builder.removeEncryptionKey(keyId);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -61,6 +61,8 @@ public class MetadataUpdateParser {
   static final String REMOVE_PARTITION_STATISTICS = "remove-partition-statistics";
   static final String REMOVE_PARTITION_SPECS = "remove-partition-specs";
   static final String REMOVE_SCHEMAS = "remove-schemas";
+  static final String ADD_ENCRYPTION_KEY = "add-encryption-key";
+  static final String REMOVE_ENCRYPTION_KEY = "remove-encryption-key";
 
   // AssignUUID
   private static final String UUID = "uuid";
@@ -134,6 +136,12 @@ public class MetadataUpdateParser {
   // RemoveSchemas
   private static final String SCHEMA_IDS = "schema-ids";
 
+  // AddEncryptionKey
+  private static final String ENCRYPTION_KEY = "encryption-key";
+
+  // RemoveEncryptionKey
+  private static final String KEY_ID = "key-id";
+
   private static final Map<Class<? extends MetadataUpdate>, String> ACTIONS =
       ImmutableMap.<Class<? extends MetadataUpdate>, String>builder()
           .put(MetadataUpdate.AssignUUID.class, ASSIGN_UUID)
@@ -160,6 +168,8 @@ public class MetadataUpdateParser {
           .put(MetadataUpdate.SetCurrentViewVersion.class, SET_CURRENT_VIEW_VERSION)
           .put(MetadataUpdate.RemovePartitionSpecs.class, REMOVE_PARTITION_SPECS)
           .put(MetadataUpdate.RemoveSchemas.class, REMOVE_SCHEMAS)
+          .put(MetadataUpdate.AddEncryptionKey.class, ADD_ENCRYPTION_KEY)
+          .put(MetadataUpdate.RemoveEncryptionKey.class, REMOVE_ENCRYPTION_KEY)
           .buildOrThrow();
 
   public static String toJson(MetadataUpdate metadataUpdate) {
@@ -265,6 +275,12 @@ public class MetadataUpdateParser {
       case REMOVE_SCHEMAS:
         writeRemoveSchemas((MetadataUpdate.RemoveSchemas) metadataUpdate, generator);
         break;
+      case ADD_ENCRYPTION_KEY:
+        writeAddEncryptionKey((MetadataUpdate.AddEncryptionKey) metadataUpdate, generator);
+        break;
+      case REMOVE_ENCRYPTION_KEY:
+        writeRemoveEncryptionKey((MetadataUpdate.RemoveEncryptionKey) metadataUpdate, generator);
+        break;
       default:
         throw new IllegalArgumentException(
             String.format(
@@ -340,6 +356,10 @@ public class MetadataUpdateParser {
         return readRemovePartitionSpecs(jsonNode);
       case REMOVE_SCHEMAS:
         return readRemoveSchemas(jsonNode);
+      case ADD_ENCRYPTION_KEY:
+        return readAddEncryptionKey(jsonNode);
+      case REMOVE_ENCRYPTION_KEY:
+        return readRemoveEncryptionKey(jsonNode);
       default:
         throw new UnsupportedOperationException(
             String.format("Cannot convert metadata update action to json: %s", action));
@@ -481,6 +501,17 @@ public class MetadataUpdateParser {
   private static void writeRemoveSchemas(
       MetadataUpdate.RemoveSchemas metadataUpdate, JsonGenerator gen) throws IOException {
     JsonUtil.writeIntegerArray(SCHEMA_IDS, metadataUpdate.schemaIds(), gen);
+  }
+
+  private static void writeAddEncryptionKey(
+      MetadataUpdate.AddEncryptionKey update, JsonGenerator gen) throws IOException {
+    gen.writeFieldName(ENCRYPTION_KEY);
+    EncryptedKeyParser.toJson(update.key(), gen);
+  }
+
+  private static void writeRemoveEncryptionKey(
+      MetadataUpdate.RemoveEncryptionKey update, JsonGenerator gen) throws IOException {
+    gen.writeStringField(KEY_ID, update.keyId());
   }
 
   private static MetadataUpdate readAssignUUID(JsonNode node) {
@@ -638,5 +669,19 @@ public class MetadataUpdateParser {
 
   private static MetadataUpdate readRemoveSchemas(JsonNode node) {
     return new MetadataUpdate.RemoveSchemas(JsonUtil.getIntegerSet(SCHEMA_IDS, node));
+  }
+
+  private static MetadataUpdate readAddEncryptionKey(JsonNode node) {
+    JsonNode keyNode = node.get(ENCRYPTION_KEY);
+    Preconditions.checkArgument(
+        keyNode != null && keyNode.isObject(),
+        "Invalid encryption key, must be non-null object: %s",
+        keyNode);
+    return new MetadataUpdate.AddEncryptionKey(EncryptedKeyParser.fromJson(keyNode));
+  }
+
+  private static MetadataUpdate readRemoveEncryptionKey(JsonNode node) {
+    String keyId = JsonUtil.getString(KEY_ID, node);
+    return new MetadataUpdate.RemoveEncryptionKey(keyId);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -132,7 +132,7 @@ public class RewriteTablePathUtil {
         // TODO: update partition statistics file paths
         metadata.partitionStatisticsFiles(),
         metadata.nextRowId(),
-        metadata.keys(),
+        metadata.encryptionKeys(),
         metadata.changes());
   }
 

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -132,6 +132,7 @@ public class RewriteTablePathUtil {
         // TODO: update partition statistics file paths
         metadata.partitionStatisticsFiles(),
         metadata.nextRowId(),
+        metadata.keys(),
         metadata.changes());
   }
 

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -206,7 +206,8 @@ public class RewriteTablePathUtil {
               snapshot.schemaId(),
               newManifestListLocation,
               snapshot.firstRowId(),
-              snapshot.addedRows());
+              snapshot.addedRows(),
+              snapshot.keyId());
       newSnapshots.add(newSnapshot);
     }
     return newSnapshots;

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -53,6 +53,7 @@ public class SnapshotParser {
   private static final String SCHEMA_ID = "schema-id";
   private static final String FIRST_ROW_ID = "first-row-id";
   private static final String ADDED_ROWS = "added-rows";
+  private static final String KEY_ID = "key-id";
 
   static void toJson(Snapshot snapshot, JsonGenerator generator) throws IOException {
     generator.writeStartObject();
@@ -105,6 +106,8 @@ public class SnapshotParser {
     if (snapshot.addedRows() != null) {
       generator.writeNumberField(ADDED_ROWS, snapshot.addedRows());
     }
+
+    JsonUtil.writeStringFieldIfPresent(KEY_ID, snapshot.keyId(), generator);
 
     generator.writeEndObject();
   }
@@ -171,6 +174,8 @@ public class SnapshotParser {
     Long firstRowId = JsonUtil.getLongOrNull(FIRST_ROW_ID, node);
     Long addedRows = JsonUtil.getLongOrNull(ADDED_ROWS, node);
 
+    String keyId = JsonUtil.getStringOrNull(KEY_ID, node);
+
     if (node.has(MANIFEST_LIST)) {
       // the manifest list is stored in a manifest list file
       String manifestList = JsonUtil.getString(MANIFEST_LIST, node);
@@ -184,7 +189,8 @@ public class SnapshotParser {
           schemaId,
           manifestList,
           firstRowId,
-          addedRows);
+          addedRows,
+          keyId);
 
     } else {
       // fall back to an embedded manifest list. pass in the manifest's InputFile so length can be

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -322,7 +322,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         base.currentSchemaId(),
         manifestList.location(),
         nextRowId,
-        assignedRows);
+        assignedRows,
+        null);
   }
 
   protected abstract Map<String, String> summary();

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -26,9 +26,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
@@ -260,6 +262,7 @@ public class TableMetadata implements Serializable {
   private final List<PartitionStatisticsFile> partitionStatisticsFiles;
   private final List<MetadataUpdate> changes;
   private final long nextRowId;
+  private final List<EncryptedKey> keys;
   private SerializableSupplier<List<Snapshot>> snapshotsSupplier;
   private volatile List<Snapshot> snapshots;
   private volatile Map<Long, Snapshot> snapshotsById;
@@ -292,6 +295,7 @@ public class TableMetadata implements Serializable {
       List<StatisticsFile> statisticsFiles,
       List<PartitionStatisticsFile> partitionStatisticsFiles,
       long nextRowId,
+      List<EncryptedKey> keys,
       List<MetadataUpdate> changes) {
     Preconditions.checkArgument(
         specs != null && !specs.isEmpty(), "Partition specs cannot be null or empty");
@@ -311,6 +315,7 @@ public class TableMetadata implements Serializable {
     Preconditions.checkArgument(
         metadataFileLocation == null || changes.isEmpty(),
         "Cannot create TableMetadata with a metadata location and changes");
+    Preconditions.checkArgument(keys != null, "Keys cannot be null");
 
     this.metadataFileLocation = metadataFileLocation;
     this.formatVersion = formatVersion;
@@ -333,6 +338,7 @@ public class TableMetadata implements Serializable {
     this.snapshotsLoaded = snapshotsSupplier == null;
     this.snapshotLog = snapshotLog;
     this.previousFiles = previousFiles;
+    this.keys = keys;
 
     // changes are carried through until metadata is read from a file
     this.changes = changes;
@@ -582,6 +588,10 @@ public class TableMetadata implements Serializable {
 
   public long nextRowId() {
     return nextRowId;
+  }
+
+  public List<EncryptedKey> keys() {
+    return keys;
   }
 
   /** Updates the schema */
@@ -915,6 +925,7 @@ public class TableMetadata implements Serializable {
     private final Map<Long, List<PartitionStatisticsFile>> partitionStatisticsFiles;
     private boolean suppressHistoricalSnapshots = false;
     private long nextRowId;
+    private final List<EncryptedKey> keys;
 
     // change tracking
     private final List<MetadataUpdate> changes;
@@ -934,6 +945,7 @@ public class TableMetadata implements Serializable {
     private final Map<Integer, Schema> schemasById;
     private final Map<Integer, PartitionSpec> specsById;
     private final Map<Integer, SortOrder> sortOrdersById;
+    private final Map<String, EncryptedKey> keysById;
 
     private Builder() {
       this(DEFAULT_TABLE_FORMAT_VERSION);
@@ -954,6 +966,7 @@ public class TableMetadata implements Serializable {
       this.startingChangeCount = 0;
       this.snapshotLog = Lists.newArrayList();
       this.previousFiles = Lists.newArrayList();
+      this.keys = Lists.newArrayList();
       this.refs = Maps.newHashMap();
       this.statisticsFiles = Maps.newHashMap();
       this.partitionStatisticsFiles = Maps.newHashMap();
@@ -961,6 +974,7 @@ public class TableMetadata implements Serializable {
       this.schemasById = Maps.newHashMap();
       this.specsById = Maps.newHashMap();
       this.sortOrdersById = Maps.newHashMap();
+      this.keysById = Maps.newHashMap();
       this.nextRowId = INITIAL_ROW_ID;
     }
 
@@ -982,6 +996,7 @@ public class TableMetadata implements Serializable {
       this.properties = Maps.newHashMap(base.properties);
       this.currentSnapshotId = base.currentSnapshotId;
       this.snapshots = Lists.newArrayList(base.snapshots());
+      this.keys = Lists.newArrayList(base.keys);
       this.changes = Lists.newArrayList(base.changes);
       this.startingChangeCount = changes.size();
 
@@ -995,6 +1010,8 @@ public class TableMetadata implements Serializable {
       this.schemasById = Maps.newHashMap(base.schemasById);
       this.specsById = Maps.newHashMap(base.specsById);
       this.sortOrdersById = Maps.newHashMap(base.sortOrdersById);
+      this.keysById =
+          keys.stream().collect(Collectors.toMap(EncryptedKey::keyId, Function.identity()));
 
       this.nextRowId = base.nextRowId;
     }
@@ -1500,6 +1517,31 @@ public class TableMetadata implements Serializable {
       return this;
     }
 
+    public Builder addEncryptedKey(EncryptedKey key) {
+      if (keysById.containsKey(key.keyId())) {
+        // already exists
+        return this;
+      }
+
+      keys.add(key);
+      keysById.put(key.keyId(), key);
+
+      changes.add(new MetadataUpdate.AddEncryptionKey(key));
+
+      return this;
+    }
+
+    public Builder removeEncryptedKey(String keyId) {
+      boolean removed = keys.removeIf(key -> key.keyId().equals(keyId));
+      keysById.remove(keyId);
+
+      if (removed) {
+        changes.add(new MetadataUpdate.RemoveEncryptionKey(keyId));
+      }
+
+      return this;
+    }
+
     public Builder discardChanges() {
       this.discardChanges = true;
       return this;
@@ -1578,6 +1620,7 @@ public class TableMetadata implements Serializable {
               .flatMap(List::stream)
               .collect(Collectors.toList()),
           nextRowId,
+          keys,
           discardChanges ? ImmutableList.of() : ImmutableList.copyOf(changes));
     }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -231,9 +231,9 @@ public class TableMetadataParser {
       generator.writeNumberField(NEXT_ROW_ID, metadata.nextRowId());
     }
 
-    if (metadata.keys() != null) {
+    if (metadata.encryptionKeys() != null && !metadata.encryptionKeys().isEmpty()) {
       generator.writeArrayFieldStart(ENCRYPTION_KEYS);
-      for (EncryptedKey key : metadata.keys()) {
+      for (EncryptedKey key : metadata.encryptionKeys()) {
         EncryptedKeyParser.toJson(key, generator);
       }
       generator.writeEndArray();

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -34,6 +34,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import org.apache.iceberg.TableMetadata.MetadataLogEntry;
 import org.apache.iceberg.TableMetadata.SnapshotLogEntry;
+import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -110,6 +111,7 @@ public class TableMetadataParser {
   static final String METADATA_LOG = "metadata-log";
   static final String STATISTICS = "statistics";
   static final String PARTITION_STATISTICS = "partition-statistics";
+  static final String ENCRYPTION_KEYS = "encryption-keys";
   static final String NEXT_ROW_ID = "next-row-id";
   static final int MIN_NULL_CURRENT_SNAPSHOT_VERSION = 3;
 
@@ -227,6 +229,14 @@ public class TableMetadataParser {
 
     if (metadata.formatVersion() >= 3) {
       generator.writeNumberField(NEXT_ROW_ID, metadata.nextRowId());
+    }
+
+    if (metadata.keys() != null) {
+      generator.writeArrayFieldStart(ENCRYPTION_KEYS);
+      for (EncryptedKey key : metadata.keys()) {
+        EncryptedKeyParser.toJson(key, generator);
+      }
+      generator.writeEndArray();
     }
 
     toJson(metadata.refs(), generator);
@@ -472,6 +482,13 @@ public class TableMetadataParser {
 
     long lastUpdatedMillis = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);
 
+    List<EncryptedKey> keys;
+    if (node.has(ENCRYPTION_KEYS)) {
+      keys = JsonUtil.getObjectList(ENCRYPTION_KEYS, node, EncryptedKeyParser::fromJson);
+    } else {
+      keys = List.of();
+    }
+
     Map<String, SnapshotRef> refs;
     if (node.has(REFS)) {
       refs = refsFromJson(node.get(REFS));
@@ -562,6 +579,7 @@ public class TableMetadataParser {
         statisticsFiles,
         partitionStatisticsFiles,
         lastRowId,
+        keys,
         ImmutableList.of() /* no changes from the file */);
   }
 

--- a/core/src/main/java/org/apache/iceberg/encryption/BaseEncryptedKey.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/BaseEncryptedKey.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.encryption;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public class BaseEncryptedKey implements EncryptedKey {
   private final String keyId;
@@ -29,6 +30,8 @@ public class BaseEncryptedKey implements EncryptedKey {
 
   public BaseEncryptedKey(
       String keyId, ByteBuffer keyMetadata, String encryptedById, Map<String, String> properties) {
+    Preconditions.checkArgument(keyId != null, "Key id cannot be null");
+    Preconditions.checkArgument(keyMetadata != null, "Encrypted key metadata cannot be null");
     this.keyId = keyId;
     this.keyMetadata = keyMetadata;
     this.encryptedById = encryptedById;

--- a/core/src/main/java/org/apache/iceberg/encryption/BaseEncryptedKey.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/BaseEncryptedKey.java
@@ -18,25 +18,40 @@
  */
 package org.apache.iceberg.encryption;
 
-import java.util.List;
+import java.nio.ByteBuffer;
 import java.util.Map;
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
-public class EncryptionTestHelpers {
+public class BaseEncryptedKey implements EncryptedKey {
+  private final String keyId;
+  private final ByteBuffer keyMetadata;
+  private final String encryptedById;
+  private final Map<String, String> properties;
 
-  private EncryptionTestHelpers() {}
+  public BaseEncryptedKey(
+      String keyId, ByteBuffer keyMetadata, String encryptedById, Map<String, String> properties) {
+    this.keyId = keyId;
+    this.keyMetadata = keyMetadata;
+    this.encryptedById = encryptedById;
+    this.properties = properties;
+  }
 
-  public static EncryptionManager createEncryptionManager() {
-    Map<String, String> catalogProperties = Maps.newHashMap();
-    catalogProperties.put(
-        CatalogProperties.ENCRYPTION_KMS_IMPL, UnitestKMS.class.getCanonicalName());
-    Map<String, String> tableProperties = Maps.newHashMap();
-    tableProperties.put(TableProperties.ENCRYPTION_TABLE_KEY, UnitestKMS.MASTER_KEY_NAME1);
-    tableProperties.put(TableProperties.FORMAT_VERSION, "2");
+  @Override
+  public String keyId() {
+    return keyId;
+  }
 
-    return EncryptionUtil.createEncryptionManager(
-        List.of(), tableProperties, EncryptionUtil.createKmsClient(catalogProperties));
+  @Override
+  public ByteBuffer encryptedKeyMetadata() {
+    return keyMetadata;
+  }
+
+  @Override
+  public String encryptedById() {
+    return encryptedById;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.encryption;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.TableProperties;
@@ -71,7 +72,7 @@ public class EncryptionUtil {
   }
 
   public static EncryptionManager createEncryptionManager(
-      Map<String, String> tableProperties, KeyManagementClient kmsClient) {
+      List<EncryptedKey> keys, Map<String, String> tableProperties, KeyManagementClient kmsClient) {
     Preconditions.checkArgument(kmsClient != null, "Invalid KMS client: null");
     String tableKeyId = tableProperties.get(TableProperties.ENCRYPTION_TABLE_KEY);
 

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
@@ -71,7 +71,19 @@ public class EncryptionUtil {
     return kmsClient;
   }
 
+  /**
+   * Create a standard encryption manager.
+   *
+   * @deprecated will be removed in 1.11.0; use {@link #createEncryptionManager(List, Map,
+   *     KeyManagementClient)} instead.
+   */
+  @Deprecated
   public static EncryptionManager createEncryptionManager(
+      Map<String, String> tableProperties, KeyManagementClient kmsClient) {
+    return createEncryptionManager(List.of(), tableProperties, kmsClient);
+  }
+
+  static EncryptionManager createEncryptionManager(
       List<EncryptedKey> keys, Map<String, String> tableProperties, KeyManagementClient kmsClient) {
     Preconditions.checkArgument(kmsClient != null, "Invalid KMS client: null");
     String tableKeyId = tableProperties.get(TableProperties.ENCRYPTION_TABLE_KEY);

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -201,6 +201,14 @@ public class JsonUtil {
         BaseEncoding.base16().decode(pNode.textValue().toUpperCase(Locale.ROOT)));
   }
 
+  public static Map<String, String> getStringMapOrNull(String property, JsonNode node) {
+    if (!node.has(property)) {
+      return null;
+    }
+
+    return getStringMap(property, node);
+  }
+
   public static Map<String, String> getStringMap(String property, JsonNode node) {
     Preconditions.checkArgument(node.has(property), "Cannot parse missing map: %s", property);
     JsonNode pNode = node.get(property);
@@ -354,6 +362,34 @@ public class JsonUtil {
   public static void writeLongFieldIfPresent(String key, Long value, JsonGenerator generator)
       throws IOException {
     writeLongFieldIf(value != null, key, value, generator);
+  }
+
+  public static <T> List<T> getObjectListOrNull(
+      String property, JsonNode node, FromJson<T> fromJson) {
+    if (!node.has(property)) {
+      return null;
+    }
+
+    return getObjectList(property, node, fromJson);
+  }
+
+  public static <T> List<T> getObjectList(String property, JsonNode node, FromJson<T> fromJson) {
+    Preconditions.checkArgument(node.has(property), "Cannot parse missing list: %s", property);
+    Iterator<T> iter =
+        new JsonArrayIterator<>(property, node) {
+          @Override
+          T convert(JsonNode element) {
+            return fromJson.parse(element);
+          }
+
+          @Override
+          void validate(JsonNode element) {
+            Preconditions.checkArgument(
+                element.isObject(), "Cannot parse object from non-object value: %s", element);
+          }
+        };
+
+    return ImmutableList.copyOf(iter);
   }
 
   abstract static class JsonArrayIterator<T> implements Iterator<T> {

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -364,6 +364,18 @@ public class JsonUtil {
     writeLongFieldIf(value != null, key, value, generator);
   }
 
+  public static void writeStringFieldIfPresent(String key, String value, JsonGenerator generator)
+      throws IOException {
+    writeStringFieldIf(value != null, key, value, generator);
+  }
+
+  private static void writeStringFieldIf(
+      boolean condition, String key, String value, JsonGenerator generator) throws IOException {
+    if (condition) {
+      generator.writeStringField(key, value);
+    }
+  }
+
   public static <T> List<T> getObjectListOrNull(
       String property, JsonNode node, FromJson<T> fromJson) {
     if (!node.has(property)) {

--- a/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
@@ -203,6 +203,7 @@ public class TestDataTaskParser {
                 1,
                 "file:/tmp/manifest1.avro",
                 null,
+                null,
                 null),
             new BaseSnapshot(
                 2L,
@@ -213,6 +214,7 @@ public class TestDataTaskParser {
                 summary2,
                 1,
                 "file:/tmp/manifest2.avro",
+                null,
                 null,
                 null));
 

--- a/core/src/test/java/org/apache/iceberg/TestEncryptedKeyParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestEncryptedKeyParser.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/org/apache/iceberg/TestEncryptedKeyParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestEncryptedKeyParser.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import org.apache.iceberg.encryption.BaseEncryptedKey;
+import org.apache.iceberg.encryption.EncryptedKey;
+import org.junit.jupiter.api.Test;
+
+public class TestEncryptedKeyParser {
+  private static final byte[] KEY_BYTES = "key".getBytes(StandardCharsets.UTF_8);
+  private static final String BASE64_KEY = Base64.getEncoder().encodeToString(KEY_BYTES);
+
+  @Test
+  public void testMinimalMetadataFromJson() {
+    EncryptedKey key =
+        EncryptedKeyParser.fromJson(
+            "{\"key-id\": \"a\", \"encrypted-key-metadata\": \"" + BASE64_KEY + "\"}");
+
+    assertThat(key.keyId()).isEqualTo("a");
+    assertThat(key.encryptedKeyMetadata()).isEqualTo(ByteBuffer.wrap(KEY_BYTES));
+    assertThat(key.encryptedById()).isNull();
+    assertThat(key.properties()).isEmpty();
+  }
+
+  @Test
+  public void testRoundTrip() {
+    EncryptedKey key =
+        new BaseEncryptedKey("a", ByteBuffer.wrap(KEY_BYTES), "b", Map.of("test", "value"));
+
+    EncryptedKey actual = EncryptedKeyParser.fromJson(EncryptedKeyParser.toJson(key));
+
+    assertThat(actual.keyId()).isEqualTo(key.keyId());
+    assertThat(actual.encryptedKeyMetadata()).isEqualTo(key.encryptedKeyMetadata());
+    assertThat(actual.encryptedById()).isEqualTo(key.encryptedById());
+    assertThat(actual.properties()).isEqualTo(key.properties());
+  }
+
+  @Test
+  public void testMissingKeyId() {
+    assertThatThrownBy(
+            () ->
+                EncryptedKeyParser.fromJson("{\"encrypted-key-metadata\": \"" + BASE64_KEY + "\"}"))
+        .hasMessage("Cannot parse missing string: key-id")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void testMissingKeyMetadata() {
+    assertThatThrownBy(() -> EncryptedKeyParser.fromJson("{\"key-id\": \"a\"}"))
+        .hasMessage("Cannot parse missing string: encrypted-key-metadata")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -377,7 +377,8 @@ public class TestMetadataUpdateParser {
             schemaId,
             manifestList,
             firstRowId,
-            addedRows);
+            addedRows,
+            "key-1");
     String snapshotJson = SnapshotParser.toJson(snapshot, /* pretty */ false);
     String expected = String.format("{\"action\":\"%s\",\"snapshot\":%s}", action, snapshotJson);
     MetadataUpdate update = new MetadataUpdate.AddSnapshot(snapshot);
@@ -409,7 +410,8 @@ public class TestMetadataUpdateParser {
             schemaId,
             manifestList,
             lastRowId,
-            addedRows);
+            addedRows,
+            "key-1");
     String snapshotJson = SnapshotParser.toJson(snapshot, /* pretty */ false);
     String json = String.format("{\"action\":\"%s\",\"snapshot\":%s}", action, snapshotJson);
     MetadataUpdate expected = new MetadataUpdate.AddSnapshot(snapshot);

--- a/core/src/test/java/org/apache/iceberg/TestRowLineageMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowLineageMetadata.java
@@ -70,37 +70,41 @@ public class TestRowLineageMetadata {
   @Test
   public void testSnapshotRowIDValidation() {
     Snapshot snapshot =
-        new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", null, null);
+        new BaseSnapshot(
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", null, null, null);
     assertThat(snapshot.firstRowId()).isNull();
     assertThat(snapshot.addedRows()).isNull();
 
     // added-rows will be set to null if first-row-id is null
     snapshot =
-        new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", null, 10L);
+        new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", null, 10L, null);
     assertThat(snapshot.firstRowId()).isNull();
     assertThat(snapshot.addedRows()).isNull();
 
     // added-rows and first-row-id can be 0
-    snapshot = new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 0L, 0L);
+    snapshot =
+        new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 0L, 0L, null);
     assertThat(snapshot.firstRowId()).isEqualTo(0);
     assertThat(snapshot.addedRows()).isEqualTo(0);
 
     assertThatThrownBy(
             () ->
                 new BaseSnapshot(
-                    0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 10L, null))
+                    0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 10L, null, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid added-rows (required when first-row-id is set): null");
 
     assertThatThrownBy(
             () ->
-                new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 0L, -1L))
+                new BaseSnapshot(
+                    0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 0L, -1L, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid added-rows (cannot be negative): -1");
 
     assertThatThrownBy(
             () ->
-                new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", -1L, 1L))
+                new BaseSnapshot(
+                    0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", -1L, 1L, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid first-row-id (cannot be negative): -1");
   }
@@ -115,7 +119,7 @@ public class TestRowLineageMetadata {
 
     Snapshot addRows =
         new BaseSnapshot(
-            0, 1, null, 0, DataOperations.APPEND, null, 1, "foo", base.nextRowId(), newRows);
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "foo", base.nextRowId(), newRows, null);
 
     TableMetadata firstAddition = TableMetadata.buildFrom(base).addSnapshot(addRows).build();
 
@@ -123,7 +127,17 @@ public class TestRowLineageMetadata {
 
     Snapshot addMoreRows =
         new BaseSnapshot(
-            1, 2, 1L, 0, DataOperations.APPEND, null, 1, "foo", firstAddition.nextRowId(), newRows);
+            1,
+            2,
+            1L,
+            0,
+            DataOperations.APPEND,
+            null,
+            1,
+            "foo",
+            firstAddition.nextRowId(),
+            newRows,
+            null);
 
     TableMetadata secondAddition =
         TableMetadata.buildFrom(firstAddition).addSnapshot(addMoreRows).build();
@@ -140,7 +154,7 @@ public class TestRowLineageMetadata {
     TableMetadata base = baseMetadata();
 
     Snapshot invalidLastRow =
-        new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "foo", null, newRows);
+        new BaseSnapshot(0, 1, null, 0, DataOperations.APPEND, null, 1, "foo", null, newRows, null);
 
     assertThatThrownBy(() -> TableMetadata.buildFrom(base).addSnapshot(invalidLastRow))
         .isInstanceOf(ValidationException.class)
@@ -149,12 +163,12 @@ public class TestRowLineageMetadata {
     // add rows to check TableMetadata validation; Snapshot rejects negative next-row-id
     Snapshot addRows =
         new BaseSnapshot(
-            0, 1, null, 0, DataOperations.APPEND, null, 1, "foo", base.nextRowId(), newRows);
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "foo", base.nextRowId(), newRows, null);
     TableMetadata added = TableMetadata.buildFrom(base).addSnapshot(addRows).build();
 
     Snapshot invalidNewRows =
         new BaseSnapshot(
-            1, 2, 1L, 0, DataOperations.APPEND, null, 1, "foo", added.nextRowId() - 1, 10L);
+            1, 2, 1L, 0, DataOperations.APPEND, null, 1, "foo", added.nextRowId() - 1, 10L, null);
 
     assertThatThrownBy(() -> TableMetadata.buildFrom(added).addSnapshot(invalidNewRows))
         .isInstanceOf(ValidationException.class)

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -40,6 +40,7 @@ public class TestSnapshotJson {
     int snapshotId = 23;
     Long parentId = null;
     String manifestList = createManifestListWithManifestFiles(snapshotId, parentId);
+    String keyId = "key-1";
 
     Snapshot expected =
         new BaseSnapshot(
@@ -52,7 +53,8 @@ public class TestSnapshotJson {
             1,
             manifestList,
             null,
-            null);
+            null,
+            keyId);
     String json = SnapshotParser.toJson(expected);
     Snapshot snapshot = SnapshotParser.fromJson(json);
 
@@ -63,6 +65,7 @@ public class TestSnapshotJson {
     assertThat(snapshot.schemaId()).isEqualTo(1);
     assertThat(snapshot.firstRowId()).isNull();
     assertThat(snapshot.addedRows()).isNull();
+    assertThat(snapshot.keyId()).isEqualTo(keyId);
   }
 
   @Test
@@ -81,6 +84,7 @@ public class TestSnapshotJson {
             null,
             null,
             manifestList,
+            null,
             null,
             null);
     String json = SnapshotParser.toJson(expected);
@@ -112,6 +116,7 @@ public class TestSnapshotJson {
             ImmutableMap.of("files-added", "4", "files-deleted", "100"),
             3,
             manifestList,
+            null,
             null,
             null);
 
@@ -152,7 +157,8 @@ public class TestSnapshotJson {
             null,
             manifestList,
             firstRowId,
-            addedRows);
+            addedRows,
+            null);
     String json = SnapshotParser.toJson(expected);
     Snapshot snapshot = SnapshotParser.fromJson(json);
 

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -198,6 +198,7 @@ public class TestTableMetadata {
             statisticsFiles,
             partitionStatisticsFiles,
             40,
+            ImmutableList.of(),
             ImmutableList.of());
 
     String asJson = TableMetadataParser.toJson(expected);
@@ -300,6 +301,7 @@ public class TestTableMetadata {
             ImmutableList.of(),
             ImmutableList.of(),
             0,
+            ImmutableList.of(),
             ImmutableList.of());
 
     String asJson = toJsonWithoutSpecAndSchemaList(expected);
@@ -421,6 +423,7 @@ public class TestTableMetadata {
                     ImmutableList.of(),
                     ImmutableList.of(),
                     0L,
+                    ImmutableList.of(),
                     ImmutableList.of()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Current snapshot ID does not match main branch");
@@ -468,6 +471,7 @@ public class TestTableMetadata {
                     ImmutableList.of(),
                     ImmutableList.of(),
                     0L,
+                    ImmutableList.of(),
                     ImmutableList.of()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Current snapshot is not set, but main branch exists");
@@ -509,6 +513,7 @@ public class TestTableMetadata {
                     ImmutableList.of(),
                     ImmutableList.of(),
                     0L,
+                    ImmutableList.of(),
                     ImmutableList.of()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith("does not exist in the existing snapshots list");
@@ -625,6 +630,7 @@ public class TestTableMetadata {
             ImmutableList.of(),
             ImmutableList.of(),
             0L,
+            ImmutableList.of(),
             ImmutableList.of());
 
     String asJson = TableMetadataParser.toJson(base);
@@ -713,6 +719,7 @@ public class TestTableMetadata {
             ImmutableList.of(),
             ImmutableList.of(),
             0L,
+            ImmutableList.of(),
             ImmutableList.of());
 
     previousMetadataLog.add(latestPreviousMetadata);
@@ -816,6 +823,7 @@ public class TestTableMetadata {
             ImmutableList.of(),
             ImmutableList.of(),
             0L,
+            ImmutableList.of(),
             ImmutableList.of());
 
     previousMetadataLog.add(latestPreviousMetadata);
@@ -923,6 +931,7 @@ public class TestTableMetadata {
             ImmutableList.of(),
             ImmutableList.of(),
             0L,
+            ImmutableList.of(),
             ImmutableList.of());
 
     previousMetadataLog.add(latestPreviousMetadata);
@@ -970,6 +979,7 @@ public class TestTableMetadata {
                     ImmutableList.of(),
                     ImmutableList.of(),
                     0L,
+                    ImmutableList.of(),
                     ImmutableList.of()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("UUID is required in format v2");
@@ -1006,6 +1016,7 @@ public class TestTableMetadata {
                     ImmutableList.of(),
                     ImmutableList.of(),
                     0L,
+                    ImmutableList.of(),
                     ImmutableList.of()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
@@ -1053,6 +1064,7 @@ public class TestTableMetadata {
                 ImmutableList.of(),
                 ImmutableList.of(),
                 0L,
+                ImmutableList.of(),
                 ImmutableList.of()))
         .isNotNull();
 

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -116,6 +116,7 @@ public class TestTableMetadata {
             null,
             manifestList,
             null,
+            null,
             null);
 
     long currentSnapshotId = System.currentTimeMillis();
@@ -132,6 +133,7 @@ public class TestTableMetadata {
             null,
             7,
             manifestList,
+            null,
             null,
             null);
 
@@ -256,6 +258,7 @@ public class TestTableMetadata {
             null,
             manifestList,
             null,
+            null,
             null);
 
     long currentSnapshotId = System.currentTimeMillis();
@@ -272,6 +275,7 @@ public class TestTableMetadata {
             null,
             null,
             manifestList,
+            null,
             null,
             null);
 
@@ -361,6 +365,7 @@ public class TestTableMetadata {
             null,
             manifestList,
             null,
+            null,
             null);
 
     long currentSnapshotId = System.currentTimeMillis();
@@ -378,6 +383,7 @@ public class TestTableMetadata {
             null,
             7,
             manifestList,
+            null,
             null,
             null);
 
@@ -437,7 +443,7 @@ public class TestTableMetadata {
         createManifestListWithManifestFile(snapshotId, null, "file:/tmp/manifest1.avro");
     Snapshot snapshot =
         new BaseSnapshot(
-            0, snapshotId, null, snapshotId, null, null, null, manifestList, null, null);
+            0, snapshotId, null, snapshotId, null, null, null, manifestList, null, null, null);
 
     Schema schema = new Schema(6, Types.NestedField.required(10, "x", Types.StringType.get()));
 
@@ -578,6 +584,7 @@ public class TestTableMetadata {
             null,
             manifestList,
             null,
+            null,
             null);
 
     long currentSnapshotId = System.currentTimeMillis();
@@ -594,6 +601,7 @@ public class TestTableMetadata {
             null,
             null,
             manifestList,
+            null,
             null,
             null);
 
@@ -656,6 +664,7 @@ public class TestTableMetadata {
             null,
             manifestList,
             null,
+            null,
             null);
     long currentSnapshotId = System.currentTimeMillis();
 
@@ -672,6 +681,7 @@ public class TestTableMetadata {
             null,
             null,
             manifestList,
+            null,
             null,
             null);
 
@@ -751,6 +761,7 @@ public class TestTableMetadata {
             null,
             manifestList,
             null,
+            null,
             null);
 
     long currentSnapshotId = System.currentTimeMillis();
@@ -767,6 +778,7 @@ public class TestTableMetadata {
             null,
             null,
             manifestList,
+            null,
             null,
             null);
 
@@ -859,6 +871,7 @@ public class TestTableMetadata {
             null,
             manifestList,
             null,
+            null,
             null);
 
     long currentSnapshotId = System.currentTimeMillis();
@@ -875,6 +888,7 @@ public class TestTableMetadata {
             null,
             null,
             manifestList,
+            null,
             null,
             null);
 


### PR DESCRIPTION
This implements the spec changes from #12162.

It adds the `encryption-keys` list to `TableMetadata` that stores an `EncryptedKey`. The `TableMetadata.Builder` is updated with `addEncryptionKey` and `removeEncryptionKey` methods, along with corresponding REST protocol metadata updates. This also adds `key-id` to snapshot metadata.