### PR TITLE
GCP: Add Google Authentication Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -718,6 +718,7 @@ project(':iceberg-gcp') {
     testImplementation libs.esotericsoftware.kryo
     testImplementation libs.mockserver.netty
     testImplementation libs.mockserver.client.java
+    testImplementation libs.mockito.junit.jupiter
   }
 }
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -62,9 +62,6 @@ public class GCPProperties implements Serializable {
    */
   public static final int GCS_DELETE_BATCH_SIZE_DEFAULT = 50;
 
-  public static final String GCP_CREDENTIALS_PATH_PROPERTY = "gcp.auth.credentials-path";
-  public static final String GCP_SCOPES_PROPERTY = "gcp.auth.scopes";
-
   private final Map<String, String> allProperties;
 
   private String projectId;

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -62,6 +62,9 @@ public class GCPProperties implements Serializable {
    */
   public static final int GCS_DELETE_BATCH_SIZE_DEFAULT = 50;
 
+  public static final String GCP_CREDENTIALS_PATH_PROPERTY = "gcp.auth.credentials-path";
+  public static final String GCP_SCOPES_PROPERTY = "gcp.auth.scopes";
+
   private final Map<String, String> allProperties;
 
   private String projectId;

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
@@ -124,11 +124,12 @@ public class GoogleAuthManager implements AuthManager {
     return new GoogleAuthSession(credentials);
   }
 
-  /** Returns a session for a specific context. Defaults to the catalog session. */
+  /**
+   * Returns a session for a specific context. Defaults to the catalog session. For GCP, tokens are
+   * typically not context-specific in this manner.
+   */
   @Override
   public AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent) {
-    // For GCP, tokens are typically not context-specific in this manner.
-    // Re-using the parent (which should be a GoogleAuthSession) is appropriate.
     return parent;
   }
 
@@ -136,14 +137,10 @@ public class GoogleAuthManager implements AuthManager {
   @Override
   public AuthSession tableSession(
       TableIdentifier table, Map<String, String> properties, AuthSession parent) {
-    // Similar to contextualSession, GCP tokens are generally not table-specific.
     return parent;
   }
 
   /** Closes the manager. This is a no-op for GoogleAuthManager. */
   @Override
-  public void close() {
-    // No-op. Credentials lifecycle is managed by the GoogleCredentials object itself or by the
-    // application.
-  }
+  public void close() {}
 }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.auth;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.auth.AuthManager;
+import org.apache.iceberg.rest.auth.AuthSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An authentication manager that uses Google Credentials (typically Application Default
+ * Credentials) to create {@link GoogleAuthSession} instances.
+ *
+ * <p>This manager can be configured with properties such as:
+ *
+ * <ul>
+ *   <li>{@code gcp.auth.credentials-path}: Path to a service account JSON key file. If not set,
+ *       Application Default Credentials will be used.
+ *   <li>{@code gcp.auth.scopes}: Comma-separated list of OAuth scopes to request. Defaults to
+ *       "https://www.googleapis.com/auth/cloud-platform".
+ * </ul>
+ */
+public class GoogleAuthManager implements AuthManager {
+  private static final Logger LOG = LoggerFactory.getLogger(GoogleAuthManager.class);
+  public static final String DEFAULT_SCOPES = "https://www.googleapis.com/auth/cloud-platform";
+  private final String name;
+
+  private GoogleCredentials credentials;
+  private boolean initialized = false;
+
+  public GoogleAuthManager(String managerName) {
+    this.name = managerName;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  private void initialize(Map<String, String> properties) {
+    if (initialized) {
+      return;
+    }
+
+    String credentialsPath = properties.get(GCPProperties.GCP_CREDENTIALS_PATH_PROPERTY);
+    String scopesString =
+        properties.getOrDefault(GCPProperties.GCP_SCOPES_PROPERTY, DEFAULT_SCOPES);
+    List<String> scopes = ImmutableList.copyOf(scopesString.split(","));
+
+    try {
+      if (credentialsPath != null && !credentialsPath.isEmpty()) {
+        LOG.info("Using Google credentials from path: {}", credentialsPath);
+        try (FileInputStream credentialsStream = new FileInputStream(credentialsPath)) {
+          this.credentials = GoogleCredentials.fromStream(credentialsStream).createScoped(scopes);
+        }
+      } else {
+        LOG.info("Using Application Default Credentials with scopes: {}", scopesString);
+        this.credentials = GoogleCredentials.getApplicationDefault().createScoped(scopes);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to load Google credentials", e);
+    }
+    this.initialized = true;
+  }
+
+  /**
+   * Initializes and returns a short-lived session, typically for fetching configuration. This
+   * implementation reuses the long-lived catalog session logic.
+   */
+  @Override
+  public AuthSession initSession(RESTClient initClient, Map<String, String> properties) {
+    return catalogSession(initClient, properties);
+  }
+
+  /**
+   * Returns a long-lived session tied to the catalog's lifecycle. This session uses Google
+   * Application Default Credentials or a specified service account.
+   *
+   * @param sharedClient The long-lived RESTClient (not used by this implementation for credential
+   *     fetching).
+   * @param properties Configuration properties for the auth manager.
+   * @return A {@link GoogleAuthSession}.
+   * @throws UncheckedIOException if credential loading fails.
+   */
+  @Override
+  public AuthSession catalogSession(RESTClient sharedClient, Map<String, String> properties) {
+    initialize(properties);
+    Preconditions.checkState(
+        credentials != null, "GoogleAuthManager not initialized or failed to load credentials");
+    return new GoogleAuthSession(credentials);
+  }
+
+  /** Returns a session for a specific context. Defaults to the catalog session. */
+  @Override
+  public AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent) {
+    // For GCP, tokens are typically not context-specific in this manner.
+    // Re-using the parent (which should be a GoogleAuthSession) is appropriate.
+    // Or, if properties for a specific context were available, a new GoogleAuthSession could be
+    // derived.
+    if (parent instanceof GoogleAuthSession) {
+      return parent;
+    }
+    // Fallback to a new catalog-level session if the parent is not a GoogleAuthSession for some
+    // reason.
+    // This would require properties to be available or a default initialization.
+    LOG.warn(
+        "Parent session is not a GoogleAuthSession. Creating a new default catalog session. This might not be intended.");
+    return catalogSession(
+        null, Collections.emptyMap()); // Assuming default ADC without specific props
+  }
+
+  /** Returns a session for a specific table or view. Defaults to the catalog session. */
+  @Override
+  public AuthSession tableSession(
+      TableIdentifier table, Map<String, String> properties, AuthSession parent) {
+    // Similar to contextualSession, GCP tokens are generally not table-specific.
+    if (parent instanceof GoogleAuthSession) {
+      return parent;
+    }
+    LOG.warn(
+        "Parent session for table {} is not a GoogleAuthSession. Creating a new default catalog session.",
+        table);
+    return catalogSession(null, properties);
+  }
+
+  /** Closes the manager. This is a no-op for GoogleAuthManager. */
+  @Override
+  public void close() {
+    // No-op. Credentials lifecycle is managed by the GoogleCredentials object itself or by the
+    // application.
+  }
+}

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
@@ -60,7 +60,7 @@ public class GoogleAuthManager implements AuthManager {
     this.name = managerName;
   }
 
-  public String getName() {
+  public String name() {
     return name;
   }
 
@@ -87,6 +87,7 @@ public class GoogleAuthManager implements AuthManager {
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to load Google credentials", e);
     }
+
     this.initialized = true;
   }
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
@@ -22,7 +22,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.catalog.SessionCatalog;
@@ -123,18 +122,7 @@ public class GoogleAuthManager implements AuthManager {
   public AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent) {
     // For GCP, tokens are typically not context-specific in this manner.
     // Re-using the parent (which should be a GoogleAuthSession) is appropriate.
-    // Or, if properties for a specific context were available, a new GoogleAuthSession could be
-    // derived.
-    if (parent instanceof GoogleAuthSession) {
-      return parent;
-    }
-    // Fallback to a new catalog-level session if the parent is not a GoogleAuthSession for some
-    // reason.
-    // This would require properties to be available or a default initialization.
-    LOG.warn(
-        "Parent session is not a GoogleAuthSession. Creating a new default catalog session. This might not be intended.");
-    return catalogSession(
-        null, Collections.emptyMap()); // Assuming default ADC without specific props
+    return parent;
   }
 
   /** Returns a session for a specific table or view. Defaults to the catalog session. */
@@ -142,13 +130,7 @@ public class GoogleAuthManager implements AuthManager {
   public AuthSession tableSession(
       TableIdentifier table, Map<String, String> properties, AuthSession parent) {
     // Similar to contextualSession, GCP tokens are generally not table-specific.
-    if (parent instanceof GoogleAuthSession) {
-      return parent;
-    }
-    LOG.warn(
-        "Parent session for table {} is not a GoogleAuthSession. Creating a new default catalog session.",
-        table);
-    return catalogSession(null, properties);
+    return parent;
   }
 
   /** Closes the manager. This is a no-op for GoogleAuthManager. */

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthManager.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class GoogleAuthManager implements AuthManager {
   private static final Logger LOG = LoggerFactory.getLogger(GoogleAuthManager.class);
+  private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
   public static final String DEFAULT_SCOPES = "https://www.googleapis.com/auth/cloud-platform";
   public static final String GCP_CREDENTIALS_PATH_PROPERTY = "gcp.auth.credentials-path";
   public static final String GCP_SCOPES_PROPERTY = "gcp.auth.scopes";
@@ -77,8 +78,7 @@ public class GoogleAuthManager implements AuthManager {
     List<String> scopes =
         Strings.isNullOrEmpty(scopesString)
             ? ImmutableList.of()
-            : ImmutableList.copyOf(
-                Splitter.on(',').trimResults().omitEmptyStrings().splitToList(scopesString));
+            : ImmutableList.copyOf(SPLITTER.splitToList(scopesString));
 
     try {
       if (credentialsPath != null && !credentialsPath.isEmpty()) {

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthSession.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthSession.java
@@ -44,7 +44,7 @@ public class GoogleAuthSession implements AuthSession {
    * @param credentials The GoogleCredentials to use for authentication.
    */
   public GoogleAuthSession(GoogleCredentials credentials) {
-    Preconditions.checkArgument(credentials != null, "credentials can not be null");
+    Preconditions.checkArgument(credentials != null, "Invalid credentials: null");
     this.credentials = credentials;
   }
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthSession.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthSession.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.auth;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import org.apache.iceberg.rest.HTTPHeaders;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.ImmutableHTTPRequest;
+import org.apache.iceberg.rest.auth.AuthSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An authentication session that uses Google Credentials (typically Application Default
+ * Credentials) to obtain an OAuth2 access token and add it to HTTP requests.
+ */
+public class GoogleAuthSession implements AuthSession {
+  private static final Logger LOG = LoggerFactory.getLogger(GoogleAuthSession.class);
+  private final GoogleCredentials credentials;
+
+  /**
+   * Constructs a GoogleAuthSession with the provided GoogleCredentials.
+   *
+   * @param credentials The GoogleCredentials to use for authentication.
+   */
+  public GoogleAuthSession(GoogleCredentials credentials) {
+    this.credentials = credentials;
+  }
+
+  /**
+   * Authenticates the given HTTP request by adding an "Authorization: Bearer token" header. The
+   * access token is obtained from the GoogleCredentials.
+   *
+   * @param request The HTTPRequest to authenticate.
+   * @return A new HTTPRequest with the added Authorization header.
+   * @throws UncheckedIOException if an IOException occurs while refreshing the access token.
+   */
+  @Override
+  public HTTPRequest authenticate(HTTPRequest request) {
+    try {
+      // Ensure the credentials have a valid token, refreshing if necessary.
+      // refreshIfExpired() returns true if the token was refreshed, false otherwise.
+      // In either case, getAccessToken() after this call should provide a usable token.
+      credentials.refreshIfExpired();
+      AccessToken token = credentials.getAccessToken();
+
+      if (token != null && token.getTokenValue() != null) {
+        HTTPHeaders newHeaders =
+            request
+                .headers()
+                .putIfAbsent(
+                    HTTPHeaders.of(
+                        HTTPHeaders.HTTPHeader.of(
+                            "Authorization", "Bearer " + token.getTokenValue())));
+        return newHeaders.equals(request.headers())
+            ? request
+            : ImmutableHTTPRequest.builder().from(request).headers(newHeaders).build();
+      } else {
+        LOG.warn(
+            "Failed to obtain Google access token. Request will be sent without Authorization header.");
+        return request;
+      }
+    } catch (IOException e) {
+      LOG.error("IOException while trying to refresh Google access token", e);
+      throw new UncheckedIOException("Failed to refresh Google access token", e);
+    }
+  }
+
+  /**
+   * Closes the session. This is a no-op for GoogleAuthSession as the lifecycle of GoogleCredentials
+   * is not managed by this session.
+   */
+  @Override
+  public void close() {
+    // No-op
+  }
+}

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthSession.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthSession.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * An authentication session that uses Google Credentials (typically Application Default
  * Credentials) to obtain an OAuth2 access token and add it to HTTP requests.
  */
-public class GoogleAuthSession implements AuthSession {
+class GoogleAuthSession implements AuthSession {
   private static final Logger LOG = LoggerFactory.getLogger(GoogleAuthSession.class);
   private final GoogleCredentials credentials;
 
@@ -43,7 +43,7 @@ public class GoogleAuthSession implements AuthSession {
    *
    * @param credentials The GoogleCredentials to use for authentication.
    */
-  public GoogleAuthSession(GoogleCredentials credentials) {
+  GoogleAuthSession(GoogleCredentials credentials) {
     Preconditions.checkArgument(credentials != null, "Invalid credentials: null");
     this.credentials = credentials;
   }
@@ -59,9 +59,6 @@ public class GoogleAuthSession implements AuthSession {
   @Override
   public HTTPRequest authenticate(HTTPRequest request) {
     try {
-      // Ensure the credentials have a valid token, refreshing if necessary.
-      // refreshIfExpired() returns true if the token was refreshed, false otherwise.
-      // In either case, getAccessToken() after this call should provide a usable token.
       credentials.refreshIfExpired();
       AccessToken token = credentials.getAccessToken();
 
@@ -77,9 +74,8 @@ public class GoogleAuthSession implements AuthSession {
             ? request
             : ImmutableHTTPRequest.builder().from(request).headers(newHeaders).build();
       } else {
-        LOG.warn(
-            "Failed to obtain Google access token. Request will be sent without Authorization header.");
-        return request;
+        throw new IllegalStateException(
+            "Failed to obtain Google access token. Cannot authenticate request.");
       }
     } catch (IOException e) {
       LOG.error("IOException while trying to refresh Google access token", e);

--- a/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthSession.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/auth/GoogleAuthSession.java
@@ -22,6 +22,7 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.rest.HTTPHeaders;
 import org.apache.iceberg.rest.HTTPRequest;
 import org.apache.iceberg.rest.ImmutableHTTPRequest;
@@ -43,6 +44,7 @@ public class GoogleAuthSession implements AuthSession {
    * @param credentials The GoogleCredentials to use for authentication.
    */
   public GoogleAuthSession(GoogleCredentials credentials) {
+    Preconditions.checkArgument(credentials != null, "credentials can not be null");
     this.credentials = credentials;
   }
 

--- a/gcp/src/test/java/org/apache/iceberg/gcp/auth/TestGoogleAuthManager.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/auth/TestGoogleAuthManager.java
@@ -81,7 +81,7 @@ public class TestGoogleAuthManager {
 
   @Test
   public void providesCorrectManagerName() {
-    assertThat(authManager.getName()).isEqualTo(MANAGER_NAME);
+    assertThat(authManager.name()).isEqualTo(MANAGER_NAME);
   }
 
   @Test

--- a/gcp/src/test/java/org/apache/iceberg/gcp/auth/TestGoogleAuthSession.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/auth/TestGoogleAuthSession.java
@@ -129,7 +129,7 @@ public class TestGoogleAuthSession {
   }
 
   @Test
-  public void returnsOriginalRequestWhenAccessTokenIsNull() {
+  public void throwsExceptionWhenAccessTokenIsNull() {
     when(credentials.getAccessToken()).thenReturn(null);
 
     HTTPRequest originalRequest =
@@ -138,14 +138,14 @@ public class TestGoogleAuthSession {
             .path(TEST_RELATIVE_PATH)
             .method(HTTPRequest.HTTPMethod.GET)
             .build();
-    HTTPRequest authenticatedRequest = session.authenticate(originalRequest);
 
-    assertThat(authenticatedRequest).isSameAs(originalRequest);
-    assertThat(authenticatedRequest.headers().entries()).isEmpty();
+    assertThatThrownBy(() -> session.authenticate(originalRequest))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Failed to obtain Google access token. Cannot authenticate request.");
   }
 
   @Test
-  public void returnsOriginalRequestWhenTokenValueIsNull() {
+  public void throwsExceptionWhenTokenValueIsNull() {
     when(credentials.getAccessToken()).thenReturn(accessToken);
     when(accessToken.getTokenValue()).thenReturn(null);
 
@@ -155,10 +155,10 @@ public class TestGoogleAuthSession {
             .path(TEST_RELATIVE_PATH)
             .method(HTTPRequest.HTTPMethod.GET)
             .build();
-    HTTPRequest authenticatedRequest = session.authenticate(originalRequest);
 
-    assertThat(authenticatedRequest).isSameAs(originalRequest);
-    assertThat(authenticatedRequest.headers().entries()).isEmpty();
+    assertThatThrownBy(() -> session.authenticate(originalRequest))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Failed to obtain Google access token. Cannot authenticate request.");
   }
 
   @Test

--- a/gcp/src/test/java/org/apache/iceberg/gcp/auth/TestGoogleAuthSession.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/auth/TestGoogleAuthSession.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.auth;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import org.apache.iceberg.rest.HTTPHeaders;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.ImmutableHTTPRequest;
+import org.apache.iceberg.rest.auth.AuthSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TestGoogleAuthSession {
+
+  @Mock private GoogleCredentials credentials;
+  @Mock private AccessToken accessToken;
+
+  private AuthSession session;
+  private static final String TEST_TOKEN_VALUE = "test-token-12345";
+  private URI testBaseUri;
+  private static final String TEST_RELATIVE_PATH = "v1/some/resource";
+
+  @BeforeEach
+  public void beforeEach() throws URISyntaxException {
+    this.session = new GoogleAuthSession(credentials);
+    this.testBaseUri = new URI("http://localhost:8080");
+  }
+
+  @Test
+  public void addsAuthHeaderOnSuccessfulTokenFetch() throws IOException {
+    when(credentials.getAccessToken()).thenReturn(accessToken);
+    when(accessToken.getTokenValue()).thenReturn(TEST_TOKEN_VALUE);
+
+    HTTPRequest originalRequest =
+        ImmutableHTTPRequest.builder()
+            .baseUri(testBaseUri)
+            .path(TEST_RELATIVE_PATH)
+            .method(HTTPRequest.HTTPMethod.GET)
+            .build();
+    HTTPRequest authenticatedRequest = session.authenticate(originalRequest);
+
+    verify(credentials).refreshIfExpired();
+    verify(credentials).getAccessToken();
+
+    Assertions.assertNotSame(
+        originalRequest, authenticatedRequest, "A new request object should be returned");
+
+    HTTPHeaders headers = authenticatedRequest.headers();
+    Assertions.assertEquals(1, headers.entries().size());
+    Assertions.assertTrue(headers.contains("Authorization"), "Should contain Authorization header");
+
+    Set<HTTPHeaders.HTTPHeader> authHeaderEntries = headers.entries("Authorization");
+    Assertions.assertEquals(1, authHeaderEntries.size(), "Should have one Authorization header");
+    Assertions.assertEquals(
+        "Bearer " + TEST_TOKEN_VALUE,
+        authHeaderEntries.iterator().next().value(),
+        "Authorization header should be set correctly");
+  }
+
+  @Test
+  public void preservesExistingAuthHeader() throws IOException {
+    String existingAuthHeaderValue = "Bearer existing-bearer-token";
+    HTTPHeaders initialHeaders =
+        HTTPHeaders.of(HTTPHeaders.HTTPHeader.of("Authorization", existingAuthHeaderValue));
+    HTTPRequest originalRequest =
+        ImmutableHTTPRequest.builder()
+            .baseUri(testBaseUri)
+            .path(TEST_RELATIVE_PATH)
+            .method(HTTPRequest.HTTPMethod.GET)
+            .headers(initialHeaders)
+            .build();
+
+    when(credentials.getAccessToken()).thenReturn(accessToken);
+    when(accessToken.getTokenValue()).thenReturn(TEST_TOKEN_VALUE);
+
+    HTTPRequest authenticatedRequest = session.authenticate(originalRequest);
+
+    verify(credentials).refreshIfExpired();
+
+    Assertions.assertSame(
+        originalRequest,
+        authenticatedRequest,
+        "Original request object should be returned if header exists");
+
+    HTTPHeaders resultingHeaders = authenticatedRequest.headers();
+    Assertions.assertEquals(1, resultingHeaders.entries().size());
+    Assertions.assertEquals(
+        existingAuthHeaderValue,
+        resultingHeaders.entries("Authorization").iterator().next().value(),
+        "Existing Authorization header should be preserved");
+  }
+
+  @Test
+  public void propagatesIOExceptionAsUncheckedOnTokenRefreshFailure() throws IOException {
+    doThrow(new IOException("Failed to refresh token")).when(credentials).refreshIfExpired();
+
+    HTTPRequest originalRequest =
+        ImmutableHTTPRequest.builder()
+            .baseUri(testBaseUri)
+            .path(TEST_RELATIVE_PATH)
+            .method(HTTPRequest.HTTPMethod.GET)
+            .build();
+
+    UncheckedIOException thrown =
+        Assertions.assertThrows(
+            UncheckedIOException.class,
+            () -> session.authenticate(originalRequest),
+            "Should throw UncheckedIOException on refresh failure");
+
+    Assertions.assertEquals("Failed to refresh Google access token", thrown.getMessage());
+    Assertions.assertInstanceOf(IOException.class, thrown.getCause());
+    verify(credentials).refreshIfExpired();
+  }
+
+  @Test
+  public void returnsOriginalRequestWhenAccessTokenIsNull() throws IOException {
+    when(credentials.getAccessToken()).thenReturn(null);
+
+    HTTPRequest originalRequest =
+        ImmutableHTTPRequest.builder()
+            .baseUri(testBaseUri)
+            .path(TEST_RELATIVE_PATH)
+            .method(HTTPRequest.HTTPMethod.GET)
+            .build();
+    HTTPRequest authenticatedRequest = session.authenticate(originalRequest);
+
+    Assertions.assertSame(
+        originalRequest, authenticatedRequest, "Request should be unchanged when token is null");
+    Assertions.assertTrue(
+        authenticatedRequest.headers().entries().isEmpty(), "Headers should be empty");
+  }
+
+  @Test
+  public void returnsOriginalRequestWhenTokenValueIsNull() throws IOException {
+    when(credentials.getAccessToken()).thenReturn(accessToken);
+    when(accessToken.getTokenValue()).thenReturn(null);
+
+    HTTPRequest originalRequest =
+        ImmutableHTTPRequest.builder()
+            .baseUri(testBaseUri)
+            .path(TEST_RELATIVE_PATH)
+            .method(HTTPRequest.HTTPMethod.GET)
+            .build();
+    HTTPRequest authenticatedRequest = session.authenticate(originalRequest);
+
+    Assertions.assertSame(
+        originalRequest,
+        authenticatedRequest,
+        "Request should be unchanged when token value is null");
+    Assertions.assertTrue(
+        authenticatedRequest.headers().entries().isEmpty(), "Headers should be empty");
+  }
+
+  @Test
+  public void sessionCloseBehavesAsNoOp() {
+    Assertions.assertDoesNotThrow(session::close);
+  }
+}

--- a/gcp/src/test/java/org/apache/iceberg/gcp/auth/TestGoogleAuthSession.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/auth/TestGoogleAuthSession.java
@@ -44,13 +44,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class TestGoogleAuthSession {
 
+  private static final String TEST_TOKEN_VALUE = "test-token-12345";
+  private static final String TEST_RELATIVE_PATH = "v1/some/resource";
   @Mock private GoogleCredentials credentials;
   @Mock private AccessToken accessToken;
 
   private AuthSession session;
-  private static final String TEST_TOKEN_VALUE = "test-token-12345";
   private URI testBaseUri;
-  private static final String TEST_RELATIVE_PATH = "v1/some/resource";
 
   @BeforeEach
   public void beforeEach() throws URISyntaxException {
@@ -78,10 +78,8 @@ public class TestGoogleAuthSession {
 
     HTTPHeaders headers = authenticatedRequest.headers();
     assertThat(headers.contains("Authorization")).isTrue();
-    assertThat(headers.entries("Authorization"))
-        .hasSize(1)
-        .extracting("value")
-        .containsExactly("Bearer " + TEST_TOKEN_VALUE);
+    assertThat(authenticatedRequest.headers().entries())
+        .containsExactly(HTTPHeaders.HTTPHeader.of("Authorization", "Bearer " + TEST_TOKEN_VALUE));
   }
 
   @Test
@@ -105,11 +103,8 @@ public class TestGoogleAuthSession {
     verify(credentials).refreshIfExpired();
 
     assertThat(authenticatedRequest).isSameAs(originalRequest);
-    assertThat(authenticatedRequest.headers().entries("Authorization"))
-        .hasSize(1)
-        .extracting("value")
-        .first()
-        .isEqualTo(existingAuthHeaderValue);
+    assertThat(authenticatedRequest.headers().entries())
+        .containsExactly(HTTPHeaders.HTTPHeader.of("Authorization", existingAuthHeaderValue));
   }
 
   @Test
@@ -134,7 +129,7 @@ public class TestGoogleAuthSession {
   }
 
   @Test
-  public void returnsOriginalRequestWhenAccessTokenIsNull() throws IOException {
+  public void returnsOriginalRequestWhenAccessTokenIsNull() {
     when(credentials.getAccessToken()).thenReturn(null);
 
     HTTPRequest originalRequest =
@@ -150,7 +145,7 @@ public class TestGoogleAuthSession {
   }
 
   @Test
-  public void returnsOriginalRequestWhenTokenValueIsNull() throws IOException {
+  public void returnsOriginalRequestWhenTokenValueIsNull() {
     when(credentials.getAccessToken()).thenReturn(accessToken);
     when(accessToken.getTokenValue()).thenReturn(null);
 


### PR DESCRIPTION
This PR introduces a dedicated GoogleAuthManager for the Iceberg REST client, enabling robust and streamlined authentication with Google Cloud Platform (GCP) services by delegating authentication to GCP's auth library.

***Why add a specific GoogleAuthManager?***

Currently, Iceberg's AuthManager and the generic OAuth2Manager provide a good baseline for authentication. However, connecting to services on Google Cloud often uses specific patterns that a generic manager doesn't fully simplify. This new GoogleAuthManager makes life easier for folks using Iceberg REST catalogs behind GCP Auth Service 

The existing OAuth2Manager is great for standard OAuth2 flows (like client credentials) but it does not support [authorization code workflow](https://datatracker.ietf.org/doc/html/rfc6749#section-6). 

The GoogleAuthManager introduces authentication methods that are more convenient for GCP users, differing from the generic OAuth2 flow:

- Application Default Credentials (ADC) Support: Provides out-of-the-box, zero-configuration authentication when the Iceberg client runs within GCP environments (e.g., Compute Engine, GKE, Cloud Functions). This is a significant usability improvement over manually setting up OAuth2 parameters.
- Service Account Key File Support: Allows users to authenticate by directly providing a path to a GCP service account JSON key file. This is a common and secure way to authenticate applications with GCP services, and is more specific than the generic token or client secret mechanisms.
- Configurable OAuth Scopes: While the generic OAuth2Manager also supports scopes, GoogleAuthManager defaults to scopes commonly used for GCP services and allows easy customization via the gcp.auth.scopes property.

While our current OAuth2Manager can be used with tokens from service accounts, it doesn't natively understand refresh token workflow and the ADC discovery process or how to directly consume a service account JSON file for its credentials. 

This dedicated manager ensures that Iceberg can authenticate with GCP-backed REST catalog services in the most efficient, secure, and user-friendly manner, aligning with common GCP practices. The GoogleAuthManager bridges this gap for a more seamless Iceberg Rest experience on GCP.

