### PR TITLE
[REST] Add option to configure TLS settings in REST client

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -52,6 +52,7 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.protocol.BasicHttpContext;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.exceptions.RESTException;
@@ -381,7 +382,11 @@ public class HTTPClient extends BaseHTTPClient {
     if (tlsConfigurer != null) {
       connectionManagerBuilder.setTlsSocketStrategy(
           new DefaultClientTlsStrategy(
-              tlsConfigurer.sslContext(), tlsConfigurer.hostnameVerifier()));
+              tlsConfigurer.sslContext(),
+              tlsConfigurer.supportedProtocols(),
+              tlsConfigurer.supportedCipherSuites(),
+              SSLBufferMode.STATIC,
+              tlsConfigurer.hostnameVerifier()));
     }
 
     return connectionManagerBuilder.build();

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -412,7 +412,16 @@ public class HTTPClient extends BaseHTTPClient {
           e);
     }
 
-    TLSConfigurer configurer = ctor.newInstance();
+    TLSConfigurer configurer;
+    try {
+      configurer = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize TLSConfigurer, %s does not implement TLSConfigurer.", impl),
+          e);
+    }
+
     configurer.initialize(properties);
 
     return configurer;

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -39,6 +39,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -52,6 +53,7 @@ import org.apache.hc.core5.http.protocol.BasicHttpContext;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.iceberg.IcebergBuild;
+import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -59,6 +61,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
 import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.auth.TLSConfigurer;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
@@ -87,6 +90,8 @@ public class HTTPClient extends BaseHTTPClient {
   static final String REST_CONNECTION_TIMEOUT_MS = "rest.client.connection-timeout-ms";
 
   @VisibleForTesting static final String REST_SOCKET_TIMEOUT_MS = "rest.client.socket-timeout-ms";
+
+  static final String REST_TLS_CONFIGURER = "rest.client.tls.configurer-impl";
 
   private final URI baseUri;
   private final CloseableHttpClient httpClient;
@@ -359,7 +364,7 @@ public class HTTPClient extends BaseHTTPClient {
       connectionManagerBuilder.setDefaultConnectionConfig(connectionConfig);
     }
 
-    return connectionManagerBuilder
+    connectionManagerBuilder
         .useSystemProperties()
         .setMaxConnTotal(
             Integer.getInteger(
@@ -368,8 +373,44 @@ public class HTTPClient extends BaseHTTPClient {
                     properties, REST_MAX_CONNECTIONS, REST_MAX_CONNECTIONS_DEFAULT)))
         .setMaxConnPerRoute(
             PropertyUtil.propertyAsInt(
-                properties, REST_MAX_CONNECTIONS_PER_ROUTE, REST_MAX_CONNECTIONS_PER_ROUTE_DEFAULT))
-        .build();
+                properties,
+                REST_MAX_CONNECTIONS_PER_ROUTE,
+                REST_MAX_CONNECTIONS_PER_ROUTE_DEFAULT));
+
+    TLSConfigurer tlsConfigurer = loadTlsConfigurer(properties);
+    if (tlsConfigurer != null) {
+      connectionManagerBuilder.setTlsSocketStrategy(
+          new DefaultClientTlsStrategy(
+              tlsConfigurer.sslContext(), tlsConfigurer.hostnameVerifier()));
+    }
+
+    return connectionManagerBuilder.build();
+  }
+
+  private static TLSConfigurer loadTlsConfigurer(Map<String, String> properties) {
+    String impl = properties.get(REST_TLS_CONFIGURER);
+    if (impl == null) {
+      return null;
+    }
+
+    DynConstructors.Ctor<TLSConfigurer> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(TLSConfigurer.class)
+              .loader(HTTPClient.class.getClassLoader())
+              .impl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize TLSConfigurer implementation %s: %s", impl, e.getMessage()),
+          e);
+    }
+
+    TLSConfigurer configurer = ctor.newInstance();
+    configurer.initialize(properties);
+
+    return configurer;
   }
 
   @VisibleForTesting

