### PR TITLE
Core: Fix incremental compute of partition stats with COW deletes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
@@ -39,7 +39,6 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.base.Predicate;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Queues;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -163,7 +162,7 @@ public class PartitionStatsHandler {
     if (statisticsFile == null) {
       LOG.info(
           "Using full compute as previous statistics file is not present for incremental compute.");
-      stats = computeStats(table, snapshot, file -> true, false /* incremental */).values();
+      stats = computeStats(table, snapshot, Sets.newHashSet()).values();
     } else {
       stats = computeAndMergeStatsIncremental(table, snapshot, partitionType, statisticsFile);
     }
@@ -276,7 +275,8 @@ public class PartitionStatsHandler {
     PartitionMap<PartitionStats> statsMap = PartitionMap.create(table.specs());
     // read previous stats, note that partition field will be read as GenericRecord
     try (CloseableIterable<PartitionStats> oldStats =
-        readPartitionStatsFile(schema(partitionType), Files.localInput(previousStatsFile.path()))) {
+        readPartitionStatsFile(
+            schema(partitionType), table.io().newInputFile(previousStatsFile.path()))) {
       oldStats.forEach(
           partitionStats ->
               statsMap.put(partitionStats.specId(), partitionStats.partition(), partitionStats));
@@ -336,16 +336,29 @@ public class PartitionStatsHandler {
         Sets.newHashSet(
             SnapshotUtil.ancestorIdsBetween(
                 toSnapshot.snapshotId(), fromSnapshot.snapshotId(), table::snapshot));
-    Predicate<ManifestFile> manifestFilePredicate =
-        manifestFile -> snapshotIdsRange.contains(manifestFile.snapshotId());
-    return computeStats(table, toSnapshot, manifestFilePredicate, true /* incremental */);
+    return computeStats(table, toSnapshot, snapshotIdsRange);
   }
 
   private static PartitionMap<PartitionStats> computeStats(
-      Table table, Snapshot snapshot, Predicate<ManifestFile> predicate, boolean incremental) {
+      Table table, Snapshot snapshot, Set<Long> snapshotIdsRange) {
     StructType partitionType = Partitioning.partitionType(table);
-    List<ManifestFile> manifests =
-        snapshot.allManifests(table.io()).stream().filter(predicate).collect(Collectors.toList());
+    boolean incremental = !snapshotIdsRange.isEmpty();
+
+    List<ManifestFile> manifests;
+    if (incremental) {
+      // DELETED manifest entries are not carried over to subsequent snapshots.
+      // So, for incremental computation, gather the manifests added by each snapshot
+      // instead of relying solely on those from the latest snapshot.
+      manifests =
+          snapshotIdsRange.stream()
+              .flatMap(
+                  id ->
+                      table.snapshot(id).allManifests(table.io()).stream()
+                          .filter(file -> file.snapshotId().equals(id)))
+              .collect(Collectors.toList());
+    } else {
+      manifests = snapshot.allManifests(table.io());
+    }
 
     Queue<PartitionMap<PartitionStats>> statsByManifest = Queues.newConcurrentLinkedQueue();
     Tasks.foreach(manifests)

--- a/core/src/test/java/org/apache/iceberg/PartitionStatsHandlerTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/PartitionStatsHandlerTestBase.java
@@ -522,6 +522,46 @@ public abstract class PartitionStatsHandlerTestBase {
     assertThat(latestStatsFile).isEqualTo(statisticsFile);
   }
 
+  @Test
+  public void testLatestStatsFileWithBranch() throws Exception {
+    Table testTable =
+        TestTables.create(
+            tempDir("stats_file_branch"), "stats_file_branch", SCHEMA, SPEC, 2, fileFormatProperty);
+    DataFile dataFile =
+        FileGenerationUtil.generateDataFile(testTable, TestHelpers.Row.of("foo", "A"));
+
+    /*
+                                             * [statsMainB]
+          ---- snapshotA  ------ snapshotMainB
+                        \
+                         \
+                          \
+                           snapshotBranchB(branch:b1)
+    */
+
+    testTable.newAppend().appendFile(dataFile).commit();
+    long snapshotAId = testTable.currentSnapshot().snapshotId();
+
+    testTable.newAppend().appendFile(dataFile).commit();
+    long snapshotMainBId = testTable.currentSnapshot().snapshotId();
+
+    String branchName = "b1";
+    testTable.manageSnapshots().createBranch(branchName, snapshotAId).commit();
+    testTable.newAppend().appendFile(dataFile).commit();
+    long snapshotBranchBId = testTable.snapshot(branchName).snapshotId();
+
+    PartitionStatisticsFile statsMainB =
+        PartitionStatsHandler.computeAndWriteStatsFile(testTable, snapshotMainBId);
+    testTable.updatePartitionStatistics().setPartitionStatistics(statsMainB).commit();
+
+    // should find latest stats for snapshotMainB
+    assertThat(PartitionStatsHandler.latestStatsFile(testTable, snapshotMainBId))
+        .isEqualTo(statsMainB);
+
+    // should not find latest stats for snapshotBranchB
+    assertThat(PartitionStatsHandler.latestStatsFile(testTable, snapshotBranchBId)).isNull();
+  }
+
   private static StructLike partitionRecord(
       Types.StructType partitionType, String val1, String val2) {
     GenericRecord record = GenericRecord.create(partitionType);

--- a/orc/src/test/java/org/apache/iceberg/TestOrcPartitionStatsHandler.java
+++ b/orc/src/test/java/org/apache/iceberg/TestOrcPartitionStatsHandler.java
@@ -55,6 +55,13 @@ public class TestOrcPartitionStatsHandler extends PartitionStatsHandlerTestBase 
   }
 
   @Override
+  public void testLatestStatsFileWithBranch() throws Exception {
+    assertThatThrownBy(super::testLatestStatsFileWithBranch)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot write using unregistered internal data format: ORC");
+  }
+
+  @Override
   public void testCopyOnWriteDelete() throws Exception {
     assertThatThrownBy(super::testCopyOnWriteDelete)
         .isInstanceOf(UnsupportedOperationException.class)

--- a/orc/src/test/java/org/apache/iceberg/TestOrcPartitionStatsHandler.java
+++ b/orc/src/test/java/org/apache/iceberg/TestOrcPartitionStatsHandler.java
@@ -53,4 +53,11 @@ public class TestOrcPartitionStatsHandler extends PartitionStatsHandlerTestBase 
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Cannot write using unregistered internal data format: ORC");
   }
+
+  @Override
+  public void testCopyOnWriteDelete() throws Exception {
+    assertThatThrownBy(super::testCopyOnWriteDelete)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot write using unregistered internal data format: ORC");
+  }
 }


### PR DESCRIPTION
Fixes an edge case where deleted entires information is not carried to next snapshot. So, incremental stats compute was wrong for this copy on write case. Fix is to apply incremental stats compute snapshot by snapshot for its added manifest.

Also fallback when stats file exist for table but not for current snapshot chain, instead of throwing exception.  

Fixes: #13155 