### PR TITLE
Core: Keep track of data files to be removed for orphaned DV detection

### DIFF
--- a/core/src/jmh/java/org/apache/iceberg/RewriteDataFilesBenchmark.java
+++ b/core/src/jmh/java/org/apache/iceberg/RewriteDataFilesBenchmark.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DataFileSet;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * A benchmark that evaluates the performance of rewriting data files in the table.
+ *
+ * <p>To run this benchmark: <code>
+ *   ./gradlew :iceberg-core:jmh
+ *       -PjmhIncludeRegex=RewriteDataFilesBenchmark
+ *       -PjmhOutputPath=benchmark/rewrite-data-files-benchmark.txt
+ * </code>
+ */
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.SingleShotTime)
+@Timeout(time = 10, timeUnit = TimeUnit.MINUTES)
+public class RewriteDataFilesBenchmark {
+
+  private static final String TABLE_IDENT = "tblX";
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "int_col", Types.IntegerType.get()),
+          required(2, "long_col", Types.LongType.get()),
+          required(3, "decimal_col", Types.DecimalType.of(10, 10)),
+          required(4, "date_col", Types.DateType.get()),
+          required(5, "timestamp_col", Types.TimestampType.withoutZone()),
+          required(6, "timestamp_tz_col", Types.TimestampType.withZone()),
+          required(7, "str_col", Types.StringType.get()));
+  private static final PartitionSpec SPEC = PartitionSpec.unpartitioned();
+  private static final HadoopTables TABLES = new HadoopTables();
+
+  private Table table;
+  private DataFileSet dataFilesToRemove;
+  private DataFileSet dataFilesToAdd;
+
+  @Param({"50000", "100000", "500000", "1000000", "2000000"})
+  private int numFiles;
+
+  @Param({"5", "25", "50", "100"})
+  private int percentDataFilesRewritten;
+
+  @Setup
+  public void setupBenchmark() throws IOException {
+    initTable();
+    initFiles();
+  }
+
+  @TearDown
+  public void tearDownBenchmark() {
+    dropTable();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void rewriteDataFiles() {
+    Snapshot currentSnapshot = table.currentSnapshot();
+    RewriteFiles rewriteFiles = table.newRewrite();
+    rewriteFiles.validateFromSnapshot(currentSnapshot.snapshotId());
+    dataFilesToAdd.forEach(rewriteFiles::addFile);
+    dataFilesToRemove.forEach(rewriteFiles::deleteFile);
+    rewriteFiles.commit();
+    table.manageSnapshots().rollbackTo(currentSnapshot.snapshotId()).commit();
+  }
+
+  private void initTable() {
+    if (TABLES.exists(TABLE_IDENT)) {
+      TABLES.dropTable(TABLE_IDENT);
+    }
+
+    this.table =
+        TABLES.create(
+            SCHEMA, SPEC, ImmutableMap.of(TableProperties.FORMAT_VERSION, "3"), TABLE_IDENT);
+  }
+
+  private void dropTable() {
+    TABLES.dropTable(TABLE_IDENT);
+  }
+
+  private void initFiles() throws IOException {
+    List<DataFile> pendingDataFiles = Lists.newArrayListWithExpectedSize(numFiles);
+    int numDataFilesToRewrite = (int) Math.ceil(numFiles * (percentDataFilesRewritten / 100.0));
+    Map<String, DataFile> filesToReplace = Maps.newHashMapWithExpectedSize(numDataFilesToRewrite);
+    RowDelta rowDelta = table.newRowDelta();
+    for (int ordinal = 0; ordinal < numFiles; ordinal++) {
+      DataFile dataFile = generateDataFile();
+      rowDelta.addRows(dataFile);
+      DeleteFile deleteFile = FileGenerationUtil.generateDV(table, dataFile);
+      rowDelta.addDeletes(deleteFile);
+      if (numDataFilesToRewrite > 0) {
+        filesToReplace.put(dataFile.location(), dataFile);
+        DataFile pendingDataFile = generateDataFile(dataFile.recordCount());
+        rowDelta.addRows(pendingDataFile);
+        pendingDataFiles.add(pendingDataFile);
+        numDataFilesToRewrite--;
+      }
+    }
+
+    rowDelta.commit();
+
+    List<DataFile> dataFilesReadFromManifests = Lists.newArrayList();
+    for (ManifestFile deleteManifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> manifestReader =
+          ManifestFiles.read(deleteManifest, table.io())) {
+        manifestReader
+            .iterator()
+            .forEachRemaining(
+                file -> {
+                  if (filesToReplace.containsKey(file.location())) {
+                    dataFilesReadFromManifests.add(file);
+                  }
+                });
+      }
+    }
+
+    this.dataFilesToRemove = DataFileSet.of(dataFilesReadFromManifests);
+    this.dataFilesToAdd = DataFileSet.of(pendingDataFiles);
+  }
+
+  private DataFile generateDataFile() {
+    return generateDataFile(-1L);
+  }
+
+  private DataFile generateDataFile(long recordCount) {
+    Schema schema = table.schema();
+    PartitionSpec spec = table.spec();
+    LocationProvider locations = table.locationProvider();
+    String path = locations.newDataLocation(spec, null, FileGenerationUtil.generateFileName());
+    long fileSize = ThreadLocalRandom.current().nextLong(50_000L);
+    MetricsConfig metricsConfig = MetricsConfig.forTable(table);
+    Metrics metrics =
+        FileGenerationUtil.generateRandomMetrics(
+            schema, metricsConfig, ImmutableMap.of(), ImmutableMap.of());
+    if (recordCount > 0) {
+      metrics =
+          new Metrics(
+              recordCount,
+              metrics.columnSizes(),
+              metrics.valueCounts(),
+              metrics.nullValueCounts(),
+              metrics.nanValueCounts());
+    }
+
+    return DataFiles.builder(spec)
+        .withPath(path)
+        .withFileSizeInBytes(fileSize)
+        .withFormat(FileFormat.PARQUET)
+        .withMetrics(metrics)
+        .build();
+  }
+}

