### PR TITLE
Docs: Add Delete Granularity option to write configuration

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -87,7 +87,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.update.isolation-level                         | serializable                | Isolation level for update commands: serializable or snapshot                                                                                                                                     |
 | write.merge.mode                                     | copy-on-write               | Mode used for merge commands: copy-on-write or merge-on-read (v2 only)                                                                                                                            |
 | write.merge.isolation-level                          | serializable                | Isolation level for merge commands: serializable or snapshot                                                                                                                                      |
-| write.delete.granularity                             | partition                   | Controls the granularity of generated delete files: __partition__ or __file__                                                                                                                     |
+| write.delete.granularity                             | partition                   | Controls the granularity of generated delete files: partition or file                                                                                                                     |
 
 ### Table behavior properties
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -87,6 +87,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.update.isolation-level                         | serializable                | Isolation level for update commands: serializable or snapshot                                                                                                                                     |
 | write.merge.mode                                     | copy-on-write               | Mode used for merge commands: copy-on-write or merge-on-read (v2 only)                                                                                                                            |
 | write.merge.isolation-level                          | serializable                | Isolation level for merge commands: serializable or snapshot                                                                                                                                      |
+| write.delete.granularity                             | partition                   | Controls the granularity of generated delete files: __partition__ or __file__                                                                                                                     |
 
 ### Table behavior properties
 

--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -256,6 +256,7 @@ df.writeTo("catalog.db.table")
 | compression-level      | Table write.(fileformat).compression-level | Overrides this table's compression level for Parquet and Avro tables for this write |
 | compression-strategy   | Table write.orc.compression-strategy       | Overrides this table's compression strategy for ORC tables for this write |
 | distribution-mode | See [Spark Writes](spark-writes.md#writing-distribution-modes) for defaults | Override this table's distribution mode for this write |
+| delete-granularity | file | Override this table's delete granularity for this write |
 
 CommitMetadata provides an interface to add custom metadata to a snapshot summary during a SQL execution, which can be beneficial for purposes such as auditing or change tracking. If properties start with `snapshot-property.`, then that prefix will be removed from each property. Here is an example:
 


### PR DESCRIPTION
Currently there's no the "Delete Granularity" option in the documentation for the Iceberg's table properties and Spark write configuation. This documentation adds the description of that granularity option.