### PR TITLE
Core, Spark: Propagate orphaned delete files when rewriting data files

### DIFF
--- a/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
@@ -21,6 +21,8 @@ package org.apache.iceberg;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
 
 /**
  * API for overwriting files in a table.
@@ -74,6 +76,19 @@ public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
    * @return this for method chaining
    */
   OverwriteFiles deleteFile(DataFile file);
+
+  /**
+   * Deletes a set of data files from the table with their respective delete files.
+   *
+   * @param dataFilesToDelete the data files to be deleted from the table
+   * @param deleteFilesToDelete the delete files corresponding to the data files to be deleted from
+   *     the table
+   * @return this for method chaining
+   */
+  default OverwriteFiles deleteFiles(
+      DataFileSet dataFilesToDelete, DeleteFileSet deleteFilesToDelete) {
+    throw new UnsupportedOperationException("Deleting data and delete files is not supported");
+  }
 
   /**
    * Signal that each file added to the table must match the overwrite expression.

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -230,7 +230,9 @@ public interface RewriteDataFiles
     }
 
     default int removedDeleteFilesCount() {
-      return 0;
+      return rewriteResults().stream()
+          .mapToInt(FileGroupRewriteResult::removedDeleteFilesCount)
+          .sum();
     }
   }
 
@@ -247,6 +249,10 @@ public interface RewriteDataFiles
 
     default long rewrittenBytesCount() {
       return 0L;
+    }
+
+    default int removedDeleteFilesCount() {
+      return 0;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
 
 public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
     implements OverwriteFiles {
@@ -67,6 +68,20 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
   @Override
   public OverwriteFiles addFile(DataFile file) {
     add(file);
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles deleteFiles(
+      DataFileSet dataFilesToDelete, DeleteFileSet deleteFilesToDelete) {
+    for (DataFile dataFile : dataFilesToDelete) {
+      deleteFile(dataFile);
+    }
+
+    for (DeleteFile deleteFile : deleteFilesToDelete) {
+      delete(deleteFile);
+    }
+
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFiles.java
@@ -75,6 +75,12 @@ interface BaseRewriteDataFiles extends RewriteDataFiles {
     default long rewrittenBytesCount() {
       return RewriteDataFiles.FileGroupRewriteResult.super.rewrittenBytesCount();
     }
+
+    @Override
+    @Value.Default
+    default int removedDeleteFilesCount() {
+      return RewriteDataFiles.FileGroupRewriteResult.super.removedDeleteFilesCount();
+    }
   }
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -75,11 +75,11 @@ public class RewriteDataFilesCommitManager {
   public void commitFileGroups(Set<RewriteFileGroup> fileGroups) {
     DataFileSet rewrittenDataFiles = DataFileSet.create();
     DataFileSet addedDataFiles = DataFileSet.create();
-    DeleteFileSet rewritableDeletes = DeleteFileSet.create();
+    DeleteFileSet danglingDVs = DeleteFileSet.create();
     for (RewriteFileGroup group : fileGroups) {
       rewrittenDataFiles.addAll(group.rewrittenFiles());
       addedDataFiles.addAll(group.addedFiles());
-      rewritableDeletes.addAll(group.rewritableDeletes());
+      danglingDVs.addAll(group.danglingDVs());
     }
 
     RewriteFiles rewrite = table.newRewrite().validateFromSnapshot(startingSnapshotId);
@@ -90,7 +90,7 @@ public class RewriteDataFilesCommitManager {
 
     rewrittenDataFiles.forEach(rewrite::deleteFile);
     addedDataFiles.forEach(rewrite::addFile);
-    rewritableDeletes.forEach(rewrite::deleteFile);
+    danglingDVs.forEach(rewrite::deleteFile);
 
     snapshotProperties.forEach(rewrite::set);
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,18 +75,22 @@ public class RewriteDataFilesCommitManager {
   public void commitFileGroups(Set<RewriteFileGroup> fileGroups) {
     DataFileSet rewrittenDataFiles = DataFileSet.create();
     DataFileSet addedDataFiles = DataFileSet.create();
+    DeleteFileSet rewritableDeletes = DeleteFileSet.create();
     for (RewriteFileGroup group : fileGroups) {
       rewrittenDataFiles.addAll(group.rewrittenFiles());
       addedDataFiles.addAll(group.addedFiles());
+      rewritableDeletes.addAll(group.rewritableDeletes());
     }
 
     RewriteFiles rewrite = table.newRewrite().validateFromSnapshot(startingSnapshotId);
     if (useStartingSequenceNumber) {
       long sequenceNumber = table.snapshot(startingSnapshotId).sequenceNumber();
-      rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles, sequenceNumber);
-    } else {
-      rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles);
+      rewrite.dataSequenceNumber(sequenceNumber);
     }
+
+    rewrittenDataFiles.forEach(rewrite::deleteFile);
+    addedDataFiles.forEach(rewrite::addFile);
+    rewritableDeletes.forEach(rewrite::deleteFile);
 
     snapshotProperties.forEach(rewrite::set);
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -23,12 +23,15 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.actions.RewriteDataFiles.FileGroupInfo;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
 
 /**
  * Container class representing a set of files to be rewritten by a RewriteAction and the new files
@@ -59,6 +62,12 @@ public class RewriteFileGroup extends RewriteGroupBase<FileGroupInfo, FileScanTa
         .collect(Collectors.toCollection(DataFileSet::create));
   }
 
+  public Set<DeleteFile> rewritableDeletes() {
+    return fileScanTasks().stream()
+        .flatMap(task -> task.deletes().stream().filter(ContentFileUtil::isDV))
+        .collect(Collectors.toCollection(DeleteFileSet::create));
+  }
+
   public Set<DataFile> addedFiles() {
     return addedFiles;
   }
@@ -70,6 +79,7 @@ public class RewriteFileGroup extends RewriteGroupBase<FileGroupInfo, FileScanTa
         .addedDataFilesCount(addedFiles.size())
         .rewrittenDataFilesCount(fileScanTasks().size())
         .rewrittenBytesCount(inputFilesSizeInBytes())
+        .removedDeleteFilesCount(rewritableDeletes().size())
         .build();
   }
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -62,7 +62,7 @@ public class RewriteFileGroup extends RewriteGroupBase<FileGroupInfo, FileScanTa
         .collect(Collectors.toCollection(DataFileSet::create));
   }
 
-  public Set<DeleteFile> rewritableDeletes() {
+  public Set<DeleteFile> danglingDVs() {
     return fileScanTasks().stream()
         .flatMap(task -> task.deletes().stream().filter(ContentFileUtil::isDV))
         .collect(Collectors.toCollection(DeleteFileSet::create));
@@ -79,7 +79,7 @@ public class RewriteFileGroup extends RewriteGroupBase<FileGroupInfo, FileScanTa
         .addedDataFilesCount(addedFiles.size())
         .rewrittenDataFilesCount(fileScanTasks().size())
         .rewrittenBytesCount(inputFilesSizeInBytes())
-        .removedDeleteFilesCount(rewritableDeletes().size())
+        .removedDeleteFilesCount(danglingDVs().size())
         .build();
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -172,14 +172,16 @@ public class RewriteDataFilesSparkAction
         partialProgressEnabled
             ? doExecuteWithPartialProgress(plan, commitManager(startingSnapshotId))
             : doExecute(plan, commitManager(startingSnapshotId));
+    ImmutableRewriteDataFiles.Result result = resultBuilder.build();
 
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
           new RemoveDanglingDeletesSparkAction(spark(), table);
       int removedCount = Iterables.size(action.execute().removedDeleteFiles());
-      resultBuilder.removedDeleteFilesCount(removedCount);
+      return result.withRemovedDeleteFilesCount(result.removedDeleteFilesCount() + removedCount);
     }
-    return resultBuilder.build();
+
+    return result;
   }
 
   private void init(long startingSnapshotId) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -177,8 +177,9 @@ public class RewriteDataFilesSparkAction
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
           new RemoveDanglingDeletesSparkAction(spark(), table);
-      int removedCount = Iterables.size(action.execute().removedDeleteFiles());
-      return result.withRemovedDeleteFilesCount(result.removedDeleteFilesCount() + removedCount);
+      int removedDeleteFiles = Iterables.size(action.execute().removedDeleteFiles());
+      return result.withRemovedDeleteFilesCount(
+          result.removedDeleteFilesCount() + removedDeleteFiles);
     }
 
     return result;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -51,13 +51,13 @@ import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.io.RollingDataWriter;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
 import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -230,14 +230,14 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
 
   private void abort(WriterCommitMessage[] messages) {
     if (cleanupOnAbort) {
-      SparkCleanupUtil.deleteFiles("job abort", table.io(), files(messages));
+      SparkCleanupUtil.deleteFiles("job abort", table.io(), Lists.newArrayList(files(messages)));
     } else {
       LOG.warn("Skipping cleanup of written files");
     }
   }
 
-  private List<DataFile> files(WriterCommitMessage[] messages) {
-    List<DataFile> files = Lists.newArrayList();
+  private DataFileSet files(WriterCommitMessage[] messages) {
+    DataFileSet files = DataFileSet.create();
 
     for (WriterCommitMessage message : messages) {
       if (message != null) {
@@ -294,7 +294,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private class DynamicOverwrite extends BaseBatchWrite {
     @Override
     public void commit(WriterCommitMessage[] messages) {
-      List<DataFile> files = files(messages);
+      DataFileSet files = files(messages);
 
       if (files.isEmpty()) {
         LOG.info("Dynamic overwrite is empty, skipping commit");
@@ -312,7 +312,6 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       if (isolationLevel == SERIALIZABLE) {
         dynamicOverwrite.validateNoConflictingData();
         dynamicOverwrite.validateNoConflictingDeletes();
-
       } else if (isolationLevel == SNAPSHOT) {
         dynamicOverwrite.validateNoConflictingDeletes();
       }
@@ -357,7 +356,6 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       if (isolationLevel == SERIALIZABLE) {
         overwriteFiles.validateNoConflictingDeletes();
         overwriteFiles.validateNoConflictingData();
-
       } else if (isolationLevel == SNAPSHOT) {
         overwriteFiles.validateNoConflictingDeletes();
       }
@@ -377,11 +375,23 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       this.isolationLevel = isolationLevel;
     }
 
-    private List<DataFile> overwrittenFiles() {
+    private DataFileSet overwrittenFiles() {
       if (scan == null) {
-        return ImmutableList.of();
+        return DataFileSet.create();
       } else {
-        return scan.tasks().stream().map(FileScanTask::file).collect(Collectors.toList());
+        return scan.tasks().stream()
+            .map(FileScanTask::file)
+            .collect(Collectors.toCollection(DataFileSet::create));
+      }
+    }
+
+    private DeleteFileSet rewritableDeletes() {
+      if (scan == null) {
+        return DeleteFileSet.create();
+      } else {
+        return scan.tasks().stream()
+            .flatMap(task -> task.deletes().stream())
+            .collect(Collectors.toCollection(DeleteFileSet::create));
       }
     }
 
@@ -402,11 +412,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     public void commit(WriterCommitMessage[] messages) {
       OverwriteFiles overwriteFiles = table.newOverwrite();
 
-      List<DataFile> overwrittenFiles = overwrittenFiles();
+      DataFileSet overwrittenFiles = overwrittenFiles();
       int numOverwrittenFiles = overwrittenFiles.size();
-      for (DataFile overwrittenFile : overwrittenFiles) {
-        overwriteFiles.deleteFile(overwrittenFile);
-      }
+      DeleteFileSet rewritableDeletes = rewritableDeletes();
+      overwriteFiles.deleteFiles(overwrittenFiles, rewritableDeletes);
 
       int numAddedFiles = 0;
       for (DataFile file : files(messages)) {
@@ -480,7 +489,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     @Override
     public void commit(WriterCommitMessage[] messages) {
       FileRewriteCoordinator coordinator = FileRewriteCoordinator.get();
-      coordinator.stageRewrite(table, fileSetID, DataFileSet.of(files(messages)));
+      coordinator.stageRewrite(table, fileSetID, files(messages));
     }
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.DataFileSet;
 import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.spark.TaskContext;
@@ -385,12 +386,12 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       }
     }
 
-    private DeleteFileSet rewritableDeletes() {
+    private DeleteFileSet danglingDVs() {
       if (scan == null) {
         return DeleteFileSet.create();
       } else {
         return scan.tasks().stream()
-            .flatMap(task -> task.deletes().stream())
+            .flatMap(task -> task.deletes().stream().filter(ContentFileUtil::isDV))
             .collect(Collectors.toCollection(DeleteFileSet::create));
       }
     }
@@ -414,8 +415,8 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
 
       DataFileSet overwrittenFiles = overwrittenFiles();
       int numOverwrittenFiles = overwrittenFiles.size();
-      DeleteFileSet rewritableDeletes = rewritableDeletes();
-      overwriteFiles.deleteFiles(overwrittenFiles, rewritableDeletes);
+      DeleteFileSet danglingDVs = danglingDVs();
+      overwriteFiles.deleteFiles(overwrittenFiles, danglingDVs);
 
       int numAddedFiles = 0;
       for (DataFile file : files(messages)) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -543,7 +543,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
-  public void removeOrphanedDVsFromDeleteManifest() throws Exception {
+  public void removeDanglingDVsFromDeleteManifest() throws Exception {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     Table table = createTable();
     int numDataFiles = 5;
@@ -565,11 +565,11 @@ public class TestRewriteDataFilesAction extends TestBase {
     Set<DeleteFile> deleteFiles = TestHelpers.deleteFiles(table);
     assertThat(deleteFiles).hasSize(numDataFiles);
 
+    Set<String> validDataFilePaths =
+        TestHelpers.dataFiles(table).stream()
+            .map(ContentFile::location)
+            .collect(Collectors.toSet());
     for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
-      Set<String> validDataFilePaths =
-          TestHelpers.dataFiles(table).stream()
-              .map(ContentFile::location)
-              .collect(Collectors.toSet());
       ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(
               manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
@@ -595,11 +595,10 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(TestHelpers.dataFiles(table)).hasSize(1);
     assertThat(TestHelpers.deleteFiles(table)).isEmpty();
 
-    Set<String> validDataFilePaths =
+    validDataFilePaths =
         TestHelpers.dataFiles(table).stream()
             .map(ContentFile::location)
             .collect(Collectors.toSet());
-
     for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
       ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -51,11 +51,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -539,6 +543,75 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void removeOrphanedDVsFromDeleteManifest() throws Exception {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+    Table table = createTable();
+    int numDataFiles = 5;
+    // 100 / 5 = 20 records per data file
+    writeRecords(numDataFiles, 100);
+    int numPositionsToDelete = 10;
+    table.refresh();
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    assertThat(dataFiles).hasSize(numDataFiles);
+
+    RowDelta rowDelta = table.newRowDelta();
+    for (DataFile dataFile : dataFiles) {
+      writeDV(table, dataFile.partition(), dataFile.location(), numPositionsToDelete)
+          .forEach(rowDelta::addDeletes);
+    }
+
+    rowDelta.commit();
+
+    Set<DeleteFile> deleteFiles = TestHelpers.deleteFiles(table);
+    assertThat(deleteFiles).hasSize(numDataFiles);
+
+    for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
+      Set<String> validDataFilePaths =
+          TestHelpers.dataFiles(table).stream()
+              .map(ContentFile::location)
+              .collect(Collectors.toSet());
+      ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(
+              manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
+      for (DeleteFile deleteFile : reader) {
+        // make sure there are no orphaned DVs
+        assertThat(validDataFilePaths).contains(deleteFile.referencedDataFile());
+      }
+    }
+
+    // all data files should be rewritten. Set MIN_INPUT_FILES > to the number of data files so that
+    // compaction is only triggered when the delete ratio of >= 30% is hit
+    RewriteDataFiles.Result result =
+        SparkActions.get(spark)
+            .rewriteDataFiles(table)
+            .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "10")
+            .option(SizeBasedFileRewritePlanner.MIN_FILE_SIZE_BYTES, "0")
+            .execute();
+
+    assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
+    assertThat(result.removedDeleteFilesCount()).isEqualTo(numDataFiles);
+
+    table.refresh();
+    assertThat(TestHelpers.dataFiles(table)).hasSize(1);
+    assertThat(TestHelpers.deleteFiles(table)).isEmpty();
+
+    Set<String> validDataFilePaths =
+        TestHelpers.dataFiles(table).stream()
+            .map(ContentFile::location)
+            .collect(Collectors.toSet());
+
+    for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
+      ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(
+              manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
+      for (DeleteFile deleteFile : reader) {
+        // make sure there are no orphaned DVs
+        assertThat(validDataFilePaths).contains(deleteFile.referencedDataFile());
+      }
+    }
+  }
+
+  @TestTemplate
   public void testRemoveDangledEqualityDeletesPartitionEvolution() {
     Table table =
         TABLES.create(
@@ -656,7 +729,9 @@ public class TestRewriteDataFilesAction extends TestBase {
         .containsExactly(1, 2, 1);
     shouldHaveMinSequenceNumberInPartition(table, "data_file.partition.c1 == 1", 3);
 
-    shouldHaveSnapshots(table, 5);
+    // v3 removes orphaned DVs during rewrite already, so there should be one snapshot less
+    int expectedSnapshots = formatVersion >= 3 ? 4 : 5;
+    shouldHaveSnapshots(table, expectedSnapshots);
     assertThat(table.currentSnapshot().summary()).containsEntry("total-position-deletes", "0");
     assertEquals("Rows must match", expectedRecords, currentData());
   }
@@ -693,6 +768,9 @@ public class TestRewriteDataFilesAction extends TestBase {
             .execute();
     assertThat(result.rewrittenDataFilesCount()).as("Action should rewrite 1 data files").isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+    if (formatVersion >= 3) {
+      assertThat(result.removedDeleteFilesCount()).isEqualTo(dataFiles.size());
+    }
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
@@ -706,7 +784,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(table.currentSnapshot().deleteManifests(table.io()).get(0).addedRowsCount())
         .as("Delete manifest added row count should equal total count")
-        .isEqualTo(total);
+        // v3 removes orphaned DVs during rewrite
+        .isEqualTo(formatVersion >= 3 ? 0 : 1);
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -172,14 +172,16 @@ public class RewriteDataFilesSparkAction
         partialProgressEnabled
             ? doExecuteWithPartialProgress(plan, commitManager(startingSnapshotId))
             : doExecute(plan, commitManager(startingSnapshotId));
+    ImmutableRewriteDataFiles.Result result = resultBuilder.build();
 
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
           new RemoveDanglingDeletesSparkAction(spark(), table);
       int removedCount = Iterables.size(action.execute().removedDeleteFiles());
-      resultBuilder.removedDeleteFilesCount(removedCount);
+      return result.withRemovedDeleteFilesCount(result.removedDeleteFilesCount() + removedCount);
     }
-    return resultBuilder.build();
+
+    return result;
   }
 
   private void init(long startingSnapshotId) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -177,8 +177,9 @@ public class RewriteDataFilesSparkAction
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
           new RemoveDanglingDeletesSparkAction(spark(), table);
-      int removedCount = Iterables.size(action.execute().removedDeleteFiles());
-      return result.withRemovedDeleteFilesCount(result.removedDeleteFilesCount() + removedCount);
+      int removedDeleteFiles = Iterables.size(action.execute().removedDeleteFiles());
+      return result.withRemovedDeleteFilesCount(
+          result.removedDeleteFilesCount() + removedDeleteFiles);
     }
 
     return result;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -51,13 +51,13 @@ import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.io.RollingDataWriter;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
 import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -241,14 +241,14 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
 
   private void abort(WriterCommitMessage[] messages) {
     if (cleanupOnAbort) {
-      SparkCleanupUtil.deleteFiles("job abort", table.io(), files(messages));
+      SparkCleanupUtil.deleteFiles("job abort", table.io(), Lists.newArrayList(files(messages)));
     } else {
       LOG.warn("Skipping cleanup of written files");
     }
   }
 
-  private List<DataFile> files(WriterCommitMessage[] messages) {
-    List<DataFile> files = Lists.newArrayList();
+  private DataFileSet files(WriterCommitMessage[] messages) {
+    DataFileSet files = DataFileSet.create();
 
     for (WriterCommitMessage message : messages) {
       if (message != null) {
@@ -305,7 +305,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private class DynamicOverwrite extends BaseBatchWrite {
     @Override
     public void commit(WriterCommitMessage[] messages) {
-      List<DataFile> files = files(messages);
+      DataFileSet files = files(messages);
 
       if (files.isEmpty()) {
         LOG.info("Dynamic overwrite is empty, skipping commit");
@@ -323,7 +323,6 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       if (isolationLevel == SERIALIZABLE) {
         dynamicOverwrite.validateNoConflictingData();
         dynamicOverwrite.validateNoConflictingDeletes();
-
       } else if (isolationLevel == SNAPSHOT) {
         dynamicOverwrite.validateNoConflictingDeletes();
       }
@@ -368,7 +367,6 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       if (isolationLevel == SERIALIZABLE) {
         overwriteFiles.validateNoConflictingDeletes();
         overwriteFiles.validateNoConflictingData();
-
       } else if (isolationLevel == SNAPSHOT) {
         overwriteFiles.validateNoConflictingDeletes();
       }
@@ -388,11 +386,23 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       this.isolationLevel = isolationLevel;
     }
 
-    private List<DataFile> overwrittenFiles() {
+    private DataFileSet overwrittenFiles() {
       if (scan == null) {
-        return ImmutableList.of();
+        return DataFileSet.create();
       } else {
-        return scan.tasks().stream().map(FileScanTask::file).collect(Collectors.toList());
+        return scan.tasks().stream()
+            .map(FileScanTask::file)
+            .collect(Collectors.toCollection(DataFileSet::create));
+      }
+    }
+
+    private DeleteFileSet rewritableDeletes() {
+      if (scan == null) {
+        return DeleteFileSet.create();
+      } else {
+        return scan.tasks().stream()
+            .flatMap(task -> task.deletes().stream())
+            .collect(Collectors.toCollection(DeleteFileSet::create));
       }
     }
 
@@ -413,11 +423,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     public void commit(WriterCommitMessage[] messages) {
       OverwriteFiles overwriteFiles = table.newOverwrite();
 
-      List<DataFile> overwrittenFiles = overwrittenFiles();
+      DataFileSet overwrittenFiles = overwrittenFiles();
       int numOverwrittenFiles = overwrittenFiles.size();
-      for (DataFile overwrittenFile : overwrittenFiles) {
-        overwriteFiles.deleteFile(overwrittenFile);
-      }
+      DeleteFileSet rewritableDeletes = rewritableDeletes();
+      overwriteFiles.deleteFiles(overwrittenFiles, rewritableDeletes);
 
       int numAddedFiles = 0;
       for (DataFile file : files(messages)) {
@@ -491,7 +500,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     @Override
     public void commit(WriterCommitMessage[] messages) {
       FileRewriteCoordinator coordinator = FileRewriteCoordinator.get();
-      coordinator.stageRewrite(table, fileSetID, DataFileSet.of(files(messages)));
+      coordinator.stageRewrite(table, fileSetID, files(messages));
     }
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -543,7 +543,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
-  public void removeOrphanedDVsFromDeleteManifest() throws Exception {
+  public void removeDanglingDVsFromDeleteManifest() throws Exception {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     Table table = createTable();
     int numDataFiles = 5;
@@ -565,11 +565,11 @@ public class TestRewriteDataFilesAction extends TestBase {
     Set<DeleteFile> deleteFiles = TestHelpers.deleteFiles(table);
     assertThat(deleteFiles).hasSize(numDataFiles);
 
+    Set<String> validDataFilePaths =
+        TestHelpers.dataFiles(table).stream()
+            .map(ContentFile::location)
+            .collect(Collectors.toSet());
     for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
-      Set<String> validDataFilePaths =
-          TestHelpers.dataFiles(table).stream()
-              .map(ContentFile::location)
-              .collect(Collectors.toSet());
       ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(
               manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
@@ -595,11 +595,10 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(TestHelpers.dataFiles(table)).hasSize(1);
     assertThat(TestHelpers.deleteFiles(table)).isEmpty();
 
-    Set<String> validDataFilePaths =
+    validDataFilePaths =
         TestHelpers.dataFiles(table).stream()
             .map(ContentFile::location)
             .collect(Collectors.toSet());
-
     for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
       ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -51,11 +51,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -539,6 +543,75 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void removeOrphanedDVsFromDeleteManifest() throws Exception {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+    Table table = createTable();
+    int numDataFiles = 5;
+    // 100 / 5 = 20 records per data file
+    writeRecords(numDataFiles, 100);
+    int numPositionsToDelete = 10;
+    table.refresh();
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    assertThat(dataFiles).hasSize(numDataFiles);
+
+    RowDelta rowDelta = table.newRowDelta();
+    for (DataFile dataFile : dataFiles) {
+      writeDV(table, dataFile.partition(), dataFile.location(), numPositionsToDelete)
+          .forEach(rowDelta::addDeletes);
+    }
+
+    rowDelta.commit();
+
+    Set<DeleteFile> deleteFiles = TestHelpers.deleteFiles(table);
+    assertThat(deleteFiles).hasSize(numDataFiles);
+
+    for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
+      Set<String> validDataFilePaths =
+          TestHelpers.dataFiles(table).stream()
+              .map(ContentFile::location)
+              .collect(Collectors.toSet());
+      ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(
+              manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
+      for (DeleteFile deleteFile : reader) {
+        // make sure there are no orphaned DVs
+        assertThat(validDataFilePaths).contains(deleteFile.referencedDataFile());
+      }
+    }
+
+    // all data files should be rewritten. Set MIN_INPUT_FILES > to the number of data files so that
+    // compaction is only triggered when the delete ratio of >= 30% is hit
+    RewriteDataFiles.Result result =
+        SparkActions.get(spark)
+            .rewriteDataFiles(table)
+            .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "10")
+            .option(SizeBasedFileRewritePlanner.MIN_FILE_SIZE_BYTES, "0")
+            .execute();
+
+    assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
+    assertThat(result.removedDeleteFilesCount()).isEqualTo(numDataFiles);
+
+    table.refresh();
+    assertThat(TestHelpers.dataFiles(table)).hasSize(1);
+    assertThat(TestHelpers.deleteFiles(table)).isEmpty();
+
+    Set<String> validDataFilePaths =
+        TestHelpers.dataFiles(table).stream()
+            .map(ContentFile::location)
+            .collect(Collectors.toSet());
+
+    for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
+      ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(
+              manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
+      for (DeleteFile deleteFile : reader) {
+        // make sure there are no orphaned DVs
+        assertThat(validDataFilePaths).contains(deleteFile.referencedDataFile());
+      }
+    }
+  }
+
+  @TestTemplate
   public void testRemoveDangledEqualityDeletesPartitionEvolution() {
     Table table =
         TABLES.create(
@@ -656,7 +729,9 @@ public class TestRewriteDataFilesAction extends TestBase {
         .containsExactly(1, 2, 1);
     shouldHaveMinSequenceNumberInPartition(table, "data_file.partition.c1 == 1", 3);
 
-    shouldHaveSnapshots(table, 5);
+    // v3 removes orphaned DVs during rewrite already, so there should be one snapshot less
+    int expectedSnapshots = formatVersion >= 3 ? 4 : 5;
+    shouldHaveSnapshots(table, expectedSnapshots);
     assertThat(table.currentSnapshot().summary()).containsEntry("total-position-deletes", "0");
     assertEquals("Rows must match", expectedRecords, currentData());
   }
@@ -693,6 +768,9 @@ public class TestRewriteDataFilesAction extends TestBase {
             .execute();
     assertThat(result.rewrittenDataFilesCount()).as("Action should rewrite 1 data files").isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+    if (formatVersion >= 3) {
+      assertThat(result.removedDeleteFilesCount()).isEqualTo(dataFiles.size());
+    }
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
@@ -706,7 +784,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(table.currentSnapshot().deleteManifests(table.io()).get(0).addedRowsCount())
         .as("Delete manifest added row count should equal total count")
-        .isEqualTo(total);
+        // v3 removes orphaned DVs during rewrite
+        .isEqualTo(formatVersion >= 3 ? 0 : 1);
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -172,14 +172,16 @@ public class RewriteDataFilesSparkAction
         partialProgressEnabled
             ? doExecuteWithPartialProgress(plan, commitManager(startingSnapshotId))
             : doExecute(plan, commitManager(startingSnapshotId));
+    ImmutableRewriteDataFiles.Result result = resultBuilder.build();
 
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
           new RemoveDanglingDeletesSparkAction(spark(), table);
       int removedCount = Iterables.size(action.execute().removedDeleteFiles());
-      resultBuilder.removedDeleteFilesCount(removedCount);
+      return result.withRemovedDeleteFilesCount(result.removedDeleteFilesCount() + removedCount);
     }
-    return resultBuilder.build();
+
+    return result;
   }
 
   private void init(long startingSnapshotId) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -177,8 +177,9 @@ public class RewriteDataFilesSparkAction
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
           new RemoveDanglingDeletesSparkAction(spark(), table);
-      int removedCount = Iterables.size(action.execute().removedDeleteFiles());
-      return result.withRemovedDeleteFilesCount(result.removedDeleteFilesCount() + removedCount);
+      int removedDeleteFiles = Iterables.size(action.execute().removedDeleteFiles());
+      return result.withRemovedDeleteFilesCount(
+          result.removedDeleteFilesCount() + removedDeleteFiles);
     }
 
     return result;

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -51,13 +51,13 @@ import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.io.RollingDataWriter;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
 import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
 import org.apache.spark.TaskContext;
 import org.apache.spark.TaskContext$;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -241,14 +241,14 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
 
   private void abort(WriterCommitMessage[] messages) {
     if (cleanupOnAbort) {
-      SparkCleanupUtil.deleteFiles("job abort", table.io(), files(messages));
+      SparkCleanupUtil.deleteFiles("job abort", table.io(), Lists.newArrayList(files(messages)));
     } else {
       LOG.warn("Skipping cleanup of written files");
     }
   }
 
-  private List<DataFile> files(WriterCommitMessage[] messages) {
-    List<DataFile> files = Lists.newArrayList();
+  private DataFileSet files(WriterCommitMessage[] messages) {
+    DataFileSet files = DataFileSet.create();
 
     for (WriterCommitMessage message : messages) {
       if (message != null) {
@@ -305,7 +305,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private class DynamicOverwrite extends BaseBatchWrite {
     @Override
     public void commit(WriterCommitMessage[] messages) {
-      List<DataFile> files = files(messages);
+      DataFileSet files = files(messages);
 
       if (files.isEmpty()) {
         LOG.info("Dynamic overwrite is empty, skipping commit");
@@ -323,7 +323,6 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       if (isolationLevel == SERIALIZABLE) {
         dynamicOverwrite.validateNoConflictingData();
         dynamicOverwrite.validateNoConflictingDeletes();
-
       } else if (isolationLevel == SNAPSHOT) {
         dynamicOverwrite.validateNoConflictingDeletes();
       }
@@ -368,7 +367,6 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       if (isolationLevel == SERIALIZABLE) {
         overwriteFiles.validateNoConflictingDeletes();
         overwriteFiles.validateNoConflictingData();
-
       } else if (isolationLevel == SNAPSHOT) {
         overwriteFiles.validateNoConflictingDeletes();
       }
@@ -388,11 +386,23 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       this.isolationLevel = isolationLevel;
     }
 
-    private List<DataFile> overwrittenFiles() {
+    private DataFileSet overwrittenFiles() {
       if (scan == null) {
-        return ImmutableList.of();
+        return DataFileSet.create();
       } else {
-        return scan.tasks().stream().map(FileScanTask::file).collect(Collectors.toList());
+        return scan.tasks().stream()
+            .map(FileScanTask::file)
+            .collect(Collectors.toCollection(DataFileSet::create));
+      }
+    }
+
+    private DeleteFileSet rewritableDeletes() {
+      if (scan == null) {
+        return DeleteFileSet.create();
+      } else {
+        return scan.tasks().stream()
+            .flatMap(task -> task.deletes().stream())
+            .collect(Collectors.toCollection(DeleteFileSet::create));
       }
     }
 
@@ -413,11 +423,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     public void commit(WriterCommitMessage[] messages) {
       OverwriteFiles overwriteFiles = table.newOverwrite();
 
-      List<DataFile> overwrittenFiles = overwrittenFiles();
+      DataFileSet overwrittenFiles = overwrittenFiles();
       int numOverwrittenFiles = overwrittenFiles.size();
-      for (DataFile overwrittenFile : overwrittenFiles) {
-        overwriteFiles.deleteFile(overwrittenFile);
-      }
+      DeleteFileSet rewritableDeletes = rewritableDeletes();
+      overwriteFiles.deleteFiles(overwrittenFiles, rewritableDeletes);
 
       int numAddedFiles = 0;
       for (DataFile file : files(messages)) {
@@ -491,7 +500,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     @Override
     public void commit(WriterCommitMessage[] messages) {
       FileRewriteCoordinator coordinator = FileRewriteCoordinator.get();
-      coordinator.stageRewrite(table, fileSetID, DataFileSet.of(files(messages)));
+      coordinator.stageRewrite(table, fileSetID, files(messages));
     }
   }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -543,7 +543,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
-  public void removeOrphanedDVsFromDeleteManifest() throws Exception {
+  public void removeDanglingDVsFromDeleteManifest() throws Exception {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     Table table = createTable();
     int numDataFiles = 5;
@@ -565,11 +565,11 @@ public class TestRewriteDataFilesAction extends TestBase {
     Set<DeleteFile> deleteFiles = TestHelpers.deleteFiles(table);
     assertThat(deleteFiles).hasSize(numDataFiles);
 
+    Set<String> validDataFilePaths =
+        TestHelpers.dataFiles(table).stream()
+            .map(ContentFile::location)
+            .collect(Collectors.toSet());
     for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
-      Set<String> validDataFilePaths =
-          TestHelpers.dataFiles(table).stream()
-              .map(ContentFile::location)
-              .collect(Collectors.toSet());
       ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(
               manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
@@ -595,11 +595,10 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(TestHelpers.dataFiles(table)).hasSize(1);
     assertThat(TestHelpers.deleteFiles(table)).isEmpty();
 
-    Set<String> validDataFilePaths =
+    validDataFilePaths =
         TestHelpers.dataFiles(table).stream()
             .map(ContentFile::location)
             .collect(Collectors.toSet());
-
     for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
       ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -51,11 +51,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -539,6 +543,75 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void removeOrphanedDVsFromDeleteManifest() throws Exception {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+    Table table = createTable();
+    int numDataFiles = 5;
+    // 100 / 5 = 20 records per data file
+    writeRecords(numDataFiles, 100);
+    int numPositionsToDelete = 10;
+    table.refresh();
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    assertThat(dataFiles).hasSize(numDataFiles);
+
+    RowDelta rowDelta = table.newRowDelta();
+    for (DataFile dataFile : dataFiles) {
+      writeDV(table, dataFile.partition(), dataFile.location(), numPositionsToDelete)
+          .forEach(rowDelta::addDeletes);
+    }
+
+    rowDelta.commit();
+
+    Set<DeleteFile> deleteFiles = TestHelpers.deleteFiles(table);
+    assertThat(deleteFiles).hasSize(numDataFiles);
+
+    for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
+      Set<String> validDataFilePaths =
+          TestHelpers.dataFiles(table).stream()
+              .map(ContentFile::location)
+              .collect(Collectors.toSet());
+      ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(
+              manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
+      for (DeleteFile deleteFile : reader) {
+        // make sure there are no orphaned DVs
+        assertThat(validDataFilePaths).contains(deleteFile.referencedDataFile());
+      }
+    }
+
+    // all data files should be rewritten. Set MIN_INPUT_FILES > to the number of data files so that
+    // compaction is only triggered when the delete ratio of >= 30% is hit
+    RewriteDataFiles.Result result =
+        SparkActions.get(spark)
+            .rewriteDataFiles(table)
+            .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "10")
+            .option(SizeBasedFileRewritePlanner.MIN_FILE_SIZE_BYTES, "0")
+            .execute();
+
+    assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
+    assertThat(result.removedDeleteFilesCount()).isEqualTo(numDataFiles);
+
+    table.refresh();
+    assertThat(TestHelpers.dataFiles(table)).hasSize(1);
+    assertThat(TestHelpers.deleteFiles(table)).isEmpty();
+
+    Set<String> validDataFilePaths =
+        TestHelpers.dataFiles(table).stream()
+            .map(ContentFile::location)
+            .collect(Collectors.toSet());
+
+    for (ManifestFile manifestFile : table.currentSnapshot().deleteManifests(table.io())) {
+      ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(
+              manifestFile, table.io(), ((BaseTable) table).operations().current().specsById());
+      for (DeleteFile deleteFile : reader) {
+        // make sure there are no orphaned DVs
+        assertThat(validDataFilePaths).contains(deleteFile.referencedDataFile());
+      }
+    }
+  }
+
+  @TestTemplate
   public void testRemoveDangledEqualityDeletesPartitionEvolution() {
     Table table =
         TABLES.create(
@@ -656,7 +729,9 @@ public class TestRewriteDataFilesAction extends TestBase {
         .containsExactly(1, 2, 1);
     shouldHaveMinSequenceNumberInPartition(table, "data_file.partition.c1 == 1", 3);
 
-    shouldHaveSnapshots(table, 5);
+    // v3 removes orphaned DVs during rewrite already, so there should be one snapshot less
+    int expectedSnapshots = formatVersion >= 3 ? 4 : 5;
+    shouldHaveSnapshots(table, expectedSnapshots);
     assertThat(table.currentSnapshot().summary()).containsEntry("total-position-deletes", "0");
     assertEquals("Rows must match", expectedRecords, currentData());
   }
@@ -693,6 +768,9 @@ public class TestRewriteDataFilesAction extends TestBase {
             .execute();
     assertThat(result.rewrittenDataFilesCount()).as("Action should rewrite 1 data files").isOne();
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+    if (formatVersion >= 3) {
+      assertThat(result.removedDeleteFilesCount()).isEqualTo(dataFiles.size());
+    }
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
@@ -706,7 +784,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(table.currentSnapshot().deleteManifests(table.io()).get(0).addedRowsCount())
         .as("Delete manifest added row count should equal total count")
-        .isEqualTo(total);
+        // v3 removes orphaned DVs during rewrite
+        .isEqualTo(formatVersion >= 3 ? 0 : 1);
   }
 
   @TestTemplate


### PR DESCRIPTION
To conform to the v3 spec we're propagating orphaned DVs down to the actual APIs that rewrite/overwrite data files. That way we can ensure that there are no orphaned DVs left in delete manifests