### PR TITLE
Use short string in Variant when possible

### DIFF
--- a/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Random;
+import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
@@ -57,7 +59,13 @@ public class TestPrimitiveWrapper {
         Variants.of(new BigDecimal("9876543210.123456789")), // decimal16
         Variants.of(new BigDecimal("-9876543210.123456789")), // decimal16
         Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Variants.of("iceberg"),
+        Variants.of("iceberg"), // short string below 255 bytes to test value offset size of 1
+        Variants.of(
+            RandomUtil.generateString(
+                300,
+                new Random(
+                    871925))), // string exceeding 255 bytes to test value offset sizes of 2, 3, and
+        // 4 bytes
       };
 
   @ParameterizedTest

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceFailover.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceFailover.java
@@ -44,9 +44,8 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.junit5.MiniClusterExtension;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.util.function.ThrowingConsumer;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -62,6 +61,7 @@ import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.sink.FlinkSink;
 import org.apache.iceberg.flink.source.assigner.SimpleSplitAssignerFactory;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -111,6 +111,18 @@ public class TestIcebergSourceFailover {
         SINK_CATALOG_EXTENSION
             .catalog()
             .createTable(TestFixtures.SINK_TABLE_IDENTIFIER, TestFixtures.SCHEMA);
+  }
+
+  @BeforeEach
+  protected void startMiniCluster(@InjectMiniCluster MiniCluster miniCluster) throws Exception {
+    if (!miniCluster.isRunning()) {
+      miniCluster.start();
+    }
+  }
+
+  @AfterEach
+  protected void stopMiniCluster(@InjectMiniCluster MiniCluster miniCluster) throws Exception {
+    miniCluster.close();
   }
 
   protected IcebergSource.Builder<RowData> sourceBuilder() {
@@ -183,15 +195,15 @@ public class TestIcebergSourceFailover {
   }
 
   @Test
-  public void testBoundedWithTaskManagerFailover() throws Exception {
-    runTestWithNewMiniCluster(
-        miniCluster -> testBoundedIcebergSource(FailoverType.TM, miniCluster));
+  public void testBoundedWithTaskManagerFailover(@InjectMiniCluster MiniCluster miniCluster)
+      throws Exception {
+    testBoundedIcebergSource(FailoverType.TM, miniCluster);
   }
 
   @Test
-  public void testBoundedWithJobManagerFailover() throws Exception {
-    runTestWithNewMiniCluster(
-        miniCluster -> testBoundedIcebergSource(FailoverType.JM, miniCluster));
+  public void testBoundedWithJobManagerFailover(@InjectMiniCluster MiniCluster miniCluster)
+      throws Exception {
+    testBoundedIcebergSource(FailoverType.JM, miniCluster);
   }
 
   private void testBoundedIcebergSource(FailoverType failoverType, MiniCluster miniCluster)
@@ -224,15 +236,15 @@ public class TestIcebergSourceFailover {
   }
 
   @Test
-  public void testContinuousWithTaskManagerFailover() throws Exception {
-    runTestWithNewMiniCluster(
-        miniCluster -> testContinuousIcebergSource(FailoverType.TM, miniCluster));
+  public void testContinuousWithTaskManagerFailover(@InjectMiniCluster MiniCluster miniCluster)
+      throws Exception {
+    testContinuousIcebergSource(FailoverType.TM, miniCluster);
   }
 
   @Test
-  public void testContinuousWithJobManagerFailover() throws Exception {
-    runTestWithNewMiniCluster(
-        miniCluster -> testContinuousIcebergSource(FailoverType.JM, miniCluster));
+  public void testContinuousWithJobManagerFailover(@InjectMiniCluster MiniCluster miniCluster)
+      throws Exception {
+    testContinuousIcebergSource(FailoverType.JM, miniCluster);
   }
 
   private void testContinuousIcebergSource(FailoverType failoverType, MiniCluster miniCluster)
@@ -313,20 +325,6 @@ public class TestIcebergSourceFailover {
   // ------------------------------------------------------------------------
   // test utilities copied from Flink's FileSourceTextLinesITCase
   // ------------------------------------------------------------------------
-
-  private static void runTestWithNewMiniCluster(ThrowingConsumer<MiniCluster, Exception> testMethod)
-      throws Exception {
-    MiniClusterWithClientResource miniCluster = null;
-    try {
-      miniCluster = new MiniClusterWithClientResource(MINI_CLUSTER_RESOURCE_CONFIG);
-      miniCluster.before();
-      testMethod.accept(miniCluster.getMiniCluster());
-    } finally {
-      if (miniCluster != null) {
-        miniCluster.after();
-      }
-    }
-  }
 
   private enum FailoverType {
     NONE,


### PR DESCRIPTION
PR for https://github.com/apache/iceberg/issues/13282.

Save 4 bytes for short strings stored in Variant by reserving first byte only for header. Regular strings continue to use 1 (header) + 4 (offset sizes) bytes.
