### PR TITLE
REST: Add property for configuring user agent in http client

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -82,6 +82,7 @@ public class HTTPClient extends BaseHTTPClient {
   static final String REST_PROXY_PORT = "rest.client.proxy.port";
   static final String REST_PROXY_USERNAME = "rest.client.proxy.username";
   static final String REST_PROXY_PASSWORD = "rest.client.proxy.password";
+  static final String REST_USER_AGENT = "rest.client.user-agent";
 
   @VisibleForTesting
   static final String REST_CONNECTION_TIMEOUT_MS = "rest.client.connection-timeout-ms";
@@ -115,6 +116,11 @@ public class HTTPClient extends BaseHTTPClient {
 
     int maxRetries = PropertyUtil.propertyAsInt(properties, REST_MAX_RETRIES, 5);
     clientBuilder.setRetryStrategy(new ExponentialHttpRequestRetryStrategy(maxRetries));
+
+    String userAgent = PropertyUtil.propertyAsString(properties, REST_USER_AGENT, null);
+    if (userAgent != null) {
+      clientBuilder.setUserAgent(userAgent);
+    }
 
     if (proxy != null) {
       if (proxyCredsProvider != null) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -71,6 +71,8 @@ public class TestHTTPClient {
 
   private static final int PORT = 1080;
   private static final String BEARER_AUTH_TOKEN = "auth_token";
+  private static final String USER_AGENT = "User-Agent";
+  private static final String TEST_USER_AGENT = "Test-User-Agent";
   private static final String URI = String.format("http://127.0.0.1:%d", PORT);
   private static final ObjectMapper MAPPER = RESTObjectMapper.mapper();
 
@@ -83,7 +85,10 @@ public class TestHTTPClient {
   public static void beforeClass() {
     mockServer = startClientAndServer(PORT);
     restClient =
-        HTTPClient.builder(ImmutableMap.of()).uri(URI).withAuthSession(AuthSession.EMPTY).build();
+        HTTPClient.builder(ImmutableMap.of(HTTPClient.REST_USER_AGENT, TEST_USER_AGENT))
+            .uri(URI)
+            .withAuthSession(AuthSession.EMPTY)
+            .build();
     icebergBuildGitCommitShort = IcebergBuild.gitCommitShortId();
     icebergBuildFullVersion = IcebergBuild.fullVersion();
   }
@@ -461,7 +466,8 @@ public class TestHTTPClient {
             .withMethod(method.name().toUpperCase(Locale.ROOT))
             .withHeader("Authorization", "Bearer " + BEARER_AUTH_TOKEN)
             .withHeader(HTTPClient.CLIENT_VERSION_HEADER, icebergBuildFullVersion)
-            .withHeader(HTTPClient.CLIENT_GIT_COMMIT_SHORT_HEADER, icebergBuildGitCommitShort);
+            .withHeader(HTTPClient.CLIENT_GIT_COMMIT_SHORT_HEADER, icebergBuildGitCommitShort)
+            .withHeader(USER_AGENT, TEST_USER_AGENT);
 
     if (method.usesRequestBody()) {
       mockRequest = mockRequest.withBody(asJson);


### PR DESCRIPTION
### About the change 

This change attempts to add UA so that clients can set this at their end and it can supplement the server for audit and debugging purpose, we do have `X-Client-Version` which helps solve most of the cases as this helps server understand that  what version of the client the server is interacted, but in a world where we want to see the logs at server end and identify what happened to a client will be very hard. 

Putting this change out to see if folks are interested in this !

### Testing 
Added a new UT