### PR TITLE
REST spec: Remove update to enable row lineage

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -395,10 +395,6 @@ class RemoveSchemasUpdate(BaseUpdate):
     schema_ids: List[int] = Field(..., alias='schema-ids')
 
 
-class EnableRowLineageUpdate(BaseUpdate):
-    action: str = Field('enable-row-lineage', const=True)
-
-
 class TableRequirement(BaseModel):
     type: str
 
@@ -1193,7 +1189,6 @@ class TableUpdate(BaseModel):
         RemoveStatisticsUpdate,
         RemovePartitionSpecsUpdate,
         RemoveSchemasUpdate,
-        EnableRowLineageUpdate,
     ]
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2679,7 +2679,6 @@ components:
           remove-partition-statistics: '#/components/schemas/RemovePartitionStatisticsUpdate'
           remove-partition-specs: '#/components/schemas/RemovePartitionSpecsUpdate'
           remove-schemas: '#/components/schemas/RemoveSchemasUpdate'
-          enable-row-lineage: '#/components/schemas/EnableRowLineageUpdate'
       type: object
       required:
         - action
@@ -2998,15 +2997,6 @@ components:
           items:
             type: integer
 
-    # Disabling Row Lineage is Forbidden
-    EnableRowLineageUpdate:
-      allOf:
-        - $ref: '#/components/schemas/BaseUpdate'
-      properties:
-        action:
-          type: string
-          const: "enable-row-lineage"
-
     TableUpdate:
       anyOf:
         - $ref: '#/components/schemas/AssignUUIDUpdate'
@@ -3028,7 +3018,6 @@ components:
         - $ref: '#/components/schemas/RemoveStatisticsUpdate'
         - $ref: '#/components/schemas/RemovePartitionSpecsUpdate'
         - $ref: '#/components/schemas/RemoveSchemasUpdate'
-        - $ref: '#/components/schemas/EnableRowLineageUpdate'
 
     ViewUpdate:
       anyOf:


### PR DESCRIPTION
This PR removes the table action to enable row lineage because it is always on for v3 tables.