### PR TITLE
Fix(catalog): Only remove metadata files if TableOp created a new one

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -152,8 +152,10 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
       }
     } finally {
       try {
-        if (commitStatus == CommitStatus.FAILURE) {
-          // if anything went wrong, clean up the uncommitted metadata file
+        if (commitStatus == CommitStatus.FAILURE
+            && !Objects.equals(newMetadataLocation, metadata.metadataFileLocation())) {
+          // if anything went wrong, clean up the uncommitted metadata file, if a new one was
+          // created
           io().deleteFile(newMetadataLocation);
         }
       } catch (RuntimeException e) {

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
@@ -23,6 +23,7 @@ import com.google.api.services.bigquery.model.Table;
 import com.google.api.services.bigquery.model.TableReference;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.iceberg.BaseMetastoreOperations;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.SnapshotSummary;
@@ -110,7 +111,10 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
       try {
         if (commitStatus == BaseMetastoreOperations.CommitStatus.FAILURE) {
           LOG.warn("Failed to commit updates to table {}", tableName());
-          io().deleteFile(newMetadataLocation);
+          if (!Objects.equals(newMetadataLocation, metadata.metadataFileLocation())) {
+            // Only clean up newly created metadata files.
+            io().deleteFile(newMetadataLocation);
+          }
         }
       } catch (RuntimeException e) {
         LOG.error(

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.nessie;
 
+import java.util.Objects;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
@@ -133,7 +134,10 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
           .orElse(ex);
     } finally {
       if (failure) {
-        io().deleteFile(newMetadataLocation);
+        if (!Objects.equals(newMetadataLocation, metadata.metadataFileLocation())) {
+          // Only clean up newly created metadata files.
+          io().deleteFile(newMetadataLocation);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #13014 

In multiple Table ops (Glue, Dynamo, BigQuery and Nessie) a failing operation will clean up the metadata file.
However it should only do so if it was the one to create the metadata file in the first place.

Otherwise, an operation like `registerTable` could corrupt other catalog that rely on the existence of the metadata file