--- a/core/src/jmh/java/org/apache/iceberg/RewriteDataFilesBenchmark.java
+++ b/core/src/jmh/java/org/apache/iceberg/RewriteDataFilesBenchmark.java
@@ -145,9 +145,8 @@ public class RewriteDataFilesBenchmark {
     rowDelta.commit();
 
     List<DataFile> dataFilesReadFromManifests = Lists.newArrayList();
-    for (ManifestFile deleteManifest : table.currentSnapshot().dataManifests(table.io())) {
-      try (ManifestReader<DataFile> manifestReader =
-          ManifestFiles.read(deleteManifest, table.io())) {
+    for (ManifestFile dataManifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> manifestReader = ManifestFiles.read(dataManifest, table.io())) {
         manifestReader
             .iterator()
             .forEachRemaining(

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -920,6 +920,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   @Override
   public List<ManifestFile> apply(TableMetadata base, Snapshot snapshot) {
+    Set<DataFile> filesToBeDeleted = filterManager.filesToBeDeleted();
+    deleteFilterManager.removeDanglingDeletesFor(filesToBeDeleted);
     // filter any existing manifests
     List<ManifestFile> filtered =
         filterManager.filterManifests(
@@ -1129,6 +1131,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     @Override
     protected Set<DataFile> newFileSet() {
       return DataFileSet.create();
+    }
+
+    @Override
+    protected void removeDanglingDeletesFor(Set<DataFile> dataFiles) {
+      throw new UnsupportedOperationException("Cannot remove dangling deletes");
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -723,11 +724,10 @@ public class TestRowDelta extends TestBase {
         table.newRowDelta().addRows(FILE_A).addDeletes(fileADeletes()).addDeletes(fileBDeletes()),
         branch);
 
-    long deltaSnapshotId = latestSnapshot(table, branch).snapshotId();
     assertThat(latestSnapshot(table, branch).sequenceNumber()).isEqualTo(1);
     assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(1);
 
-    // deleting a specific data file will not affect a delete file
+    // deleting a specific data file will not affect a delete file in v2 or less
     commit(table, table.newDelete().deleteFile(FILE_A), branch);
 
     Snapshot deleteSnap = latestSnapshot(table, branch);
@@ -743,21 +743,23 @@ public class TestRowDelta extends TestBase {
         files(FILE_A),
         statuses(Status.DELETED));
 
-    assertThat(deleteSnap.deleteManifests(table.io())).hasSize(1);
+    Iterator<Long> ids = formatVersion >= 3 ? ids(2L, 1L) : ids(1L, 1L);
+    Iterator<Status> statuses =
+        formatVersion >= 3
+            ? statuses(Status.DELETED, Status.EXISTING)
+            : statuses(Status.ADDED, Status.ADDED);
     validateDeleteManifest(
         deleteSnap.deleteManifests(table.io()).get(0),
         dataSeqs(1L, 1L),
         fileSeqs(1L, 1L),
-        ids(deltaSnapshotId, deltaSnapshotId),
+        ids,
         files(fileADeletes(), fileBDeletes()),
-        statuses(Status.ADDED, Status.ADDED));
+        statuses);
 
     // the manifest that removed FILE_A will be dropped next commit, causing the min sequence number
-    // of all data files
-    // to be 2, the largest known sequence number. this will cause FILE_A_DELETES to be removed
-    // because it is too old
-    // to apply to any data files.
-    commit(table, table.newRowDelta().removeDeletes(FILE_B_DELETES), branch);
+    // of all data files to be 2, the largest known sequence number. This will cause FILE_A_DELETES
+    // to be removed because it is too old to apply to any data files.
+    commit(table, table.newRowDelta().removeDeletes(fileBDeletes()), branch);
 
     Snapshot nextSnap = latestSnapshot(table, branch);
     assertThat(nextSnap.sequenceNumber()).isEqualTo(3);
@@ -770,7 +772,7 @@ public class TestRowDelta extends TestBase {
         dataSeqs(1L, 1L),
         fileSeqs(1L, 1L),
         ids(nextSnap.snapshotId(), nextSnap.snapshotId()),
-        files(fileADeletes(), fileBDeletes()),
+        formatVersion >= 3 ? files(fileBDeletes()) : files(fileADeletes(), fileBDeletes()),
         statuses(Status.DELETED, Status.DELETED));
   }
 
@@ -803,9 +805,9 @@ public class TestRowDelta extends TestBase {
         deleteSnap.deleteManifests(table.io()).get(0),
         dataSeqs(1L),
         fileSeqs(1L),
-        ids(deltaSnapshotId),
+        ids(formatVersion >= 3 ? deleteSnap.snapshotId() : deltaSnapshotId),
         files(fileADeletes()),
-        statuses(Status.ADDED));
+        statuses(formatVersion >= 3 ? Status.DELETED : Status.ADDED));
 
     // the manifest that removed FILE_A will be dropped next merging commit, but FastAppend will not
     // remove it
@@ -839,9 +841,9 @@ public class TestRowDelta extends TestBase {
         nextSnap.deleteManifests(table.io()).get(0),
         dataSeqs(1L),
         fileSeqs(1L),
-        ids(deltaSnapshotId),
+        ids(formatVersion >= 3 ? deleteSnap.snapshotId() : deltaSnapshotId),
         files(fileADeletes()),
-        statuses(Status.ADDED));
+        statuses(formatVersion >= 3 ? Status.DELETED : Status.ADDED));
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -724,6 +724,7 @@ public class TestRowDelta extends TestBase {
         table.newRowDelta().addRows(FILE_A).addDeletes(fileADeletes()).addDeletes(fileBDeletes()),
         branch);
 
+    long deltaSnapshotId = latestSnapshot(table, branch).snapshotId();
     assertThat(latestSnapshot(table, branch).sequenceNumber()).isEqualTo(1);
     assertThat(table.ops().current().lastSequenceNumber()).isEqualTo(1);
 
@@ -743,7 +744,10 @@ public class TestRowDelta extends TestBase {
         files(FILE_A),
         statuses(Status.DELETED));
 
-    Iterator<Long> ids = formatVersion >= 3 ? ids(2L, 1L) : ids(1L, 1L);
+    Iterator<Long> ids =
+        formatVersion >= 3
+            ? ids(deleteSnap.snapshotId(), deltaSnapshotId)
+            : ids(deltaSnapshotId, deltaSnapshotId);
     Iterator<Status> statuses =
         formatVersion >= 3
             ? statuses(Status.DELETED, Status.EXISTING)

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -307,8 +307,7 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
 
     runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
 
-    // After #11131 we don't remove the delete files
-    assertFileNum(table, 1, 3);
+    assertFileNum(table, 1, 1);
 
     SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(1, "c")));
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -307,8 +307,7 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
 
     runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
 
-    // After #11131 we don't remove the delete files
-    assertFileNum(table, 1, 3);
+    assertFileNum(table, 1, 1);
 
     SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(1, "c")));
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -307,8 +307,7 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
 
     runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
 
