### PR TITLE
Kafka Connect: Add option to fail connector task after max retries

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -81,6 +81,10 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
 | iceberg.control.commit.threads             | Number of threads to use for commits, default is (cores * 2)                                                     |
+| iceberg.control.commit.max-retry           | Max number of retry to use for commits, default is 3                                                             
+| iceberg.control.commit.min-retry-wait-ms   | Minimum wait time in ms to wait before retry, default is 60,000 (60 sec)                                         |
+| iceberg.control.commit.max-retry-wait-ms   | Maximum wait time in ms to wait before retry, default is 300,000 (5 minutes)                                     |
+| fail.on.max.commit.retries                 | Whether to fail the connector task after maximum number of retries has been reached, default is false            |
 | iceberg.coordinator.transactional.prefix   | Prefix for the transactional id to use for the coordinator producer, default is to use no/empty prefix           |
 | iceberg.catalog                            | Name of the catalog, default is `iceberg`                                                                        |
 | iceberg.catalog.*                          | Properties passed through to Iceberg catalog initialization                                                      |
@@ -94,7 +98,7 @@ contain the name of the table.
 
 ### Kafka configuration
 
-By default the connector will attempt to use Kafka client config from the worker properties for connecting to
+By default, the connector will attempt to use Kafka client config from the worker properties for connecting to
 the control topic. If that config cannot be read for some reason, Kafka client settings
 can be set explicitly using `iceberg.kafka.*` properties.
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -88,11 +88,14 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String COMMIT_THREADS_PROP = "iceberg.control.commit.threads";
   private static final String COMMIT_MAX_RETRIES_PROP = "iceberg.control.commit.max-retries";
   private static final int COMMIT_MAX_RETRIES_DEFAULT = 3;
-  private static final String COMMIT_MIN_RETRY_WAIT_MS_PROP = "iceberg.control.commit.min-retry-wait-ms";
+  private static final String COMMIT_MIN_RETRY_WAIT_MS_PROP =
+      "iceberg.control.commit.min-retry-wait-ms";
   private static final int COMMIT_MIN_RETRY_WAIT_MS_DEFAULT = 100;
-  private static final String COMMIT_MAX_RETRY_WAIT_MS_PROP = "iceberg.control.commit.max-retry-wait-ms";
+  private static final String COMMIT_MAX_RETRY_WAIT_MS_PROP =
+      "iceberg.control.commit.max-retry-wait-ms";
   private static final int COMMIT_MAX_RETRY_WAIT_MS_DEFAULT = 60_000;
-  private static final String COMMIT_TOTAL_RETRY_TIME_MS_PROP = "iceberg.control.commit.total-retry-time-ms";
+  private static final String COMMIT_TOTAL_RETRY_TIME_MS_PROP =
+      "iceberg.control.commit.total-retry-time-ms";
   private static final int COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT = 300_000; // 5 minutes
   public static final String FAIL_ON_MAX_COMMIT_RETRIES = "fail.on.max.commit.retries";
   public static final boolean FAIL_ON_MAX_COMMIT_RETRIES_DEFAULT = false;
