### PR TITLE
[#13209] Docs site: adding configuration table for REST catalog auth

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -143,13 +143,9 @@ The properties can be manually constructed or passed in from a compute engine li
 Spark uses its session properties as catalog properties, see more details in the [Spark configuration](spark-configuration.md#catalog-configuration) section.
 Flink passes in catalog properties through `CREATE CATALOG` statement, see more details in the [Flink](flink.md#adding-catalogs) section.
 
-<!-- 
-\bOAuth2Properties\b
-\.token\b
-\boauth2-server-uri\b
--->
-
 ### Catalog REST auth properties
+
+Below are the properties used to configure authentication for the REST catalog. These properties allow you to set up basic or OAuth2 authentication for accessing the REST catalog.
 
 | Property                          | Default            | Description                                            |
 | --------------------------------- | ------------------ | ------------------------------------------------------ |
@@ -161,7 +157,6 @@ Flink passes in catalog properties through `CREATE CATALOG` statement, see more 
 | rest.auth.token-expires-in-ms     | 3600000 (1 hour)   | The time in milliseconds after which the OAuth2 token expires. Used to determine when to refresh the token. Defaults to 1 hour. |
 | rest.auth.token-refresh-enabled   | true               | Controls whether a token should be refreshed if information about its expiration time is available. Defaults to `true`. |
 | rest.auth.scope                   | catalog            | Additional scope for OAuth2.                           |
-
 
 ### Lock catalog properties
 


### PR DESCRIPTION
Addresses issue #13209

Adds a new section and configuration table to the `configuration.md` page of the MkDocs site, called "Catalog REST auth properties," with entries for how to configure the REST authentication using basic or oauth2.

![image](https://github.com/user-attachments/assets/8883b790-e465-4ab0-a2c2-f07eae4cb4d2)


Please let me know if there is anything I'm missing. Thanks in advance!