### PR TITLE
Flink: Fix npe in TaskResultAggregator when job recovery

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TaskResultAggregator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TaskResultAggregator.java
@@ -61,7 +61,7 @@ public class TaskResultAggregator extends AbstractStreamOperator<TaskResult>
   private final String taskName;
   private final int taskIndex;
   private final List<Exception> exceptions;
-  private transient Long startTime;
+  private transient long startTime;
 
   public TaskResultAggregator(String tableName, String taskName, int taskIndex) {
     Preconditions.checkNotNull(tableName, "Table name should no be null");
@@ -71,12 +71,6 @@ public class TaskResultAggregator extends AbstractStreamOperator<TaskResult>
     this.taskName = taskName;
     this.taskIndex = taskIndex;
     this.exceptions = Lists.newArrayList();
-  }
-
-  @Override
-  public void open() throws Exception {
-    super.open();
-    this.startTime = 0L;
   }
 
   @Override

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TaskResultAggregator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TaskResultAggregator.java
@@ -71,6 +71,11 @@ public class TaskResultAggregator extends AbstractStreamOperator<TaskResult>
     this.taskName = taskName;
     this.taskIndex = taskIndex;
     this.exceptions = Lists.newArrayList();
+  }
+
+  @Override
+  public void open() throws Exception {
+    super.open();
     this.startTime = 0L;
   }
 
@@ -87,16 +92,18 @@ public class TaskResultAggregator extends AbstractStreamOperator<TaskResult>
 
   @Override
   public void processWatermark(Watermark mark) throws Exception {
-    TaskResult response = new TaskResult(taskIndex, startTime, exceptions.isEmpty(), exceptions);
-    output.collect(new StreamRecord<>(response));
-    LOG.info(
-        "Aggregated result for table {}, task {}[{}] is {}",
-        tableName,
-        taskName,
-        taskIndex,
-        response);
-    exceptions.clear();
-    startTime = 0L;
+    if (startTime != 0L) {
+      TaskResult response = new TaskResult(taskIndex, startTime, exceptions.isEmpty(), exceptions);
+      output.collect(new StreamRecord<>(response));
+      LOG.info(
+          "Aggregated result for table {}, task {}[{}] is {}",
+          tableName,
+          taskName,
+          taskIndex,
+          response);
+      exceptions.clear();
+      startTime = 0L;
+    }
 
     super.processWatermark(mark);
   }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.iceberg.DataFile;
@@ -83,6 +84,7 @@ public class OperatorTestBase {
 
   static final long EVENT_TIME = 10L;
   static final long EVENT_TIME_2 = 11L;
+  static final Watermark WATERMARK = new Watermark(EVENT_TIME);
   protected static final String DUMMY_TASK_NAME = "dummyTask";
   protected static final String DUMMY_TABLE_NAME = "dummyTable";
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTaskResultAggregator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTaskResultAggregator.java
@@ -20,8 +20,9 @@ package org.apache.iceberg.flink.maintenance.operator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
 import org.apache.iceberg.flink.maintenance.api.TaskResult;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
@@ -36,10 +37,42 @@ class TestTaskResultAggregator extends OperatorTestBase {
     try (TwoInputStreamOperatorTestHarness<Trigger, Exception, TaskResult> testHarness =
         new TwoInputStreamOperatorTestHarness<>(taskResultAggregator)) {
       testHarness.open();
-      testHarness.processWatermark1(new Watermark(EVENT_TIME));
-      testHarness.processWatermark2(new Watermark(EVENT_TIME));
+      testHarness.processBothWatermarks(WATERMARK);
       ConcurrentLinkedQueue<Object> output = testHarness.getOutput();
-      assertThat(output).containsOnlyOnce(new Watermark(EVENT_TIME));
+      assertThat(output).containsOnlyOnce(WATERMARK);
+    }
+  }
+
+  @Test
+  void testProcessWatermarkWithoutElement() throws Exception {
+    TaskResultAggregator taskResultAggregator =
+        new TaskResultAggregator("table-name", "task-name", 0);
+    try (TwoInputStreamOperatorTestHarness<Trigger, Exception, TaskResult> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(taskResultAggregator)) {
+      testHarness.open();
+      testHarness.processBothWatermarks(WATERMARK);
+      List<TaskResult> taskResults = testHarness.extractOutputValues();
+      assertThat(taskResults).hasSize(0);
+    }
+  }
+
+  @Test
+  void testProcessWatermark() throws Exception {
+    TaskResultAggregator taskResultAggregator =
+        new TaskResultAggregator("table-name", "task-name", 0);
+    try (TwoInputStreamOperatorTestHarness<Trigger, Exception, TaskResult> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(taskResultAggregator)) {
+      testHarness.open();
+
+      testHarness.processElement1(new StreamRecord<>(Trigger.create(EVENT_TIME, 0)));
+      testHarness.processBothWatermarks(WATERMARK);
+      List<TaskResult> taskResults = testHarness.extractOutputValues();
+      assertThat(taskResults).hasSize(1);
+      TaskResult taskResult = taskResults.get(0);
+      assertThat(taskResult.taskIndex()).isEqualTo(0);
+      assertThat(taskResult.startEpoch()).isEqualTo(EVENT_TIME);
+      assertThat(taskResult.success()).isEqualTo(true);
+      assertThat(taskResult.exceptions()).hasSize(0);
     }
   }
 }


### PR DESCRIPTION
Now the `startTime` in `TaskResultAggregator` is a transient `Long` that is initialized when the object is created, not in the `open` method. When the job recovers from a failure, it becomes null and causes a NPE when `processWatermark` is call before `processElement1` constructing the required `long` for `TaskResult`.

https://github.com/apache/iceberg/blob/c2478968e65368c61799d8ca4b89506a61ca3e7c/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TaskResultAggregator.java#L64

This PR aims to change the initialization of `startTime` to the `open` method. If `startTime` is 0, the `TaskResult` will not be propagated downstream; instead, it will rely on the advancement of the watermark to reach downstream operators.