-    // After #11131 we don't remove the delete files
-    assertFileNum(table, 1, 3);
+    assertFileNum(table, 1, 1);
 
     SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(1, "c")));
 


### PR DESCRIPTION
This keeps track of all data files to be removed/rewritten in **MergingSnapshotProducer** and passes those to the **ManifestFilterManager** for deletes. Once **ManifestFilterManager** goes through delete manifests, it also checks whether a DV references any of the data files to be removed. 
This is needed in addition to https://github.com/apache/iceberg/pull/13245 so that we can properly remove orphaned DVs when e.g. a metadata-only delete is performed.

The below benchmark shows that tracking data files to be removed and then detecting orphaned DVs when delete manifests are looked at is only adding a small fraction to the throughput.

without tracking data files to be removed
=========================================

```
Benchmark                                   (numFiles)  (percentDataFilesRewritten)  Mode  Cnt   Score   Error  Units
RewriteDataFilesBenchmark.rewriteDataFiles       50000                            5    ss    5   0.497 ± 0.061   s/op
RewriteDataFilesBenchmark.rewriteDataFiles       50000                           25    ss    5   0.649 ± 0.080   s/op
RewriteDataFilesBenchmark.rewriteDataFiles       50000                           50    ss    5   1.889 ± 0.096   s/op
RewriteDataFilesBenchmark.rewriteDataFiles       50000                          100    ss    5   2.093 ± 0.125   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      100000                            5    ss    5   0.503 ± 0.040   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      100000                           25    ss    5   1.941 ± 0.154   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      100000                           50    ss    5   2.139 ± 0.165   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      100000                          100    ss    5   2.474 ± 0.149   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      500000                            5    ss    5   1.054 ± 0.067   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      500000                           25    ss    5   2.577 ± 0.247   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      500000                           50    ss    5   3.318 ± 1.121   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      500000                          100    ss    5   5.792 ± 1.725   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     1000000                            5    ss    5   1.352 ± 0.122   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     1000000                           25    ss    5   3.252 ± 0.325   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     1000000                           50    ss    5   4.887 ± 0.548   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     1000000                          100    ss    5   8.297 ± 1.991   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     2000000                            5    ss    5   2.536 ± 0.232   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     2000000                           25    ss    5   5.227 ± 1.042   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     2000000                           50    ss    5   7.545 ± 2.052   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     2000000                          100    ss    5  18.058 ± 4.773   s/op
```

