### PR TITLE
[CORE][REST]: Add context aware response parsing

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1285,6 +1285,12 @@ acceptedBreaks:
     - code: "java.field.removedWithConstant"
       old: "field org.apache.iceberg.TableProperties.ROW_LINEAGE"
       justification: "Removing deprecations for 1.10.0"
+    - code: "java.method.abstractMethodAdded"
+      new: "method <T extends org.apache.iceberg.rest.RESTResponse> T org.apache.iceberg.rest.BaseHTTPClient::execute(org.apache.iceberg.rest.HTTPRequest,\
+        \ java.lang.Class<T>, java.util.function.Consumer<org.apache.iceberg.rest.responses.ErrorResponse>,\
+        \ java.util.function.Consumer<java.util.Map<java.lang.String, java.lang.String>>,\
+        \ com.fasterxml.jackson.databind.InjectableValues)"
+      justification: "Add context aware parsing"
     - code: "java.method.removed"
       old: "method boolean org.apache.iceberg.TableMetadata::rowLineageEnabled()"
       justification: "Removing deprecations for 1.10.0"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1289,7 +1289,7 @@ acceptedBreaks:
       new: "method <T extends org.apache.iceberg.rest.RESTResponse> T org.apache.iceberg.rest.BaseHTTPClient::execute(org.apache.iceberg.rest.HTTPRequest,\
         \ java.lang.Class<T>, java.util.function.Consumer<org.apache.iceberg.rest.responses.ErrorResponse>,\
         \ java.util.function.Consumer<java.util.Map<java.lang.String, java.lang.String>>,\
-        \ com.fasterxml.jackson.databind.InjectableValues)"
+        \ org.apache.iceberg.rest.ParserContext)"
       justification: "Add context aware parsing"
     - code: "java.method.removed"
       old: "method boolean org.apache.iceberg.TableMetadata::rowLineageEnabled()"

--- a/core/src/main/java/org/apache/iceberg/rest/BaseHTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/BaseHTTPClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.rest;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
@@ -78,6 +79,18 @@ public abstract class BaseHTTPClient implements RESTClient {
   }
 
   @Override
+  public <T extends RESTResponse> T get(
+      String path,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      InjectableValues injectableValues) {
+    HTTPRequest request = buildRequest(HTTPMethod.GET, path, queryParams, headers, null);
+    return execute(request, responseType, errorHandler, h -> {}, injectableValues);
+  }
+
+  @Override
   public <T extends RESTResponse> T post(
       String path,
       RESTRequest body,
@@ -98,6 +111,19 @@ public abstract class BaseHTTPClient implements RESTClient {
       Consumer<Map<String, String>> responseHeaders) {
     HTTPRequest request = buildRequest(HTTPMethod.POST, path, null, headers, body);
     return execute(request, responseType, errorHandler, responseHeaders);
+  }
+
+  @Override
+  public <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders,
+      InjectableValues injectableValues) {
+    HTTPRequest request = buildRequest(HTTPMethod.POST, path, null, headers, body);
+    return execute(request, responseType, errorHandler, responseHeaders, injectableValues);
   }
 
   @Override
@@ -123,4 +149,11 @@ public abstract class BaseHTTPClient implements RESTClient {
       Class<T> responseType,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders);
+
+  protected abstract <T extends RESTResponse> T execute(
+      HTTPRequest request,
+      Class<T> responseType,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders,
+      InjectableValues injectableValues);
 }

--- a/core/src/main/java/org/apache/iceberg/rest/BaseHTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/BaseHTTPClient.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.rest;
 
-import com.fasterxml.jackson.databind.InjectableValues;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
@@ -85,9 +84,9 @@ public abstract class BaseHTTPClient implements RESTClient {
       Class<T> responseType,
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler,
-      InjectableValues injectableValues) {
+      ParserContext parserContext) {
     HTTPRequest request = buildRequest(HTTPMethod.GET, path, queryParams, headers, null);
-    return execute(request, responseType, errorHandler, h -> {}, injectableValues);
+    return execute(request, responseType, errorHandler, h -> {}, parserContext);
   }
 
   @Override
@@ -121,9 +120,9 @@ public abstract class BaseHTTPClient implements RESTClient {
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders,
-      InjectableValues injectableValues) {
+      ParserContext parserContext) {
     HTTPRequest request = buildRequest(HTTPMethod.POST, path, null, headers, body);
-    return execute(request, responseType, errorHandler, responseHeaders, injectableValues);
+    return execute(request, responseType, errorHandler, responseHeaders, parserContext);
   }
 
   @Override
