### PR TITLE
Docs: Add custom table location description for Flink

### DIFF
--- a/docs/docs/flink-ddl.md
+++ b/docs/docs/flink-ddl.md
@@ -152,6 +152,18 @@ Table create commands support the commonly used [Flink create clauses](https://n
 * `COMMENT 'table document'` to set a table description.
 * `WITH ('key'='value', ...)` to set [table configuration](configuration.md) which will be stored in Iceberg table properties.
 
+To specify the table location, use `WITH ('location'='fully-qualified-uri')` instead of `LOCATION`:
+
+```sql
+CREATE TABLE `hive_catalog`.`default`.`sample` (
+    id BIGINT COMMENT 'unique id',
+    data STRING NOT NULL
+) WITH (
+    'format-version'='2', 
+    'location'='hdfs//nn:8020/custom-path'
+);
+```
+
 Currently, it does not support computed column and watermark definition etc.
 
 #### `PRIMARY KEY`


### PR DESCRIPTION
Currently the Flink document doesn't mention about how to customize the table location in FlinkSQL, and the document only shows the way to specify the location with `warehouse`. The `LOCATION` caluse cannot be used in FlinkSQL, and the way of the customization is not clear for users. Therefore, this doc tries to add the description to customize the location for Flink Iceberg.