### PR TITLE
Core: Enhance logging messages for snapshot expiration

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -227,7 +227,7 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
 
   @Override
   public ExpireSnapshots expireSnapshots() {
-    return new RemoveSnapshots(ops);
+    return new RemoveSnapshots(name, ops);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -261,7 +261,7 @@ public class BaseTransaction implements Transaction {
   @Override
   public ExpireSnapshots expireSnapshots() {
     checkLastOperationCommitted("ExpireSnapshots");
-    ExpireSnapshots expire = new RemoveSnapshots(transactionOps);
+    ExpireSnapshots expire = new RemoveSnapshots(tableName, transactionOps);
     expire.deleteWith(enqueueDelete);
     updates.add(expire);
     return expire;

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1279,7 +1279,10 @@ public class TestRemoveSnapshots extends TestBase {
 
     assertThatThrownBy(() -> removeSnapshots(table).expireSnapshotId(snapshotId).commit())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot expire 2. Still referenced by refs: [branch]");
+        .hasMessage(
+            String.format(
+                "Cannot expire 2 in the table %s. Still referenced by refs: [branch]",
+                table.name()));
   }
 
   @TestTemplate
@@ -1295,7 +1298,9 @@ public class TestRemoveSnapshots extends TestBase {
 
     assertThatThrownBy(() -> removeSnapshots(table).expireSnapshotId(snapshotId).commit())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot expire 1. Still referenced by refs: [tag]");
+        .hasMessage(
+            String.format(
+                "Cannot expire 1 in the table %s. Still referenced by refs: [tag]", table.name()));
   }
 
   @TestTemplate


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ae0146b7-e35d-4e7b-89b6-4f8bf3ee9c13)

When Iceberg cleans up snapshots, the output logs do not contain table names, so the information is not clear enough when cleaning up multiple tables,