### PR TITLE
Spark 3.4: Migrate tests in sql

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -18,96 +18,105 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE_REST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
-import java.util.Map;
+import java.nio.file.Files;
 import java.util.UUID;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestCreateTable extends SparkCatalogTestBase {
-  public TestCreateTable(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestCreateTable extends CatalogTestBase {
 
-  @After
+  @AfterEach
   public void dropTestTable() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testTransformIgnoreCase() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
     sql(
         "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
             + "USING iceberg partitioned by (HOURS(ts))",
         tableName);
-    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent)).as("Table should already exist").isTrue();
     sql(
         "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
             + "USING iceberg partitioned by (hours(ts))",
         tableName);
-    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent)).as("Table should already exist").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testTransformSingularForm() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
     sql(
         "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
             + "USING iceberg partitioned by (hour(ts))",
         tableName);
-    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent)).as("Table should exist").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testTransformPluralForm() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
     sql(
         "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
             + "USING iceberg partitioned by (hours(ts))",
         tableName);
-    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent)).as("Table should exist").isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTable() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql("CREATE TABLE %s (id BIGINT NOT NULL, data STRING) USING iceberg", tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertNotNull("Should load the new table", table);
+    assertThat(table).as("Should load the new table").isNotNull();
 
     StructType expectedSchema =
         StructType.of(
             NestedField.required(1, "id", Types.LongType.get()),
             NestedField.optional(2, "data", Types.StringType.get()));
-    Assert.assertEquals(
-        "Should have the expected schema", expectedSchema, table.schema().asStruct());
-    Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
-    Assert.assertNull(
-        "Should not have the default format set",
-        table.properties().get(TableProperties.DEFAULT_FILE_FORMAT));
+    assertThat(table.schema().asStruct())
+        .as("Should have the expected schema")
+        .isEqualTo(expectedSchema);
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTablePartitionedByUUID() {
     assertThat(validationCatalog.tableExists(tableIdent)).isFalse();
     Schema schema = new Schema(1, Types.NestedField.optional(1, "uuid", Types.UUIDType.get()));
@@ -126,13 +135,14 @@ public class TestCreateTable extends SparkCatalogTestBase {
 
     sql("INSERT INTO %s VALUES('%s')", tableName, uuid);
 
-    assertThat(sql("SELECT uuid FROM %s", tableName)).hasSize(1).element(0).isEqualTo(row(uuid));
+    assertThat(sql("SELECT uuid FROM %s", tableName)).singleElement().isEqualTo(row(uuid));
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTableInRootNamespace() {
-    Assume.assumeTrue(
-        "Hadoop has no default namespace configured", "testhadoop".equals(catalogName));
+    assumeThat(catalogName)
+        .as("Hadoop has no default namespace configured")
+        .isEqualTo("testhadoop");
 
     try {
       sql("CREATE TABLE %s.table (id bigint) USING iceberg", catalogName);
@@ -141,30 +151,30 @@ public class TestCreateTable extends SparkCatalogTestBase {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTableUsingParquet() {
-    Assume.assumeTrue(
-        "Not working with session catalog because Spark will not use v2 for a Parquet table",
-        !"spark_catalog".equals(catalogName));
+    assumeThat(catalogName)
+        .as("Not working with session catalog because Spark will not use v2 for a Parquet table")
+        .isNotEqualTo("spark_catalog");
 
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql("CREATE TABLE %s (id BIGINT NOT NULL, data STRING) USING parquet", tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertNotNull("Should load the new table", table);
+    assertThat(table).as("Should load the new table").isNotNull();
 
     StructType expectedSchema =
         StructType.of(
             NestedField.required(1, "id", Types.LongType.get()),
             NestedField.optional(2, "data", Types.StringType.get()));
-    Assert.assertEquals(
-        "Should have the expected schema", expectedSchema, table.schema().asStruct());
-    Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
-    Assert.assertEquals(
-        "Should not have default format parquet",
-        "parquet",
-        table.properties().get(TableProperties.DEFAULT_FILE_FORMAT));
+    assertThat(table.schema().asStruct())
+        .as("Should have the expected schema")
+        .isEqualTo(expectedSchema);
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).containsEntry(TableProperties.DEFAULT_FILE_FORMAT, "parquet");
 
     assertThatThrownBy(
             () ->
@@ -175,9 +185,11 @@ public class TestCreateTable extends SparkCatalogTestBase {
         .hasMessage("Unsupported format in USING: crocodile");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTablePartitionedBy() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql(
         "CREATE TABLE %s "
@@ -187,7 +199,7 @@ public class TestCreateTable extends SparkCatalogTestBase {
         tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertNotNull("Should load the new table", table);
+    assertThat(table).as("Should load the new table").isNotNull();
 
     StructType expectedSchema =
         StructType.of(
@@ -195,8 +207,9 @@ public class TestCreateTable extends SparkCatalogTestBase {
             NestedField.optional(2, "created_at", Types.TimestampType.withZone()),
             NestedField.optional(3, "category", Types.StringType.get()),
             NestedField.optional(4, "data", Types.StringType.get()));
-    Assert.assertEquals(
-        "Should have the expected schema", expectedSchema, table.schema().asStruct());
+    assertThat(table.schema().asStruct())
+        .as("Should have the expected schema")
+        .isEqualTo(expectedSchema);
 
     PartitionSpec expectedSpec =
         PartitionSpec.builderFor(new Schema(expectedSchema.fields()))
@@ -204,16 +217,15 @@ public class TestCreateTable extends SparkCatalogTestBase {
             .bucket("id", 8)
             .day("created_at")
             .build();
-    Assert.assertEquals("Should be partitioned correctly", expectedSpec, table.spec());
-
-    Assert.assertNull(
-        "Should not have the default format set",
-        table.properties().get(TableProperties.DEFAULT_FILE_FORMAT));
+    assertThat(table.spec()).as("Should be partitioned correctly").isEqualTo(expectedSpec);
+    assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTableColumnComments() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql(
         "CREATE TABLE %s "
@@ -222,23 +234,24 @@ public class TestCreateTable extends SparkCatalogTestBase {
         tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertNotNull("Should load the new table", table);
+    assertThat(table).as("Should load the new table").isNotNull();
 
     StructType expectedSchema =
         StructType.of(
             NestedField.required(1, "id", Types.LongType.get(), "Unique identifier"),
             NestedField.optional(2, "data", Types.StringType.get(), "Data value"));
-    Assert.assertEquals(
-        "Should have the expected schema", expectedSchema, table.schema().asStruct());
-    Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
-    Assert.assertNull(
-        "Should not have the default format set",
-        table.properties().get(TableProperties.DEFAULT_FILE_FORMAT));
+    assertThat(table.schema().asStruct())
+        .as("Should have the expected schema")
+        .isEqualTo(expectedSchema);
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTableComment() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql(
         "CREATE TABLE %s "
@@ -248,34 +261,33 @@ public class TestCreateTable extends SparkCatalogTestBase {
         tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertNotNull("Should load the new table", table);
+    assertThat(table).as("Should load the new table").isNotNull();
 
     StructType expectedSchema =
         StructType.of(
             NestedField.required(1, "id", Types.LongType.get()),
             NestedField.optional(2, "data", Types.StringType.get()));
-    Assert.assertEquals(
-        "Should have the expected schema", expectedSchema, table.schema().asStruct());
-    Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
-    Assert.assertNull(
-        "Should not have the default format set",
-        table.properties().get(TableProperties.DEFAULT_FILE_FORMAT));
-    Assert.assertEquals(
-        "Should have the table comment set in properties",
-        "Table doc",
-        table.properties().get(TableCatalog.PROP_COMMENT));
+    assertThat(table.schema().asStruct())
+        .as("Should have the expected schema")
+        .isEqualTo(expectedSchema);
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties())
+        .doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT)
+        .containsEntry(TableCatalog.PROP_COMMENT, "Table doc");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTableLocation() throws Exception {
-    Assume.assumeTrue(
-        "Cannot set custom locations for Hadoop catalog tables",
-        !(validationCatalog instanceof HadoopCatalog));
+    assumeThat(validationCatalog)
+        .as("Cannot set custom locations for Hadoop catalog tables")
+        .isNotInstanceOf(HadoopCatalog.class);
 
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
-    File tableLocation = temp.newFolder();
-    Assert.assertTrue(tableLocation.delete());
+    File tableLocation = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableLocation.delete()).isTrue();
 
     String location = "file:" + tableLocation;
 
@@ -287,24 +299,25 @@ public class TestCreateTable extends SparkCatalogTestBase {
         tableName, location);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertNotNull("Should load the new table", table);
+    assertThat(table).as("Should load the new table").isNotNull();
 
     StructType expectedSchema =
         StructType.of(
             NestedField.required(1, "id", Types.LongType.get()),
             NestedField.optional(2, "data", Types.StringType.get()));
-    Assert.assertEquals(
-        "Should have the expected schema", expectedSchema, table.schema().asStruct());
-    Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
-    Assert.assertNull(
-        "Should not have the default format set",
-        table.properties().get(TableProperties.DEFAULT_FILE_FORMAT));
-    Assert.assertEquals("Should have a custom table location", location, table.location());
+    assertThat(table.schema().asStruct())
+        .as("Should have the expected schema")
+        .isEqualTo(expectedSchema);
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
+    assertThat(table.location()).as("Should have a custom table location").isEqualTo(location);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateTableProperties() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql(
         "CREATE TABLE %s "
@@ -314,22 +327,69 @@ public class TestCreateTable extends SparkCatalogTestBase {
         tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertNotNull("Should load the new table", table);
+    assertThat(table).as("Should load the new table").isNotNull();
 
     StructType expectedSchema =
         StructType.of(
             NestedField.required(1, "id", Types.LongType.get()),
             NestedField.optional(2, "data", Types.StringType.get()));
-    Assert.assertEquals(
-        "Should have the expected schema", expectedSchema, table.schema().asStruct());
-    Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
-    Assert.assertEquals("Should have property p1", "2", table.properties().get("p1"));
-    Assert.assertEquals("Should have property p2", "x", table.properties().get("p2"));
+    assertThat(table.schema().asStruct())
+        .as("Should have the expected schema")
+        .isEqualTo(expectedSchema);
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).containsEntry("p1", "2").containsEntry("p2", "x");
   }
 
-  @Test
+  @TestTemplate
+  public void testCreateTableCommitProperties() {
+    assumeThat(catalogConfig.get(ICEBERG_CATALOG_TYPE))
+        .as(
+            "need to fix https://github.com/apache/iceberg/issues/11554 before enabling this for the REST catalog")
+        .isNotEqualTo(ICEBERG_CATALOG_TYPE_REST);
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CREATE TABLE %s "
+                        + "(id BIGINT NOT NULL, data STRING) "
+                        + "USING iceberg "
+                        + "TBLPROPERTIES ('commit.retry.num-retries'='x', p2='x')",
+                    tableName))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Table property commit.retry.num-retries must have integer value");
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CREATE TABLE %s "
+                        + "(id BIGINT NOT NULL, data STRING) "
+                        + "USING iceberg "
+                        + "TBLPROPERTIES ('commit.retry.max-wait-ms'='-1')",
+                    tableName))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Table property commit.retry.max-wait-ms must have non negative integer value");
+
+    sql(
+        "CREATE TABLE %s "
+            + "(id BIGINT NOT NULL, data STRING) "
+            + "USING iceberg "
+            + "TBLPROPERTIES ('commit.retry.num-retries'='1', 'commit.retry.max-wait-ms'='3000')",
+        tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.properties())
+        .containsEntry(TableProperties.COMMIT_NUM_RETRIES, "1")
+        .containsEntry(TableProperties.COMMIT_MAX_RETRY_WAIT_MS, "3000");
+  }
+
+  @TestTemplate
   public void testCreateTableWithFormatV2ThroughTableProperty() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql(
         "CREATE TABLE %s "
@@ -339,15 +399,16 @@ public class TestCreateTable extends SparkCatalogTestBase {
         tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals(
-        "should create table using format v2",
-        2,
-        ((BaseTable) table).operations().current().formatVersion());
+    assertThat(((BaseTable) table).operations().current().formatVersion())
+        .as("should create table using format v2")
+        .isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testUpgradeTableWithFormatV2ThroughTableProperty() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql(
         "CREATE TABLE %s "
@@ -358,15 +419,21 @@ public class TestCreateTable extends SparkCatalogTestBase {
 
     Table table = validationCatalog.loadTable(tableIdent);
     TableOperations ops = ((BaseTable) table).operations();
-    Assert.assertEquals("should create table using format v1", 1, ops.refresh().formatVersion());
+    assertThat(ops.refresh().formatVersion())
+        .as("should create table using format v1")
+        .isEqualTo(1);
 
     sql("ALTER TABLE %s SET TBLPROPERTIES ('format-version'='2')", tableName);
-    Assert.assertEquals("should update table to use format v2", 2, ops.refresh().formatVersion());
+    assertThat(ops.refresh().formatVersion())
+        .as("should update table to use format v2")
+        .isEqualTo(2);
   }
 
-  @Test
+  @TestTemplate
   public void testDowngradeTableToFormatV1ThroughTablePropertyFails() {
-    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
 
     sql(
         "CREATE TABLE %s "
@@ -377,7 +444,9 @@ public class TestCreateTable extends SparkCatalogTestBase {
 
     Table table = validationCatalog.loadTable(tableIdent);
     TableOperations ops = ((BaseTable) table).operations();
-    Assert.assertEquals("should create table using format v2", 2, ops.refresh().formatVersion());
+    assertThat(ops.refresh().formatVersion())
+        .as("should create table using format v2")
+        .isEqualTo(2);
 
     assertThatThrownBy(
             () -> sql("ALTER TABLE %s SET TBLPROPERTIES ('format-version'='1')", tableName))

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
@@ -26,38 +26,51 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PlanningMode;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.execution.SparkPlan;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestFilterPushDown extends SparkTestBaseWithCatalog {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestFilterPushDown extends TestBaseWithCatalog {
 
-  @Parameterized.Parameters(name = "planningMode = {0}")
-  public static Object[] parameters() {
-    return new Object[] {LOCAL, DISTRIBUTED};
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, planningMode = {0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties(),
+        LOCAL
+      },
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties(),
+        DISTRIBUTED
+      }
+    };
   }
 
-  private final PlanningMode planningMode;
+  @Parameter(index = 3)
+  private PlanningMode planningMode;
 
-  public TestFilterPushDown(PlanningMode planningMode) {
-    this.planningMode = planningMode;
-  }
-
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS tmp_view");
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithDecimalValues() {
     sql(
         "CREATE TABLE %s (id INT, salary DECIMAL(10, 2), dep STRING)"
@@ -76,7 +89,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         ImmutableList.of(row(2, new BigDecimal("100.05"), "d1")));
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithIdentityTransform() {
     sql(
         "CREATE TABLE %s (id INT, salary INT, dep STRING)"
@@ -188,7 +201,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         ImmutableList.of(row(5, 500, "d5")));
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithHoursTransform() {
     sql(
         "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
@@ -234,7 +247,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithDaysTransform() {
     sql(
         "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
@@ -277,7 +290,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithMonthsTransform() {
     sql(
         "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
@@ -320,7 +333,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithYearsTransform() {
     sql(
         "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
@@ -363,7 +376,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithBucketTransform() {
     sql(
         "CREATE TABLE %s (id INT, salary INT, dep STRING)"
@@ -382,7 +395,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         ImmutableList.of(row(1, 100, "d1")));
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithTruncateTransform() {
     sql(
         "CREATE TABLE %s (id INT, salary INT, dep STRING)"
@@ -407,7 +420,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         ImmutableList.of(row(1, 100, "d1")));
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithSpecEvolutionAndIdentityTransforms() {
     sql(
         "CREATE TABLE %s (id INT, salary INT, dep STRING, sub_dep STRING)"
@@ -448,7 +461,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         ImmutableList.of(row(1, 100, "d1", "sd1")));
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithSpecEvolutionAndTruncateTransform() {
     sql(
         "CREATE TABLE %s (id INT, salary INT, dep STRING)"
@@ -489,7 +502,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         ImmutableList.of(row(1, 100, "d1")));
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithSpecEvolutionAndTimeTransforms() {
     sql(
         "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
@@ -526,7 +539,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         });
   }
 
-  @Test
+  @TestTemplate
   public void testFilterPushdownWithSpecialFloatingPointPartitionValues() {
     sql(
         "CREATE TABLE %s (id INT, salary DOUBLE)" + "USING iceberg " + "PARTITIONED BY (salary)",

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.sql;
 
 import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
 import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE_REST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
@@ -28,88 +29,130 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.apache.iceberg.spark.CatalogTestBase;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestNamespaceSQL extends SparkCatalogTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestNamespaceSQL extends CatalogTestBase {
   private static final Namespace NS = Namespace.of("db");
 
-  private final String fullNamespace;
-  private final boolean isHadoopCatalog;
+  @Parameter(index = 3)
+  private String fullNamespace;
 
-  public TestNamespaceSQL(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-    this.fullNamespace = ("spark_catalog".equals(catalogName) ? "" : catalogName + ".") + NS;
-    this.isHadoopCatalog = "testhadoop".equals(catalogName);
+  @Parameter(index = 4)
+  private boolean isHadoopCatalog;
+
+  @Parameters(
+      name =
+          "catalogName = {0}, implementation = {1}, config = {2}, fullNameSpace = {3}, isHadoopCatalog = {4}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties(),
+        SparkCatalogConfig.HIVE.catalogName() + "." + NS.toString(),
+        false
+      },
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties(),
+        SparkCatalogConfig.HADOOP.catalogName() + "." + NS,
+        true
+      },
+      {
+        SparkCatalogConfig.SPARK.catalogName(),
+        SparkCatalogConfig.SPARK.implementation(),
+        SparkCatalogConfig.SPARK.properties(),
+        NS.toString(),
+        false
+      }
+    };
   }
 
-  @After
+  @AfterEach
   public void cleanNamespaces() {
     sql("DROP TABLE IF EXISTS %s.table", fullNamespace);
     sql("DROP NAMESPACE IF EXISTS %s", fullNamespace);
   }
 
-  @Test
+  @TestTemplate
   public void testCreateNamespace() {
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
     sql("CREATE NAMESPACE %s", fullNamespace);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
   }
 
-  @Test
+  @TestTemplate
   public void testDefaultNamespace() {
-    Assume.assumeFalse("Hadoop has no default namespace configured", isHadoopCatalog);
+    assumeThat(isHadoopCatalog).as("Hadoop has no default namespace configured").isFalse();
     assumeThat(catalogConfig.get(ICEBERG_CATALOG_TYPE))
         .as("REST has no default namespace configured")
         .isNotEqualTo(ICEBERG_CATALOG_TYPE_REST);
 
     sql("USE %s", catalogName);
 
-    Object[] current = Iterables.getOnlyElement(sql("SHOW CURRENT NAMESPACE"));
-    Assert.assertEquals("Should use the current catalog", current[0], catalogName);
-    Assert.assertEquals("Should use the configured default namespace", current[1], "default");
+    assertThat(sql("SHOW CURRENT NAMESPACE"))
+        .singleElement()
+        .satisfies(
+            ns -> {
+              assertThat(ns).containsExactly(catalogName, "default");
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testDropEmptyNamespace() {
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
     sql("CREATE NAMESPACE %s", fullNamespace);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
 
     sql("DROP NAMESPACE %s", fullNamespace);
 
-    Assert.assertFalse(
-        "Namespace should have been dropped", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should have been dropped")
+        .isFalse();
   }
 
-  @Test
+  @TestTemplate
   public void testDropNonEmptyNamespace() {
-    Assume.assumeFalse("Session catalog has flaky behavior", "spark_catalog".equals(catalogName));
+    assumeThat(catalogName).as("Session catalog has flaky behavior").isNotEqualTo("spark_catalog");
 
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
     sql("CREATE NAMESPACE %s", fullNamespace);
     sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullNamespace);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
-    Assert.assertTrue(
-        "Table should exist", validationCatalog.tableExists(TableIdentifier.of(NS, "table")));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
+    assertThat(validationCatalog.tableExists(TableIdentifier.of(NS, "table")))
+        .as("Table should exist")
+        .isTrue();
 
     assertThatThrownBy(() -> sql("DROP NAMESPACE %s", fullNamespace))
         .isInstanceOfAny(NamespaceNotEmptyException.class, BadRequestException.class)
@@ -118,135 +161,149 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
     sql("DROP TABLE %s.table", fullNamespace);
   }
 
-  @Test
+  @TestTemplate
   public void testListTables() {
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
     sql("CREATE NAMESPACE %s", fullNamespace);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
 
     List<Object[]> rows = sql("SHOW TABLES IN %s", fullNamespace);
-    Assert.assertEquals("Should not list any tables", 0, rows.size());
+    assertThat(rows).as("Should not list any tables").isEmpty();
 
     sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullNamespace);
 
-    Object[] row = Iterables.getOnlyElement(sql("SHOW TABLES IN %s", fullNamespace));
-    Assert.assertEquals("Namespace should match", "db", row[0]);
-    Assert.assertEquals("Table name should match", "table", row[1]);
+    assertThat(sql("SHOW TABLES IN %s", fullNamespace))
+        .singleElement()
+        .satisfies(
+            row -> {
+              assertThat(row).containsExactly("db", "table", false);
+            });
   }
 
-  @Test
+  @TestTemplate
   public void testListNamespace() {
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
     sql("CREATE NAMESPACE %s", fullNamespace);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
 
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
     if (isHadoopCatalog
         || catalogConfig.get(ICEBERG_CATALOG_TYPE).equals(ICEBERG_CATALOG_TYPE_REST)) {
-      Assert.assertEquals("Should have 1 namespace", 1, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals("Should have only db namespace", ImmutableSet.of("db"), namespaceNames);
+      assertThat(namespaces)
+          .singleElement()
+          .satisfies(
+              ns -> {
+                assertThat(ns).containsExactly("db");
+              });
     } else {
-      Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
+      assertThat(namespaces).as("Should have 2 namespaces").hasSize(2);
       Set<String> namespaceNames =
           namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals(
-          "Should have default and db namespaces",
-          ImmutableSet.of("default", "db"),
-          namespaceNames);
+      assertThat(namespaceNames)
+          .as("Should have default and db namespaces")
+          .containsExactlyInAnyOrder("default", "db");
     }
 
     List<Object[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
-
-    Set<String> nestedNames =
-        nestedNamespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-    Assert.assertEquals("Should not have nested namespaces", ImmutableSet.of(), nestedNames);
+    assertThat(nestedNamespaces).as("Should not have nested namespaces").isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testCreateNamespaceWithMetadata() {
-    Assume.assumeFalse("HadoopCatalog does not support namespace metadata", isHadoopCatalog);
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isFalse();
 
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
     sql("CREATE NAMESPACE %s WITH PROPERTIES ('prop'='value')", fullNamespace);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
 
     Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
 
-    Assert.assertEquals(
-        "Namespace should have expected prop value", "value", nsMetadata.get("prop"));
+    assertThat(nsMetadata).containsEntry("prop", "value");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateNamespaceWithComment() {
-    Assume.assumeFalse("HadoopCatalog does not support namespace metadata", isHadoopCatalog);
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isFalse();
 
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
     sql("CREATE NAMESPACE %s COMMENT 'namespace doc'", fullNamespace);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
 
     Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
 
-    Assert.assertEquals(
-        "Namespace should have expected comment", "namespace doc", nsMetadata.get("comment"));
+    assertThat(nsMetadata).containsEntry("comment", "namespace doc");
   }
 
-  @Test
+  @TestTemplate
   public void testCreateNamespaceWithLocation() throws Exception {
-    Assume.assumeFalse("HadoopCatalog does not support namespace locations", isHadoopCatalog);
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isFalse();
 
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
-    File location = temp.newFile();
-    Assert.assertTrue(location.delete());
+    File location = File.createTempFile("junit", null, temp.toFile());
+    assertThat(location.delete()).isTrue();
 
     sql("CREATE NAMESPACE %s LOCATION '%s'", fullNamespace, location);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
 
     Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
 
-    Assert.assertEquals(
-        "Namespace should have expected location",
-        "file:" + location.getPath(),
-        nsMetadata.get("location"));
+    assertThat(nsMetadata).containsEntry("location", "file:" + location.getPath());
   }
 
-  @Test
+  @TestTemplate
   public void testSetProperties() {
-    Assume.assumeFalse("HadoopCatalog does not support namespace metadata", isHadoopCatalog);
+    assumeThat(isHadoopCatalog).as("HadoopCatalog does not support namespace metadata").isFalse();
 
-    Assert.assertFalse(
-        "Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
 
     sql("CREATE NAMESPACE %s", fullNamespace);
 
-    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should exist")
+        .isTrue();
 
     Map<String, String> defaultMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
-    Assert.assertFalse(
-        "Default metadata should not have custom property", defaultMetadata.containsKey("prop"));
+    assertThat(defaultMetadata)
+        .as("Default metadata should not have custom property")
+        .doesNotContainKey("prop");
 
     sql("ALTER NAMESPACE %s SET PROPERTIES ('prop'='value')", fullNamespace);
 
     Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
 
-    Assert.assertEquals(
-        "Namespace should have expected prop value", "value", nsMetadata.get("prop"));
+    assertThat(nsMetadata).containsEntry("prop", "value");
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.spark.sql;
 
-import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
-import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE_REST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -103,9 +101,6 @@ public class TestNamespaceSQL extends CatalogTestBase {
   @TestTemplate
   public void testDefaultNamespace() {
     assumeThat(isHadoopCatalog).as("Hadoop has no default namespace configured").isFalse();
-    assumeThat(catalogConfig.get(ICEBERG_CATALOG_TYPE))
-        .as("REST has no default namespace configured")
-        .isNotEqualTo(ICEBERG_CATALOG_TYPE_REST);
 
     sql("USE %s", catalogName);
 
@@ -200,8 +195,7 @@ public class TestNamespaceSQL extends CatalogTestBase {
 
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
-    if (isHadoopCatalog
-        || catalogConfig.get(ICEBERG_CATALOG_TYPE).equals(ICEBERG_CATALOG_TYPE_REST)) {
+    if (isHadoopCatalog) {
       assertThat(namespaces)
           .singleElement()
           .satisfies(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestRefreshTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestRefreshTable.java
@@ -19,35 +19,33 @@
 package org.apache.iceberg.spark.sql;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestRefreshTable extends SparkCatalogTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRefreshTable extends CatalogTestBase {
 
-  public TestRefreshTable(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @Before
+  @BeforeEach
   public void createTables() {
     sql("CREATE TABLE %s (key int, value int) USING iceberg", tableName);
     sql("INSERT INTO %s VALUES (1,1)", tableName);
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testRefreshCommand() {
     // We are not allowed to change the session catalog after it has been initialized, so build a
     // new one

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -18,37 +18,69 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.Spark3Util;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSelect extends SparkCatalogTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSelect extends CatalogTestBase {
   private int scanEventCount = 0;
   private ScanEvent lastScanEvent = null;
-  private String binaryTableName = tableName("binary_table");
 
-  public TestSelect(String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
+  @Parameter(index = 3)
+  private String binaryTableName;
 
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, binaryTableName = {3}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties(),
+        SparkCatalogConfig.HIVE.catalogName() + ".default.binary_table"
+      },
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties(),
+        SparkCatalogConfig.HADOOP.catalogName() + ".default.binary_table"
+      },
+      {
+        SparkCatalogConfig.SPARK.catalogName(),
+        SparkCatalogConfig.SPARK.implementation(),
+        SparkCatalogConfig.SPARK.properties(),
+        "default.binary_table"
+      }
+    };
+  }
+
+  @BeforeEach
+  public void createTables() {
     // register a scan event listener to validate pushdown
     Listeners.register(
         event -> {
@@ -56,10 +88,7 @@ public class TestSelect extends SparkCatalogTestBase {
           lastScanEvent = event;
         },
         ScanEvent.class);
-  }
 
-  @Before
-  public void createTables() {
     sql("CREATE TABLE %s (id bigint, data string, float float) USING iceberg", tableName);
     sql("INSERT INTO %s VALUES (1, 'a', 1.0), (2, 'b', 2.0), (3, 'c', float('NaN'))", tableName);
 
@@ -67,13 +96,13 @@ public class TestSelect extends SparkCatalogTestBase {
     this.lastScanEvent = null;
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS %s", binaryTableName);
   }
 
-  @Test
+  @TestTemplate
   public void testSelect() {
     List<Object[]> expected =
         ImmutableList.of(row(1L, "a", 1.0F), row(2L, "b", 2.0F), row(3L, "c", Float.NaN));
@@ -81,7 +110,32 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Should return all expected rows", expected, sql("SELECT * FROM %s", tableName));
   }
 
-  @Test
+  @TestTemplate
+  public void testSelectWithSpecifiedTargetSplitSize() {
+    List<Object[]> expected =
+        ImmutableList.of(row(1L, "a", 1.0F), row(2L, "b", 2.0F), row(3L, "c", Float.NaN));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    table.updateProperties().set("read.split.target-size", "1024").commit();
+    spark.sql("REFRESH TABLE " + tableName);
+    assertEquals("Should return all expected rows", expected, sql("SELECT * FROM %s", tableName));
+
+    // Query failed when `SPLIT_SIZE` < 0
+    table.updateProperties().set(SPLIT_SIZE, "-1").commit();
+    spark.sql("REFRESH TABLE " + tableName);
+    assertThatThrownBy(() -> sql("SELECT * FROM %s", tableName))
+        .hasMessageContaining("Split size must be > 0: -1")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // Query failed when `SPLIT_SIZE` == 0
+    table.updateProperties().set(SPLIT_SIZE, "0").commit();
+    spark.sql("REFRESH TABLE " + tableName);
+    assertThatThrownBy(() -> sql("SELECT * FROM %s", tableName))
+        .hasMessageContaining("Split size must be > 0: 0")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @TestTemplate
   public void testSelectRewrite() {
     List<Object[]> expected = ImmutableList.of(row(3L, "c", Float.NaN));
 
@@ -90,29 +144,28 @@ public class TestSelect extends SparkCatalogTestBase {
         expected,
         sql("SELECT * FROM %s where float = float('NaN')", tableName));
 
-    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
-    Assert.assertEquals(
-        "Should push down expected filter",
-        "(float IS NOT NULL AND is_nan(float))",
-        Spark3Util.describe(lastScanEvent.filter()));
+    assertThat(scanEventCount).as("Should create only one scan").isEqualTo(1);
+    assertThat(Spark3Util.describe(lastScanEvent.filter()))
+        .as("Should push down expected filter")
+        .isEqualTo("(float IS NOT NULL AND is_nan(float))");
   }
 
-  @Test
+  @TestTemplate
   public void testProjection() {
     List<Object[]> expected = ImmutableList.of(row(1L), row(2L), row(3L));
 
     assertEquals("Should return all expected rows", expected, sql("SELECT id FROM %s", tableName));
 
-    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
-    Assert.assertEquals(
-        "Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
-    Assert.assertEquals(
-        "Should project only the id column",
-        validationCatalog.loadTable(tableIdent).schema().select("id").asStruct(),
-        lastScanEvent.projection().asStruct());
+    assertThat(scanEventCount).as("Should create only one scan").isEqualTo(1);
+    assertThat(lastScanEvent.filter())
+        .as("Should not push down a filter")
+        .isEqualTo(Expressions.alwaysTrue());
+    assertThat(lastScanEvent.projection().asStruct())
+        .as("Should project only the id column")
+        .isEqualTo(validationCatalog.loadTable(tableIdent).schema().select("id").asStruct());
   }
 
-  @Test
+  @TestTemplate
   public void testExpressionPushdown() {
     List<Object[]> expected = ImmutableList.of(row("b"));
 
@@ -121,18 +174,17 @@ public class TestSelect extends SparkCatalogTestBase {
         expected,
         sql("SELECT data FROM %s WHERE id = 2", tableName));
 
-    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
-    Assert.assertEquals(
-        "Should push down expected filter",
-        "(id IS NOT NULL AND id = 2)",
-        Spark3Util.describe(lastScanEvent.filter()));
-    Assert.assertEquals(
-        "Should project only id and data columns",
-        validationCatalog.loadTable(tableIdent).schema().select("id", "data").asStruct(),
-        lastScanEvent.projection().asStruct());
+    assertThat(scanEventCount).as("Should create only one scan").isEqualTo(1);
+    assertThat(Spark3Util.describe(lastScanEvent.filter()))
+        .as("Should push down expected filter")
+        .isEqualTo("(id IS NOT NULL AND id = 2)");
+    assertThat(lastScanEvent.projection().asStruct())
+        .as("Should project only id and data columns")
+        .isEqualTo(
+            validationCatalog.loadTable(tableIdent).schema().select("id", "data").asStruct());
   }
 
-  @Test
+  @TestTemplate
   public void testMetadataTables() {
     assertEquals(
         "Snapshot metadata table",
@@ -140,7 +192,7 @@ public class TestSelect extends SparkCatalogTestBase {
         sql("SELECT * FROM %s.snapshots", tableName));
   }
 
-  @Test
+  @TestTemplate
   public void testSnapshotInTableName() {
     // get the snapshot ID of the last write and get the current row set as expected
     long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();
@@ -165,7 +217,7 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Snapshot at specific ID " + snapshotId, expected, fromDF);
   }
 
-  @Test
+  @TestTemplate
   public void testTimestampInTableName() {
     // get a timestamp just after the last write and get the current row set as expected
     long snapshotTs = validationCatalog.loadTable(tableIdent).currentSnapshot().timestampMillis();
@@ -191,7 +243,7 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Snapshot at timestamp " + timestamp, expected, fromDF);
   }
 
-  @Test
+  @TestTemplate
   public void testVersionAsOf() {
     // get the snapshot ID of the last write and get the current row set as expected
     long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();
@@ -221,7 +273,7 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Snapshot at specific ID " + snapshotId, expected, fromDF);
   }
 
-  @Test
+  @TestTemplate
   public void testTagReference() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -252,7 +304,7 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Snapshot at specific tag reference name", expected, fromDF);
   }
 
-  @Test
+  @TestTemplate
   public void testUseSnapshotIdForTagReferenceAsOf() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId1 = table.currentSnapshot().snapshotId();
@@ -277,7 +329,65 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Snapshot at specific tag reference name", actual, travelWithLongResult);
   }
 
-  @Test
+  @TestTemplate
+  public void readAndWriteWithBranchAfterSchemaChange() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    String branchName = "test_branch";
+    table.manageSnapshots().createBranch(branchName, table.currentSnapshot().snapshotId()).commit();
+
+    List<Object[]> expected =
+        Arrays.asList(row(1L, "a", 1.0f), row(2L, "b", 2.0f), row(3L, "c", Float.NaN));
+    assertThat(sql("SELECT * FROM %s", tableName)).containsExactlyElementsOf(expected);
+
+    // change schema on the table and add more data
+    sql("ALTER TABLE %s DROP COLUMN float", tableName);
+    sql("ALTER TABLE %s ADD COLUMN new_col date", tableName);
+    sql(
+        "INSERT INTO %s VALUES (4, 'd', date('2024-04-04')), (5, 'e', date('2024-05-05'))",
+        tableName);
+
+    // time-travel query using snapshot id should return the snapshot's schema
+    long branchSnapshotId = table.refs().get(branchName).snapshotId();
+    assertThat(sql("SELECT * FROM %s VERSION AS OF %s", tableName, branchSnapshotId))
+        .containsExactlyElementsOf(expected);
+
+    // querying the head of the branch should return the table's schema
+    assertThat(sql("SELECT * FROM %s VERSION AS OF '%s'", tableName, branchName))
+        .containsExactly(row(1L, "a", null), row(2L, "b", null), row(3L, "c", null));
+
+    if (!"spark_catalog".equals(catalogName)) {
+      // querying the head of the branch using 'branch_' should return the table's schema
+      assertThat(sql("SELECT * FROM %s.branch_%s", tableName, branchName))
+          .containsExactly(row(1L, "a", null), row(2L, "b", null), row(3L, "c", null));
+    }
+
+    // writing to a branch uses the table's schema
+    sql(
+        "INSERT INTO %s.branch_%s VALUES (6L, 'f', cast('2023-06-06' as date)), (7L, 'g', cast('2023-07-07' as date))",
+        tableName, branchName);
+
+    // querying the head of the branch returns the table's schema
+    assertThat(sql("SELECT * FROM %s VERSION AS OF '%s'", tableName, branchName))
+        .containsExactlyInAnyOrder(
+            row(1L, "a", null),
+            row(2L, "b", null),
+            row(3L, "c", null),
+            row(6L, "f", java.sql.Date.valueOf("2023-06-06")),
+            row(7L, "g", java.sql.Date.valueOf("2023-07-07")));
+
+    // using DataFrameReader with the 'branch' option should return the table's schema
+    Dataset<Row> df =
+        spark.read().format("iceberg").option(SparkReadOptions.BRANCH, branchName).load(tableName);
+    assertThat(rowsToJava(df.collectAsList()))
+        .containsExactlyInAnyOrder(
+            row(1L, "a", null),
+            row(2L, "b", null),
+            row(3L, "c", null),
+            row(6L, "f", java.sql.Date.valueOf("2023-06-06")),
+            row(7L, "g", java.sql.Date.valueOf("2023-07-07")));
+  }
+
+  @TestTemplate
   public void testBranchReference() {
     Table table = validationCatalog.loadTable(tableIdent);
     long snapshotId = table.currentSnapshot().snapshotId();
@@ -313,14 +423,14 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Snapshot at specific branch reference name", expected, fromDF);
   }
 
-  @Test
+  @TestTemplate
   public void testUnknownReferenceAsOf() {
     assertThatThrownBy(() -> sql("SELECT * FROM %s VERSION AS OF 'test_unknown'", tableName))
         .hasMessageContaining("Cannot find matching snapshot ID or reference name for version")
         .isInstanceOf(ValidationException.class);
   }
 
-  @Test
+  @TestTemplate
   public void testTimestampAsOf() {
     long snapshotTs = validationCatalog.loadTable(tableIdent).currentSnapshot().timestampMillis();
     long timestamp = waitUntilAfter(snapshotTs + 1000);
@@ -367,7 +477,7 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Snapshot at timestamp " + timestamp, expected, fromDF);
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidTimeTravelBasedOnBothAsOfAndTableIdentifier() {
     // get the snapshot ID of the last write
     long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();
@@ -422,7 +532,7 @@ public class TestSelect extends SparkCatalogTestBase {
         .hasMessage("Cannot do time-travel based on both table identifier and AS OF");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidTimeTravelAgainstBranchIdentifierWithAsOf() {
     long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();
     validationCatalog.loadTable(tableIdent).manageSnapshots().createBranch("b1").commit();
@@ -442,7 +552,7 @@ public class TestSelect extends SparkCatalogTestBase {
         .hasMessage("Cannot do time-travel based on both table identifier and AS OF");
   }
 
-  @Test
+  @TestTemplate
   public void testSpecifySnapshotAndTimestamp() {
     // get the snapshot ID of the last write
     long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();
@@ -470,7 +580,7 @@ public class TestSelect extends SparkCatalogTestBase {
                 snapshotId, timestamp));
   }
 
-  @Test
+  @TestTemplate
   public void testBinaryInFilter() {
     sql("CREATE TABLE %s (id bigint, binary binary) USING iceberg", binaryTableName);
     sql("INSERT INTO %s VALUES (1, X''), (2, X'1111'), (3, X'11')", binaryTableName);
@@ -482,7 +592,7 @@ public class TestSelect extends SparkCatalogTestBase {
         sql("SELECT id, binary FROM %s where binary > X'11'", binaryTableName));
   }
 
-  @Test
+  @TestTemplate
   public void testComplexTypeFilter() {
     String complexTypeTableName = tableName("complex_table");
     sql(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -45,7 +46,9 @@ import org.apache.spark.sql.functions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestAggregatePushDown extends CatalogTestBase {
 
   @BeforeAll

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.UUID;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -42,7 +43,9 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestCreateTable extends CatalogTestBase {
 
   @AfterEach
@@ -109,10 +112,8 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.schema().asStruct())
         .as("Should have the expected schema")
         .isEqualTo(expectedSchema);
-    assertThat(table.spec().fields()).as("Should not be partitioned").hasSize(0);
-    assertThat(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT))
-        .as("Should not have the default format set")
-        .isNull();
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
   }
 
   @TestTemplate
@@ -134,7 +135,7 @@ public class TestCreateTable extends CatalogTestBase {
 
     sql("INSERT INTO %s VALUES('%s')", tableName, uuid);
 
-    assertThat(sql("SELECT uuid FROM %s", tableName)).hasSize(1).element(0).isEqualTo(row(uuid));
+    assertThat(sql("SELECT uuid FROM %s", tableName)).singleElement().isEqualTo(row(uuid));
   }
 
   @TestTemplate
@@ -172,10 +173,8 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.schema().asStruct())
         .as("Should have the expected schema")
         .isEqualTo(expectedSchema);
-    assertThat(table.spec().fields()).as("Should not be partitioned").hasSize(0);
-    assertThat(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT))
-        .as("Should not have default format parquet")
-        .isEqualTo("parquet");
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).containsEntry(TableProperties.DEFAULT_FILE_FORMAT, "parquet");
 
     assertThatThrownBy(
             () ->
@@ -219,10 +218,7 @@ public class TestCreateTable extends CatalogTestBase {
             .day("created_at")
             .build();
     assertThat(table.spec()).as("Should be partitioned correctly").isEqualTo(expectedSpec);
-
-    assertThat(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT))
-        .as("Should not have the default format set")
-        .isNull();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
   }
 
   @TestTemplate
@@ -247,10 +243,8 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.schema().asStruct())
         .as("Should have the expected schema")
         .isEqualTo(expectedSchema);
-    assertThat(table.spec().fields()).as("Should not be partitioned").hasSize(0);
-    assertThat(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT))
-        .as("Should not have the default format set")
-        .isNull();
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
   }
 
   @TestTemplate
@@ -276,13 +270,10 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.schema().asStruct())
         .as("Should have the expected schema")
         .isEqualTo(expectedSchema);
-    assertThat(table.spec().fields()).as("Should not be partitioned").hasSize(0);
-    assertThat(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT))
-        .as("Should not have the default format set")
-        .isNull();
-    assertThat(table.properties().get(TableCatalog.PROP_COMMENT))
-        .as("Should have the table comment set in properties")
-        .isEqualTo("Table doc");
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties())
+        .doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT)
+        .containsEntry(TableCatalog.PROP_COMMENT, "Table doc");
   }
 
   @TestTemplate
@@ -317,10 +308,8 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.schema().asStruct())
         .as("Should have the expected schema")
         .isEqualTo(expectedSchema);
-    assertThat(table.spec().fields()).as("Should not be partitioned").hasSize(0);
-    assertThat(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT))
-        .as("Should not have the default format set")
-        .isNull();
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
+    assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
     assertThat(table.location()).as("Should have a custom table location").isEqualTo(location);
   }
 
@@ -347,7 +336,7 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.schema().asStruct())
         .as("Should have the expected schema")
         .isEqualTo(expectedSchema);
-    assertThat(table.spec().fields()).as("Should not be partitioned").hasSize(0);
+    assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
     assertThat(table.properties()).containsEntry("p1", "2").containsEntry("p2", "x");
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
@@ -24,6 +24,7 @@ import static org.apache.spark.sql.functions.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -34,7 +35,9 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestCreateTableAsSelect extends CatalogTestBase {
 
   @Parameter(index = 3)
@@ -92,8 +95,7 @@ public class TestCreateTableAsSelect extends CatalogTestBase {
     assertThat(ctasTable.schema().asStruct())
         .as("Should have expected nullable schema")
         .isEqualTo(expectedSchema.asStruct());
-
-    assertThat(ctasTable.spec().fields()).as("Should be an unpartitioned table").hasSize(0);
+    assertThat(ctasTable.spec().fields()).as("Should be an unpartitioned table").isEmpty();
     assertEquals(
         "Should have rows matching the source table",
         sql("SELECT * FROM %s ORDER BY id", sourceName),
@@ -194,15 +196,10 @@ public class TestCreateTableAsSelect extends CatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
     assertThat(rtasTable.snapshots()).as("Table should have expected snapshots").hasSize(2);
-    assertThat(rtasTable.properties().get("prop1"))
-        .as("Should have updated table property")
-        .isEqualTo("newval1");
-    assertThat(rtasTable.properties().get("prop2"))
-        .as("Should have preserved table property")
-        .isEqualTo("val2");
-    assertThat(rtasTable.properties().get("prop3"))
-        .as("Should have new table property")
-        .isEqualTo("val3");
+    assertThat(rtasTable.properties())
+        .containsEntry("prop1", "newval1")
+        .containsEntry("prop2", "val2")
+        .containsEntry("prop3", "val3");
   }
 
   @TestTemplate
@@ -272,7 +269,7 @@ public class TestCreateTableAsSelect extends CatalogTestBase {
     assertThat(ctasTable.schema().asStruct())
         .as("Should have expected nullable schema")
         .isEqualTo(expectedSchema.asStruct());
-    assertThat(ctasTable.spec().fields()).as("Should be an unpartitioned table").hasSize(0);
+    assertThat(ctasTable.spec().fields()).as("Should be an unpartitioned table").isEmpty();
     assertEquals(
         "Should have rows matching the source table",
         sql("SELECT * FROM %s ORDER BY id", sourceName),

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -32,7 +33,9 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestDeleteFrom extends CatalogTestBase {
   @AfterEach
   public void removeTables() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestDropTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestDropTable.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
@@ -34,7 +35,9 @@ import org.apache.iceberg.spark.CatalogTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestDropTable extends CatalogTestBase {
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.spark.sql;
 
-import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
-import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE_REST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -102,9 +100,6 @@ public class TestNamespaceSQL extends CatalogTestBase {
   @TestTemplate
   public void testDefaultNamespace() {
     assumeThat(isHadoopCatalog).as("Hadoop has no default namespace configured").isFalse();
-    assumeThat(catalogConfig.get(ICEBERG_CATALOG_TYPE))
-        .as("REST has no default namespace configured")
-        .isNotEqualTo(ICEBERG_CATALOG_TYPE_REST);
 
     sql("USE %s", catalogName);
 
@@ -199,8 +194,7 @@ public class TestNamespaceSQL extends CatalogTestBase {
 
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
-    if (isHadoopCatalog
-        || catalogConfig.get(ICEBERG_CATALOG_TYPE).equals(ICEBERG_CATALOG_TYPE_REST)) {
+    if (isHadoopCatalog) {
       assertThat(namespaces)
           .singleElement()
           .satisfies(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestRefreshTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestRefreshTable.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.sql;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.CatalogTestBase;
@@ -28,7 +29,9 @@ import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestRefreshTable extends CatalogTestBase {
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.events.Listeners;
@@ -44,7 +45,9 @@ import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSelect extends CatalogTestBase {
   private int scanEventCount = 0;
   private ScanEvent lastScanEvent = null;


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates the following Spark 3.4 tests in the `spark.sql` package to JUnit 5 with AssertJ:

* `TestAggregatePushDown`
* `TestCreateTable`
* `TestCreateTableAsSelect`
* `TestDeleteFrom`
* `TestDropTable`
* `TestFilterPushDown`
* `TestNamespaceSQL`
* `TestRefreshTable`
* `TestSelect`