### PR TITLE
Parquet: Fix redundant type conversion in parquet schema

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -85,7 +85,7 @@ public class TypeToMessageType {
       // unknown type is not written to data files
       Type fieldType = field(field);
       if (fieldType != null) {
-        builder.addField(field(field));
+        builder.addField(fieldType);
       }
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -99,7 +99,7 @@ public class TypeToMessageType {
       // unknown type is not written to data files
       Type fieldType = field(field);
       if (fieldType != null) {
-        builder.addField(field(field));
+        builder.addField(fieldType);
       }
     }
 


### PR DESCRIPTION
### Description
The `field(field)` method is unnecessarily called twice, once to check for null, and again to add the result. This leads to redundant computation. Might be an oversight.