### PR TITLE
Docs: Add Redpanda to vendor-related documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Daft: daft.md
   - Estuary: https://docs.estuary.dev/reference/Connectors/materialization-connectors/apache-iceberg/
   - Tinybird: https://www.tinybird.co/docs/forward/get-data-in/table-functions/iceberg
+  - Redpanda: https://docs.redpanda.com/current/manage/iceberg/about-iceberg-topics
   - RisingWave: risingwave.md
   - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
   - Presto: https://prestodb.io/docs/current/connector/iceberg.html

--- a/site/docs/blogs.md
+++ b/site/docs/blogs.md
@@ -23,6 +23,11 @@ title: "Blogs"
 Here is a list of company blogs that talk about Iceberg. The blogs are ordered from most recent to oldest.
 
 <!-- markdown-link-check-disable-next-line -->
+### [What Are Apache Iceberg Tables? Benefits and challenges](https://www.redpanda.com/blog/apache-iceberg-tables-benefits-challenges)
+**Date:** May 21, 2025, **Company**: Redpanda
+**Author**: [Redpanda](https://redpanda.com)
+
+<!-- markdown-link-check-disable-next-line -->
 ### [Real-Time Analytics on Apache Iceberg with Tinybird](https://www.tinybird.co/blog-posts/real-time-analytics-on-apache-iceberg-with-tinybird)
 **Date:** May 20, 2025, **Company**: Tinybird
 **Author**: [Alberto Romeu](https://www.linkedin.com/in/alrocar/)

--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -92,6 +92,10 @@ IOMETE is a fully-managed ready to use, batteries included Data Platform. IOMETE
 
 PuppyGraph is a cloud-native graph analytics engine that enables users to query one or more relational data stores as a unified graph model. This eliminates the overhead of deploying and maintaining a siloed graph database system, with no ETL required. [PuppyGraph’s native Apache Iceberg integration](https://docs.puppygraph.com/user-manual/getting-started/iceberg) adds native graph capabilities to your existing data lake in an easy and performant way.
 
+### [Redpanda](https://redpanda.com)
+
+Redpanda is both a cloud-native and self-hosted streaming platform whose [Iceberg topics](https://www.redpanda.com/use-case/streaming-iceberg-tables) automatically transform Kafka messages into Iceberg tables in real-time.  This allows users to query their Kafka data as part of an established Iceberg deployment, no connectors or additional technology required.  Redpanda Iceberg integrates with an expanding list of Iceberg catalogs and query engines, including many listed here.
+
 ### [RisingWave](https://risingwave.com/)
 
 [RisingWave](https://risingwave.com/) is a cloud-native streaming database for real-time data ingestion, processing, and management. It integrates with Iceberg to [read from](https://docs.risingwave.com/integrations/sources/apache-iceberg) and [write to](https://docs.risingwave.com/integrations/destinations/apache-iceberg) Iceberg tables, enabling efficient file compaction across sources like message queues, databases (via Change Data Capture), data lakes, and files. RisingWave is available as [open source](https://github.com/risingwavelabs/risingwave), a managed cloud service ([RisingWave Cloud](https://cloud.risingwave.com/auth/signin/)) with BYOC support, and an enterprise on-premises edition ([RisingWave Premium](https://docs.risingwave.com/get-started/rw-premium-edition-intro)).

--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -94,7 +94,7 @@ PuppyGraph is a cloud-native graph analytics engine that enables users to query 
 
 ### [Redpanda](https://redpanda.com)
 
-Redpanda is both a cloud-native and self-hosted streaming platform whose [Iceberg topics](https://www.redpanda.com/use-case/streaming-iceberg-tables) automatically transform Kafka messages into Iceberg tables in real-time.  This allows users to query their Kafka data as part of an established Iceberg deployment, no connectors or additional technology required.  Redpanda Iceberg integrates with an expanding list of Iceberg catalogs and query engines, including many listed here.
+Redpanda is both a cloud-native and self-hosted streaming platform whose [Iceberg topics](https://www.redpanda.com/use-case/streaming-iceberg-tables) automatically transform Kafka messages into Iceberg tables in real-time. This allows users to query their Kafka data as part of an established Iceberg deployment, no connectors or additional technology required. Redpanda Iceberg integrates with an expanding list of Iceberg catalogs and query engines, including many listed here.
 
 ### [RisingWave](https://risingwave.com/)
 


### PR DESCRIPTION
Redpanda is a streaming software company that offers the "Iceberg Topics" feature for converting Kafka messages into Iceberg tables, usable by many standard vendor Iceberg offerings.

This PR is to add us to your list of vendors.

You can reach me at lea.fester@redpanda.com if you have any questions.  

Thank you,
Lea Fester