### PR TITLE
Spark 3.4: Migrate Spark Partition Transform tests

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -24,185 +24,175 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.spark.functions.BucketFunction;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.types.DataTypes;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
-  @Before
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSparkBucketFunction extends TestBaseWithCatalog {
+  @BeforeEach
   public void useCatalog() {
     sql("USE %s", catalogName);
   }
 
-  @Test
+  @TestTemplate
   public void testSpecValues() {
-    Assert.assertEquals(
-        "Spec example: hash(34) = 2017239379",
-        2017239379,
-        new BucketFunction.BucketInt(DataTypes.IntegerType).hash(34));
+    assertThat(new BucketFunction.BucketInt(DataTypes.IntegerType).hash(34))
+        .as("Spec example: hash(34) = 2017239379")
+        .isEqualTo(2017239379);
 
-    Assert.assertEquals(
-        "Spec example: hash(34L) = 2017239379",
-        2017239379,
-        new BucketFunction.BucketLong(DataTypes.LongType).hash(34L));
+    assertThat(new BucketFunction.BucketLong(DataTypes.IntegerType).hash(34L))
+        .as("Spec example: hash(34L) = 2017239379")
+        .isEqualTo(2017239379);
 
-    Assert.assertEquals(
-        "Spec example: hash(decimal2(14.20)) = -500754589",
-        -500754589,
-        new BucketFunction.BucketDecimal(DataTypes.createDecimalType(9, 2))
-            .hash(new BigDecimal("14.20")));
+    assertThat(
+            new BucketFunction.BucketDecimal(DataTypes.createDecimalType(9, 2))
+                .hash(new BigDecimal("14.20")))
+        .as("Spec example: hash(decimal2(14.20)) = -500754589")
+        .isEqualTo(-500754589);
 
     Literal<Integer> date = Literal.of("2017-11-16").to(Types.DateType.get());
-    Assert.assertEquals(
-        "Spec example: hash(2017-11-16) = -653330422",
-        -653330422,
-        new BucketFunction.BucketInt(DataTypes.DateType).hash(date.value()));
+    assertThat(new BucketFunction.BucketInt(DataTypes.DateType).hash(date.value()))
+        .as("Spec example: hash(2017-11-16) = -653330422")
+        .isEqualTo(-653330422);
 
     Literal<Long> timestampVal =
         Literal.of("2017-11-16T22:31:08").to(Types.TimestampType.withoutZone());
-    Assert.assertEquals(
-        "Spec example: hash(2017-11-16T22:31:08) = -2047944441",
-        -2047944441,
-        new BucketFunction.BucketLong(DataTypes.TimestampType).hash(timestampVal.value()));
+    assertThat(new BucketFunction.BucketLong(DataTypes.TimestampType).hash(timestampVal.value()))
+        .as("Spec example: hash(2017-11-16T22:31:08) = -2047944441")
+        .isEqualTo(-2047944441);
 
     Literal<Long> timestampntzVal =
         Literal.of("2017-11-16T22:31:08").to(Types.TimestampType.withoutZone());
-    Assert.assertEquals(
-        "Spec example: hash(2017-11-16T22:31:08) = -2047944441",
-        -2047944441,
-        new BucketFunction.BucketLong(DataTypes.TimestampNTZType).hash(timestampntzVal.value()));
+    assertThat(
+            new BucketFunction.BucketLong(DataTypes.TimestampNTZType).hash(timestampntzVal.value()))
+        .as("Spec example: hash(2017-11-16T22:31:08) = -2047944441")
+        .isEqualTo(-2047944441);
 
-    Assert.assertEquals(
-        "Spec example: hash(\"iceberg\") = 1210000089",
-        1210000089,
-        new BucketFunction.BucketString().hash("iceberg"));
+    assertThat(new BucketFunction.BucketString().hash("iceberg"))
+        .as("Spec example: hash(\"iceberg\") = 1210000089")
+        .isEqualTo(1210000089);
 
-    Assert.assertEquals(
-        "Verify that the hash string and hash raw bytes produce the same result",
-        new BucketFunction.BucketString().hash("iceberg"),
-        new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)));
+    assertThat(new BucketFunction.BucketString().hash("iceberg".getBytes(StandardCharsets.UTF_8)))
+        .as("Verify that the hash string and hash raw bytes produce the same result")
+        .isEqualTo(new BucketFunction.BucketString().hash("iceberg"));
 
     ByteBuffer bytes = ByteBuffer.wrap(new byte[] {0, 1, 2, 3});
-    Assert.assertEquals(
-        "Spec example: hash([00 01 02 03]) = -188683207",
-        -188683207,
-        new BucketFunction.BucketBinary().hash(bytes));
+    assertThat(new BucketFunction.BucketBinary().hash(bytes))
+        .as("Spec example: hash([00 01 02 03]) = -188683207")
+        .isEqualTo(-188683207);
   }
 
