### PR TITLE
Build: Run SPARK CI on changes to RESTServerExtension

### DIFF
--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -28,6 +28,9 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
+    paths:
+    - '!open-api/**'
+    - 'open-api/src/testFixtures/java/**'
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -53,7 +56,6 @@ on:
     - 'flink/**'
     - 'kafka-connect/**'
     - 'docs/**'
-    - 'open-api/**'
     - 'format/**'
     - '.gitattributes'
     - '**/README.md'


### PR DESCRIPTION
`RESTServerExtension` is used in `org.apache.iceberg.spark.TestBaseWithCatalog` for many Spark tests. Therefore, we should rerun Spark tests on changes to `open-api/src/testFixtures/java/`.