### PR TITLE
Build: increase gradle jvm heap size from 1 GB to 1.5 GB.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,4 +32,4 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 # explicitly disable the configuration cache
 org.gradle.configuration-cache=false
-org.gradle.jvmargs=-Xmx1024m
+org.gradle.jvmargs=-Xmx1536m


### PR DESCRIPTION
Twice, I have ran into OOMError with gradle build

https://github.com/apache/iceberg/actions/runs/15146709248/job/42584083395
https://github.com/apache/iceberg/actions/runs/15146709248/job/42590212786

```

Unexpected exception thrown.
org.gradle.internal.remote.internal.MessageIOException: Could not read message from '/127.0.0.1:40376'.
	at org.gradle.internal.remote.internal.inet.SocketConnection.receive(SocketConnection.java:96)
	at org.gradle.internal.remote.internal.hub.MessageHub$ConnectionReceive.run(MessageHub.java:270)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)

	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.OutOfMemoryError: Java heap space
> Task :iceberg-spark:iceberg-spark-4.0_2.13:compileTestJava FAILED
> Task :iceberg-spark:iceberg-spark-extensions-4.0_2.13:compileJava FAILED

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':iceberg-spark:iceberg-spark-4.0_2.13:compileTestJava'.
> Java heap space: failed reallocation of scalar replaced objects
```