### PR TITLE
Spark: Don't push down predicate on changelog metadata columns in SparkScanBuilder

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -289,6 +289,14 @@ public class TestChangelogTable extends ExtensionsTestBase {
         ImmutableList.of(
             row(1, file1, 0L, false, 0, row("a")), row(2, file2, 0L, false, 0, row("b"))),
         rows);
+
+
+    assertEquals(
+            "Rows should match",
+            ImmutableList.of(),
+            sql(
+                    "SELECT _CHANGE_ORDINAL, _COMMIT_SNAPSHOT_ID, _CHANGE_TYPE FROM %s.changes WHERE _CHANGE_TYPE = 'DELETE'",
+                    tableName));
   }
 
   @TestTemplate

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.ChangelogUtil;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.IncrementalChangelogScan;
@@ -166,7 +167,7 @@ public class SparkScanBuilder
 
         if (expr != null) {
           // try binding the expression to ensure it can be pushed down
-          Binder.bind(schema.asStruct(), expr, caseSensitive);
+          Binder.bind(ChangelogUtil.dropChangelogMetadata(schema).asStruct(), expr, caseSensitive);
           expressions.add(expr);
           pushableFilters.add(predicate);
         }

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -288,6 +288,13 @@ public class TestChangelogTable extends ExtensionsTestBase {
         ImmutableList.of(
             row(1, file1, 0L, false, 0, row("a")), row(2, file2, 0L, false, 0, row("b"))),
         rows);
+
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(),
+        sql(
+            "SELECT _CHANGE_ORDINAL, _COMMIT_SNAPSHOT_ID, _CHANGE_TYPE FROM %s.changes WHERE _CHANGE_TYPE = 'DELETE'",
+            tableName));
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.ChangelogUtil;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.IncrementalChangelogScan;
@@ -166,7 +167,7 @@ public class SparkScanBuilder
 
         if (expr != null) {
           // try binding the expression to ensure it can be pushed down
-          Binder.bind(schema.asStruct(), expr, caseSensitive);
+          Binder.bind(ChangelogUtil.dropChangelogMetadata(schema).asStruct(), expr, caseSensitive);
           expressions.add(expr);
           pushableFilters.add(predicate);
         }

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -288,6 +288,14 @@ public class TestChangelogTable extends ExtensionsTestBase {
         ImmutableList.of(
             row(1, file1, 0L, false, 0, row("a")), row(2, file2, 0L, false, 0, row("b"))),
         rows);
+
+
+    assertEquals(
+            "Rows should match",
+            ImmutableList.of(),
+            sql(
+                    "SELECT _CHANGE_ORDINAL, _COMMIT_SNAPSHOT_ID, _CHANGE_TYPE FROM %s.changes WHERE _CHANGE_TYPE = 'DELETE'",
+                    tableName));
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.ChangelogUtil;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.IncrementalChangelogScan;
@@ -166,7 +167,7 @@ public class SparkScanBuilder
 
         if (expr != null) {
           // try binding the expression to ensure it can be pushed down
-          Binder.bind(schema.asStruct(), expr, caseSensitive);
+          Binder.bind(ChangelogUtil.dropChangelogMetadata(schema).asStruct(), expr, caseSensitive);
           expressions.add(expr);
           pushableFilters.add(predicate);
         }


### PR DESCRIPTION
Closes #13092