### PR TITLE
Add databend & iceberg docuement url

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Google BigQuery: https://cloud.google.com/bigquery/docs/iceberg-tables
   - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
   - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
+  - Databend: https://docs.databend.com/guides/access-data-lake/iceberg
   - Doris: https://doris.apache.org/docs/dev/lakehouse/catalogs/iceberg-catalog
   - Druid: https://druid.apache.org/docs/latest/development/extensions-contrib/iceberg/
   - DuckDB: https://duckdb.org/docs/preview/core_extensions/iceberg/overview


### PR DESCRIPTION
Hi, this pr adds how Databend(Cloud warehouse like Snowflake) works with iceberg.

Please let me know if you have any clarification. Thanks!