### PR TITLE
Enhanced License and Notice Report Generation

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -20,6 +20,7 @@
 project(":iceberg-aws-bundle") {
 
   apply plugin: 'com.gradleup.shadow'
+  apply from: "${rootDir}/license.gradle"
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -20,6 +20,7 @@
 project(":iceberg-azure-bundle") {
 
   apply plugin: 'com.gradleup.shadow'
+  apply from: "${rootDir}/license.gradle"
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,26 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+repositories {
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation 'com.github.jk1:gradle-license-report:2.9'
+}

--- a/gcp-bundle/LICENSE
+++ b/gcp-bundle/LICENSE
@@ -201,403 +201,306 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
---------------------------------------------------------------------------------
-
-This binary artifact contains:
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.2
-Project URL: https://github.com/FasterXML/jackson-core
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.android  Name: annotations  Version: 4.1.1.4
-Project URL: http://source.android.com/
-License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: api-common  Version: 2.46.1
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License: BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: gax  Version: 2.63.1
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License: BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: gax-grpc  Version: 2.63.1
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License: BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: gax-httpjson  Version: 2.63.1
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License: BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
-
---------------------------------------------------------------------------------
-
-Group: com.google.api-client  Name: google-api-client  Version: 2.7.2
-Project URL: https://developers.google.com/api-client-library/java/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: gapic-google-cloud-storage-v2  Version: 2.50.0
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: grpc-google-cloud-storage-v2  Version: 2.50.0
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.50.0
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-common-protos  Version: 2.54.1
-Project URL: https://github.com/googleapis/sdk-platform-java
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-iam-v1  Version: 1.49.1
-Project URL: https://github.com/googleapis/sdk-platform-java
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.apis  Name: google-api-services-storage  Version: v1-rev20250224-2.0.0
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth  Name: google-auth-library-credentials  Version: 1.33.1
-License: BSD New license - http://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth  Name: google-auth-library-oauth2-http  Version: 1.33.1
-License: BSD New license - http://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.auto.value  Name: auto-value-annotations  Version: 1.11.0
-Project URL: https://github.com/google/auto/tree/master/value
-License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core  Version: 2.53.1
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core-grpc  Version: 2.53.1
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core-http  Version: 2.53.1
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-storage  Version: 2.50.0
-Project URL: https://github.com/googleapis/java-storage
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.code.gson  Name: gson  Version: 2.12.1
-Project URL: https://github.com/google/gson/gson
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.errorprone  Name: error_prone_annotations  Version: 2.36.0
-License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.guava  Name: failureaccess  Version: 1.0.2
-Project URL: https://github.com/google/guava/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.guava  Name: guava  Version: 33.4.0-jre
-Project URL: https://github.com/google/guava/
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.guava  Name: listenablefuture  Version: 9999.0-empty-to-avoid-conflict-with-guava
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client  Version: 1.46.3
-Project URL: https://www.google.com/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-apache-v2  Version: 1.46.3
-Project URL: https://www.google.com/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-appengine  Version: 1.46.3
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-gson  Version: 1.46.3
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-jackson2  Version: 1.46.3
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.j2objc  Name: j2objc-annotations  Version: 3.0.0
-Project URL: https://github.com/google/j2objc/
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.oauth-client  Name: google-oauth-client  Version: 1.37.0
-Project URL: https://www.google.com/
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.protobuf  Name: protobuf-java  Version: 4.29.4
-Project URL: https://developers.google.com/protocol-buffers/
-License: BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.protobuf  Name: protobuf-java-util  Version: 4.29.4
-Project URL: https://developers.google.com/protocol-buffers/
-License: BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.re2j  Name: re2j  Version: 1.7
-Project URL: http://github.com/google/re2j
-License: Go License - https://golang.org/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: commons-codec  Name: commons-codec  Version: 1.18.0
-Project URL: https://commons.apache.org/proper/commons-codec/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles the following software packages, each of which is available under its own license terms:
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-alts  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+The following software may be included in this product: 1 component(s) licensed under the CDDL + GPLv2 with classpath exception.
+License URL: https://github.com/javaee/javax.annotation/blob/master/LICENSE
+ASF Category: B
 
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-api  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+Component(s):
+  - javax.annotation:javax.annotation-api:1.3.2 (http://jcp.org/en/jsr/detail?id=250)
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-auth  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
+The following software may be included in this product: 1 component(s) licensed under the MIT.
+License URL: https://opensource.org/license/mit
+ASF Category: A
+
+Component(s):
+  - org.slf4j:slf4j-api:2.0.17 (http://www.slf4j.org)
 
-Group: io.grpc  Name: grpc-context  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+-----BEGIN LICENSE TEXT-----
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
---------------------------------------------------------------------------------
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Group: io.grpc  Name: grpc-core  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-----END LICENSE TEXT-----
 
 --------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-googleapis  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
---------------------------------------------------------------------------------
+The following software may be included in this product: 2 component(s) licensed under the Apache 2.0.
+License URL: http://www.apache.org/licenses/LICENSE-2.0.txt
+ASF Category: A
 
-Group: io.grpc  Name: grpc-grpclb  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+Component(s):
+  - com.google.auto.value:auto-value-annotations:1.11.0 (https://github.com/google/auto/tree/main/value)
+  - com.google.errorprone:error_prone_annotations:2.38.0 (https://errorprone.info/error_prone_annotations)
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-netty-shaded  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+The following software may be included in this product: 2 component(s) licensed under the BSD-3-Clause.
+License URL: https://opensource.org/licenses/BSD-3-Clause
+ASF Category: A
 
---------------------------------------------------------------------------------
+Component(s):
+  - com.google.protobuf:protobuf-java:4.29.4 (https://developers.google.com/protocol-buffers/)
+  - com.google.protobuf:protobuf-java-util:4.29.4 (https://developers.google.com/protocol-buffers/)
 
-Group: io.grpc  Name: grpc-protobuf  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+-----BEGIN LICENSE TEXT-----
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
---------------------------------------------------------------------------------
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
-Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----END LICENSE TEXT-----
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-rls  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+The following software may be included in this product: 24 component(s) licensed under the Apache-2.0.
+License URL: https://www.apache.org/licenses/LICENSE-2.0.txt
+ASF Category: A
 
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-services  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+Component(s):
+  - com.google.api:api-common:2.49.0
+  - com.google.api:gax:2.66.0
+  - com.google.api:gax-grpc:2.66.0
+  - com.google.api:gax-httpjson:2.66.0
+  - com.google.api.grpc:gapic-google-cloud-storage-v2:2.52.3
+  - com.google.api.grpc:grpc-google-cloud-storage-v2:2.52.3
+  - com.google.api.grpc:proto-google-cloud-monitoring-v3:3.64.0 (https://github.com/googleapis/google-cloud-java)
+  - com.google.api.grpc:proto-google-cloud-storage-v2:2.52.3
+  - com.google.api.grpc:proto-google-common-protos:2.57.0 (https://github.com/googleapis/sdk-platform-java)
+  - com.google.api.grpc:proto-google-iam-v1:1.52.0 (https://github.com/googleapis/sdk-platform-java)
+  - com.google.auth:google-auth-library-credentials:1.35.0 (http://www.google.com/)
+  - com.google.auth:google-auth-library-oauth2-http:1.35.0 (http://www.google.com/)
+  - com.google.cloud:google-cloud-core:2.56.0
+  - com.google.cloud:google-cloud-core-grpc:2.56.0
+  - com.google.cloud:google-cloud-core-http:2.56.0
+  - com.google.cloud:google-cloud-monitoring:3.64.0 (https://github.com/googleapis/google-cloud-java)
+  - com.google.cloud:google-cloud-storage:2.52.3 (https://github.com/googleapis/java-storage)
+  - com.google.code.gson:gson:2.12.1 (https://github.com/google/gson)
+  - com.google.http-client:google-http-client:1.47.0 (https://www.google.com/)
+  - com.google.http-client:google-http-client-apache-v2:1.47.0 (https://www.google.com/)
+  - com.google.http-client:google-http-client-appengine:1.47.0 (https://www.google.com/)
+  - com.google.http-client:google-http-client-gson:1.47.0 (https://www.google.com/)
+  - com.google.http-client:google-http-client-jackson2:1.47.0 (https://www.google.com/)
+  - commons-codec:commons-codec:1.18.0 (https://commons.apache.org/proper/commons-codec/)
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-stub  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+The following software may be included in this product: 1 component(s) licensed under the MIT license.
+License URL: https://spdx.org/licenses/MIT.txt
+ASF Category: A
+
+Component(s):
+  - org.codehaus.mojo:animal-sniffer-annotations:1.24 (https://www.mojohaus.org)
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-xds  Version: 1.70.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
+The following software may be included in this product: 3 component(s) licensed under the Apache License, Version 2.0.
+License URL: http://www.apache.org/licenses/LICENSE-2.0.txt
+ASF Category: A
 
-Group: io.opencensus  Name: opencensus-api  Version: 0.31.1
-Project URL: https://github.com/census-instrumentation/opencensus-java
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Component(s):
+  - com.fasterxml.jackson.core:jackson-core:2.18.2 (https://github.com/FasterXML/jackson-core)
+  - com.google.guava:guava:33.4.0-jre (https://github.com/google/guava)
+  - com.google.j2objc:j2objc-annotations:3.0.0 (https://github.com/google/j2objc/)
 
 --------------------------------------------------------------------------------
 
-Group: io.opencensus  Name: opencensus-contrib-http-util  Version: 0.31.1
-Project URL: https://github.com/census-instrumentation/opencensus-java
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+The following software may be included in this product: 1 component(s) licensed under the Apache 2.0.
+License URL: http://www.apache.org/licenses/LICENSE-2.0
+ASF Category: A
 
---------------------------------------------------------------------------------
-
-Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
-Project URL: https://github.com/perfmark/perfmark
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+Component(s):
+  - com.google.android:annotations:4.1.1.4 (http://source.android.com/)
 
 --------------------------------------------------------------------------------
 
-Group: javax.annotation  Name: javax.annotation-api  Version: 1.3.2
-Project URL: https://javaee.github.io/glassfish
-Project URL: http://jcp.org/en/jsr/detail?id=250
-License: CDDL + GPLv2 with classpath exception - https://github.com/javaee/javax.annotation/blob/master/LICENSE
-
+The following software may be included in this product: 1 component(s) licensed under the Go License.
+License URL: https://golang.org/LICENSE
+ASF Category: A
+
+Component(s):
+  - com.google.re2j:re2j:1.7 (http://github.com/google/re2j)
+
 --------------------------------------------------------------------------------
 
-Group: org.checkerframework  Name: checker-qual  Version: 3.33.0
-Project URL: https://checkerframework.org/
-License: The MIT License - http://opensource.org/licenses/MIT
+The following software may be included in this product: 15 component(s) licensed under the The Apache License, Version 2.0.
+License URL: http://www.apache.org/licenses/LICENSE-2.0.txt
+ASF Category: A
 
+Component(s):
+  - com.google.cloud.opentelemetry:detector-resources-support:0.33.0 (https://github.com/GoogleCloudPlatform/opentelemetry-operations-java)
+  - com.google.cloud.opentelemetry:exporter-metrics:0.33.0 (https://github.com/GoogleCloudPlatform/opentelemetry-operations-java)
+  - com.google.cloud.opentelemetry:shared-resourcemapping:0.33.0 (https://github.com/GoogleCloudPlatform/opentelemetry-operations-java)
+  - io.opencensus:opencensus-api:0.31.1 (https://github.com/census-instrumentation/opencensus-java)
+  - io.opencensus:opencensus-contrib-http-util:0.31.1 (https://github.com/census-instrumentation/opencensus-java)
+  - io.opentelemetry:opentelemetry-api:1.47.0 (https://github.com/open-telemetry/opentelemetry-java)
+  - io.opentelemetry:opentelemetry-context:1.47.0 (https://github.com/open-telemetry/opentelemetry-java)
+  - io.opentelemetry:opentelemetry-sdk:1.47.0 (https://github.com/open-telemetry/opentelemetry-java)
+  - io.opentelemetry:opentelemetry-sdk-common:1.47.0 (https://github.com/open-telemetry/opentelemetry-java)
+  - io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.47.0 (https://github.com/open-telemetry/opentelemetry-java)
+  - io.opentelemetry:opentelemetry-sdk-logs:1.47.0 (https://github.com/open-telemetry/opentelemetry-java)
+  - io.opentelemetry:opentelemetry-sdk-metrics:1.47.0 (https://github.com/open-telemetry/opentelemetry-java)
+  - io.opentelemetry:opentelemetry-sdk-trace:1.47.0 (https://github.com/open-telemetry/opentelemetry-java)
+  - io.opentelemetry.contrib:opentelemetry-gcp-resources:1.37.0-alpha (https://github.com/open-telemetry/opentelemetry-java-contrib)
+  - io.opentelemetry.semconv:opentelemetry-semconv:1.29.0-alpha (https://github.com/open-telemetry/semantic-conventions-java)
+
+--------------------------------------------------------------------------------
+
+The following software may be included in this product: 5 component(s) licensed under the The Apache Software License, Version 2.0.
+License URL: http://www.apache.org/licenses/LICENSE-2.0.txt
+ASF Category: A
+
+Component(s):
+  - com.google.api-client:google-api-client:2.7.2 (https://developers.google.com/api-client-library/java/)
+  - com.google.apis:google-api-services-storage:v1-rev20250509-2.0.0 (http://www.google.com/)
+  - com.google.code.findbugs:jsr305:3.0.2 (http://findbugs.sourceforge.net/)
+  - com.google.guava:failureaccess:1.0.2 (https://github.com/google/guava/)
+  - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+
 --------------------------------------------------------------------------------
 
-Group: org.codehaus.mojo  Name: animal-sniffer-annotations  Version: 1.24
-License: MIT license - https://spdx.org/licenses/MIT.txt
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+The following software may be included in this product: 1 component(s) licensed under the BSD-3-Clause.
+License URL: https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
+ASF Category: A
 
---------------------------------------------------------------------------------
+Component(s):
+  - org.threeten:threetenbp:1.7.0 (https://www.threeten.org/threetenbp)
 
-Group: org.conscrypt  Name: conscrypt-openjdk-uber  Version: 2.5.2
-Project URL: https://conscrypt.org/
-License: Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
+-----BEGIN LICENSE TEXT-----
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
---------------------------------------------------------------------------------
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
-Group: org.threeten  Name: threetenbp  Version: 1.7.0
-Project URL: https://www.threeten.org
-Project URL: https://www.threeten.org/threetenbp
-License: BSD-3-Clause - https://raw.githubusercontent.com/ThreeTen/threetenbp/main/LICENSE.txt
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-----END LICENSE TEXT-----
 
 --------------------------------------------------------------------------------
 
-Group: io.opentelemetry Name: opentelemetry-api   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+The following software may be included in this product: 1 component(s) licensed under the The MIT License.
+License URL: http://opensource.org/licenses/MIT
+ASF Category: A
 
---------------------------------------------------------------------------------
+Component(s):
+  - org.checkerframework:checker-qual:3.49.0 (https://checkerframework.org/)
 
-Group: io.opentelemetry Name: opentelemetry-context   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+-----BEGIN LICENSE TEXT-----
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
---------------------------------------------------------------------------------
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Group: io.opentelemetry Name: opentelemetry-sdk   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-----END LICENSE TEXT-----
 
 --------------------------------------------------------------------------------
-
-Group: io.opentelemetry Name: opentelemetry-sdk-common   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
---------------------------------------------------------------------------------
+The following software may be included in this product: 18 component(s) licensed under the Apache 2.0.
+License URL: https://opensource.org/licenses/Apache-2.0
+ASF Category: A
 
-Group: io.opentelemetry Name: opentelemetry-sdk-logs   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Component(s):
+  - io.grpc:grpc-alts:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-api:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-auth:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-context:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-core:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-googleapis:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-grpclb:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-inprocess:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-netty-shaded:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-opentelemetry:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-protobuf:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-protobuf-lite:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-rls:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-services:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-stub:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-util:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.grpc:grpc-xds:1.70.0 (https://github.com/grpc/grpc-java)
+  - io.perfmark:perfmark-api:0.27.0 (https://github.com/perfmark/perfmark)
 
 --------------------------------------------------------------------------------
-
-Group: io.opentelemetry Name: opentelemetry-sdk-metrics Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
---------------------------------------------------------------------------------
+The following software may be included in this product: 1 component(s) licensed under the Apache 2.
+License URL: https://www.apache.org/licenses/LICENSE-2.0
+ASF Category: A
 
-Group: io.opentelemetry Name: opentelemetry-sdk-trace   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Component(s):
+  - org.conscrypt:conscrypt-openjdk-uber:2.5.2 (https://conscrypt.org/)
 
 --------------------------------------------------------------------------------
 
-Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure-spi   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
+The following software may be included in this product: 1 component(s) licensed under the The Apache Software License, Version 2.0.
+License URL: https://www.apache.org/licenses/LICENSE-2.0.txt
+ASF Category: A
 
-Group: io.opentelemetry.contrib Name: opentelemetry-gcp-resources Version: 1.37.0-alpha
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Component(s):
+  - com.google.oauth-client:google-oauth-client:1.37.0 (https://www.google.com/)
 
 --------------------------------------------------------------------------------
 
-Group: io.opentelemetry.semconv Name: opentelemetry-semconv Version: 1.27.0-alpha
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/gcp-bundle/NOTICE
+++ b/gcp-bundle/NOTICE
@@ -5,16 +5,27 @@ Copyright 2017-2025 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+
 --------------------------------------------------------------------------------
 
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.2
+This product bundles the following software packages with NOTICE files:
 
+--------------------------------------------------------------------------------
+
+This product bundles software which includes the following notice:
+  - com.fasterxml.jackson.core:jackson-core:2.18.2
+
+-----BEGIN NOTICE-----
 # Jackson JSON processor
 
 Jackson is a high-performance, Free/Open Source JSON processing library.
 It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
 been in development since 2007.
 It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
 
 ## Licensing
 
@@ -27,217 +38,89 @@ A list of contributors may be found from CREDITS(-2.x) file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
 
---------------------------------------------------------------------------------
+## FastDoubleParser
 
-NOTICE for Group: io.grpc  Name: grpc-netty-shaded  Version: 1.70.0
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
 
-|                           The Netty Project
-|                           =================
-| 
-| Please visit the Netty web site for more information:
-| 
-|   * http://netty.io/
-| 
-| Copyright 2016 The Netty Project
-| 
-| The Netty Project licenses this file to you under the Apache License,
-| version 2.0 (the "License"); you may not use this file except in compliance
-| with the License. You may obtain a copy of the License at:
-| 
-|   http://www.apache.org/licenses/LICENSE-2.0
-| 
-| Unless required by applicable law or agreed to in writing, software
-| distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-| WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-| License for the specific language governing permissions and limitations
-| under the License.
-| 
-| -------------------------------------------------------------------------------
-| This product contains a forked and modified version of Tomcat Native
-| 
-|   * LICENSE:
-|     * license/LICENSE.tomcat-native.txt (Apache License 2.0)
-|   * HOMEPAGE:
-|     * http://tomcat.apache.org/native-doc/
-|     * https://svn.apache.org/repos/asf/tomcat/native/
-| 
-| This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
-| 
-|   * LICENSE:
-|     * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
-|   * HOMEPAGE:
-|     * https://github.com/takari/maven-wrapper
-| 
-| This product contains small piece of code to support AIX, taken from netbsd.
-| 
-|   * LICENSE:
-|     * license/LICENSE.aix-netbsd.txt (OpenSSL License)
-|   * HOMEPAGE:
-|     * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
-| 
-| 
-| This product contains code from boringssl.
-| 
-|   * LICENSE (Combination ISC and OpenSSL license)
-|     * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
-|   * HOMEPAGE:
-|     * https://boringssl.googlesource.com/boringssl/
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+-----END NOTICE-----
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: io.grpc  Name: grpc-alts  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-api  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-auth  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-context  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-core  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-googleapis  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-grpclb  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-protobuf  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-rls  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-services  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-stub  Version: 1.70.0
-NOTICE for Group: io.grpc  Name: grpc-xds  Version: 1.70.0
+This product bundles software which includes the following notice:
+  - io.grpc:grpc-netty-shaded:1.70.0
 
-| Copyright 2014 The gRPC Authors
-| 
-| Licensed under the Apache License, Version 2.0 (the "License");
-| you may not use this file except in compliance with the License.
-| You may obtain a copy of the License at
-| 
-|     http://www.apache.org/licenses/LICENSE-2.0
-| 
-| Unless required by applicable law or agreed to in writing, software
-| distributed under the License is distributed on an "AS IS" BASIS,
-| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-| See the License for the specific language governing permissions and
-| limitations under the License.
-| 
-| -----------------------------------------------------------------------
-| 
-| This product contains a modified portion of 'OkHttp', an open source
-| HTTP & SPDY client for Android and Java applications, which can be obtained
-| at:
-| 
-|   * LICENSE:
-|     * okhttp/third_party/okhttp/LICENSE (Apache License 2.0)
-|   * HOMEPAGE:
-|     * https://github.com/square/okhttp
-|   * LOCATION_IN_GRPC:
-|     * okhttp/third_party/okhttp
-| 
-| This product contains a modified portion of 'Envoy', an open source
-| cloud-native high-performance edge/middle/service proxy, which can be
-| obtained at:
-| 
-|   * LICENSE:
-|     * xds/third_party/envoy/LICENSE (Apache License 2.0)
-|   * NOTICE:
-|     * xds/third_party/envoy/NOTICE
-|   * HOMEPAGE:
-|     * https://www.envoyproxy.io
-|   * LOCATION_IN_GRPC:
-|     * xds/third_party/envoy
-| 
-| This product contains a modified portion of 'protoc-gen-validate (PGV)',
-| an open source protoc plugin to generate polyglot message validators,
-| which can be obtained at:
-| 
-|   * LICENSE:
-|     * xds/third_party/protoc-gen-validate/LICENSE (Apache License 2.0)
-|   * NOTICE:
-|       * xds/third_party/protoc-gen-validate/NOTICE
-|   * HOMEPAGE:
-|     * https://github.com/envoyproxy/protoc-gen-validate
-|   * LOCATION_IN_GRPC:
-|     * xds/third_party/protoc-gen-validate
-| 
-| This product contains a modified portion of 'udpa',
-| an open source universal data plane API, which can be obtained at:
-| 
-|   * LICENSE:
-|     * xds/third_party/udpa/LICENSE (Apache License 2.0)
-|   * HOMEPAGE:
-|     * https://github.com/cncf/udpa
-|   * LOCATION_IN_GRPC:
-|     * xds/third_party/udpa
+-----BEGIN NOTICE-----
+The Netty Project
+                            =================
+
+Please visit the Netty web site for more information:
+
+  * http://netty.io/
+
+Copyright 2016 The Netty Project
+
+The Netty Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+-------------------------------------------------------------------------------
+This product contains a forked and modified version of Tomcat Native
+
+  * LICENSE:
+    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://tomcat.apache.org/native-doc/
+    * https://svn.apache.org/repos/asf/tomcat/native/
+
+This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+  * LICENSE:
+    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/takari/maven-wrapper
+
+This product contains small piece of code to support AIX, taken from netbsd.
+
+  * LICENSE:
+    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
+  * HOMEPAGE:
+    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
+
+
+This product contains code from boringssl.
+
+  * LICENSE (Combination ISC and OpenSSL license)
+    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
+  * HOMEPAGE:
+    * https://boringssl.googlesource.com/boringssl/
+-----END NOTICE-----
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
+This product bundles software which includes the following notice:
+  - commons-codec:commons-codec:1.18.0
 
-| Copyright 2019 Google LLC
-| 
-| Licensed under the Apache License, Version 2.0 (the "License");
-| you may not use this file except in compliance with the License.
-| You may obtain a copy of the License at
-| 
-|     http://www.apache.org/licenses/LICENSE-2.0
-| 
-| Unless required by applicable law or agreed to in writing, software
-| distributed under the License is distributed on an "AS IS" BASIS,
-| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-| See the License for the specific language governing permissions and
-| limitations under the License.
-| 
-| -----------------------------------------------------------------------
-| 
-| This product contains a modified portion of 'Catapult', an open source
-| Trace Event viewer for Chome, Linux, and Android applications, which can 
-| be obtained at:
-| 
-|   * LICENSE:
-|     * traceviewer/src/main/resources/io/perfmark/traceviewer/third_party/catapult/LICENSE (New BSD License)
-|   * HOMEPAGE:
-|     * https://github.com/catapult-project/catapult
-| 
-| This product contains a modified portion of 'Polymer', a library for Web
-| Components, which can be obtained at:
-|   * LICENSE:
-|     * traceviewer/src/main/resources/io/perfmark/traceviewer/third_party/polymer/LICENSE (New BSD License)
-|   * HOMEPAGE:
-|     * https://github.com/Polymer/polymer
-| 
-| 
-| This product contains a modified portion of 'ASM', an open source
-| Java Bytecode library, which can be obtained at:
-| 
-|   * LICENSE:
-|     * agent/src/main/resources/io/perfmark/agent/third_party/asm/LICENSE (BSD style License)
-|   * HOMEPAGE:
-|     * https://asm.ow2.io/
+-----BEGIN NOTICE-----
+Apache Commons Codec
+Copyright 2002-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+-----END NOTICE-----
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: org.conscrypt  Name: conscrypt-openjdk-uber  Version: 2.5.2
-
-| Copyright 2016 The Android Open Source Project
-| 
-| Licensed under the Apache License, Version 2.0 (the "License");
-| you may not use this file except in compliance with the License.
-| You may obtain a copy of the License at
-| 
-|      http://www.apache.org/licenses/LICENSE-2.0
-| 
-| Unless required by applicable law or agreed to in writing, software
-| distributed under the License is distributed on an "AS IS" BASIS,
-| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-| See the License for the specific language governing permissions and
-| limitations under the License.
-| 
-| -----------------------------------------------------------------------
-| This product contains a modified portion of `Netty`, a configurable network
-| stack in Java, which can be obtained at:
-| 
-|   * LICENSE:
-|     * licenses/LICENSE.netty.txt (Apache License 2.0)
-|   * HOMEPAGE:
-|     * http://netty.io/
-| 
-| This product contains a modified portion of `Apache Harmony`, modular Java runtime,
-| which can be obtained at:
-| 
-|   * LICENSE:
-|     * licenses/LICENSE.harmony.txt (Apache License 2.0)
-|   * HOMEPAGE:
-|     * https://harmony.apache.org/

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -20,6 +20,7 @@
 project(":iceberg-gcp-bundle") {
 
   apply plugin: 'com.gradleup.shadow'
+  apply from: "${rootDir}/license.gradle"
 
   tasks.jar.dependsOn tasks.shadowJar
 

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -60,6 +60,7 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect') {
 
 project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
   apply plugin: 'distribution'
+  apply from: "${rootDir}/license.gradle"
 
   configurations {
     hive {
@@ -76,6 +77,10 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
         force 'com.fasterxml.woodstox:woodstox-core:6.7.0'
       }
     }
+  }
+
+  licenseReport {
+    configurations = ['hive']
   }
 
   sourceSets {

--- a/license.gradle
+++ b/license.gradle
@@ -1,0 +1,363 @@
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.render.ReportRenderer
+import com.github.jk1.license.ImportedModuleData
+import com.github.jk1.license.License
+import com.github.jk1.license.LicenseReportExtension
+import com.github.jk1.license.ModuleData
+
+apply plugin: "com.github.jk1.dependency-license-report"
+
+// Helper to define file paths once
+// Define file paths as script variables for reliable access
+def generatedLicenseFile = file("${projectDir}/build/reports/dependency-license/LICENSE")
+def rootLicenseFile = file("${projectDir}/LICENSE")
+def generatedNoticeFile = file("${projectDir}/build/reports/dependency-license/NOTICE")
+def rootNoticeFile = file("${projectDir}/NOTICE")
+
+// Simplified file comparison and update tasks
+tasks.register('compareLicenseReport') {
+    doLast {
+        if (generatedLicenseFile.text != rootLicenseFile.text) {
+            throw new RuntimeException("LICENSE file has changed. Run 'gradle updateLicenseReport' to update it.")
+        }
+        if (generatedNoticeFile.text != rootNoticeFile.text) {
+            throw new RuntimeException("NOTICE file has changed. Run 'gradle updateLicenseReport' to update it.")
+        }
+    }
+}
+
+tasks.register('updateLicenseReport') {
+    doLast {
+        rootLicenseFile.text = generatedLicenseFile.text
+        rootNoticeFile.text = generatedNoticeFile.text
+    }
+}
+
+// Task dependencies
+generateLicenseReport.outputs.upToDateWhen { false }
+updateLicenseReport.dependsOn generateLicenseReport
+compareLicenseReport.dependsOn generateLicenseReport
+check.dependsOn compareLicenseReport
+
+// Custom Renderer Configuration
+licenseReport {
+    excludeBoms = true
+    renderers = [new IcebergReportRenderer()]
+}
+
+class IcebergReportRenderer implements ReportRenderer {
+
+    private Project project
+    private LicenseReportExtension config
+    private File licenseFile
+    private File noticeFile
+    private Map<String, List<ModuleData>> notices = new HashMap<>()
+    private static final String SEP = "--------------------------------------------------------------------------------"
+
+    // --- CENTRALIZED LICENSE CATEGORIZATION ---
+    // A single map to define all known license aliases and their ASF category.
+    // This simplifies maintenance. To add a new license, add its variations here.
+    // KEY: Lowercase license alias/variation. VALUE: ASF Category ('A', 'B', 'X').
+    // https://www.apache.org/legal/resolved.html
+    private static final Map<String, String> LICENSE_TO_CATEGORY_MAP = [
+            // Category A (Permissive)
+            'apache 2.0': 'A', 'apache-2.0': 'A', 'asl 2.0': 'A', 'apache license 2.0': 'A',
+            'apache license, version 2.0': 'A', 'the apache software license, version 2.0': 'A',
+            'apache v2': 'A', 'apache 2': 'A', 'apache license v2.0': 'A', 'apache': 'A', 'apache-1.1': 'A',
+            'apache software license 1.1': 'A', 'the apache license, version 2.0': 'A',
+            'apache software license - version 2.0': 'A',
+            'bsd-2-clause': 'A', 'bsd 2-clause': 'A', 'freebsd': 'A', 'simplified bsd': 'A',
+            'bsd 2-clause "simplified" license': 'A', 'bsd 2-clause "freebsd" license': 'A', 'revised bsd': 'A',
+            'bsd-3-clause': 'A', 'new bsd': 'A', 'modified bsd': 'A', 'bsd 3-clause': 'A', 'bsd new license': 'A',
+            'new bsd license': 'A', 'bsd 2-clause license': 'A', 'bsd license': 'A', 'the bsd license': 'A',
+            'bsd licence': 'A', 'the bsd 2-clause license': 'A',
+            'mit': 'A', 'mit license': 'A', 'x11': 'A', 'the mit license': 'A', 'mit-0': 'A', 'the mit license (mit)': 'A',
+            'isc': 'A', 'python-2.0': 'A', 'python software foundation license version 2': 'A',
+            'edl-1.0': 'A', 'eclipse distribution license - v 1.0': 'A', 'eclipse distribution license 1.0': 'A', 'edl 1.0': 'A',
+            'postgresql': 'A', 'postgresql license': 'A', 'public domain': 'A', 'unlicense': 'A', 'cc-pddc': 'A',
+            'w3c': 'A', 'w3c-19980720': 'A', 'w3c-20150513': 'A', 'w3c software license': 'A', 'zlib': 'A',
+            'bsl-1.0': 'A', 'boost software license version 1.0': 'A', 'go license': 'A', 'upl-1.0': 'A',
+            'bouncy castle licence': 'A',
+
+            // Category B (Weak Copyleft)
+            'cddl-1.0': 'B', 'cddl-1.1': 'B', 'cddl 1.1':'B', 'common development and distribution license': 'B', 'cddl': 'B',
+            'cpl-1.0': 'B', 'common public license version 1.0': 'B', 'common development and distribution license (cddl) version 1.0': 'B',
+            'epl-1.0': 'B', 'eclipse public license - v 1.0': 'B', 'eclipse public license 1.0': 'B', 'eclipse public license - version 1.0': 'B',
+            'epl-2.0': 'B', 'eclipse public license - v 2.0': 'B', 'eclipse public license 2.0': 'B', 'eclipse public license v. 2.0': 'B',
+            'ipa': 'B', 'ipa font license': 'B',
+            'mpl-1.0': 'B', 'mpl-1.1': 'B', 'mpl-2.0': 'B', 'mozilla public license 2.0': 'B', 'mozilla public license 1.1': 'B',
+            'gpl-2.0-with-classpath-exception': 'B', 'gpl-2.0 with classpath exception': 'B', 'gplv2 with classpath exception': 'B',
+            'gplv2 with cpe': 'B', 'gpl2 w/ cpe': 'B', 'gnu general public license, version 2 with the gnu classpath exception': 'B',
+            'cddl + gplv2 with classpath exception': 'B', // Special combo case
+
+            // Category X (Strong Copyleft or problematic)
+            'agpl-3.0-only': 'X', 'agpl-3.0-or-later': 'X', 'affero gpl': 'X',
+            'gpl-2.0-only': 'X', 'gpl-2.0-or-later': 'X', 'general public license v2': 'X',
+            'gpl-3.0-only': 'X', 'gpl-3.0-or-later': 'X', 'general public license v3': 'X',
+            'gnu lesser general public license': 'X', 'gnu general public library': 'X',
+            'lgpl-2.0-only': 'X', 'lgpl-2.0-or-later': 'X', 'lgpl v2.0': 'X',
+            'lgpl-2.1-only': 'X', 'lgpl-2.1-or-later': 'X', 'lgpl v2.1': 'X', 'lesser general public license 2.1': 'X',
+            'lgpl-3.0-only': 'X', 'lgpl-3.0-or-later': 'X', 'lgpl v3.0': 'X', 'lesser general public license 3.0': 'X',
+            'sleepycat': 'X', 'sleepycat license': 'X',
+            'bsd-4-clause': 'X', 'original bsd': 'X',
+            'json': 'X',
+            'qpl-1.0': 'X', 'sspl-1.0': 'X'
+    ]
+
+    private String normalizeLicenseName(String licenseIdentifier) {
+        if (!licenseIdentifier) return ""
+        String lower = licenseIdentifier.toLowerCase().trim()
+
+        if (lower.contains('cddl') && (lower.contains('gplv2 with classpath exception') || lower.contains('gplv2 with cpe'))) {
+            return 'cddl + gplv2 with classpath exception'
+        }
+        if (lower.contains('epl-1.0') && lower.contains('edl-1.0')) {
+            return 'edl-1.0'
+        }
+
+        return lower.replaceAll(/;link=.*/, "").replaceAll(/^\"|\"$/, "").trim()
+    }
+
+    private String getLicenseCategory(String licenseIdentifier) {
+        String normalized = normalizeLicenseName(licenseIdentifier)
+        String category = LICENSE_TO_CATEGORY_MAP[normalized]
+        if (!category) {
+            project.logger.warn("LICENSE-DEBUG: Uncategorized license. Normalized: '{}' (Original: '{}'). Please update LICENSE_TO_CATEGORY_MAP.", normalized, licenseIdentifier)
+        }
+        return category ?: "UNKNOWN"
+    }
+
+    private Map<String, String> selectExclusiveLicense(List<Map<String, String>> declaredLicenses, ModuleData moduleData) {
+        if (!declaredLicenses) return null
+        def licensesByCategory = declaredLicenses.groupBy { getLicenseCategory(it.name) }
+        def chosenLicense = licensesByCategory['A']?.first() ?: licensesByCategory['B']?.first() ?: licensesByCategory['X']?.first() ?: licensesByCategory['UNKNOWN']?.first()
+
+        if (chosenLicense) {
+            String category = getLicenseCategory(chosenLicense.name)
+            String module = "${moduleData.group}:${moduleData.name}:${moduleData.version}"
+            switch (category) {
+                case 'X':
+                    project.logger.error("ASF-POLICY-VIOLATION: Dependency {} has Category X license: {}", module, chosenLicense.name)
+                    break
+                case 'B':
+                    project.logger.warn("ASF-POLICY-INFO: Dependency {} uses Category B license '{}'. Review ASF conditions.", module, chosenLicense.name)
+                    break
+                case 'UNKNOWN':
+                    project.logger.warn("ASF-POLICY-REVIEW: Could not categorize license for {}: {}. Review manually.", module, chosenLicense.name)
+                    break
+            }
+        } else {
+            project.logger.warn("ASF-POLICY-REVIEW: No license could be chosen for ${moduleData.group}:${moduleData.name}:${moduleData.version}.")
+        }
+
+        return chosenLicense
+    }
+
+    private void printDependency(ModuleData data, Writer writer) {
+        def pomUrl = (data.poms && !data.poms.isEmpty()) ? data.poms.first().projectUrl : null
+        def pomOrgUrl = (data.poms && !data.poms.isEmpty()) ? data.poms.first()?.organization?.url : null
+        def manifestUrl = (data.manifests && !data.manifests.isEmpty()) ? data.manifests.first().url : null
+        def projectUrl = pomUrl ?: manifestUrl ?: pomOrgUrl
+
+        writer << "  - ${data.group}:${data.name}:${data.version}"
+        if (projectUrl) {
+            writer << " (${projectUrl})"
+        }
+        writer << "\n"
+
+        // Safely find and collect NOTICE files
+        if (data.licenseFiles && !data.licenseFiles.isEmpty()) {
+            data.licenseFiles.first().fileDetails?.find { it.file.toUpperCase().contains("NOTICE") }?.with {
+                File notice = new File("$config.absoluteOutputDir/$it.file")
+                if (notice.exists()) {
+                    notices.computeIfAbsent(notice.text.trim(), { [] }).add(data)
+                }
+            }
+        }
+    }
+
+    void render(ProjectData data) {
+        project = data.project
+        config = project.licenseReport
+
+        File licenseFile = new File(config.absoluteOutputDir, 'LICENSE')
+        File noticeFile = new File(config.absoluteOutputDir, 'NOTICE')
+
+        // **** START: Write the project's own license first ****
+        licenseFile.text = rootPrefix(new File(data.project.rootDir, 'LICENSE'))
+        licenseFile << "\n${SEP}\n\n"
+        licenseFile << "This product bundles the following software packages, each of which is available under its own license terms:\n"
+        licenseFile << "\n${SEP}\n\n"
+
+        noticeFile.text = rootPrefix(new File(data.project.rootDir, 'NOTICE'))
+        noticeFile << "\n${SEP}\n\nThis product bundles the following software packages with NOTICE files:\n\n${SEP}\n\n"
+
+        def dependenciesByLicense = groupDependenciesByLicense(data)
+        StringBuilder licenseReport = new StringBuilder()
+        StringBuilder noticeReport = new StringBuilder()
+
+        dependenciesByLicense.each { license, modules ->
+            licenseReport.append("The following software may be included in this product: ${modules.size()} component(s) licensed under the ${license.name}.\n")
+            if (license.url != 'N/A') {
+                licenseReport.append("License URL: ${license.url}\n")
+            }
+            licenseReport.append("ASF Category: ${license.category}\n\n")
+            licenseReport.append("Component(s):\n")
+            modules.each { module ->
+                def pomUrl = (module.poms && !module.poms.isEmpty()) ? module.poms.first().projectUrl : null
+                def pomOrgUrl = (module.poms && !module.poms.isEmpty()) ? module.poms.first()?.organization?.url : null
+                def manifestUrl = (module.manifests && !module.manifests.isEmpty()) ? module.manifests.first().url : null
+                def projectUrl = pomUrl ?: manifestUrl ?: pomOrgUrl
+
+                licenseReport.append("  - ${module.group}:${module.name}:${module.version}")
+                if (projectUrl) {
+                    licenseReport.append(" (${projectUrl})")
+                }
+                licenseReport.append("\n")
+
+                // Collect NOTICE files
+                if (module.licenseFiles && !module.licenseFiles.isEmpty()) {
+                    module.licenseFiles.first().fileDetails?.find { it.file.toUpperCase().contains("NOTICE") }?.with {
+                        File notice = new File("$config.absoluteOutputDir/$it.file")
+                        if (notice.exists()) {
+                            notices.computeIfAbsent(notice.text.trim(), { [] }).add(module)
+                        }
+                    }
+                }
+            }
+
+            if (license.text) {
+                licenseReport.append("\n-----BEGIN LICENSE TEXT-----\n")
+                licenseReport.append(license.text.trim())
+                licenseReport.append("\n-----END LICENSE TEXT-----\n")
+            }
+            licenseReport.append("\n${SEP}\n\n")
+        }
+
+        notices.each { String noticeText, List<ModuleData> projs ->
+            noticeReport.append("This product bundles software which includes the following notice:\n")
+            projs.each { ModuleData proj ->
+                noticeReport.append("  - ${proj.group}:${proj.name}:${proj.version}\n")
+            }
+            noticeReport.append("\n-----BEGIN NOTICE-----\n")
+            noticeReport.append(noticeText.trim())
+            noticeReport.append("\n-----END NOTICE-----\n")
+            noticeReport.append("\n${SEP}\n\n")
+        }
+
+        licenseFile.append(licenseReport.toString())
+        noticeFile.append(noticeReport.toString())
+    }
+
+    private Map<Map<String, Object>, List<ModuleData>> groupDependenciesByLicense(ProjectData data) {
+        def allDeps = data.allDependencies.sort() + (data.importedModules?.modules?.flatten()?.sort() ?: [])
+        def grouped = new HashMap<Map<String, Object>, List<ModuleData>>()
+
+        allDeps.each { module ->
+            def licensesToConsider = []
+            if (module instanceof ModuleData) {
+                if (module.poms && !module.poms.isEmpty()) {
+                    module.poms.first().licenses?.each { License lic ->
+                        if (lic.name?.trim()) {
+                            licensesToConsider.add([name: lic.name, url: lic.url, source: "POM"])
+                        }
+                    }
+                }
+
+                if (module.manifests && !module.manifests.isEmpty()) {
+                    module.manifests.first().with { manifest ->
+                        if (manifest.license?.trim()) {
+                            licensesToConsider.add([name: manifest.license, url: manifest.licenseUrl, source: "Manifest"])
+                        }
+                    }
+                }
+            } else if (module instanceof ImportedModuleData) {
+                if (module.license?.trim()) {
+                    licensesToConsider.add([name: module.license, url: module.licenseUrl, source: "Imported"])
+                }
+            }
+
+            def uniqueLicenses = licensesToConsider.unique { it.name.toLowerCase().trim() }
+            def selectedLicense = selectExclusiveLicense(uniqueLicenses, module)
+
+            if (selectedLicense) {
+                def licenseKey = [
+                        name: selectedLicense.name,
+                        url: selectedLicense.url ?: 'N/A',
+                        category: getLicenseCategory(selectedLicense.name),
+                        text: getLicenseText(selectedLicense.name)
+                ]
+                grouped.computeIfAbsent(licenseKey, { [] }).add(module)
+            } else {
+                def unknownLicenseKey = [name: "Unknown License", url: "N/A", category: "UNKNOWN", text: null]
+                grouped.computeIfAbsent(unknownLicenseKey, { [] }).add(module)
+            }
+        }
+        return grouped
+    }
+
+    private String getLicenseText(String licenseName) {
+        def normalized = normalizeLicenseName(licenseName)
+        switch (normalized) {
+            case 'mit':
+            case 'the mit license':
+            case 'the mit license (mit)':
+                return """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+            case 'bsd-3-clause':
+            case 'new bsd license':
+            case 'modified bsd':
+                return """
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+            default:
+                return null
+        }
+    }
+
+
+    private String rootPrefix(File rootFile) {
+        if (!rootFile.exists()) return ""
+        String text = rootFile.text
+        int sepIndex = text.indexOf(SEP)
+        return sepIndex != -1 ? text.substring(0, sepIndex) : text
+    }
+}


### PR DESCRIPTION
This pull request enhances the functionality originally introduced in PR #11977 for generating LICENSE and NOTICE files. The primary goals of this update are to improve accuracy, simplify maintenance, and provide clearer compliance feedback by aligning with Apache Software Foundation (ASF) license policies. 

I implement it based on @jbonofre 's comment on here: https://github.com/apache/iceberg/pull/11977#issuecomment-2931565362

### Key Enhancements:

* **Centralized License Categorization**: A new `LICENSE_TO_CATEGORY_MAP` provides a single, comprehensive mapping of license name variations to their corresponding ASF license category (`A`, `B`, or `X`). This simplifies the process of adding or modifying license aliases and ensures consistent categorization.

* **Automated ASF Policy Compliance Checks**:
    * Dependencies with **Category X** licenses now trigger a build error, immediately flagging critical policy violations.
    * Dependencies with **Category B** licenses generate a warning, prompting developers to review the specific ASF conditions for their use.
    * Any unrecognized or uncategorized licenses also produce a warning, ensuring that all dependencies are reviewed.

* **Robust `NOTICE` File Handling**: The script now correctly identifies and aggregates `NOTICE` files from dependencies. The content is grouped by shared `NOTICE` text, reducing redundancy and creating a cleaner, more organized final `NOTICE` file.

* **Refined Report Generation**:
    * The `LICENSE` report now includes the ASF category for each group of dependencies and a direct link to the license URL, improving clarity.
    * MIT, BSD-3-Clause are now embedded directly into the `LICENSE` file, making the report self-contained.

### How to Use the New Functionality:

1.  **Generate Reports**: Run the `gradle generateLicenseReport` task to create the `LICENSE` and `NOTICE` files in the `build/reports/dependency-license/` directory.
2.  **Update Root Files**: Run `gradle updateLicenseReport` to copy the generated files to the project's root directory.
3.  **Verify Changes**: The `check` task automatically runs `compareLicenseReport`, which will fail if the root `LICENSE` or `NOTICE` files are out of sync with the generated reports, ensuring that all changes are committed.

This updated automation will help the project maintain compliance with licensing requirements more effectively and with greater confidence.