### PR TITLE
Spark, Avro: Add support for row lineage in Avro reader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -236,13 +236,26 @@ public class ValueReaders {
       ValueReader<?> fieldReader = fieldReaders.get(pos);
       Integer fieldId = AvroSchemaUtil.fieldId(field);
       Integer projectionPos = idToPos.remove(fieldId);
-
-      Object constant = idToConstant.get(fieldId);
-      if (projectionPos != null && constant != null) {
+      if (fieldId != null && fieldId == MetadataColumns.ROW_ID.fieldId()) {
+        Long firstRowId = (Long) idToConstant.get(fieldId);
         readPlan.add(
-            Pair.of(projectionPos, ValueReaders.replaceWithConstant(fieldReader, constant)));
+            Pair.of(projectionPos, ValueReaders.rowIds(firstRowId, fieldReaders.get(pos))));
+      } else if (fieldId != null
+          && fieldId == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
+        Long firstRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
+        Long fileSeqNumber = (Long) idToConstant.get(fieldId);
+        readPlan.add(
+            Pair.of(
+                projectionPos,
+                ValueReaders.lastUpdated(firstRowId, fileSeqNumber, fieldReaders.get(pos))));
       } else {
-        readPlan.add(Pair.of(projectionPos, fieldReader));
+        Object constant = idToConstant.get(fieldId);
+        if (projectionPos != null && constant != null) {
+          readPlan.add(
+              Pair.of(projectionPos, ValueReaders.replaceWithConstant(fieldReader, constant)));
+        } else {
+          readPlan.add(Pair.of(projectionPos, fieldReader));
+        }
       }
     }
 
@@ -272,6 +285,23 @@ public class ValueReaders {
     }
 
     return readPlan;
