### PR TITLE
Spark 3.4: Migrate other sql tests

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
@@ -18,30 +18,29 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.functions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
-  public PartitionedWritesTestBase(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class PartitionedWritesTestBase extends CatalogTestBase {
 
-  @Before
+  @BeforeEach
   public void createTables() {
     sql(
         "CREATE TABLE %s (id bigint, data string) USING iceberg PARTITIONED BY (truncate(id, 3))",
@@ -49,22 +48,22 @@ public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testInsertAppend() {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Rows before insert")
+        .isEqualTo(3L);
 
     sql("INSERT INTO %s VALUES (4, 'd'), (5, 'e')", commitTarget());
 
-    Assert.assertEquals(
-        "Should have 5 rows after insert",
-        5L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 5 rows after insert")
+        .isEqualTo(5L);
 
     List<Object[]> expected =
         ImmutableList.of(row(1L, "a"), row(2L, "b"), row(3L, "c"), row(4L, "d"), row(5L, "e"));
@@ -75,18 +74,18 @@ public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testInsertOverwrite() {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Rows before overwrite")
+        .isEqualTo(3L);
 
     // 4 and 5 replace 3 in the partition (id - (id % 3)) = 3
     sql("INSERT OVERWRITE %s VALUES (4, 'd'), (5, 'e')", commitTarget());
 
-    Assert.assertEquals(
-        "Should have 4 rows after overwrite",
-        4L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 4 rows after overwrite")
+        .isEqualTo(4L);
 
     List<Object[]> expected =
         ImmutableList.of(row(1L, "a"), row(2L, "b"), row(4L, "d"), row(5L, "e"));
@@ -97,20 +96,20 @@ public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDataFrameV2Append() throws NoSuchTableException {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     List<SimpleRecord> data = ImmutableList.of(new SimpleRecord(4, "d"), new SimpleRecord(5, "e"));
     Dataset<Row> ds = spark.createDataFrame(data, SimpleRecord.class);
 
     ds.writeTo(commitTarget()).append();
 
-    Assert.assertEquals(
-        "Should have 5 rows after insert",
-        5L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 5 rows after insert")
+        .isEqualTo(5L);
 
     List<Object[]> expected =
         ImmutableList.of(row(1L, "a"), row(2L, "b"), row(3L, "c"), row(4L, "d"), row(5L, "e"));
@@ -121,20 +120,20 @@ public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDataFrameV2DynamicOverwrite() throws NoSuchTableException {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     List<SimpleRecord> data = ImmutableList.of(new SimpleRecord(4, "d"), new SimpleRecord(5, "e"));
     Dataset<Row> ds = spark.createDataFrame(data, SimpleRecord.class);
 
     ds.writeTo(commitTarget()).overwritePartitions();
 
-    Assert.assertEquals(
-        "Should have 4 rows after overwrite",
-        4L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 4 rows after overwrite")
+        .isEqualTo(4L);
 
     List<Object[]> expected =
         ImmutableList.of(row(1L, "a"), row(2L, "b"), row(4L, "d"), row(5L, "e"));
@@ -145,20 +144,20 @@ public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDataFrameV2Overwrite() throws NoSuchTableException {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     List<SimpleRecord> data = ImmutableList.of(new SimpleRecord(4, "d"), new SimpleRecord(5, "e"));
     Dataset<Row> ds = spark.createDataFrame(data, SimpleRecord.class);
 
     ds.writeTo(commitTarget()).overwrite(functions.col("id").$less(3));
 
-    Assert.assertEquals(
-        "Should have 3 rows after overwrite",
-        3L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows after overwrite")
+        .isEqualTo(3L);
 
     List<Object[]> expected = ImmutableList.of(row(3L, "c"), row(4L, "d"), row(5L, "e"));
 
@@ -168,10 +167,11 @@ public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testViewsReturnRecentResults() {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     Dataset<Row> query = spark.sql("SELECT * FROM " + commitTarget() + " WHERE id = 1");
     query.createOrReplaceTempView("tmp");
@@ -207,7 +207,7 @@ public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
         rowsToJava(actualPartitionRows.collectAsList()));
   }
 
-  @Test
+  @TestTemplate
   public void testWriteWithOutputSpec() throws NoSuchTableException {
     Table table = validationCatalog.loadTable(tableIdent);
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWrites.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWrites.java
@@ -18,12 +18,4 @@
  */
 package org.apache.iceberg.spark.sql;
 
-import java.util.Map;
-
-public class TestPartitionedWrites extends PartitionedWritesTestBase {
-
-  public TestPartitionedWrites(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-}
+public class TestPartitionedWrites extends PartitionedWritesTestBase {}

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesAsSelect.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesAsSelect.java
@@ -18,34 +18,54 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import java.util.stream.IntStream;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.spark.IcebergSpark;
-import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.types.DataTypes;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestPartitionedWritesAsSelect extends SparkTestBaseWithCatalog {
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestPartitionedWritesAsSelect extends TestBaseWithCatalog {
 
-  private final String targetTable = tableName("target_table");
+  @Parameter(index = 3)
+  private String targetTable;
 
-  @Before
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, targetTable = {3}")
+  protected static Object[][] parameters() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties(),
+        SparkCatalogConfig.HADOOP.catalogName() + ".default.target_table"
+      },
+    };
+  }
+
+  @BeforeEach
   public void createTables() {
     sql(
         "CREATE TABLE %s (id bigint, data string, category string, ts timestamp) USING iceberg",
         tableName);
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS %s", targetTable);
   }
 
-  @Test
+  @TestTemplate
   public void testInsertAsSelectAppend() {
     insertData(3);
     List<Object[]> expected = currentData();
@@ -58,10 +78,9 @@ public class TestPartitionedWritesAsSelect extends SparkTestBaseWithCatalog {
     sql(
         "INSERT INTO %s SELECT id, data, category, ts FROM %s ORDER BY ts,category",
         targetTable, tableName);
-    Assert.assertEquals(
-        "Should have 15 rows after insert",
-        3 * 5L,
-        scalarSql("SELECT count(*) FROM %s", targetTable));
+    assertThat(scalarSql("SELECT count(*) FROM %s", targetTable))
+        .as("Should have 15 rows after insert")
+        .isEqualTo(3 * 5L);
 
     assertEquals(
         "Row data should match expected",
@@ -69,7 +88,7 @@ public class TestPartitionedWritesAsSelect extends SparkTestBaseWithCatalog {
         sql("SELECT * FROM %s ORDER BY id", targetTable));
   }
 
-  @Test
+  @TestTemplate
   public void testInsertAsSelectWithBucket() {
     insertData(3);
     List<Object[]> expected = currentData();
@@ -83,10 +102,9 @@ public class TestPartitionedWritesAsSelect extends SparkTestBaseWithCatalog {
     sql(
         "INSERT INTO %s SELECT id, data, category, ts FROM %s ORDER BY iceberg_bucket8(data)",
         targetTable, tableName);
-    Assert.assertEquals(
-        "Should have 15 rows after insert",
-        3 * 5L,
-        scalarSql("SELECT count(*) FROM %s", targetTable));
+    assertThat(scalarSql("SELECT count(*) FROM %s", targetTable))
+        .as("Should have 15 rows after insert")
+        .isEqualTo(3 * 5L);
 
     assertEquals(
         "Row data should match expected",
@@ -94,7 +112,7 @@ public class TestPartitionedWritesAsSelect extends SparkTestBaseWithCatalog {
         sql("SELECT * FROM %s ORDER BY id", targetTable));
   }
 
-  @Test
+  @TestTemplate
   public void testInsertAsSelectWithTruncate() {
     insertData(3);
     List<Object[]> expected = currentData();
@@ -110,10 +128,9 @@ public class TestPartitionedWritesAsSelect extends SparkTestBaseWithCatalog {
         "INSERT INTO %s SELECT id, data, category, ts FROM %s "
             + "ORDER BY iceberg_truncate_string4(data),iceberg_truncate_long4(id)",
         targetTable, tableName);
-    Assert.assertEquals(
-        "Should have 15 rows after insert",
-        3 * 5L,
-        scalarSql("SELECT count(*) FROM %s", targetTable));
+    assertThat(scalarSql("SELECT count(*) FROM %s", targetTable))
+        .as("Should have 15 rows after insert")
+        .isEqualTo(3 * 5L);
 
     assertEquals(
         "Row data should match expected",

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToBranch.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToBranch.java
@@ -18,20 +18,14 @@
  */
 package org.apache.iceberg.spark.sql;
 
-import java.util.Map;
 import org.apache.iceberg.Table;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TestPartitionedWritesToBranch extends PartitionedWritesTestBase {
 
   private static final String BRANCH = "test";
 
-  public TestPartitionedWritesToBranch(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @Before
+  @BeforeEach
   @Override
   public void createTables() {
     super.createTables();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
@@ -21,26 +21,23 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.spark.SparkSQLProperties;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase {
 
   private static final String BRANCH = "test";
 
-  public TestPartitionedWritesToWapBranch(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
-  @Before
+  @BeforeEach
   @Override
   public void createTables() {
     spark.conf().set(SparkSQLProperties.WAP_BRANCH, BRANCH);
@@ -50,7 +47,7 @@ public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase 
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
   }
 
-  @After
+  @AfterEach
   @Override
   public void removeTables() {
     super.removeTables();
@@ -59,16 +56,11 @@ public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase 
   }
 
   @Override
-  protected String commitTarget() {
-    return tableName;
-  }
-
-  @Override
   protected String selectTarget() {
     return String.format("%s VERSION AS OF '%s'", tableName, BRANCH);
   }
 
-  @Test
+  @TestTemplate
   public void testBranchAndWapBranchCannotBothBeSetForWrite() {
     Table table = validationCatalog.loadTable(tableIdent);
     table.manageSnapshots().createBranch("test2", table.refs().get(BRANCH).snapshotId()).commit();
@@ -80,7 +72,7 @@ public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase 
             BRANCH);
   }
 
-  @Test
+  @TestTemplate
   public void testWapIdAndWapBranchCannotBothBeSetForWrite() {
     String wapId = UUID.randomUUID().toString();
     spark.conf().set(SparkSQLProperties.WAP_ID, wapId);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestUnpartitionedWrites.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestUnpartitionedWrites.java
@@ -18,12 +18,4 @@
  */
 package org.apache.iceberg.spark.sql;
 
-import java.util.Map;
-
-public class TestUnpartitionedWrites extends UnpartitionedWritesTestBase {
-
-  public TestUnpartitionedWrites(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-}
+public class TestUnpartitionedWrites extends UnpartitionedWritesTestBase {}

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestUnpartitionedWritesToBranch.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestUnpartitionedWritesToBranch.java
@@ -20,21 +20,20 @@ package org.apache.iceberg.spark.sql;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestUnpartitionedWritesToBranch extends UnpartitionedWritesTestBase {
 
   private static final String BRANCH = "test";
 
-  public TestUnpartitionedWritesToBranch(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
-
   @Override
+  @BeforeEach
   public void createTables() {
     super.createTables();
     Table table = validationCatalog.loadTable(tableIdent);
@@ -52,7 +51,7 @@ public class TestUnpartitionedWritesToBranch extends UnpartitionedWritesTestBase
     return String.format("%s VERSION AS OF '%s'", tableName, BRANCH);
   }
 
-  @Test
+  @TestTemplate
   public void testInsertIntoNonExistingBranchFails() {
     assertThatThrownBy(
             () -> sql("INSERT INTO %s.branch_not_exist VALUES (4, 'd'), (5, 'e')", tableName))

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/UnpartitionedWritesTestBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/UnpartitionedWritesTestBase.java
@@ -18,51 +18,49 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
-import java.util.Map;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.functions;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public abstract class UnpartitionedWritesTestBase extends SparkCatalogTestBase {
-  public UnpartitionedWritesTestBase(
-      String catalogName, String implementation, Map<String, String> config) {
-    super(catalogName, implementation, config);
-  }
+@ExtendWith(ParameterizedTestExtension.class)
+public abstract class UnpartitionedWritesTestBase extends CatalogTestBase {
 
-  @Before
+  @BeforeEach
   public void createTables() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
   }
 
-  @After
+  @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
-  @Test
+  @TestTemplate
   public void testInsertAppend() {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     sql("INSERT INTO %s VALUES (4, 'd'), (5, 'e')", commitTarget());
 
-    Assert.assertEquals(
-        "Should have 5 rows after insert",
-        5L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 5 rows")
+        .isEqualTo(5L);
 
     List<Object[]> expected =
         ImmutableList.of(row(1L, "a"), row(2L, "b"), row(3L, "c"), row(4L, "d"), row(5L, "e"));
@@ -73,17 +71,17 @@ public abstract class UnpartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testInsertOverwrite() {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     sql("INSERT OVERWRITE %s VALUES (4, 'd'), (5, 'e')", commitTarget());
 
-    Assert.assertEquals(
-        "Should have 2 rows after overwrite",
-        2L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 2 rows after overwrite")
+        .isEqualTo(2L);
 
     List<Object[]> expected = ImmutableList.of(row(4L, "d"), row(5L, "e"));
 
@@ -93,9 +91,9 @@ public abstract class UnpartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testInsertAppendAtSnapshot() {
-    Assume.assumeTrue(tableName.equals(commitTarget()));
+    assumeThat(tableName.equals(commitTarget())).isTrue();
     long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();
     String prefix = "snapshot_id_";
 
@@ -106,9 +104,9 @@ public abstract class UnpartitionedWritesTestBase extends SparkCatalogTestBase {
         .hasMessageStartingWith("Cannot write to table at a specific snapshot");
   }
 
-  @Test
+  @TestTemplate
   public void testInsertOverwriteAtSnapshot() {
-    Assume.assumeTrue(tableName.equals(commitTarget()));
+    assumeThat(tableName.equals(commitTarget())).isTrue();
     long snapshotId = validationCatalog.loadTable(tableIdent).currentSnapshot().snapshotId();
     String prefix = "snapshot_id_";
 
@@ -121,20 +119,20 @@ public abstract class UnpartitionedWritesTestBase extends SparkCatalogTestBase {
         .hasMessageStartingWith("Cannot write to table at a specific snapshot");
   }
 
-  @Test
+  @TestTemplate
   public void testDataFrameV2Append() throws NoSuchTableException {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     List<SimpleRecord> data = ImmutableList.of(new SimpleRecord(4, "d"), new SimpleRecord(5, "e"));
     Dataset<Row> ds = spark.createDataFrame(data, SimpleRecord.class);
 
     ds.writeTo(commitTarget()).append();
 
-    Assert.assertEquals(
-        "Should have 5 rows after insert",
-        5L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 5 rows after insert")
+        .isEqualTo(5L);
 
     List<Object[]> expected =
         ImmutableList.of(row(1L, "a"), row(2L, "b"), row(3L, "c"), row(4L, "d"), row(5L, "e"));
@@ -145,20 +143,20 @@ public abstract class UnpartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDataFrameV2DynamicOverwrite() throws NoSuchTableException {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     List<SimpleRecord> data = ImmutableList.of(new SimpleRecord(4, "d"), new SimpleRecord(5, "e"));
     Dataset<Row> ds = spark.createDataFrame(data, SimpleRecord.class);
 
     ds.writeTo(commitTarget()).overwritePartitions();
 
-    Assert.assertEquals(
-        "Should have 2 rows after overwrite",
-        2L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 2 rows after overwrite")
+        .isEqualTo(2L);
 
     List<Object[]> expected = ImmutableList.of(row(4L, "d"), row(5L, "e"));
 
@@ -168,20 +166,20 @@ public abstract class UnpartitionedWritesTestBase extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
   }
 
-  @Test
+  @TestTemplate
   public void testDataFrameV2Overwrite() throws NoSuchTableException {
-    Assert.assertEquals(
-        "Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 3 rows")
+        .isEqualTo(3L);
 
     List<SimpleRecord> data = ImmutableList.of(new SimpleRecord(4, "d"), new SimpleRecord(5, "e"));
     Dataset<Row> ds = spark.createDataFrame(data, SimpleRecord.class);
 
     ds.writeTo(commitTarget()).overwrite(functions.col("id").$less$eq(3));
 
-    Assert.assertEquals(
-        "Should have 2 rows after overwrite",
-        2L,
-        scalarSql("SELECT count(*) FROM %s", selectTarget()));
+    assertThat(scalarSql("SELECT count(*) FROM %s", selectTarget()))
+        .as("Should have 2 rows after overwrite")
+        .isEqualTo(2L);
 
     List<Object[]> expected = ImmutableList.of(row(4L, "d"), row(5L, "e"));
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -34,7 +35,9 @@ import org.apache.spark.sql.functions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public abstract class PartitionedWritesTestBase extends CatalogTestBase {
 
   @BeforeEach

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesAsSelect.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesAsSelect.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.spark.IcebergSpark;
 import org.apache.iceberg.spark.SparkCatalogConfig;
@@ -31,7 +32,9 @@ import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestPartitionedWritesAsSelect extends TestBaseWithCatalog {
 
   @Parameter(index = 3)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToBranch.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToBranch.java
@@ -18,9 +18,12 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestPartitionedWritesToBranch extends PartitionedWritesTestBase {
 
   private static final String BRANCH = "test";

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.UUID;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -29,7 +30,9 @@ import org.apache.iceberg.spark.SparkSQLProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase {
 
   private static final String BRANCH = "test";
@@ -50,11 +53,6 @@ public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase 
     super.removeTables();
     spark.conf().unset(SparkSQLProperties.WAP_BRANCH);
     spark.conf().unset(SparkSQLProperties.WAP_ID);
-  }
-
-  @Override
-  protected String commitTarget() {
-    return tableName;
   }
 
   @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestUnpartitionedWritesToBranch.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestUnpartitionedWritesToBranch.java
@@ -20,11 +20,14 @@ package org.apache.iceberg.spark.sql;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestUnpartitionedWritesToBranch extends UnpartitionedWritesTestBase {
 
   private static final String BRANCH = "test";

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/UnpartitionedWritesTestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/UnpartitionedWritesTestBase.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
+import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.source.SimpleRecord;
@@ -33,7 +34,9 @@ import org.apache.spark.sql.functions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public abstract class UnpartitionedWritesTestBase extends CatalogTestBase {
 
   @BeforeEach


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates the following Spark 3.4 other remaining tests (and some additional tests) in the `spark.sql` package to JUnit 5 with AssertJ:

* `PartitionedWritesTestBase`
  * `TestPartitionedWrites`
  * `TestPartitionedWritesToBranch`
  * `TestPartitionedWritesToWapBranch`
* `UnpartitionedWritesTestBase`
  * `TestUnPartitionedWrites`
  * `TestUnPartitionedWritesToBranch`
* `TestPartitionedWritesAsSelect`