### PR TITLE
Flink: Fix typo in JdbcLockFactory

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -235,8 +235,8 @@ public class JdbcLockFactory implements TriggerLockFactory {
         //
         // Steps:
         // 1. `unlock` removes the lock in the database, but there is a temporary connection failure
-        // 2. `lock` founds that there is no lock, so creates a new lock
-        // 3. `unlock` retires the lock removal and removes the new lock
+        // 2. `lock` finds that there is no lock, so creates a new lock
+        // 3. `unlock` retries the lock removal and removes the new lock
         //
         // To prevent the situation above we fetch the current lockId, and remove the lock
         // only with the given id.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -235,8 +235,8 @@ public class JdbcLockFactory implements TriggerLockFactory {
         //
         // Steps:
         // 1. `unlock` removes the lock in the database, but there is a temporary connection failure
-        // 2. `lock` founds that there is no lock, so creates a new lock
-        // 3. `unlock` retires the lock removal and removes the new lock
+        // 2. `lock` finds that there is no lock, so creates a new lock
+        // 3. `unlock` retries the lock removal and removes the new lock
         //
         // To prevent the situation above we fetch the current lockId, and remove the lock
         // only with the given id.

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -235,8 +235,8 @@ public class JdbcLockFactory implements TriggerLockFactory {
         //
         // Steps:
         // 1. `unlock` removes the lock in the database, but there is a temporary connection failure
-        // 2. `lock` founds that there is no lock, so creates a new lock
-        // 3. `unlock` retires the lock removal and removes the new lock
+        // 2. `lock` finds that there is no lock, so creates a new lock
+        // 3. `unlock` retries the lock removal and removes the new lock
         //
         // To prevent the situation above we fetch the current lockId, and remove the lock
         // only with the given id.


### PR DESCRIPTION
As discussion in  https://github.com/apache/iceberg/pull/12801#discussion_r2066781856. Fix some small typo in JdbcLockFactory.