@@ -155,5 +154,5 @@ public abstract class BaseHTTPClient implements RESTClient {
       Class<T> responseType,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders,
-      InjectableValues injectableValues);
+      ParserContext parserContext);
 }

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -26,7 +26,7 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.auth.AuthScope;
@@ -103,7 +103,7 @@ public class HTTPClient extends BaseHTTPClient {
   private final ObjectMapper mapper;
   private final AuthSession authSession;
   private final boolean isRootClient;
-  private final ConcurrentHashMap<Class<?>, ObjectReader> objectReaderCache = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Class<?>, ObjectReader> objectReaderCache = Maps.newConcurrentMap();
 
   private HTTPClient(
       URI baseUri,
@@ -355,8 +355,8 @@ public class HTTPClient extends BaseHTTPClient {
       }
 
       try {
-        var reader = objectReaderCache.computeIfAbsent(responseType, mapper::readerFor);
-        if (!parserContext.isEmpty()) {
+        ObjectReader reader = objectReaderCache.computeIfAbsent(responseType, mapper::readerFor);
+        if (parserContext != null && !parserContext.isEmpty()) {
           reader = reader.with(parserContext.toInjectableValues());
         }
         return reader.readValue(responseBody);

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.rest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
@@ -305,7 +304,8 @@ public class HTTPClient extends BaseHTTPClient {
       Class<T> responseType,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders) {
-    return execute(req, responseType, errorHandler, responseHeaders, new InjectableValues.Std());
+    return execute(
+        req, responseType, errorHandler, responseHeaders, ParserContext.builder().build());
   }
 
   @Override
@@ -314,7 +314,7 @@ public class HTTPClient extends BaseHTTPClient {
       Class<T> responseType,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders,
-      InjectableValues injectableValues) {
+      ParserContext parserContext) {
     HttpUriRequestBase request = new HttpUriRequestBase(req.method().name(), req.requestUri());
 
     req.headers().entries().forEach(e -> request.addHeader(e.name(), e.value()));
@@ -353,7 +353,8 @@ public class HTTPClient extends BaseHTTPClient {
       }
 
       try {
-        ObjectReader reader = mapper.readerFor(responseType).with(injectableValues);
+        ObjectReader reader =
+            mapper.readerFor(responseType).with(parserContext.toInjectableValues());
         return reader.readValue(responseBody);
       } catch (JsonProcessingException e) {
         throw new RESTException(

--- a/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
@@ -52,6 +52,7 @@ class ParserContext {
 
     public Builder add(String key, Object value) {
       Preconditions.checkNotNull(key, "Key cannot be null");
+      Preconditions.checkNotNull(value, "Value cannot be null");
       this.data.put(key, value);
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
@@ -31,6 +31,10 @@ class ParserContext {
     this.data = Collections.unmodifiableMap(builder.data);
   }
 
+  public boolean isEmpty() {
+    return data.isEmpty();
+  }
+
   public InjectableValues toInjectableValues() {
     return new InjectableValues.Std(data);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.hadoop.util.Preconditions;
+
+class ParserContext {
+
+  private final Map<String, Object> data;
+
+  private ParserContext(Builder builder) {
+    this.data = Collections.unmodifiableMap(builder.data);
+  }
+
+  public InjectableValues toInjectableValues() {
+    return new InjectableValues.Std(data);
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder {
+    private Map<String, Object> data;
+
+    private Builder() {
+      this.data = Collections.emptyMap();
+    }
+
+    public Builder add(String key, Object value) {
+      Preconditions.checkNotNull(key, "Key cannot be null");
+      this.data.put(key, value);
+      return this;
+    }
+
+    public ParserContext build() {
+      return new ParserContext(this);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.rest;
 
-import com.fasterxml.jackson.databind.InjectableValues;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -104,9 +103,9 @@ public interface RESTClient extends Closeable {
       Class<T> responseType,
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler,
-      InjectableValues injectableValues) {
-    if (injectableValues != null) {
-      throw new UnsupportedOperationException("InjectableValues is not supported");
+      ParserContext parserContext) {
+    if (parserContext != null) {
+      throw new UnsupportedOperationException("Parser context is not supported");
     }
     return get(path, queryParams, responseType, headers, errorHandler);
   }
@@ -144,9 +143,9 @@ public interface RESTClient extends Closeable {
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders,
-      InjectableValues injectableValues) {
-    if (injectableValues != null) {
-      throw new UnsupportedOperationException("InjectableValues is not supported");
+      ParserContext parserContext) {
+    if (parserContext != null) {
+      throw new UnsupportedOperationException("Parser context is not supported");
     }
     return post(path, body, responseType, headers, errorHandler, responseHeaders);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.rest;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -97,6 +98,19 @@ public interface RESTClient extends Closeable {
     return get(path, queryParams, responseType, headers.get(), errorHandler);
   }
 
+  default <T extends RESTResponse> T get(
+      String path,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      InjectableValues injectableValues) {
+    if (injectableValues != null) {
+      throw new UnsupportedOperationException("InjectableValues is not supported");
+    }
+    return get(path, queryParams, responseType, headers, errorHandler);
+  }
+
   <T extends RESTResponse> T get(
       String path,
       Map<String, String> queryParams,
@@ -121,6 +135,20 @@ public interface RESTClient extends Closeable {
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders) {
     return post(path, body, responseType, headers.get(), errorHandler, responseHeaders);
+  }
+
+  default <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders,
+      InjectableValues injectableValues) {
+    if (injectableValues != null) {
+      throw new UnsupportedOperationException("InjectableValues is not supported");
+    }
+    return post(path, body, responseType, headers, errorHandler, responseHeaders);
   }
 
   default <T extends RESTResponse> T post(

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.rest;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
@@ -606,6 +607,17 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
       Class<T> responseType,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders) {
+    return execute(
+        request, responseType, errorHandler, responseHeaders, new InjectableValues.Std());
+  }
+
+  @Override
+  protected <T extends RESTResponse> T execute(
+      HTTPRequest request,
+      Class<T> responseType,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders,
+      InjectableValues injectableValues) {
     ErrorResponse.Builder errorBuilder = ErrorResponse.builder();
     Pair<Route, Map<String, String>> routeAndVars = Route.from(request.method(), request.path());
     if (routeAndVars != null) {

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.rest;
 
-import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
@@ -608,7 +607,7 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders) {
     return execute(
-        request, responseType, errorHandler, responseHeaders, new InjectableValues.Std());
+        request, responseType, errorHandler, responseHeaders, ParserContext.builder().build());
   }
 
   @Override
@@ -617,7 +616,7 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
       Class<T> responseType,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders,
-      InjectableValues injectableValues) {
+      ParserContext parserContext) {
     ErrorResponse.Builder errorBuilder = ErrorResponse.builder();
     Pair<Route, Map<String, String>> routeAndVars = Route.from(request.method(), request.path());
     if (routeAndVars != null) {


### PR DESCRIPTION
### About the change 

Presently the REST parsers are stateless aka static, this makes hard to inject a state which can help the parser to construct the response object if it needs some prior info. Addding injectable values to the mapper and using a reader with injectable value passed during making the request will make sure that during deserialization we will get back the value injected from the DeserializationContext 

https://github.com/apache/iceberg/blob/3469cf30f2d839763813596e3f0c66ed16189c9a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java#L450


essentially something like this is possible now : 

```
      // Retrieve injectable values
      @SuppressWarnings("unchecked")
      Map<Integer, PartitionSpec> specsById =
          (Map<Integer, PartitionSpec>) context.findInjectableValue("specsById", null, null);

      boolean caseSensitive = (boolean) context.findInjectableValue("caseSensitive", null, null);
```

so now a client can essentially during making the post can pass the injectableValues and use it for stateful parsing i,e making these value available to the parser while doing deserilization.

please ref this : https://github.com/apache/iceberg/pull/13004#discussion_r2135226197 for more details.


### Why this is required 

This is required because of scan planning API response doesn't contains specs the caseSensitive field which is required for properly creating the FileScanTask / DataFile / DeleteFile objects essentially needing the state where the table has been loaded and we have already the specByID map and the caseSensitive field. Now these can be injected and percolated from the POST call to all the way to the mapper and hence to the parsers to make the cycle. 
My understanding is Since we do it this way rather than injecting the whole at mapper end, we can guarantee thread safety


ref scan planning PR : https://github.com/apache/iceberg/pull/13004/ for E2E machinery

