### PR TITLE
Spark 3.4: Migrate tests in spark.source including refactoring Spark 3.5 tests

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -64,7 +64,6 @@ import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -653,7 +652,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         .hasSameSizeAs(deletedFiles);
     // Take the diff
     expectedDeletes.removeAll(deletedFiles);
-    Assert.assertTrue("Exactly same files should be deleted", expectedDeletes.isEmpty());
+    assertThat(expectedDeletes).as("Exactly same files should be deleted").isEmpty();
   }
 
   /**
@@ -669,7 +668,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     // `B` commit
     Set<String> deletedAFiles = Sets.newHashSet();
     table.newOverwrite().addFile(FILE_B).deleteFile(FILE_A).deleteWith(deletedAFiles::add).commit();
-    Assert.assertTrue("No files should be physically deleted", deletedAFiles.isEmpty());
+    assertThat(deletedAFiles).as("No files should be physically deleted").isEmpty();
 
     // pick the snapshot 'B`
     Snapshot snapshotB = table.currentSnapshot();
@@ -704,7 +703,7 @@ public class TestExpireSnapshotsAction extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.location()));
+                        assertThat(deletedFiles).doesNotContain(item.location());
                       });
             });
 
@@ -753,7 +752,7 @@ public class TestExpireSnapshotsAction extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.location()));
+                        assertThat(deletedFiles).doesNotContain(item.location());
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 1L, 1L, firstResult);
@@ -773,7 +772,7 @@ public class TestExpireSnapshotsAction extends TestBase {
               i.addedDataFiles(table.io())
                   .forEach(
                       item -> {
-                        Assert.assertFalse(deletedFiles.contains(item.location()));
+                        assertThat(deletedFiles).doesNotContain(item.location());
                       });
             });
     checkExpirationResults(0L, 0L, 0L, 0L, 2L, secondResult);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -20,9 +20,11 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.apache.iceberg.Files.localOutput;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -47,14 +49,12 @@ import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestBaseReader {
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private Table table;
 
@@ -129,15 +129,17 @@ public class TestBaseReader {
     int countRecords = 0;
     while (reader.next()) {
       countRecords += 1;
-      Assert.assertNotNull("Reader should return non-null value", reader.get());
+      assertThat(reader.get()).as("Reader should return non-null value").isNotNull();
     }
 
-    Assert.assertEquals(
-        "Reader returned incorrect number of records", totalTasks * recordPerTask, countRecords);
+    assertThat(totalTasks * recordPerTask)
+        .as("Reader returned incorrect number of records")
+        .isEqualTo(countRecords);
     tasks.forEach(
         t ->
-            Assert.assertTrue(
-                "All iterators should be closed after read exhausion", reader.isIteratorClosed(t)));
+            assertThat(reader.isIteratorClosed(t))
+                .as("All iterators should be closed after read exhausion")
+                .isTrue());
   }
 
   @Test
@@ -145,28 +147,29 @@ public class TestBaseReader {
     Integer totalTasks = 2;
     Integer recordPerTask = 1;
     List<FileScanTask> tasks = createFileScanTasks(totalTasks, recordPerTask);
-    Assert.assertEquals(2, tasks.size());
+    assertThat(tasks).hasSize(2);
     FileScanTask firstTask = tasks.get(0);
     FileScanTask secondTask = tasks.get(1);
 
     ClosureTrackingReader reader = new ClosureTrackingReader(table, tasks);
 
     // Total of 2 elements
-    Assert.assertTrue(reader.next());
-    Assert.assertFalse(
-        "First iter should not be closed on its last element", reader.isIteratorClosed(firstTask));
+    assertThat(reader.next()).isTrue();
+    assertThat(reader.isIteratorClosed(firstTask))
+        .as("First iter should not be closed on its last element")
+        .isFalse();
 
-    Assert.assertTrue(reader.next());
-    Assert.assertTrue(
-        "First iter should be closed after moving to second iter",
-        reader.isIteratorClosed(firstTask));
-    Assert.assertFalse(
-        "Second iter should not be closed on its last element",
-        reader.isIteratorClosed(secondTask));
+    assertThat(reader.next()).isTrue();
+    assertThat(reader.isIteratorClosed(firstTask))
+        .as("First iter should be closed after moving to second iter")
+        .isTrue();
+    assertThat(reader.isIteratorClosed(secondTask))
+        .as("Second iter should not be closed on its last element")
+        .isFalse();
 
-    Assert.assertFalse(reader.next());
-    Assert.assertTrue(reader.isIteratorClosed(firstTask));
-    Assert.assertTrue(reader.isIteratorClosed(secondTask));
+    assertThat(reader.next()).isFalse();
+    assertThat(reader.isIteratorClosed(firstTask)).isTrue();
+    assertThat(reader.isIteratorClosed(secondTask)).isTrue();
   }
 
   @Test
@@ -181,8 +184,9 @@ public class TestBaseReader {
 
     tasks.forEach(
         t ->
-            Assert.assertFalse(
-                "Iterator should not be created eagerly for tasks", reader.hasIterator(t)));
+            assertThat(reader.hasIterator(t))
+                .as("Iterator should not be created eagerly for tasks")
+                .isFalse());
   }
 
   @Test
@@ -195,8 +199,8 @@ public class TestBaseReader {
 
     Integer halfDataSize = (totalTasks * recordPerTask) / 2;
     for (int i = 0; i < halfDataSize; i++) {
-      Assert.assertTrue("Reader should have some element", reader.next());
-      Assert.assertNotNull("Reader should return non-null value", reader.get());
+      assertThat(reader.next()).as("Reader should have some element").isTrue();
+      assertThat(reader.get()).as("Reader should return non-null value").isNotNull();
     }
 
     reader.close();
@@ -206,8 +210,9 @@ public class TestBaseReader {
     tasks.forEach(
         t -> {
           if (reader.hasIterator(t)) {
-            Assert.assertTrue(
-                "Iterator should be closed after read exhausion", reader.isIteratorClosed(t));
+            assertThat(reader.isIteratorClosed(t))
+                .as("Iterator should be closed after read exhausion")
+                .isTrue();
           }
         });
   }
@@ -222,20 +227,21 @@ public class TestBaseReader {
 
     // Total 100 elements, only 5 iterators have been created
     for (int i = 0; i < 45; i++) {
-      Assert.assertTrue("eader should have some element", reader.next());
-      Assert.assertNotNull("Reader should return non-null value", reader.get());
+      assertThat(reader.next()).as("Reader should have some element").isTrue();
+      assertThat(reader.get()).as("Reader should return non-null value").isNotNull();
     }
 
     for (int closeAttempt = 0; closeAttempt < 5; closeAttempt++) {
       reader.close();
       for (int i = 0; i < 5; i++) {
-        Assert.assertTrue(
-            "Iterator should be closed after read exhausion",
-            reader.isIteratorClosed(tasks.get(i)));
+        assertThat(reader.isIteratorClosed(tasks.get(i)))
+            .as("Iterator should be closed after read exhausion")
+            .isTrue();
       }
       for (int i = 5; i < 10; i++) {
-        Assert.assertFalse(
-            "Iterator should not be created eagerly for tasks", reader.hasIterator(tasks.get(i)));
+        assertThat(reader.hasIterator(tasks.get(i)))
+            .as("Iterator should not be created eagerly for tasks")
+            .isFalse();
       }
     }
   }
@@ -243,10 +249,10 @@ public class TestBaseReader {
   private List<FileScanTask> createFileScanTasks(Integer totalTasks, Integer recordPerTask)
       throws IOException {
     String desc = "make_scan_tasks";
-    File parent = temp.newFolder(desc);
+    File parent = temp.resolve(desc).toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());
+    assertThat(dataFolder.mkdirs()).as("mkdirs should succeed").isTrue();
 
     Schema schema = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -39,6 +40,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PlanningMode;
 import org.apache.iceberg.Schema;
@@ -51,7 +55,6 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.data.GenericsHelpers;
 import org.apache.iceberg.transforms.Transforms;
@@ -78,17 +81,14 @@ import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestFilteredScan {
   private static final Configuration CONF = new Configuration();
   private static final HadoopTables TABLES = new HadoopTables(CONF);
@@ -116,7 +116,7 @@ public class TestFilteredScan {
 
   private static SparkSession spark = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
 
@@ -144,46 +144,45 @@ public class TestFilteredScan {
     spark.udf().register("id_ident", (UDF1<Long, Long>) id -> id, LongType$.MODULE$);
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestFilteredScan.spark;
     TestFilteredScan.spark = null;
     currentSpark.stop();
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
-  private final String format;
-  private final boolean vectorized;
-  private final PlanningMode planningMode;
+  @Parameter(index = 0)
+  private FileFormat fileFormat;
 
-  @Parameterized.Parameters(name = "format = {0}, vectorized = {1}, planningMode = {2}")
+  @Parameter(index = 1)
+  private boolean vectorized;
+
+  @Parameter(index = 2)
+  private PlanningMode planningMode;
+
+  @Parameters(name = "format = {0}, vectorized = {1}, planningMode = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"parquet", false, LOCAL},
-      {"parquet", true, DISTRIBUTED},
-      {"avro", false, LOCAL},
-      {"orc", false, DISTRIBUTED},
-      {"orc", true, LOCAL}
+      {FileFormat.PARQUET, false, LOCAL},
+      {FileFormat.PARQUET, true, DISTRIBUTED},
+      {FileFormat.AVRO, false, LOCAL},
+      {FileFormat.ORC, false, DISTRIBUTED},
+      {FileFormat.ORC, true, LOCAL}
     };
-  }
-
-  public TestFilteredScan(String format, boolean vectorized, PlanningMode planningMode) {
-    this.format = format;
-    this.vectorized = vectorized;
-    this.planningMode = planningMode;
   }
 
   private File parent = null;
   private File unpartitioned = null;
   private List<Record> records = null;
 
-  @Before
+  @BeforeEach
   public void writeUnpartitionedTable() throws IOException {
-    this.parent = temp.newFolder("TestFilteredScan");
+    this.parent = temp.resolve("TestFilteredScan").toFile();
     this.unpartitioned = new File(parent, "unpartitioned");
     File dataFolder = new File(unpartitioned, "data");
-    Assert.assertTrue("Mkdir should succeed", dataFolder.mkdirs());
+    assertThat(dataFolder.mkdirs()).as("Mkdir should succeed").isTrue();
 
     Table table =
         TABLES.create(
@@ -196,8 +195,6 @@ public class TestFilteredScan {
                 planningMode.modeName()),
             unpartitioned.toString());
     Schema tableSchema = table.schema(); // use the table schema because ids are reassigned
-
-    FileFormat fileFormat = FileFormat.fromString(format);
 
     File testFile = new File(dataFolder, fileFormat.addExtension(UUID.randomUUID().toString()));
 
@@ -218,7 +215,7 @@ public class TestFilteredScan {
     table.newAppend().appendFile(file).commit();
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedIDFilters() {
     CaseInsensitiveStringMap options =
         new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
@@ -230,7 +227,7 @@ public class TestFilteredScan {
       Batch scan = builder.build().toBatch();
 
       InputPartition[] partitions = scan.planInputPartitions();
-      Assert.assertEquals("Should only create one task for a small file", 1, partitions.length);
+      assertThat(partitions).as("Should only create one task for a small file").hasSize(1);
 
       // validate row filtering
       assertEqualsSafe(
@@ -238,7 +235,7 @@ public class TestFilteredScan {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedCaseInsensitiveIDFilters() {
     CaseInsensitiveStringMap options =
         new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
@@ -260,7 +257,7 @@ public class TestFilteredScan {
         Batch scan = builder.build().toBatch();
 
         InputPartition[] tasks = scan.planInputPartitions();
-        Assert.assertEquals("Should only create one task for a small file", 1, tasks.length);
+        assertThat(tasks).as("Should only create one task for a small file").hasSize(1);
 
         // validate row filtering
         assertEqualsSafe(
@@ -274,7 +271,7 @@ public class TestFilteredScan {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedTimestampFilter() {
     CaseInsensitiveStringMap options =
         new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
@@ -286,7 +283,7 @@ public class TestFilteredScan {
     Batch scan = builder.build().toBatch();
 
     InputPartition[] tasks = scan.planInputPartitions();
-    Assert.assertEquals("Should only create one task for a small file", 1, tasks.length);
+    assertThat(tasks).as("Should only create one task for a small file").hasSize(1);
 
     assertEqualsSafe(
         SCHEMA.asStruct(),
@@ -297,7 +294,7 @@ public class TestFilteredScan {
             "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
   }
 
-  @Test
+  @TestTemplate
   public void testBucketPartitionedIDFilters() {
     Table table = buildPartitionedTable("bucketed_by_id", BUCKET_BY_ID, "bucket4", "id");
     CaseInsensitiveStringMap options =
@@ -305,8 +302,9 @@ public class TestFilteredScan {
 
     Batch unfiltered =
         new SparkScanBuilder(spark, TABLES.load(options.get("path")), options).build().toBatch();
-    Assert.assertEquals(
-        "Unfiltered table should created 4 read tasks", 4, unfiltered.planInputPartitions().length);
+    assertThat(unfiltered.planInputPartitions())
+        .as("Unfiltered table should created 4 read tasks")
+        .hasSize(4);
 
     for (int i = 0; i < 10; i += 1) {
       SparkScanBuilder builder =
@@ -318,7 +316,7 @@ public class TestFilteredScan {
       InputPartition[] tasks = scan.planInputPartitions();
 
       // validate predicate push-down
-      Assert.assertEquals("Should create one task for a single bucket", 1, tasks.length);
+      assertThat(tasks).as("Should only create one task for a single bucket").hasSize(1);
 
       // validate row filtering
       assertEqualsSafe(
@@ -327,7 +325,7 @@ public class TestFilteredScan {
   }
 
   @SuppressWarnings("checkstyle:AvoidNestedBlocks")
-  @Test
+  @TestTemplate
   public void testDayPartitionedTimestampFilters() {
     Table table = buildPartitionedTable("partitioned_by_day", PARTITION_BY_DAY, "ts_day", "ts");
     CaseInsensitiveStringMap options =
@@ -335,8 +333,9 @@ public class TestFilteredScan {
     Batch unfiltered =
         new SparkScanBuilder(spark, TABLES.load(options.get("path")), options).build().toBatch();
 
-    Assert.assertEquals(
-        "Unfiltered table should created 2 read tasks", 2, unfiltered.planInputPartitions().length);
+    assertThat(unfiltered.planInputPartitions())
+        .as("Unfiltered table should created 2 read tasks")
+        .hasSize(2);
 
     {
       SparkScanBuilder builder =
@@ -346,7 +345,7 @@ public class TestFilteredScan {
       Batch scan = builder.build().toBatch();
 
       InputPartition[] tasks = scan.planInputPartitions();
-      Assert.assertEquals("Should create one task for 2017-12-21", 1, tasks.length);
+      assertThat(tasks).as("Should create one task for 2017-12-21").hasSize(1);
 
       assertEqualsSafe(
           SCHEMA.asStruct(),
@@ -367,7 +366,7 @@ public class TestFilteredScan {
       Batch scan = builder.build().toBatch();
 
       InputPartition[] tasks = scan.planInputPartitions();
-      Assert.assertEquals("Should create one task for 2017-12-22", 1, tasks.length);
+      assertThat(tasks).as("Should create one task for 2017-12-22").hasSize(1);
 
       assertEqualsSafe(
           SCHEMA.asStruct(),
@@ -381,7 +380,7 @@ public class TestFilteredScan {
   }
 
   @SuppressWarnings("checkstyle:AvoidNestedBlocks")
-  @Test
+  @TestTemplate
   public void testHourPartitionedTimestampFilters() {
     Table table = buildPartitionedTable("partitioned_by_hour", PARTITION_BY_HOUR, "ts_hour", "ts");
 
@@ -390,8 +389,9 @@ public class TestFilteredScan {
     Batch unfiltered =
         new SparkScanBuilder(spark, TABLES.load(options.get("path")), options).build().toBatch();
 
-    Assert.assertEquals(
-        "Unfiltered table should created 9 read tasks", 9, unfiltered.planInputPartitions().length);
+    assertThat(unfiltered.planInputPartitions())
+        .as("Unfiltered table should created 9 read tasks")
+        .hasSize(9);
 
     {
       SparkScanBuilder builder =
@@ -401,7 +401,7 @@ public class TestFilteredScan {
       Batch scan = builder.build().toBatch();
 
       InputPartition[] tasks = scan.planInputPartitions();
-      Assert.assertEquals("Should create 4 tasks for 2017-12-21: 15, 17, 21, 22", 4, tasks.length);
+      assertThat(tasks).as("Should create 4 tasks for 2017-12-21: 15, 17, 21, 22").hasSize(4);
 
       assertEqualsSafe(
           SCHEMA.asStruct(),
@@ -422,7 +422,7 @@ public class TestFilteredScan {
       Batch scan = builder.build().toBatch();
 
       InputPartition[] tasks = scan.planInputPartitions();
-      Assert.assertEquals("Should create 2 tasks for 2017-12-22: 6, 7", 2, tasks.length);
+      assertThat(tasks).as("Should create 2 tasks for 2017-12-22: 6, 7").hasSize(2);
 
       assertEqualsSafe(
           SCHEMA.asStruct(),
@@ -436,7 +436,7 @@ public class TestFilteredScan {
   }
 
   @SuppressWarnings("checkstyle:AvoidNestedBlocks")
-  @Test
+  @TestTemplate
   public void testFilterByNonProjectedColumn() {
     {
       Schema actualProjection = SCHEMA.select("id", "data");
@@ -477,7 +477,7 @@ public class TestFilteredScan {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedByDataStartsWithFilter() {
     Table table =
         buildPartitionedTable("partitioned_by_data", PARTITION_BY_DATA, "data_ident", "data");
@@ -490,10 +490,10 @@ public class TestFilteredScan {
     pushFilters(builder, new StringStartsWith("data", "junc"));
     Batch scan = builder.build().toBatch();
 
-    Assert.assertEquals(1, scan.planInputPartitions().length);
+    assertThat(scan.planInputPartitions()).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedByDataNotStartsWithFilter() {
     Table table =
         buildPartitionedTable("partitioned_by_data", PARTITION_BY_DATA, "data_ident", "data");
@@ -506,10 +506,10 @@ public class TestFilteredScan {
     pushFilters(builder, new Not(new StringStartsWith("data", "junc")));
     Batch scan = builder.build().toBatch();
 
-    Assert.assertEquals(9, scan.planInputPartitions().length);
+    assertThat(scan.planInputPartitions()).hasSize(9);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedByIdStartsWith() {
     Table table = buildPartitionedTable("partitioned_by_id", PARTITION_BY_ID, "id_ident", "id");
 
@@ -522,10 +522,10 @@ public class TestFilteredScan {
     pushFilters(builder, new StringStartsWith("data", "junc"));
     Batch scan = builder.build().toBatch();
 
-    Assert.assertEquals(1, scan.planInputPartitions().length);
+    assertThat(scan.planInputPartitions()).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionedByIdNotStartsWith() {
     Table table = buildPartitionedTable("partitioned_by_id", PARTITION_BY_ID, "id_ident", "id");
 
@@ -538,10 +538,10 @@ public class TestFilteredScan {
     pushFilters(builder, new Not(new StringStartsWith("data", "junc")));
     Batch scan = builder.build().toBatch();
 
-    Assert.assertEquals(9, scan.planInputPartitions().length);
+    assertThat(scan.planInputPartitions()).hasSize(9);
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedStartsWith() {
     Dataset<Row> df =
         spark
@@ -553,11 +553,10 @@ public class TestFilteredScan {
     List<String> matchedData =
         df.select("data").where("data LIKE 'jun%'").as(Encoders.STRING()).collectAsList();
 
-    Assert.assertEquals(1, matchedData.size());
-    Assert.assertEquals("junction", matchedData.get(0));
+    assertThat(matchedData).singleElement().isEqualTo("junction");
   }
 
-  @Test
+  @TestTemplate
   public void testUnpartitionedNotStartsWith() {
     Dataset<Row> df =
         spark
@@ -575,8 +574,7 @@ public class TestFilteredScan {
             .filter(d -> !d.startsWith("jun"))
             .collect(Collectors.toList());
 
-    Assert.assertEquals(9, matchedData.size());
-    Assert.assertEquals(Sets.newHashSet(expected), Sets.newHashSet(matchedData));
+    assertThat(matchedData).hasSize(9).containsExactlyInAnyOrderElementsOf(expected);
   }
 
   private static Record projectFlat(Schema projection, Record record) {
@@ -596,7 +594,7 @@ public class TestFilteredScan {
     for (int i = 0; i < numRecords; i += 1) {
       GenericsHelpers.assertEqualsUnsafe(struct, expected.get(i), actual.get(i));
     }
-    Assert.assertEquals("Number of results should match expected", expected.size(), actual.size());
+    assertThat(actual).as("Number of results should match expected").hasSameSizeAs(expected);
   }
 
   public static void assertEqualsSafe(
@@ -606,7 +604,7 @@ public class TestFilteredScan {
     for (int i = 0; i < numRecords; i += 1) {
       GenericsHelpers.assertEqualsSafe(struct, expected.get(i), actual.get(i));
     }
-    Assert.assertEquals("Number of results should match expected", expected.size(), actual.size());
+    assertThat(actual).as("Number of results should match expected").hasSameSizeAs(expected);
   }
 
   private List<Record> expected(int... ordinals) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -20,10 +20,12 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.Files.localInput;
 import static org.apache.iceberg.Files.localOutput;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
@@ -55,12 +57,10 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.streaming.MemoryStream;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.StreamingQueryException;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import scala.Option;
 import scala.collection.JavaConverters;
 
@@ -88,16 +88,16 @@ public class TestForwardCompatibility {
           .addField("identity", 1, "id_zero")
           .build();
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private static SparkSession spark = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestForwardCompatibility.spark = SparkSession.builder().master("local[2]").getOrCreate();
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestForwardCompatibility.spark;
     TestForwardCompatibility.spark = null;
@@ -106,10 +106,10 @@ public class TestForwardCompatibility {
 
   @Test
   public void testSparkWriteFailsUnknownTransform() throws IOException {
-    File parent = temp.newFolder("avro");
+    File parent = temp.resolve("avro").toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    dataFolder.mkdirs();
+    assertThat(dataFolder.mkdirs()).isTrue();
 
     HadoopTables tables = new HadoopTables(CONF);
     tables.create(SCHEMA, UNKNOWN_SPEC, location.toString());
@@ -133,12 +133,12 @@ public class TestForwardCompatibility {
 
   @Test
   public void testSparkStreamingWriteFailsUnknownTransform() throws IOException, TimeoutException {
-    File parent = temp.newFolder("avro");
+    File parent = temp.resolve("avro").toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    dataFolder.mkdirs();
+    assertThat(dataFolder.mkdirs()).isTrue();
     File checkpoint = new File(parent, "checkpoint");
-    checkpoint.mkdirs();
+    assertThat(checkpoint.mkdirs()).isTrue();
 
     HadoopTables tables = new HadoopTables(CONF);
     tables.create(SCHEMA, UNKNOWN_SPEC, location.toString());
@@ -165,10 +165,10 @@ public class TestForwardCompatibility {
 
   @Test
   public void testSparkCanReadUnknownTransform() throws IOException {
-    File parent = temp.newFolder("avro");
+    File parent = temp.resolve("avro").toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    dataFolder.mkdirs();
+    assertThat(dataFolder.mkdirs()).isTrue();
 
     HadoopTables tables = new HadoopTables(CONF);
     Table table = tables.create(SCHEMA, UNKNOWN_SPEC, location.toString());
@@ -195,7 +195,7 @@ public class TestForwardCompatibility {
             .withPartitionPath("id_zero=0")
             .build();
 
-    OutputFile manifestFile = localOutput(FileFormat.AVRO.addExtension(temp.newFile().toString()));
+    OutputFile manifestFile = localOutput(FileFormat.AVRO.addExtension(temp.toFile().toString()));
     ManifestWriter<DataFile> manifestWriter = ManifestFiles.write(FAKE_SPEC, manifestFile);
     try {
       manifestWriter.add(file);
@@ -208,7 +208,7 @@ public class TestForwardCompatibility {
     Dataset<Row> df = spark.read().format("iceberg").load(location.toString());
 
     List<Row> rows = df.collectAsList();
-    Assert.assertEquals("Should contain 100 rows", 100, rows.size());
+    assertThat(rows).as("Should contain 100 rows").hasSize(100);
 
     for (int i = 0; i < expected.size(); i += 1) {
       TestHelpers.assertEqualsSafe(table.schema().asStruct(), expected.get(i), rows.get(i));

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
@@ -35,21 +36,20 @@ import org.apache.spark.sql.types.CharType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.VarcharType;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestIcebergSpark {
 
   private static SparkSession spark = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestIcebergSpark.spark = SparkSession.builder().master("local[2]").getOrCreate();
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestIcebergSpark.spark;
     TestIcebergSpark.spark = null;
@@ -60,69 +60,84 @@ public class TestIcebergSpark {
   public void testRegisterIntegerBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_int_16", DataTypes.IntegerType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_int_16(1)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1)));
   }
 
   @Test
   public void testRegisterShortBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_short_16", DataTypes.ShortType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_short_16(1S)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1)));
   }
 
   @Test
   public void testRegisterByteBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_byte_16", DataTypes.ByteType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_byte_16(1Y)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1)));
   }
 
   @Test
   public void testRegisterLongBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_long_16", DataTypes.LongType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_long_16(1L)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.LongType.get()).apply(1L), results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.LongType.get()).apply(1L)));
   }
 
   @Test
   public void testRegisterStringBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_string_16", DataTypes.StringType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_string_16('hello')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello")));
   }
 
   @Test
   public void testRegisterCharBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_char_16", new CharType(5), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_char_16('hello')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello")));
   }
 
   @Test
   public void testRegisterVarCharBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_varchar_16", new VarcharType(5), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_varchar_16('hello')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello")));
   }
 
   @Test
@@ -130,13 +145,15 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_date_16", DataTypes.DateType, 16);
     List<Row> results =
         spark.sql("SELECT iceberg_bucket_date_16(DATE '2021-06-30')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int)
-            Transforms.bucket(16)
-                .bind(Types.DateType.get())
-                .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(
+                        Transforms.bucket(16)
+                            .bind(Types.DateType.get())
+                            .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30")))));
   }
 
   @Test
@@ -147,37 +164,47 @@ public class TestIcebergSpark {
         spark
             .sql("SELECT iceberg_bucket_timestamp_16(TIMESTAMP '2021-06-30 00:00:00.000')")
             .collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int)
-            Transforms.bucket(16)
-                .bind(Types.TimestampType.withZone())
-                .apply(
-                    DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2021-06-30 00:00:00.000"))),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(
+                        Transforms.bucket(16)
+                            .bind(Types.TimestampType.withZone())
+                            .apply(
+                                DateTimeUtils.fromJavaTimestamp(
+                                    Timestamp.valueOf("2021-06-30 00:00:00.000")))));
   }
 
   @Test
   public void testRegisterBinaryBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_binary_16", DataTypes.BinaryType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_binary_16(X'0020001F')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int)
-            Transforms.bucket(16)
-                .bind(Types.BinaryType.get())
-                .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(
+                        Transforms.bucket(16)
+                            .bind(Types.BinaryType.get())
+                            .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F}))));
   }
 
   @Test
   public void testRegisterDecimalBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_decimal_16", new DecimalType(4, 2), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_decimal_16(11.11)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")),
-        results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(
+                        Transforms.bucket(16)
+                            .bind(Types.DecimalType.of(4, 2))
+                            .apply(new BigDecimal("11.11"))));
   }
 
   @Test
@@ -214,37 +241,50 @@ public class TestIcebergSpark {
   public void testRegisterIntegerTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_int_4", DataTypes.IntegerType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_int_4(1)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1)));
   }
 
   @Test
   public void testRegisterLongTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_long_4", DataTypes.LongType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_long_4(1L)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.LongType.get()).apply(1L), results.get(0).getLong(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getLong(0))
+                    .isEqualTo(Transforms.truncate(4).bind(Types.LongType.get()).apply(1L)));
   }
 
   @Test
   public void testRegisterDecimalTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_decimal_4", new DecimalType(4, 2), 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_decimal_4(11.11)").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")),
-        results.get(0).getDecimal(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getDecimal(0))
+                    .isEqualTo(
+                        Transforms.truncate(4)
+                            .bind(Types.DecimalType.of(4, 2))
+                            .apply(new BigDecimal("11.11"))));
   }
 
   @Test
   public void testRegisterStringTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_string_4", DataTypes.StringType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_string_4('hello')").collectAsList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"),
-        results.get(0).getString(0));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getString(0))
+                    .isEqualTo(Transforms.truncate(4).bind(Types.StringType.get()).apply("hello")));
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestInternalRowWrapper.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestInternalRowWrapper.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Iterator;
 import org.apache.iceberg.RecordWrapperTest;
 import org.apache.iceberg.Schema;
@@ -29,18 +31,17 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.util.StructLikeWrapper;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.Assert;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 public class TestInternalRowWrapper extends RecordWrapperTest {
 
-  @Ignore
+  @Disabled
   @Override
   public void testTimestampWithoutZone() {
     // Spark does not support timestamp without zone.
   }
 
-  @Ignore
+  @Disabled
   @Override
   public void testTime() {
     // Spark does not support time fields.
@@ -62,8 +63,8 @@ public class TestInternalRowWrapper extends RecordWrapperTest {
     StructLikeWrapper actualWrapper = StructLikeWrapper.forType(schema.asStruct());
     StructLikeWrapper expectedWrapper = StructLikeWrapper.forType(schema.asStruct());
     for (int i = 0; i < numRecords; i++) {
-      Assert.assertTrue("Should have more records", actual.hasNext());
-      Assert.assertTrue("Should have more InternalRow", expected.hasNext());
+      assertThat(actual).as("Should have more records").hasNext();
+      assertThat(expected).as("Should have more InternalRow").hasNext();
 
       StructLike recordStructLike = recordWrapper.wrap(actual.next());
       StructLike rowStructLike = rowWrapper.wrap(expected.next());
@@ -74,7 +75,7 @@ public class TestInternalRowWrapper extends RecordWrapperTest {
           expectedWrapper.set(rowStructLike));
     }
 
-    Assert.assertFalse("Shouldn't have more record", actual.hasNext());
-    Assert.assertFalse("Shouldn't have more InternalRow", expected.hasNext());
+    assertThat(actual).as("Shouldn't have more record").isExhausted();
+    assertThat(expected).as("Shouldn't have more InternalRow").isExhausted();
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -20,10 +20,12 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.PlanningMode.DISTRIBUTED;
 import static org.apache.iceberg.PlanningMode.LOCAL;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
@@ -39,6 +41,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PlanningMode;
 import org.apache.iceberg.Schema;
@@ -63,41 +69,37 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestPartitionPruning {
 
   private static final Configuration CONF = new Configuration();
   private static final HadoopTables TABLES = new HadoopTables(CONF);
 
-  @Parameterized.Parameters(name = "format = {0}, vectorized = {1}, planningMode = {2}")
+  @Parameters(name = "format = {0}, vectorized = {1}, planningMode = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"parquet", false, DISTRIBUTED},
-      {"parquet", true, LOCAL},
-      {"avro", false, DISTRIBUTED},
-      {"orc", false, LOCAL},
-      {"orc", true, DISTRIBUTED}
+      {FileFormat.PARQUET, false, DISTRIBUTED},
+      {FileFormat.PARQUET, true, LOCAL},
+      {FileFormat.AVRO, false, DISTRIBUTED},
+      {FileFormat.ORC, false, LOCAL},
+      {FileFormat.ORC, true, DISTRIBUTED}
     };
   }
 
-  private final String format;
-  private final boolean vectorized;
-  private final PlanningMode planningMode;
+  @Parameter(index = 0)
+  private FileFormat format;
 
-  public TestPartitionPruning(String format, boolean vectorized, PlanningMode planningMode) {
-    this.format = format;
-    this.vectorized = vectorized;
-    this.planningMode = planningMode;
-  }
+  @Parameter(index = 1)
+  private boolean vectorized;
+
+  @Parameter(index = 2)
+  private PlanningMode planningMode;
 
   private static SparkSession spark = null;
   private static JavaSparkContext sparkContext = null;
@@ -109,7 +111,7 @@ public class TestPartitionPruning {
   private static final Function<Object, Integer> HOUR_FUNC =
       Transforms.hour().bind(Types.TimestampType.withoutZone());
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
     TestPartitionPruning.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
@@ -133,7 +135,7 @@ public class TestPartitionPruning {
             DataTypes.IntegerType);
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestPartitionPruning.spark;
     TestPartitionPruning.spark = null;
@@ -167,7 +169,7 @@ public class TestPartitionPruning {
     return Instant.ofEpochMilli(TimeUnit.MICROSECONDS.toMillis(epochMicros));
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private java.nio.file.Path temp;
 
   private final PartitionSpec spec =
       PartitionSpec.builderFor(LOG_SCHEMA)
@@ -178,7 +180,7 @@ public class TestPartitionPruning {
           .hour("timestamp")
           .build();
 
-  @Test
+  @TestTemplate
   public void testPartitionPruningIdentityString() {
     String filterCond = "date >= '2020-02-03' AND level = 'DEBUG'";
     Predicate<Row> partCondition =
@@ -191,7 +193,7 @@ public class TestPartitionPruning {
     runTest(filterCond, partCondition);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionPruningBucketingInteger() {
     final int[] ids = new int[] {LOGS.get(3).getId(), LOGS.get(7).getId()};
     String condForIds =
@@ -208,7 +210,7 @@ public class TestPartitionPruning {
     runTest(filterCond, partCondition);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionPruningTruncatedString() {
     String filterCond = "message like 'info event%'";
     Predicate<Row> partCondition =
@@ -220,7 +222,7 @@ public class TestPartitionPruning {
     runTest(filterCond, partCondition);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionPruningTruncatedStringComparingValueShorterThanPartitionValue() {
     String filterCond = "message like 'inf%'";
     Predicate<Row> partCondition =
@@ -232,7 +234,7 @@ public class TestPartitionPruning {
     runTest(filterCond, partCondition);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionPruningHourlyPartition() {
     String filterCond;
     if (spark.version().startsWith("2")) {
@@ -256,7 +258,7 @@ public class TestPartitionPruning {
 
   private void runTest(String filterCond, Predicate<Row> partCondition) {
     File originTableLocation = createTempDir();
-    Assert.assertTrue("Temp folder should exist", originTableLocation.exists());
+    assertThat(originTableLocation).as("Temp folder should exist").exists();
 
     Table table = createTable(originTableLocation);
     Dataset<Row> logs = createTestDataset();
@@ -267,7 +269,7 @@ public class TestPartitionPruning {
             .filter(filterCond)
             .orderBy("id")
             .collectAsList();
-    Assert.assertFalse("Expected rows should be not empty", expected.isEmpty());
+    assertThat(expected).as("Expected rows should not be empty").isNotEmpty();
 
     // remove records which may be recorded during storing to table
     CountOpenLocalFileSystem.resetRecordsInPathPrefix(originTableLocation.getAbsolutePath());
@@ -282,16 +284,14 @@ public class TestPartitionPruning {
             .filter(filterCond)
             .orderBy("id")
             .collectAsList();
-    Assert.assertFalse("Actual rows should not be empty", actual.isEmpty());
-
-    Assert.assertEquals("Rows should match", expected, actual);
+    assertThat(actual).isNotEmpty().isEqualTo(expected);
 
     assertAccessOnDataFiles(originTableLocation, table, partCondition);
   }
 
   private File createTempDir() {
     try {
-      return temp.newFolder();
+      return Files.createTempDirectory(temp, "junit").toFile();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -301,7 +301,7 @@ public class TestPartitionPruning {
     String trackedTableLocation = CountOpenLocalFileSystem.convertPath(originTableLocation);
     Map<String, String> properties =
         ImmutableMap.of(
-            TableProperties.DEFAULT_FILE_FORMAT, format,
+            TableProperties.DEFAULT_FILE_FORMAT, format.toString(),
             TableProperties.DATA_PLANNING_MODE, planningMode.modeName(),
             TableProperties.DELETE_PLANNING_MODE, planningMode.modeName());
     return TABLES.create(LOG_SCHEMA, spec, properties, trackedTableLocation);
@@ -366,29 +366,31 @@ public class TestPartitionPruning {
     Set<String> filesToNotRead = extractFilePathsNotIn(files, filesToRead);
 
     // Just to be sure, they should be mutually exclusive.
-    Assert.assertTrue(Sets.intersection(filesToRead, filesToNotRead).isEmpty());
+    assertThat(filesToRead).doesNotContainAnyElementsOf(filesToNotRead);
 
-    Assert.assertFalse("The query should prune some data files.", filesToNotRead.isEmpty());
+    assertThat(filesToNotRead).as("The query should prune some data files.").isNotEmpty();
 
     // We don't check "all" data files bound to the condition are being read, as data files can be
     // pruned on
     // other conditions like lower/upper bound of columns.
-    Assert.assertFalse(
-        "Some of data files in partition range should be read. "
-            + "Read files in query: "
-            + readFilesInQuery
-            + " / data files in partition range: "
-            + filesToRead,
-        Sets.intersection(filesToRead, readFilesInQuery).isEmpty());
+    assertThat(filesToRead)
+        .as(
+            "Some of data files in partition range should be read. "
+                + "Read files in query: "
+                + readFilesInQuery
+                + " / data files in partition range: "
+                + filesToRead)
+        .containsAnyElementsOf(readFilesInQuery);
 
     // Data files which aren't bound to the condition shouldn't be read.
-    Assert.assertTrue(
-        "Data files outside of partition range should not be read. "
-            + "Read files in query: "
-            + readFilesInQuery
-            + " / data files outside of partition range: "
-            + filesToNotRead,
-        Sets.intersection(filesToNotRead, readFilesInQuery).isEmpty());
+    assertThat(filesToNotRead)
+        .as(
+            "Data files outside of partition range should not be read. "
+                + "Read files in query: "
+                + readFilesInQuery
+                + " / data files outside of partition range: "
+                + filesToNotRead)
+        .doesNotContainAnyElementsOf(readFilesInQuery);
   }
 
   private Set<String> extractFilePathsMatchingConditionOnPartition(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -20,14 +20,21 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -52,26 +59,22 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestPartitionValues {
-  @Parameterized.Parameters(name = "format = {0}, vectorized = {1}")
+  @Parameters(name = "format = {0}, vectorized = {1}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"parquet", false},
-      {"parquet", true},
-      {"avro", false},
-      {"orc", false},
-      {"orc", true}
+      {FileFormat.PARQUET, false},
+      {FileFormat.PARQUET, true},
+      {FileFormat.AVRO, false},
+      {FileFormat.ORC, false},
+      {FileFormat.ORC, true}
     };
   }
 
@@ -102,39 +105,37 @@ public class TestPartitionValues {
 
   private static SparkSession spark = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestPartitionValues.spark = SparkSession.builder().master("local[2]").getOrCreate();
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestPartitionValues.spark;
     TestPartitionValues.spark = null;
     currentSpark.stop();
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
-  private final String format;
-  private final boolean vectorized;
+  @Parameter(index = 0)
+  private FileFormat format;
 
-  public TestPartitionValues(String format, boolean vectorized) {
-    this.format = format;
-    this.vectorized = vectorized;
-  }
+  @Parameter(index = 1)
+  private boolean vectorized;
 
-  @Test
-  public void testNullPartitionValue() throws Exception {
+  @TestTemplate
+  public void testNullPartitionValue() {
     String desc = "null_part";
-    File parent = temp.newFolder(desc);
+    File parent = new File(temp.toFile(), desc);
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());
+    assertThat(dataFolder.mkdirs()).as("mkdirs should succeed").isTrue();
 
     HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     Table table = tables.create(SIMPLE_SCHEMA, SPEC, location.toString());
-    table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
+    table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format.toString()).commit();
 
     List<SimpleRecord> expected =
         Lists.newArrayList(
@@ -161,21 +162,20 @@ public class TestPartitionValues {
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testReorderedColumns() throws Exception {
     String desc = "reorder_columns";
-    File parent = temp.newFolder(desc);
+    File parent = new File(temp.toFile(), desc);
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());
+    assertThat(dataFolder.mkdirs()).as("mkdirs should succeed").isTrue();
 
     HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     Table table = tables.create(SIMPLE_SCHEMA, SPEC, location.toString());
-    table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
+    table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format.toString()).commit();
 
     List<SimpleRecord> expected =
         Lists.newArrayList(
@@ -200,21 +200,20 @@ public class TestPartitionValues {
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testReorderedColumnsNoNullability() throws Exception {
     String desc = "reorder_columns_no_nullability";
-    File parent = temp.newFolder(desc);
+    File parent = new File(temp.toFile(), desc);
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());
+    assertThat(dataFolder.mkdirs()).as("mkdirs should succeed").isTrue();
 
     HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     Table table = tables.create(SIMPLE_SCHEMA, SPEC, location.toString());
-    table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
+    table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format.toString()).commit();
 
     List<SimpleRecord> expected =
         Lists.newArrayList(
@@ -240,11 +239,10 @@ public class TestPartitionValues {
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
+  @TestTemplate
   public void testPartitionValueTypes() throws Exception {
     String[] columnNames =
         new String[] {
@@ -254,13 +252,13 @@ public class TestPartitionValues {
     HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
 
     // create a table around the source data
-    String sourceLocation = temp.newFolder("source_table").toString();
+    String sourceLocation = temp.resolve("source_table").toString();
     Table source = tables.create(SUPPORTED_PRIMITIVES, sourceLocation);
 
     // write out an Avro data file with all of the data types for source data
     List<GenericData.Record> expected = RandomData.generateList(source.schema(), 2, 128735L);
-    File avroData = temp.newFile("data.avro");
-    Assert.assertTrue(avroData.delete());
+    File avroData = File.createTempFile("data", ".avro", temp.toFile());
+    assertThat(avroData.delete()).isTrue();
     try (FileAppender<GenericData.Record> appender =
         Avro.write(Files.localOutput(avroData)).schema(source.schema()).build()) {
       appender.addAll(expected);
@@ -286,15 +284,15 @@ public class TestPartitionValues {
     for (String column : columnNames) {
       String desc = "partition_by_" + SUPPORTED_PRIMITIVES.findType(column).toString();
 
-      File parent = temp.newFolder(desc);
+      File parent = new File(temp.toFile(), desc);
       File location = new File(parent, "test");
       File dataFolder = new File(location, "data");
-      Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());
+      assertThat(dataFolder.mkdirs()).as("mkdirs should succeed").isTrue();
 
       PartitionSpec spec = PartitionSpec.builderFor(SUPPORTED_PRIMITIVES).identity(column).build();
 
       Table table = tables.create(SUPPORTED_PRIMITIVES, spec, location.toString());
-      table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
+      table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format.toString()).commit();
 
       sourceDF
           .write()
@@ -311,7 +309,7 @@ public class TestPartitionValues {
               .load(location.toString())
               .collectAsList();
 
-      Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+      assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
 
       for (int i = 0; i < expected.size(); i += 1) {
         TestHelpers.assertEqualsSafe(
@@ -320,7 +318,7 @@ public class TestPartitionValues {
     }
   }
 
-  @Test
+  @TestTemplate
   public void testNestedPartitionValues() throws Exception {
     String[] columnNames =
         new String[] {
@@ -331,13 +329,13 @@ public class TestPartitionValues {
     Schema nestedSchema = new Schema(optional(1, "nested", SUPPORTED_PRIMITIVES.asStruct()));
 
     // create a table around the source data
-    String sourceLocation = temp.newFolder("source_table").toString();
+    String sourceLocation = temp.resolve("source_table").toString();
     Table source = tables.create(nestedSchema, sourceLocation);
 
     // write out an Avro data file with all of the data types for source data
     List<GenericData.Record> expected = RandomData.generateList(source.schema(), 2, 128735L);
-    File avroData = temp.newFile("data.avro");
-    Assert.assertTrue(avroData.delete());
+    File avroData = File.createTempFile("data", ".avro", temp.toFile());
+    assertThat(avroData.delete()).isTrue();
     try (FileAppender<GenericData.Record> appender =
         Avro.write(Files.localOutput(avroData)).schema(source.schema()).build()) {
       appender.addAll(expected);
@@ -363,16 +361,16 @@ public class TestPartitionValues {
     for (String column : columnNames) {
       String desc = "partition_by_" + SUPPORTED_PRIMITIVES.findType(column).toString();
 
-      File parent = temp.newFolder(desc);
+      File parent = new File(temp.toFile(), desc);
       File location = new File(parent, "test");
       File dataFolder = new File(location, "data");
-      Assert.assertTrue("mkdirs should succeed", dataFolder.mkdirs());
+      assertThat(dataFolder.mkdirs()).as("mkdirs should succeed").isTrue();
 
       PartitionSpec spec =
           PartitionSpec.builderFor(nestedSchema).identity("nested." + column).build();
 
       Table table = tables.create(nestedSchema, spec, location.toString());
-      table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
+      table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format.toString()).commit();
 
       sourceDF
           .write()
@@ -389,7 +387,7 @@ public class TestPartitionValues {
               .load(location.toString())
               .collectAsList();
 
-      Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+      assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
 
       for (int i = 0; i < expected.size(); i += 1) {
         TestHelpers.assertEqualsSafe(nestedSchema.asStruct(), expected.get(i), actual.get(i));
@@ -403,7 +401,7 @@ public class TestPartitionValues {
    * thrown with the message like: Cannot cast org.apache.spark.unsafe.types.UTF8String to
    * java.lang.CharSequence
    */
