### PR TITLE
Implement error handling mechanism for DataException

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.connect.data.ErrorTolerance;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -79,6 +80,8 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.schema-force-optional";
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
+  private static final String ERROR_TOLERANCE = "errors.tolerance";
+  private static final String ERROR_LOG_INCLUDE_MESSAGES = "errors.log.include.messages";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PREFIX_PROP = "iceberg.control.group-id-prefix";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -93,6 +96,9 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   private static final String NAME_PROP = "name";
   private static final String BOOTSTRAP_SERVERS_PROP = "bootstrap.servers";
+
+  private static final String DEFAULT_ERROR_TOLERANCE = ErrorTolerance.NONE.toString();
+  private static final String DEFAULT_ERROR_LOG_INCLUDE_MESSAGES = "false";
 
   private static final String DEFAULT_CATALOG_NAME = "iceberg";
   private static final String DEFAULT_CONTROL_TOPIC = "control-iceberg";
@@ -177,6 +183,18 @@ public class IcebergSinkConfig extends AbstractConfig {
         DEFAULT_CATALOG_NAME,
         Importance.MEDIUM,
         "Iceberg catalog name");
+    configDef.define(
+        ERROR_TOLERANCE,
+        ConfigDef.Type.STRING,
+        DEFAULT_ERROR_TOLERANCE,
+        Importance.MEDIUM,
+        "Behavior for tolerating errors during connector operation. 'none' is the default value and signals that any error will result in an immediate connector task failure; 'all' changes the behavior to skip over problematic records.");
+    configDef.define(
+        ERROR_LOG_INCLUDE_MESSAGES,
+        ConfigDef.Type.BOOLEAN,
+        DEFAULT_ERROR_LOG_INCLUDE_MESSAGES,
+        Importance.MEDIUM,
+        "If true, write each error and the details of the failed operation and problematic record to the Connect application log. This is 'false' by default, so that only errors that are not tolerated are reported.");
     configDef.define(
         CONTROL_TOPIC_PROP,
         ConfigDef.Type.STRING,
@@ -432,6 +450,14 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public JsonConverter jsonConverter() {
     return jsonConverter;
+  }
+
+  public String errorTolerance() {
+    return getString(ERROR_TOLERANCE);
+  }
+
+  public boolean errorLogIncludeMessages() {
+    return getBoolean(ERROR_LOG_INCLUDE_MESSAGES);
   }
 
   @VisibleForTesting

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/ErrorTolerance.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/ErrorTolerance.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.connect.data;
+
+import java.util.Locale;
+
+public enum ErrorTolerance {
+
+  /** Tolerate no errors. */
+  NONE,
+
+  /** Tolerate all errors. */
+  ALL;
+
+  public String value() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+}


### PR DESCRIPTION
Iceberg Kafka Connector fails when invalid message is received and records are not published to Iceberg or DLQ. To change this behaviour, support for following configurations for handling invalid data exception is implemented:

[errors.tolerance](https://kafka.apache.org/32/generated/sink_connector_config.html#sinkconnectorconfigs_errors.tolerance): Behavior for tolerating errors during connector operation. 'none' is the default value and signals that any error will result in an immediate connector task failure; 'all' changes the behavior to skip over problematic records.

[errors.log.include.messages](https://kafka.apache.org/32/generated/sink_connector_config.html#sinkconnectorconfigs_errors.log.include.messages): Whether to include in the log the Connect record that resulted in a failure. For sink records, the topic, partition, offset, and timestamp will be logged. For source records, the key and value (and their schemas), all headers, and the timestamp, Kafka topic, Kafka partition, source partition, and source offset will be logged. This is 'false' by default, which will prevent record keys, values, and headers from being written to log files.