### PR TITLE
typo: `next_row_id` -> `next-row-id`

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -1685,7 +1685,7 @@ Row-level delete changes:
 Row lineage changes:
 
 * Writers must set the table's `next-row-id` and use the existing `next-row-id` as the `first-row-id` when creating new snapshots
-    * When a table is upgraded to v3, `next_row_id` should be initialized to 0
+    * When a table is upgraded to v3, `next-row-id` should be initialized to 0
     * When committing a new snapshot `next-row-id` must be incremented by at least the number of newly assigned row ids in the snapshot
     * It is recommended to increment `next-row-id` by the total `added_rows_count` and `existing_rows_count` of all manifests assigned a `first_row_id`
 * Writers must assign a `first_row_id` to new data manifests when writing a manifest list


### PR DESCRIPTION
Everything else is referenced as `next-row-id` 