### PR TITLE
Make PartitionSpec.Builder::identity public

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -449,7 +449,7 @@ public class PartitionSpec implements Serializable {
       return sourceColumn;
     }
 
-    Builder identity(String sourceName, String targetName) {
+    public Builder identity(String sourceName, String targetName) {
       return identity(findSourceColumn(sourceName), targetName);
     }
 


### PR DESCRIPTION
This PR addresses https://github.com/apache/iceberg/issues/12943

Every other transform has 2 public overloads: one that takes a targetName, and one that does not. The one exception is identity, where the overload with targetName is not public. This looks like an oversight. This functionality is needed to support partition transforms with renamed source columns correctly.