-  @Test
+  @TestTemplate
   public void testBucketIntegers() {
-    Assert.assertEquals(
-        "Byte type should bucket similarly to integer",
-        3,
-        scalarSql("SELECT system.bucket(10, 8Y)"));
-    Assert.assertEquals(
-        "Short type should bucket similarly to integer",
-        3,
-        scalarSql("SELECT system.bucket(10, 8S)"));
+    assertThat(scalarSql("SELECT system.bucket(10, 8Y)"))
+        .as("Byte type should bucket similarly to integer")
+        .isEqualTo(3);
+    assertThat(scalarSql("SELECT system.bucket(10, 8S)"))
+        .as("Short type should bucket similarly to integer")
+        .isEqualTo(3);
     // Integers
-    Assert.assertEquals(3, scalarSql("SELECT system.bucket(10, 8)"));
-    Assert.assertEquals(79, scalarSql("SELECT system.bucket(100, 34)"));
-    Assert.assertNull(scalarSql("SELECT system.bucket(1, CAST(null AS INT))"));
+    assertThat(scalarSql("SELECT system.bucket(10, 8)")).isEqualTo(3);
+    assertThat(scalarSql("SELECT system.bucket(100, 34)")).isEqualTo(79);
+    assertThat(scalarSql("SELECT system.bucket(1, CAST(null AS INT))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testBucketDates() {
-    Assert.assertEquals(3, scalarSql("SELECT system.bucket(10, date('1970-01-09'))"));
-    Assert.assertEquals(79, scalarSql("SELECT system.bucket(100, date('1970-02-04'))"));
-    Assert.assertNull(scalarSql("SELECT system.bucket(1, CAST(null AS DATE))"));
+    assertThat(scalarSql("SELECT system.bucket(10, date('1970-01-09'))")).isEqualTo(3);
+    assertThat(scalarSql("SELECT system.bucket(100, date('1970-02-04'))")).isEqualTo(79);
+    assertThat(scalarSql("SELECT system.bucket(1, CAST(null AS DATE))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testBucketLong() {
-    Assert.assertEquals(79, scalarSql("SELECT system.bucket(100, 34L)"));
-    Assert.assertEquals(76, scalarSql("SELECT system.bucket(100, 0L)"));
-    Assert.assertEquals(97, scalarSql("SELECT system.bucket(100, -34L)"));
-    Assert.assertEquals(0, scalarSql("SELECT system.bucket(2, -1L)"));
-    Assert.assertNull(scalarSql("SELECT system.bucket(2, CAST(null AS LONG))"));
+    assertThat(scalarSql("SELECT system.bucket(100, 34L)")).isEqualTo(79);
+    assertThat(scalarSql("SELECT system.bucket(100, 0L)")).isEqualTo(76);
+    assertThat(scalarSql("SELECT system.bucket(100, -34L)")).isEqualTo(97);
+    assertThat(scalarSql("SELECT system.bucket(2, -1L)")).isEqualTo(0);
+    assertThat(scalarSql("SELECT system.bucket(2, CAST(null AS LONG))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testBucketDecimal() {
-    Assert.assertEquals(56, scalarSql("SELECT system.bucket(64, CAST('12.34' as DECIMAL(9, 2)))"));
-    Assert.assertEquals(13, scalarSql("SELECT system.bucket(18, CAST('12.30' as DECIMAL(9, 2)))"));
-    Assert.assertEquals(2, scalarSql("SELECT system.bucket(16, CAST('12.999' as DECIMAL(9, 3)))"));
-    Assert.assertEquals(21, scalarSql("SELECT system.bucket(32, CAST('0.05' as DECIMAL(5, 2)))"));
-    Assert.assertEquals(85, scalarSql("SELECT system.bucket(128, CAST('0.05' as DECIMAL(9, 2)))"));
-    Assert.assertEquals(3, scalarSql("SELECT system.bucket(18, CAST('0.05' as DECIMAL(9, 2)))"));
+    assertThat(scalarSql("SELECT system.bucket(64, CAST('12.34' as DECIMAL(9, 2)))")).isEqualTo(56);
+    assertThat(scalarSql("SELECT system.bucket(18, CAST('12.30' as DECIMAL(9, 2)))")).isEqualTo(13);
+    assertThat(scalarSql("SELECT system.bucket(16, CAST('12.999' as DECIMAL(9, 3)))")).isEqualTo(2);
+    assertThat(scalarSql("SELECT system.bucket(32, CAST('0.05' as DECIMAL(5, 2)))")).isEqualTo(21);
+    assertThat(scalarSql("SELECT system.bucket(128, CAST('0.05' as DECIMAL(9, 2)))")).isEqualTo(85);
+    assertThat(scalarSql("SELECT system.bucket(18, CAST('0.05' as DECIMAL(9, 2)))")).isEqualTo(3);
 
-    Assert.assertNull(
-        "Null input should return null",
-        scalarSql("SELECT system.bucket(2, CAST(null AS decimal))"));
+    assertThat(scalarSql("SELECT system.bucket(2, CAST(null AS decimal))"))
+        .as("Null input should return null")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testBucketTimestamp() {
-    Assert.assertEquals(
-        99, scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01-01 00:00:00 UTC+00:00')"));
-    Assert.assertEquals(
-        85, scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01-31 09:26:56 UTC+00:00')"));
-    Assert.assertEquals(
-        62, scalarSql("SELECT system.bucket(100, TIMESTAMP '2022-08-08 00:00:00 UTC+00:00')"));
-    Assert.assertNull(scalarSql("SELECT system.bucket(2, CAST(null AS timestamp))"));
+    assertThat(scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01-01 00:00:00 UTC+00:00')"))
+        .isEqualTo(99);
+    assertThat(scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01-31 09:26:56 UTC+00:00')"))
+        .isEqualTo(85);
+    assertThat(scalarSql("SELECT system.bucket(100, TIMESTAMP '2022-08-08 00:00:00 UTC+00:00')"))
+        .isEqualTo(62);
+    assertThat(scalarSql("SELECT system.bucket(2, CAST(null AS timestamp))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testBucketString() {
-    Assert.assertEquals(4, scalarSql("SELECT system.bucket(5, 'abcdefg')"));
-    Assert.assertEquals(122, scalarSql("SELECT system.bucket(128, 'abc')"));
-    Assert.assertEquals(54, scalarSql("SELECT system.bucket(64, 'abcde')"));
-    Assert.assertEquals(8, scalarSql("SELECT system.bucket(12, '测试')"));
-    Assert.assertEquals(1, scalarSql("SELECT system.bucket(16, '测试raul试测')"));
-    Assert.assertEquals(
-        "Varchar should work like string",
-        1,
-        scalarSql("SELECT system.bucket(16, CAST('测试raul试测' AS varchar(8)))"));
-    Assert.assertEquals(
-        "Char should work like string",
-        1,
-        scalarSql("SELECT system.bucket(16, CAST('测试raul试测' AS char(8)))"));
-    Assert.assertEquals(
-        "Should not fail on the empty string", 0, scalarSql("SELECT system.bucket(16, '')"));
-    Assert.assertNull(
-        "Null input should return null as output",
-        scalarSql("SELECT system.bucket(16, CAST(null AS string))"));
+    assertThat(scalarSql("SELECT system.bucket(5, 'abcdefg')")).isEqualTo(4);
+    assertThat(scalarSql("SELECT system.bucket(128, 'abc')")).isEqualTo(122);
+    assertThat(scalarSql("SELECT system.bucket(64, 'abcde')")).isEqualTo(54);
+    assertThat(scalarSql("SELECT system.bucket(12, '测试')")).isEqualTo(8);
+    assertThat(scalarSql("SELECT system.bucket(16, '测试raul试测')")).isEqualTo(1);
+    assertThat(scalarSql("SELECT system.bucket(16, CAST('测试raul试测' AS varchar(8)))"))
+        .as("Varchar should work like string")
+        .isEqualTo(1);
+    assertThat(scalarSql("SELECT system.bucket(16, CAST('测试raul试测' AS char(8)))"))
+        .as("Char should work like string")
+        .isEqualTo(1);
+    assertThat(scalarSql("SELECT system.bucket(16, '')"))
+        .as("Should not fail on the empty string")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.bucket(16, CAST(null AS string))"))
+        .as("Null input should return null as output")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testBucketBinary() {
-    Assert.assertEquals(
-        1, scalarSql("SELECT system.bucket(10, X'0102030405060708090a0b0c0d0e0f')"));
-    Assert.assertEquals(10, scalarSql("SELECT system.bucket(12, %s)", asBytesLiteral("abcdefg")));
-    Assert.assertEquals(13, scalarSql("SELECT system.bucket(18, %s)", asBytesLiteral("abc\0\0")));
-    Assert.assertEquals(42, scalarSql("SELECT system.bucket(48, %s)", asBytesLiteral("abc")));
-    Assert.assertEquals(3, scalarSql("SELECT system.bucket(16, %s)", asBytesLiteral("测试_")));
+    assertThat(scalarSql("SELECT system.bucket(10, X'0102030405060708090a0b0c0d0e0f')"))
+        .isEqualTo(1);
+    assertThat(scalarSql("SELECT system.bucket(12, %s)", asBytesLiteral("abcdefg"))).isEqualTo(10);
+    assertThat(scalarSql("SELECT system.bucket(18, %s)", asBytesLiteral("abc\0\0"))).isEqualTo(13);
+    assertThat(scalarSql("SELECT system.bucket(48, %s)", asBytesLiteral("abc"))).isEqualTo(42);
+    assertThat(scalarSql("SELECT system.bucket(16, %s)", asBytesLiteral("测试_"))).isEqualTo(3);
 
-    Assert.assertNull(
-        "Null input should return null as output",
-        scalarSql("SELECT system.bucket(100, CAST(null AS binary))"));
+    assertThat(scalarSql("SELECT system.bucket(100, CAST(null AS binary))"))
+        .as("Null input should return null as output")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testNumBucketsAcceptsShortAndByte() {
-    Assert.assertEquals(
-        "Short types should be usable for the number of buckets field",
-        1,
-        scalarSql("SELECT system.bucket(5S, 1L)"));
+    assertThat(scalarSql("SELECT system.bucket(5S, 1L)"))
+        .as("Short types should be usable for the number of buckets field")
+        .isEqualTo(1);
 
-    Assert.assertEquals(
-        "Byte types should be allowed for the number of buckets field",
-        1,
-        scalarSql("SELECT system.bucket(5Y, 1)"));
+    assertThat(scalarSql("SELECT system.bucket(5Y, 1)"))
+        .as("Byte types should be allowed for the number of buckets field")
+        .isEqualTo(1);
   }
 
-  @Test
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.bucket()"))
         .isInstanceOf(AnalysisException.class)
@@ -220,7 +210,7 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
             "Function 'bucket' cannot process input: (int, bigint, int): Wrong number of inputs (expected numBuckets and value)");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidTypesCannotBeUsedForNumberOfBuckets() {
     assertThatThrownBy(() -> scalarSql("SELECT system.bucket(CAST('12.34' as DECIMAL(9, 2)), 10)"))
         .isInstanceOf(AnalysisException.class)
@@ -250,7 +240,7 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
             "Function 'bucket' cannot process input: (interval day to second, int): Expected number of buckets to be tinyint, shortint or int");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidTypesForBucketColumn() {
     assertThatThrownBy(() -> scalarSql("SELECT system.bucket(10, cast(12.3456 as float))"))
         .isInstanceOf(AnalysisException.class)
@@ -287,7 +277,7 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
             "Function 'bucket' cannot process input: (int, interval day to second)");
   }
 
-  @Test
+  @TestTemplate
   public void testThatMagicFunctionsAreInvoked() {
     // TinyInt
     assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5, 6Y)"))

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
@@ -18,74 +18,68 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.Date;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSparkDaysFunction extends SparkTestBaseWithCatalog {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSparkDaysFunction extends TestBaseWithCatalog {
 
-  @Before
+  @BeforeEach
   public void useCatalog() {
     sql("USE %s", catalogName);
   }
 
-  @Test
+  @TestTemplate
   public void testDates() {
-    Assert.assertEquals(
-        "Expected to produce 2017-12-01",
-        Date.valueOf("2017-12-01"),
-        scalarSql("SELECT system.days(date('2017-12-01'))"));
-    Assert.assertEquals(
-        "Expected to produce 1970-01-01",
-        Date.valueOf("1970-01-01"),
-        scalarSql("SELECT system.days(date('1970-01-01'))"));
-    Assert.assertEquals(
-        "Expected to produce 1969-12-31",
-        Date.valueOf("1969-12-31"),
-        scalarSql("SELECT system.days(date('1969-12-31'))"));
-    Assert.assertNull(scalarSql("SELECT system.days(CAST(null AS DATE))"));
+    assertThat(scalarSql("SELECT system.days(date('2017-12-01'))"))
+        .as("Expected to produce 2017-12-01")
+        .isEqualTo(Date.valueOf("2017-12-01"));
+    assertThat(scalarSql("SELECT system.days(date('1970-01-01'))"))
+        .as("Expected to produce 1970-01-01")
+        .isEqualTo(Date.valueOf("1970-01-01"));
+    assertThat(scalarSql("SELECT system.days(date('1969-12-31'))"))
+        .as("Expected to produce 1969-12-31")
+        .isEqualTo(Date.valueOf("1969-12-31"));
+    assertThat(scalarSql("SELECT system.days(CAST(null AS DATE))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTimestamps() {
-    Assert.assertEquals(
-        "Expected to produce 2017-12-01",
-        Date.valueOf("2017-12-01"),
-        scalarSql("SELECT system.days(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"));
-    Assert.assertEquals(
-        "Expected to produce 1970-01-01",
-        Date.valueOf("1970-01-01"),
-        scalarSql("SELECT system.days(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"));
-    Assert.assertEquals(
-        "Expected to produce 1969-12-31",
-        Date.valueOf("1969-12-31"),
-        scalarSql("SELECT system.days(TIMESTAMP '1969-12-31 23:59:58.999999 UTC+00:00')"));
-    Assert.assertNull(scalarSql("SELECT system.days(CAST(null AS TIMESTAMP))"));
+    assertThat(scalarSql("SELECT system.days(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 2017-12-01")
+        .isEqualTo(Date.valueOf("2017-12-01"));
+    assertThat(scalarSql("SELECT system.days(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"))
+        .as("Expected to produce 1970-01-01")
+        .isEqualTo(Date.valueOf("1970-01-01"));
+    assertThat(scalarSql("SELECT system.days(TIMESTAMP '1969-12-31 23:59:58.999999 UTC+00:00')"))
+        .as("Expected to produce 1969-12-31")
+        .isEqualTo(Date.valueOf("1969-12-31"));
+    assertThat(scalarSql("SELECT system.days(CAST(null AS TIMESTAMP))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTimestampNtz() {
-    Assert.assertEquals(
-        "Expected to produce 2017-12-01",
-        Date.valueOf("2017-12-01"),
-        scalarSql("SELECT system.days(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"));
-    Assert.assertEquals(
-        "Expected to produce 1970-01-01",
-        Date.valueOf("1970-01-01"),
-        scalarSql("SELECT system.days(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"));
-    Assert.assertEquals(
-        "Expected to produce 1969-12-31",
-        Date.valueOf("1969-12-31"),
-        scalarSql("SELECT system.days(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999 UTC')"));
-    Assert.assertNull(scalarSql("SELECT system.days(CAST(null AS TIMESTAMP_NTZ))"));
+    assertThat(scalarSql("SELECT system.days(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
+        .as("Expected to produce 2017-12-01")
+        .isEqualTo(Date.valueOf("2017-12-01"));
+    assertThat(scalarSql("SELECT system.days(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"))
+        .as("Expected to produce 1970-01-01")
+        .isEqualTo(Date.valueOf("1970-01-01"));
+    assertThat(scalarSql("SELECT system.days(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999 UTC')"))
+        .as("Expected to produce 1969-12-31")
+        .isEqualTo(Date.valueOf("1969-12-31"));
+    assertThat(scalarSql("SELECT system.days(CAST(null AS TIMESTAMP_NTZ))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.days()"))
         .isInstanceOf(AnalysisException.class)
@@ -98,7 +92,7 @@ public class TestSparkDaysFunction extends SparkTestBaseWithCatalog {
             "Function 'days' cannot process input: (date, date): Wrong number of inputs");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidInputTypes() {
     assertThatThrownBy(() -> scalarSql("SELECT system.days(1)"))
         .isInstanceOf(AnalysisException.class)

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
@@ -18,56 +18,53 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSparkHoursFunction extends SparkTestBaseWithCatalog {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSparkHoursFunction extends TestBaseWithCatalog {
 
-  @Before
+  @BeforeEach
   public void useCatalog() {
     sql("USE %s", catalogName);
   }
 
-  @Test
+  @TestTemplate
   public void testTimestamps() {
-    Assert.assertEquals(
-        "Expected to produce 17501 * 24 + 10",
-        420034,
-        scalarSql("SELECT system.hours(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"));
-    Assert.assertEquals(
-        "Expected to produce 0 * 24 + 0 = 0",
-        0,
-        scalarSql("SELECT system.hours(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"));
-    Assert.assertEquals(
-        "Expected to produce -1",
-        -1,
-        scalarSql("SELECT system.hours(TIMESTAMP '1969-12-31 23:59:58.999999 UTC+00:00')"));
-    Assert.assertNull(scalarSql("SELECT system.hours(CAST(null AS TIMESTAMP))"));
+    assertThat(scalarSql("SELECT system.hours(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 17501 * 24 + 10")
+        .isEqualTo(420034);
+    assertThat(scalarSql("SELECT system.hours(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"))
+        .as("Expected to produce 0 * 24 + 0 = 0")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.hours(TIMESTAMP '1969-12-31 23:59:58.999999 UTC+00:00')"))
+        .as("Expected to produce -1")
+        .isEqualTo(-1);
+    assertThat(scalarSql("SELECT system.hours(CAST(null AS TIMESTAMP))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTimestampsNtz() {
-    Assert.assertEquals(
-        "Expected to produce 17501 * 24 + 10",
-        420034,
-        scalarSql("SELECT system.hours(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"));
-    Assert.assertEquals(
-        "Expected to produce 0 * 24 + 0 = 0",
-        0,
-        scalarSql("SELECT system.hours(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"));
-    Assert.assertEquals(
-        "Expected to produce -1",
-        -1,
-        scalarSql("SELECT system.hours(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999 UTC')"));
-    Assert.assertNull(scalarSql("SELECT system.hours(CAST(null AS TIMESTAMP_NTZ))"));
+    assertThat(scalarSql("SELECT system.hours(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
+        .as("Expected to produce 17501 * 24 + 10")
+        .isEqualTo(420034);
+    assertThat(scalarSql("SELECT system.hours(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"))
+        .as("Expected to produce 0 * 24 + 0 = 0")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.hours(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999 UTC')"))
+        .as("Expected to produce -1")
+        .isEqualTo(-1);
+    assertThat(scalarSql("SELECT system.hours(CAST(null AS TIMESTAMP_NTZ))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.hours()"))
         .isInstanceOf(AnalysisException.class)
@@ -81,7 +78,7 @@ public class TestSparkHoursFunction extends SparkTestBaseWithCatalog {
             "Function 'hours' cannot process input: (date, date): Wrong number of inputs");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidInputTypes() {
     assertThatThrownBy(() -> scalarSql("SELECT system.hours(1)"))
         .isInstanceOf(AnalysisException.class)

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
@@ -21,70 +21,65 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.spark.functions.MonthsFunction;
 import org.apache.spark.sql.AnalysisException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSparkMonthsFunction extends SparkTestBaseWithCatalog {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSparkMonthsFunction extends TestBaseWithCatalog {
 
-  @Before
+  @BeforeEach
   public void useCatalog() {
     sql("USE %s", catalogName);
   }
 
-  @Test
+  @TestTemplate
   public void testDates() {
-    Assert.assertEquals(
-        "Expected to produce 47 * 12 + 11 = 575",
-        575,
-        scalarSql("SELECT system.months(date('2017-12-01'))"));
-    Assert.assertEquals(
-        "Expected to produce 0 * 12 + 0 = 0",
-        0,
-        scalarSql("SELECT system.months(date('1970-01-01'))"));
-    Assert.assertEquals(
-        "Expected to produce -1", -1, scalarSql("SELECT system.months(date('1969-12-31'))"));
-    Assert.assertNull(scalarSql("SELECT system.months(CAST(null AS DATE))"));
+    assertThat(scalarSql("SELECT system.months(date('2017-12-01'))"))
+        .as("Expected to produce 47 * 12 + 11 = 575")
+        .isEqualTo(575);
+    assertThat(scalarSql("SELECT system.months(date('1970-01-01'))"))
+        .as("Expected to produce 0 * 12 + 0 = 0")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.months(date('1969-12-31'))"))
+        .as("Expected to produce -1")
+        .isEqualTo(-1);
+    assertThat(scalarSql("SELECT system.months(CAST(null AS DATE))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTimestamps() {
-    Assert.assertEquals(
-        "Expected to produce 47 * 12 + 11 = 575",
-        575,
-        scalarSql("SELECT system.months(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"));
-    Assert.assertEquals(
-        "Expected to produce 0 * 12 + 0 = 0",
-        0,
-        scalarSql("SELECT system.months(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"));
-    Assert.assertEquals(
-        "Expected to produce -1",
-        -1,
-        scalarSql("SELECT system.months(TIMESTAMP '1969-12-31 23:59:58.999999 UTC+00:00')"));
-    Assert.assertNull(scalarSql("SELECT system.months(CAST(null AS TIMESTAMP))"));
+    assertThat(scalarSql("SELECT system.months(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 47 * 12 + 11 = 575")
+        .isEqualTo(575);
+    assertThat(scalarSql("SELECT system.months(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"))
+        .as("Expected to produce 0 * 12 + 0 = 0")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.months(TIMESTAMP '1969-12-31 23:59:58.999999 UTC+00:00')"))
+        .as("Expected to produce -1")
+        .isEqualTo(-1);
+    assertThat(scalarSql("SELECT system.months(CAST(null AS TIMESTAMP))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTimestampNtz() {
-    Assert.assertEquals(
-        "Expected to produce 47 * 12 + 11 = 575",
-        575,
-        scalarSql("SELECT system.months(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"));
-    Assert.assertEquals(
-        "Expected to produce 0 * 12 + 0 = 0",
-        0,
-        scalarSql("SELECT system.months(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"));
-    Assert.assertEquals(
-        "Expected to produce -1",
-        -1,
-        scalarSql("SELECT system.months(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999 UTC')"));
-    Assert.assertNull(scalarSql("SELECT system.months(CAST(null AS TIMESTAMP_NTZ))"));
+    assertThat(scalarSql("SELECT system.months(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
+        .as("Expected to produce 47 * 12 + 11 = 575")
+        .isEqualTo(575);
+    assertThat(scalarSql("SELECT system.months(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"))
+        .as("Expected to produce 0 * 12 + 0 = 0")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.months(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999 UTC')"))
+        .as("Expected to produce -1")
+        .isEqualTo(-1);
+    assertThat(scalarSql("SELECT system.months(CAST(null AS TIMESTAMP_NTZ))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.months()"))
         .isInstanceOf(AnalysisException.class)
@@ -98,7 +93,7 @@ public class TestSparkMonthsFunction extends SparkTestBaseWithCatalog {
             "Function 'months' cannot process input: (date, date): Wrong number of inputs");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidInputTypes() {
     assertThatThrownBy(() -> scalarSql("SELECT system.months(1)"))
         .isInstanceOf(AnalysisException.class)
@@ -111,7 +106,7 @@ public class TestSparkMonthsFunction extends SparkTestBaseWithCatalog {
             "Function 'months' cannot process input: (bigint): Expected value to be date or timestamp");
   }
 
-  @Test
+  @TestTemplate
   public void testThatMagicFunctionsAreInvoked() {
     String dateValue = "date('2017-12-01')";
     String dateTransformClass = MonthsFunction.DateToMonthsFunction.class.getName();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -23,249 +23,232 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
-  public TestSparkTruncateFunction() {}
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSparkTruncateFunction extends TestBaseWithCatalog {
 
-  @Before
+  @BeforeEach
   public void useCatalog() {
     sql("USE %s", catalogName);
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateTinyInt() {
-    Assert.assertEquals((byte) 0, scalarSql("SELECT system.truncate(10, 0Y)"));
-    Assert.assertEquals((byte) 0, scalarSql("SELECT system.truncate(10, 1Y)"));
-    Assert.assertEquals((byte) 0, scalarSql("SELECT system.truncate(10, 5Y)"));
-    Assert.assertEquals((byte) 0, scalarSql("SELECT system.truncate(10, 9Y)"));
-    Assert.assertEquals((byte) 10, scalarSql("SELECT system.truncate(10, 10Y)"));
-    Assert.assertEquals((byte) 10, scalarSql("SELECT system.truncate(10, 11Y)"));
-    Assert.assertEquals((byte) -10, scalarSql("SELECT system.truncate(10, -1Y)"));
-    Assert.assertEquals((byte) -10, scalarSql("SELECT system.truncate(10, -5Y)"));
-    Assert.assertEquals((byte) -10, scalarSql("SELECT system.truncate(10, -10Y)"));
-    Assert.assertEquals((byte) -20, scalarSql("SELECT system.truncate(10, -11Y)"));
+    assertThat(scalarSql("SELECT system.truncate(10, 0Y)")).isEqualTo((byte) 0);
+    assertThat(scalarSql("SELECT system.truncate(10, 1Y)")).isEqualTo((byte) 0);
+    assertThat(scalarSql("SELECT system.truncate(10, 5Y)")).isEqualTo((byte) 0);
+    assertThat(scalarSql("SELECT system.truncate(10, 9Y)")).isEqualTo((byte) 0);
+    assertThat(scalarSql("SELECT system.truncate(10, 10Y)")).isEqualTo((byte) 10);
+    assertThat(scalarSql("SELECT system.truncate(10, 11Y)")).isEqualTo((byte) 10);
+    assertThat(scalarSql("SELECT system.truncate(10, -1Y)")).isEqualTo((byte) -10);
+    assertThat(scalarSql("SELECT system.truncate(10, -5Y)")).isEqualTo((byte) -10);
+    assertThat(scalarSql("SELECT system.truncate(10, -10Y)")).isEqualTo((byte) -10);
+    assertThat(scalarSql("SELECT system.truncate(10, -11Y)")).isEqualTo((byte) -20);
 
     // Check that different widths can be used
-    Assert.assertEquals((byte) -2, scalarSql("SELECT system.truncate(2, -1Y)"));
+    assertThat(scalarSql("SELECT system.truncate(2, -1Y)")).isEqualTo((byte) -2);
 
-    Assert.assertNull(
-        "Null input should return null",
-        scalarSql("SELECT system.truncate(2, CAST(null AS tinyint))"));
+    assertThat(scalarSql("SELECT system.truncate(2, CAST(null AS tinyint))"))
+        .as("Null input should return null")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateSmallInt() {
-    Assert.assertEquals((short) 0, scalarSql("SELECT system.truncate(10, 0S)"));
-    Assert.assertEquals((short) 0, scalarSql("SELECT system.truncate(10, 1S)"));
-    Assert.assertEquals((short) 0, scalarSql("SELECT system.truncate(10, 5S)"));
-    Assert.assertEquals((short) 0, scalarSql("SELECT system.truncate(10, 9S)"));
-    Assert.assertEquals((short) 10, scalarSql("SELECT system.truncate(10, 10S)"));
-    Assert.assertEquals((short) 10, scalarSql("SELECT system.truncate(10, 11S)"));
-    Assert.assertEquals((short) -10, scalarSql("SELECT system.truncate(10, -1S)"));
-    Assert.assertEquals((short) -10, scalarSql("SELECT system.truncate(10, -5S)"));
-    Assert.assertEquals((short) -10, scalarSql("SELECT system.truncate(10, -10S)"));
-    Assert.assertEquals((short) -20, scalarSql("SELECT system.truncate(10, -11S)"));
+    assertThat(scalarSql("SELECT system.truncate(10, 0S)")).isEqualTo((short) 0);
+    assertThat(scalarSql("SELECT system.truncate(10, 1S)")).isEqualTo((short) 0);
+    assertThat(scalarSql("SELECT system.truncate(10, 5S)")).isEqualTo((short) 0);
+    assertThat(scalarSql("SELECT system.truncate(10, 9S)")).isEqualTo((short) 0);
+    assertThat(scalarSql("SELECT system.truncate(10, 10S)")).isEqualTo((short) 10);
+    assertThat(scalarSql("SELECT system.truncate(10, 11S)")).isEqualTo((short) 10);
+    assertThat(scalarSql("SELECT system.truncate(10, -1S)")).isEqualTo((short) -10);
+    assertThat(scalarSql("SELECT system.truncate(10, -5S)")).isEqualTo((short) -10);
+    assertThat(scalarSql("SELECT system.truncate(10, -10S)")).isEqualTo((short) -10);
+    assertThat(scalarSql("SELECT system.truncate(10, -11S)")).isEqualTo((short) -20);
 
     // Check that different widths can be used
-    Assert.assertEquals((short) -2, scalarSql("SELECT system.truncate(2, -1S)"));
+    assertThat(scalarSql("SELECT system.truncate(2, -1S)")).isEqualTo((short) -2);
 
-    Assert.assertNull(
-        "Null input should return null",
-        scalarSql("SELECT system.truncate(2, CAST(null AS smallint))"));
+    assertThat(scalarSql("SELECT system.truncate(2, CAST(null AS smallint))"))
+        .as("Null input should return null")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateInt() {
-    Assert.assertEquals(0, scalarSql("SELECT system.truncate(10, 0)"));
-    Assert.assertEquals(0, scalarSql("SELECT system.truncate(10, 1)"));
-    Assert.assertEquals(0, scalarSql("SELECT system.truncate(10, 5)"));
-    Assert.assertEquals(0, scalarSql("SELECT system.truncate(10, 9)"));
-    Assert.assertEquals(10, scalarSql("SELECT system.truncate(10, 10)"));
-    Assert.assertEquals(10, scalarSql("SELECT system.truncate(10, 11)"));
-    Assert.assertEquals(-10, scalarSql("SELECT system.truncate(10, -1)"));
-    Assert.assertEquals(-10, scalarSql("SELECT system.truncate(10, -5)"));
-    Assert.assertEquals(-10, scalarSql("SELECT system.truncate(10, -10)"));
-    Assert.assertEquals(-20, scalarSql("SELECT system.truncate(10, -11)"));
+    assertThat(scalarSql("SELECT system.truncate(10, 0)")).isEqualTo(0);
+    assertThat(scalarSql("SELECT system.truncate(10, 1)")).isEqualTo(0);
+    assertThat(scalarSql("SELECT system.truncate(10, 5)")).isEqualTo(0);
+    assertThat(scalarSql("SELECT system.truncate(10, 9)")).isEqualTo(0);
+    assertThat(scalarSql("SELECT system.truncate(10, 10)")).isEqualTo(10);
+    assertThat(scalarSql("SELECT system.truncate(10, 11)")).isEqualTo(10);
+    assertThat(scalarSql("SELECT system.truncate(10, -1)")).isEqualTo(-10);
+    assertThat(scalarSql("SELECT system.truncate(10, -5)")).isEqualTo(-10);
+    assertThat(scalarSql("SELECT system.truncate(10, -10)")).isEqualTo(-10);
+    assertThat(scalarSql("SELECT system.truncate(10, -11)")).isEqualTo(-20);
 
     // Check that different widths can be used
-    Assert.assertEquals(-2, scalarSql("SELECT system.truncate(2, -1)"));
-    Assert.assertEquals(0, scalarSql("SELECT system.truncate(300, 1)"));
+    assertThat(scalarSql("SELECT system.truncate(2, -1)")).isEqualTo(-2);
+    assertThat(scalarSql("SELECT system.truncate(300, 1)")).isEqualTo(0);
 
-    Assert.assertNull(
-        "Null input should return null", scalarSql("SELECT system.truncate(2, CAST(null AS int))"));
+    assertThat(scalarSql("SELECT system.truncate(2, CAST(null AS int))"))
+        .as("Null input should return null")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateBigInt() {
-    Assert.assertEquals(0L, scalarSql("SELECT system.truncate(10, 0L)"));
-    Assert.assertEquals(0L, scalarSql("SELECT system.truncate(10, 1L)"));
-    Assert.assertEquals(0L, scalarSql("SELECT system.truncate(10, 5L)"));
-    Assert.assertEquals(0L, scalarSql("SELECT system.truncate(10, 9L)"));
-    Assert.assertEquals(10L, scalarSql("SELECT system.truncate(10, 10L)"));
-    Assert.assertEquals(10L, scalarSql("SELECT system.truncate(10, 11L)"));
-    Assert.assertEquals(-10L, scalarSql("SELECT system.truncate(10, -1L)"));
-    Assert.assertEquals(-10L, scalarSql("SELECT system.truncate(10, -5L)"));
-    Assert.assertEquals(-10L, scalarSql("SELECT system.truncate(10, -10L)"));
-    Assert.assertEquals(-20L, scalarSql("SELECT system.truncate(10, -11L)"));
+    assertThat(scalarSql("SELECT system.truncate(10, 0L)")).isEqualTo(0L);
+    assertThat(scalarSql("SELECT system.truncate(10, 1L)")).isEqualTo(0L);
+    assertThat(scalarSql("SELECT system.truncate(10, 5L)")).isEqualTo(0L);
+    assertThat(scalarSql("SELECT system.truncate(10, 9L)")).isEqualTo(0L);
+    assertThat(scalarSql("SELECT system.truncate(10, 10L)")).isEqualTo(10L);
+    assertThat(scalarSql("SELECT system.truncate(10, 11L)")).isEqualTo(10L);
+    assertThat(scalarSql("SELECT system.truncate(10, -1L)")).isEqualTo(-10L);
+    assertThat(scalarSql("SELECT system.truncate(10, -5L)")).isEqualTo(-10L);
+    assertThat(scalarSql("SELECT system.truncate(10, -10L)")).isEqualTo(-10L);
+    assertThat(scalarSql("SELECT system.truncate(10, -11L)")).isEqualTo(-20L);
 
     // Check that different widths can be used
-    Assert.assertEquals(-2L, scalarSql("SELECT system.truncate(2, -1L)"));
+    assertThat(scalarSql("SELECT system.truncate(2, -1L)")).isEqualTo(-2L);
 
-    Assert.assertNull(
-        "Null input should return null",
-        scalarSql("SELECT system.truncate(2, CAST(null AS bigint))"));
+    assertThat(scalarSql("SELECT system.truncate(2, CAST(null AS bigint))"))
+        .as("Null input should return null")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateDecimal() {
     // decimal truncation works by applying the decimal scale to the width: ie 10 scale 2 = 0.10
-    Assert.assertEquals(
-        new BigDecimal("12.30"),
-        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "12.34"));
+    assertThat(scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "12.34"))
+        .isEqualTo(new BigDecimal("12.30"));
 
-    Assert.assertEquals(
-        new BigDecimal("12.30"),
-        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "12.30"));
+    assertThat(scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "12.30"))
+        .isEqualTo(new BigDecimal("12.30"));
 
-    Assert.assertEquals(
-        new BigDecimal("12.290"),
-        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 3)))", "12.299"));
+    assertThat(scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 3)))", "12.299"))
+        .isEqualTo(new BigDecimal("12.290"));
 
-    Assert.assertEquals(
-        new BigDecimal("0.03"),
-        scalarSql("SELECT system.truncate(3, CAST(%s as DECIMAL(5, 2)))", "0.05"));
+    assertThat(scalarSql("SELECT system.truncate(3, CAST(%s as DECIMAL(5, 2)))", "0.05"))
+        .isEqualTo(new BigDecimal("0.03"));
 
-    Assert.assertEquals(
-        new BigDecimal("0.00"),
-        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "0.05"));
+    assertThat(scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "0.05"))
+        .isEqualTo(new BigDecimal("0.00"));
 
-    Assert.assertEquals(
-        new BigDecimal("-0.10"),
-        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "-0.05"));
+    assertThat(scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "-0.05"))
+        .isEqualTo(new BigDecimal("-0.10"));
 
-    Assert.assertEquals(
-        "Implicit decimal scale and precision should be allowed",
-        new BigDecimal("12345.3480"),
-        scalarSql("SELECT system.truncate(10, 12345.3482)"));
+    assertThat(scalarSql("SELECT system.truncate(10, 12345.3482)"))
+        .as("Implicit decimal scale and precision should be allowed")
+        .isEqualTo(new BigDecimal("12345.3480"));
 
     BigDecimal truncatedDecimal =
         (BigDecimal) scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(6, 4)))", "-0.05");
-    Assert.assertEquals(
-        "Truncating a decimal should return a decimal with the same scale",
-        4,
-        truncatedDecimal.scale());
+    assertThat(truncatedDecimal.scale())
+        .as("Truncating a decimal should return a decimal with the same scale")
+        .isEqualTo(4);
 
-    Assert.assertEquals(
-        "Truncating a decimal should return a decimal with the correct scale",
-        BigDecimal.valueOf(-500, 4),
-        truncatedDecimal);
+    assertThat(truncatedDecimal)
+        .as("Truncating a decimal should return a decimal with the correct scale")
+        .isEqualTo(BigDecimal.valueOf(-500, 4));
 
-    Assert.assertNull(
-        "Null input should return null",
-        scalarSql("SELECT system.truncate(2, CAST(null AS decimal))"));
+    assertThat(scalarSql("SELECT system.truncate(2, CAST(null AS decimal))"))
+        .as("Null input should return null")
+        .isNull();
   }
 
   @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
-  @Test
+  @TestTemplate
   public void testTruncateString() {
-    Assert.assertEquals(
-        "Should system.truncate strings longer than length",
-        "abcde",
-        scalarSql("SELECT system.truncate(5, 'abcdefg')"));
+    assertThat(scalarSql("SELECT system.truncate(5, 'abcdefg')"))
+        .as("Should system.truncate strings longer than length")
+        .isEqualTo("abcde");
 
-    Assert.assertEquals(
-        "Should not pad strings shorter than length",
-        "abc",
-        scalarSql("SELECT system.truncate(5, 'abc')"));
+    assertThat(scalarSql("SELECT system.truncate(5, 'abc')"))
+        .as("Should not pad strings shorter than length")
+        .isEqualTo("abc");
 
-    Assert.assertEquals(
-        "Should not alter strings equal to length",
-        "abcde",
-        scalarSql("SELECT system.truncate(5, 'abcde')"));
+    assertThat(scalarSql("SELECT system.truncate(5, 'abcde')"))
+        .as("Should not alter strings equal to length")
+        .isEqualTo("abcde");
 
-    Assert.assertEquals(
-        "Strings with multibyte unicode characters should should truncate along codepoint boundaries",
-        "イロ",
-        scalarSql("SELECT system.truncate(2, 'イロハニホヘト')"));
+    assertThat(scalarSql("SELECT system.truncate(2, 'イロハニホヘト')"))
+        .as("Strings with multibyte unicode characters should truncate along codepoint boundaries")
+        .isEqualTo("イロ");
 
-    Assert.assertEquals(
-        "Strings with multibyte unicode characters should truncate along codepoint boundaries",
-        "イロハ",
-        scalarSql("SELECT system.truncate(3, 'イロハニホヘト')"));
+    assertThat(scalarSql("SELECT system.truncate(3, 'イロハニホヘト')"))
+        .as("Strings with multibyte unicode characters should truncate along codepoint boundaries")
+        .isEqualTo("イロハ");
 
-    Assert.assertEquals(
-        "Strings with multibyte unicode characters should not alter input with fewer codepoints than width",
-        "イロハニホヘト",
-        scalarSql("SELECT system.truncate(7, 'イロハニホヘト')"));
+    assertThat(scalarSql("SELECT system.truncate(7, 'イロハニホヘト')"))
+        .as(
+            "Strings with multibyte unicode characters should not alter input with fewer codepoints than width")
+        .isEqualTo("イロハニホヘト");
 
     String stringWithTwoCodePointsEachFourBytes = "\uD800\uDC00\uD800\uDC00";
-    Assert.assertEquals(
-        "String truncation on four byte codepoints should work as expected",
-        "\uD800\uDC00",
-        scalarSql("SELECT system.truncate(1, '%s')", stringWithTwoCodePointsEachFourBytes));
+    assertThat(scalarSql("SELECT system.truncate(1, '%s')", stringWithTwoCodePointsEachFourBytes))
+        .as("String truncation on four byte codepoints should work as expected")
+        .isEqualTo("\uD800\uDC00");
 
-    Assert.assertEquals(
-        "Should handle three-byte UTF-8 characters appropriately",
-        "测",
-        scalarSql("SELECT system.truncate(1, '测试')"));
+    assertThat(scalarSql("SELECT system.truncate(1, '测试')"))
+        .as("Should handle three-byte UTF-8 characters appropriately")
+        .isEqualTo("测");
 
-    Assert.assertEquals(
-        "Should handle three-byte UTF-8 characters mixed with two byte utf-8 characters",
-        "测试ra",
-        scalarSql("SELECT system.truncate(4, '测试raul试测')"));
+    assertThat(scalarSql("SELECT system.truncate(4, '测试raul试测')"))
+        .as("Should handle three-byte UTF-8 characters mixed with two byte utf-8 characters")
+        .isEqualTo("测试ra");
 
-    Assert.assertEquals(
-        "Should not fail on the empty string", "", scalarSql("SELECT system.truncate(10, '')"));
+    assertThat(scalarSql("SELECT system.truncate(10, '')"))
+        .as("Should not fail on the empty string")
+        .isEqualTo("");
 
-    Assert.assertNull(
-        "Null input should return null as output",
-        scalarSql("SELECT system.truncate(3, CAST(null AS string))"));
+    assertThat(scalarSql("SELECT system.truncate(3, CAST(null AS string))"))
+        .as("Null input should return null as output")
+        .isNull();
 
-    Assert.assertEquals(
-        "Varchar should work like string",
-        "测试ra",
-        scalarSql("SELECT system.truncate(4, CAST('测试raul试测' AS varchar(8)))"));
+    assertThat(scalarSql("SELECT system.truncate(4, CAST('测试raul试测' AS varchar(8)))"))
+        .as("Varchar should work like string")
+        .isEqualTo("测试ra");
 
-    Assert.assertEquals(
-        "Char should work like string",
-        "测试ra",
-        scalarSql("SELECT system.truncate(4, CAST('测试raul试测' AS char(8)))"));
+    assertThat(scalarSql("SELECT system.truncate(4, CAST('测试raul试测' AS char(8)))"))
+        .as("Char should work like string")
+        .isEqualTo("测试ra");
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateBinary() {
-    Assert.assertArrayEquals(
-        new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-        (byte[]) scalarSql("SELECT system.truncate(10, X'0102030405060708090a0b0c0d0e0f')"));
-    Assert.assertArrayEquals(
-        "Should return the same input when value is equal to truncation width",
-        "abc".getBytes(StandardCharsets.UTF_8),
-        (byte[]) scalarSql("SELECT system.truncate(3, %s)", asBytesLiteral("abcdefg")));
-    Assert.assertArrayEquals(
-        "Should not truncate, pad, or trim the input when its length is less than the width",
-        "abc\0\0".getBytes(StandardCharsets.UTF_8),
-        (byte[]) scalarSql("SELECT system.truncate(10, %s)", asBytesLiteral("abc\0\0")));
-    Assert.assertArrayEquals(
-        "Should not pad the input when its length is equal to the width",
-        "abc".getBytes(StandardCharsets.UTF_8),
-        (byte[]) scalarSql("SELECT system.truncate(3, %s)", asBytesLiteral("abc")));
-    Assert.assertArrayEquals(
-        "Should handle three-byte UTF-8 characters appropriately",
-        "测试".getBytes(StandardCharsets.UTF_8),
-        (byte[]) scalarSql("SELECT system.truncate(6, %s)", asBytesLiteral("测试_")));
+    assertThat((byte[]) scalarSql("SELECT system.truncate(10, X'0102030405060708090a0b0c0d0e0f')"))
+        .isEqualTo(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
 
-    Assert.assertNull(
-        "Null input should return null as output",
-        scalarSql("SELECT system.truncate(3, CAST(null AS binary))"));
+    assertThat((byte[]) scalarSql("SELECT system.truncate(3, %s)", asBytesLiteral("abcdefg")))
+        .as("Should return the same input when value is equal to truncation width")
+        .isEqualTo("abc".getBytes(StandardCharsets.UTF_8));
+
+    assertThat((byte[]) scalarSql("SELECT system.truncate(10, %s)", asBytesLiteral("abc\0\0")))
+        .as("Should not truncate, pad, or trim the input when its length is less than the width")
+        .isEqualTo("abc\0\0".getBytes(StandardCharsets.UTF_8));
+
+    assertThat((byte[]) scalarSql("SELECT system.truncate(3, %s)", asBytesLiteral("abc")))
+        .as("Should not pad the input when its length is equal to the width")
+        .isEqualTo("abc".getBytes(StandardCharsets.UTF_8));
+
+    assertThat((byte[]) scalarSql("SELECT system.truncate(6, %s)", asBytesLiteral("测试_")))
+        .as("Should handle three-byte UTF-8 characters appropriately")
+        .isEqualTo("测试".getBytes(StandardCharsets.UTF_8));
+
+    assertThat(scalarSql("SELECT system.truncate(3, CAST(null AS binary))"))
+        .as("Null input should return null as output")
+        .isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTruncateUsingDataframeForWidthWithVaryingWidth() {
     // This situation is atypical but allowed. Typically, width is static as data is partitioned on
     // one width.
@@ -278,26 +261,23 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
             .selectExpr("system.truncate(width, value) as truncated_value")
             .filter("truncated_value == 0")
             .count();
-    Assert.assertEquals(
-        "A truncate function with variable widths should be usable on dataframe columns",
-        rumRows,
-        numNonZero);
+    assertThat(numNonZero)
+        .as("A truncate function with variable widths should be usable on dataframe columns")
+        .isEqualTo(rumRows);
   }
 
-  @Test
+  @TestTemplate
   public void testWidthAcceptsShortAndByte() {
-    Assert.assertEquals(
-        "Short types should be usable for the width field",
-        0L,
-        scalarSql("SELECT system.truncate(5S, 1L)"));
+    assertThat(scalarSql("SELECT system.truncate(5S, 1L)"))
+        .as("Short types should be usable for the width field")
+        .isEqualTo(0L);
 
-    Assert.assertEquals(
-        "Byte types should be allowed for the width field",
-        0,
-        scalarSql("SELECT system.truncate(5Y, 1)"));
+    assertThat(scalarSql("SELECT system.truncate(5Y, 1)"))
+        .as("Byte types should be allowed for the width field")
+        .isEqualTo(0);
   }
 
-  @Test
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.truncate()"))
         .isInstanceOf(AnalysisException.class)
@@ -315,7 +295,7 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
             "Function 'truncate' cannot process input: (int, bigint, int): Wrong number of inputs (expected width and value)");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidTypesCannotBeUsedForWidth() {
     assertThatThrownBy(
             () -> scalarSql("SELECT system.truncate(CAST('12.34' as DECIMAL(9, 2)), 10)"))
@@ -343,7 +323,7 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
             "Function 'truncate' cannot process input: (interval day to second, int): Expected truncation width to be tinyint, shortint or int");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidTypesForTruncationColumn() {
     assertThatThrownBy(() -> scalarSql("SELECT system.truncate(10, cast(12.3456 as float))"))
         .isInstanceOf(AnalysisException.class)
@@ -385,7 +365,7 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
             "Function 'truncate' cannot process input: (int, interval day to second): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary");
   }
 
-  @Test
+  @TestTemplate
   public void testMagicFunctionsResolveForTinyIntAndSmallIntWidths() {
     // Magic functions have staticinvoke in the explain output. Nonmagic calls use
     // applyfunctionexpression instead.
@@ -403,7 +383,7 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
             "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateBigInt");
   }
 
-  @Test
+  @TestTemplate
   public void testThatMagicFunctionsAreInvoked() {
     // Magic functions have `staticinvoke` in the explain output.
     // Non-magic calls have `applyfunctionexpression` instead.

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
@@ -21,72 +21,62 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.spark.functions.YearsFunction;
 import org.apache.spark.sql.AnalysisException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
 
-public class TestSparkYearsFunction extends SparkTestBaseWithCatalog {
+public class TestSparkYearsFunction extends TestBaseWithCatalog {
 
-  @Before
+  @BeforeEach
   public void useCatalog() {
     sql("USE %s", catalogName);
   }
 
-  @Test
+  @TestTemplate
   public void testDates() {
-    Assert.assertEquals(
-        "Expected to produce 2017 - 1970 = 47",
-        47,
-        scalarSql("SELECT system.years(date('2017-12-01'))"));
-    Assert.assertEquals(
-        "Expected to produce 1970 - 1970 = 0",
-        0,
-        scalarSql("SELECT system.years(date('1970-01-01'))"));
-    Assert.assertEquals(
-        "Expected to produce 1969 - 1970 = -1",
-        -1,
-        scalarSql("SELECT system.years(date('1969-12-31'))"));
-    Assert.assertNull(scalarSql("SELECT system.years(CAST(null AS DATE))"));
+    assertThat(scalarSql("SELECT system.years(date('2017-12-01'))"))
+        .as("Expected to produce 2017 - 1970 = 47")
+        .isEqualTo(47);
+    assertThat(scalarSql("SELECT system.years(date('1970-01-01'))"))
+        .as("Expected to produce 1970 - 1970 = 0")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.years(date('1969-12-31'))"))
+        .as("Expected to produce 1969 - 1970 = -1")
+        .isEqualTo(-1);
+    assertThat(scalarSql("SELECT system.years(CAST(null AS DATE))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTimestamps() {
-    Assert.assertEquals(
-        "Expected to produce 2017 - 1970 = 47",
-        47,
-        scalarSql("SELECT system.years(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"));
-    Assert.assertEquals(
-        "Expected to produce 1970 - 1970 = 0",
-        0,
-        scalarSql("SELECT system.years(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"));
-    Assert.assertEquals(
-        "Expected to produce 1969 - 1970 = -1",
-        -1,
-        scalarSql("SELECT system.years(TIMESTAMP '1969-12-31 23:59:58.999999 UTC+00:00')"));
-    Assert.assertNull(scalarSql("SELECT system.years(CAST(null AS TIMESTAMP))"));
+    assertThat(scalarSql("SELECT system.years(TIMESTAMP '2017-12-01 10:12:55.038194 UTC+00:00')"))
+        .as("Expected to produce 2017 - 1970 = 47")
+        .isEqualTo(47);
+    assertThat(scalarSql("SELECT system.years(TIMESTAMP '1970-01-01 00:00:01.000001 UTC+00:00')"))
+        .as("Expected to produce 1970 - 1970 = 0")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.years(TIMESTAMP '1969-12-31 23:59:58.999999 UTC+00:00')"))
+        .as("Expected to produce 1969 - 1970 = -1")
+        .isEqualTo(-1);
+    assertThat(scalarSql("SELECT system.years(CAST(null AS TIMESTAMP))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testTimestampNtz() {
-    Assert.assertEquals(
-        "Expected to produce 2017 - 1970 = 47",
-        47,
-        scalarSql("SELECT system.years(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"));
-    Assert.assertEquals(
-        "Expected to produce 1970 - 1970 = 0",
-        0,
-        scalarSql("SELECT system.years(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"));
-    Assert.assertEquals(
-        "Expected to produce 1969 - 1970 = -1",
-        -1,
-        scalarSql("SELECT system.years(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999 UTC')"));
-    Assert.assertNull(scalarSql("SELECT system.years(CAST(null AS TIMESTAMP_NTZ))"));
+    assertThat(scalarSql("SELECT system.years(TIMESTAMP_NTZ '2017-12-01 10:12:55.038194 UTC')"))
+        .as("Expected to produce 2017 - 1970 = 47")
+        .isEqualTo(47);
+    assertThat(scalarSql("SELECT system.years(TIMESTAMP_NTZ '1970-01-01 00:00:01.000001 UTC')"))
+        .as("Expected to produce 1970 - 1970 = 0")
+        .isEqualTo(0);
+    assertThat(scalarSql("SELECT system.years(TIMESTAMP_NTZ '1969-12-31 23:59:58.999999 UTC')"))
+        .as("Expected to produce 1969 - 1970 = -1")
+        .isEqualTo(-1);
+    assertThat(scalarSql("SELECT system.years(CAST(null AS TIMESTAMP_NTZ))")).isNull();
   }
 
-  @Test
+  @TestTemplate
   public void testWrongNumberOfArguments() {
     assertThatThrownBy(() -> scalarSql("SELECT system.years()"))
         .isInstanceOf(AnalysisException.class)
@@ -100,7 +90,7 @@ public class TestSparkYearsFunction extends SparkTestBaseWithCatalog {
             "Function 'years' cannot process input: (date, date): Wrong number of inputs");
   }
 
-  @Test
+  @TestTemplate
   public void testInvalidInputTypes() {
     assertThatThrownBy(() -> scalarSql("SELECT system.years(1)"))
         .isInstanceOf(AnalysisException.class)
@@ -113,7 +103,7 @@ public class TestSparkYearsFunction extends SparkTestBaseWithCatalog {
             "Function 'years' cannot process input: (bigint): Expected value to be date or timestamp");
   }
 
-  @Test
+  @TestTemplate
   public void testThatMagicFunctionsAreInvoked() {
     String dateValue = "date('2017-12-01')";
     String dateTransformClass = YearsFunction.DateToYearsFunction.class.getName();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -20,11 +20,15 @@ package org.apache.iceberg.spark.sql;
 
 import static org.apache.iceberg.PlanningMode.DISTRIBUTED;
 import static org.apache.iceberg.PlanningMode.LOCAL;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PlanningMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -32,10 +36,11 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
@@ -44,19 +49,30 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructType;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(Parameterized.class)
-public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
 
-  @Parameterized.Parameters(name = "planningMode = {0}")
-  public static Object[] parameters() {
-    return new Object[] {LOCAL, DISTRIBUTED};
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, planningMode = {3}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties(),
+        LOCAL
+      },
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties(),
+        DISTRIBUTED
+      },
+    };
   }
 
   private static final String OTHER_TABLE_NAME = "other_table";
@@ -96,18 +112,15 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
           SparkSQLProperties.PRESERVE_DATA_GROUPING,
           "true");
 
-  private final PlanningMode planningMode;
+  @Parameter(index = 3)
+  private PlanningMode planningMode;
 
-  public TestStoragePartitionedJoins(PlanningMode planningMode) {
-    this.planningMode = planningMode;
-  }
-
-  @BeforeClass
+  @BeforeAll
   public static void setupSparkConf() {
     spark.conf().set("spark.sql.shuffle.partitions", "4");
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS %s", tableName(OTHER_TABLE_NAME));
@@ -115,107 +128,107 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
 
   // TODO: add tests for truncate transforms once SPARK-40295 is released
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnByteColumn() throws NoSuchTableException {
     checkJoin("byte_col", "TINYINT", "bucket(4, byte_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnShortColumn() throws NoSuchTableException {
     checkJoin("short_col", "SMALLINT", "bucket(4, short_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnIntColumn() throws NoSuchTableException {
     checkJoin("int_col", "INT", "bucket(16, int_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnLongColumn() throws NoSuchTableException {
     checkJoin("long_col", "BIGINT", "bucket(16, long_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnTimestampColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP", "bucket(16, timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnTimestampNtzColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP_NTZ", "bucket(16, timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnDateColumn() throws NoSuchTableException {
     checkJoin("date_col", "DATE", "bucket(8, date_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnDecimalColumn() throws NoSuchTableException {
     checkJoin("decimal_col", "DECIMAL(20, 2)", "bucket(8, decimal_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithBucketingOnBinaryColumn() throws NoSuchTableException {
     checkJoin("binary_col", "BINARY", "bucket(8, binary_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithYearsOnTimestampColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP", "years(timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithYearsOnTimestampNtzColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP_NTZ", "years(timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithYearsOnDateColumn() throws NoSuchTableException {
     checkJoin("date_col", "DATE", "years(date_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithMonthsOnTimestampColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP", "months(timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithMonthsOnTimestampNtzColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP_NTZ", "months(timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithMonthsOnDateColumn() throws NoSuchTableException {
     checkJoin("date_col", "DATE", "months(date_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithDaysOnTimestampColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP", "days(timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithDaysOnTimestampNtzColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP_NTZ", "days(timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithDaysOnDateColumn() throws NoSuchTableException {
     checkJoin("date_col", "DATE", "days(date_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithHoursOnTimestampColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP", "hours(timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithHoursOnTimestampNtzColumn() throws NoSuchTableException {
     checkJoin("timestamp_col", "TIMESTAMP_NTZ", "hours(timestamp_col)");
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithMultipleTransformTypes() throws NoSuchTableException {
     String createTableStmt =
         "CREATE TABLE %s ("
@@ -304,7 +317,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithCompatibleSpecEvolution() {
     // create a table with an empty spec
     sql(
@@ -357,7 +370,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithIncompatibleSpecs() {
     sql(
         "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
@@ -397,7 +410,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithUnpartitionedTables() {
     sql(
         "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
@@ -437,7 +450,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithEmptyTable() {
     sql(
         "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
@@ -469,7 +482,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithOneSplitTables() {
     sql(
         "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
@@ -503,7 +516,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testJoinsWithMismatchingPartitionKeys() {
     sql(
         "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
@@ -537,7 +550,7 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         tableName(OTHER_TABLE_NAME));
   }
 
-  @Test
+  @TestTemplate
   public void testAggregates() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
@@ -628,10 +641,9 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         () -> {
           String plan = executeAndKeepPlan(query, args).toString();
           int actualNumShuffles = StringUtils.countMatches(plan, "Exchange");
-          Assert.assertEquals(
-              "Number of shuffles with enabled SPJ must match",
-              expectedNumShufflesWithSPJ,
-              actualNumShuffles);
+          assertThat(actualNumShuffles)
+              .as("Number of shuffles with enabled SPJ must match")
+              .isEqualTo(expectedNumShufflesWithSPJ);
 
           rowsWithSPJ.set(sql(query, args));
         });
@@ -641,10 +653,9 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
         () -> {
           String plan = executeAndKeepPlan(query, args).toString();
           int actualNumShuffles = StringUtils.countMatches(plan, "Exchange");
-          Assert.assertEquals(
-              "Number of shuffles with disabled SPJ must match",
-              expectedNumShufflesWithoutSPJ,
-              actualNumShuffles);
+          assertThat(actualNumShuffles)
+              .as("Number of shuffles with disabled SPJ must match")
+              .isEqualTo(expectedNumShufflesWithoutSPJ);
 
           rowsWithoutSPJ.set(sql(query, args));
         });

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
@@ -33,7 +34,9 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkBucketFunction extends TestBaseWithCatalog {
   @BeforeEach
   public void useCatalog() {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDaysFunction.java
@@ -22,11 +22,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.Date;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkDaysFunction extends TestBaseWithCatalog {
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkHoursFunction.java
@@ -21,11 +21,14 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkHoursFunction extends TestBaseWithCatalog {
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkMonthsFunction.java
@@ -21,12 +21,15 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.spark.functions.MonthsFunction;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkMonthsFunction extends TestBaseWithCatalog {
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -23,12 +23,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkTruncateFunction extends TestBaseWithCatalog {
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkYearsFunction.java
@@ -21,12 +21,15 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.spark.functions.YearsFunction;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkYearsFunction extends TestBaseWithCatalog {
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestTimestampWithoutZone.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestTimestampWithoutZone.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -41,7 +42,9 @@ import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestTimestampWithoutZone extends CatalogTestBase {
 
   private static final String NEW_TABLE_NAME = "created_table";


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates the following Spark 3.4 partition transform tests (and some additional tests) in the `spark.sql` package to JUnit 5 with AssertJ:


Partition transform:
* `TestSparkBucketFunction`
* `TestSparkDaysFunction`
* `TestSparkHoursFunction`
* `TestSparkMonthsFunction`
* `TestSparkTruncateFunction`
* `TestSparkYearsFunction`

Others:
* `TestTimestampWithoutZone`
* `TestStoragePartitionedJoins`


