### PR TITLE
Spark: Include manifest lists in `allFiles` in `TestRemoveOrphanFilesProcedure`

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.ReachableFileUtil;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
@@ -635,6 +636,11 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
       allFiles.add(new FilePathLastModifiedRecord(manifest.path(), lastModifiedTimestamp));
     }
 
+    for (Snapshot snapshot : table.snapshots()) {
+      allFiles.add(
+          new FilePathLastModifiedRecord(snapshot.manifestListLocation(), lastModifiedTimestamp));
+    }
+
     Dataset<Row> compareToFileList =
         spark
             .createDataFrame(allFiles, FilePathLastModifiedRecord.class)
@@ -716,6 +722,11 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
 
     for (ManifestFile manifest : TestHelpers.dataManifests(table)) {
       allFiles.add(new FilePathLastModifiedRecord(manifest.path(), lastModifiedTimestamp));
+    }
+
+    for (Snapshot snapshot : table.snapshots()) {
+      allFiles.add(
+          new FilePathLastModifiedRecord(snapshot.manifestListLocation(), lastModifiedTimestamp));
     }
 
     Dataset<Row> compareToFileList =


### PR DESCRIPTION
`all_files` in the `file_list_view` used in some `TestRemoveOrphanFilesProcedure` tests contained only the data files, manifests, and metadata JSONs but not manifest lists.

This PR makes the small change of including manifest lists for the sake of readability.