### PR TITLE
AWS: Skip cleanup of analytics accelerator when disabled

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/PrefixedS3Client.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/PrefixedS3Client.java
@@ -114,7 +114,9 @@ class PrefixedS3Client implements AutoCloseable {
 
     if (null != s3AsyncClient) {
       // cleanup usage in analytics accelerator if any
-      AnalyticsAcceleratorUtil.cleanupCache(s3AsyncClient, s3FileIOProperties);
+      if (s3FileIOProperties().isS3AnalyticsAcceleratorEnabled()) {
+        AnalyticsAcceleratorUtil.cleanupCache(s3AsyncClient, s3FileIOProperties);
+      }
       s3AsyncClient.close();
     }
   }


### PR DESCRIPTION
If an S3AsyncClient has been used from S3FileIO and the analytics accelerator is disabled (is disabled by default), the S3FileIO may throw an exception during closing if the analytics accelerator is not on the classpath.

Closes #13133