### PR TITLE
backport_max_files_rewrite_option

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -171,6 +171,18 @@ public class RewriteDataFiles {
     }
 
     /**
+     * Configures max files to rewrite. See {@link BinPackRewriteFilePlanner#MAX_FILES_TO_REWRITE}
+     * for more details.
+     *
+     * @param maxFilesToRewrite maximum files to rewrite
+     */
+    public Builder maxFilesToRewrite(int maxFilesToRewrite) {
+      this.rewriteOptions.put(
+          BinPackRewriteFilePlanner.MAX_FILES_TO_REWRITE, String.valueOf(maxFilesToRewrite));
+      return this;
+    }
+
+    /**
      * The input is a {@link DataStream} with {@link Trigger} events and every event should be
      * immediately followed by a {@link Watermark} with the same timestamp as the event.
      *

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -170,6 +170,12 @@ public class RewriteDataFiles {
       return this;
     }
 
+    /**
+     * Configures max files to rewrite. See {@link BinPackRewriteFilePlanner#MAX_FILES_TO_REWRITE}
+     * for more details.
+     *
+     * @param maxFilesToRewrite maximum files to rewrite
+     */
     public Builder maxFilesToRewrite(int maxFilesToRewrite) {
       this.rewriteOptions.put(
           BinPackRewriteFilePlanner.MAX_FILES_TO_REWRITE, String.valueOf(maxFilesToRewrite));

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -171,6 +171,18 @@ public class RewriteDataFiles {
     }
 
     /**
+     * Configures max files to rewrite. See {@link BinPackRewriteFilePlanner#MAX_FILES_TO_REWRITE}
+     * for more details.
+     *
+     * @param maxFilesToRewrite maximum files to rewrite
+     */
+    public Builder maxFilesToRewrite(int maxFilesToRewrite) {
+      this.rewriteOptions.put(
+          BinPackRewriteFilePlanner.MAX_FILES_TO_REWRITE, String.valueOf(maxFilesToRewrite));
+      return this;
+    }
+
+    /**
      * The input is a {@link DataStream} with {@link Trigger} events and every event should be
      * immediately followed by a {@link Watermark} with the same timestamp as the event.
      *

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -78,7 +78,8 @@ public class RewriteDataFilesSparkAction
           USE_STARTING_SEQUENCE_NUMBER,
           REWRITE_JOB_ORDER,
           OUTPUT_SPEC_ID,
-          REMOVE_DANGLING_DELETES);
+          REMOVE_DANGLING_DELETES,
+          BinPackRewriteFilePlanner.MAX_FILES_TO_REWRITE);
 
   private static final RewriteDataFilesSparkAction.Result EMPTY_RESULT =
       ImmutableRewriteDataFiles.Result.builder().rewriteResults(ImmutableList.of()).build();


### PR DESCRIPTION
Backport changes to flink 1.19 , 2.0 and spark 4.0 
Original PR : https://github.com/apache/iceberg/pull/12824