### PR TITLE
Catalogs: consistently handle non-existent identifiers when loading tables/views

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -103,7 +103,10 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
       TableIdentifier baseTableIdentifier = TableIdentifier.of(identifier.namespace().levels());
       TableOperations ops = newTableOps(baseTableIdentifier);
       if (ops.current() == null) {
-        throw new NoSuchTableException("Table does not exist: %s", baseTableIdentifier);
+        // We can't know if the identifier is really targeting a metadata table
+        // (e.g. ns1.table1.history) or a regular table (e.g. ns1.ns2.history),
+        // so include the original identifier in the message error.
+        throw new NoSuchTableException("Table does not exist: %s", identifier);
       }
 
       return MetadataTableUtils.createMetadataTableInstance(
@@ -115,6 +118,7 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
 
   protected boolean isValidMetadataIdentifier(TableIdentifier identifier) {
     return MetadataTableType.from(identifier.name()) != null
+        && identifier.namespace().levels().length > 1
         && isValidIdentifier(TableIdentifier.of(identifier.namespace().levels()));
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -400,7 +400,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     } catch (NoSuchTableException original) {
       metadataType = MetadataTableType.from(identifier.name());
-      if (metadataType != null) {
+      if (metadataType != null && identifier.namespace().levels().length > 1) {
         // attempt to load a metadata table using the identifier's namespace as the base table
         TableIdentifier baseIdent = TableIdentifier.of(identifier.namespace().levels());
         try {

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
@@ -71,4 +71,9 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
   protected boolean supportsEmptyNamespace() {
     return true;
   }
+
+  @Override
+  protected boolean supportsNestedNamespaces() {
+    return true;
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryViewCatalog.java
@@ -60,4 +60,9 @@ public class TestInMemoryViewCatalog extends ViewCatalogTests<InMemoryCatalog> {
   protected boolean supportsEmptyNamespace() {
     return true;
   }
+
+  @Override
+  protected boolean supportsNestedNamespaces() {
+    return true;
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcViewCatalog.java
@@ -91,6 +91,11 @@ public class TestJdbcViewCatalog extends ViewCatalogTests<JdbcCatalog> {
     return true;
   }
 
+  @Override
+  protected boolean supportsNestedNamespaces() {
+    return true;
+  }
+
   @Test
   public void testCommitExceptionWithoutMessage() {
     TableIdentifier identifier = TableIdentifier.of("namespace1", "view");

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -162,6 +162,11 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
     }
   }
 
+  @Override
+  protected boolean supportsNestedNamespaces() {
+    return true;
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {21, 30})
   public void testPaginationForListViews(int numberOfItems) {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieViewCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieViewCatalog.java
@@ -158,6 +158,11 @@ public class TestNessieViewCatalog extends ViewCatalogTests<NessieCatalog> {
     return true;
   }
 
+  @Override
+  protected boolean supportsNestedNamespaces() {
+    return true;
+  }
+
   // Overriding the below rename view testcases to exclude checking same view metadata after rename.
   // Nessie adds extra properties (like commit id) on every operation. Hence, view metadata will not
   // be same after rename.

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.spark.CatalogTestBase;
@@ -114,6 +115,26 @@ public class TestCreateTable extends CatalogTestBase {
         .isEqualTo(expectedSchema);
     assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
     assertThat(table.properties()).doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT);
+  }
+
+  @TestTemplate
+  public void testTableWithMetadataTableName() {
+    TableIdentifier identifier = TableIdentifier.of("default", "files");
+    String name = tableName(identifier.name());
+    assertThat(validationCatalog.tableExists(identifier))
+        .as("Table should not already exist")
+        .isFalse();
+
+    sql("CREATE TABLE %s (id BIGINT NOT NULL, data STRING) USING iceberg", name);
+
+    Table table = validationCatalog.loadTable(identifier);
+    assertThat(table).as("Should load the new table").isNotNull();
+
+    Table metadataTable =
+        validationCatalog.loadTable(TableIdentifier.of("default", "files", "files"));
+    assertThat(metadataTable).as("Should load the new table").isNotNull();
+
+    sql("DROP TABLE %s", name);
   }
 
   @TestTemplate


### PR DESCRIPTION
Fixes #13115