### PR TITLE
spark 4.0 : SPJ : add hour to day reducer

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
@@ -183,6 +183,11 @@ public class DateTimeUtil {
         LocalDateTime.parse(timestampString, DateTimeFormatter.ISO_LOCAL_DATE_TIME));
   }
 
+  public static int hoursToDays(int hours) {
+    LocalDate date = EPOCH.toLocalDateTime().plusHours(hours).toLocalDate();
+    return daysFromDate(date);
+  }
+
   public static int daysToYears(int days) {
     return convertDays(days, ChronoUnit.YEARS);
   }

--- a/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
@@ -88,4 +88,12 @@ public class TestDateTimeUtil {
     assertThat(Transforms.hour().toHumanString(Types.IntegerType.get(), 419686))
         .isEqualTo("2017-11-16-22");
   }
+
+  @Test
+  public void hourToDaysPositive() {
+    long micros = DateTimeUtil.isoTimestampToMicros("2025-06-26T22:55:00.000001001");
+    int expectedDays = DateTimeUtil.microsToDays(micros);
+    assertThat(DateTimeUtil.hoursToDays(DateTimeUtil.microsToHours(micros)))
+        .isEqualTo(expectedDays);
+  }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/functions/DaysFunction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/functions/DaysFunction.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.spark.functions;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
+import org.apache.spark.sql.connector.catalog.functions.Reducer;
+import org.apache.spark.sql.connector.catalog.functions.ReducibleFunction;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.DateType;
@@ -60,7 +62,8 @@ public class DaysFunction extends UnaryUnboundFunction {
     return "days";
   }
 
