### PR TITLE
AWS, GCS: Fix issue with Kryo and empty immutable collections

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -103,7 +103,8 @@ public class S3FileIO
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
   private transient StackTraceElement[] createStack;
-  private List<StorageCredential> storageCredentials = ImmutableList.of();
+  // use modifiable collection for Kryo serde
+  private List<StorageCredential> storageCredentials = Lists.newArrayList();
   private transient volatile Map<String, PrefixedS3Client> clientByPrefix;
 
   /**

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -73,7 +73,8 @@ public class ResolvingFileIO
   private final transient StackTraceElement[] createStack;
   private SerializableMap<String, String> properties;
   private SerializableSupplier<Configuration> hadoopConf;
-  private List<StorageCredential> storageCredentials = List.of();
+  // use modifiable collection for Kryo serde
+  private List<StorageCredential> storageCredentials = Lists.newArrayList();
 
   /**
    * No-arg constructor to load the FileIO dynamically.

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -70,7 +70,8 @@ public class GCSFileIO implements DelegateFileIO, SupportsStorageCredentials {
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
   private SerializableMap<String, String> properties = null;
-  private List<StorageCredential> storageCredentials = ImmutableList.of();
+  // use modifiable collection for Kryo serde
+  private List<StorageCredential> storageCredentials = Lists.newArrayList();
   private transient volatile Map<String, PrefixedStorage> storageByPrefix;
 
   /**

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSFileIOTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSFileIOTest.java
@@ -423,6 +423,34 @@ public class GCSFileIOTest {
   }
 
   @Test
+  public void fileIOWithPrefixedStorageClientWithoutCredentialsKryoSerialization()
+      throws IOException {
+    GCSFileIO fileIO = new GCSFileIO();
+    fileIO.initialize(
+        Map.of(GCS_OAUTH2_TOKEN, "gcsTokenFromProperties", GCS_OAUTH2_TOKEN_EXPIRES_AT, "1000"));
+
+    assertThat(fileIO.client("gs")).isInstanceOf(Storage.class);
+    assertThat(fileIO.client("gs://bucket1/my-path/tableX")).isInstanceOf(Storage.class);
+    assertThat(fileIO.client("gs://bucket1/my-path/tableX").getOptions().getCredentials())
+        .isInstanceOf(OAuth2Credentials.class)
+        .extracting("value")
+        .extracting("temporaryAccess")
+        .isEqualTo(new AccessToken("gcsTokenFromProperties", new Date(1000L)));
+
+    GCSFileIO roundTripIO = TestHelpers.KryoHelpers.roundTripSerialize(fileIO);
+    assertThat(roundTripIO).isNotNull();
+    assertThat(roundTripIO.credentials()).isEqualTo(fileIO.credentials()).isEmpty();
+
+    assertThat(roundTripIO.client("gs")).isInstanceOf(Storage.class);
+    assertThat(roundTripIO.client("gs://bucket1/my-path/tableX")).isInstanceOf(Storage.class);
+    assertThat(roundTripIO.client("gs://bucket1/my-path/tableX").getOptions().getCredentials())
+        .isInstanceOf(OAuth2Credentials.class)
+        .extracting("value")
+        .extracting("temporaryAccess")
+        .isEqualTo(new AccessToken("gcsTokenFromProperties", new Date(1000L)));
+  }
+
+  @Test
   public void fileIOWithPrefixedStorageClientKryoSerialization() throws IOException {
     GCSFileIO fileIO = new GCSFileIO();
     fileIO.setCredentials(
@@ -472,6 +500,33 @@ public class GCSFileIOTest {
   }
 
   @Test
+  public void fileIOWithPrefixedStorageClientWithoutCredentialsJavaSerialization()
+      throws IOException, ClassNotFoundException {
+    GCSFileIO fileIO = new GCSFileIO();
+    fileIO.initialize(
+        Map.of(GCS_OAUTH2_TOKEN, "gcsTokenFromProperties", GCS_OAUTH2_TOKEN_EXPIRES_AT, "1000"));
+
+    assertThat(fileIO.client("gs")).isInstanceOf(Storage.class);
+    assertThat(fileIO.client("gs://bucket1/my-path/tableX")).isInstanceOf(Storage.class);
+    assertThat(fileIO.client("gs://bucket1/my-path/tableX").getOptions().getCredentials())
+        .isInstanceOf(OAuth2Credentials.class)
+        .extracting("value")
+        .extracting("temporaryAccess")
+        .isEqualTo(new AccessToken("gcsTokenFromProperties", new Date(1000L)));
+
+    GCSFileIO roundTripIO = TestHelpers.roundTripSerialize(fileIO);
+    assertThat(roundTripIO.credentials()).isEqualTo(fileIO.credentials()).isEmpty();
+
+    assertThat(roundTripIO.client("gs")).isInstanceOf(Storage.class);
+    assertThat(roundTripIO.client("gs://bucket1/my-path/tableX")).isInstanceOf(Storage.class);
+    assertThat(roundTripIO.client("gs://bucket1/my-path/tableX").getOptions().getCredentials())
+        .isInstanceOf(OAuth2Credentials.class)
+        .extracting("value")
+        .extracting("temporaryAccess")
+        .isEqualTo(new AccessToken("gcsTokenFromProperties", new Date(1000L)));
+  }
+
+  @Test
   public void fileIOWithPrefixedStorageClientJavaSerialization()
       throws IOException, ClassNotFoundException {
     GCSFileIO fileIO = new GCSFileIO();
@@ -505,6 +560,19 @@ public class GCSFileIOTest {
         .extracting("value")
         .extracting("temporaryAccess")
         .isEqualTo(new AccessToken("gcsTokenFromCredential", new Date(2000L)));
+  }
+
+  @Test
+  public void resolvingFileIOLoadWithoutStorageCredentials()
+      throws IOException, ClassNotFoundException {
+    ResolvingFileIO resolvingFileIO = new ResolvingFileIO();
+    resolvingFileIO.initialize(ImmutableMap.of());
+
+    ResolvingFileIO fileIO = TestHelpers.KryoHelpers.roundTripSerialize(resolvingFileIO);
+    assertThat(fileIO.credentials()).isEmpty();
+
+    fileIO = TestHelpers.roundTripSerialize(resolvingFileIO);
+    assertThat(fileIO.credentials()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
While looking at https://github.com/apache/iceberg/issues/13174 I've noticed an issue with Kryo and empty  storage credentials. 
I've added some tests that reproduce the original issue with Kryo, where the empty immutable collection can't be serded and fails when it is accessed with something like

```
Cannot read the array length because "this.array" is null
java.lang.NullPointerException: Cannot read the array length because "this.array" is null
	at org.apache.iceberg.relocated.com.google.common.collect.RegularImmutableList.size(RegularImmutableList.java:47)
	at org.apache.iceberg.relocated.com.google.common.collect.Lists.equalsImpl(Lists.java:1039)
	at org.apache.iceberg.relocated.com.google.common.collect.ImmutableList.equals(ImmutableList.java:708)
	at org.assertj.core.internal.StandardComparisonStrategy.areEqual(StandardComparisonStrategy.java:108)
	at org.assertj.core.internal.Objects.areEqual(Objects.java:228)
	at org.assertj.core.internal.Objects.assertEqual(Objects.java:219)
	at org.assertj.core.api.AbstractAssert.isEqualTo(AbstractAssert.java:374)
	at org.assertj.core.api.AbstractIterableAssert.isEqualTo(AbstractIterableAssert.java:4065)
	at org.assertj.core.api.AbstractListAssert.isEqualTo(AbstractListAssert.java:276)
	at org.assertj.core.api.ListAssert.isEqualTo(ListAssert.java:100)
	at org.apache.iceberg.gcp.gcs.GCSFileIOTest.fileIOWithPrefixedStorageClientWithoutCredentialsKryoSerialization(GCSFileIOTest.java:442)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

This applies to the `storageCredentials` in `GCSFileIO` / `S3FileIO` / `ResolvingFileIO`