### PR TITLE
Spark 3.4: Migrate other JUnit 4 dependant tests to JUnit 5

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
@@ -57,7 +57,7 @@ public class SparkTestHelperBase {
   protected void assertEquals(
       String context, List<Object[]> expectedRows, List<Object[]> actualRows) {
     assertThat(actualRows)
-        .as(context + ": number of results should match")
+        .as("%s: number of results should match", context)
         .hasSameSizeAs(expectedRows);
     for (int row = 0; row < expectedRows.size(); row += 1) {
       Object[] expected = expectedRows.get(row);
@@ -84,7 +84,7 @@ public class SparkTestHelperBase {
         }
       } else if (expectedValue != ANY) {
         assertThat(actualValue)
-            .as(context + " col " + (col + 1) + " contents should match")
+            .as("%s contents should match", context)
             .isEqualTo(expectedValue);
       }
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.spark.sql.Row;
-import org.junit.Assert;
 
 public class SparkTestHelperBase {
   protected static final Object ANY = new Object();
@@ -55,12 +56,13 @@ public class SparkTestHelperBase {
 
   protected void assertEquals(
       String context, List<Object[]> expectedRows, List<Object[]> actualRows) {
-    Assert.assertEquals(
-        context + ": number of results should match", expectedRows.size(), actualRows.size());
+    assertThat(actualRows)
+        .as(context + ": number of results should match")
+        .hasSameSizeAs(expectedRows);
     for (int row = 0; row < expectedRows.size(); row += 1) {
       Object[] expected = expectedRows.get(row);
       Object[] actual = actualRows.get(row);
-      Assert.assertEquals("Number of columns should match", expected.length, actual.length);
+      assertThat(actual).as("Number of columns should match").hasSameSizeAs(expected);
       for (int col = 0; col < actualRows.get(row).length; col += 1) {
         String newContext = String.format("%s: row %d col %d", context, row + 1, col + 1);
         assertEquals(newContext, expected, actual);
@@ -69,19 +71,21 @@ public class SparkTestHelperBase {
   }
 
   protected void assertEquals(String context, Object[] expectedRow, Object[] actualRow) {
-    Assert.assertEquals("Number of columns should match", expectedRow.length, actualRow.length);
+    assertThat(actualRow).as("Number of columns should match").hasSameSizeAs(expectedRow);
     for (int col = 0; col < actualRow.length; col += 1) {
       Object expectedValue = expectedRow[col];
       Object actualValue = actualRow[col];
       if (expectedValue != null && expectedValue.getClass().isArray()) {
         String newContext = String.format("%s (nested col %d)", context, col + 1);
         if (expectedValue instanceof byte[]) {
-          Assert.assertArrayEquals(newContext, (byte[]) expectedValue, (byte[]) actualValue);
+          assertThat(actualValue).as(newContext).isEqualTo(expectedValue);
         } else {
           assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
         }
       } else if (expectedValue != ANY) {
-        Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
+        assertThat(actualValue)
+            .as(context + " col " + (col + 1) + " contents should match")
+            .isEqualTo(expectedValue);
       }
     }
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
@@ -83,9 +83,7 @@ public class SparkTestHelperBase {
           assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
         }
       } else if (expectedValue != ANY) {
-        assertThat(actualValue)
-            .as("%s contents should match", context)
-            .isEqualTo(expectedValue);
+        assertThat(actualValue).as("%s contents should match", context).isEqualTo(expectedValue);
       }
     }
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -18,7 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,8 +34,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestChangelogIterator extends SparkTestHelperBase {
   private static final String DELETE = ChangelogOperation.DELETE.name();
@@ -78,7 +78,7 @@ public class TestChangelogIterator extends SparkTestHelperBase {
         Arrays.asList(RowType.DELETED, RowType.INSERTED, RowType.CARRY_OVER, RowType.UPDATED),
         0,
         permutations);
-    Assert.assertEquals(24, permutations.size());
+    assertThat(permutations).hasSize(24);
 
     for (Object[] permutation : permutations) {
       validate(permutation);
@@ -196,10 +196,10 @@ public class TestChangelogIterator extends SparkTestHelperBase {
     Iterator<Row> iterator =
         ChangelogIterator.computeUpdates(rowsWithDuplication.iterator(), SCHEMA, IDENTIFIER_FIELDS);
 
-    assertThrows(
-        "Cannot compute updates because there are multiple rows with the same identifier fields([id, name]). Please make sure the rows are unique.",
-        IllegalStateException.class,
-        () -> Lists.newArrayList(iterator));
+    assertThatThrownBy(() -> Lists.newArrayList(iterator))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Cannot compute updates because there are multiple rows with the same identifier fields([id,name]). Please make sure the rows are unique.");
 
     // still allow extra insert rows
     rowsWithDuplication =

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -40,8 +42,7 @@ import org.apache.spark.sql.sources.IsNull;
 import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkFilters {
 
@@ -59,54 +60,68 @@ public class TestSparkFilters {
           IsNull isNull = IsNull.apply(quoted);
           Expression expectedIsNull = Expressions.isNull(unquoted);
           Expression actualIsNull = SparkFilters.convert(isNull);
-          Assert.assertEquals(
-              "IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
+          assertThat(actualIsNull)
+              .asString()
+              .as("IsNull must match")
+              .isEqualTo(expectedIsNull.toString());
 
           IsNotNull isNotNull = IsNotNull.apply(quoted);
           Expression expectedIsNotNull = Expressions.notNull(unquoted);
           Expression actualIsNotNull = SparkFilters.convert(isNotNull);
-          Assert.assertEquals(
-              "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
+          assertThat(actualIsNotNull)
+              .asString()
+              .as("IsNotNull must match")
+              .isEqualTo(expectedIsNotNull.toString());
 
           LessThan lt = LessThan.apply(quoted, 1);
           Expression expectedLt = Expressions.lessThan(unquoted, 1);
           Expression actualLt = SparkFilters.convert(lt);
-          Assert.assertEquals("LessThan must match", expectedLt.toString(), actualLt.toString());
+          assertThat(actualLt)
+              .asString()
+              .as("LessThan must match")
+              .isEqualTo(expectedLt.toString());
 
           LessThanOrEqual ltEq = LessThanOrEqual.apply(quoted, 1);
           Expression expectedLtEq = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualLtEq = SparkFilters.convert(ltEq);
-          Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq.toString(), actualLtEq.toString());
+          assertThat(actualLtEq)
+              .asString()
+              .as("LessThanOrEqual must match")
+              .isEqualTo(expectedLtEq.toString());
 
           GreaterThan gt = GreaterThan.apply(quoted, 1);
           Expression expectedGt = Expressions.greaterThan(unquoted, 1);
           Expression actualGt = SparkFilters.convert(gt);
-          Assert.assertEquals("GreaterThan must match", expectedGt.toString(), actualGt.toString());
+          assertThat(actualGt)
+              .asString()
+              .as("GreaterThan must match")
+              .isEqualTo(expectedGt.toString());
 
           GreaterThanOrEqual gtEq = GreaterThanOrEqual.apply(quoted, 1);
           Expression expectedGtEq = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualGtEq = SparkFilters.convert(gtEq);
-          Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq.toString(), actualGtEq.toString());
+          assertThat(actualGtEq)
+              .asString()
+              .as("GreaterThanOrEqual must match")
+              .isEqualTo(expectedGtEq.toString());
 
           EqualTo eq = EqualTo.apply(quoted, 1);
           Expression expectedEq = Expressions.equal(unquoted, 1);
           Expression actualEq = SparkFilters.convert(eq);
-          Assert.assertEquals("EqualTo must match", expectedEq.toString(), actualEq.toString());
+          assertThat(actualEq).asString().as("EqualTo must match").isEqualTo(expectedEq.toString());
 
           EqualNullSafe eqNullSafe = EqualNullSafe.apply(quoted, 1);
           Expression expectedEqNullSafe = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe = SparkFilters.convert(eqNullSafe);
-          Assert.assertEquals(
-              "EqualNullSafe must match",
-              expectedEqNullSafe.toString(),
-              actualEqNullSafe.toString());
+          assertThat(actualEqNullSafe)
+              .asString()
+              .as("EqualNullSafe must match")
+              .isEqualTo(expectedEqNullSafe.toString());
 
           In in = In.apply(quoted, new Integer[] {1});
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkFilters.convert(in);
-          Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+          assertThat(actualIn).asString().as("In must match").isEqualTo(expectedIn.toString());
         });
   }
 
@@ -120,14 +135,14 @@ public class TestSparkFilters {
     Expression timestampExpression = SparkFilters.convert(GreaterThan.apply("x", timestamp));
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    Assert.assertEquals(
-        "Generated Timestamp expression should be correct",
-        rawExpression.toString(),
-        timestampExpression.toString());
-    Assert.assertEquals(
-        "Generated Instant expression should be correct",
-        rawExpression.toString(),
-        instantExpression.toString());
+    assertThat(timestampExpression)
+        .asString()
+        .as("Generated Timestamp expression should be correct")
+        .isEqualTo(rawExpression.toString());
+    assertThat(instantExpression)
+        .asString()
+        .as("Generated Instant expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -139,10 +154,10 @@ public class TestSparkFilters {
     Expression instantExpression = SparkFilters.convert(GreaterThan.apply("x", ldt));
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    Assert.assertEquals(
-        "Generated Instant expression should be correct",
-        rawExpression.toString(),
-        instantExpression.toString());
+    assertThat(instantExpression)
+        .asString()
+        .as("Generated Instant expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -155,15 +170,15 @@ public class TestSparkFilters {
     Expression dateExpression = SparkFilters.convert(GreaterThan.apply("x", date));
     Expression rawExpression = Expressions.greaterThan("x", epochDay);
 
-    Assert.assertEquals(
-        "Generated localdate expression should be correct",
-        rawExpression.toString(),
-        localDateExpression.toString());
+    assertThat(localDateExpression)
+        .asString()
+        .as("Generated localdate expression should be correct")
+        .isEqualTo(rawExpression.toString());
 
-    Assert.assertEquals(
-        "Generated date expression should be correct",
-        rawExpression.toString(),
-        dateExpression.toString());
+    assertThat(dateExpression)
+        .asString()
+        .as("Generated date expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -171,7 +186,7 @@ public class TestSparkFilters {
     Not filter =
         Not.apply(And.apply(EqualTo.apply("col1", 1), In.apply("col2", new Integer[] {1, 2})));
     Expression converted = SparkFilters.convert(filter);
-    Assert.assertNull("Expression should not be converted", converted);
+    assertThat(converted).as("Expression should not be converted").isNull();
   }
 
   @Test
@@ -180,6 +195,6 @@ public class TestSparkFilters {
     Expression actual = SparkFilters.convert(filter);
     Expression expected =
         Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
-    Assert.assertEquals("Expressions should match", expected.toString(), actual.toString());
+    assertThat(actual).asString().as("Expressions should match").isEqualTo(expected.toString());
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -19,8 +19,8 @@
 package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.List;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
@@ -28,8 +28,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.MetadataAttribute;
 import org.apache.spark.sql.types.StructType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkSchemaUtil {
   private static final Schema TEST_SCHEMA =
@@ -44,24 +43,23 @@ public class TestSparkSchemaUtil {
           MetadataColumns.ROW_POSITION);
 
   @Test
-  public void testEstimateSizeMaxValue() throws IOException {
-    Assert.assertEquals(
-        "estimateSize returns Long max value",
-        Long.MAX_VALUE,
-        SparkSchemaUtil.estimateSize(null, Long.MAX_VALUE));
+  public void testEstimateSizeMaxValue() {
+    assertThat(SparkSchemaUtil.estimateSize(null, Long.MAX_VALUE))
+        .as("estimateSize returns Long max value")
+        .isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
-  public void testEstimateSizeWithOverflow() throws IOException {
+  public void testEstimateSizeWithOverflow() {
     long tableSize =
         SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), Long.MAX_VALUE - 1);
-    Assert.assertEquals("estimateSize handles overflow", Long.MAX_VALUE, tableSize);
+    assertThat(tableSize).as("estimateSize handles overflow").isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
-  public void testEstimateSize() throws IOException {
+  public void testEstimateSize() {
     long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), 1);
-    Assert.assertEquals("estimateSize matches with expected approximation", 24, tableSize);
+    assertThat(tableSize).as("estimateSize matches with expected approximation").isEqualTo(24);
   }
 
   @Test
@@ -71,13 +69,13 @@ public class TestSparkSchemaUtil {
         scala.collection.JavaConverters.seqAsJavaList(structType.toAttributes());
     for (AttributeReference attrRef : attrRefs) {
       if (MetadataColumns.isMetadataColumn(attrRef.name())) {
-        Assert.assertTrue(
-            "metadata columns should have __metadata_col in attribute metadata",
-            MetadataAttribute.unapply(attrRef).isDefined());
+        assertThat(MetadataAttribute.unapply(attrRef).isDefined())
+            .as("metadata columns should have __metadata_col in attribute metadata")
+            .isTrue();
       } else {
-        Assert.assertFalse(
-            "non metadata columns should not have __metadata_col in attribute metadata",
-            MetadataAttribute.unapply(attrRef).isDefined());
+        assertThat(MetadataAttribute.unapply(attrRef).isDefined())
+            .as("non metadata columns should not have __metadata_col in attribute metadata")
+            .isFalse();
       }
     }
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -29,8 +29,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkTableUtil {
   @Test
@@ -69,13 +68,15 @@ public class TestSparkTableUtil {
     MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
     MetricsConfig deserialized = KryoHelpers.roundTripSerialize(config);
 
-    Assert.assertEquals(
-        MetricsModes.Full.get().toString(), deserialized.columnMode("col1").toString());
-    Assert.assertEquals(
-        MetricsModes.Truncate.withLength(16).toString(),
-        deserialized.columnMode("col2").toString());
-    Assert.assertEquals(
-        MetricsModes.Counts.get().toString(), deserialized.columnMode("col3").toString());
+    assertThat(deserialized.columnMode("col1"))
+        .asString()
+        .isEqualTo(MetricsModes.Full.get().toString());
+    assertThat(deserialized.columnMode("col2"))
+        .asString()
+        .isEqualTo(MetricsModes.Truncate.withLength(16).toString());
+    assertThat(deserialized.columnMode("col3"))
+        .asString()
+        .isEqualTo(MetricsModes.Counts.get().toString());
   }
 
   @Test
@@ -92,12 +93,14 @@ public class TestSparkTableUtil {
     MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
     MetricsConfig deserialized = TestHelpers.roundTripSerialize(config);
 
-    Assert.assertEquals(
-        MetricsModes.Full.get().toString(), deserialized.columnMode("col1").toString());
-    Assert.assertEquals(
-        MetricsModes.Truncate.withLength(16).toString(),
-        deserialized.columnMode("col2").toString());
-    Assert.assertEquals(
-        MetricsModes.Counts.get().toString(), deserialized.columnMode("col3").toString());
+    assertThat(deserialized.columnMode("col1"))
+        .asString()
+        .isEqualTo(MetricsModes.Full.get().toString());
+    assertThat(deserialized.columnMode("col2"))
+        .asString()
+        .isEqualTo(MetricsModes.Truncate.withLength(16).toString());
+    assertThat(deserialized.columnMode("col3"))
+        .asString()
+        .isEqualTo(MetricsModes.Counts.get().toString());
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -52,8 +52,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkV2Filters {
 
@@ -90,98 +89,130 @@ public class TestSparkV2Filters {
           Predicate isNull = new Predicate("IS_NULL", attrOnly);
           Expression expectedIsNull = Expressions.isNull(unquoted);
           Expression actualIsNull = SparkV2Filters.convert(isNull);
-          Assert.assertEquals(
-              "IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
+          assertThat(actualIsNull)
+              .asString()
+              .as("IsNull must match")
+              .isEqualTo(expectedIsNull.toString());
 
           Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
           Expression expectedIsNotNull = Expressions.notNull(unquoted);
           Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
-          Assert.assertEquals(
-              "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
+          assertThat(actualIsNotNull)
+              .asString()
+              .as("IsNotNull must match")
+              .isEqualTo(expectedIsNotNull.toString());
 
           Predicate lt1 = new Predicate("<", attrAndValue);
           Expression expectedLt1 = Expressions.lessThan(unquoted, 1);
           Expression actualLt1 = SparkV2Filters.convert(lt1);
-          Assert.assertEquals("LessThan must match", expectedLt1.toString(), actualLt1.toString());
+          assertThat(actualLt1)
+              .asString()
+              .as("LessThan must match")
+              .isEqualTo(expectedLt1.toString());
 
           Predicate lt2 = new Predicate("<", valueAndAttr);
           Expression expectedLt2 = Expressions.greaterThan(unquoted, 1);
           Expression actualLt2 = SparkV2Filters.convert(lt2);
-          Assert.assertEquals("LessThan must match", expectedLt2.toString(), actualLt2.toString());
+          assertThat(actualLt2)
+              .asString()
+              .as("LessThan must match")
+              .isEqualTo(expectedLt2.toString());
 
           Predicate ltEq1 = new Predicate("<=", attrAndValue);
           Expression expectedLtEq1 = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualLtEq1 = SparkV2Filters.convert(ltEq1);
-          Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq1.toString(), actualLtEq1.toString());
+          assertThat(actualLtEq1)
+              .asString()
+              .as("LessThanOrEqual must match")
+              .isEqualTo(expectedLtEq1.toString());
 
           Predicate ltEq2 = new Predicate("<=", valueAndAttr);
           Expression expectedLtEq2 = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualLtEq2 = SparkV2Filters.convert(ltEq2);
-          Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq2.toString(), actualLtEq2.toString());
+          assertThat(actualLtEq2)
+              .asString()
+              .as("LessThanOrEqual must match")
+              .isEqualTo(expectedLtEq2.toString());
 
           Predicate gt1 = new Predicate(">", attrAndValue);
           Expression expectedGt1 = Expressions.greaterThan(unquoted, 1);
           Expression actualGt1 = SparkV2Filters.convert(gt1);
-          Assert.assertEquals(
-              "GreaterThan must match", expectedGt1.toString(), actualGt1.toString());
+          assertThat(actualGt1)
+              .asString()
+              .as("GreaterThan must match")
+              .isEqualTo(expectedGt1.toString());
 
           Predicate gt2 = new Predicate(">", valueAndAttr);
           Expression expectedGt2 = Expressions.lessThan(unquoted, 1);
           Expression actualGt2 = SparkV2Filters.convert(gt2);
-          Assert.assertEquals(
-              "GreaterThan must match", expectedGt2.toString(), actualGt2.toString());
+          assertThat(actualGt2)
+              .asString()
+              .as("GreaterThan must match")
+              .isEqualTo(expectedGt2.toString());
 
           Predicate gtEq1 = new Predicate(">=", attrAndValue);
           Expression expectedGtEq1 = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualGtEq1 = SparkV2Filters.convert(gtEq1);
-          Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq1.toString(), actualGtEq1.toString());
+          assertThat(actualGtEq1)
+              .asString()
+              .as("GreaterThanOrEqual must match")
+              .isEqualTo(expectedGtEq1.toString());
 
           Predicate gtEq2 = new Predicate(">=", valueAndAttr);
           Expression expectedGtEq2 = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualGtEq2 = SparkV2Filters.convert(gtEq2);
-          Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq2.toString(), actualGtEq2.toString());
+          assertThat(actualGtEq2)
+              .asString()
+              .as("GreaterThanOrEqual must match")
+              .isEqualTo(expectedGtEq2.toString());
 
           Predicate eq1 = new Predicate("=", attrAndValue);
           Expression expectedEq1 = Expressions.equal(unquoted, 1);
           Expression actualEq1 = SparkV2Filters.convert(eq1);
-          Assert.assertEquals("EqualTo must match", expectedEq1.toString(), actualEq1.toString());
+          assertThat(actualEq1)
+              .asString()
+              .as("EqualTo must match")
+              .isEqualTo(expectedEq1.toString());
 
           Predicate eq2 = new Predicate("=", valueAndAttr);
           Expression expectedEq2 = Expressions.equal(unquoted, 1);
           Expression actualEq2 = SparkV2Filters.convert(eq2);
-          Assert.assertEquals("EqualTo must match", expectedEq2.toString(), actualEq2.toString());
+          assertThat(actualEq2)
+              .asString()
+              .as("EqualTo must match")
+              .isEqualTo(expectedEq2.toString());
 
           Predicate notEq1 = new Predicate("<>", attrAndValue);
           Expression expectedNotEq1 = Expressions.notEqual(unquoted, 1);
           Expression actualNotEq1 = SparkV2Filters.convert(notEq1);
-          Assert.assertEquals(
-              "NotEqualTo must match", expectedNotEq1.toString(), actualNotEq1.toString());
+          assertThat(actualNotEq1)
+              .asString()
+              .as("NotEqualTo must match")
+              .isEqualTo(expectedNotEq1.toString());
 
           Predicate notEq2 = new Predicate("<>", valueAndAttr);
           Expression expectedNotEq2 = Expressions.notEqual(unquoted, 1);
           Expression actualNotEq2 = SparkV2Filters.convert(notEq2);
-          Assert.assertEquals(
-              "NotEqualTo must match", expectedNotEq2.toString(), actualNotEq2.toString());
+          assertThat(actualNotEq2)
+              .asString()
+              .as("NotEqualTo must match")
+              .isEqualTo(expectedNotEq2.toString());
 
           Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
           Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
-          Assert.assertEquals(
-              "EqualNullSafe must match",
-              expectedEqNullSafe1.toString(),
-              actualEqNullSafe1.toString());
+          assertThat(actualEqNullSafe1)
+              .asString()
+              .as("EqualNullSafe must match")
+              .isEqualTo(expectedEqNullSafe1.toString());
 
           Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
           Expression expectedEqNullSafe2 = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
-          Assert.assertEquals(
-              "EqualNullSafe must match",
-              expectedEqNullSafe2.toString(),
-              actualEqNullSafe2.toString());
+          assertThat(actualEqNullSafe2)
+              .asString()
+              .as("EqualNullSafe must match")
+              .isEqualTo(expectedEqNullSafe2.toString());
 
           LiteralValue str =
               new LiteralValue(UTF8String.fromString("iceberg"), DataTypes.StringType);
@@ -190,18 +221,20 @@ public class TestSparkV2Filters {
           Predicate startsWith = new Predicate("STARTS_WITH", attrAndStr);
           Expression expectedStartsWith = Expressions.startsWith(unquoted, "iceberg");
           Expression actualStartsWith = SparkV2Filters.convert(startsWith);
-          Assert.assertEquals(
-              "StartsWith must match", expectedStartsWith.toString(), actualStartsWith.toString());
+          assertThat(actualStartsWith)
+              .asString()
+              .as("StartsWith must match")
+              .isEqualTo(expectedStartsWith.toString());
 
           Predicate in = new Predicate("IN", attrAndValue);
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkV2Filters.convert(in);
-          Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+          assertThat(actualIn).asString().as("In must match").isEqualTo(expectedIn.toString());
 
           Predicate and = new And(lt1, eq1);
           Expression expectedAnd = Expressions.and(expectedLt1, expectedEq1);
           Expression actualAnd = SparkV2Filters.convert(and);
-          Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
+          assertThat(actualAnd).asString().as("And must match").isEqualTo(expectedAnd.toString());
 
           org.apache.spark.sql.connector.expressions.Expression[] attrAndAttr =
               new org.apache.spark.sql.connector.expressions.Expression[] {
@@ -210,21 +243,21 @@ public class TestSparkV2Filters {
           Predicate invalid = new Predicate("<", attrAndAttr);
           Predicate andWithInvalidLeft = new And(invalid, eq1);
           Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
-          Assert.assertEquals("And must match", convertedAnd, null);
+          assertThat(convertedAnd).as("And must match").isNull();
 
           Predicate or = new Or(lt1, eq1);
           Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
           Expression actualOr = SparkV2Filters.convert(or);
-          Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
+          assertThat(actualOr).asString().as("Or must match").isEqualTo(expectedOr.toString());
 
           Predicate orWithInvalidLeft = new Or(invalid, eq1);
           Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
-          Assert.assertEquals("Or must match", convertedOr, null);
+          assertThat(convertedOr).as("Or must match").isNull();
 
           Predicate not = new Not(lt1);
           Expression expectedNot = Expressions.not(expectedLt1);
           Expression actualNot = SparkV2Filters.convert(not);
-          Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
+          assertThat(actualNot).asString().as("Not must match").isEqualTo(expectedNot.toString());
         });
   }
 
@@ -380,10 +413,10 @@ public class TestSparkV2Filters {
     Expression tsExpression = SparkV2Filters.convert(predicate);
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    Assert.assertEquals(
-        "Generated Timestamp expression should be correct",
-        rawExpression.toString(),
-        tsExpression.toString());
+    assertThat(tsExpression)
+        .asString()
+        .as("Generated Timestamp expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -400,10 +433,10 @@ public class TestSparkV2Filters {
     Expression dateExpression = SparkV2Filters.convert(predicate);
     Expression rawExpression = Expressions.greaterThan("x", epochDay);
 
-    Assert.assertEquals(
-        "Generated date expression should be correct",
-        rawExpression.toString(),
-        dateExpression.toString());
+    assertThat(dateExpression)
+        .asString()
+        .as("Generated date expression should be correct")
+        .isEqualTo(rawExpression.toString());
   }
 
   @Test
@@ -422,7 +455,7 @@ public class TestSparkV2Filters {
 
     Not filter = new Not(new And(equal, in));
     Expression converted = SparkV2Filters.convert(filter);
-    Assert.assertNull("Expression should not be converted", converted);
+    assertThat(converted).as("Expression should not be converted").isNull();
   }
 
   @Test
@@ -439,7 +472,7 @@ public class TestSparkV2Filters {
     Expression actual = SparkV2Filters.convert(not);
     Expression expected =
         Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
-    Assert.assertEquals("Expressions should match", expected.toString(), actual.toString());
+    assertThat(actual).asString().as("Expressions should match").isEqualTo(expected.toString());
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
@@ -18,14 +18,15 @@
  */
 package org.apache.iceberg.spark;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkValueConverter {
   @Test
@@ -86,9 +87,8 @@ public class TestSparkValueConverter {
     Row sparkRow = RowFactory.create(1, null);
     Record record = GenericRecord.create(schema);
     record.set(0, 1);
-    Assert.assertEquals(
-        "Round-trip conversion should produce original value",
-        record,
-        SparkValueConverter.convert(schema, sparkRow));
+    assertThat(SparkValueConverter.convert(schema, sparkRow))
+        .as("Round-trip conversion should produce original value")
+        .isEqualTo(record);
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -22,12 +22,13 @@ import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -36,6 +37,9 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
@@ -54,64 +58,61 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestSparkDataWrite {
   private static final Configuration CONF = new Configuration();
-  private final FileFormat format;
-  private final String branch;
+
+  @Parameter(index = 0)
+  private FileFormat format;
+
+  @Parameter(index = 1)
+  private String branch;
+
   private static SparkSession spark = null;
   private static final Schema SCHEMA =
       new Schema(
           optional(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
 
-  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir private Path temp;
 
-  @Parameterized.Parameters(name = "format = {0}, branch = {1}")
-  public static Object[] parameters() {
-    return new Object[] {
-      new Object[] {"parquet", null},
-      new Object[] {"parquet", "main"},
-      new Object[] {"parquet", "testBranch"},
-      new Object[] {"avro", null},
-      new Object[] {"orc", "testBranch"}
+  @Parameters(name = "format = {0}, branch = {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      new Object[] {FileFormat.PARQUET, null},
+      new Object[] {FileFormat.PARQUET, "main"},
+      new Object[] {FileFormat.PARQUET, "testBranch"},
+      new Object[] {FileFormat.AVRO, null},
+      new Object[] {FileFormat.ORC, "testBranch"}
     };
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void startSpark() {
     TestSparkDataWrite.spark = SparkSession.builder().master("local[2]").getOrCreate();
   }
 
-  @Parameterized.AfterParam
-  public static void clearSourceCache() {
+  @AfterEach
+  public void clearSourceCache() {
     ManualSource.clearTables();
   }
 
-  @AfterClass
+  @AfterAll
   public static void stopSpark() {
     SparkSession currentSpark = TestSparkDataWrite.spark;
     TestSparkDataWrite.spark = null;
     currentSpark.stop();
   }
 
-  public TestSparkDataWrite(String format, String branch) {
-    this.format = FileFormat.fromString(format);
-    this.branch = branch;
-  }
-
-  @Test
-  public void testBasicWrite() throws IOException {
-    File parent = temp.newFolder(format.toString());
+  @TestTemplate
+  public void testBasicWrite() {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -139,31 +140,30 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
     for (ManifestFile manifest :
         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
       for (DataFile file : ManifestFiles.read(manifest, table.io())) {
         // TODO: avro not support split
         if (!format.equals(FileFormat.AVRO)) {
-          Assert.assertNotNull("Split offsets not present", file.splitOffsets());
+          assertThat(file.splitOffsets()).as("Split offsets not present").isNotNull();
         }
-        Assert.assertEquals("Should have reported record count as 1", 1, file.recordCount());
+        assertThat(file.recordCount()).as("Should have reported record count as 1").isEqualTo(1);
         // TODO: append more metric info
         if (format.equals(FileFormat.PARQUET)) {
-          Assert.assertNotNull("Column sizes metric not present", file.columnSizes());
-          Assert.assertNotNull("Counts metric not present", file.valueCounts());
-          Assert.assertNotNull("Null value counts metric not present", file.nullValueCounts());
-          Assert.assertNotNull("Lower bounds metric not present", file.lowerBounds());
-          Assert.assertNotNull("Upper bounds metric not present", file.upperBounds());
+          assertThat(file.columnSizes()).as("Column sizes metric not present").isNotNull();
+          assertThat(file.valueCounts()).as("Counts metric not present").isNotNull();
+          assertThat(file.nullValueCounts()).as("Null value counts metric not present").isNotNull();
+          assertThat(file.lowerBounds()).as("Lower bounds metric not present").isNotNull();
+          assertThat(file.upperBounds()).as("Upper bounds metric not present").isNotNull();
         }
       }
     }
   }
 
-  @Test
-  public void testAppend() throws IOException {
-    File parent = temp.newFolder(format.toString());
+  @TestTemplate
+  public void testAppend() {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -209,13 +209,12 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
-  public void testEmptyOverwrite() throws IOException {
-    File parent = temp.newFolder(format.toString());
+  @TestTemplate
+  public void testEmptyOverwrite() {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -255,13 +254,12 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
-  public void testOverwrite() throws IOException {
-    File parent = temp.newFolder(format.toString());
+  @TestTemplate
+  public void testOverwrite() {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -308,13 +306,12 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
-  public void testUnpartitionedOverwrite() throws IOException {
-    File parent = temp.newFolder(format.toString());
+  @TestTemplate
+  public void testUnpartitionedOverwrite() {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -351,13 +348,12 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
-  public void testUnpartitionedCreateWithTargetFileSizeViaTableProperties() throws IOException {
-    File parent = temp.newFolder(format.toString());
+  @TestTemplate
+  public void testUnpartitionedCreateWithTargetFileSizeViaTableProperties() {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -391,8 +387,7 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
     for (ManifestFile manifest :
@@ -402,33 +397,37 @@ public class TestSparkDataWrite {
       }
     }
 
-    Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
-    Assert.assertTrue(
-        "All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
+    assertThat(files)
+        .hasSize(4)
+        .allSatisfy(
+            dataFile ->
+                assertThat(dataFile.recordCount())
+                    .as("All DataFiles contain 1000 rows")
+                    .isEqualTo(1000));
   }
 
-  @Test
-  public void testPartitionedCreateWithTargetFileSizeViaOption() throws IOException {
+  @TestTemplate
+  public void testPartitionedCreateWithTargetFileSizeViaOption() {
     partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.NONE);
   }
 
-  @Test
-  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption() throws IOException {
+  @TestTemplate
+  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption() {
     partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.TABLE);
   }
 
-  @Test
-  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption2() throws IOException {
+  @TestTemplate
+  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption2() {
     partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.JOB);
   }
 
-  @Test
-  public void testWriteProjection() throws IOException {
-    Assume.assumeTrue(
-        "Not supported in Spark 3; analysis requires all columns are present",
-        spark.version().startsWith("2"));
+  @TestTemplate
+  public void testWriteProjection() {
+    assumeThat(spark.version())
+        .as("Not supported in Spark 3; analysis requires all columns are present")
+        .startsWith("2");
 
-    File parent = temp.newFolder(format.toString());
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -456,17 +455,16 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
-  public void testWriteProjectionWithMiddle() throws IOException {
-    Assume.assumeTrue(
-        "Not supported in Spark 3; analysis requires all columns are present",
-        spark.version().startsWith("2"));
+  @TestTemplate
+  public void testWriteProjectionWithMiddle() {
+    assumeThat(spark.version())
+        .as("Not supported in Spark 3; analysis requires all columns are present")
+        .startsWith("2");
 
-    File parent = temp.newFolder(format.toString());
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -501,13 +499,12 @@ public class TestSparkDataWrite {
 
     List<ThreeColumnRecord> actual =
         result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
-  @Test
-  public void testViewsReturnRecentResults() throws IOException {
-    File parent = temp.newFolder(format.toString());
+  @TestTemplate
+  public void testViewsReturnRecentResults() {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -537,8 +534,7 @@ public class TestSparkDataWrite {
     List<SimpleRecord> actual1 =
         spark.table("tmp").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     List<SimpleRecord> expected1 = Lists.newArrayList(new SimpleRecord(1, "a"));
-    Assert.assertEquals("Number of rows should match", expected1.size(), actual1.size());
-    Assert.assertEquals("Result rows should match", expected1, actual1);
+    assertThat(actual1).hasSameSizeAs(expected1).isEqualTo(expected1);
 
     df.select("id", "data")
         .write()
@@ -551,13 +547,11 @@ public class TestSparkDataWrite {
         spark.table("tmp").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     List<SimpleRecord> expected2 =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(1, "a"));
-    Assert.assertEquals("Number of rows should match", expected2.size(), actual2.size());
-    Assert.assertEquals("Result rows should match", expected2, actual2);
+    assertThat(actual2).hasSameSizeAs(expected2).isEqualTo(expected2);
   }
 
-  public void partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType option)
-      throws IOException {
-    File parent = temp.newFolder(format.toString());
+  public void partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType option) {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
 
@@ -620,8 +614,7 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
-    Assert.assertEquals("Result rows should match", expected, actual);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
     for (ManifestFile manifest :
@@ -631,14 +624,18 @@ public class TestSparkDataWrite {
       }
     }
 
-    Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
-    Assert.assertTrue(
-        "All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
+    assertThat(files)
+        .hasSize(8)
+        .allSatisfy(
+            dataFile ->
+                assertThat(dataFile.recordCount())
+                    .as("All DataFiles contain 1000 rows")
+                    .isEqualTo(1000));
   }
 
-  @Test
-  public void testCommitUnknownException() throws IOException {
-    File parent = temp.newFolder(format.toString());
+  @TestTemplate
+  public void testCommitUnknownException() {
+    File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "commitunknown");
     String targetLocation = locationWithBranch(location);
 
@@ -706,10 +703,8 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals(
-        "Number of rows should match", records.size() + records2.size(), actual.size());
     assertThat(actual)
-        .describedAs("Result rows should match")
+        .hasSize(records.size() + records2.size())
         .containsExactlyInAnyOrder(
             ImmutableList.<SimpleRecord>builder()
                 .addAll(records)

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -18,13 +18,14 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -52,7 +53,7 @@ public class TestSparkTable extends CatalogTestBase {
     SparkTable table2 = (SparkTable) catalog.loadTable(identifier);
 
     // different instances pointing to the same table must be equivalent
-    Assert.assertNotSame("References must be different", table1, table2);
-    Assert.assertEquals("Tables must be equivalent", table1, table2);
+    assertThat(table1).as("References must be different").isNotSameAs(table2);
+    assertThat(table1).as("Tables must be equivalent").isEqualTo(table2);
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
@@ -57,7 +57,7 @@ public class SparkTestHelperBase {
   protected void assertEquals(
       String context, List<Object[]> expectedRows, List<Object[]> actualRows) {
     assertThat(actualRows)
-        .as(context + ": number of results should match")
+        .as("%s: number of results should match", context)
         .hasSameSizeAs(expectedRows);
     for (int row = 0; row < expectedRows.size(); row += 1) {
       Object[] expected = expectedRows.get(row);
@@ -80,9 +80,7 @@ public class SparkTestHelperBase {
           assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
         }
       } else if (expectedValue != ANY) {
-        assertThat(actualValue)
-            .as(context + " col " + (col + 1) + " contents should match")
-            .isEqualTo(expectedValue);
+        assertThat(actualValue).as("%s contents should match", context).isEqualTo(expectedValue);
       }
     }
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -60,61 +60,68 @@ public class TestSparkFilters {
           IsNull isNull = IsNull.apply(quoted);
           Expression expectedIsNull = Expressions.isNull(unquoted);
           Expression actualIsNull = SparkFilters.convert(isNull);
-          assertThat(actualIsNull.toString())
+          assertThat(actualIsNull)
+              .asString()
               .as("IsNull must match")
               .isEqualTo(expectedIsNull.toString());
 
           IsNotNull isNotNull = IsNotNull.apply(quoted);
           Expression expectedIsNotNull = Expressions.notNull(unquoted);
           Expression actualIsNotNull = SparkFilters.convert(isNotNull);
-          assertThat(actualIsNotNull.toString())
+          assertThat(actualIsNotNull)
+              .asString()
               .as("IsNotNull must match")
               .isEqualTo(expectedIsNotNull.toString());
 
           LessThan lt = LessThan.apply(quoted, 1);
           Expression expectedLt = Expressions.lessThan(unquoted, 1);
           Expression actualLt = SparkFilters.convert(lt);
-          assertThat(actualLt.toString())
+          assertThat(actualLt)
+              .asString()
               .as("LessThan must match")
               .isEqualTo(expectedLt.toString());
 
           LessThanOrEqual ltEq = LessThanOrEqual.apply(quoted, 1);
           Expression expectedLtEq = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualLtEq = SparkFilters.convert(ltEq);
-          assertThat(actualLtEq.toString())
+          assertThat(actualLtEq)
+              .asString()
               .as("LessThanOrEqual must match")
               .isEqualTo(expectedLtEq.toString());
 
           GreaterThan gt = GreaterThan.apply(quoted, 1);
           Expression expectedGt = Expressions.greaterThan(unquoted, 1);
           Expression actualGt = SparkFilters.convert(gt);
-          assertThat(actualGt.toString())
+          assertThat(actualGt)
+              .asString()
               .as("GreaterThan must match")
               .isEqualTo(expectedGt.toString());
 
           GreaterThanOrEqual gtEq = GreaterThanOrEqual.apply(quoted, 1);
           Expression expectedGtEq = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualGtEq = SparkFilters.convert(gtEq);
-          assertThat(actualGtEq.toString())
+          assertThat(actualGtEq)
+              .asString()
               .as("GreaterThanOrEqual must match")
               .isEqualTo(expectedGtEq.toString());
 
           EqualTo eq = EqualTo.apply(quoted, 1);
           Expression expectedEq = Expressions.equal(unquoted, 1);
           Expression actualEq = SparkFilters.convert(eq);
-          assertThat(actualEq.toString()).as("EqualTo must match").isEqualTo(expectedEq.toString());
+          assertThat(actualEq).asString().as("EqualTo must match").isEqualTo(expectedEq.toString());
 
           EqualNullSafe eqNullSafe = EqualNullSafe.apply(quoted, 1);
           Expression expectedEqNullSafe = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe = SparkFilters.convert(eqNullSafe);
-          assertThat(actualEqNullSafe.toString())
+          assertThat(actualEqNullSafe)
+              .asString()
               .as("EqualNullSafe must match")
               .isEqualTo(expectedEqNullSafe.toString());
 
           In in = In.apply(quoted, new Integer[] {1});
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkFilters.convert(in);
-          assertThat(actualIn.toString()).as("In must match").isEqualTo(expectedIn.toString());
+          assertThat(actualIn).asString().as("In must match").isEqualTo(expectedIn.toString());
         });
   }
 
@@ -128,11 +135,13 @@ public class TestSparkFilters {
     Expression timestampExpression = SparkFilters.convert(GreaterThan.apply("x", timestamp));
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    assertThat(timestampExpression.toString())
+    assertThat(timestampExpression)
+        .asString()
         .as("Generated Timestamp expression should be correct")
         .isEqualTo(rawExpression.toString());
 
-    assertThat(instantExpression.toString())
+    assertThat(instantExpression)
+        .asString()
         .as("Generated Instant expression should be correct")
         .isEqualTo(rawExpression.toString());
   }
@@ -146,7 +155,8 @@ public class TestSparkFilters {
     Expression instantExpression = SparkFilters.convert(GreaterThan.apply("x", ldt));
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    assertThat(instantExpression.toString())
+    assertThat(instantExpression)
+        .asString()
         .as("Generated Instant expression should be correct")
         .isEqualTo(rawExpression.toString());
   }
@@ -161,11 +171,13 @@ public class TestSparkFilters {
     Expression dateExpression = SparkFilters.convert(GreaterThan.apply("x", date));
     Expression rawExpression = Expressions.greaterThan("x", epochDay);
 
-    assertThat(localDateExpression.toString())
+    assertThat(localDateExpression)
+        .asString()
         .as("Generated localdate expression should be correct")
         .isEqualTo(rawExpression.toString());
 
-    assertThat(dateExpression.toString())
+    assertThat(dateExpression)
+        .asString()
         .as("Generated date expression should be correct")
         .isEqualTo(rawExpression.toString());
   }
@@ -184,6 +196,6 @@ public class TestSparkFilters {
     Expression actual = SparkFilters.convert(filter);
     Expression expected =
         Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
-    assertThat(actual.toString()).as("Expressions should match").isEqualTo(expected.toString());
+    assertThat(actual).asString().as("Expressions should match").isEqualTo(expected.toString());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.List;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
@@ -45,21 +44,21 @@ public class TestSparkSchemaUtil {
           MetadataColumns.ROW_POSITION);
 
   @Test
-  public void testEstimateSizeMaxValue() throws IOException {
+  public void testEstimateSizeMaxValue() {
     assertThat(SparkSchemaUtil.estimateSize(null, Long.MAX_VALUE))
         .as("estimateSize returns Long max value")
         .isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
-  public void testEstimateSizeWithOverflow() throws IOException {
+  public void testEstimateSizeWithOverflow() {
     long tableSize =
         SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), Long.MAX_VALUE - 1);
     assertThat(tableSize).as("estimateSize handles overflow").isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
-  public void testEstimateSize() throws IOException {
+  public void testEstimateSize() {
     long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), 1);
     assertThat(tableSize).as("estimateSize matches with expected approximation").isEqualTo(24);
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -68,11 +68,14 @@ public class TestSparkTableUtil {
     MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
     MetricsConfig deserialized = KryoHelpers.roundTripSerialize(config);
 
-    assertThat(deserialized.columnMode("col1").toString())
+    assertThat(deserialized.columnMode("col1"))
+        .asString()
         .isEqualTo(MetricsModes.Full.get().toString());
-    assertThat(deserialized.columnMode("col2").toString())
+    assertThat(deserialized.columnMode("col2"))
+        .asString()
         .isEqualTo(MetricsModes.Truncate.withLength(16).toString());
-    assertThat(deserialized.columnMode("col3").toString())
+    assertThat(deserialized.columnMode("col3"))
+        .asString()
         .isEqualTo(MetricsModes.Counts.get().toString());
   }
 
@@ -90,11 +93,14 @@ public class TestSparkTableUtil {
     MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
     MetricsConfig deserialized = TestHelpers.roundTripSerialize(config);
 
-    assertThat(deserialized.columnMode("col1").toString())
+    assertThat(deserialized.columnMode("col1"))
+        .asString()
         .isEqualTo(MetricsModes.Full.get().toString());
-    assertThat(deserialized.columnMode("col2").toString())
+    assertThat(deserialized.columnMode("col2"))
+        .asString()
         .isEqualTo(MetricsModes.Truncate.withLength(16).toString());
-    assertThat(deserialized.columnMode("col3").toString())
+    assertThat(deserialized.columnMode("col3"))
+        .asString()
         .isEqualTo(MetricsModes.Counts.get().toString());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -89,112 +89,128 @@ public class TestSparkV2Filters {
           Predicate isNull = new Predicate("IS_NULL", attrOnly);
           Expression expectedIsNull = Expressions.isNull(unquoted);
           Expression actualIsNull = SparkV2Filters.convert(isNull);
-          assertThat(actualIsNull.toString())
+          assertThat(actualIsNull)
+              .asString()
               .as("IsNull must match")
               .isEqualTo(expectedIsNull.toString());
 
           Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
           Expression expectedIsNotNull = Expressions.notNull(unquoted);
           Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
-          assertThat(actualIsNotNull.toString())
+          assertThat(actualIsNotNull)
+              .asString()
               .as("IsNotNull must match")
               .isEqualTo(expectedIsNotNull.toString());
 
           Predicate lt1 = new Predicate("<", attrAndValue);
           Expression expectedLt1 = Expressions.lessThan(unquoted, 1);
           Expression actualLt1 = SparkV2Filters.convert(lt1);
-          assertThat(actualLt1.toString())
+          assertThat(actualLt1)
+              .asString()
               .as("LessThan must match")
               .isEqualTo(expectedLt1.toString());
 
           Predicate lt2 = new Predicate("<", valueAndAttr);
           Expression expectedLt2 = Expressions.greaterThan(unquoted, 1);
           Expression actualLt2 = SparkV2Filters.convert(lt2);
-          assertThat(actualLt2.toString())
+          assertThat(actualLt2)
+              .asString()
               .as("LessThan must match")
               .isEqualTo(expectedLt2.toString());
 
           Predicate ltEq1 = new Predicate("<=", attrAndValue);
           Expression expectedLtEq1 = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualLtEq1 = SparkV2Filters.convert(ltEq1);
-          assertThat(actualLtEq1.toString())
+          assertThat(actualLtEq1)
+              .asString()
               .as("LessThanOrEqual must match")
               .isEqualTo(expectedLtEq1.toString());
 
           Predicate ltEq2 = new Predicate("<=", valueAndAttr);
           Expression expectedLtEq2 = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualLtEq2 = SparkV2Filters.convert(ltEq2);
-          assertThat(actualLtEq2.toString())
+          assertThat(actualLtEq2)
+              .asString()
               .as("LessThanOrEqual must match")
               .isEqualTo(expectedLtEq2.toString());
 
           Predicate gt1 = new Predicate(">", attrAndValue);
           Expression expectedGt1 = Expressions.greaterThan(unquoted, 1);
           Expression actualGt1 = SparkV2Filters.convert(gt1);
-          assertThat(actualGt1.toString())
+          assertThat(actualGt1)
+              .asString()
               .as("GreaterThan must match")
               .isEqualTo(expectedGt1.toString());
 
           Predicate gt2 = new Predicate(">", valueAndAttr);
           Expression expectedGt2 = Expressions.lessThan(unquoted, 1);
           Expression actualGt2 = SparkV2Filters.convert(gt2);
-          assertThat(actualGt2.toString())
+          assertThat(actualGt2)
+              .asString()
               .as("GreaterThan must match")
               .isEqualTo(expectedGt2.toString());
 
           Predicate gtEq1 = new Predicate(">=", attrAndValue);
           Expression expectedGtEq1 = Expressions.greaterThanOrEqual(unquoted, 1);
           Expression actualGtEq1 = SparkV2Filters.convert(gtEq1);
-          assertThat(actualGtEq1.toString())
+          assertThat(actualGtEq1)
+              .asString()
               .as("GreaterThanOrEqual must match")
               .isEqualTo(expectedGtEq1.toString());
 
           Predicate gtEq2 = new Predicate(">=", valueAndAttr);
           Expression expectedGtEq2 = Expressions.lessThanOrEqual(unquoted, 1);
           Expression actualGtEq2 = SparkV2Filters.convert(gtEq2);
-          assertThat(actualGtEq2.toString())
+          assertThat(actualGtEq2)
+              .asString()
               .as("GreaterThanOrEqual must match")
               .isEqualTo(expectedGtEq2.toString());
 
           Predicate eq1 = new Predicate("=", attrAndValue);
           Expression expectedEq1 = Expressions.equal(unquoted, 1);
           Expression actualEq1 = SparkV2Filters.convert(eq1);
-          assertThat(actualEq1.toString())
+          assertThat(actualEq1)
+              .asString()
               .as("EqualTo must match")
               .isEqualTo(expectedEq1.toString());
 
           Predicate eq2 = new Predicate("=", valueAndAttr);
           Expression expectedEq2 = Expressions.equal(unquoted, 1);
           Expression actualEq2 = SparkV2Filters.convert(eq2);
-          assertThat(actualEq2.toString())
+          assertThat(actualEq2)
+              .asString()
               .as("EqualTo must match")
               .isEqualTo(expectedEq2.toString());
 
           Predicate notEq1 = new Predicate("<>", attrAndValue);
           Expression expectedNotEq1 = Expressions.notEqual(unquoted, 1);
           Expression actualNotEq1 = SparkV2Filters.convert(notEq1);
-          assertThat(actualNotEq1.toString())
+          assertThat(actualNotEq1)
+              .asString()
               .as("NotEqualTo must match")
               .isEqualTo(expectedNotEq1.toString());
 
           Predicate notEq2 = new Predicate("<>", valueAndAttr);
           Expression expectedNotEq2 = Expressions.notEqual(unquoted, 1);
           Expression actualNotEq2 = SparkV2Filters.convert(notEq2);
-          assertThat(actualNotEq2.toString())
+          assertThat(actualNotEq2)
+              .asString()
               .as("NotEqualTo must match")
               .isEqualTo(expectedNotEq2.toString());
 
           Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
           Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
-          assertThat(actualEqNullSafe1.toString())
+          assertThat(actualEqNullSafe1)
+              .asString()
               .as("EqualNullSafe must match")
               .isEqualTo(expectedEqNullSafe1.toString());
 
           Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
           Expression expectedEqNullSafe2 = Expressions.equal(unquoted, 1);
           Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
-          assertThat(actualEqNullSafe2.toString())
+          assertThat(actualEqNullSafe2)
+              .asString()
               .as("EqualNullSafe must match")
               .isEqualTo(expectedEqNullSafe2.toString());
 
@@ -205,19 +221,20 @@ public class TestSparkV2Filters {
           Predicate startsWith = new Predicate("STARTS_WITH", attrAndStr);
           Expression expectedStartsWith = Expressions.startsWith(unquoted, "iceberg");
           Expression actualStartsWith = SparkV2Filters.convert(startsWith);
-          assertThat(actualStartsWith.toString())
+          assertThat(actualStartsWith)
+              .asString()
               .as("StartsWith must match")
               .isEqualTo(expectedStartsWith.toString());
 
           Predicate in = new Predicate("IN", attrAndValue);
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkV2Filters.convert(in);
-          assertThat(actualIn.toString()).as("In must match").isEqualTo(expectedIn.toString());
+          assertThat(actualIn).asString().as("In must match").isEqualTo(expectedIn.toString());
 
           Predicate and = new And(lt1, eq1);
           Expression expectedAnd = Expressions.and(expectedLt1, expectedEq1);
           Expression actualAnd = SparkV2Filters.convert(and);
-          assertThat(actualAnd.toString()).as("And must match").isEqualTo(expectedAnd.toString());
+          assertThat(actualAnd).asString().as("And must match").isEqualTo(expectedAnd.toString());
 
           org.apache.spark.sql.connector.expressions.Expression[] attrAndAttr =
               new org.apache.spark.sql.connector.expressions.Expression[] {
@@ -231,7 +248,7 @@ public class TestSparkV2Filters {
           Predicate or = new Or(lt1, eq1);
           Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
           Expression actualOr = SparkV2Filters.convert(or);
-          assertThat(actualOr.toString()).as("Or must match").isEqualTo(expectedOr.toString());
+          assertThat(actualOr).asString().as("Or must match").isEqualTo(expectedOr.toString());
 
           Predicate orWithInvalidLeft = new Or(invalid, eq1);
           Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
@@ -240,7 +257,7 @@ public class TestSparkV2Filters {
           Predicate not = new Not(lt1);
           Expression expectedNot = Expressions.not(expectedLt1);
           Expression actualNot = SparkV2Filters.convert(not);
-          assertThat(actualNot.toString()).as("Not must match").isEqualTo(expectedNot.toString());
+          assertThat(actualNot).asString().as("Not must match").isEqualTo(expectedNot.toString());
         });
   }
 
@@ -396,7 +413,8 @@ public class TestSparkV2Filters {
     Expression tsExpression = SparkV2Filters.convert(predicate);
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    assertThat(tsExpression.toString())
+    assertThat(tsExpression)
+        .asString()
         .as("Generated Timestamp expression should be correct")
         .isEqualTo(rawExpression.toString());
   }
@@ -415,7 +433,8 @@ public class TestSparkV2Filters {
     Expression dateExpression = SparkV2Filters.convert(predicate);
     Expression rawExpression = Expressions.greaterThan("x", epochDay);
 
-    assertThat(dateExpression.toString())
+    assertThat(dateExpression)
+        .asString()
         .as("Generated date expression should be correct")
         .isEqualTo(rawExpression.toString());
   }
@@ -453,7 +472,7 @@ public class TestSparkV2Filters {
     Expression actual = SparkV2Filters.convert(not);
     Expression expected =
         Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
-    assertThat(actual.toString()).as("Expressions should match").isEqualTo(expected.toString());
+    assertThat(actual).asString().as("Expressions should match").isEqualTo(expected.toString());
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -24,7 +24,6 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +97,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionById() throws IOException {
+  public void testSnapshotSelectionById() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -145,7 +144,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByTimestamp() throws IOException {
+  public void testSnapshotSelectionByTimestamp() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -197,7 +196,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByInvalidSnapshotId() throws IOException {
+  public void testSnapshotSelectionByInvalidSnapshotId() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -212,7 +211,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByInvalidTimestamp() throws IOException {
+  public void testSnapshotSelectionByInvalidTimestamp() {
     long timestamp = System.currentTimeMillis();
 
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
@@ -232,7 +231,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionBySnapshotIdAndTimestamp() throws IOException {
+  public void testSnapshotSelectionBySnapshotIdAndTimestamp() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -264,7 +263,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByTag() throws IOException {
+  public void testSnapshotSelectionByTag() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -300,7 +299,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByBranch() throws IOException {
+  public void testSnapshotSelectionByBranch() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -336,7 +335,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByBranchAndTagFails() throws IOException {
+  public void testSnapshotSelectionByBranchAndTagFails() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -367,7 +366,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByTimestampAndBranchOrTagFails() throws IOException {
+  public void testSnapshotSelectionByTimestampAndBranchOrTagFails() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -410,7 +409,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByBranchWithSchemaChange() throws IOException {
+  public void testSnapshotSelectionByBranchWithSchemaChange() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -467,7 +466,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testWritingToBranchAfterSchemaChange() throws IOException {
+  public void testWritingToBranchAfterSchemaChange() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);
@@ -541,7 +540,7 @@ public class TestSnapshotSelection {
   }
 
   @TestTemplate
-  public void testSnapshotSelectionByTagWithSchemaChange() throws IOException {
+  public void testSnapshotSelectionByTagWithSchemaChange() {
     String tableLocation = temp.resolve("iceberg-table").toFile().toString();
 
     HadoopTables tables = new HadoopTables(CONF);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +111,7 @@ public class TestSparkDataWrite {
   }
 
   @TestTemplate
-  public void testBasicWrite() throws IOException {
+  public void testBasicWrite() {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
@@ -141,8 +140,7 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
     for (ManifestFile manifest :
         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
       for (DataFile file : ManifestFiles.read(manifest, table.io())) {
@@ -164,7 +162,7 @@ public class TestSparkDataWrite {
   }
 
   @TestTemplate
-  public void testAppend() throws IOException {
+  public void testAppend() {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
@@ -211,12 +209,11 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
   @TestTemplate
-  public void testEmptyOverwrite() throws IOException {
+  public void testEmptyOverwrite() {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
@@ -257,12 +254,11 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
   @TestTemplate
-  public void testOverwrite() throws IOException {
+  public void testOverwrite() {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
@@ -310,12 +306,11 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
   @TestTemplate
-  public void testUnpartitionedOverwrite() throws IOException {
+  public void testUnpartitionedOverwrite() {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
@@ -353,12 +348,11 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
   @TestTemplate
-  public void testUnpartitionedCreateWithTargetFileSizeViaTableProperties() throws IOException {
+  public void testUnpartitionedCreateWithTargetFileSizeViaTableProperties() {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
@@ -393,8 +387,7 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
     for (ManifestFile manifest :
@@ -404,29 +397,32 @@ public class TestSparkDataWrite {
       }
     }
 
-    assertThat(files).as("Should have 4 DataFiles").hasSize(4);
-    assertThat(files.stream())
-        .as("All DataFiles contain 1000 rows")
-        .allMatch(d -> d.recordCount() == 1000);
+    assertThat(files)
+        .hasSize(4)
+        .allSatisfy(
+            dataFile ->
+                assertThat(dataFile.recordCount())
+                    .as("All DataFiles contain 1000 rows")
+                    .isEqualTo(1000));
   }
 
   @TestTemplate
-  public void testPartitionedCreateWithTargetFileSizeViaOption() throws IOException {
+  public void testPartitionedCreateWithTargetFileSizeViaOption() {
     partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.NONE);
   }
 
   @TestTemplate
-  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption() throws IOException {
+  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption() {
     partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.TABLE);
   }
 
   @TestTemplate
-  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption2() throws IOException {
+  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption2() {
     partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.JOB);
   }
 
   @TestTemplate
-  public void testWriteProjection() throws IOException {
+  public void testWriteProjection() {
     assumeThat(spark.version())
         .as("Not supported in Spark 3; analysis requires all columns are present")
         .startsWith("2");
@@ -459,12 +455,11 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
   @TestTemplate
-  public void testWriteProjectionWithMiddle() throws IOException {
+  public void testWriteProjectionWithMiddle() {
     assumeThat(spark.version())
         .as("Not supported in Spark 3; analysis requires all columns are present")
         .startsWith("2");
@@ -504,12 +499,11 @@ public class TestSparkDataWrite {
 
     List<ThreeColumnRecord> actual =
         result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
   @TestTemplate
-  public void testViewsReturnRecentResults() throws IOException {
+  public void testViewsReturnRecentResults() {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
@@ -540,8 +534,7 @@ public class TestSparkDataWrite {
     List<SimpleRecord> actual1 =
         spark.table("tmp").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     List<SimpleRecord> expected1 = Lists.newArrayList(new SimpleRecord(1, "a"));
-    assertThat(actual1).as("Number of rows should match").hasSameSizeAs(expected1);
-    assertThat(actual1).as("Result rows should match").isEqualTo(expected1);
+    assertThat(actual1).hasSameSizeAs(expected1).isEqualTo(expected1);
 
     df.select("id", "data")
         .write()
@@ -554,12 +547,10 @@ public class TestSparkDataWrite {
         spark.table("tmp").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     List<SimpleRecord> expected2 =
         Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(1, "a"));
-    assertThat(actual2).as("Number of rows should match").hasSameSizeAs(expected2);
-    assertThat(actual2).as("Result rows should match").isEqualTo(expected2);
+    assertThat(actual2).hasSameSizeAs(expected2).isEqualTo(expected2);
   }
 
-  public void partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType option)
-      throws IOException {
+  public void partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType option) {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "test");
     String targetLocation = locationWithBranch(location);
@@ -623,8 +614,7 @@ public class TestSparkDataWrite {
 
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSameSizeAs(expected);
-    assertThat(actual).as("Result rows should match").isEqualTo(expected);
+    assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
     for (ManifestFile manifest :
@@ -633,14 +623,17 @@ public class TestSparkDataWrite {
         files.add(file);
       }
     }
-    assertThat(files).as("Should have 8 DataFiles").hasSize(8);
-    assertThat(files.stream())
-        .as("All DataFiles contain 1000 rows")
-        .allMatch(d -> d.recordCount() == 1000);
+    assertThat(files)
+        .hasSize(8)
+        .allSatisfy(
+            dataFile ->
+                assertThat(dataFile.recordCount())
+                    .as("All DataFiles contain 1000 rows")
+                    .isEqualTo(1000));
   }
 
   @TestTemplate
-  public void testCommitUnknownException() throws IOException {
+  public void testCommitUnknownException() {
     File parent = temp.resolve(format.toString()).toFile();
     File location = new File(parent, "commitunknown");
     String targetLocation = locationWithBranch(location);
@@ -709,9 +702,8 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
     List<SimpleRecord> actual =
         result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    assertThat(actual).as("Number of rows should match").hasSize(records.size() + records2.size());
     assertThat(actual)
-        .describedAs("Result rows should match")
+        .hasSize(records.size() + records2.size())
         .containsExactlyInAnyOrder(
             ImmutableList.<SimpleRecord>builder()
                 .addAll(records)


### PR DESCRIPTION
*Migrate Spark 3.4 tests based on JUnit 4 to Junit5 with AssertJ style. This is related to https://github.com/apache/iceberg/issues/7160*

This PR migrate the other JUnit 4 tests to JUnit 5 and complete the Spark migration. The following classes are included in this PR:


`source`
* `TestReadProjection` including refactoring Spark 3.5 tests
* `TestSnapshotSelection`
* `TestSparkDataWrite` including refactoring Spark 3.5 tests
* `TestSparkReadProjection`

Others:
* `SparkTestHelperBase`
* `TestChangelogIterator`
* `TestSparkTableUtil` including refactoring Spark 3.5 tests
* `TestSparkSchemaUtil`
* `TestSparkTable`
* `TestSparkFilters` including refactoring Spark 3.5 tests
* `TestSparkV2Filters` including refactoring Spark 3.5 tests
* `TestSparkValueConverter`
