### PR TITLE
Hive: Throw exception for when listing a non-existing namespace

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -508,7 +508,7 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public List<Namespace> listNamespaces(Namespace namespace) {
-    if (!isValidateNamespace(namespace) && !namespace.isEmpty()) {
+    if (!namespace.isEmpty() && (!isValidateNamespace(namespace) || !namespaceExists(namespace))) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
     if (!namespace.isEmpty()) {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -1212,7 +1212,6 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
 
   @Test
   @Override
-  @Disabled("Hive currently returns an empty list instead of throwing a NoSuchNamespaceException")
   public void testListNonExistingNamespace() {
     super.testListNonExistingNamespace();
   }


### PR DESCRIPTION
Throw exception for when listing a non-existing namespace

Fixes https://github.com/apache/iceberg/issues/12874