-  @Test
+  @TestTemplate
   public void testPartitionedByNestedString() throws Exception {
     // schema and partition spec
     Schema nestedSchema =
@@ -417,7 +415,7 @@ public class TestPartitionValues {
 
     // create table
     HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
-    String baseLocation = temp.newFolder("partition_by_nested_string").toString();
+    String baseLocation = temp.resolve("partition_by_nested_string").toString();
     tables.create(nestedSchema, spec, baseLocation);
 
     // input data frame
@@ -448,12 +446,12 @@ public class TestPartitionValues {
             .load(baseLocation)
             .collectAsList();
 
-    Assert.assertEquals("Number of rows should match", rows.size(), actual.size());
+    assertThat(actual).as("Number of rows should match").hasSameSizeAs(rows);
   }
 
-  @Test
+  @TestTemplate
   public void testReadPartitionColumn() throws Exception {
-    Assume.assumeTrue("Temporary skip ORC", !"orc".equals(format));
+    assumeThat(format).as("Temporary skip ORC").isNotEqualTo(FileFormat.ORC);
 
     Schema nestedSchema =
         new Schema(
@@ -469,9 +467,9 @@ public class TestPartitionValues {
 
     // create table
     HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
-    String baseLocation = temp.newFolder("partition_by_nested_string").toString();
+    String baseLocation = temp.resolve("partition_by_nested_string").toString();
     Table table = tables.create(nestedSchema, spec, baseLocation);
-    table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
+    table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format.toString()).commit();
 
     // write into iceberg
     MapFunction<Long, ComplexRecord> func =
@@ -495,10 +493,10 @@ public class TestPartitionValues {
             .as(Encoders.STRING())
             .collectAsList();
 
-    Assert.assertEquals("Number of rows should match", 10, actual.size());
+    assertThat(actual).as("Number of rows should match").hasSize(10);
 
     List<String> inputRecords =
         IntStream.range(0, 10).mapToObj(i -> "name_" + i).collect(Collectors.toList());
-    Assert.assertEquals("Read object should be matched", inputRecords, actual);
+    assertThat(actual).as("Read object should be matched").isEqualTo(inputRecords);
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Map;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -29,8 +31,7 @@ import org.apache.spark.sql.connector.expressions.aggregate.Count;
 import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
 import org.apache.spark.sql.connector.expressions.aggregate.Max;
 import org.apache.spark.sql.connector.expressions.aggregate.Min;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkAggregates {
 
@@ -50,27 +51,26 @@ public class TestSparkAggregates {
           Max max = new Max(namedReference);
           Expression expectedMax = Expressions.max(unquoted);
           Expression actualMax = SparkAggregates.convert(max);
-          Assert.assertEquals("Max must match", expectedMax.toString(), actualMax.toString());
+          assertThat(actualMax).asString().isEqualTo(expectedMax.toString());
 
           Min min = new Min(namedReference);
           Expression expectedMin = Expressions.min(unquoted);
           Expression actualMin = SparkAggregates.convert(min);
-          Assert.assertEquals("Min must match", expectedMin.toString(), actualMin.toString());
+          assertThat(actualMin).asString().isEqualTo(expectedMin.toString());
 
           Count count = new Count(namedReference, false);
           Expression expectedCount = Expressions.count(unquoted);
           Expression actualCount = SparkAggregates.convert(count);
-          Assert.assertEquals("Count must match", expectedCount.toString(), actualCount.toString());
+          assertThat(actualCount).asString().isEqualTo(expectedCount.toString());
 
           Count countDistinct = new Count(namedReference, true);
           Expression convertedCountDistinct = SparkAggregates.convert(countDistinct);
-          Assert.assertNull("Count Distinct is converted to null", convertedCountDistinct);
+          assertThat(convertedCountDistinct).as("Count Distinct is converted to null").isNull();
 
           CountStar countStar = new CountStar();
           Expression expectedCountStar = Expressions.countStar();
           Expression actualCountStar = SparkAggregates.convert(countStar);
-          Assert.assertEquals(
-              "CountStar must match", expectedCountStar.toString(), actualCountStar.toString());
+          assertThat(actualCountStar).asString().isEqualTo(expectedCountStar.toString());
         });
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -70,12 +70,11 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructType;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestSparkDataFile {
 
@@ -119,13 +118,13 @@ public class TestSparkDataFile {
   private static SparkSession spark;
   private static JavaSparkContext sparkContext = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestSparkDataFile.spark = SparkSession.builder().master("local[2]").getOrCreate();
     TestSparkDataFile.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestSparkDataFile.spark;
     TestSparkDataFile.spark = null;
@@ -133,12 +132,11 @@ public class TestSparkDataFile {
     currentSpark.stop();
   }
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private File tableDir;
   private String tableLocation = null;
 
-  @Before
+  @BeforeEach
   public void setupTableLocation() throws Exception {
-    File tableDir = temp.newFolder();
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStreamingOffset.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStreamingOffset.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Arrays;
 import org.apache.iceberg.util.JsonUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestStreamingOffset {
 
@@ -35,10 +36,9 @@ public class TestStreamingOffset {
           new StreamingOffset(System.currentTimeMillis(), 3L, false),
           new StreamingOffset(System.currentTimeMillis(), 4L, true)
         };
-    Assert.assertArrayEquals(
-        "StreamingOffsets should match",
-        expected,
-        Arrays.stream(expected).map(elem -> StreamingOffset.fromJson(elem.json())).toArray());
+    assertThat(Arrays.stream(expected).map(elem -> StreamingOffset.fromJson(elem.json())).toArray())
+        .as("StreamingOffsets should match")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -51,6 +51,6 @@ public class TestStreamingOffset {
     actual.put("scan_all_files", false);
     String expectedJson = expected.json();
     String actualJson = JsonUtil.mapper().writeValueAsString(actual);
-    Assert.assertEquals("Json should match", expectedJson, actualJson);
+    assertThat(actualJson).isEqualTo(expectedJson);
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
@@ -19,10 +19,12 @@
 package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
@@ -30,7 +32,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopTables;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
@@ -43,12 +44,10 @@ import org.apache.spark.sql.execution.streaming.MemoryStream;
 import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.StreamingQueryException;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import scala.Option;
 import scala.collection.JavaConverters;
 
@@ -60,9 +59,9 @@ public class TestStructuredStreaming {
           optional(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
   private static SparkSession spark = null;
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestStructuredStreaming.spark =
         SparkSession.builder()
@@ -71,7 +70,7 @@ public class TestStructuredStreaming {
             .getOrCreate();
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestStructuredStreaming.spark;
     TestStructuredStreaming.spark = null;
@@ -80,7 +79,7 @@ public class TestStructuredStreaming {
 
   @Test
   public void testStreamingWriteAppendMode() throws Exception {
-    File parent = temp.newFolder("parquet");
+    File parent = temp.resolve("parquet").toFile();
     File location = new File(parent, "test-table");
     File checkpoint = new File(parent, "checkpoint");
 
@@ -119,7 +118,7 @@ public class TestStructuredStreaming {
 
       // remove the last commit to force Spark to reprocess batch #1
       File lastCommitFile = new File(checkpoint + "/commits/1");
-      Assert.assertTrue("The commit file must be deleted", lastCommitFile.delete());
+      assertThat(lastCommitFile.delete()).as("The commit file must be deleted").isTrue();
       Files.deleteIfExists(Paths.get(checkpoint + "/commits/.1.crc"));
 
       // restart the query from the checkpoint
@@ -130,9 +129,8 @@ public class TestStructuredStreaming {
       Dataset<Row> result = spark.read().format("iceberg").load(location.toString());
       List<SimpleRecord> actual =
           result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-      Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-      Assert.assertEquals("Result rows should match", expected, actual);
-      Assert.assertEquals("Number of snapshots should match", 2, Iterables.size(table.snapshots()));
+      assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+      assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {
         query.stop();
@@ -142,7 +140,7 @@ public class TestStructuredStreaming {
 
   @Test
   public void testStreamingWriteCompleteMode() throws Exception {
-    File parent = temp.newFolder("parquet");
+    File parent = temp.resolve("parquet").toFile();
     File location = new File(parent, "test-table");
     File checkpoint = new File(parent, "checkpoint");
 
@@ -180,7 +178,7 @@ public class TestStructuredStreaming {
 
       // remove the last commit to force Spark to reprocess batch #1
       File lastCommitFile = new File(checkpoint + "/commits/1");
-      Assert.assertTrue("The commit file must be deleted", lastCommitFile.delete());
+      assertThat(lastCommitFile.delete()).as("The commit file must be deleted").isTrue();
       Files.deleteIfExists(Paths.get(checkpoint + "/commits/.1.crc"));
 
       // restart the query from the checkpoint
@@ -191,9 +189,8 @@ public class TestStructuredStreaming {
       Dataset<Row> result = spark.read().format("iceberg").load(location.toString());
       List<SimpleRecord> actual =
           result.orderBy("data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-      Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-      Assert.assertEquals("Result rows should match", expected, actual);
-      Assert.assertEquals("Number of snapshots should match", 2, Iterables.size(table.snapshots()));
+      assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+      assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {
         query.stop();
@@ -203,7 +200,7 @@ public class TestStructuredStreaming {
 
   @Test
   public void testStreamingWriteCompleteModeWithProjection() throws Exception {
-    File parent = temp.newFolder("parquet");
+    File parent = temp.resolve("parquet").toFile();
     File location = new File(parent, "test-table");
     File checkpoint = new File(parent, "checkpoint");
 
@@ -241,7 +238,7 @@ public class TestStructuredStreaming {
 
       // remove the last commit to force Spark to reprocess batch #1
       File lastCommitFile = new File(checkpoint + "/commits/1");
-      Assert.assertTrue("The commit file must be deleted", lastCommitFile.delete());
+      assertThat(lastCommitFile.delete()).as("The commit file must be deleted").isTrue();
       Files.deleteIfExists(Paths.get(checkpoint + "/commits/.1.crc"));
 
       // restart the query from the checkpoint
@@ -252,9 +249,8 @@ public class TestStructuredStreaming {
       Dataset<Row> result = spark.read().format("iceberg").load(location.toString());
       List<SimpleRecord> actual =
           result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-      Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-      Assert.assertEquals("Result rows should match", expected, actual);
-      Assert.assertEquals("Number of snapshots should match", 2, Iterables.size(table.snapshots()));
+      assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+      assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {
         query.stop();
@@ -264,7 +260,7 @@ public class TestStructuredStreaming {
 
   @Test
   public void testStreamingWriteUpdateMode() throws Exception {
-    File parent = temp.newFolder("parquet");
+    File parent = temp.resolve("parquet").toFile();
     File location = new File(parent, "test-table");
     File checkpoint = new File(parent, "checkpoint");
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
@@ -21,10 +21,11 @@ package org.apache.iceberg.spark.source;
 import static org.apache.iceberg.spark.SparkSchemaUtil.convert;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -49,12 +50,10 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestWriteMetricsConfig {
 
@@ -73,18 +72,18 @@ public class TestWriteMetricsConfig {
                   required(4, "id", Types.IntegerType.get()),
                   required(5, "data", Types.StringType.get()))));
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
   private static SparkSession spark = null;
   private static JavaSparkContext sc = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestWriteMetricsConfig.spark = SparkSession.builder().master("local[2]").getOrCreate();
     TestWriteMetricsConfig.sc = JavaSparkContext.fromSparkContext(spark.sparkContext());
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestWriteMetricsConfig.spark;
     TestWriteMetricsConfig.spark = null;
@@ -93,8 +92,8 @@ public class TestWriteMetricsConfig {
   }
 
   @Test
-  public void testFullMetricsCollectionForParquet() throws IOException {
-    String tableLocation = temp.newFolder("iceberg-table").toString();
+  public void testFullMetricsCollectionForParquet() {
+    String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.unpartitioned();
@@ -116,16 +115,16 @@ public class TestWriteMetricsConfig {
 
     for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
       DataFile file = task.file();
-      Assert.assertEquals(2, file.nullValueCounts().size());
-      Assert.assertEquals(2, file.valueCounts().size());
-      Assert.assertEquals(2, file.lowerBounds().size());
-      Assert.assertEquals(2, file.upperBounds().size());
+      assertThat(file.nullValueCounts()).hasSize(2);
+      assertThat(file.valueCounts()).hasSize(2);
+      assertThat(file.lowerBounds()).hasSize(2);
+      assertThat(file.upperBounds()).hasSize(2);
     }
   }
 
   @Test
-  public void testCountMetricsCollectionForParquet() throws IOException {
-    String tableLocation = temp.newFolder("iceberg-table").toString();
+  public void testCountMetricsCollectionForParquet() {
+    String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.unpartitioned();
@@ -147,16 +146,16 @@ public class TestWriteMetricsConfig {
 
     for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
       DataFile file = task.file();
-      Assert.assertEquals(2, file.nullValueCounts().size());
-      Assert.assertEquals(2, file.valueCounts().size());
-      Assert.assertTrue(file.lowerBounds().isEmpty());
-      Assert.assertTrue(file.upperBounds().isEmpty());
+      assertThat(file.nullValueCounts()).hasSize(2);
+      assertThat(file.valueCounts()).hasSize(2);
+      assertThat(file.lowerBounds()).isEmpty();
+      assertThat(file.upperBounds()).isEmpty();
     }
   }
 
   @Test
-  public void testNoMetricsCollectionForParquet() throws IOException {
-    String tableLocation = temp.newFolder("iceberg-table").toString();
+  public void testNoMetricsCollectionForParquet() {
+    String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.unpartitioned();
@@ -178,16 +177,16 @@ public class TestWriteMetricsConfig {
 
     for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
       DataFile file = task.file();
-      Assert.assertTrue(file.nullValueCounts().isEmpty());
-      Assert.assertTrue(file.valueCounts().isEmpty());
-      Assert.assertTrue(file.lowerBounds().isEmpty());
-      Assert.assertTrue(file.upperBounds().isEmpty());
+      assertThat(file.nullValueCounts()).isEmpty();
+      assertThat(file.valueCounts()).isEmpty();
+      assertThat(file.lowerBounds()).isEmpty();
+      assertThat(file.upperBounds()).isEmpty();
     }
   }
 
   @Test
-  public void testCustomMetricCollectionForParquet() throws IOException {
-    String tableLocation = temp.newFolder("iceberg-table").toString();
+  public void testCustomMetricCollectionForParquet() {
+    String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.unpartitioned();
@@ -212,18 +211,16 @@ public class TestWriteMetricsConfig {
     Types.NestedField id = schema.findField("id");
     for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
       DataFile file = task.file();
-      Assert.assertEquals(2, file.nullValueCounts().size());
-      Assert.assertEquals(2, file.valueCounts().size());
-      Assert.assertEquals(1, file.lowerBounds().size());
-      Assert.assertTrue(file.lowerBounds().containsKey(id.fieldId()));
-      Assert.assertEquals(1, file.upperBounds().size());
-      Assert.assertTrue(file.upperBounds().containsKey(id.fieldId()));
+      assertThat(file.nullValueCounts()).hasSize(2);
+      assertThat(file.valueCounts()).hasSize(2);
+      assertThat(file.lowerBounds()).hasSize(1).containsKey(id.fieldId());
+      assertThat(file.upperBounds()).hasSize(1).containsKey(id.fieldId());
     }
   }
 
   @Test
-  public void testBadCustomMetricCollectionForParquet() throws IOException {
-    String tableLocation = temp.newFolder("iceberg-table").toString();
+  public void testBadCustomMetricCollectionForParquet() {
+    String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.unpartitioned();
@@ -238,8 +235,8 @@ public class TestWriteMetricsConfig {
   }
 
   @Test
-  public void testCustomMetricCollectionForNestedParquet() throws IOException {
-    String tableLocation = temp.newFolder("iceberg-table").toString();
+  public void testCustomMetricCollectionForNestedParquet() {
+    String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.builderFor(COMPLEX_SCHEMA).identity("strCol").build();
@@ -270,28 +267,26 @@ public class TestWriteMetricsConfig {
       DataFile file = task.file();
 
       Map<Integer, Long> nullValueCounts = file.nullValueCounts();
-      Assert.assertEquals(3, nullValueCounts.size());
-      Assert.assertTrue(nullValueCounts.containsKey(longCol.fieldId()));
-      Assert.assertTrue(nullValueCounts.containsKey(recordId.fieldId()));
-      Assert.assertTrue(nullValueCounts.containsKey(recordData.fieldId()));
+      assertThat(nullValueCounts)
+          .hasSize(3)
+          .containsKeys(longCol.fieldId(), recordId.fieldId(), recordData.fieldId());
 
       Map<Integer, Long> valueCounts = file.valueCounts();
-      Assert.assertEquals(3, valueCounts.size());
-      Assert.assertTrue(valueCounts.containsKey(longCol.fieldId()));
-      Assert.assertTrue(valueCounts.containsKey(recordId.fieldId()));
-      Assert.assertTrue(valueCounts.containsKey(recordData.fieldId()));
+      assertThat(valueCounts)
+          .hasSize(3)
+          .containsKeys(longCol.fieldId(), recordId.fieldId(), recordData.fieldId());
 
       Map<Integer, ByteBuffer> lowerBounds = file.lowerBounds();
-      Assert.assertEquals(2, lowerBounds.size());
-      Assert.assertTrue(lowerBounds.containsKey(recordId.fieldId()));
+      assertThat(lowerBounds).hasSize(2).containsKey(recordId.fieldId());
+
       ByteBuffer recordDataLowerBound = lowerBounds.get(recordData.fieldId());
-      Assert.assertEquals(2, ByteBuffers.toByteArray(recordDataLowerBound).length);
+      assertThat(ByteBuffers.toByteArray(recordDataLowerBound)).hasSize(2);
 
       Map<Integer, ByteBuffer> upperBounds = file.upperBounds();
-      Assert.assertEquals(2, upperBounds.size());
-      Assert.assertTrue(upperBounds.containsKey(recordId.fieldId()));
+      assertThat(upperBounds).hasSize(2).containsKey(recordId.fieldId());
+
       ByteBuffer recordDataUpperBound = upperBounds.get(recordData.fieldId());
-      Assert.assertEquals(2, ByteBuffers.toByteArray(recordDataUpperBound).length);
+      assertThat(ByteBuffers.toByteArray(recordDataUpperBound)).hasSize(2);
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -108,7 +108,7 @@ public class TestForwardCompatibility {
     File parent = temp.resolve("avro").toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    dataFolder.mkdirs();
+    assertThat(dataFolder.mkdirs()).isTrue();
 
     HadoopTables tables = new HadoopTables(CONF);
     tables.create(SCHEMA, UNKNOWN_SPEC, location.toString());
@@ -135,9 +135,9 @@ public class TestForwardCompatibility {
     File parent = temp.resolve("avro").toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    dataFolder.mkdirs();
+    assertThat(dataFolder.mkdirs()).isTrue();
     File checkpoint = new File(parent, "checkpoint");
-    checkpoint.mkdirs();
+    assertThat(checkpoint.mkdirs()).isTrue();
 
     HadoopTables tables = new HadoopTables(CONF);
     tables.create(SCHEMA, UNKNOWN_SPEC, location.toString());
@@ -167,7 +167,7 @@ public class TestForwardCompatibility {
     File parent = temp.resolve("avro").toFile();
     File location = new File(parent, "test");
     File dataFolder = new File(location, "data");
-    dataFolder.mkdirs();
+    assertThat(dataFolder.mkdirs()).isTrue();
 
     HadoopTables tables = new HadoopTables(CONF);
     Table table = tables.create(SCHEMA, UNKNOWN_SPEC, location.toString());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -60,64 +60,84 @@ public class TestIcebergSpark {
   public void testRegisterIntegerBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_int_16", DataTypes.IntegerType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_int_16(1)").collectAsList();
-
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1)));
   }
 
   @Test
   public void testRegisterShortBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_short_16", DataTypes.ShortType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_short_16(1S)").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1)));
   }
 
   @Test
   public void testRegisterByteBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_byte_16", DataTypes.ByteType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_byte_16(1Y)").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1)));
   }
 
   @Test
   public void testRegisterLongBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_long_16", DataTypes.LongType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_long_16(1L)").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(Transforms.bucket(16).bind(Types.LongType.get()).apply(1L));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.LongType.get()).apply(1L)));
   }
 
   @Test
   public void testRegisterStringBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_string_16", DataTypes.StringType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_string_16('hello')").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello")));
   }
 
   @Test
   public void testRegisterCharBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_char_16", new CharType(5), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_char_16('hello')").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello")));
   }
 
   @Test
   public void testRegisterVarCharBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_varchar_16", new VarcharType(5), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_varchar_16('hello')").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.bucket(16).bind(Types.StringType.get()).apply("hello")));
   }
 
   @Test
@@ -125,12 +145,15 @@ public class TestIcebergSpark {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_date_16", DataTypes.DateType, 16);
     List<Row> results =
         spark.sql("SELECT iceberg_bucket_date_16(DATE '2021-06-30')").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(
-            Transforms.bucket(16)
-                .bind(Types.DateType.get())
-                .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(
+                        Transforms.bucket(16)
+                            .bind(Types.DateType.get())
+                            .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30")))));
   }
 
   @Test
@@ -141,35 +164,47 @@ public class TestIcebergSpark {
         spark
             .sql("SELECT iceberg_bucket_timestamp_16(TIMESTAMP '2021-06-30 00:00:00.000')")
             .collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(
-            Transforms.bucket(16)
-                .bind(Types.TimestampType.withZone())
-                .apply(
-                    DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2021-06-30 00:00:00.000"))));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(
+                        Transforms.bucket(16)
+                            .bind(Types.TimestampType.withZone())
+                            .apply(
+                                DateTimeUtils.fromJavaTimestamp(
+                                    Timestamp.valueOf("2021-06-30 00:00:00.000")))));
   }
 
   @Test
   public void testRegisterBinaryBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_binary_16", DataTypes.BinaryType, 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_binary_16(X'0020001F')").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(
-            Transforms.bucket(16)
-                .bind(Types.BinaryType.get())
-                .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(
+                        Transforms.bucket(16)
+                            .bind(Types.BinaryType.get())
+                            .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F}))));
   }
 
   @Test
   public void testRegisterDecimalBucketUDF() {
     IcebergSpark.registerBucketUDF(spark, "iceberg_bucket_decimal_16", new DecimalType(4, 2), 16);
     List<Row> results = spark.sql("SELECT iceberg_bucket_decimal_16(11.11)").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(
-            Transforms.bucket(16).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(
+                        Transforms.bucket(16)
+                            .bind(Types.DecimalType.of(4, 2))
+                            .apply(new BigDecimal("11.11"))));
   }
 
   @Test
@@ -206,36 +241,50 @@ public class TestIcebergSpark {
   public void testRegisterIntegerTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_int_4", DataTypes.IntegerType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_int_4(1)").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getInt(0))
-        .isEqualTo(Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getInt(0))
+                    .isEqualTo(Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1)));
   }
 
   @Test
   public void testRegisterLongTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_long_4", DataTypes.LongType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_long_4(1L)").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getLong(0))
-        .isEqualTo(Transforms.truncate(4).bind(Types.LongType.get()).apply(1L));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getLong(0))
+                    .isEqualTo(Transforms.truncate(4).bind(Types.LongType.get()).apply(1L)));
   }
 
   @Test
   public void testRegisterDecimalTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_decimal_4", new DecimalType(4, 2), 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_decimal_4(11.11)").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getDecimal(0))
-        .isEqualTo(
-            Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getDecimal(0))
+                    .isEqualTo(
+                        Transforms.truncate(4)
+                            .bind(Types.DecimalType.of(4, 2))
+                            .apply(new BigDecimal("11.11"))));
   }
 
   @Test
   public void testRegisterStringTruncateUDF() {
     IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_string_4", DataTypes.StringType, 4);
     List<Row> results = spark.sql("SELECT iceberg_truncate_string_4('hello')").collectAsList();
-    assertThat(results).hasSize(1);
-    assertThat(results.get(0).getString(0))
-        .isEqualTo(Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"));
+    assertThat(results)
+        .singleElement()
+        .satisfies(
+            row ->
+                assertThat(row.getString(0))
+                    .isEqualTo(Transforms.truncate(4).bind(Types.StringType.get()).apply("hello")));
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -83,16 +84,16 @@ public class TestPartitionPruning {
   @Parameters(name = "format = {0}, vectorized = {1}, planningMode = {2}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"parquet", false, DISTRIBUTED},
-      {"parquet", true, LOCAL},
-      {"avro", false, DISTRIBUTED},
-      {"orc", false, LOCAL},
-      {"orc", true, DISTRIBUTED}
+      {FileFormat.PARQUET, false, DISTRIBUTED},
+      {FileFormat.PARQUET, true, LOCAL},
+      {FileFormat.AVRO, false, DISTRIBUTED},
+      {FileFormat.ORC, false, LOCAL},
+      {FileFormat.ORC, true, DISTRIBUTED}
     };
   }
 
   @Parameter(index = 0)
-  private String format;
+  private FileFormat format;
 
   @Parameter(index = 1)
   private boolean vectorized;
@@ -283,9 +284,7 @@ public class TestPartitionPruning {
             .filter(filterCond)
             .orderBy("id")
             .collectAsList();
-    assertThat(actual).as("Actual rows should not be empty").isNotEmpty();
-
-    assertThat(actual).as("Rows should match").isEqualTo(expected);
+    assertThat(actual).isNotEmpty().isEqualTo(expected);
 
     assertAccessOnDataFiles(originTableLocation, table, partCondition);
   }
@@ -302,7 +301,7 @@ public class TestPartitionPruning {
     String trackedTableLocation = CountOpenLocalFileSystem.convertPath(originTableLocation);
     Map<String, String> properties =
         ImmutableMap.of(
-            TableProperties.DEFAULT_FILE_FORMAT, format,
+            TableProperties.DEFAULT_FILE_FORMAT, format.toString(),
             TableProperties.DATA_PLANNING_MODE, planningMode.modeName(),
             TableProperties.DELETE_PLANNING_MODE, planningMode.modeName());
     return TABLES.create(LOG_SCHEMA, spec, properties, trackedTableLocation);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAggregates.java
@@ -51,23 +51,17 @@ public class TestSparkAggregates {
           Max max = new Max(namedReference);
           Expression expectedMax = Expressions.max(unquoted);
           Expression actualMax = SparkAggregates.convert(max);
-          assertThat(String.valueOf(actualMax))
-              .as("Max must match")
-              .isEqualTo(expectedMax.toString());
+          assertThat(actualMax).asString().isEqualTo(expectedMax.toString());
 
           Min min = new Min(namedReference);
           Expression expectedMin = Expressions.min(unquoted);
           Expression actualMin = SparkAggregates.convert(min);
-          assertThat(String.valueOf(actualMin))
-              .as("Min must match")
-              .isEqualTo(expectedMin.toString());
+          assertThat(actualMin).asString().isEqualTo(expectedMin.toString());
 
           Count count = new Count(namedReference, false);
           Expression expectedCount = Expressions.count(unquoted);
           Expression actualCount = SparkAggregates.convert(count);
-          assertThat(String.valueOf(actualCount))
-              .as("Count must match")
-              .isEqualTo(expectedCount.toString());
+          assertThat(actualCount).asString().isEqualTo(expectedCount.toString());
 
           Count countDistinct = new Count(namedReference, true);
           Expression convertedCountDistinct = SparkAggregates.convert(countDistinct);
@@ -76,9 +70,7 @@ public class TestSparkAggregates {
           CountStar countStar = new CountStar();
           Expression expectedCountStar = Expressions.countStar();
           Expression actualCountStar = SparkAggregates.convert(countStar);
-          assertThat(String.valueOf(actualCountStar))
-              .as("CountStar must match")
-              .isEqualTo(expectedCountStar.toString());
+          assertThat(actualCountStar).asString().isEqualTo(expectedCountStar.toString());
         });
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -136,7 +136,7 @@ public class TestSparkDataFile {
   private String tableLocation = null;
 
   @BeforeEach
-  public void setupTableLocation() throws Exception {
+  public void setupTableLocation() {
     this.tableLocation = tableDir.toURI().toString();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
@@ -130,8 +130,7 @@ public class TestStructuredStreaming {
       List<SimpleRecord> actual =
           result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-      assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-      assertThat(actual).as("Result rows should match").isEqualTo(expected);
+      assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
       assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {
@@ -192,8 +191,7 @@ public class TestStructuredStreaming {
       List<SimpleRecord> actual =
           result.orderBy("data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-      assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-      assertThat(actual).as("Result rows should match").isEqualTo(expected);
+      assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
       assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {
@@ -254,8 +252,7 @@ public class TestStructuredStreaming {
       List<SimpleRecord> actual =
           result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
 
-      assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-      assertThat(actual).as("Result rows should match").isEqualTo(expected);
+      assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
       assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
@@ -24,7 +24,6 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.List;
@@ -93,7 +92,7 @@ public class TestWriteMetricsConfig {
   }
 
   @Test
-  public void testFullMetricsCollectionForParquet() throws IOException {
+  public void testFullMetricsCollectionForParquet() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -116,7 +115,6 @@ public class TestWriteMetricsConfig {
 
     for (FileScanTask task : table.newScan().includeColumnStats().planFiles()) {
       DataFile file = task.file();
-
       assertThat(file.nullValueCounts()).hasSize(2);
       assertThat(file.valueCounts()).hasSize(2);
       assertThat(file.lowerBounds()).hasSize(2);
@@ -125,7 +123,7 @@ public class TestWriteMetricsConfig {
   }
 
   @Test
-  public void testCountMetricsCollectionForParquet() throws IOException {
+  public void testCountMetricsCollectionForParquet() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -156,7 +154,7 @@ public class TestWriteMetricsConfig {
   }
 
   @Test
-  public void testNoMetricsCollectionForParquet() throws IOException {
+  public void testNoMetricsCollectionForParquet() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -187,7 +185,7 @@ public class TestWriteMetricsConfig {
   }
 
   @Test
-  public void testCustomMetricCollectionForParquet() throws IOException {
+  public void testCustomMetricCollectionForParquet() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -221,7 +219,7 @@ public class TestWriteMetricsConfig {
   }
 
   @Test
-  public void testBadCustomMetricCollectionForParquet() throws IOException {
+  public void testBadCustomMetricCollectionForParquet() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -237,7 +235,7 @@ public class TestWriteMetricsConfig {
   }
 
   @Test
-  public void testCustomMetricCollectionForNestedParquet() throws IOException {
+  public void testCustomMetricCollectionForNestedParquet() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -271,16 +269,12 @@ public class TestWriteMetricsConfig {
       Map<Integer, Long> nullValueCounts = file.nullValueCounts();
       assertThat(nullValueCounts)
           .hasSize(3)
-          .containsKey(longCol.fieldId())
-          .containsKey(recordId.fieldId())
-          .containsKey(recordData.fieldId());
+          .containsKeys(longCol.fieldId(), recordId.fieldId(), recordData.fieldId());
 
       Map<Integer, Long> valueCounts = file.valueCounts();
       assertThat(valueCounts)
           .hasSize(3)
-          .containsKey(longCol.fieldId())
-          .containsKey(recordId.fieldId())
-          .containsKey(recordData.fieldId());
+          .containsKeys(longCol.fieldId(), recordId.fieldId(), recordData.fieldId());
 
       Map<Integer, ByteBuffer> lowerBounds = file.lowerBounds();
       assertThat(lowerBounds).hasSize(2).containsKey(recordId.fieldId());


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrates the following tests in `spark.source` to JUnit 5 with AssertJ:

* `TestBaseReader` 
* `TestFilteredScan`
* `TestForwardCompatibility`
* `TestIcebergSpark` including refactoring Spark 3.5 tests
* `TestInternalRowWrapper`
* `TestPartitionPruning` including refactoring Spark 3.5 tests
* `TestPartitionValues` including refactoring Spark 3.5 tests
* `TestSparkAggregates` including refactoring Spark 3.5 tests
* `TestSparkDataFile`
* `TestSparkReaderWithBloomFilter`
* `TestStreamingOffset`
* `TestStructuredStreaming` including refactoring Spark 3.5 tests
* `TestWriteMetricsConfig` including refactoring Spark 3.5 tests

Plus, add `TestExpireSnapshotsAction`  which is partially migrated. 
