### PR TITLE
Spark 4.0: Add a test for DataFrame API support for MERGE INTO

### DIFF
--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -31,10 +31,12 @@ import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_OPEN_FILE_COST;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
+import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.lit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static scala.collection.JavaConverters.mapAsScalaMapConverter;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,8 +97,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     sql("DROP TABLE IF EXISTS source");
   }
 
-  @TestTemplate
-  public void testMergeWithAllClauses() {
+  private void mergeWithAllClauses(boolean useSql) {
     createAndInitTable(
         "id INT, dep STRING",
         "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n"
@@ -111,20 +112,40 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             + "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
             + "{ \"id\": 5, \"dep\": \"emp-id-5\" }");
 
-    sql(
-        "MERGE INTO %s AS t USING source AS s "
-            + "ON t.id == s.id "
-            + "WHEN MATCHED AND t.id = 1 THEN "
-            + "  UPDATE SET * "
-            + "WHEN MATCHED AND t.id = 2 THEN "
-            + "  DELETE "
-            + "WHEN NOT MATCHED THEN "
-            + "  INSERT * "
-            + "WHEN NOT MATCHED BY SOURCE AND t.id = 3 THEN "
-            + "  UPDATE SET dep = 'invalid' "
-            + "WHEN NOT MATCHED BY SOURCE AND t.id = 4 THEN "
-            + "  DELETE ",
-        commitTarget());
+    if (useSql) {
+      sql(
+          "MERGE INTO %s AS t USING source AS s "
+              + "ON t.id == s.id "
+              + "WHEN MATCHED AND t.id = 1 THEN "
+              + "  UPDATE SET * "
+              + "WHEN MATCHED AND t.id = 2 THEN "
+              + "  DELETE "
+              + "WHEN NOT MATCHED THEN "
+              + "  INSERT * "
+              + "WHEN NOT MATCHED BY SOURCE AND t.id = 3 THEN "
+              + "  UPDATE SET dep = 'invalid' "
+              + "WHEN NOT MATCHED BY SOURCE AND t.id = 4 THEN "
+              + "  DELETE ",
+          commitTarget());
+
+    } else {
+      spark
+          .table("source")
+          .mergeInto(commitTarget(), col(commitTarget() + ".id").equalTo(col("source.id")))
+          .whenMatched(col(commitTarget() + ".id").equalTo(lit(1)))
+          .updateAll()
+          .whenMatched(col(commitTarget() + ".id").equalTo(lit(2)))
+          .delete()
+          .whenNotMatched()
+          .insertAll()
+          .whenNotMatchedBySource(col(commitTarget() + ".id").equalTo(lit(3)))
+          .update(
+              scala.collection.immutable.Map.from(
+                  mapAsScalaMapConverter(ImmutableMap.of("dep", lit("invalid"))).asScala()))
+          .whenNotMatchedBySource(col(commitTarget() + ".id").equalTo(lit(4)))
+          .delete()
+          .merge();
+    }
 
     assertEquals(
         "Should have expected rows",
@@ -135,6 +156,16 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             // row(4, "emp-id-4) // deleted (not matched by source)
             row(5, "emp-id-5")), // new
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testMergeWithAllClauses() {
+    mergeWithAllClauses(true);
+  }
+
+  @TestTemplate
+  public void testMergeWithAllClausesUsingDataFrameAPI() {
+    mergeWithAllClauses(false);
   }
 
   @TestTemplate


### PR DESCRIPTION
Since Spark 4.0 added support in DataFrameWriterV2 for MERGE INTO ([SPARK-46207](https://issues.apache.org/jira/browse/SPARK-46207)), it would be useful to have a test for that support.