### PR TITLE
Docs: Fix list rendering and typos (#13075)

### DIFF
--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -382,7 +382,9 @@ s3://my-table-data-bucket/my_ns.db/my_table/0101/0110/1001/10110010/category=ord
 ```
 
 Note, the path resolution logic for `ObjectStoreLocationProvider` is `write.data.path` then `<tableLocation>/data`.
+
 However, for the older versions up to 0.12.0, the logic is as follows:
+
 - before 0.12.0, `write.object-storage.path` must be set.
 - at 0.12.0, `write.object-storage.path` then `write.folder-storage.path` then `<tableLocation>/data`.
 - at 2.0.0 `write.object-storage.path` and `write.folder-storage.path` will be removed

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -391,6 +391,8 @@ SET table.exec.iceberg.use-v2-sink = true;
 ## Writing with DataStream
 
 To use SinkV2 based implementation, replace `FlinkSink` with `IcebergSink` in the provided snippets.
-Warning: There are some slight differences between these implementations:
-- The `RANGE` distribution mode is not yet available for the `IcebergSink`
-- When using `IcebergSink` use `uidSuffix` instead of the `uidPrefix`
+!!! warning
+    There are some slight differences between these implementations:
+
+     - The `RANGE` distribution mode is not yet available for the `IcebergSink`
+     - When using `IcebergSink` use `uidSuffix` instead of the `uidPrefix`

--- a/docs/docs/hive.md
+++ b/docs/docs/hive.md
@@ -386,6 +386,7 @@ ALTER TABLE orders REPLACE COLUMNS (remaining string);
 
 #### Partition evolution
 You change the partitioning schema using the following commands:
+
 * Change the partitioning schema to new identity partitions:
 ```sql
 ALTER TABLE default.customers SET PARTITION SPEC (last_name);
@@ -394,6 +395,7 @@ ALTER TABLE default.customers SET PARTITION SPEC (last_name);
 ```sql
 ALTER TABLE order SET PARTITION SPEC (month(ts));
 ```
+
 #### Table migration
 You can migrate Avro / Parquet / ORC external tables to Iceberg tables using the following command:
 ```sql

--- a/docs/docs/spark-queries.md
+++ b/docs/docs/spark-queries.md
@@ -327,9 +327,10 @@ SELECT * FROM prod.db.table.files;
 
 !!! info
     Content refers to type of content stored by the data file:
-      * 0  Data
-      * 1  Position Deletes
-      * 2  Equality Deletes
+
+      - 0 - Data
+      - 1 - Position Deletes
+      - 2 - Equality Deletes
 
 To show only data files or delete files, query `prod.db.table.data_files` and `prod.db.table.delete_files` respectively.
 To show all files, data files and delete files across all tracked snapshots, query `prod.db.table.all_files`, `prod.db.table.all_data_files` and `prod.db.table.all_delete_files` respectively.

--- a/site/README.md
+++ b/site/README.md
@@ -115,7 +115,7 @@ make clean
 
 #### Testing local changes on versioned docs
 
-When you build the docs as described above, by default the versioned docs are mounted from the upstream remote repositiory called `iceberg_docs`. One exception is the `nightly` version that is a soft link to the local `docs/` folder.
+When you build the docs as described above, by default the versioned docs are mounted from the upstream remote repository called `iceberg_docs`. One exception is the `nightly` version that is a soft link to the local `docs/` folder.
 
 When you make changes to some of the historical versioned docs in a local git branch you can mount this git branch instead of the remote one by setting the following environment variables:
 
@@ -125,7 +125,7 @@ When you make changes to some of the historical versioned docs in a local git br
 
 #### Offline mode
 
-One of the great advantages to the MkDocs material plugin is the [offline feature](https://squidfunk.github.io/mkdocs-material/plugins/offline). You can view the Iceberg docs without the need of a server. To enable OFFLINE builds, add theOFFLINE environment variable to either `build` or `serve` recipes.
+One of the great advantages to the MkDocs material plugin is the [offline feature](https://squidfunk.github.io/mkdocs-material/plugins/offline). You can view the Iceberg docs without the need of a server. To enable OFFLINE builds, add the OFFLINE environment variable to either `build` or `serve` recipes.
 
 ```sh
 make build OFFLINE=true
@@ -136,7 +136,7 @@ make build OFFLINE=true
 
 ## Release process
 
-Deploying the docs is a two step process:
+Deploying the docs is a two-step process:
 
 > [!WARNING]  
 > The `make release` directive is currently unavailable as we wanted to discuss the best way forward on how or if we should automate the release. It involves taking an existing snapshot of the versioned documentation, and potentially automerging the [`docs` branch](https://github.com/apache/iceberg/tree/docs) and the [`javadoc` branch](https://github.com/apache/iceberg/tree/javadoc) which are independent from the `main` branch. Once this is complete, we can create a pull request with an offline build of the documentation to verify everything renders correctly, and then have the release manager merge that PR to finalize the docs release. So the real process would be manually invoking a docs release action, then merging a pull request.


### PR DESCRIPTION
Fixes #13075

The issue with rendering list is related to a missing blank line between paragraphs and lists. I found more similar issues and fixed them in this PR as well.

Here are the screenshots of the fixed lists from the local instance:

1. Integrations / AWS:
<img width="752" alt="image" src="https://github.com/user-attachments/assets/17631172-9a5b-4083-b445-63a7d933a78c" />

2. Flink / Flink Writes

<img width="637" alt="image" src="https://github.com/user-attachments/assets/1ff3ee94-3ae9-4127-be17-ac6dde0e1fb5" />

3. Hive

<img width="628" alt="image" src="https://github.com/user-attachments/assets/09892d7e-41ac-40bf-a589-9813bad9ec1a" />

4. Spark / Queries (**original example of the issue**)

<img width="657" alt="image" src="https://github.com/user-attachments/assets/12d0d7c4-62de-4e57-8bf8-127ff826d721" />


