### PR TITLE
Follow up to address comments in variant array writer

### DIFF
--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -103,7 +103,7 @@ public class TestVariantWriters {
   private static final ByteBuffer NESTED_ARRAY_BUFFER =
       VariantTestUtil.createArray(
           array(Variants.of("string"), Variants.of("iceberg")),
-          array(Variants.of("string"), Variants.of("iceberg")));
+          array(Variants.of("apple"), Variants.of("banana")));
   private static final ByteBuffer MIXED_NESTED_ARRAY_BUFFER =
       VariantTestUtil.createArray(
           array(Variants.of("string"), Variants.of("iceberg"), Variants.of(34)),


### PR DESCRIPTION
Fix up to address the comments in https://github.com/apache/iceberg/pull/12847: update the shredding to only apply when all the array elements are of a uniform type instead of using most common type. That will make verification straightforward. 