### PR TITLE
Spark: Fix row lineage inheritance for distributed planning

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -197,18 +197,6 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         3
       },
       {
-        "testhadoop",
-        SparkCatalog.class.getName(),
-        ImmutableMap.of("type", "hadoop"),
-        FileFormat.PARQUET,
-        false,
-        WRITE_DISTRIBUTION_MODE_HASH,
-        true,
-        null,
-        DISTRIBUTED,
-        3
-      },
-      {
         "spark_catalog",
         SparkSessionCatalog.class.getName(),
         ImmutableMap.of(

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -197,6 +197,18 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         3
       },
       {
+        "testhadoop",
+        SparkCatalog.class.getName(),
+        ImmutableMap.of("type", "hadoop"),
+        FileFormat.PARQUET,
+        false,
+        WRITE_DISTRIBUTION_MODE_HASH,
+        true,
+        null,
+        DISTRIBUTED,
+        3
+      },
+      {
         "spark_catalog",
         SparkSessionCatalog.class.getName(),
         ImmutableMap.of(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -36,8 +36,6 @@ public class ManifestFileBean implements ManifestFile, Serializable {
   private Long addedSnapshotId = null;
   private Integer content = null;
   private Long sequenceNumber = null;
-
-  /* No getter for firstRowId as it should not be a required field when creating its encoder */
   private Long firstRowId = null;
 
   public static ManifestFileBean fromManifest(ManifestFile manifest) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -37,6 +37,9 @@ public class ManifestFileBean implements ManifestFile, Serializable {
   private Integer content = null;
   private Long sequenceNumber = null;
 
+  /* No getter for firstRowId as it should not be a required field when creating its encoder */
+  private Long firstRowId = null;
+
   public static ManifestFileBean fromManifest(ManifestFile manifest) {
     ManifestFileBean bean = new ManifestFileBean();
 
@@ -46,6 +49,7 @@ public class ManifestFileBean implements ManifestFile, Serializable {
     bean.setAddedSnapshotId(manifest.snapshotId());
     bean.setContent(manifest.content().id());
     bean.setSequenceNumber(manifest.sequenceNumber());
+    bean.setFirstRowId(manifest.firstRowId());
 
     return bean;
   }
@@ -96,6 +100,10 @@ public class ManifestFileBean implements ManifestFile, Serializable {
 
   public void setSequenceNumber(Long sequenceNumber) {
     this.sequenceNumber = sequenceNumber;
+  }
+
+  public void setFirstRowId(Long firstRowId) {
+    this.firstRowId = firstRowId;
   }
 
   @Override
@@ -171,6 +179,11 @@ public class ManifestFileBean implements ManifestFile, Serializable {
   @Override
   public ByteBuffer keyMetadata() {
     return null;
+  }
+
+  @Override
+  public Long firstRowId() {
+    return firstRowId;
   }
 
   @Override


### PR DESCRIPTION
For Spark Distributed planning we use a `ManifestFileBean` implementation of ManifestFile which is serializable and encodes the minimal amount of manifest fields required during distributed planning. This was missing firstRowId and as a result null values would be propogated for the inherited firstRowId. This fixes the issue by simply adding the firstRowId field to the bean which will be set correctly and as a result be inherited correctly during Spark distributed planning.

 I discovered this when going through the DML row lineage tests and noticed we weren't exercising a distributed planning case and after enabling, debugged. I added another test parameter set for distributed planning.