### PR TITLE
core: Send single snapshot to remove rather than in bulk

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1432,24 +1432,18 @@ public class TableMetadata implements Serializable {
     private Builder rewriteSnapshotsInternal(Collection<Long> idsToRemove, boolean suppress) {
       List<Snapshot> retainedSnapshots =
           Lists.newArrayListWithExpectedSize(snapshots.size() - idsToRemove.size());
-      Set<Long> snapshotIdsToRemove = Sets.newHashSet();
-
       for (Snapshot snapshot : snapshots) {
         long snapshotId = snapshot.snapshotId();
         if (idsToRemove.contains(snapshotId)) {
           snapshotsById.remove(snapshotId);
           if (!suppress) {
-            snapshotIdsToRemove.add(snapshotId);
+            changes.add(new MetadataUpdate.RemoveSnapshot(snapshotId));
           }
           removeStatistics(snapshotId);
           removePartitionStatistics(snapshotId);
         } else {
           retainedSnapshots.add(snapshot);
         }
-      }
-
-      if (!snapshotIdsToRemove.isEmpty()) {
-        changes.add(new MetadataUpdate.RemoveSnapshots(snapshotIdsToRemove));
       }
 
       this.snapshots = retainedSnapshots;
@@ -1838,11 +1832,7 @@ public class TableMetadata implements Serializable {
       Set<Long> intermediateSnapshotIds = intermediateSnapshotIdSet(changes, currentSnapshotId);
       boolean hasIntermediateSnapshots = !intermediateSnapshotIds.isEmpty();
       boolean hasRemovedSnapshots =
-          changes.stream()
-              .anyMatch(
-                  change ->
-                      change instanceof MetadataUpdate.RemoveSnapshots
-                          || change instanceof MetadataUpdate.RemoveSnapshot);
+          changes.stream().anyMatch(MetadataUpdate.RemoveSnapshot.class::isInstance);
 
       if (!hasIntermediateSnapshots && !hasRemovedSnapshots) {
         return snapshotLog;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1832,7 +1832,11 @@ public class TableMetadata implements Serializable {
       Set<Long> intermediateSnapshotIds = intermediateSnapshotIdSet(changes, currentSnapshotId);
       boolean hasIntermediateSnapshots = !intermediateSnapshotIds.isEmpty();
       boolean hasRemovedSnapshots =
-          changes.stream().anyMatch(MetadataUpdate.RemoveSnapshot.class::isInstance);
+          changes.stream()
+              .anyMatch(
+                  change ->
+                      change instanceof MetadataUpdate.RemoveSnapshots
+                          || change instanceof MetadataUpdate.RemoveSnapshot);
 
       if (!hasIntermediateSnapshots && !hasRemovedSnapshots) {
         return snapshotLog;


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/12670 introduces a behavior change that requires the REST catalog server to upgrade to 1.9.x as well, otherwise, the client with 1.9.x cannot talk to the existing server.

This PR is to revert back to the 1.8.x behavior in core that the client will send single snapshot to remove that the existing server can understand.

This PR is only fixing in 1.9.x branch.