### PR TITLE
Flink: Dynamic Iceberg Sink: Add HashKeyGenerator / RowDataEvolver / TableUpdateOperator

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/EqualityFieldKeySelector.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/EqualityFieldKeySelector.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.flink.sink;
 
 import java.util.List;
-import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.Schema;
@@ -30,10 +30,11 @@ import org.apache.iceberg.util.StructLikeWrapper;
 import org.apache.iceberg.util.StructProjection;
 
 /**
- * Create a {@link KeySelector} to shuffle by equality fields, to ensure same equality fields record
- * will be emitted to same writer in order.
+ * Create a {@link NonThrowingKeySelector} to shuffle by equality fields, to ensure same equality
+ * fields record will be emitted to same writer in order.
  */
-class EqualityFieldKeySelector implements KeySelector<RowData, Integer> {
+@Internal
+public class EqualityFieldKeySelector implements NonThrowingKeySelector<RowData, Integer> {
 
   private final Schema schema;
   private final RowType flinkSchema;
@@ -43,7 +44,8 @@ class EqualityFieldKeySelector implements KeySelector<RowData, Integer> {
   private transient StructProjection structProjection;
   private transient StructLikeWrapper structLikeWrapper;
 
-  EqualityFieldKeySelector(Schema schema, RowType flinkSchema, List<Integer> equalityFieldIds) {
+  public EqualityFieldKeySelector(
+      Schema schema, RowType flinkSchema, List<Integer> equalityFieldIds) {
     this.schema = schema;
     this.flinkSchema = flinkSchema;
     this.deleteSchema = TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds));

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/NonThrowingKeySelector.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/NonThrowingKeySelector.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.functions.KeySelector;
+
+/**
+ * A non-throwing variant of Flink's {@link KeySelector}. This avoids having to convert checked
+ * exceptions to runtime exceptions.
+ */
+@Internal
+public interface NonThrowingKeySelector<I, K> extends KeySelector<I, K> {
+
+  @Override
+  K getKey(I value);
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionKeySelector.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionKeySelector.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.flink.sink;
 
-import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.PartitionKey;
@@ -27,11 +27,12 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.RowDataWrapper;
 
 /**
- * Create a {@link KeySelector} to shuffle by partition key, then each partition/bucket will be
- * wrote by only one task. That will reduce lots of small files in partitioned fanout write policy
- * for {@link FlinkSink}.
+ * Create a {@link NonThrowingKeySelector} to shuffle by partition key, then each partition/bucket
+ * will be wrote by only one task. That will reduce lots of small files in partitioned fanout write
+ * policy for {@link FlinkSink}.
  */
-class PartitionKeySelector implements KeySelector<RowData, String> {
+@Internal
+public class PartitionKeySelector implements NonThrowingKeySelector<RowData, String> {
 
   private final Schema schema;
   private final PartitionKey partitionKey;
@@ -39,7 +40,7 @@ class PartitionKeySelector implements KeySelector<RowData, String> {
 
   private transient RowDataWrapper rowDataWrapper;
 
-  PartitionKeySelector(PartitionSpec spec, Schema schema, RowType flinkSchema) {
+  public PartitionKeySelector(PartitionSpec spec, Schema schema, RowType flinkSchema) {
     this.schema = schema;
     this.partitionKey = new PartitionKey(spec, schema);
     this.flinkSchema = flinkSchema;

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+
+class DynamicSinkUtil {
+
+  private DynamicSinkUtil() {}
+
+  static List<Integer> getEqualityFieldIds(List<String> equalityFields, Schema schema) {
+    if (equalityFields == null || equalityFields.isEmpty()) {
+      if (!schema.identifierFieldIds().isEmpty()) {
+        return Lists.newArrayList(schema.identifierFieldIds());
+      } else {
+        return Collections.emptyList();
+      }
+    }
+    List<Integer> equalityFieldIds = Lists.newArrayListWithCapacity(equalityFields.size());
+    for (String equalityField : equalityFields) {
+      Types.NestedField field = schema.findField(equalityField);
+      Preconditions.checkNotNull(
+          field, "Equality field %s does not exist in schema", equalityField);
+      equalityFieldIds.add(field.fieldId());
+    }
+    return equalityFieldIds;
+  }
+
+  static int safeAbs(int input) {
+    if (input >= 0) {
+      return input;
+    }
+    if (input == Integer.MIN_VALUE) {
+      // -Integer.MIN_VALUE would be Integer.MIN_VALUE due to integer overflow. Map to
+      // Integer.MAX_VALUE instead!
+      return Integer.MAX_VALUE;
+    }
+    return -input;
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.CatalogLoader;
+
+@Internal
+class DynamicTableUpdateOperator
+    extends RichMapFunction<DynamicRecordInternal, DynamicRecordInternal> {
+  private final CatalogLoader catalogLoader;
+  private final int cacheMaximumSize;
+  private final long cacheRefreshMs;
+  private transient TableUpdater updater;
+
+  DynamicTableUpdateOperator(
+      CatalogLoader catalogLoader, int cacheMaximumSize, long cacheRefreshMs) {
+    this.catalogLoader = catalogLoader;
+    this.cacheMaximumSize = cacheMaximumSize;
+    this.cacheRefreshMs = cacheRefreshMs;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    Catalog catalog = catalogLoader.loadCatalog();
+    this.updater =
+        new TableUpdater(
+            new TableMetadataCache(catalog, cacheMaximumSize, cacheRefreshMs), catalog);
+  }
+
+  @Override
+  public DynamicRecordInternal map(DynamicRecordInternal data) throws Exception {
+    Tuple3<Schema, CompareSchemasVisitor.Result, PartitionSpec> newData =
+        updater.update(
+            TableIdentifier.parse(data.tableName()), data.branch(), data.schema(), data.spec());
+
+    data.setSchema(newData.f0);
+    data.setSpec(newData.f2);
+
+    if (newData.f1 == CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED) {
+      RowData newRowData = RowDataEvolver.convert(data.rowData(), data.schema(), newData.f0);
+      data.setRowData(newRowData);
+    }
+
+    return data;
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.sink.EqualityFieldKeySelector;
+import org.apache.iceberg.flink.sink.NonThrowingKeySelector;
+import org.apache.iceberg.flink.sink.PartitionKeySelector;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The HashKeyGenerator is responsible for creating the appropriate hash key for Flink's keyBy
+ * operation. The hash key is generated depending on the user-provided DynamicRecord and the table
+ * metadata. Under the hood, we maintain a set of Flink {@link KeySelector}s which implement the
+ * appropriate Iceberg {@link DistributionMode}. For every table, we randomly select a consistent
+ * subset of writer subtasks which receive data via their associated keys, depending on the chosen
+ * DistributionMode.
+ *
+ * <p>Caching ensures that a new key selector is also created when the table metadata (e.g. schema,
+ * spec) or the user-provided metadata changes (e.g. distribution mode, write parallelism).
+ */
+class HashKeyGenerator {
+  private static final Logger LOG = LoggerFactory.getLogger(HashKeyGenerator.class);
+
+  private final int maxWriteParallelism;
+  private final Cache<SelectorKey, NonThrowingKeySelector<RowData, Integer>> keySelectorCache;
+
+  HashKeyGenerator(int maxCacheSize, int maxWriteParallelism) {
+    this.maxWriteParallelism = maxWriteParallelism;
+    this.keySelectorCache = Caffeine.newBuilder().maximumSize(maxCacheSize).build();
+  }
+
+  Integer generateKey(DynamicRecord dynamicRecord) {
+    return generateKey(dynamicRecord, null, null, null);
+  }
+
+  Integer generateKey(
+      DynamicRecord dynamicRecord,
+      @Nullable Schema tableSchema,
+      @Nullable PartitionSpec tableSpec,
+      @Nullable RowData overrideRowData) {
+    String tableIdent = dynamicRecord.tableIdentifier().toString();
+    SelectorKey cacheKey =
+        new SelectorKey(
+            tableIdent,
+            dynamicRecord.branch(),
+            tableSchema != null ? tableSchema.schemaId() : null,
+            tableSpec != null ? tableSpec.specId() : null,
+            dynamicRecord.schema(),
+            dynamicRecord.spec(),
+            dynamicRecord.equalityFields());
+    return keySelectorCache
+        .get(
+            cacheKey,
+            k ->
+                getKeySelector(
+                    tableIdent,
+                    MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema()),
+                    MoreObjects.firstNonNull(tableSpec, dynamicRecord.spec()),
+                    MoreObjects.firstNonNull(
+                        dynamicRecord.distributionMode(), DistributionMode.NONE),
+                    MoreObjects.firstNonNull(
+                        dynamicRecord.equalityFields(), Collections.emptyList()),
+                    dynamicRecord.writeParallelism()))
+        .getKey(overrideRowData != null ? overrideRowData : dynamicRecord.rowData());
+  }
+
+  private NonThrowingKeySelector<RowData, Integer> getKeySelector(
+      String tableName,
+      Schema schema,
+      PartitionSpec spec,
+      DistributionMode mode,
+      List<String> equalityFields,
+      int writeParallelism) {
+    LOG.info("Write distribution mode is '{}'", mode.modeName());
+    switch (mode) {
+      case NONE:
+        if (equalityFields.isEmpty()) {
+          return tableKeySelector(tableName, writeParallelism, maxWriteParallelism);
+        } else {
+          LOG.info("Distribute rows by equality fields, because there are equality fields set");
+          return equalityFieldKeySelector(
+              tableName, schema, equalityFields, writeParallelism, maxWriteParallelism);
+        }
+
+      case HASH:
+        if (equalityFields.isEmpty()) {
+          if (spec.isUnpartitioned()) {
+            LOG.warn(
+                "Fallback to use 'none' distribution mode, because there are no equality fields set "
+                    + "and table is unpartitioned");
+            return tableKeySelector(tableName, writeParallelism, maxWriteParallelism);
+          } else {
+            return partitionKeySelector(
+                tableName, schema, spec, writeParallelism, maxWriteParallelism);
+          }
+        } else {
+          if (spec.isUnpartitioned()) {
+            LOG.info(
+                "Distribute rows by equality fields, because there are equality fields set "
+                    + "and table is unpartitioned");
+            return equalityFieldKeySelector(
+                tableName, schema, equalityFields, writeParallelism, maxWriteParallelism);
+          } else {
+            for (PartitionField partitionField : spec.fields()) {
+              Preconditions.checkState(
+                  equalityFields.contains(partitionField.name()),
+                  "In 'hash' distribution mode with equality fields set, partition field '%s' "
+                      + "should be included in equality fields: '%s'",
+                  partitionField,
+                  schema.columns().stream()
+                      .filter(c -> equalityFields.contains(c.name()))
+                      .collect(Collectors.toList()));
+            }
+            return partitionKeySelector(
+                tableName, schema, spec, writeParallelism, maxWriteParallelism);
+          }
+        }
+
+      case RANGE:
+        if (schema.identifierFieldIds().isEmpty()) {
+          LOG.warn(
+              "Fallback to use 'none' distribution mode, because there are no equality fields set "
+                  + "and {}=range is not supported yet in flink",
+              WRITE_DISTRIBUTION_MODE);
+          return tableKeySelector(tableName, writeParallelism, maxWriteParallelism);
+        } else {
+          LOG.info(
+              "Distribute rows by equality fields, because there are equality fields set "
+                  + "and{}=range is not supported yet in flink",
+              WRITE_DISTRIBUTION_MODE);
+          return equalityFieldKeySelector(
+              tableName, schema, equalityFields, writeParallelism, maxWriteParallelism);
+        }
+
+      default:
+        throw new IllegalArgumentException("Unrecognized " + WRITE_DISTRIBUTION_MODE + ": " + mode);
+    }
+  }
+
+  private static NonThrowingKeySelector<RowData, Integer> equalityFieldKeySelector(
+      String tableName,
+      Schema schema,
+      List<String> equalityFields,
+      int writeParallelism,
+      int maxWriteParallelism) {
+    return new TargetLimitedKeySelector(
+        new EqualityFieldKeySelector(
+            schema,
+            FlinkSchemaUtil.convert(schema),
+            DynamicSinkUtil.getEqualityFieldIds(equalityFields, schema)),
+        tableName.hashCode(),
+        writeParallelism,
+        maxWriteParallelism);
+  }
+
+  private static NonThrowingKeySelector<RowData, Integer> partitionKeySelector(
+      String tableName,
+      Schema schema,
+      PartitionSpec spec,
+      int writeParallelism,
+      int maxWriteParallelism) {
+    NonThrowingKeySelector<RowData, String> inner =
+        new PartitionKeySelector(spec, schema, FlinkSchemaUtil.convert(schema));
+    return new TargetLimitedKeySelector(
+        in -> inner.getKey(in).hashCode(),
+        tableName.hashCode(),
+        writeParallelism,
+        maxWriteParallelism);
+  }
+
+  private static NonThrowingKeySelector<RowData, Integer> tableKeySelector(
+      String tableName, int writeParallelism, int maxWriteParallelism) {
+    return new TargetLimitedKeySelector(
+        new RoundRobinKeySelector<>(writeParallelism),
+        tableName.hashCode(),
+        writeParallelism,
+        maxWriteParallelism);
+  }
+
+  /**
+   * Generates a new key using the salt as a base, and reduces the target key range of the {@link
+   * #wrapped} {@link NonThrowingKeySelector} to {@link #writeParallelism}.
+   */
+  private static class TargetLimitedKeySelector
+      implements NonThrowingKeySelector<RowData, Integer> {
+    private final NonThrowingKeySelector<RowData, Integer> wrapped;
+    private final int writeParallelism;
+    private final int[] distinctKeys;
+
+    @SuppressWarnings("checkstyle:ParameterAssignment")
+    TargetLimitedKeySelector(
+        NonThrowingKeySelector<RowData, Integer> wrapped,
+        int salt,
+        int writeParallelism,
+        int maxWriteParallelism) {
+      if (writeParallelism > maxWriteParallelism) {
+        LOG.warn(
+            "writeParallelism {} is greater than maxWriteParallelism {}. Capping writeParallelism at {}",
+            writeParallelism,
+            maxWriteParallelism,
+            maxWriteParallelism);
+        writeParallelism = maxWriteParallelism;
+      }
+      this.wrapped = wrapped;
+      this.writeParallelism = writeParallelism;
+      this.distinctKeys = new int[writeParallelism];
+
+      // Ensures that the generated keys are always result in unique slotId
+      Set<Integer> targetSlots = Sets.newHashSetWithExpectedSize(writeParallelism);
+      int nextKey = salt;
+      for (int i = 0; i < writeParallelism; ++i) {
+        int subtaskId = subtaskId(nextKey, writeParallelism, maxWriteParallelism);
+        while (targetSlots.contains(subtaskId)) {
+          ++nextKey;
+          subtaskId = subtaskId(nextKey, writeParallelism, maxWriteParallelism);
+        }
+
+        targetSlots.add(subtaskId);
+        distinctKeys[i] = nextKey;
+        ++nextKey;
+      }
+    }
+
+    @Override
+    public Integer getKey(RowData value) {
+      return distinctKeys[
+          DynamicSinkUtil.safeAbs(wrapped.getKey(value).hashCode()) % writeParallelism];
+    }
+
+    private static int subtaskId(int key, int writeParallelism, int maxWriteParallelism) {
+      return KeyGroupRangeAssignment.computeOperatorIndexForKeyGroup(
+          maxWriteParallelism,
+          writeParallelism,
+          KeyGroupRangeAssignment.computeKeyGroupForKeyHash(key, maxWriteParallelism));
+    }
+  }
+
+  /**
+   * Generates evenly distributed keys between [0..{@link #maxTarget}) range using round-robin
+   * algorithm.
+   *
+   * @param <T> unused input for key generation
+   */
+  private static class RoundRobinKeySelector<T> implements NonThrowingKeySelector<T, Integer> {
+    private final int maxTarget;
+    private int lastTarget = 0;
+
+    RoundRobinKeySelector(int maxTarget) {
+      this.maxTarget = maxTarget;
+    }
+
+    @Override
+    public Integer getKey(T value) {
+      lastTarget = (lastTarget + 1) % maxTarget;
+      return lastTarget;
+    }
+  }
+
+  /**
+   * Cache key for the {@link NonThrowingKeySelector}. Only contains the {@link Schema} and the
+   * {@link PartitionSpec} if their ids are not provided.
+   */
+  static class SelectorKey {
+    private final String tableName;
+    private final String branch;
+    private final Integer schemaId;
+    private final Integer specId;
+    private final Schema schema;
+    private final PartitionSpec spec;
+    private final List<String> equalityFields;
+
+    SelectorKey(
+        String tableName,
+        String branch,
+        @Nullable Integer tableSchemaId,
+        @Nullable Integer tableSpecId,
+        Schema schema,
+        PartitionSpec spec,
+        List<String> equalityFields) {
+      this.tableName = tableName;
+      this.branch = branch;
+      this.schemaId = tableSchemaId;
+      this.specId = tableSpecId;
+      this.schema = tableSchemaId == null ? schema : null;
+      this.spec = tableSpecId == null ? spec : null;
+      this.equalityFields = equalityFields;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+
+      if (other == null || getClass() != other.getClass()) {
+        return false;
+      }
+
+      SelectorKey that = (SelectorKey) other;
+      return Objects.equals(tableName, that.tableName)
+          && Objects.equals(branch, that.branch)
+          && Objects.equals(schemaId, that.schemaId)
+          && Objects.equals(specId, that.specId)
+          && Objects.equals(schema, that.schema)
+          && Objects.equals(spec, that.spec)
+          && Objects.equals(equalityFields, that.equalityFields);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(tableName, branch, schemaId, specId, schema, spec, equalityFields);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("tableName", tableName)
+          .add("branch", branch)
+          .add("schemaId", schemaId)
+          .add("specId", specId)
+          .add("schema", schema)
+          .add("spec", spec)
+          .add("equalityFields", equalityFields)
+          .toString();
+    }
+  }
+
+  @VisibleForTesting
+  Cache<SelectorKey, NonThrowingKeySelector<RowData, Integer>> getKeySelectorCache() {
+    return keySelectorCache;
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/RowDataEvolver.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/RowDataEvolver.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * A RowDataEvolver is responsible to change the input RowData to make it compatible with the target
+ * schema. This is done when
+ *
+ * <ol>
+ *   <li>The input schema has fewer fields than the target schema.
+ *   <li>The table types are wider than the input type.
+ *   <li>The field order differs for source and target schema.
+ * </ol>
+ *
+ * <p>The resolution is as follows:
+ *
+ * <ol>
+ *   <li>In the first case, we would add a null values for the missing field (if the field is
+ *       optional).
+ *   <li>In the second case, we would convert the data for the input field to a wider type, e.g. int
+ *       (input type) => long (table type).
+ *   <li>In the third case, we would rearrange the input data to match the target table.
+ * </ol>
+ */
+class RowDataEvolver {
+  private RowDataEvolver() {}
+
+  public static RowData convert(RowData sourceData, Schema sourceSchema, Schema targetSchema) {
+    return convertStruct(
+        sourceData, FlinkSchemaUtil.convert(sourceSchema), FlinkSchemaUtil.convert(targetSchema));
+  }
+
+  private static Object convert(Object object, LogicalType sourceType, LogicalType targetType) {
+    if (object == null) {
+      return null;
+    }
+
+    switch (targetType.getTypeRoot()) {
+      case BOOLEAN:
+      case INTEGER:
+      case FLOAT:
+      case VARCHAR:
+      case DATE:
+      case TIME_WITHOUT_TIME_ZONE:
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+      case BINARY:
+      case VARBINARY:
+        return object;
+      case DOUBLE:
+        if (object instanceof Float) {
+          return ((Float) object).doubleValue();
+        } else {
+          return object;
+        }
+      case BIGINT:
+        if (object instanceof Integer) {
+          return ((Integer) object).longValue();
+        } else {
+          return object;
+        }
+      case DECIMAL:
+        DecimalType toDecimalType = (DecimalType) targetType;
+        DecimalData decimalData = (DecimalData) object;
+        if (((DecimalType) sourceType).getPrecision() == toDecimalType.getPrecision()) {
+          return object;
+        } else {
+          return DecimalData.fromBigDecimal(
+              decimalData.toBigDecimal(), toDecimalType.getPrecision(), toDecimalType.getScale());
+        }
+      case TIMESTAMP_WITHOUT_TIME_ZONE:
+        if (object instanceof Integer) {
+          LocalDateTime dateTime =
+              LocalDateTime.of(LocalDate.ofEpochDay((Integer) object), LocalTime.MIN);
+          return TimestampData.fromLocalDateTime(dateTime);
+        } else {
+          return object;
+        }
+      case ROW:
+        return convertStruct((RowData) object, (RowType) sourceType, (RowType) targetType);
+      case ARRAY:
+        return convertArray((ArrayData) object, (ArrayType) sourceType, (ArrayType) targetType);
+      case MAP:
+        return convertMap((MapData) object, (MapType) sourceType, (MapType) targetType);
+      default:
+        throw new UnsupportedOperationException("Not a supported type: " + targetType);
+    }
+  }
+
+  private static RowData convertStruct(RowData sourceData, RowType sourceType, RowType targetType) {
+    GenericRowData targetData = new GenericRowData(targetType.getFields().size());
+    List<RowType.RowField> targetFields = targetType.getFields();
+    for (int i = 0; i < targetFields.size(); i++) {
+      RowType.RowField targetField = targetFields.get(i);
+
+      int sourceFieldId = sourceType.getFieldIndex(targetField.getName());
+      if (sourceFieldId == -1) {
+        if (targetField.getType().isNullable()) {
+          targetData.setField(i, null);
+        } else {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Field %s in target schema %s is non-nullable but does not exist in source schema.",
+                  i + 1, targetType));
+        }
+      } else {
+        RowData.FieldGetter getter =
+            RowData.createFieldGetter(sourceType.getTypeAt(sourceFieldId), sourceFieldId);
+        targetData.setField(
+            i,
+            convert(
+                getter.getFieldOrNull(sourceData),
+                sourceType.getFields().get(sourceFieldId).getType(),
+                targetField.getType()));
+      }
+    }
+
+    return targetData;
+  }
+
+  private static ArrayData convertArray(
+      ArrayData sourceData, ArrayType sourceType, ArrayType targetType) {
+    LogicalType fromElementType = sourceType.getElementType();
+    LogicalType toElementType = targetType.getElementType();
+    ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(fromElementType);
+    Object[] convertedArray = new Object[sourceData.size()];
+    for (int i = 0; i < convertedArray.length; i++) {
+      convertedArray[i] =
+          convert(elementGetter.getElementOrNull(sourceData, i), fromElementType, toElementType);
+    }
+    return new GenericArrayData(convertedArray);
+  }
+
+  private static MapData convertMap(MapData sourceData, MapType sourceType, MapType targetType) {
+    LogicalType fromMapKeyType = sourceType.getKeyType();
+    LogicalType fromMapValueType = sourceType.getValueType();
+    LogicalType toMapKeyType = targetType.getKeyType();
+    LogicalType toMapValueType = targetType.getValueType();
+    ArrayData keyArray = sourceData.keyArray();
+    ArrayData valueArray = sourceData.valueArray();
+    ArrayData.ElementGetter keyGetter = ArrayData.createElementGetter(fromMapKeyType);
+    ArrayData.ElementGetter valueGetter = ArrayData.createElementGetter(fromMapValueType);
+    Map<Object, Object> convertedMap = Maps.newLinkedHashMap();
+    for (int i = 0; i < keyArray.size(); ++i) {
+      convertedMap.put(
+          convert(keyGetter.getElementOrNull(keyArray, i), fromMapKeyType, toMapKeyType),
+          convert(valueGetter.getElementOrNull(valueArray, i), fromMapValueType, toMapValueType));
+    }
+
+    return new GenericMapData(convertedMap);
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import static org.apache.iceberg.flink.TestFixtures.DATABASE;
+import static org.apache.iceberg.flink.TestFixtures.TABLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class TestDynamicTableUpdateOperator {
+
+  @RegisterExtension
+  private static final HadoopCatalogExtension CATALOG_EXTENSION =
+      new HadoopCatalogExtension(DATABASE, TABLE);
+
+  private static final Schema SCHEMA1 =
+      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+  private static final Schema SCHEMA2 =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+  @Test
+  void testDynamicTableUpdateOperatorNewTable() throws Exception {
+    int cacheMaximumSize = 10;
+    int cacheRefreshMs = 1000;
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier table = TableIdentifier.of(TABLE);
+
+    assertThat(catalog.tableExists(table)).isFalse();
+    DynamicTableUpdateOperator operator =
+        new DynamicTableUpdateOperator(
+            CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize, cacheRefreshMs);
+    operator.open(null);
+
+    DynamicRecordInternal input =
+        new DynamicRecordInternal(
+            TABLE,
+            "branch",
+            SCHEMA1,
+            GenericRowData.of(1, "test"),
+            PartitionSpec.unpartitioned(),
+            42,
+            false,
+            Collections.emptyList());
+    DynamicRecordInternal output = operator.map(input);
+
+    assertThat(catalog.tableExists(table)).isTrue();
+    assertThat(input).isEqualTo(output);
+  }
+
+  @Test
+  void testDynamicTableUpdateOperatorSchemaChange() throws Exception {
+    int cacheMaximumSize = 10;
+    int cacheRefreshMs = 1000;
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier table = TableIdentifier.of(TABLE);
+
+    DynamicTableUpdateOperator operator =
+        new DynamicTableUpdateOperator(
+            CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize, cacheRefreshMs);
+    operator.open(null);
+
+    catalog.createTable(table, SCHEMA1);
+    DynamicRecordInternal input =
+        new DynamicRecordInternal(
+            TABLE,
+            "branch",
+            SCHEMA2,
+            GenericRowData.of(1, "test"),
+            PartitionSpec.unpartitioned(),
+            42,
+            false,
+            Collections.emptyList());
+    DynamicRecordInternal output = operator.map(input);
+
+    assertThat(catalog.loadTable(table).schema().sameSchema(SCHEMA2)).isTrue();
+    assertThat(input).isEqualTo(output);
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.sink.NonThrowingKeySelector;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestHashKeyGenerator {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.required(2, "data", Types.StringType.get()));
+
+  private static final String BRANCH = "main";
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of("default", "table");
+
+  @Test
+  void testRoundRobinWithDistributionModeNone() {
+    int writeParallelism = 10;
+    int maxWriteParallelism = 2;
+    HashKeyGenerator generator = new HashKeyGenerator(1, maxWriteParallelism);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+
+    GenericRowData row = GenericRowData.of(1, StringData.fromString("z"));
+    int writeKey1 =
+        getWriteKey(
+            generator, spec, DistributionMode.NONE, writeParallelism, Collections.emptyList(), row);
+    int writeKey2 =
+        getWriteKey(
+            generator, spec, DistributionMode.NONE, writeParallelism, Collections.emptyList(), row);
+    int writeKey3 =
+        getWriteKey(
+            generator, spec, DistributionMode.NONE, writeParallelism, Collections.emptyList(), row);
+    int writeKey4 =
+        getWriteKey(
+            generator, spec, DistributionMode.NONE, writeParallelism, Collections.emptyList(), row);
+
+    assertThat(writeKey1).isNotEqualTo(writeKey2);
+    assertThat(writeKey3).isEqualTo(writeKey1);
+    assertThat(writeKey4).isEqualTo(writeKey2);
+  }
+
+  @Test
+  void testBucketingWithDistributionModeHash() {
+    int writeParallelism = 3;
+    HashKeyGenerator generator = new HashKeyGenerator(1, 8);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
+
+    GenericRowData row1 = GenericRowData.of(1, StringData.fromString("a"));
+    GenericRowData row2 = GenericRowData.of(1, StringData.fromString("b"));
+    GenericRowData row3 = GenericRowData.of(2, StringData.fromString("c"));
+    GenericRowData row4 = GenericRowData.of(2, StringData.fromString("d"));
+
+    int writeKey1 =
+        getWriteKey(
+            generator,
+            spec,
+            DistributionMode.HASH,
+            writeParallelism,
+            Collections.emptyList(),
+            row1);
+    int writeKey2 =
+        getWriteKey(
+            generator,
+            spec,
+            DistributionMode.HASH,
+            writeParallelism,
+            Collections.emptyList(),
+            row2);
+    int writeKey3 =
+        getWriteKey(
+            generator,
+            spec,
+            DistributionMode.HASH,
+            writeParallelism,
+            Collections.emptyList(),
+            row3);
+    int writeKey4 =
+        getWriteKey(
+            generator,
+            spec,
+            DistributionMode.HASH,
+            writeParallelism,
+            Collections.emptyList(),
+            row4);
+
+    assertThat(writeKey1).isEqualTo(writeKey2);
+    assertThat(writeKey3).isNotEqualTo(writeKey1);
+    assertThat(writeKey4).isEqualTo(writeKey3);
+  }
+
+  @Test
+  void testEqualityKeys() {
+    int writeParallelism = 2;
+    HashKeyGenerator generator = new HashKeyGenerator(16, 8);
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    GenericRowData row1 = GenericRowData.of(1, StringData.fromString("foo"));
+    GenericRowData row2 = GenericRowData.of(1, StringData.fromString("bar"));
+    GenericRowData row3 = GenericRowData.of(2, StringData.fromString("baz"));
+    List<String> equalityColumns = Collections.singletonList("id");
+
+    int writeKey1 =
+        getWriteKey(
+            generator,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism,
+            equalityColumns,
+            row1);
+    int writeKey2 =
+        getWriteKey(
+            generator,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism,
+            equalityColumns,
+            row2);
+    int writeKey3 =
+        getWriteKey(
+            generator,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism,
+            equalityColumns,
+            row3);
+
+    assertThat(writeKey1).isEqualTo(writeKey2);
+    assertThat(writeKey2).isNotEqualTo(writeKey3);
+  }
+
+  @Test
+  void testCapAtMaxWriteParallelism() {
+    int writeParallelism = 10;
+    int maxWriteParallelism = 5;
+    HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    Set<Integer> writeKeys = Sets.newHashSet();
+    for (int i = 0; i < 20; i++) {
+      GenericRowData row = GenericRowData.of(i, StringData.fromString("z"));
+      writeKeys.add(
+          getWriteKey(
+              generator,
+              unpartitioned,
+              DistributionMode.NONE,
+              writeParallelism,
+              Collections.emptyList(),
+              row));
+    }
+
+    assertThat(writeKeys).hasSize(maxWriteParallelism);
+  }
+
+  @Test
+  void testHashModeWithoutEqualityFieldsFallsBackToNone() {
+    int writeParallelism = 2;
+    HashKeyGenerator generator = new HashKeyGenerator(16, 8);
+    Schema noIdSchema = new Schema(Types.NestedField.required(1, "x", Types.StringType.get()));
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    DynamicRecord record =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            noIdSchema,
+            GenericRowData.of(StringData.fromString("v")),
+            unpartitioned,
+            DistributionMode.HASH,
+            writeParallelism);
+
+    int writeKey1 = generator.generateKey(record);
+    int writeKey2 = generator.generateKey(record);
+    int writeKey3 = generator.generateKey(record);
+    assertThat(writeKey1).isNotEqualTo(writeKey2);
+    assertThat(writeKey3).isEqualTo(writeKey1);
+  }
+
+  @Test
+  void testOverrides() {
+    int maxCacheSize = 10;
+    int writeParallelism = 5;
+    int maxWriteParallelism = 10;
+    HashKeyGenerator generator = new HashKeyGenerator(maxCacheSize, maxWriteParallelism);
+
+    DynamicRecord record =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            SCHEMA,
+            GenericRowData.of(1, StringData.fromString("foo")),
+            PartitionSpec.unpartitioned(),
+            DistributionMode.NONE,
+            writeParallelism);
+
+    int writeKey1 = generator.generateKey(record);
+    int writeKey2 = generator.generateKey(record);
+    // Assert that we are bucketing via NONE (round-robin)
+    assertThat(writeKey1).isNotEqualTo(writeKey2);
+
+    // Schema has different id
+    Schema overrideSchema = new Schema(42, SCHEMA.columns());
+    // Spec has different id
+    PartitionSpec overrideSpec = PartitionSpec.builderFor(SCHEMA).withSpecId(42).build();
+    RowData overrideData = GenericRowData.of(1L, StringData.fromString("foo"));
+
+    // We get a new key selector for the schema which starts off on the same offset
+    assertThat(generator.generateKey(record, overrideSchema, null, null)).isEqualTo(writeKey1);
+    // We get a new key selector for the spec which starts off on the same offset
+    assertThat(generator.generateKey(record, null, overrideSpec, null)).isEqualTo(writeKey1);
+    // We get the same key selector which yields a different result for the overridden data
+    assertThat(generator.generateKey(record, null, null, overrideData)).isNotEqualTo(writeKey1);
+  }
+
+  @Test
+  void testMultipleTables() {
+    int maxCacheSize = 10;
+    int writeParallelism = 2;
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(maxCacheSize, maxWriteParallelism);
+
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    GenericRowData rowData = GenericRowData.of(1, StringData.fromString("foo"));
+
+    DynamicRecord record1 =
+        new DynamicRecord(
+            TableIdentifier.of("a", "table"),
+            BRANCH,
+            SCHEMA,
+            rowData,
+            unpartitioned,
+            DistributionMode.HASH,
+            writeParallelism);
+    record1.setEqualityFields(Collections.singletonList("id"));
+    DynamicRecord record2 =
+        new DynamicRecord(
+            TableIdentifier.of("other", "table"),
+            BRANCH,
+            SCHEMA,
+            rowData,
+            unpartitioned,
+            DistributionMode.HASH,
+            writeParallelism);
+    record2.setEqualityFields(Collections.singletonList("id"));
+
+    // Consistent hashing for the same record due to HASH distribution mode
+    int writeKeyRecord1 = generator.generateKey(record1);
+    assertThat(writeKeyRecord1).isEqualTo(generator.generateKey(record1));
+    int writeKeyRecord2 = generator.generateKey(record2);
+    assertThat(writeKeyRecord2).isEqualTo(generator.generateKey(record2));
+
+    // But the write keys are for different tables and should not be equal
+    assertThat(writeKeyRecord1).isNotEqualTo(writeKeyRecord2);
+  }
+
+  @Test
+  void testCaching() {
+    int maxCacheSize = 1;
+    int writeParallelism = 2;
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(maxCacheSize, maxWriteParallelism);
+    Cache<HashKeyGenerator.SelectorKey, NonThrowingKeySelector<RowData, Integer>> keySelectorCache =
+        generator.getKeySelectorCache();
+
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+    DynamicRecord record =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            SCHEMA,
+            GenericRowData.of(1, StringData.fromString("foo")),
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+
+    int writeKey1 = generator.generateKey(record);
+    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+
+    int writeKey2 = generator.generateKey(record);
+    assertThat(writeKey2).isNotEqualTo(writeKey1);
+    // Manually clean up because the cleanup is not always triggered
+    keySelectorCache.cleanUp();
+    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+
+    int writeKey3 = generator.generateKey(record);
+    // Manually clean up because the cleanup is not always triggered
+    keySelectorCache.cleanUp();
+    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+    // We create a new key selector which will start off at the same position
+    assertThat(writeKey1).isEqualTo(writeKey3);
+  }
+
+  private static int getWriteKey(
+      HashKeyGenerator generator,
+      PartitionSpec spec,
+      DistributionMode mode,
+      int writeParallelism,
+      List<String> equalityFields,
+      GenericRowData row) {
+    DynamicRecord record =
+        new DynamicRecord(TABLE_IDENTIFIER, BRANCH, SCHEMA, row, spec, mode, writeParallelism);
+    record.setEqualityFields(equalityFields);
+    return generator.generateKey(record);
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataEvolver.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataEvolver.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Days;
+import org.junit.jupiter.api.Test;
+
+class TestRowDataEvolver {
+
+  static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+  static final Schema SCHEMA2 =
+      new Schema(
+          Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()),
+          Types.NestedField.optional(3, "onemore", Types.DoubleType.get()));
+
+  @Test
+  void testPrimitiveTypes() {
+    DataGenerator generator = new DataGenerators.Primitives();
+    assertThat(
+            RowDataEvolver.convert(
+                generator.generateFlinkRowData(),
+                generator.icebergSchema(),
+                generator.icebergSchema()))
+        .isEqualTo(generator.generateFlinkRowData());
+  }
+
+  @Test
+  void testAddColumn() {
+    assertThat(RowDataEvolver.convert(SimpleDataUtil.createRowData(1, "a"), SCHEMA, SCHEMA2))
+        .isEqualTo(GenericRowData.of(1, StringData.fromString("a"), null));
+  }
+
+  @Test
+  void testAddRequiredColumn() {
+    Schema currentSchema = new Schema(Types.NestedField.optional(1, "id", Types.IntegerType.get()));
+    Schema targetSchema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            required(2, "data", Types.StringType.get()));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> RowDataEvolver.convert(GenericRowData.of(42), currentSchema, targetSchema));
+  }
+
+  @Test
+  void testIntToLong() {
+    Schema schemaWithLong =
+        new Schema(
+            Types.NestedField.optional(2, "id", Types.LongType.get()),
+            Types.NestedField.optional(4, "data", Types.StringType.get()));
+
+    assertThat(
+            RowDataEvolver.convert(
+                SimpleDataUtil.createRowData(1, "a"), SimpleDataUtil.SCHEMA, schemaWithLong))
+        .isEqualTo(GenericRowData.of(1L, StringData.fromString("a")));
+  }
+
+  @Test
+  void testFloatToDouble() {
+    Schema schemaWithFloat =
+        new Schema(Types.NestedField.optional(1, "float2double", Types.FloatType.get()));
+    Schema schemaWithDouble =
+        new Schema(Types.NestedField.optional(2, "float2double", Types.DoubleType.get()));
+
+    assertThat(RowDataEvolver.convert(GenericRowData.of(1.5f), schemaWithFloat, schemaWithDouble))
+        .isEqualTo(GenericRowData.of(1.5d));
+  }
+
+  @Test
+  void testDateToTimestamp() {
+    Schema schemaWithFloat =
+        new Schema(Types.NestedField.optional(1, "date2timestamp", Types.DateType.get()));
+    Schema schemaWithDouble =
+        new Schema(
+            Types.NestedField.optional(2, "date2timestamp", Types.TimestampType.withoutZone()));
+
+    DateTime time = new DateTime(2022, 1, 10, 0, 0, 0, 0, DateTimeZone.UTC);
+    int days =
+        Days.daysBetween(new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC), time).getDays();
+
+    assertThat(RowDataEvolver.convert(GenericRowData.of(days), schemaWithFloat, schemaWithDouble))
+        .isEqualTo(GenericRowData.of(TimestampData.fromEpochMillis(time.getMillis())));
+  }
+
+  @Test
+  void testIncreasePrecision() {
+    Schema before =
+        new Schema(Types.NestedField.required(14, "decimal_field", Types.DecimalType.of(9, 2)));
+    Schema after =
+        new Schema(Types.NestedField.required(14, "decimal_field", Types.DecimalType.of(10, 2)));
+
+    assertThat(
+            RowDataEvolver.convert(
+                GenericRowData.of(DecimalData.fromBigDecimal(new BigDecimal("-1.50"), 9, 2)),
+                before,
+                after))
+        .isEqualTo(GenericRowData.of(DecimalData.fromBigDecimal(new BigDecimal("-1.50"), 10, 2)));
+  }
+
+  @Test
+  void testStructAddOptionalFields() {
+    DataGenerator generator = new DataGenerators.StructOfPrimitive();
+    RowData oldData = generator.generateFlinkRowData();
+    Schema oldSchema = generator.icebergSchema();
+    Types.NestedField structField = oldSchema.columns().get(1);
+    Schema newSchema =
+        new Schema(
+            oldSchema.columns().get(0),
+            Types.NestedField.required(
+                10,
+                structField.name(),
+                Types.StructType.of(
+                    required(101, "id", Types.IntegerType.get()),
+                    optional(103, "optional", Types.StringType.get()),
+                    required(102, "name", Types.StringType.get()))));
+    RowData newData =
+        GenericRowData.of(
+            StringData.fromString("row_id_value"),
+            GenericRowData.of(1, null, StringData.fromString("Jane")));
+
+    assertThat(RowDataEvolver.convert(oldData, oldSchema, newSchema)).isEqualTo(newData);
+  }
+
+  @Test
+  void testStructAddRequiredFieldsWithOptionalRoot() {
+    DataGenerator generator = new DataGenerators.StructOfPrimitive();
+    RowData oldData = generator.generateFlinkRowData();
+    Schema oldSchema = generator.icebergSchema();
+    Types.NestedField structField = oldSchema.columns().get(1);
+    Schema newSchema =
+        new Schema(
+            oldSchema.columns().get(0),
+            Types.NestedField.optional(
+                10,
+                "newFieldOptionalField",
+                Types.StructType.of(
+                    Types.NestedField.optional(
+                        structField.fieldId(),
+                        structField.name(),
+                        Types.StructType.of(
+                            optional(101, "id", Types.IntegerType.get()),
+                            // Required columns which leads to nulling the entire struct
+                            required(103, "required", Types.StringType.get()),
+                            required(102, "name", Types.StringType.get()))))));
+
+    RowData expectedData = GenericRowData.of(StringData.fromString("row_id_value"), null);
+
+    assertThat(RowDataEvolver.convert(oldData, oldSchema, newSchema)).isEqualTo(expectedData);
+  }
+
+  @Test
+  void testStructAddRequiredFields() {
+    DataGenerator generator = new DataGenerators.StructOfPrimitive();
+    RowData oldData = generator.generateFlinkRowData();
+    Schema oldSchema = generator.icebergSchema();
+    Types.NestedField structField = oldSchema.columns().get(1);
+    Schema newSchema =
+        new Schema(
+            oldSchema.columns().get(0),
+            Types.NestedField.required(
+                10,
+                structField.name(),
+                Types.StructType.of(
+                    required(101, "id", Types.IntegerType.get()),
+                    required(103, "required", Types.StringType.get()),
+                    required(102, "name", Types.StringType.get()))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> RowDataEvolver.convert(oldData, oldSchema, newSchema));
+  }
+
+  @Test
+  void testMap() {
+    DataGenerator generator = new DataGenerators.MapOfPrimitives();
+    RowData oldData = generator.generateFlinkRowData();
+    Schema oldSchema = generator.icebergSchema();
+    Types.NestedField mapField = oldSchema.columns().get(1);
+    Schema newSchema =
+        new Schema(
+            oldSchema.columns().get(0),
+            Types.NestedField.optional(
+                10,
+                mapField.name(),
+                Types.MapType.ofRequired(101, 102, Types.StringType.get(), Types.LongType.get())));
+    RowData newData =
+        GenericRowData.of(
+            StringData.fromString("row_id_value"),
+            new GenericMapData(
+                ImmutableMap.of(
+                    StringData.fromString("Jane"), 1L, StringData.fromString("Joe"), 2L)));
+
+    assertThat(RowDataEvolver.convert(oldData, oldSchema, newSchema)).isEqualTo(newData);
+  }
+
+  @Test
+  void testArray() {
+    DataGenerator generator = new DataGenerators.ArrayOfPrimitive();
+    RowData oldData = generator.generateFlinkRowData();
+    Schema oldSchema = generator.icebergSchema();
+    Types.NestedField arrayField = oldSchema.columns().get(1);
+    Schema newSchema =
+        new Schema(
+            oldSchema.columns().get(0),
+            Types.NestedField.optional(
+                10, arrayField.name(), Types.ListType.ofOptional(101, Types.LongType.get())));
+    RowData newData =
+        GenericRowData.of(
+            StringData.fromString("row_id_value"), new GenericArrayData(new Long[] {1L, 2L, 3L}));
+
+    assertThat(RowDataEvolver.convert(oldData, oldSchema, newSchema)).isEqualTo(newData);
+  }
+}


### PR DESCRIPTION
This change adds the following components for the Flink Dynamic Iceberg Sink:

### HashKeyGenerator

A hash key generator which will be used in DynamicIcebergSink class (next PR) to implement one of Iceberg's DistributionModes (NONE, HASH, RANGE).

The HashKeyGenerator is responsible for creating the appropriate hash key for Flink's keyBy operation. The hash key is generated depending on the user-provided DynamicRecord and the table metadata. Under the hood, we maintain a set of Flink KeySelectors which implement the appropriate Iceberg DistributionMode. For every table, we randomly select a consistent subset of writer subtasks which receive data via their associated keys, depending on the chosen DistributionMode.

Caching ensures that a new key selector is also created when the table metadata (e.g. schema, spec) or the user-provided metadata changes (e.g. distribution mode, write parallelism).

### RowDataEvolver

RowDataEvolver is responsible to change the input RowData to make it compatible with the target schema. This is done when:

1. The input schema has fewer fields than the target schema.
2. The table types are wider than the input type.
3. The field order differs for source and target schema.

The resolution is as follows:

In the first case, we would add a null values for the missing field (if the field is optional). In the second case, we would convert the data for the input field to a wider type, e.g. int (input type) => long (table type). In the third case, we would rearrange the input data to match the target table.

### DynamicUpdateOperator

A dedicated operator to updating the schema / spec for the table associated with a DynamicRecord.