+  }
+
+  public static ValueReader<Long> rowIds(Long baseRowId, ValueReader<?> idReader) {
+    if (baseRowId != null) {
+      return new RowIdReader(baseRowId, (ValueReader<Long>) idReader);
+    } else {
+      return ValueReaders.constant(null);
+    }
+  }
+
+  public static ValueReader<Long> lastUpdated(
+      Long baseRowId, Long fileLastUpdated, ValueReader<?> seqReader) {
+    if (fileLastUpdated != null && baseRowId != null) {
+      return new LastUpdatedSeqReader(fileLastUpdated, (ValueReader<Long>) seqReader);
+    } else {
+      return ValueReaders.constant(null);
+    }
   }
 
   private static Map<Integer, Integer> idToPos(Types.StructType struct) {
@@ -1233,6 +1263,66 @@ public class ValueReaders {
     @Override
     public void setRowPositionSupplier(Supplier<Long> posSupplier) {
       this.currentPosition = posSupplier.get() - 1;
+    }
+  }
+
+  static class RowIdReader implements ValueReader<Long>, SupportsRowPosition {
+    private final long firstRowId;
+    private final ValueReader<Long> idReader;
+    private final ValueReader<Long> posReader;
+
+    RowIdReader(Long firstRowId, ValueReader<Long> idReader) {
+      this.firstRowId = firstRowId;
+      this.idReader = idReader != null ? idReader : ValueReaders.constant(null);
+      this.posReader = positions();
+    }
+
+    @Override
+    public Long read(Decoder ignored, Object reuse) throws IOException {
+      Long id = idReader.read(ignored, reuse);
+      long pos = posReader.read(ignored, reuse);
+
+      if (id != null) {
+        return id;
+      }
+
+      return firstRowId + pos;
+    }
+
+    @Override
+    public void skip(Decoder decoder) throws IOException {
+      idReader.skip(decoder);
+      posReader.skip(decoder);
+    }
+
+    @Override
+    public void setRowPositionSupplier(Supplier<Long> posSupplier) {
+      ((SupportsRowPosition) posReader).setRowPositionSupplier(posSupplier);
+    }
+  }
+
+  static class LastUpdatedSeqReader implements ValueReader<Long> {
+    private final long fileLastUpdated;
+    private final ValueReader<Long> seqReader;
+
+    LastUpdatedSeqReader(long fileLastUpdated, ValueReader<Long> seqReader) {
+      this.fileLastUpdated = fileLastUpdated;
+      this.seqReader = seqReader;
+    }
+
+    @Override
+    public Long read(Decoder ignored, Object reuse) throws IOException {
+      Long lastUpdated = seqReader.read(ignored, reuse);
+      if (lastUpdated != null) {
+        return lastUpdated;
+      }
+
+      return fileLastUpdated;
+    }
+
+    @Override
+    public void skip(Decoder decoder) throws IOException {
+      seqReader.skip(decoder);
     }
   }
 }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -197,6 +197,18 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         3
       },
       {
+        "testhadoop",
+        SparkCatalog.class.getName(),
+        ImmutableMap.of("type", "hadoop"),
+        FileFormat.PARQUET,
+        false,
+        WRITE_DISTRIBUTION_MODE_HASH,
+        true,
+        null,
+        DISTRIBUTED,
+        3
+      },
+      {
         "spark_catalog",
         SparkSessionCatalog.class.getName(),
         ImmutableMap.of(

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -193,18 +193,6 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         WRITE_DISTRIBUTION_MODE_HASH,
         true,
         null,
-        LOCAL,
-        3
-      },
-      {
-        "testhadoop",
-        SparkCatalog.class.getName(),
-        ImmutableMap.of("type", "hadoop"),
-        FileFormat.PARQUET,
-        false,
-        WRITE_DISTRIBUTION_MODE_HASH,
-        true,
-        null,
         DISTRIBUTED,
         3
       },

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRowLevelOperationsWithLineage.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRowLevelOperationsWithLineage.java
@@ -90,7 +90,8 @@ public abstract class TestRowLevelOperationsWithLineage extends SparkRowLevelOpe
   public void beforeEach() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     // ToDo: Remove these as row lineage inheritance gets implemented in the other readers
-    assumeThat(fileFormat).isEqualTo(FileFormat.PARQUET);
+    assumeThat(fileFormat.equals(FileFormat.PARQUET) || fileFormat.equals(FileFormat.AVRO))
+        .isTrue();
     assumeThat(vectorized).isFalse();
   }
 
@@ -111,6 +112,7 @@ public abstract class TestRowLevelOperationsWithLineage extends SparkRowLevelOpe
         "source",
         "id int, data string",
         "{ \"id\": 101, \"data\": \"updated_b\" }\n " + "{ \"id\": 200, \"data\": \"f\" }\n");
