### PR TITLE
Flink: Backport Add lockFactory open in LockRemover for table maintenance to Flink 1.20 and 1.19

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/LockRemover.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/LockRemover.java
@@ -125,6 +125,7 @@ public class LockRemover extends AbstractStreamOperator<Void>
           .gauge(TableMaintenanceMetrics.LAST_RUN_DURATION_MS, duration::get);
     }
 
+    lockFactory.open();
     this.lock = lockFactory.createLock();
     this.recoveryLock = lockFactory.createRecoveryLock();
   }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
@@ -293,24 +293,35 @@ class TestLockRemover extends OperatorTestBase {
   }
 
   private static class TestingLockFactory implements TriggerLockFactory {
+
+    private boolean open = false;
+
     @Override
     public void open() {
-      // Do nothing
+      open = true;
     }
 
     @Override
     public Lock createLock() {
+      if (!open) {
+        throw new IllegalStateException("Lock factory not open");
+      }
+
       return LOCK;
     }
 
     @Override
     public Lock createRecoveryLock() {
+      if (!open) {
+        throw new IllegalStateException("Lock factory not open");
+      }
+
       return RECOVERY_LOCK;
     }
 
     @Override
     public void close() {
-      // Do nothing
+      open = false;
     }
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/LockRemover.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/LockRemover.java
@@ -125,6 +125,7 @@ public class LockRemover extends AbstractStreamOperator<Void>
           .gauge(TableMaintenanceMetrics.LAST_RUN_DURATION_MS, duration::get);
     }
 
+    lockFactory.open();
     this.lock = lockFactory.createLock();
     this.recoveryLock = lockFactory.createRecoveryLock();
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestLockRemover.java
@@ -293,24 +293,35 @@ class TestLockRemover extends OperatorTestBase {
   }
 
   private static class TestingLockFactory implements TriggerLockFactory {
+
+    private boolean open = false;
+
     @Override
     public void open() {
-      // Do nothing
+      open = true;
     }
 
     @Override
     public Lock createLock() {
+      if (!open) {
+        throw new IllegalStateException("Lock factory not open");
+      }
+
       return LOCK;
     }
 
     @Override
     public Lock createRecoveryLock() {
+      if (!open) {
+        throw new IllegalStateException("Lock factory not open");
+      }
+
       return RECOVERY_LOCK;
     }
 
     @Override
     public void close() {
-      // Do nothing
+      open = false;
     }
   }
 


### PR DESCRIPTION
This pr is backport https://github.com/apache/iceberg/pull/12900 to  Flink 1.20 and 1.19.