### PR TITLE
Support for TIME, TIMESTAMPNTZ_NANO, UUID types in Inclusive Metrics Evaluator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/VariantExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/VariantExpressionUtil.java
@@ -148,6 +148,7 @@ class VariantExpressionUtil {
               (Integer) DateTimeUtil.nanosToDays(((Number) value.asPrimitive().get()).longValue());
         }
     }
+
     return null;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluatorWithExtract.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluatorWithExtract.java
@@ -1031,6 +1031,6 @@ public class TestInclusiveMetricsEvaluatorWithExtract {
     DataFile file =
         new TestDataFile("file.parquet", Row.of(), 50, null, null, null, lowerBounds, upperBounds);
     Expression expr = equal(extract("variant", "$.event_uuid", PhysicalType.UUID.name()), uuid);
-    assertThat(shouldRead(expr, file)).as("Should read: many possible timestamps" + expr).isTrue();
+    assertThat(shouldRead(expr, file)).as("Should read: many possible UUIDs" + expr).isTrue();
   }
 }


### PR DESCRIPTION
Added support for following types in VariantExpressionUtil:

PhysicalType.TIME
PhysicalType.TIMESTAMPNTZ_NANO
PhysicalType.TIMESTAMPTZ_NANO
PhysicalType.UUID

In addition to covering unit tests for above types, added tests for TIMESTAMPNTZ and TIMESTAMPTZ types as well.