### PR TITLE
Docs: Add DuckDB

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
   - Doris: https://doris.apache.org/docs/dev/lakehouse/catalogs/iceberg-catalog
   - Druid: https://druid.apache.org/docs/latest/development/extensions-contrib/iceberg/
+  - DuckDB: https://duckdb.org/docs/preview/core_extensions/iceberg/overview
   - Kafka Connect: kafka-connect.md
   - Integrations:
     - aws.md


### PR DESCRIPTION
This PR adds DuckDB in the menu among the systems supporting Iceberg. The link points to DuckDB's [`iceberg` extension](https://duckdb.org/docs/preview/core_extensions/iceberg/overview).