### PR TITLE
Core: Improve pagination logic to handle null pageToken

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -111,7 +111,8 @@ public class CatalogHandlers {
   }
 
   private static <T> Pair<List<T>, String> paginate(List<T> list, String pageToken, int pageSize) {
-    int pageStart = INITIAL_PAGE_TOKEN.equals(pageToken) ? 0 : Integer.parseInt(pageToken);
+    boolean isFirstPage = pageToken == null || pageToken.equals(INITIAL_PAGE_TOKEN);
+    int pageStart = isFirstPage ? 0 : Integer.parseInt(pageToken);
     if (pageStart >= list.size()) {
       return Pair.of(Collections.emptyList(), null);
     }


### PR DESCRIPTION
Allow listing tables, views and namespaces in rest catalog without `pageToken` query parameter when `pageSize` query parameter is included. Closes #13119

Examples:
- http://localhost:8181/v1/namespaces?pageSize=1
- http://localhost:8181/v1/namespaces/default/tables?pageSize=1
- http://localhost:8181/v1/namespaces/default/views?pageSize=1