### PR TITLE
Backport ThreadPools introduce newExitingWorkerPool and newFixedThreadPool to Flink 1.19 and Spark 3.4

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -104,7 +104,7 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
     Preconditions.checkArgument(
         maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
     this.workerPool =
-        ThreadPools.newWorkerPool(
+        ThreadPools.newFixedThreadPool(
             "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     this.continuousEmptyCheckpoints = 0;
     this.compactMode = compactMode;
@@ -312,5 +312,6 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
   @Override
   public void close() throws IOException {
     tableLoader.close();
+    workerPool.shutdown();
   }
 }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -455,7 +455,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
 
     final String operatorID = getRuntimeContext().getOperatorUniqueID();
     this.workerPool =
-        ThreadPools.newWorkerPool("iceberg-worker-pool-" + operatorID, workerPoolSize);
+        ThreadPools.newFixedThreadPool("iceberg-worker-pool-" + operatorID, workerPoolSize);
   }
 
   @Override

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
@@ -93,7 +93,7 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
     // Called in Job manager, so it is OK to load table from catalog.
     tableLoader.open();
     final ExecutorService workerPool =
-        ThreadPools.newWorkerPool("iceberg-plan-worker-pool", context.planParallelism());
+        ThreadPools.newFixedThreadPool("iceberg-plan-worker-pool", context.planParallelism());
     try (TableLoader loader = tableLoader) {
       Table table = loader.loadTable();
       return FlinkSplitPlanner.planInputSplits(table, context, workerPool);

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -151,7 +151,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
     }
 
     ExecutorService workerPool =
-        ThreadPools.newWorkerPool(threadName, scanContext.planParallelism());
+        ThreadPools.newFixedThreadPool(threadName, scanContext.planParallelism());
     try (TableLoader loader = tableLoader.clone()) {
       loader.open();
       this.batchSplits =

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
@@ -106,7 +106,7 @@ public class StreamingMonitorFunction extends RichSourceFunction<FlinkInputSplit
         "context should be instance of StreamingRuntimeContext");
     final String operatorID = ((StreamingRuntimeContext) runtimeContext).getOperatorUniqueID();
     this.workerPool =
-        ThreadPools.newWorkerPool(
+        ThreadPools.newFixedThreadPool(
             "iceberg-worker-pool-" + operatorID, scanContext.planParallelism());
   }
 

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -64,7 +64,7 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
     this.workerPool =
         isSharedPool
             ? ThreadPools.getWorkerPool()
-            : ThreadPools.newWorkerPool(
+            : ThreadPools.newFixedThreadPool(
                 "iceberg-plan-worker-pool-" + threadName, scanContext.planParallelism());
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -452,7 +452,9 @@ public class SparkTableUtil {
    * @param sourceTableIdent an identifier of the source Spark table
    * @param targetTable an Iceberg table where to import the data
    * @param stagingDir a staging directory to store temporary manifest files
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    */
   public static void importSparkTable(
       SparkSession spark,
@@ -510,7 +512,9 @@ public class SparkTableUtil {
    * @param partitionFilter only import partitions whose values match those in the map, can be
    *     partially defined
    * @param checkDuplicateFiles if true, throw exception if import results in a duplicate data file
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    */
   public static void importSparkTable(
       SparkSession spark,
@@ -546,7 +550,9 @@ public class SparkTableUtil {
    * @param checkDuplicateFiles if true, throw exception if import results in a duplicate data file
    * @param ignoreMissingFiles if true, ignore {@link FileNotFoundException} when running {@link
    *     #listPartition} for the Spark partitions
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    */
   public static void importSparkTable(
       SparkSession spark,
@@ -768,7 +774,9 @@ public class SparkTableUtil {
    * @param spec a partition spec
    * @param stagingDir a staging directory to store temporary manifest files
    * @param checkDuplicateFiles if true, throw exception if import results in a duplicate data file
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    */
   public static void importSparkPartitions(
       SparkSession spark,
@@ -793,7 +801,9 @@ public class SparkTableUtil {
    * @param checkDuplicateFiles if true, throw exception if import results in a duplicate data file
    * @param ignoreMissingFiles if true, ignore {@link FileNotFoundException} when running {@link
    *     #listPartition} for the Spark partitions
-   * @param service executor service to use for file reading
+   * @param service executor service to use for file reading. If null, file reading will be
+   *     performed on the current thread. If non-null, the provided ExecutorService will be shutdown
+   *     within this method after file reading is complete.
    */
   public static void importSparkPartitions(
       SparkSession spark,


### PR DESCRIPTION
In https://github.com/apache/iceberg/pull/13250#issuecomment-2948867578, We find https://github.com/apache/iceberg/pull/11073 missing some change to the Flink 1.19 and Spark 3.4( Spark only javadoc ).

This pr is backport the missing part to the corresponding version.