with tracking data files to be removed
======================================
```
RewriteDataFilesBenchmark.rewriteDataFiles       50000                            5    ss    5   0.626 ± 0.080   s/op
RewriteDataFilesBenchmark.rewriteDataFiles       50000                           25    ss    5   0.813 ± 0.081   s/op
RewriteDataFilesBenchmark.rewriteDataFiles       50000                           50    ss    5   2.013 ± 0.037   s/op
RewriteDataFilesBenchmark.rewriteDataFiles       50000                          100    ss    5   2.316 ± 0.137   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      100000                            5    ss    5   0.676 ± 0.036   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      100000                           25    ss    5   2.036 ± 0.105   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      100000                           50    ss    5   2.125 ± 0.107   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      100000                          100    ss    5   2.856 ± 0.138   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      500000                            5    ss    5   1.319 ± 0.049   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      500000                           25    ss    5   3.314 ± 0.265   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      500000                           50    ss    5   4.219 ± 0.498   s/op
RewriteDataFilesBenchmark.rewriteDataFiles      500000                          100    ss    5   6.164 ± 0.736   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     1000000                            5    ss    5   2.010 ± 0.224   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     1000000                           25    ss    5   3.961 ± 0.137   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     1000000                           50    ss    5   5.771 ± 0.839   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     1000000                          100    ss    5   9.082 ± 0.869   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     2000000                            5    ss    5   3.772 ± 0.602   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     2000000                           25    ss    5   6.558 ± 0.939   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     2000000                           50    ss    5   9.179 ± 1.330   s/op
RewriteDataFilesBenchmark.rewriteDataFiles     2000000                          100    ss    5  23.623 ± 8.387   s/op
```