### PR TITLE
Spec: Remove misleading statement about source-ids

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -1467,8 +1467,6 @@ In some cases partition specs are stored using only the field list instead of th
 
 The `field-id` property was added for each partition field in v2. In v1, the reference implementation assigned field ids sequentially in each spec starting at 1,000. See Partition Evolution for more details.
 
-In v3 metadata, writers must use only `source-ids` because v3 requires reader support for multi-arg transforms.
-
 Older versions of the reference implementation can read tables with transforms unknown to it, ignoring them. But other implementations may break if they encounter unknown transforms. All v3 readers are required to read tables with unknown transforms, ignoring them. Writers should not write using partition specs that use unknown transforms.
 
 ### Sort Orders


### PR DESCRIPTION
In https://github.com/apache/iceberg/pull/12644, the spec was clarified that for a partition field, `source-id` should always be written if has a single-argument transform, and `source-ids` should be written instead if it has a multi-argument transform.

There is a statement left over that conflicts with the above. In this PR, we remove that statement.

