### PR TITLE
API, Build: Explicitly pass version into Git Properties Plugin

### DIFF
--- a/api/src/test/java/org/apache/iceberg/TestIcebergBuild.java
+++ b/api/src/test/java/org/apache/iceberg/TestIcebergBuild.java
@@ -50,15 +50,15 @@ public class TestIcebergBuild {
    * This test is for Source Releases. When we have a source release we use a version.txt file in
    * the parent directory of this module to actually set the "version" which should be included in
    * the gradle build properties used by IcebergBuild.
-   *
-   * @throws IOException
    */
   @Test
   public void testVersionMatchesFile() throws IOException {
     Path versionPath = Paths.get("../version.txt").toAbsolutePath();
     assumeThat(java.nio.file.Files.exists(versionPath)).isTrue();
     String versionText = java.nio.file.Files.readString(versionPath).trim();
-    assertThat(IcebergBuild.version()).isEqualTo(versionText);
+    assertThat(IcebergBuild.version())
+        .isEqualTo(versionText)
+        .as("IcebergBuild.version() should match version file");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/TestIcebergBuild.java
+++ b/api/src/test/java/org/apache/iceberg/TestIcebergBuild.java
@@ -47,9 +47,10 @@ public class TestIcebergBuild {
   }
 
   /**
-   * This test is for Source Releases. When we have a source release we use a version.txt
-   * file in the parent directory of this module to actually set the "version" which should
-   * be included in the gradle build properties used by IcebergBuild.
+   * This test is for Source Releases. When we have a source release we use a version.txt file in
+   * the parent directory of this module to actually set the "version" which should be included in
+   * the gradle build properties used by IcebergBuild.
+   *
    * @throws IOException
    */
   @Test

--- a/api/src/test/java/org/apache/iceberg/TestIcebergBuild.java
+++ b/api/src/test/java/org/apache/iceberg/TestIcebergBuild.java
@@ -19,7 +19,11 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
@@ -35,6 +39,25 @@ public class TestIcebergBuild {
                 + " (commit "
                 + IcebergBuild.gitCommitId()
                 + ")");
+  }
+
+  @Test
+  public void testVersionNotUnspecified() {
+    assertThat(IcebergBuild.version()).isNotEqualTo("unspecified");
+  }
+
+  /**
+   * This test is for Source Releases. When we have a source release we use a version.txt
+   * file in the parent directory of this module to actually set the "version" which should
+   * be included in the gradle build properties used by IcebergBuild.
+   * @throws IOException
+   */
+  @Test
+  public void testVersionMatchesFile() throws IOException {
+    Path versionPath = Paths.get("../version.txt").toAbsolutePath();
+    assumeThat(java.nio.file.Files.exists(versionPath)).isTrue();
+    String versionText = java.nio.file.Files.readString(versionPath).trim();
+    assertThat(IcebergBuild.version()).isEqualTo(versionText);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/TestIcebergBuild.java
+++ b/api/src/test/java/org/apache/iceberg/TestIcebergBuild.java
@@ -46,6 +46,14 @@ public class TestIcebergBuild {
     assertThat(IcebergBuild.version()).isNotEqualTo("unspecified");
   }
 
+  @Test
+  public void testVersionMatchesSystemProperty() {
+    assumeThat(System.getProperty("project.version")).isNotNull();
+    assertThat(IcebergBuild.version())
+        .isEqualTo(System.getProperty("project.version"))
+        .as("IcebergBuild.version() should match system property project.version");
+  }
+
   /**
    * This test is for Source Releases. When we have a source release we use a version.txt file in
    * the parent directory of this module to actually set the "version" which should be included in

--- a/build.gradle
+++ b/build.gradle
@@ -234,6 +234,8 @@ subprojects {
       events "failed"
       exceptionFormat "full"
     }
+
+    systemProperty 'project.version', project.version
   }
 
   plugins.withType(ScalaPlugin.class) {

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ gitProperties {
   failOnNoGitDirectory = true
   keys = ['git.branch', 'git.build.version', 'git.closest.tag.name','git.commit.id.abbrev', 'git.commit.id',
           'git.commit.message.short', 'git.commit.time', 'git.tags']
+  version = projectVersion
 }
 generateGitProperties.outputs.upToDateWhen { false }
 


### PR DESCRIPTION
Fixes #12926

The underlying issue is that we automatically bumped the Git Properties plugin which now uses a slightly different mechanism for determining what the version of the project is from before. To avoid any issues in the future, I decided to just explicitly pass in our custom version function to the plugin. 

I then added a few tests to check that we don't have an undefined value and if a version.txt file is present make sure it matches.