### PR TITLE
Use short string in Variant when possible

### DIFF
--- a/api/src/main/java/org/apache/iceberg/variants/VariantUtil.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantUtil.java
@@ -181,6 +181,10 @@ class VariantUtil {
     return (byte) ((isLarge ? 0b10000 : 0) | (offsetSize - 1) << 2 | 0b11);
   }
 
+  static byte shortStringHeader(int length) {
+    return (byte) ((length << 2) | BASIC_TYPE_SHORT_STRING);
+  }
+
   static BasicType basicType(int header) {
     int basicType = header & BASIC_TYPE_MASK;
     switch (basicType) {

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedArray.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedArray.java
@@ -25,6 +25,8 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestSerializedArray {
   private static final VariantMetadata EMPTY_METADATA = SerializedMetadata.EMPTY_V1_METADATA;
@@ -75,16 +77,11 @@ public class TestSerializedArray {
 
     assertThat(array.type()).isEqualTo(PhysicalType.ARRAY);
     assertThat(array.numElements()).isEqualTo(5);
-    assertThat(array.get(0).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(0).asPrimitive().get()).isEqualTo("a");
-    assertThat(array.get(1).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(1).asPrimitive().get()).isEqualTo("b");
-    assertThat(array.get(2).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(2).asPrimitive().get()).isEqualTo("c");
-    assertThat(array.get(3).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(3).asPrimitive().get()).isEqualTo("d");
-    assertThat(array.get(4).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(4).asPrimitive().get()).isEqualTo("e");
+    VariantTestUtil.assertVariantString(array.get(0), "a");
+    VariantTestUtil.assertVariantString(array.get(1), "b");
+    VariantTestUtil.assertVariantString(array.get(2), "c");
+    VariantTestUtil.assertVariantString(array.get(3), "d");
+    VariantTestUtil.assertVariantString(array.get(4), "e");
 
     assertThatThrownBy(() -> array.get(5))
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)
@@ -98,24 +95,12 @@ public class TestSerializedArray {
 
     assertThat(array.type()).isEqualTo(PhysicalType.ARRAY);
     assertThat(array.numElements()).isEqualTo(6);
-    assertThat(array.get(0).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(0).asPrimitive().get()).isEqualTo("a");
-    assertThat(array.get(0).asPrimitive().sizeInBytes()).isEqualTo(2);
-    assertThat(array.get(1).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(1).asPrimitive().get()).isEqualTo("b");
-    assertThat(array.get(1).asPrimitive().sizeInBytes()).isEqualTo(2);
-    assertThat(array.get(2).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(2).asPrimitive().get()).isEqualTo("c");
-    assertThat(array.get(2).asPrimitive().sizeInBytes()).isEqualTo(2);
-    assertThat(array.get(3).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(3).asPrimitive().get()).isEqualTo("iceberg");
-    assertThat(array.get(3).asPrimitive().sizeInBytes()).isEqualTo(8);
-    assertThat(array.get(4).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(4).asPrimitive().get()).isEqualTo("d");
-    assertThat(array.get(4).asPrimitive().sizeInBytes()).isEqualTo(2);
-    assertThat(array.get(5).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(5).asPrimitive().get()).isEqualTo("e");
-    assertThat(array.get(5).asPrimitive().sizeInBytes()).isEqualTo(2);
+    VariantTestUtil.assertVariantString(array.get(0), "a");
+    VariantTestUtil.assertVariantString(array.get(1), "b");
+    VariantTestUtil.assertVariantString(array.get(2), "c");
+    VariantTestUtil.assertVariantString(array.get(3), "iceberg");
+    VariantTestUtil.assertVariantString(array.get(4), "d");
+    VariantTestUtil.assertVariantString(array.get(5), "e");
 
     assertThatThrownBy(() -> array.get(6))
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)
@@ -137,14 +122,11 @@ public class TestSerializedArray {
     assertThat(array.get(0).asPrimitive().get()).isEqualTo(17396);
     assertThat(array.get(1).type()).isEqualTo(PhysicalType.INT8);
     assertThat(array.get(1).asPrimitive().get()).isEqualTo((byte) 34);
-    assertThat(array.get(2).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(2).asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(array.get(2), "iceberg");
     assertThat(array.get(3).type()).isEqualTo(PhysicalType.NULL);
     assertThat(array.get(3).asPrimitive().get()).isEqualTo(null);
-    assertThat(array.get(4).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(4).asPrimitive().get()).isEqualTo("e");
-    assertThat(array.get(5).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(5).asPrimitive().get()).isEqualTo("b");
+    VariantTestUtil.assertVariantString(array.get(4), "e");
+    VariantTestUtil.assertVariantString(array.get(5), "b");
     assertThat(array.get(6).type()).isEqualTo(PhysicalType.BOOLEAN_FALSE);
     assertThat(array.get(6).asPrimitive().get()).isEqualTo(false);
     assertThat(array.get(8).type()).isEqualTo(PhysicalType.BOOLEAN_TRUE);
@@ -159,22 +141,25 @@ public class TestSerializedArray {
     assertThat(array.get(7).type()).isEqualTo(PhysicalType.ARRAY);
     SerializedArray actualNested = (SerializedArray) array.get(7);
     assertThat(actualNested.numElements()).isEqualTo(3);
-    assertThat(actualNested.get(0).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(actualNested.get(0).asPrimitive().get()).isEqualTo("a");
-    assertThat(actualNested.get(1).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(actualNested.get(1).asPrimitive().get()).isEqualTo("c");
-    assertThat(actualNested.get(2).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(actualNested.get(2).asPrimitive().get()).isEqualTo("d");
+    VariantTestUtil.assertVariantString(actualNested.get(0), "a");
+    VariantTestUtil.assertVariantString(actualNested.get(1), "c");
+    VariantTestUtil.assertVariantString(actualNested.get(2), "d");
 
     assertThatThrownBy(() -> actualNested.get(3))
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)
         .hasMessage("Index 3 out of bounds for length 3");
   }
 
-  @Test
-  public void testTwoByteOffsets() {
-    // a string larger than 255 bytes to push the value offset size above 1 byte
-    String randomString = RandomUtil.generateString(300, random);
+  @ParameterizedTest
+  @ValueSource(
+      ints = {
+        300, // a big string larger than 255 bytes to push the value offset size above 1 byte to
+        // test TwoByteOffsets
+        70_000 // a really-big string larger than 65535 bytes to push the value offset size above 1
+        // byte to test ThreeByteOffsets
+      })
+  public void testMultiByteOffsets(int multiByteOffset) {
+    String randomString = RandomUtil.generateString(multiByteOffset, random);
     SerializedPrimitive bigString = VariantTestUtil.createString(randomString);
 
     ByteBuffer buffer = VariantTestUtil.createArray(bigString, A, B, C);
@@ -182,47 +167,10 @@ public class TestSerializedArray {
 
     assertThat(array.type()).isEqualTo(PhysicalType.ARRAY);
     assertThat(array.numElements()).isEqualTo(4);
-    assertThat(array.get(0).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(0).asPrimitive().get()).isEqualTo(randomString);
-    assertThat(array.get(0).asPrimitive().sizeInBytes()).isEqualTo(5 + randomString.length());
-    assertThat(array.get(1).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(1).asPrimitive().get()).isEqualTo("a");
-    assertThat(array.get(1).asPrimitive().sizeInBytes()).isEqualTo(2);
-    assertThat(array.get(2).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(2).asPrimitive().get()).isEqualTo("b");
-    assertThat(array.get(2).asPrimitive().sizeInBytes()).isEqualTo(2);
-    assertThat(array.get(3).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(3).asPrimitive().get()).isEqualTo("c");
-    assertThat(array.get(3).asPrimitive().sizeInBytes()).isEqualTo(2);
-
-    assertThatThrownBy(() -> array.get(4))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessage("Index 4 out of bounds for length 4");
-  }
-
-  @Test
-  public void testThreeByteOffsets() {
-    // a string larger than 65535 bytes to push the value offset size above 1 byte
-    String randomString = RandomUtil.generateString(70_000, random);
-    SerializedPrimitive reallyBigString = VariantTestUtil.createString(randomString);
-
-    ByteBuffer buffer = VariantTestUtil.createArray(reallyBigString, A, B, C);
-    SerializedArray array = SerializedArray.from(EMPTY_METADATA, buffer, buffer.get(0));
-
-    assertThat(array.type()).isEqualTo(PhysicalType.ARRAY);
-    assertThat(array.numElements()).isEqualTo(4);
-    assertThat(array.get(0).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(0).asPrimitive().get()).isEqualTo(randomString);
-    assertThat(array.get(0).asPrimitive().sizeInBytes()).isEqualTo(5 + randomString.length());
-    assertThat(array.get(1).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(1).asPrimitive().get()).isEqualTo("a");
-    assertThat(array.get(1).asPrimitive().sizeInBytes()).isEqualTo(2);
-    assertThat(array.get(2).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(2).asPrimitive().get()).isEqualTo("b");
-    assertThat(array.get(2).asPrimitive().sizeInBytes()).isEqualTo(2);
-    assertThat(array.get(3).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(array.get(3).asPrimitive().get()).isEqualTo("c");
-    assertThat(array.get(3).asPrimitive().sizeInBytes()).isEqualTo(2);
+    VariantTestUtil.assertVariantString(array.get(0), randomString);
+    VariantTestUtil.assertVariantString(array.get(1), "a");
+    VariantTestUtil.assertVariantString(array.get(2), "b");
+    VariantTestUtil.assertVariantString(array.get(3), "c");
 
     assertThatThrownBy(() -> array.get(4))
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedArray.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedArray.java
@@ -100,16 +100,22 @@ public class TestSerializedArray {
     assertThat(array.numElements()).isEqualTo(6);
     assertThat(array.get(0).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(0).asPrimitive().get()).isEqualTo("a");
+    assertThat(array.get(0).asPrimitive().sizeInBytes()).isEqualTo(2);
     assertThat(array.get(1).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(1).asPrimitive().get()).isEqualTo("b");
+    assertThat(array.get(1).asPrimitive().sizeInBytes()).isEqualTo(2);
     assertThat(array.get(2).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(2).asPrimitive().get()).isEqualTo("c");
+    assertThat(array.get(2).asPrimitive().sizeInBytes()).isEqualTo(2);
     assertThat(array.get(3).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(3).asPrimitive().get()).isEqualTo("iceberg");
+    assertThat(array.get(3).asPrimitive().sizeInBytes()).isEqualTo(8);
     assertThat(array.get(4).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(4).asPrimitive().get()).isEqualTo("d");
+    assertThat(array.get(4).asPrimitive().sizeInBytes()).isEqualTo(2);
     assertThat(array.get(5).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(5).asPrimitive().get()).isEqualTo("e");
+    assertThat(array.get(5).asPrimitive().sizeInBytes()).isEqualTo(2);
 
     assertThatThrownBy(() -> array.get(6))
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)
@@ -178,12 +184,16 @@ public class TestSerializedArray {
     assertThat(array.numElements()).isEqualTo(4);
     assertThat(array.get(0).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(0).asPrimitive().get()).isEqualTo(randomString);
+    assertThat(array.get(0).asPrimitive().sizeInBytes()).isEqualTo(5 + randomString.length());
     assertThat(array.get(1).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(1).asPrimitive().get()).isEqualTo("a");
+    assertThat(array.get(1).asPrimitive().sizeInBytes()).isEqualTo(2);
     assertThat(array.get(2).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(2).asPrimitive().get()).isEqualTo("b");
+    assertThat(array.get(2).asPrimitive().sizeInBytes()).isEqualTo(2);
     assertThat(array.get(3).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(3).asPrimitive().get()).isEqualTo("c");
+    assertThat(array.get(3).asPrimitive().sizeInBytes()).isEqualTo(2);
 
     assertThatThrownBy(() -> array.get(4))
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)
@@ -203,12 +213,16 @@ public class TestSerializedArray {
     assertThat(array.numElements()).isEqualTo(4);
     assertThat(array.get(0).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(0).asPrimitive().get()).isEqualTo(randomString);
+    assertThat(array.get(0).asPrimitive().sizeInBytes()).isEqualTo(5 + randomString.length());
     assertThat(array.get(1).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(1).asPrimitive().get()).isEqualTo("a");
+    assertThat(array.get(1).asPrimitive().sizeInBytes()).isEqualTo(2);
     assertThat(array.get(2).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(2).asPrimitive().get()).isEqualTo("b");
+    assertThat(array.get(2).asPrimitive().sizeInBytes()).isEqualTo(2);
     assertThat(array.get(3).type()).isEqualTo(PhysicalType.STRING);
     assertThat(array.get(3).asPrimitive().get()).isEqualTo("c");
+    assertThat(array.get(3).asPrimitive().sizeInBytes()).isEqualTo(2);
 
     assertThatThrownBy(() -> array.get(4))
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -254,8 +254,6 @@ public class TestSerializedObject {
 
   @Test
     public void testShortStringsInVariantPrimitives() {
-    Map<String, SerializedShortString> fields = Maps.newHashMap();
-
     // note that order doesn't matter. fields are sorted by name
     Map<String, VariantValue> data =
             ImmutableMap.of(

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -256,11 +256,11 @@ public class TestSerializedObject {
   public void testShortStringsInVariantPrimitives() {
     // note that order doesn't matter. fields are sorted by name
     Map<String, VariantValue> data =
-            ImmutableMap.of(
-                    "5-byte-header",
-                    VariantTestUtil.createString("iceberg"),
-                    "1-byte-header",
-                    VariantTestUtil.createShortString("iceberg"));
+        ImmutableMap.of(
+            "5-byte-header",
+            VariantTestUtil.createString("iceberg"),
+            "1-byte-header",
+            VariantTestUtil.createShortString("iceberg"));
     ByteBuffer meta = VariantTestUtil.createMetadata(data.keySet(), true /* sort names */);
     ByteBuffer value = VariantTestUtil.createObject(meta, data);
 
@@ -272,11 +272,11 @@ public class TestSerializedObject {
 
     assertThat(object.get("5-byte-header").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("5-byte-header").asPrimitive().get()).isEqualTo("iceberg");
-    assertThat(object.get("5-byte-header").asPrimitive().sizeInBytes()).isEqualTo(5+7);
+    assertThat(object.get("5-byte-header").asPrimitive().sizeInBytes()).isEqualTo(5 + 7);
 
     assertThat(object.get("1-byte-header").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("1-byte-header").asPrimitive().get()).isEqualTo("iceberg");
-    assertThat(object.get("1-byte-header").asPrimitive().sizeInBytes()).isEqualTo(1+7);
+    assertThat(object.get("1-byte-header").asPrimitive().sizeInBytes()).isEqualTo(1 + 7);
   }
 
   @ParameterizedTest

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -189,7 +189,18 @@ public class TestSerializedObject {
     SerializedPrimitive bigString = VariantTestUtil.createString(randomString);
 
     // note that order doesn't matter. fields are sorted by name
-    Map<String, VariantValue> data = ImmutableMap.of("big", bigString, "a", I1, "b", I2, "c", I3);
+    Map<String, VariantValue> data =
+        ImmutableMap.of(
+            "small",
+            VariantTestUtil.createShortString("iceberg"),
+            "big",
+            bigString,
+            "a",
+            I1,
+            "b",
+            I2,
+            "c",
+            I3);
     ByteBuffer meta = VariantTestUtil.createMetadata(data.keySet(), true /* sort names */);
     ByteBuffer value = VariantTestUtil.createObject(meta, data);
 
@@ -197,7 +208,7 @@ public class TestSerializedObject {
     SerializedObject object = SerializedObject.from(metadata, value, value.get(0));
 
     assertThat(object.type()).isEqualTo(PhysicalType.OBJECT);
-    assertThat(object.numFields()).isEqualTo(4);
+    assertThat(object.numFields()).isEqualTo(5);
 
     assertThat(object.get("a").type()).isEqualTo(PhysicalType.INT8);
     assertThat(object.get("a").asPrimitive().get()).isEqualTo((byte) 1);
@@ -207,6 +218,10 @@ public class TestSerializedObject {
     assertThat(object.get("c").asPrimitive().get()).isEqualTo((byte) 3);
     assertThat(object.get("big").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("big").asPrimitive().get()).isEqualTo(randomString);
+    assertThat(object.get("big").asPrimitive().sizeInBytes()).isEqualTo(5 + randomString.length());
+    assertThat(object.get("small").type()).isEqualTo(PhysicalType.STRING);
+    assertThat(object.get("small").asPrimitive().get()).isEqualTo("iceberg");
+    assertThat(object.get("small").asPrimitive().sizeInBytes()).isEqualTo(8);
   }
 
   @Test
@@ -217,7 +232,17 @@ public class TestSerializedObject {
 
     // note that order doesn't matter. fields are sorted by name
     Map<String, VariantValue> data =
-        ImmutableMap.of("really-big", reallyBigString, "a", I1, "b", I2, "c", I3);
+        ImmutableMap.of(
+            "small",
+            VariantTestUtil.createShortString("iceberg"),
+            "really-big",
+            reallyBigString,
+            "a",
+            I1,
+            "b",
+            I2,
+            "c",
+            I3);
     ByteBuffer meta = VariantTestUtil.createMetadata(data.keySet(), true /* sort names */);
     ByteBuffer value = VariantTestUtil.createObject(meta, data);
 
@@ -235,6 +260,11 @@ public class TestSerializedObject {
     assertThat(object.get("c").asPrimitive().get()).isEqualTo((byte) 3);
     assertThat(object.get("really-big").type()).isEqualTo(PhysicalType.STRING);
     assertThat(object.get("really-big").asPrimitive().get()).isEqualTo(randomString);
+    assertThat(object.get("really-big").asPrimitive().sizeInBytes())
+        .isEqualTo(5 + randomString.length());
+    assertThat(object.get("small").type()).isEqualTo(PhysicalType.STRING);
+    assertThat(object.get("small").asPrimitive().get()).isEqualTo("iceberg");
+    assertThat(object.get("small").asPrimitive().sizeInBytes()).isEqualTo(8);
   }
 
   @ParameterizedTest
@@ -261,6 +291,8 @@ public class TestSerializedObject {
       VariantValue fieldValue = object.get(entry.getKey());
       assertThat(fieldValue.type()).isEqualTo(PhysicalType.STRING);
       assertThat(fieldValue.asPrimitive().get()).isEqualTo(entry.getValue().get());
+      assertThat(fieldValue.asPrimitive().sizeInBytes())
+          .isEqualTo(5 + entry.getValue().get().toString().length());
     }
   }
 

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -253,7 +253,7 @@ public class TestSerializedObject {
   }
 
   @Test
-    public void testShortStringsInVariantPrimitives() {
+  public void testShortStringsInVariantPrimitives() {
     // note that order doesn't matter. fields are sorted by name
     Map<String, VariantValue> data =
             ImmutableMap.of(

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -255,8 +255,8 @@ public class TestSerializedObject {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public void testLargeObjectUsingShortStringWithBigHeader(boolean sortFieldNames) {
-    Map<String, VariantPrimitive<?>> fields = Maps.newHashMap();
+    public void testLargeObjectUsingShortStringWithBigHeader(boolean sortFieldNames) {
+    Map<String, SerializedPrimitive> fields = Maps.newHashMap();
     for (int i = 0; i < 10_000; i += 1) {
       fields.put(
           RandomUtil.generateString(10, random),
@@ -272,7 +272,7 @@ public class TestSerializedObject {
     assertThat(object.type()).isEqualTo(PhysicalType.OBJECT);
     assertThat(object.numFields()).isEqualTo(10_000);
 
-    for (Map.Entry<String, VariantPrimitive<?>> entry : fields.entrySet()) {
+    for (Map.Entry<String, SerializedPrimitive> entry : fields.entrySet()) {
       VariantValue fieldValue = object.get(entry.getKey());
       assertThat(fieldValue.type()).isEqualTo(PhysicalType.STRING);
       assertThat(fieldValue.asPrimitive().get()).isEqualTo(entry.getValue().get());

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -250,7 +250,7 @@ public class TestSerializedObject {
     SerializedObject object = SerializedObject.from(metadata, value, value.get(0));
 
     assertThat(object.type()).isEqualTo(PhysicalType.OBJECT);
-    assertThat(object.numFields()).isEqualTo(4);
+    assertThat(object.numFields()).isEqualTo(5);
 
     assertThat(object.get("a").type()).isEqualTo(PhysicalType.INT8);
     assertThat(object.get("a").asPrimitive().get()).isEqualTo((byte) 1);

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.variants;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.Map;

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.variants;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -248,7 +248,8 @@ public class TestSerializedObject {
 
     for (Map.Entry<String, VariantPrimitive<?>> entry : fields.entrySet()) {
       VariantValue fieldValue = object.get(entry.getKey());
-      VariantTestUtil.assertVariantString(fieldValue, entry.getValue().get().toString());
+      assertThat(fieldValue.getClass()).isEqualTo(SerializedPrimitive.class);
+      assertThat(fieldValue.asPrimitive().sizeInBytes()).isEqualTo(5 + 10);
     }
   }
 

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
@@ -442,6 +442,7 @@ public class TestSerializedPrimitives {
 
     assertThat(value.type()).isEqualTo(PhysicalType.STRING);
     assertThat(value.get()).isEqualTo("iceberg");
+    assertThat(value.sizeInBytes()).isEqualTo(12);
   }
 
   @Test
@@ -451,6 +452,7 @@ public class TestSerializedPrimitives {
 
     assertThat(value.type()).isEqualTo(PhysicalType.STRING);
     assertThat(value.get()).isEqualTo("iceberg");
+    assertThat(value.sizeInBytes()).isEqualTo(8);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
@@ -450,9 +450,7 @@ public class TestSerializedPrimitives {
     VariantPrimitive<?> value =
         SerializedShortString.from(new byte[] {0b11101, 'i', 'c', 'e', 'b', 'e', 'r', 'g'});
 
-    assertThat(value.type()).isEqualTo(PhysicalType.STRING);
-    assertThat(value.get()).isEqualTo("iceberg");
-    assertThat(value.sizeInBytes()).isEqualTo(8);
+    VariantTestUtil.assertVariantString(value, "iceberg");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/variants/VariantTestUtil.java
+++ b/api/src/test/java/org/apache/iceberg/variants/VariantTestUtil.java
@@ -32,6 +32,9 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 public class VariantTestUtil {
+
+  private static final int MAX_SHORT_STRING_LENGTH = 63;
+
   private VariantTestUtil() {}
 
   public static void assertEqual(VariantMetadata expected, VariantMetadata actual) {
@@ -79,11 +82,10 @@ public class VariantTestUtil {
   }
 
   public static void assertVariantString(VariantValue actual, String expected) {
-    int maxShortStringLength = 64;
     int expectedLength = expected.length();
     assertThat(actual.type()).isEqualTo(PhysicalType.STRING);
     assertThat(actual.asPrimitive().get()).isEqualTo(expected);
-    if (expectedLength < maxShortStringLength) {
+    if (expectedLength <= MAX_SHORT_STRING_LENGTH) {
       assertThat(actual.getClass()).isEqualTo(SerializedShortString.class);
       assertThat(actual.asPrimitive().sizeInBytes()).isEqualTo(1 + expectedLength);
     } else {
@@ -124,7 +126,7 @@ public class VariantTestUtil {
   /** Creates a short string primitive of max 63 bytes to use only 1 header */
   static SerializedShortString createShortString(String string) {
     Preconditions.checkArgument(
-        string.length() <= 63,
+        string.length() <= MAX_SHORT_STRING_LENGTH,
         "Short String length is " + string.length() + ",  should not be greater than 63");
     byte[] utf8 = string.getBytes(StandardCharsets.UTF_8);
     ByteBuffer buffer = ByteBuffer.allocate(1 + utf8.length).order(ByteOrder.LITTLE_ENDIAN);

--- a/api/src/test/java/org/apache/iceberg/variants/VariantTestUtil.java
+++ b/api/src/test/java/org/apache/iceberg/variants/VariantTestUtil.java
@@ -121,8 +121,11 @@ public class VariantTestUtil {
     return SerializedPrimitive.from(buffer, buffer.get(0));
   }
 
-  /** Creates a short string primitive of max 63 chars to use only 1 header */
+  /** Creates a short string primitive of max 63 bytes to use only 1 header */
   static SerializedShortString createShortString(String string) {
+    Preconditions.checkArgument(
+        string.length() <= 63,
+        "Short String length is " + string.length() + ",  should not be greater than 63");
     byte[] utf8 = string.getBytes(StandardCharsets.UTF_8);
     ByteBuffer buffer = ByteBuffer.allocate(1 + utf8.length).order(ByteOrder.LITTLE_ENDIAN);
     buffer.put(0, VariantUtil.shortStringHeader(utf8.length));

--- a/api/src/test/java/org/apache/iceberg/variants/VariantTestUtil.java
+++ b/api/src/test/java/org/apache/iceberg/variants/VariantTestUtil.java
@@ -107,6 +107,15 @@ public class VariantTestUtil {
     return SerializedPrimitive.from(buffer, buffer.get(0));
   }
 
+  /** Creates a short string primitive of max 63 chars to use only 1 header */
+  static SerializedShortString createShortString(String string) {
+    byte[] utf8 = string.getBytes(StandardCharsets.UTF_8);
+    ByteBuffer buffer = ByteBuffer.allocate(1 + utf8.length).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.put(0, (byte) (VariantUtil.primitiveHeader(utf8.length) | 0b00000001));
+    writeBufferAbsolute(buffer, 1, ByteBuffer.wrap(utf8));
+    return SerializedShortString.from(buffer, buffer.get(0));
+  }
+
   public static ByteBuffer variantBuffer(Map<String, VariantValue> data) {
     ByteBuffer meta = VariantTestUtil.createMetadata(data.keySet(), true /* sort names */);
     ByteBuffer value = VariantTestUtil.createObject(meta, data);

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -53,7 +53,7 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
   private static final byte TIMESTAMPNTZ_NANOS_HEADER =
       VariantUtil.primitiveHeader(Primitives.TYPE_TIMESTAMPNTZ_NANOS);
   private static final byte UUID_HEADER = VariantUtil.primitiveHeader(Primitives.TYPE_UUID);
-  private static final int MAX_SHORT_STRING_LENGTH = 64;
+  private static final int MAX_SHORT_STRING_LENGTH = 63;
 
   private final PhysicalType type;
   private final T value;
@@ -115,7 +115,7 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
-        if (buffer.remaining() < MAX_SHORT_STRING_LENGTH) {
+        if (buffer.remaining() <= MAX_SHORT_STRING_LENGTH) {
           return 1 + buffer.remaining(); // 1 header + value length
         }
         return 5 + buffer.remaining(); // 1 header + 4 length + value length
@@ -214,7 +214,7 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
-        if (buffer.remaining() < MAX_SHORT_STRING_LENGTH) {
+        if (buffer.remaining() <= MAX_SHORT_STRING_LENGTH) {
           outBuffer.put(offset, VariantUtil.shortStringHeader(buffer.remaining()));
           VariantUtil.writeBufferAbsolute(outBuffer, offset + 1, buffer);
           return 1 + buffer.remaining();

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -53,8 +53,7 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
   private static final byte TIMESTAMPNTZ_NANOS_HEADER =
       VariantUtil.primitiveHeader(Primitives.TYPE_TIMESTAMPNTZ_NANOS);
   private static final byte UUID_HEADER = VariantUtil.primitiveHeader(Primitives.TYPE_UUID);
-  private static final int SHORT_STRING_LENGTH = 64;
-  private static final int SHORT_STRING_LENGTH_UMASK = 0b00000001;
+  private static final int MAX_SHORT_STRING_LENGTH = 64;
 
   private final PhysicalType type;
   private final T value;
@@ -113,12 +112,11 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
       case BINARY:
         return 5 + ((ByteBuffer) value).remaining(); // 1 header + 4 length + value length
       case STRING:
-        byte[] valueBytes = ((String) value).getBytes(StandardCharsets.UTF_8);
         if (null == buffer) {
-          this.buffer = ByteBuffer.wrap(valueBytes);
+          this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
-        if (valueBytes.length < SHORT_STRING_LENGTH) {
-          return 1 + buffer.remaining(); // 1 header + 1 length + value length
+        if (buffer.remaining() < MAX_SHORT_STRING_LENGTH) {
+          return 1 + buffer.remaining(); // 1 header + value length
         }
         return 5 + buffer.remaining(); // 1 header + 4 length + value length
       case UUID:
@@ -213,14 +211,11 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
         VariantUtil.writeBufferAbsolute(outBuffer, offset + 5, binary);
         return 5 + binary.remaining();
       case STRING:
-        byte[] valueBytes = ((String) value).getBytes(StandardCharsets.UTF_8);
         if (null == buffer) {
-          this.buffer = ByteBuffer.wrap(valueBytes);
+          this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
-        if (valueBytes.length < SHORT_STRING_LENGTH) {
-          outBuffer.put(
-              offset,
-              (byte) (VariantUtil.primitiveHeader(valueBytes.length) | SHORT_STRING_LENGTH_UMASK));
+        if (buffer.remaining() < MAX_SHORT_STRING_LENGTH) {
+          outBuffer.put(offset, VariantUtil.shortStringHeader(buffer.remaining()));
           VariantUtil.writeBufferAbsolute(outBuffer, offset + 1, buffer);
           return 1 + buffer.remaining();
         } else {

--- a/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
@@ -59,13 +59,12 @@ public class TestPrimitiveWrapper {
         Variants.of(new BigDecimal("9876543210.123456789")), // decimal16
         Variants.of(new BigDecimal("-9876543210.123456789")), // decimal16
         Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Variants.of("iceberg"), // short string below 255 bytes to test value offset size of 1
+        Variants.of("icebergicebergicebergicebergicebergicebergicebergicebergiceberg"), // short string of 63 (9*7) chars
         Variants.of(
             RandomUtil.generateString(
-                300,
+                64,
                 new Random(
-                    871925))), // string exceeding 255 bytes to test value offset sizes of 2, 3, and
-        // 4 bytes
+                    1))), // string of 64 chars
       };
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Random;
+import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
@@ -57,7 +59,13 @@ public class TestPrimitiveWrapper {
         Variants.of(new BigDecimal("9876543210.123456789")), // decimal16
         Variants.of(new BigDecimal("-9876543210.123456789")), // decimal16
         Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Variants.of("iceberg"),
+        Variants.of("iceberg"), // short string below 255 bytes to test value offset size of 1
+        Variants.of(
+            RandomUtil.generateString(
+                300,
+                new Random(
+                    871925))), // string exceeding 255 bytes to test value offset sizes of 2, 3, and
+        // 4 bytes
       };
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
@@ -59,12 +59,10 @@ public class TestPrimitiveWrapper {
         Variants.of(new BigDecimal("9876543210.123456789")), // decimal16
         Variants.of(new BigDecimal("-9876543210.123456789")), // decimal16
         Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),
-        Variants.of("icebergicebergicebergicebergicebergicebergicebergicebergiceberg"), // short string of 63 (9*7) chars
         Variants.of(
-            RandomUtil.generateString(
-                64,
-                new Random(
-                    1))), // string of 64 chars
+            "icebergicebergicebergicebergicebergicebergicebergicebergiceberg"), // short string of
+        // 63 (9*7) chars
+        Variants.of(RandomUtil.generateString(64, new Random(1))), // string of 64 chars
       };
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/variants/TestShreddedObject.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestShreddedObject.java
@@ -73,8 +73,7 @@ public class TestShreddedObject {
     assertThat(actual.numFields()).isEqualTo(3);
     assertThat(actual.get("a")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("a").asPrimitive().get()).isEqualTo(34);
-    assertThat(actual.get("b")).isInstanceOf(VariantPrimitive.class);
-    assertThat(actual.get("b").asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(actual.get("b"), "iceberg");
     assertThat(actual.get("c")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("c").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
@@ -92,8 +91,7 @@ public class TestShreddedObject {
     assertThat(actual.numFields()).isEqualTo(3);
     assertThat(actual.get("a")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("a").asPrimitive().get()).isEqualTo(34);
-    assertThat(actual.get("b")).isInstanceOf(VariantPrimitive.class);
-    assertThat(actual.get("b").asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(actual.get("b"), "iceberg");
     assertThat(actual.get("c")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("c").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
@@ -111,8 +109,7 @@ public class TestShreddedObject {
     assertThat(actual.numFields()).isEqualTo(3);
     assertThat(actual.get("a")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("a").asPrimitive().get()).isEqualTo(34);
-    assertThat(actual.get("b")).isInstanceOf(VariantPrimitive.class);
-    assertThat(actual.get("b").asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(actual.get("b"), "iceberg");
     assertThat(actual.get("c")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("c").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
@@ -130,8 +127,7 @@ public class TestShreddedObject {
     assertThat(actual.numFields()).isEqualTo(3);
     assertThat(actual.get("a")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("a").asPrimitive().get()).isEqualTo(34);
-    assertThat(actual.get("b")).isInstanceOf(VariantPrimitive.class);
-    assertThat(actual.get("b").asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(actual.get("b"), "iceberg");
     assertThat(actual.get("c")).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get("c").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
@@ -237,12 +233,10 @@ public class TestShreddedObject {
 
     assertThat(object.get("a").type()).isEqualTo(PhysicalType.INT32);
     assertThat(object.get("a").asPrimitive().get()).isEqualTo(34);
-    assertThat(object.get("b").type()).isEqualTo(PhysicalType.STRING);
-    assertThat(object.get("b").asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(object.get("b"), "iceberg");
     assertThat(object.get("c").type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(object.get("c").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
-    assertThat(object.get("big").type()).isEqualTo(PhysicalType.STRING);
-    assertThat(object.get("big").asPrimitive().get()).isEqualTo(randomString);
+    VariantTestUtil.assertVariantString(object.get("big"), randomString);
   }
 
   @ParameterizedTest
@@ -268,8 +262,7 @@ public class TestShreddedObject {
 
     for (Map.Entry<String, VariantPrimitive<String>> entry : fields.entrySet()) {
       VariantValue fieldValue = object.get(entry.getKey());
-      assertThat(fieldValue.type()).isEqualTo(PhysicalType.STRING);
-      assertThat(fieldValue.asPrimitive().get()).isEqualTo(entry.getValue().get());
+      VariantTestUtil.assertVariantString(fieldValue, entry.getValue().get());
     }
   }
 
@@ -298,8 +291,7 @@ public class TestShreddedObject {
 
     assertThat(object.get("aa").type()).isEqualTo(PhysicalType.INT32);
     assertThat(object.get("aa").asPrimitive().get()).isEqualTo(34);
-    assertThat(object.get("AA").type()).isEqualTo(PhysicalType.STRING);
-    assertThat(object.get("AA").asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(object.get("AA"), "iceberg");
     assertThat(object.get("ZZ").type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(object.get("ZZ").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
@@ -329,8 +321,7 @@ public class TestShreddedObject {
 
     assertThat(object.get("aa").type()).isEqualTo(PhysicalType.INT32);
     assertThat(object.get("aa").asPrimitive().get()).isEqualTo(34);
-    assertThat(object.get("AA").type()).isEqualTo(PhysicalType.STRING);
-    assertThat(object.get("AA").asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(object.get("AA"), "iceberg");
     assertThat(object.get("ZZ").type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(object.get("ZZ").asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }

--- a/core/src/test/java/org/apache/iceberg/variants/TestValueArray.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestValueArray.java
@@ -65,8 +65,7 @@ public class TestValueArray {
     assertThat(actual.numElements()).isEqualTo(3);
     assertThat(actual.get(0)).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get(0).asPrimitive().get()).isEqualTo(34);
-    assertThat(actual.get(1)).isInstanceOf(VariantPrimitive.class);
-    assertThat(actual.get(1).asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(actual.get(1), "iceberg");
     assertThat(actual.get(2)).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get(2).asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
@@ -83,8 +82,7 @@ public class TestValueArray {
     assertThat(actual.numElements()).isEqualTo(3);
     assertThat(actual.get(0)).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get(0).asPrimitive().get()).isEqualTo(34);
-    assertThat(actual.get(1)).isInstanceOf(VariantPrimitive.class);
-    assertThat(actual.get(1).asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(actual.get(1), "iceberg");
     assertThat(actual.get(2)).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get(2).asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
   }
@@ -109,12 +107,10 @@ public class TestValueArray {
 
     assertThat(actualArray.get(0).type()).isEqualTo(PhysicalType.INT32);
     assertThat(actualArray.get(0).asPrimitive().get()).isEqualTo(34);
-    assertThat(actualArray.get(1).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(actualArray.get(1).asPrimitive().get()).isEqualTo("iceberg");
+    VariantTestUtil.assertVariantString(actualArray.get(1), "iceberg");
     assertThat(actualArray.get(2).type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(actualArray.get(2).asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
-    assertThat(actualArray.get(3).type()).isEqualTo(PhysicalType.STRING);
-    assertThat(actualArray.get(3).asPrimitive().get()).isEqualTo(randomString);
+    VariantTestUtil.assertVariantString(actualArray.get(3), randomString);
   }
 
   @Test


### PR DESCRIPTION
PR for https://github.com/apache/iceberg/issues/13282.

Save 4 bytes for short strings stored in Variant by reserving first byte only for header. Regular strings continue to use 1 (header) + 4 (offset sizes) bytes.