### PR TITLE
Arrow: Avoid deprecated ArrowType.Decimal constructor

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/ArrowSchemaUtil.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/ArrowSchemaUtil.java
@@ -89,7 +89,7 @@ public class ArrowSchemaUtil {
         break;
       case DECIMAL:
         final Types.DecimalType decimalType = (Types.DecimalType) field.type();
-        arrowType = new ArrowType.Decimal(decimalType.precision(), decimalType.scale());
+        arrowType = new ArrowType.Decimal(decimalType.precision(), decimalType.scale(), 128);
         break;
       case STRING:
         arrowType = ArrowType.Utf8.INSTANCE;

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
@@ -780,9 +780,12 @@ public class ArrowReaderTest {
                 "uuid_nullable",
                 new FieldType(true, new ArrowType.FixedSizeBinary(16), null),
                 null),
-            new Field("decimal", new FieldType(false, new ArrowType.Decimal(9, 2), null), null),
             new Field(
-                "decimal_nullable", new FieldType(true, new ArrowType.Decimal(9, 2), null), null));
+                "decimal", new FieldType(false, new ArrowType.Decimal(9, 2, 128), null), null),
+            new Field(
+                "decimal_nullable",
+                new FieldType(true, new ArrowType.Decimal(9, 2, 128), null),
+                null));
     List<Field> filteredFields =
         allFields.stream()
             .filter(f -> columnSet.contains(f.getName()))


### PR DESCRIPTION
`Decimal(int precision, int scale)` constructor is deprecated.

https://github.com/apache/arrow-java/blob/b459647910a6a373fb9f3d9cd0eb8cc717932bed/vector/src/main/codegen/templates/ArrowType.java#L180-L191