### PR TITLE
Spark 3.4: Migrate tests in spark.data including refactoring Spark 3.5 tests

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -48,7 +48,6 @@ import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.Assert;
 import scala.collection.Seq;
 
 public class GenericsHelpers {
@@ -84,8 +83,9 @@ public class GenericsHelpers {
   private static void assertEqualsSafe(Types.MapType map, Map<?, ?> expected, Map<?, ?> actual) {
     Type keyType = map.keyType();
     Type valueType = map.valueType();
-    Assert.assertEquals(
-        "Should have the same number of keys", expected.keySet().size(), actual.keySet().size());
+    assertThat(actual.keySet())
+        .as("Should have the same number of keys")
+        .hasSameSizeAs(expected.keySet());
 
     for (Object expectedKey : expected.keySet()) {
       Object matchingKey = null;
@@ -99,7 +99,7 @@ public class GenericsHelpers {
         }
       }
 
-      Assert.assertNotNull("Should have a matching key", matchingKey);
+      assertThat(matchingKey).as("Should have a matching key").isNotNull();
       assertEqualsSafe(valueType, expected.get(expectedKey), actual.get(matchingKey));
     }
   }
@@ -116,13 +116,11 @@ public class GenericsHelpers {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case DATE:
         assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
-        assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
-        Assert.assertEquals(
-            "ISO-8601 date should be equal", expected.toString(), actual.toString());
+        assertThat(actual).isInstanceOf(Date.class).asString().isEqualTo(expected);
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
@@ -137,7 +135,7 @@ public class GenericsHelpers {
           assertThat(expected)
               .as("Should expect an OffsetDateTime")
               .isInstanceOf(OffsetDateTime.class);
-          Assert.assertEquals("Timestamp should be equal", expected, actualTs);
+          assertThat(actualTs).as("Timestamp should be equal").isEqualTo(expected);
         } else {
           // Timestamp
           assertThat(actual).as("Should be a LocalDateTime").isInstanceOf(LocalDateTime.class);
@@ -146,33 +144,33 @@ public class GenericsHelpers {
           assertThat(expected)
               .as("Should expect an LocalDateTime")
               .isInstanceOf(LocalDateTime.class);
-          Assert.assertEquals("Timestamp should be equal", expected, ts);
+          assertThat(actual).as("Timestamp should be equal").isEqualTo(expected);
         }
         break;
       case STRING:
-        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        Assert.assertEquals("Strings should be equal", String.valueOf(expected), actual);
+        assertThat(actual)
+            .isInstanceOf(String.class)
+            .asString()
+            .isEqualTo(String.valueOf(expected));
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        Assert.assertEquals("UUID string representation should match", expected.toString(), actual);
+        assertThat(actual)
+            .isInstanceOf(String.class)
+            .asString()
+            .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
         assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals("Bytes should match", (byte[]) expected, (byte[]) actual);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(expected);
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((ByteBuffer) expected).array(), (byte[]) actual);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
-        assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
-        Assert.assertEquals("BigDecimals should be equal", expected, actual);
+        assertThat(actual).isInstanceOf(BigDecimal.class).isEqualTo(expected);
         break;
       case STRUCT:
         assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
@@ -251,13 +249,14 @@ public class GenericsHelpers {
       case INTEGER:
       case LONG:
       case FLOAT:
-      case DOUBLE:
-        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case DATE:
         assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
         int expectedDays = (int) ChronoUnit.DAYS.between(EPOCH_DAY, (LocalDate) expected);
-        Assert.assertEquals("Primitive value should be equal to expected", expectedDays, actual);
+        assertThat(actual)
+            .as("Primitive value should be equal to expected")
+            .isEqualTo(expectedDays);
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
@@ -266,44 +265,47 @@ public class GenericsHelpers {
               .as("Should expect an OffsetDateTime")
               .isInstanceOf(OffsetDateTime.class);
           long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);
-          Assert.assertEquals(
-              "Primitive value should be equal to expected", expectedMicros, actual);
+          assertThat(actual)
+              .as("Primitive value should be equal to expected")
+              .isEqualTo(expectedMicros);
         } else {
           assertThat(expected)
               .as("Should expect an LocalDateTime")
               .isInstanceOf(LocalDateTime.class);
           long expectedMicros =
               ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) expected).atZone(ZoneId.of("UTC")));
-          Assert.assertEquals(
-              "Primitive value should be equal to expected", expectedMicros, actual);
+          assertThat(actual)
+              .as("Primitive value should be equal to expected")
+              .isEqualTo(expectedMicros);
         }
         break;
       case STRING:
