### PR TITLE
Spark: Make maxRecordPerMicrobatch a soft limit

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -225,7 +225,7 @@ spark.read
 | streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch |
 
 !!! warning
-    streaming-max-rows-per-micro-batch option sets a “soft max”, meaning that a batch processes approximately this amount of records and may process more than the limit in order to make the streaming query move forward in cases when the smallest input unit is larger than this limit.
+    streaming-max-rows-per-micro-batch option sets a “soft max”, a batch will always include all the rows in the next unprocessed data file but additional files will not be included if doing so would exceed the soft-max.
 
 
 

--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -225,7 +225,7 @@ spark.read
 | streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch |
 
 !!! warning
-    streaming-max-rows-per-micro-batch option sets a “soft max”, a batch will always include all the rows in the next unprocessed data file but additional files will not be included if doing so would exceed the soft-max.
+    streaming-max-rows-per-micro-batch option sets a “soft max”, a batch will always include all the rows in the next unprocessed data file but additional files will not be included if doing so would exceed the soft max limit.
 
 
 

--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -225,8 +225,7 @@ spark.read
 | streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch |
 
 !!! warning
-    streaming-max-rows-per-micro-batch should always be greater than the number of records in any data file in the table.
-    The smallest unit that will be streamed is a single file, so if a data file contains more records than this limit, the stream will get stuck at this file.
+    streaming-max-rows-per-micro-batch option sets a “soft max”, meaning that a batch processes approximately this amount of records and may process more than the limit in order to make the streaming query move forward in cases when the smallest input unit is larger than this limit.
 
 
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -412,7 +412,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsAdmissio
           while (taskIter.hasNext()) {
             FileScanTask task = taskIter.next();
             if (curPos >= startPosOfSnapOffset) {
-              if ((curFilesAdded + 1) > getMaxFiles(limit)) > getMaxRows(limit)) {
+              if ((curFilesAdded + 1) > getMaxFiles(limit)) {
                 shouldContinueReading = false;
                 break;
               }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -422,7 +422,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsAdmissio
               curFilesAdded += 1;
               curRecordCount += task.file().recordCount();
 
-              if (curRecordCount > getMaxRows(limit)) {
+              if (curRecordCount >= getMaxRows(limit)) {
                 // we included the file, so increment the number of files
                 // read in the current snapshot.
                 ++curPos;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -414,7 +414,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsAdmissio
             if (curPos >= startPosOfSnapOffset) {
               if ((curFilesAdded + 1) > getMaxFiles(limit)) {
                 // On including the file it might happen that we might exceed, the configured
-                // soft limit on the number of records, since this is a soft limit it acceptable.
+                // soft limit on the number of records, since this is a soft limit its acceptable.
                 shouldContinueReading = false;
                 break;
               }
@@ -422,9 +422,8 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsAdmissio
               curFilesAdded += 1;
               curRecordCount += task.file().recordCount();
 
-              if (curRecordCount > getMaxRows(limit)) {
-                // we included the file, so increment the number of files
-                // read in the current snapshot.
+              // stop reading further for current micro-batch, if any of limits are hit.
+              if (curRecordCount >= getMaxRows(limit) || curFilesAdded >= getMaxFiles(limit)) {
                 ++curPos;
                 shouldContinueReading = false;
                 break;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -422,8 +422,9 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsAdmissio
               curFilesAdded += 1;
               curRecordCount += task.file().recordCount();
 
-              // stop reading further for current micro-batch, if any of limits are hit.
-              if (curRecordCount >= getMaxRows(limit) || curFilesAdded >= getMaxFiles(limit)) {
+              if (curRecordCount > getMaxRows(limit)) {
+                // we included the file, so increment the number of files
+                // read in the current snapshot.
                 ++curPos;
                 shouldContinueReading = false;
                 break;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -198,7 +198,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     assertThat(
             microBatchCount(
                 ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2")))
-        .isEqualTo(4);
+        .isEqualTo(2);
 
     StreamingQuery query =
         startStream(ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2"));

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -156,32 +156,25 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   @TestTemplate
   public void testReadStreamWithMaxFiles1() throws Exception {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")))
-        .isEqualTo(6);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"),
+        List.of(1L, 2L, 1L, 1L, 1L, 1L));
   }
 
   @TestTemplate
   public void testReadStreamWithMaxFiles2() throws Exception {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "2")))
-        .isEqualTo(3);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "2"),
+        List.of(3L, 2L, 2L));
   }
 
   @TestTemplate
   public void testReadStreamWithMaxRows1() throws Exception {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
-
-    // 3 snapshots 3 micro-batch
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "1")))
-        .isEqualTo(3);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "1"),
+        List.of(1L, 2L, 1L, 1L, 1L, 1L));
 
     // soft limit of 1 is being enforced, the stream is not blocked.
     StreamingQuery query = startStream(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "1");
@@ -194,11 +187,9 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   @TestTemplate
   public void testReadStreamWithMaxRows2() throws Exception {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2")))
-        .isEqualTo(3);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2"),
+        List.of(3L, 2L, 2L));
 
     StreamingQuery query =
         startStream(ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2"));
@@ -211,23 +202,18 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   @TestTemplate
   public void testReadStreamWithMaxRows4() throws Exception {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "4")))
-        .isEqualTo(2);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "4"), List.of(4L, 3L));
   }
 
   @TestTemplate
   public void testReadStreamWithCompositeReadLimit() throws Exception {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(
-                    SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1",
-                    SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2")))
-        .isEqualTo(6);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(
+            SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1",
+            SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2"),
+        List.of(1L, 2L, 1L, 1L, 1L, 1L));
   }
 
   @TestTemplate
@@ -539,11 +525,9 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     appendDataAsMultipleSnapshots(expected);
 
     makeRewriteDataFiles();
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")))
-        .isEqualTo(6);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"),
+        List.of(1L, 2L, 1L, 1L, 1L, 1L));
   }
 
   @TestTemplate