--- a/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.auth;
+
+import java.util.Map;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import org.apache.hc.client5.http.ssl.HttpsSupport;
+import org.apache.hc.core5.ssl.SSLContexts;
+
+public interface TLSConfigurer {
+
+  default void initialize(Map<String, String> properties) {}
+
+  default SSLContext sslContext() {
+    return SSLContexts.createDefault();
+  }
+
+  default HostnameVerifier hostnameVerifier() {
+    return HttpsSupport.getDefaultHostnameVerifier();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
@@ -35,4 +35,12 @@ public interface TLSConfigurer {
   default HostnameVerifier hostnameVerifier() {
     return HttpsSupport.getDefaultHostnameVerifier();
   }
+
+  default String[] supportedProtocols() {
+    return null;
+  }
+
+  default String[] supportedCipherSuites() {
+    return null;
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -50,6 +50,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.auth.TLSConfigurer;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.junit.jupiter.api.AfterAll;
@@ -78,6 +79,14 @@ public class TestHTTPClient {
   private static String icebergBuildFullVersion;
   private static ClientAndServer mockServer;
   private static RESTClient restClient;
+
+  public static class DefaultTLSConfigurer implements TLSConfigurer {
+    public static int count = 0;
+
+    public DefaultTLSConfigurer() {
+      count++;
+    }
+  }
 
   @BeforeAll
   public static void beforeClass() {
@@ -330,6 +339,16 @@ public class TestHTTPClient {
         .isEqualTo(HTTPClient.REST_MAX_CONNECTIONS_DEFAULT);
     assertThat(poolingHttpClientConnectionManager.getDefaultMaxPerRoute())
         .isEqualTo(HTTPClient.REST_MAX_CONNECTIONS_PER_ROUTE_DEFAULT);
+  }
+
+  @Test
+  public void testTLSConfigurer() {
+    Map<String, String> properties =
+        ImmutableMap.of(HTTPClient.REST_TLS_CONFIGURER, DefaultTLSConfigurer.class.getName());
+    HttpClientConnectionManager connectionManager =
+        HTTPClient.configureConnectionManager(properties);
+    assertThat(connectionManager).isInstanceOf(PoolingHttpClientConnectionManager.class);
+    assertThat(DefaultTLSConfigurer.count).isEqualTo(1);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -356,7 +356,7 @@ public class TestHTTPClient {
   }
 
   @Test
-  public void testLoadTLSConfigurer_NoArgConstructorNotFound() {
+  public void testLoadTLSConfigurerNoArgConstructorNotFound() {
     Map<String, String> properties =
         ImmutableMap.of(
             HTTPClient.REST_TLS_CONFIGURER, TLSConfigurerMissingNoArgCtor.class.getName());
@@ -368,7 +368,7 @@ public class TestHTTPClient {
   }
 
   @Test
-  public void testLoadTLSConfigurer_ClassNotFound() {
+  public void testLoadTLSConfigurerClassNotFound() {
     Map<String, String> properties =
         ImmutableMap.of(HTTPClient.REST_TLS_CONFIGURER, "TLSConfigurerDoesNotExist");
     assertThatThrownBy(() -> HTTPClient.configureConnectionManager(properties))
@@ -378,7 +378,7 @@ public class TestHTTPClient {
   }
 
   @Test
-  public void testLoadTLSConfigurer_NotImplementTLSConfigurer() {
+  public void testLoadTLSConfigurerNotImplementTLSConfigurer() {
     Map<String, String> properties =
         ImmutableMap.of(HTTPClient.REST_TLS_CONFIGURER, Object.class.getName());
     assertThatThrownBy(() -> HTTPClient.configureConnectionManager(properties))


### PR DESCRIPTION
This PR adds an option to the REST client to configure TLS settings via a pluggable configurer class. Java supports setting some TLS parameters via System properties, but doing so will affect all connections, and causes issues with clients such as the S3 client.

Also, while some basic parameters could be set via catalog properties, using a plugin approach allows the most flexibility when configuring mutual authentication, which can involve custom logic for certificate and host name verification. This aligns with the pluggable model currently used for AuthManagers.

If useful, we could follow this PR up with an implementation that is driven off of catalog properties, for cases that don't need special logic. This would allow setting the keystore and the truststore sepcifically for the REST client, for example.