-  private abstract static class BaseToDaysFunction extends BaseScalarFunction<Integer> {
+  protected abstract static class BaseToDaysFunction extends BaseScalarFunction<Integer>
+      implements ReducibleFunction<Integer, Integer> {
     @Override
     public String name() {
       return "days";
@@ -69,6 +72,11 @@ public class DaysFunction extends UnaryUnboundFunction {
     @Override
     public DataType resultType() {
       return DataTypes.DateType;
+    }
+
+    @Override
+    public Reducer<Integer, Integer> reducer(ReducibleFunction<?, ?> otherFunction) {
+      return null;
     }
   }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
@@ -18,9 +18,12 @@
  */
 package org.apache.iceberg.spark.functions;
 
+import java.io.Serializable;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
+import org.apache.spark.sql.connector.catalog.functions.Reducer;
+import org.apache.spark.sql.connector.catalog.functions.ReducibleFunction;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.TimestampNTZType;
@@ -57,7 +60,19 @@ public class HoursFunction extends UnaryUnboundFunction {
     return "hours";
   }
 
-  public static class TimestampToHoursFunction extends BaseScalarFunction<Integer> {
+  public abstract static class BaseToHourFunction extends BaseScalarFunction<Integer>
+      implements ReducibleFunction<Integer, Integer> {
+    @Override
+    public Reducer<Integer, Integer> reducer(ReducibleFunction<?, ?> otherBucketFunction) {
+
+      if (otherBucketFunction instanceof DaysFunction.BaseToDaysFunction) {
+        return new HourToDaysReducer();
+      }
+      return null;
+    }
+  }
+
+  public static class TimestampToHoursFunction extends BaseToHourFunction {
     // magic method used in codegen
     public static int invoke(long micros) {
       return DateTimeUtil.microsToHours(micros);
@@ -90,7 +105,7 @@ public class HoursFunction extends UnaryUnboundFunction {
     }
   }
 
-  public static class TimestampNtzToHoursFunction extends BaseScalarFunction<Integer> {
+  public static class TimestampNtzToHoursFunction extends BaseToHourFunction {
     // magic method used in codegen
     public static int invoke(long micros) {
       return DateTimeUtil.microsToHours(micros);
@@ -120,6 +135,13 @@ public class HoursFunction extends UnaryUnboundFunction {
     public Integer produceResult(InternalRow input) {
       // return null for null input to match what Spark does in codegen
       return input.isNullAt(0) ? null : invoke(input.getLong(0));
+    }
+  }
+
+  public static class HourToDaysReducer implements Reducer<Integer, Integer>, Serializable {
+    @Override
+    public Integer reduce(Integer hour) {
+      return DateTimeUtil.hoursToDays(hour);
     }
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/functions/HoursFunction.java
@@ -64,7 +64,6 @@ public class HoursFunction extends UnaryUnboundFunction {
       implements ReducibleFunction<Integer, Integer> {
     @Override
     public Reducer<Integer, Integer> reducer(ReducibleFunction<?, ?> otherBucketFunction) {
-
       if (otherBucketFunction instanceof DaysFunction.BaseToDaysFunction) {
         return new HourToDaysReducer();
       }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -735,16 +735,15 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
 
     sql(createTableStmt, tableName, tablePropsAsString(TABLE_PROPERTIES));
 
-    sql("INSERT INTO %s VALUES (1L, 100, 'software', TIMESTAMP('2024-11-11 10:00:00'))", tableName);
-    sql("INSERT INTO %s VALUES (2L, 101, 'hr', TIMESTAMP('2024-11-10 09:00:00'))", tableName);
     sql(
-        "INSERT INTO %s VALUES (3L, 102, 'operation', TIMESTAMP('2024-11-10 11:00:00'))",
+        "INSERT INTO %s VALUES "
+            + "(1L, 100, 'software', TIMESTAMP('2024-11-11 10:00:00')),"
+            + "(2L, 101, 'hr', TIMESTAMP('2024-11-10 09:00:00')),"
+            + "(3L, 102, 'operation', TIMESTAMP('2024-11-10 11:00:00')),"
+            + "(4L, 103, 'sales', TIMESTAMP('2024-11-10 10:00:00')),"
+            + "(5L, 104, 'marketing', TIMESTAMP('2024-11-11 10:00:00')),"
+            + "(6L, 105, 'pr', TIMESTAMP('2024-11-10 10:00:00'))",
         tableName);
-    sql("INSERT INTO %s VALUES (4L, 103, 'sales', TIMESTAMP('2024-11-10 10:00:00'))", tableName);
-    sql(
-        "INSERT INTO %s VALUES (5L, 104, 'marketing', TIMESTAMP('2024-11-11 10:00:00'))",
-        tableName);
-    sql("INSERT INTO %s VALUES (6L, 105, 'pr', TIMESTAMP('2024-11-10 10:00:00'))", tableName);
 
     String create2ndTableStmt =
         "CREATE TABLE %s ("
@@ -758,15 +757,13 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
     sql(create2ndTableStmt, otherTableName, tablePropsAsString(TABLE_PROPERTIES));
 
     sql(
-        "INSERT INTO %s VALUES (1L, 100, 'software', TIMESTAMP('2024-11-11 10:00:00'))",
+        "INSERT INTO %s VALUES "
+            + "(1L, 100, 'software', TIMESTAMP('2024-11-11 10:00:00')),"
+            + "(3L, 102, 'operation', TIMESTAMP('2024-11-10 11:00:00')),"
+            + "(5L, 104, 'marketing', TIMESTAMP('2024-11-11 10:00:00')),"
+            + "(5L, 104, 'marketing', TIMESTAMP('2024-11-11 10:00:00')),"
+            + "(6L, 105, 'pr', TIMESTAMP('2024-11-10 10:00:00'))",
         otherTableName);
-    sql(
-        "INSERT INTO %s VALUES (3L, 102, 'operation', TIMESTAMP('2024-11-10 11:00:00'))",
-        otherTableName);
-    sql(
-        "INSERT INTO %s VALUES (5L, 104, 'marketing', TIMESTAMP('2024-11-11 10:00:00'))",
-        otherTableName);
-    sql("INSERT INTO %s VALUES (6L, 105, 'pr', TIMESTAMP('2024-11-10 10:00:00'))", otherTableName);
 
     assertPartitioningAwarePlan(
         1, /* expected num of shuffles with SPJ */

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -724,6 +724,62 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
         tableName(OTHER_TABLE_NAME));
   }
 
+  @TestTemplate
+  public void testJoinsHourToDays() throws NoSuchTableException {
+    String createTableStmt =
+        "CREATE TABLE %s ("
+            + "id BIGINT, int_col INT,dep STRING,timestamp_col TIMESTAMP) "
+            + "USING iceberg "
+            + "PARTITIONED BY (days(timestamp_col)) "
+            + "TBLPROPERTIES (%s)";
+
+    sql(createTableStmt, tableName, tablePropsAsString(TABLE_PROPERTIES));
+
+    sql("INSERT INTO %s VALUES (1L, 100, 'software', TIMESTAMP('2024-11-11 10:00:00'))", tableName);
+    sql("INSERT INTO %s VALUES (2L, 101, 'hr', TIMESTAMP('2024-11-10 09:00:00'))", tableName);
+    sql(
+        "INSERT INTO %s VALUES (3L, 102, 'operation', TIMESTAMP('2024-11-10 11:00:00'))",
+        tableName);
+    sql("INSERT INTO %s VALUES (4L, 103, 'sales', TIMESTAMP('2024-11-10 10:00:00'))", tableName);
+    sql(
+        "INSERT INTO %s VALUES (5L, 104, 'marketing', TIMESTAMP('2024-11-11 10:00:00'))",
+        tableName);
+    sql("INSERT INTO %s VALUES (6L, 105, 'pr', TIMESTAMP('2024-11-10 10:00:00'))", tableName);
+
+    String create2ndTableStmt =
+        "CREATE TABLE %s ("
+            + "id BIGINT, int_col INT, dep STRING, timestamp_col TIMESTAMP) "
+            + "USING iceberg "
+            + "PARTITIONED BY (hours(timestamp_col)) "
+            + "TBLPROPERTIES (%s)";
+
+    String otherTableName = tableName(OTHER_TABLE_NAME);
+
+    sql(create2ndTableStmt, otherTableName, tablePropsAsString(TABLE_PROPERTIES));
+
+    sql(
+        "INSERT INTO %s VALUES (1L, 100, 'software', TIMESTAMP('2024-11-11 10:00:00'))",
+        otherTableName);
+    sql(
+        "INSERT INTO %s VALUES (3L, 102, 'operation', TIMESTAMP('2024-11-10 11:00:00'))",
+        otherTableName);
+    sql(
+        "INSERT INTO %s VALUES (5L, 104, 'marketing', TIMESTAMP('2024-11-11 10:00:00'))",
+        otherTableName);
+    sql("INSERT INTO %s VALUES (6L, 105, 'pr', TIMESTAMP('2024-11-10 10:00:00'))", otherTableName);
+
+    assertPartitioningAwarePlan(
+        1, /* expected num of shuffles with SPJ */
+        3, /* expected num of shuffles without SPJ */
+        "SELECT * "
+            + "FROM %s t1 "
+            + "INNER JOIN %s t2 "
+            + "ON t1.id = t2.id and t1.timestamp_col = t2.timestamp_col "
+            + "ORDER BY t1.id, t1.int_col, t1.dep, t2.id, t2.int_col, t2.dep",
+        tableName,
+        otherTableName);
+  }
+
   private void checkJoin(String sourceColumnName, String sourceColumnType, String transform)
       throws NoSuchTableException {
 


### PR DESCRIPTION
This PR introduces a reducer function to support Storage Partition Join (SPJ) for two iceberg tables one partitioned by day and another one partitioned by hour and join key contains the partitioned column.  At spark level, when SPJ finds the compatible partition transformation is involved on both side of the table, SPJ then uses this iceberg reducer function (hourToDays) to group hour partitions to day level and performs join.