### PR TITLE
Docs: Fix broken links in Flink Configuration documentation

### DIFF
--- a/docs/docs/flink-configuration.md
+++ b/docs/docs/flink-configuration.md
@@ -195,7 +195,6 @@ base weight of `2%` of targeted weight of `1,000` for every write task. It would
 avoid placing more than `50` data files (one per day) on one writer task no matter how small
 they are.
 
-This is only applicable to {@link StatisticsType#Map} for low-cardinality scenario. For
-{@link StatisticsType#Sketch} high-cardinality sort columns, they are usually not used as
+This is only applicable to [`StatisticsType.Map`](../../javadoc/{{ icebergVersion }}/org/apache/iceberg/flink/sink/shuffle/StatisticsType.html#Map) for low-cardinality scenario. For [`StatisticsType.Sketch`](../../javadoc/{{ icebergVersion }}/org/apache/iceberg/flink/sink/shuffle/StatisticsType.html#Sketch) high-cardinality sort columns, they are usually not used as
 partition columns. Otherwise, too many partitions and small files may be generated during
 write. Sketch range partitioner simply splits high-cardinality keys into ordered ranges.


### PR DESCRIPTION
### What this PR does

This PR fixes broken `{@link ...}` tags in the Flink Configuration documentation by converting them into proper Markdown links.

Fixes #13285

### Why is this necessary

The original links used JavaDoc-style `{@link ...}` syntax, which is not rendered correctly in Markdown.

### How this was fixed

- Replaced `{@link StatisticsType#Map}` with [`StatisticsType.Map`](../../javadoc/{{ icebergVersion }}/org/apache/iceberg/flink/sink/shuffle/StatisticsType.html#Map)
- Replaced `{@link StatisticsType#Sketch}` with [`StatisticsType.Sketch`](../../javadoc/{{ icebergVersion }}/org/apache/iceberg/flink/sink/shuffle/StatisticsType.html#Sketch)

These changes follow the link style already used elsewhere in the documentation (e.g., `PendingUpdate` references).