-        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        Assert.assertEquals("Strings should be equal", expected, actual.toString());
+        assertThat(actual)
+            .isInstanceOf(UTF8String.class)
+            .asString()
+            .isEqualTo(String.valueOf(expected));
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        Assert.assertEquals(
-            "UUID string representation should match", expected.toString(), actual.toString());
+        assertThat(actual)
+            .isInstanceOf(UTF8String.class)
+            .asString()
+            .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
         assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals("Bytes should match", (byte[]) expected, (byte[]) actual);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(expected);
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((ByteBuffer) expected).array(), (byte[]) actual);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
         assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
-        Assert.assertEquals(
-            "BigDecimals should be equal", expected, ((Decimal) actual).toJavaBigDecimal());
+        assertThat(((Decimal) actual).toJavaBigDecimal())
+            .as("BigDecimals should be equal")
+            .isEqualTo(expected);
         break;
       case STRUCT:
         assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -249,6 +249,7 @@ public class GenericsHelpers {
       case INTEGER:
       case LONG:
       case FLOAT:
+      case DOUBLE:
         assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case DATE:

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -567,9 +567,9 @@ public class TestHelpers {
         Object expectedKey = getValue(expectedKeyArray, e, keyType);
         Object actualValue = actual.get(expectedKey);
         if (actualValue == null) {
-          assertThat(true)
+          assertThat(expected.valueArray().isNullAt(e))
               .as(prefix + ".key=" + expectedKey + " has null")
-              .isEqualTo(expected.valueArray().isNullAt(e));
+              .isTrue();
         } else {
           switch (valueType.typeId()) {
             case BOOLEAN:

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -83,7 +83,6 @@ import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.types.TimestampType$;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.Assert;
 import scala.collection.Seq;
 
 public class TestHelpers {
@@ -169,7 +168,7 @@ public class TestHelpers {
         }
       }
 
-      Assert.assertNotNull("Should have a matching key", matchingKey);
+      assertThat(matchingKey).as("Should have a matching key").isNotNull();
       assertEqualsSafe(valueType, expected.get(expectedKey), actual.get(matchingKey));
     }
   }
@@ -189,14 +188,16 @@ public class TestHelpers {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case DATE:
         assertThat(expected).as("Should be an int").isInstanceOf(Integer.class);
         assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
-        int daysFromEpoch = (Integer) expected;
-        LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, daysFromEpoch);
-        Assert.assertEquals("ISO-8601 date should be equal", date.toString(), actual.toString());
+        LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, (Integer) expected);
+        assertThat(actual)
+            .as("ISO-8601 date should be equal")
+            .asString()
+            .isEqualTo(String.valueOf(date));
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
@@ -208,7 +209,7 @@ public class TestHelpers {
           Timestamp ts = (Timestamp) actual;
           // milliseconds from nanos has already been added by getTime
           long tsMicros = (ts.getTime() * 1000) + ((ts.getNanos() / 1000) % 1000);
-          Assert.assertEquals("Timestamp micros should be equal", expected, tsMicros);
+          assertThat(tsMicros).as("Timestamp micros should be equal").isEqualTo(expected);
         } else {
           assertThat(actual).as("Should be a LocalDateTime").isInstanceOf(LocalDateTime.class);
 
@@ -216,17 +217,18 @@ public class TestHelpers {
           Instant instant = ts.toInstant(ZoneOffset.UTC);
           // milliseconds from nanos has already been added by getTime
           long tsMicros = (instant.toEpochMilli() * 1000) + ((ts.getNano() / 1000) % 1000);
-          Assert.assertEquals("Timestamp micros should be equal", expected, tsMicros);
+          assertThat(tsMicros).as("Timestamp micros should be equal").isEqualTo(expected);
         }
         break;
       case STRING:
-        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        Assert.assertEquals("Strings should be equal", String.valueOf(expected), actual);
+        assertThat(actual).isInstanceOf(String.class).isEqualTo(String.valueOf(expected));
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        Assert.assertEquals("UUID string representation should match", expected.toString(), actual);
+        assertThat(actual)
+            .isInstanceOf(String.class)
+            .asString()
+            .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
         // generated data is written using Avro or Parquet/Avro so generated rows use
@@ -242,19 +244,15 @@ public class TestHelpers {
               "Invalid expected value, not byte[] or Fixed: " + expected);
         }
 
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(expectedBytes);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(expectedBytes);
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((ByteBuffer) expected).array(), (byte[]) actual);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
-        assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
-        Assert.assertEquals("BigDecimals should be equal", expected, actual);
+        assertThat(actual).isInstanceOf(BigDecimal.class).isEqualTo(expected);
         break;
       case STRUCT:
         assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