@@ -246,14 +249,14 @@ public class IcebergSinkConfig extends AbstractConfig {
         ConfigDef.Type.INT,
         COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
         Importance.MEDIUM,
-       "Total retry time for commit, in milliseconds");
+        "Total retry time for commit, in milliseconds");
     configDef.define(
         FAIL_ON_MAX_COMMIT_RETRIES,
         ConfigDef.Type.BOOLEAN,
         FAIL_ON_MAX_COMMIT_RETRIES_DEFAULT,
         Importance.MEDIUM,
-        "If true, the connector will fail when commit operations fail after maximum retry attempts. " +
-                    "If false, the connector will log the error and continue operation, attempting again in the next cycle.");
+        "If true, the connector will fail when commit operations fail after maximum retry attempts. "
+            + "If false, the connector will log the error and continue operation, attempting again in the next cycle.");
     configDef.define(
         TRANSACTIONAL_PREFIX_PROP,
         ConfigDef.Type.STRING,

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -132,25 +132,27 @@ class Coordinator extends Channel {
   private void commit(boolean partialCommit) {
     try {
       Tasks.foreach(ImmutableList.of(partialCommit))
-              .retry(config.commitMaxRetries())
-              .exponentialBackoff(
-                      config.commitMinRetryWaitMs(),
-                      config.commitMaxRetryWaitMs(),
-                      config.commitTotalRetryTimeMs(),
-                      2.0 /* exponential */)
-              .onlyRetryOn(Exception.class)
-              .run(
-                      item -> {
-                        doCommit(partialCommit);
-                      });
+          .retry(config.commitMaxRetries())
+          .exponentialBackoff(
+              config.commitMinRetryWaitMs(),
+              config.commitMaxRetryWaitMs(),
+              config.commitTotalRetryTimeMs(),
+              2.0 /* exponential */)
+          .onlyRetryOn(Exception.class)
+          .run(
+              item -> {
+                doCommit(partialCommit);
+              });
     } catch (Exception e) {
       LOG.error("Commit failed after {} retries", config.commitMaxRetries(), e);
 
       if (config.failOnMaxCommitRetries()) {
-        throw new ConnectException("Commit operation failed after maximum retry attempts: " +
-                config.commitMaxRetries(), e);
+        throw new ConnectException(
+            "Commit operation failed after maximum retry attempts: " + config.commitMaxRetries(),
+            e);
       } else {
-        LOG.warn("Connector will continue and try again next cycle. Set 'fail.on.max.commit.retries' to true to fail fast on persistent commit errors.");
+        LOG.warn(
+            "Connector will continue and try again next cycle. Set 'fail.on.max.commit.retries' to true to fail fast on persistent commit errors.");
       }
     } finally {
       commitState.endCurrentCommit();

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkConfig.java
@@ -67,14 +67,14 @@ public class TestIcebergSinkConfig {
   @Test
   public void testCommitRetryConfiguration() {
     Map<String, String> props =
-            ImmutableMap.of(
-                    "iceberg.catalog.type", "rest",
-                    "topics", "source-topic",
-                    "iceberg.tables", "db.landing",
-                    "iceberg.control.commit.max-retries", "5",
-                    "iceberg.control.commit.min-retry-wait-ms", "200",
-                    "iceberg.control.commit.max-retry-wait-ms", "120000",
-                    "iceberg.control.commit.total-retry-time-ms", "600000");
+        ImmutableMap.of(
+            "iceberg.catalog.type", "rest",
+            "topics", "source-topic",
+            "iceberg.tables", "db.landing",
+            "iceberg.control.commit.max-retries", "5",
+            "iceberg.control.commit.min-retry-wait-ms", "200",
+            "iceberg.control.commit.max-retry-wait-ms", "120000",
+            "iceberg.control.commit.total-retry-time-ms", "600000");
     IcebergSinkConfig config = new IcebergSinkConfig(props);
     assertThat(config.commitMaxRetries()).isEqualTo(5);
     assertThat(config.commitMinRetryWaitMs()).isEqualTo(200);
@@ -82,23 +82,24 @@ public class TestIcebergSinkConfig {
     assertThat(config.commitTotalRetryTimeMs()).isEqualTo(600_000);
     assertThat(config.failOnMaxCommitRetries()).isFalse();
   }
+
   @Test
   public void testFailOnMaxCommitRetries() {
     Map<String, String> propsEnabled =
-            ImmutableMap.of(
-                    "iceberg.catalog.type", "rest",
-                    "topics", "source-topic",
-                    "iceberg.tables", "db.landing",
-                    "fail.on.max.commit.retries", "true");
+        ImmutableMap.of(
+            "iceberg.catalog.type", "rest",
+            "topics", "source-topic",
+            "iceberg.tables", "db.landing",
+            "fail.on.max.commit.retries", "true");
     IcebergSinkConfig configEnabled = new IcebergSinkConfig(propsEnabled);
     assertThat(configEnabled.failOnMaxCommitRetries()).isTrue();
 
     Map<String, String> propsDisabled =
-            ImmutableMap.of(
-                    "iceberg.catalog.type", "rest",
-                    "topics", "source-topic",
-                    "iceberg.tables", "db.landing",
-                    "fail.on.max.commit.retries", "false");
+        ImmutableMap.of(
+            "iceberg.catalog.type", "rest",
+            "topics", "source-topic",
+            "iceberg.tables", "db.landing",
+            "fail.on.max.commit.retries", "false");
     IcebergSinkConfig configDisabled = new IcebergSinkConfig(propsDisabled);
     assertThat(configDisabled.failOnMaxCommitRetries()).isFalse();
   }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkConfig.java
@@ -57,6 +57,50 @@ public class TestIcebergSinkConfig {
             "iceberg.tables", "db.landing");
     IcebergSinkConfig config = new IcebergSinkConfig(props);
     assertThat(config.commitIntervalMs()).isEqualTo(300_000);
+    assertThat(config.commitMaxRetries()).isEqualTo(3);
+    assertThat(config.commitMinRetryWaitMs()).isEqualTo(100);
+    assertThat(config.commitMaxRetryWaitMs()).isEqualTo(60_000);
+    assertThat(config.commitTotalRetryTimeMs()).isEqualTo(300_000);
+    assertThat(config.failOnMaxCommitRetries()).isFalse();
+  }
+
+  @Test
+  public void testCommitRetryConfiguration() {
+    Map<String, String> props =
+            ImmutableMap.of(
+                    "iceberg.catalog.type", "rest",
+                    "topics", "source-topic",
+                    "iceberg.tables", "db.landing",
+                    "iceberg.control.commit.max-retries", "5",
+                    "iceberg.control.commit.min-retry-wait-ms", "200",
+                    "iceberg.control.commit.max-retry-wait-ms", "120000",
+                    "iceberg.control.commit.total-retry-time-ms", "600000");
+    IcebergSinkConfig config = new IcebergSinkConfig(props);
+    assertThat(config.commitMaxRetries()).isEqualTo(5);
+    assertThat(config.commitMinRetryWaitMs()).isEqualTo(200);
+    assertThat(config.commitMaxRetryWaitMs()).isEqualTo(120_000);
+    assertThat(config.commitTotalRetryTimeMs()).isEqualTo(600_000);
+    assertThat(config.failOnMaxCommitRetries()).isFalse();
+  }
+  @Test
+  public void testFailOnMaxCommitRetries() {
+    Map<String, String> propsEnabled =
+            ImmutableMap.of(
+                    "iceberg.catalog.type", "rest",
+                    "topics", "source-topic",
+                    "iceberg.tables", "db.landing",
+                    "fail.on.max.commit.retries", "true");
+    IcebergSinkConfig configEnabled = new IcebergSinkConfig(propsEnabled);
+    assertThat(configEnabled.failOnMaxCommitRetries()).isTrue();
+
+    Map<String, String> propsDisabled =
+            ImmutableMap.of(
+                    "iceberg.catalog.type", "rest",
+                    "topics", "source-topic",
+                    "iceberg.tables", "db.landing",
+                    "fail.on.max.commit.retries", "false");
+    IcebergSinkConfig configDisabled = new IcebergSinkConfig(propsDisabled);
+    assertThat(configDisabled.failOnMaxCommitRetries()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Hi team,

I add a few more configs:
```java
  private static final String COMMIT_MAX_RETRIES_PROP = "iceberg.control.commit.max-retries";
  private static final int COMMIT_MAX_RETRIES_DEFAULT = 3;
  private static final String COMMIT_MIN_RETRY_WAIT_MS_PROP = "iceberg.control.commit.min-retry-wait-ms";
  private static final int COMMIT_MIN_RETRY_WAIT_MS_DEFAULT = 100;
  private static final String COMMIT_MAX_RETRY_WAIT_MS_PROP = "iceberg.control.commit.max-retry-wait-ms";
  private static final int COMMIT_MAX_RETRY_WAIT_MS_DEFAULT = 60_000;
  private static final String COMMIT_TOTAL_RETRY_TIME_MS_PROP = "iceberg.control.commit.total-retry-time-ms";
  private static final int COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT = 300_000; // 5 minutes
  public static final String FAIL_ON_MAX_COMMIT_RETRIES = "fail.on.max.commit.retries";
  public static final boolean FAIL_ON_MAX_COMMIT_RETRIES_DEFAULT = false;
```

if we set `fail.on.max.commit.retries=true`, the connector task will fails after some retries. The default value of `fail.on.max.commit.retries` is `false` to maintain backward compatibility

Fixes https://github.com/apache/iceberg/issues/13117