@@ -554,11 +538,8 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     appendDataAsMultipleSnapshots(expected);
 
     makeRewriteDataFiles();
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "4")))
-        .isEqualTo(2);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "4"), List.of(4L, 3L));
   }
 
   @TestTemplate
@@ -569,15 +550,13 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     appendDataAsMultipleSnapshots(expected);
 
     makeRewriteDataFiles();
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(
-                    SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH,
-                    "4",
-                    SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH,
-                    "1")))
-        .isEqualTo(6);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(
+            SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH,
+            "4",
+            SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH,
+            "1"),
+        List.of(1L, 2L, 1L, 1L, 1L, 1L));
   }
 
   @TestTemplate
@@ -588,11 +567,9 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
     makeRewriteDataFiles();
     makeRewriteDataFiles();
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")))
-        .isEqualTo(6);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"),
+        List.of(1L, 2L, 1L, 1L, 1L, 1L));
   }
 
   @TestTemplate
@@ -605,11 +582,9 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     makeRewriteDataFiles();
 
     appendDataAsMultipleSnapshots(expected);
-
-    assertThat(
-            microBatchCount(
-                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")))
-        .isEqualTo(12);
+    assertMicroBatchRecordSizes(
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"),
+        List.of(1L, 2L, 1L, 1L, 1L, 1L, 1L, 2L, 1L, 1L, 1L, 1L));
   }
 
   @TestTemplate
@@ -776,21 +751,25 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
         ImmutableMap.of(key, value, SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"));
   }
 
-  private int microBatchCount(Map<String, String> options) throws TimeoutException {
+  private void assertMicroBatchRecordSizes(
+      Map<String, String> options, List<Long> expectedMicroBatchRecordSize)
+      throws TimeoutException {
     Dataset<Row> ds = spark.readStream().options(options).format("iceberg").load(tableName);
 
+    List<Long> syncList = Collections.synchronizedList(Lists.newArrayList());
     ds.writeStream()
         .options(options)
         .foreachBatch(
             (VoidFunction2<Dataset<Row>, Long>)
                 (dataset, batchId) -> {
                   microBatches.getAndIncrement();
+                  syncList.add(dataset.count());
                 })
         .start()
         .processAllAvailable();
 
     stopStreams();
-    return microBatches.get();
+    assertThat(syncList).containsExactlyInAnyOrderElementsOf(expectedMicroBatchRecordSize);
   }
 
   private List<SimpleRecord> rowsAvailable(StreamingQuery query) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -198,7 +198,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     assertThat(
             microBatchCount(
                 ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2")))
-        .isEqualTo(2);
+        .isEqualTo(3);
 
     StreamingQuery query =
         startStream(ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "2"));

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -177,20 +177,18 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   public void testReadStreamWithMaxRows1() throws Exception {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
 
-    // only 1 micro-batch will be formed and we will read data partially
+    // 3 snapshots 3 micro-batch
     assertThat(
             microBatchCount(
                 ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "1")))
-        .isEqualTo(1);
+        .isEqualTo(3);
 
-    StreamingQuery query =
-        startStream(ImmutableMap.of(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "1"));
+    // soft limit of 1 is being enforced, the stream is not blocked.
+    StreamingQuery query = startStream(SparkReadOptions.STREAMING_MAX_ROWS_PER_MICRO_BATCH, "1");
 
-    // check answer correctness only 1 record read the micro-batch will be stuck
     List<SimpleRecord> actual = rowsAvailable(query);
     assertThat(actual)
-        .containsExactlyInAnyOrderElementsOf(
-            Lists.newArrayList(TEST_DATA_MULTIPLE_SNAPSHOTS.get(0).get(0)));
+        .containsExactlyInAnyOrderElementsOf(Iterables.concat(TEST_DATA_MULTIPLE_SNAPSHOTS));
   }
 
   @TestTemplate


### PR DESCRIPTION
### About the change

Make _maxRecordsPerMicrobatch_ a soft limit, as the cases like for ex max number of records is less than the totalRecords of a file, would expect us to read the file partially (current behavior), this can't be just a row group boundary or something which we can incorporate in our scan tasks as if like splitting it at the record count cutoff, hence its very difficult to define the boundary, it would be better if we make the make this a soft limit as if and when including a file if it can be contained within the limit its fine, otherwise include the whole file and be done with that particular micro-batch stream.

This change is motivated by two major factors : 
1. stream being stuck presently leading to poor UX https://github.com/apache/iceberg/pull/12217#discussion_r1962211721
2. Softlimit is what other solution enforce for ex : delta [doc](https://docs.databricks.com/aws/en/structured-streaming/delta-lake) 

 **_maxBytesPerTrigger: How much data gets processed in each micro-batch. This option sets a “soft max”, meaning that a batch processes approximately this amount of data and may process more than the limit in order to make the streaming query move forward in cases when the smallest input unit is larger than this limit. This is not set by default._**
 
 
 ### Testing done 
 
 Modified the existing UT which mimics stuckness to pass now.