@@ -340,20 +338,19 @@ public class TestHelpers {
       case LONG:
         assertThat(actual).as("Should be a long").isInstanceOf(Long.class);
         if (expected instanceof Integer) {
-          Assert.assertEquals("Values didn't match", ((Number) expected).longValue(), actual);
+          assertThat(actual).as("Values didn't match").isEqualTo(((Number) expected).longValue());
         } else {
-          Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+          assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         }
         break;
       case DOUBLE:
         assertThat(actual).as("Should be a double").isInstanceOf(Double.class);
         if (expected instanceof Float) {
-          Assert.assertEquals(
-              "Values didn't match",
-              Double.doubleToLongBits(((Number) expected).doubleValue()),
-              Double.doubleToLongBits((double) actual));
+          assertThat(Double.doubleToLongBits((double) actual))
+              .as("Values didn't match")
+              .isEqualTo(Double.doubleToLongBits(((Number) expected).doubleValue()));
         } else {
-          Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+          assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         }
         break;
       case INTEGER:
@@ -361,17 +358,17 @@ public class TestHelpers {
       case BOOLEAN:
       case DATE:
       case TIMESTAMP:
-        Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case STRING:
-        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        Assert.assertEquals("Strings should be equal", expected, actual.toString());
+        assertThat(actual).isInstanceOf(UTF8String.class).asString().isEqualTo(expected);
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        Assert.assertEquals(
-            "UUID string representation should match", expected.toString(), actual.toString());
+        assertThat(actual)
+            .isInstanceOf(UTF8String.class)
+            .asString()
+            .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
         // generated data is written using Avro or Parquet/Avro so generated rows use
@@ -392,15 +389,14 @@ public class TestHelpers {
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        Assert.assertArrayEquals(
-            "Bytes should match", ((ByteBuffer) expected).array(), (byte[]) actual);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
         assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
-        Assert.assertEquals(
-            "BigDecimals should be equal", expected, ((Decimal) actual).toJavaBigDecimal());
+        assertThat(((Decimal) actual).toJavaBigDecimal())
+            .as("BigDecimals should be equal")
+            .isEqualTo(expected);
         break;
       case STRUCT:
         assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
@@ -436,7 +432,7 @@ public class TestHelpers {
   public static void assertEquals(
       String prefix, Types.StructType type, InternalRow expected, Row actual) {
     if (expected == null || actual == null) {
-      Assert.assertEquals(prefix, expected, actual);
+      assertThat(actual).as(prefix).isEqualTo(expected);
     } else {
       List<Types.NestedField> fields = type.fields();
       for (int c = 0; c < fields.size(); ++c) {
@@ -452,10 +448,9 @@ public class TestHelpers {
           case DECIMAL:
           case DATE:
           case TIMESTAMP:
-            Assert.assertEquals(
-                prefix + "." + fieldName + " - " + childType,
-                getValue(expected, c, childType),
-                getPrimitiveValue(actual, c, childType));
+            assertThat(getPrimitiveValue(actual, c, childType))
+                .as(prefix + "." + fieldName + " - " + childType)
+                .isEqualTo(getValue(expected, c, childType));
             break;
           case UUID:
           case FIXED:
@@ -499,9 +494,9 @@ public class TestHelpers {
   private static void assertEqualsLists(
       String prefix, Types.ListType type, ArrayData expected, List actual) {
     if (expected == null || actual == null) {
-      Assert.assertEquals(prefix, expected, actual);
+      assertThat(actual).as(prefix).isEqualTo(expected);
     } else {
-      Assert.assertEquals(prefix + " length", expected.numElements(), actual.size());
+      assertThat(actual).as(prefix + "length").hasSize(expected.numElements());
       Type childType = type.elementType();
       for (int e = 0; e < expected.numElements(); ++e) {
         switch (childType.typeId()) {
@@ -514,10 +509,10 @@ public class TestHelpers {
           case DECIMAL:
           case DATE:
           case TIMESTAMP:
-            Assert.assertEquals(
-                prefix + ".elem " + e + " - " + childType,
-                getValue(expected, e, childType),
-                actual.get(e));
+            assertThat(actual)
+                .as(prefix + ".elem " + e + " - " + childType)
+                .element(e)
+                .isEqualTo(getValue(expected, e, childType));
             break;
           case UUID:
           case FIXED:
@@ -561,21 +556,20 @@ public class TestHelpers {
   private static void assertEqualsMaps(
       String prefix, Types.MapType type, MapData expected, Map<?, ?> actual) {
     if (expected == null || actual == null) {
-      Assert.assertEquals(prefix, expected, actual);
+      assertThat(actual).as(prefix).isEqualTo(expected);
     } else {
       Type keyType = type.keyType();
       Type valueType = type.valueType();
       ArrayData expectedKeyArray = expected.keyArray();
       ArrayData expectedValueArray = expected.valueArray();
-      Assert.assertEquals(prefix + " length", expected.numElements(), actual.size());
+      assertThat(actual).as(prefix + " length").hasSize(expectedKeyArray.numElements());
       for (int e = 0; e < expected.numElements(); ++e) {
         Object expectedKey = getValue(expectedKeyArray, e, keyType);
         Object actualValue = actual.get(expectedKey);
         if (actualValue == null) {
-          Assert.assertEquals(
-              prefix + ".key=" + expectedKey + " has null",
-              true,
-              expected.valueArray().isNullAt(e));
+          assertThat(true)
+              .as(prefix + ".key=" + expectedKey + " has null")
+              .isEqualTo(expected.valueArray().isNullAt(e));
         } else {
           switch (valueType.typeId()) {
             case BOOLEAN:
@@ -587,10 +581,9 @@ public class TestHelpers {
             case DECIMAL:
             case DATE:
             case TIMESTAMP:
-              Assert.assertEquals(
-                  prefix + ".key=" + expectedKey + " - " + valueType,
-                  getValue(expectedValueArray, e, valueType),
-                  actual.get(expectedKey));
+              assertThat(actual.get(expectedKey))
+                  .as(prefix + ".key=" + expectedKey + " - " + valueType)
+                  .isEqualTo(getValue(expectedValueArray, e, valueType));
               break;
             case UUID:
             case FIXED:
@@ -720,11 +713,7 @@ public class TestHelpers {
   }
 
   private static void assertEqualBytes(String context, byte[] expected, byte[] actual) {
-    if (expected == null || actual == null) {
-      Assert.assertEquals(context, expected, actual);
-    } else {
-      Assert.assertArrayEquals(context, expected, actual);
-    }
+    assertThat(actual).as(context).isEqualTo(expected);
   }
 
   static void assertEquals(Schema schema, Object expected, Object actual) {
@@ -764,13 +753,15 @@ public class TestHelpers {
     } else if (type instanceof BinaryType) {
       assertEqualBytes(context, (byte[]) expected, (byte[]) actual);
     } else {
-      Assert.assertEquals("Value should match expected: " + context, expected, actual);
+      assertThat(actual).as("Value should match expected: " + context).isEqualTo(expected);
     }
   }
 
   private static void assertEquals(
       String context, StructType struct, InternalRow expected, InternalRow actual) {
-    Assert.assertEquals("Should have correct number of fields", struct.size(), actual.numFields());
+    assertThat(actual.numFields())
+        .as("Should have correct number of fields")
+        .isEqualTo(struct.size());
     for (int i = 0; i < actual.numFields(); i += 1) {
       StructField field = struct.fields()[i];
       DataType type = field.dataType();
@@ -790,8 +781,9 @@ public class TestHelpers {
 
   private static void assertEquals(
       String context, ArrayType array, ArrayData expected, ArrayData actual) {
-    Assert.assertEquals(
-        "Should have the same number of elements", expected.numElements(), actual.numElements());
+    assertThat(actual.numElements())
+        .as("Should have the same number of elements")
+        .isEqualTo(expected.numElements());
     DataType type = array.elementType();
     for (int i = 0; i < actual.numElements(); i += 1) {
       assertEquals(
@@ -803,8 +795,9 @@ public class TestHelpers {
   }
 
   private static void assertEquals(String context, MapType map, MapData expected, MapData actual) {
-    Assert.assertEquals(
-        "Should have the same number of elements", expected.numElements(), actual.numElements());
+    assertThat(actual.numElements())
+        .as("Should have the same number of elements")
+        .isEqualTo(expected.numElements());
 
     DataType keyType = map.keyType();
     ArrayData expectedKeys = expected.keyArray();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -19,22 +19,22 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestOrcWrite {
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private static final Schema SCHEMA =
       new Schema(
@@ -42,8 +42,8 @@ public class TestOrcWrite {
 
   @Test
   public void splitOffsets() throws IOException {
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     Iterable<InternalRow> rows = RandomData.generateSpark(SCHEMA, 1, 0L);
     FileAppender<InternalRow> writer =
@@ -54,6 +54,6 @@ public class TestOrcWrite {
 
     writer.addAll(rows);
     writer.close();
-    Assert.assertNotNull("Split offsets not present", writer.splitOffsets());
+    assertThat(writer.splitOffsets()).as("Split offsets not present").isNotEmpty();
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -20,9 +20,11 @@ package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
@@ -34,14 +36,12 @@ import org.apache.iceberg.parquet.ParquetAvroValueReaders;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.schema.MessageType;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestParquetAvroReader {
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private static final Schema COMPLEX_SCHEMA =
       new Schema(
@@ -87,7 +87,7 @@ public class TestParquetAvroReader {
           optional(2, "slide", Types.StringType.get()),
           required(25, "foo", Types.DecimalType.of(7, 5)));
 
-  @Ignore
+  @Disabled
   public void testStructSchema() throws IOException {
     Schema structSchema =
         new Schema(
@@ -145,7 +145,7 @@ public class TestParquetAvroReader {
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
   }
 
-  @Ignore
+  @Disabled
   public void testWithOldReadPath() throws IOException {
     File testFile = writeTestData(COMPLEX_SCHEMA, 500_000, 1985);
     // RandomData uses the root record name "test", which must match for records to be equal
@@ -194,8 +194,8 @@ public class TestParquetAvroReader {
   public void testCorrectness() throws IOException {
     Iterable<Record> records = RandomData.generate(COMPLEX_SCHEMA, 50_000, 34139);
 
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(testFile)).schema(COMPLEX_SCHEMA).build()) {
@@ -217,15 +217,15 @@ public class TestParquetAvroReader {
       Iterator<Record> iter = records.iterator();
       for (Record actual : reader) {
         Record expected = iter.next();
-        Assert.assertEquals("Record " + recordNum + " should match expected", expected, actual);
+        assertThat(actual).as("Record " + recordNum + " should match expected").isEqualTo(expected);
         recordNum += 1;
       }
     }
   }
 
   private File writeTestData(Schema schema, int numRecords, int seed) throws IOException {
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(testFile)).schema(schema).build()) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroWriter.java
@@ -20,9 +20,11 @@ package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
@@ -35,13 +37,11 @@ import org.apache.iceberg.parquet.ParquetAvroWriter;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.schema.MessageType;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestParquetAvroWriter {
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private static final Schema COMPLEX_SCHEMA =
       new Schema(
@@ -90,8 +90,8 @@ public class TestParquetAvroWriter {
   public void testCorrectness() throws IOException {
     Iterable<Record> records = RandomData.generate(COMPLEX_SCHEMA, 50_000, 34139);
 
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(testFile))
@@ -115,7 +115,7 @@ public class TestParquetAvroWriter {
       Iterator<Record> iter = records.iterator();
       for (Record actual : reader) {
         Record expected = iter.next();
-        Assert.assertEquals("Record " + recordNum + " should match expected", expected, actual);
+        assertThat(actual).as("Record " + recordNum + " should match expected").isEqualTo(expected);
         recordNum += 1;
       }
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -18,14 +18,15 @@
  */
 package org.apache.iceberg.spark.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.ZoneId;
 import java.util.TimeZone;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.TimestampFormatter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkDateTimes {
   @Test
@@ -46,8 +47,10 @@ public class TestSparkDateTimes {
 
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
-    String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
+    assertThat(DateTimeUtils.toJavaDate(date.value()))
+        .as("Should be the same date (" + date.value() + ")")
+        .asString()
+        .isEqualTo(dateString);
   }
 
   @Test
@@ -68,7 +71,8 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = formatter.format(ts.value());
-    Assert.assertEquals(
-        "Should be the same timestamp (" + ts.value() + ")", sparkRepr, sparkTimestamp);
+    assertThat(sparkTimestamp)
+        .as("Should be the same timestamp (" + ts.value() + ")")
+        .isEqualTo(sparkRepr);
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
@@ -19,9 +19,12 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,6 +32,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
@@ -50,15 +56,12 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkOrcReadMetadataColumns {
   private static final Schema DATA_SCHEMA =
       new Schema(
@@ -95,24 +98,20 @@ public class TestSparkOrcReadMetadataColumns {
     }
   }
 
-  @Parameterized.Parameters(name = "vectorized = {0}")
-  public static Object[] parameters() {
-    return new Object[] {false, true};
+  @Parameters(name = "vectorized = {0}")
+  public static Collection<Boolean> parameters() {
+    return Arrays.asList(false, true);
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private java.nio.file.Path temp;
 
-  private boolean vectorized;
+  @Parameter private boolean vectorized;
   private File testFile;
 
-  public TestSparkOrcReadMetadataColumns(boolean vectorized) {
-    this.vectorized = vectorized;
-  }
-
-  @Before
+  @BeforeEach
   public void writeFile() throws IOException {
-    testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    testFile = File.createTempFile("junit", null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =
         ORC.write(Files.localOutput(testFile))
@@ -127,18 +126,18 @@ public class TestSparkOrcReadMetadataColumns {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbers() throws IOException {
     readAndValidate(null, null, null, EXPECTED_ROWS);
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbersWithFilter() throws IOException {
     readAndValidate(
         Expressions.greaterThanOrEqual("id", 500), null, null, EXPECTED_ROWS.subList(500, 1000));
   }
 
-  @Test
+  @TestTemplate
   public void testReadRowNumbersWithSplits() throws IOException {
     Reader reader;
     try {
@@ -201,10 +200,10 @@ public class TestSparkOrcReadMetadataColumns {
       final Iterator<InternalRow> actualRows = reader.iterator();
       final Iterator<InternalRow> expectedRows = expected.iterator();
       while (expectedRows.hasNext()) {
-        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
+        assertThat(actualRows).as("Should have expected number of rows").hasNext();
         TestHelpers.assertEquals(PROJECTION_SCHEMA, expectedRows.next(), actualRows.next());
       }
-      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
+      assertThat(actualRows).as("Should not have extra rows").isExhausted();
     } finally {
       if (reader != null) {
         reader.close();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestSparkParquetWriter {
   @TempDir private Path temp;
 
-  public static final Schema SCHEMA =
+  private static final Schema SCHEMA =
       new Schema(
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.required(2, "id_long", Types.LongType.get()));

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -18,27 +18,39 @@
  */
 package org.apache.iceberg.spark.data;
 
+import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
+import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_FPP_PREFIX;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
 import java.util.Iterator;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestSparkParquetWriter {
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
+
+  public static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.required(2, "id_long", Types.LongType.get()));
 
   private static final Schema COMPLEX_SCHEMA =
       new Schema(
@@ -88,8 +100,8 @@ public class TestSparkParquetWriter {
     int numRows = 50_000;
     Iterable<InternalRow> records = RandomData.generateSpark(COMPLEX_SCHEMA, numRows, 19981);
 
-    File testFile = temp.newFile();
-    Assert.assertTrue("Delete should succeed", testFile.delete());
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
     try (FileAppender<InternalRow> writer =
         Parquet.write(Files.localOutput(testFile))
@@ -110,10 +122,33 @@ public class TestSparkParquetWriter {
       Iterator<InternalRow> expected = records.iterator();
       Iterator<InternalRow> rows = reader.iterator();
       for (int i = 0; i < numRows; i += 1) {
-        Assert.assertTrue("Should have expected number of rows", rows.hasNext());
+        assertThat(rows).as("Should have expected number of rows").hasNext();
         TestHelpers.assertEquals(COMPLEX_SCHEMA, expected.next(), rows.next());
       }
-      Assert.assertFalse("Should not have extra rows", rows.hasNext());
+      assertThat(rows).as("Should not have extra rows").isExhausted();
+    }
+  }
+
+  @Test
+  public void testFpp() throws IOException, NoSuchFieldException, IllegalAccessException {
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    try (FileAppender<InternalRow> writer =
+        Parquet.write(Files.localOutput(testFile))
+            .schema(SCHEMA)
+            .set(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "id", "true")
+            .set(PARQUET_BLOOM_FILTER_COLUMN_FPP_PREFIX + "id", "0.05")
+            .createWriterFunc(
+                msgType ->
+                    SparkParquetWriters.buildWriter(SparkSchemaUtil.convert(SCHEMA), msgType))
+            .build()) {
+      // Using reflection to access the private 'props' field in ParquetWriter
+      Field propsField = writer.getClass().getDeclaredField("props");
+      propsField.setAccessible(true);
+      ParquetProperties props = (ParquetProperties) propsField.get(writer);
+      MessageType parquetSchema = ParquetSchemaUtil.convert(SCHEMA, "test");
+      ColumnDescriptor descriptor = parquetSchema.getColumnDescription(new String[] {"id"});
+      double fpp = props.getBloomFilterFPP(descriptor).getAsDouble();
+      assertThat(fpp).isEqualTo(0.05);
     }
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryFallbackToPlainEncodingVectorizedReads.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryFallbackToPlainEncodingVectorizedReads.java
@@ -28,8 +28,8 @@ import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Function;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.data.RandomData;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestParquetDictionaryFallbackToPlainEncodingVectorizedReads
     extends TestParquetVectorizedReads {
@@ -64,11 +64,11 @@ public class TestParquetDictionaryFallbackToPlainEncodingVectorizedReads
 
   @Test
   @Override
-  @Ignore // Fallback encoding not triggered when data is mostly null
+  @Disabled // Fallback encoding not triggered when data is mostly null
   public void testMostlyNullsForOptionalFields() {}
 
   @Test
   @Override
-  @Ignore // Ignored since this code path is already tested in TestParquetVectorizedReads
+  @Disabled // Ignored since this code path is already tested in TestParquetVectorizedReads
   public void testVectorizedReadsWithNewContainers() throws IOException {}
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.spark.data.parquet.vectorized;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -48,9 +50,7 @@ import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestParquetVectorizedReads extends AvroDataTest {
   private static final int NUM_ROWS = 200_000;
@@ -104,12 +104,12 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       Function<GenericData.Record, GenericData.Record> transform)
       throws IOException {
     // Write test data
-    Assume.assumeTrue(
-        "Parquet Avro cannot write non-string map keys",
-        null
-            == TypeUtil.find(
+    assumeThat(
+            TypeUtil.find(
                 writeSchema,
-                type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()));
+                type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()))
+        .as("Parquet Avro cannot write non-string map keys")
+        .isNull();
 
     Iterable<GenericData.Record> expected =
         generateData(writeSchema, numRecords, seed, nullPercentage, transform);
@@ -181,7 +181,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         numRowsRead += batch.numRows();
         TestHelpers.assertEqualsBatch(schema.asStruct(), expectedIter, batch);
       }
-      Assert.assertEquals(expectedSize, numRowsRead);
+      assertThat(numRowsRead).isEqualTo(expectedSize);
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -133,9 +133,10 @@ public class GenericsHelpers {
         break;
       case DATE:
         assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
-        assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
-        assertThat(actual.toString())
+        assertThat(actual)
+            .isInstanceOf(Date.class)
             .as("ISO-8601 date should be equal")
+            .asString()
             .isEqualTo(String.valueOf(expected));
         break;
       case TIMESTAMP:
@@ -165,32 +166,29 @@ public class GenericsHelpers {
         }
         break;
       case STRING:
-        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        assertThat(actual.toString())
-            .as("Strings should be equal")
+        assertThat(actual)
+            .isInstanceOf(String.class)
+            .asString()
             .isEqualTo(String.valueOf(expected));
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        assertThat(actual.toString())
-            .as("UUID string representation should match")
+        assertThat(actual)
+            .isInstanceOf(String.class)
+            .asString()
             .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
         assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(expected);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(expected);
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
-        assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
-        assertThat(actual).as("BigDecimals should be equal").isEqualTo(expected);
+        assertThat(actual).isInstanceOf(BigDecimal.class).isEqualTo(expected);
         break;
       case STRUCT:
         assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
@@ -352,27 +350,25 @@ public class GenericsHelpers {
         }
         break;
       case STRING:
-        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        assertThat(actual.toString())
-            .as("Strings should be equal")
+        assertThat(actual)
+            .isInstanceOf(UTF8String.class)
+            .asString()
             .isEqualTo(String.valueOf(expected));
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        assertThat(actual.toString())
-            .as("UUID string representation should match")
+        assertThat(actual)
+            .isInstanceOf(UTF8String.class)
+            .asString()
             .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
         assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(expected);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(expected);
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -580,9 +580,9 @@ public class TestHelpers {
         Object expectedKey = getValue(expectedKeyArray, e, keyType);
         Object actualValue = actual.get(expectedKey);
         if (actualValue == null) {
-          assertThat(true)
+          assertThat(expected.valueArray().isNullAt(e))
               .as(prefix + ".key=" + expectedKey + " has null")
-              .isEqualTo(expected.valueArray().isNullAt(e));
+              .isTrue();
         } else {
           switch (valueType.typeId()) {
             case BOOLEAN:

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -207,8 +207,9 @@ public class TestHelpers {
         assertThat(expected).as("Should be an int").isInstanceOf(Integer.class);
         assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
         LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, (Integer) expected);
-        assertThat(actual.toString())
+        assertThat(actual)
             .as("ISO-8601 date should be equal")
+            .asString()
             .isEqualTo(String.valueOf(date));
         break;
       case TIMESTAMP:
@@ -233,14 +234,13 @@ public class TestHelpers {
         }
         break;
       case STRING:
-        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        assertThat(actual).as("Strings should be equal").isEqualTo(String.valueOf(expected));
+        assertThat(actual).isInstanceOf(String.class).isEqualTo(String.valueOf(expected));
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        assertThat(actual).as("Should be a String").isInstanceOf(String.class);
-        assertThat(actual.toString())
-            .as("UUID string representation should match")
+        assertThat(actual)
+            .isInstanceOf(String.class)
+            .asString()
             .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
@@ -257,18 +257,15 @@ public class TestHelpers {
               "Invalid expected value, not byte[] or Fixed: " + expected);
         }
 
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(expectedBytes);
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(expectedBytes);
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
-        assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
-        assertThat(actual).as("BigDecimals should be equal").isEqualTo(expected);
+        assertThat(actual).isInstanceOf(BigDecimal.class).isEqualTo(expected);
         break;
       case STRUCT:
         assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
@@ -377,14 +374,13 @@ public class TestHelpers {
         assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case STRING:
-        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        assertThat(actual.toString()).as("Strings should be equal").isEqualTo(expected);
+        assertThat(actual).isInstanceOf(UTF8String.class).asString().isEqualTo(expected);
         break;
       case UUID:
         assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
-        assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
-        assertThat(actual.toString())
-            .as("UUID string representation should match")
+        assertThat(actual)
+            .isInstanceOf(UTF8String.class)
+            .asString()
             .isEqualTo(String.valueOf(expected));
         break;
       case FIXED:
@@ -406,8 +402,7 @@ public class TestHelpers {
         break;
       case BINARY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
-        assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
-        assertThat(actual).as("Bytes should match").isEqualTo(((ByteBuffer) expected).array());
+        assertThat(actual).isInstanceOf(byte[].class).isEqualTo(((ByteBuffer) expected).array());
         break;
       case DECIMAL:
         assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
@@ -514,7 +509,7 @@ public class TestHelpers {
     if (expected == null || actual == null) {
       assertThat(actual).as(prefix).isEqualTo(expected);
     } else {
-      assertThat(actual.size()).as(prefix + "length").isEqualTo(expected.numElements());
+      assertThat(actual).as(prefix + "length").hasSize(expected.numElements());
       Type childType = type.elementType();
       for (int e = 0; e < expected.numElements(); ++e) {
         switch (childType.typeId()) {
@@ -527,8 +522,9 @@ public class TestHelpers {
           case DECIMAL:
           case DATE:
           case TIMESTAMP:
-            assertThat(actual.get(e))
+            assertThat(actual)
                 .as(prefix + ".elem " + e + " - " + childType)
+                .element(e)
                 .isEqualTo(getValue(expected, e, childType));
             break;
           case UUID:
@@ -579,7 +575,7 @@ public class TestHelpers {
       Type valueType = type.valueType();
       ArrayData expectedKeyArray = expected.keyArray();
       ArrayData expectedValueArray = expected.valueArray();
-      assertThat(actual.size()).as(prefix + " length").isEqualTo(expected.numElements());
+      assertThat(actual).as(prefix + " length").hasSize(expectedKeyArray.numElements());
       for (int e = 0; e < expected.numElements(); ++e) {
         Object expectedKey = getValue(expectedKeyArray, e, keyType);
         Object actualValue = actual.get(expectedKey);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestOrcWrite.java
@@ -54,6 +54,6 @@ public class TestOrcWrite {
 
     writer.addAll(rows);
     writer.close();
-    assertThat(writer.splitOffsets()).as("Split offsets not present").isNotNull();
+    assertThat(writer.splitOffsets()).as("Split offsets not present").isNotEmpty();
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -47,9 +47,9 @@ public class TestSparkDateTimes {
 
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
-    String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    assertThat(sparkDate)
+    assertThat(DateTimeUtils.toJavaDate(date.value()))
         .as("Should be the same date (" + date.value() + ")")
+        .asString()
         .isEqualTo(dateString);
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestSparkParquetWriter {
   @TempDir private Path temp;
 
-  public static final Schema SCHEMA =
+  private static final Schema SCHEMA =
       new Schema(
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.required(2, "id_long", Types.LongType.get()));


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates the following tests in `spark.data` to JUnit 5 with AssertJ:

`data.parquet.vectorized`
* `TestParquetDictionaryFallbackToPlainEncodingVectorizedReads`
* `TestParquetVectorizedReads`

`data`
* `GenericsHelpers` including refactoring Spark 3.5 tests
* `TestHelpers` including refectoring Spark 3.5 tests
* `TestOrcWrite` 
* `TestParquetAvroReader`
* `TestParquetAvroWriter`
* `TestSparkAvroEnums`
* `TestSparkDateTimes`
* `TestSparkOrcReadMetadataColumns`
* `TestSparkParquetReadMetadataColumns`
* `TestSparkParquetWriter` including the backport from https://github.com/apache/iceberg/pull/10149