+
     sql(
         "MERGE INTO %s AS t USING source AS s "
             + "ON t.id == s.id "
@@ -399,8 +401,8 @@ public abstract class TestRowLevelOperationsWithLineage extends SparkRowLevelOpe
   private List<Object[]> rowsWithLineageAndFilePos() {
     return sql(
         "SELECT s._last_updated_sequence_number, s.id, s.data, s._row_id, files.first_row_id, s._pos FROM %s"
-            + " AS s JOIN %s.files AS files ON files.file_path = s._file ORDER BY s._row_id",
-        selectTarget(), selectTarget());
+            + " AS s JOIN %s.files VERSION AS OF '%s' AS files ON files.file_path = s._file ORDER BY s._row_id",
+        selectTarget(), tableName, branch != null ? branch : "main");
   }
 
   private List<Object[]> rowsWithLineage() {
@@ -472,6 +474,7 @@ public abstract class TestRowLevelOperationsWithLineage extends SparkRowLevelOpe
   }
 
   private Snapshot latestSnapshot(Table table) {
+    table.refresh();
     return branch != null ? table.snapshot(branch) : table.currentSnapshot();
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -36,6 +36,7 @@ public class ManifestFileBean implements ManifestFile, Serializable {
   private Long addedSnapshotId = null;
   private Integer content = null;
   private Long sequenceNumber = null;
+  private Long firstRowId = null;
 
   public static ManifestFileBean fromManifest(ManifestFile manifest) {
     ManifestFileBean bean = new ManifestFileBean();
@@ -46,6 +47,7 @@ public class ManifestFileBean implements ManifestFile, Serializable {
     bean.setAddedSnapshotId(manifest.snapshotId());
     bean.setContent(manifest.content().id());
     bean.setSequenceNumber(manifest.sequenceNumber());
+    bean.setFirstRowId(manifest.firstRowId());
 
     return bean;
   }
@@ -96,6 +98,10 @@ public class ManifestFileBean implements ManifestFile, Serializable {
 
   public void setSequenceNumber(Long sequenceNumber) {
     this.sequenceNumber = sequenceNumber;
+  }
+
+  public void setFirstRowId(Long firstRowId) {
+    this.firstRowId = firstRowId;
   }
 
   @Override
@@ -171,6 +177,11 @@ public class ManifestFileBean implements ManifestFile, Serializable {
   @Override
   public ByteBuffer keyMetadata() {
     return null;
+  }
+
+  @Override
+  public Long firstRowId() {
+    return firstRowId;
   }
 
   @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -18,18 +18,19 @@
  */
 package org.apache.iceberg.spark.data;
 
-import static org.apache.iceberg.spark.data.TestHelpers.assertEqualsUnsafe;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
-import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.catalyst.InternalRow;
 
@@ -40,35 +41,51 @@ public class TestSparkAvroReader extends AvroDataTest {
   }
 
   @Override
-  protected void writeAndValidate(Schema writeSchema, Schema expectedSchema) throws IOException {
-    List<Record> expected = RandomData.generateList(writeSchema, 100, 0L);
-
+  protected void writeAndValidate(
+      Schema writeSchema, Schema expectedSchema, List<org.apache.iceberg.data.Record> records)
+      throws IOException {
     File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
 
-    try (FileAppender<Record> writer =
-        Avro.write(Files.localOutput(testFile)).schema(writeSchema).named("test").build()) {
-      for (Record rec : expected) {
-        writer.add(rec);
+    try (DataWriter<Record> dataWriter =
+        Avro.writeData(Files.localOutput(testFile))
+            .schema(writeSchema)
+            .createWriterFunc(org.apache.iceberg.data.avro.DataWriter::create)
+            .withSpec(PartitionSpec.unpartitioned())
+            .build()) {
+      for (org.apache.iceberg.data.Record rec : records) {
+        dataWriter.write(rec);
       }
     }
 
     List<InternalRow> rows;
     try (AvroIterable<InternalRow> reader =
         Avro.read(Files.localInput(testFile))
-            .createResolvingReader(SparkPlannedAvroReader::create)
+            .createResolvingReader(schema -> SparkPlannedAvroReader.create(schema, ID_TO_CONSTANT))
             .project(expectedSchema)
             .build()) {
       rows = Lists.newArrayList(reader);
     }
 
-    for (int i = 0; i < expected.size(); i += 1) {
-      assertEqualsUnsafe(expectedSchema.asStruct(), expected.get(i), rows.get(i));
+    for (int i = 0; i < records.size(); i += 1) {
+      GenericsHelpers.assertEqualsUnsafe(
+          expectedSchema.asStruct(), records.get(i), rows.get(i), ID_TO_CONSTANT, i);
     }
   }
 
   @Override
+  protected void writeAndValidate(Schema writeSchema, Schema expectedSchema) throws IOException {
+    List<Record> expected = RandomGenericData.generate(writeSchema, 100, 0L);
+    writeAndValidate(writeSchema, expectedSchema, expected);
+  }
+
+  @Override
   protected boolean supportsDefaultValues() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsRowLineage() {
     return true;
   }
 }


### PR DESCRIPTION
Depends on #13061 

This change adds support for row lineage in the Avro reader.