### PR TITLE
docs: Mark Rust ADLS FileIO as implemented

### DIFF
--- a/site/docs/status.md
+++ b/site/docs/status.md
@@ -74,7 +74,7 @@ This section lists the libraries that implement the Apache Iceberg specification
 | Hadoop Filesystem | Y    | Y         | Y    | Y  |
 | S3 Compatible     | Y    | Y         | Y    | Y  |
 | GCS Compatible    | Y    | Y         | Y    | Y  |
-| ADLS Compatible   | Y    | Y         | N    | Y  |
+| ADLS Compatible   | Y    | Y         | Y    | Y  |
 
 ## Table Maintenance Operations
 


### PR DESCRIPTION
Since https://github.com/apache/iceberg-rust/issues/1360, Iceberg Rust implements the ADLS FileIO. This PR updates the [status page](https://github.com/apache/iceberg-rust/issues/1360) accordingly.

The change is not released yet, so we might want to wait before merging this PR.