### PR TITLE
Parquet: Fix to ensure that last updated sequence numbers for V2 and earlier tables are null

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -200,7 +200,7 @@ public class ParquetValueReaders {
       Long baseRowId = (Long) idToConstant.get(id);
       return ParquetValueReaders.rowIds(baseRowId, reader);
     } else if (id == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
-      Long baseRowId = (Long) idToConstant.get(id);
+      Long baseRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
       Long fileSeqNumber = (Long) idToConstant.get(id);
       return ParquetValueReaders.lastUpdated(baseRowId, fileSeqNumber, reader);
     } else if (idToConstant.containsKey(id)) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
@@ -316,6 +316,21 @@ public class TestSparkMetadataColumns extends TestBase {
         sql("SELECT _spec_id, _partition, _renamed_spec_id FROM %s", TABLE_NAME));
   }
 
+  @TestTemplate
+  public void testRowLineageColumnsAreNullBeforeV3() {
+    assumeThat(formatVersion).isLessThan(3);
+    // ToDo: When the other readers have row lineage plumbed through, remove these assumptions
+    assumeThat(vectorized).isFalse();
+    assumeThat(fileFormat).isEqualTo(FileFormat.PARQUET);
+
+    sql("INSERT INTO TABLE %s VALUES (1L, 'a1', 'b1')", TABLE_NAME);
+
+    assertEquals(
+        "Rows must match",
+        ImmutableList.of(row(1L, null, null)),
+        sql("SELECT id, _row_id, _last_updated_sequence_number FROM %s", TABLE_NAME));
+  }
+
   private void createAndInitTable() throws IOException {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(FORMAT_VERSION, String.valueOf(formatVersion));


### PR DESCRIPTION
Currently, there's a bug in the Parquet reader where when creating the last updated sequence reader, the passed in baseRowId is actually the sequence number as well. 

Note that this issue doesn't impact V3+ tables which actually support row lineage, but rather just leads to odd results when projecting these columns from V2 tables where row lineage isn't even supported. It should still be possible to project these columns in older tables but they should always just be null since lineage isn't tracked for those.

This baseRowId is used to determine if we should project nulls or not for the sequence number. Since we always inherit the sequence number regardless of the format version, the current implementation leads to non-null sequence numbers being read instead of the null parquet reader being initialized. 

This fixes the issue by simply making sure we pass through the baseRowId correctly, and for the V2 case this will always be null and fall through to initializing the null reader. A test is added to ensure that nulls are projected for these fields.