### PR TITLE
Add BigQuery Dependencies for Iceberg GCP Bundle

### DIFF
--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -26,6 +26,8 @@ project(":iceberg-gcp-bundle") {
   dependencies {
     implementation platform(libs.google.libraries.bom)
     implementation "com.google.cloud:google-cloud-storage"
+    implementation "com.google.cloud:google-cloud-bigquery"
+    implementation "com.google.cloud:google-cloud-core"
   }
 
   shadowJar {


### PR DESCRIPTION
This PR introduces the necessary BigQuery client dependencies to the Apache Iceberg GCP bundle. These dependencies are essential forthe BigQuery Catalog which we recently merged.