### PR TITLE
AWS: Fix double-checked-locking pattern in S3FileIO.

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -434,9 +434,9 @@ public class S3FileIO
     if (null == clientByPrefix) {
       synchronized (this) {
         if (null == clientByPrefix) {
-          this.clientByPrefix = Maps.newHashMap();
+          Map<String, PrefixedS3Client> localClientByPrefix = Maps.newHashMap();
 
-          clientByPrefix.put(
+          localClientByPrefix.put(
               ROOT_PREFIX, new PrefixedS3Client(ROOT_PREFIX, properties, s3, s3Async));
           storageCredentials.stream()
               .filter(c -> c.prefix().startsWith(ROOT_PREFIX))
@@ -449,11 +449,12 @@ public class S3FileIO
                             .putAll(storageCredential.config())
                             .buildKeepingLast();
 
-                    clientByPrefix.put(
+                    localClientByPrefix.put(
                         storageCredential.prefix(),
                         new PrefixedS3Client(
                             storageCredential.prefix(), propertiesWithCredentials, s3, s3Async));
                   });
+          this.clientByPrefix = localClientByPrefix;
         }
       }
     }


### PR DESCRIPTION
## Fix: double-checked-locking pattern in S3FileIO.

### Ensure Thread-Safe Initialization of `clientByPrefix`

This PR addresses a thread-safety issue during the lazy initialization of the `clientByPrefix` map. Previously, the shared map was being assigned before it was fully populated, which could lead to race conditions and visibility issues in a concurrent environment.

### Changes:
- Introduced a local variable `localClientByPrefix` inside the synchronized block.
- Populated this local map with all required entries.
- Only after full initialization, assigned it to the shared `clientByPrefix` field.

### Benefits:
- Prevents other threads from observing a partially initialized map.
- Eliminates the risk of `NullPointerException` due to premature assignment.
- Aligns with best practices for safe publication in multi-threaded contexts.

```diff
- this.clientByPrefix = Maps.newHashMap();
+ Map<String, PrefixedS3Client> localClientByPrefix = Maps.newHashMap();
...
+ this.clientByPrefix = localClientByPrefix;