### PR TITLE
iceberg kafka metrics reporter

### DIFF
--- a/docs/docs/metrics-reporting.md
+++ b/docs/docs/metrics-reporting.md
@@ -123,6 +123,19 @@ This is the default when using the [`RESTCatalog`](https://github.com/apache/ice
 
 Sending metrics via REST can be controlled with the `rest-metrics-reporting-enabled` (defaults to `true`) property.
 
+### KafkaMetricsReporter
+The `KafkaMetricsReporter` is a custom implementation of the `MetricsReporter` interface that allows reporting Iceberg metrics to a Kafka topic. This reporter is designed to serialize metrics reports into JSON format and send them as Kafka messages.
+
+#### Configuration
+
+The `IcebergKafkaMetricsReporter` can be configured using the following properties:
+
+- **`metrics-reporter.kafka.topic`**: Specifies the Kafka topic to which metrics will be sent. Defaults to `iceberg-metrics`.
+- **`metrics-reporter.kafka.*`**: Any additional Kafka producer properties can be set using this prefix. For example:
+  - `metrics-reporter.kafka.bootstrap.servers`: Specifies the Kafka bootstrap servers.
+
+q
+
 
 ## Implementing a custom Metrics Reporter
 

--- a/experimental/kafka-metrics-reporter/build.gradle
+++ b/experimental/kafka-metrics-reporter/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+project(':iceberg-experimental:iceberg-kafka-metrics-reporter') {
+    dependencies {
+        api project(':iceberg-api')
+        implementation project(':iceberg-core')
+        implementation project(':iceberg-common')
+        implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+
+
+        implementation libs.kafka.clients
+        implementation libs.jackson.core
+        implementation libs.jackson.databind
+
+        testImplementation  libs.kafka.clients
+    }
+
+    test {
+        useJUnitPlatform()
+    }
+}

--- a/experimental/kafka-metrics-reporter/src/main/java/org/apache/iceberg/experimental/KafkaMetricsReporter.java
+++ b/experimental/kafka-metrics-reporter/src/main/java/org/apache/iceberg/experimental/KafkaMetricsReporter.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.experimental;
+
+import java.util.Map;
+import java.util.Properties;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.CommitReportParser;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.metrics.ScanReportParser;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A custom {@link MetricsReporter} implementation that can be used to report metrics to Kafka. */
+public class KafkaMetricsReporter implements MetricsReporter {
+  public static final String ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY = "metrics-reporter.kafka.";
+  public static final String ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_KEY =
+      ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY + "topic";
+  public static final String ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT = "iceberg-metrics";
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaMetricsReporter.class);
+  private Producer<String, String> producer;
+  private String topic;
+
+  public KafkaMetricsReporter() {}
+
+  @VisibleForTesting
+  KafkaMetricsReporter(Producer<String, String> producer) {
+    this(producer, ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT);
+  }
+
+  @VisibleForTesting
+  KafkaMetricsReporter(Producer<String, String> producer, String topic) {
+    this.producer = producer;
+    this.topic = topic;
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    this.topic =
+        properties.getOrDefault(
+            ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_KEY, ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT);
+
+    this.producer = new KafkaProducer<String, String>(toProducerProperties(properties));
+    LOG.info("Initialized IcebergKafkaMetricsReporter with properties");
+  }
+
+  @VisibleForTesting
+  Properties toProducerProperties(Map<String, String> properties) {
+    Properties producerProps = new Properties();
+
+    // Set default properties for Kafka producer
+    producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    producerProps.put(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+    // Fill the properties from the provided map
+    properties.forEach(
+        (key, value) -> {
+          if (key.startsWith(ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY)) {
+            producerProps.putIfAbsent(
+                key.substring(ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY.length()), value);
+          }
+        });
+
+    producerProps.remove(ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_KEY);
+
+    return producerProps;
+  }
+
+  /**
+   * Converts the provided {@link MetricsReport} into a Kafka {@link ProducerRecord}.
+   *
+   * @param report the metrics report to convert
+   * @param reportTopic the Kafka topic to which the record will be sent
+   * @return a {@link ProducerRecord} containing the JSON representation of the report
+   */
+  @VisibleForTesting
+  ProducerRecord<String, String> toProducerRecord(MetricsReport report, String reportTopic) {
+    ProducerRecord<String, String> record;
+
+    if (report instanceof ScanReport) {
+      record =
+          new ProducerRecord<>(
+              reportTopic,
+              report.getClass().getName(),
+              ScanReportParser.toJson((ScanReport) report, false));
+    } else if (report instanceof CommitReport) {
+      record =
+          new ProducerRecord<>(
+              reportTopic,
+              report.getClass().getName(),
+              CommitReportParser.toJson((CommitReport) report, false));
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported MetricsReport type: " + report.getClass().getName());
+    }
+
+    return record;
+  }
+
+  @Override
+  public void report(MetricsReport report) {
+    if (report == null) {
+      LOG.warn("Received invalid metrics report: null");
+      return;
+    }
+    try {
+      ProducerRecord<String, String> record = toProducerRecord(report, topic);
+      producer.send(record).get();
+      LOG.info("Reported metrics to Kafka topic: {}", topic);
+    } catch (Exception e) {
+      LOG.warn("Failed to report metrics to Kafka topic {}", topic, e);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (producer != null) {
+      producer.close();
+      LOG.info("Closed IcebergKafkaMetricsReporter");
+    }
+  }
+}

--- a/experimental/kafka-metrics-reporter/src/test/java/org/apache/iceberg/experimental/KafkaMetricsReporterTest.java
+++ b/experimental/kafka-metrics-reporter/src/test/java/org/apache/iceberg/experimental/KafkaMetricsReporterTest.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.experimental;
+
+import static org.apache.iceberg.experimental.KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.metrics.CommitMetrics;
+import org.apache.iceberg.metrics.CommitMetricsResult;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.ImmutableCommitReport;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.metrics.ScanMetrics;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.BytesSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+public class KafkaMetricsReporterTest {
+
+  @Test
+  public void testReport() throws Exception {
+    // Set up mock Kafka producer
+    MockProducer<String, String> mockProducer =
+        new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+
+    KafkaMetricsReporter reporter = new KafkaMetricsReporter(mockProducer);
+
+    MetricsReport scanReport =
+        ImmutableScanReport.builder()
+            .tableName("test-table")
+            .schemaId(4)
+            .addProjectedFieldIds(1, 2, 3)
+            .addProjectedFieldNames("c1", "c2", "c3")
+            .snapshotId(23L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
+            .build();
+
+    String scanReportExpectedJson =
+        "{\"table-name\":\"test-table\",\"snapshot-id\":23,\"filter\":true,\"schema-id\":4,"
+            + "\"projected-field-ids\":[1,2,3],\"projected-field-names\":[\"c1\",\"c2\",\"c3\"],"
+            + "\"metrics\":{}}";
+
+    // Send the report
+    reporter.report(scanReport);
+
+    // Verify that one record was sent to Kafka
+    List<ProducerRecord<String, String>> history = mockProducer.history();
+    assertThat(history.size()).isEqualTo(1);
+    ProducerRecord<String, String> scanReportRecord = history.get(0);
+    assertThat(scanReportRecord.topic())
+        .isEqualTo(KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT);
+    assertThat(scanReportRecord.key()).isEqualTo(ImmutableScanReport.class.getName());
+    assertThat(scanReportRecord.value()).isEqualTo(scanReportExpectedJson);
+
+    CommitReport commitReport =
+        ImmutableCommitReport.builder()
+            .tableName("roundTripTableName")
+            .snapshotId(23L)
+            .operation("DELETE")
+            .sequenceNumber(4L)
+            .commitMetrics(CommitMetricsResult.from(CommitMetrics.noop(), Map.of()))
+            .build();
+
+    String commitReportExpectedJson =
+        "{\"table-name\":\"roundTripTableName\",\"snapshot-id\":23,\"sequence-number\":4,"
+            + "\"operation\":\"DELETE\",\"metrics\":{}}";
+
+    reporter.report(commitReport);
+
+    history = mockProducer.history();
+    assertThat(history.size()).isEqualTo(2);
+    ProducerRecord<String, String> commitReportRecord = history.get(1);
+    assertThat(commitReportRecord.topic())
+        .isEqualTo(KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT);
+    assertThat(commitReportRecord.key()).isEqualTo(ImmutableCommitReport.class.getName());
+    assertThat(commitReportRecord.value()).isEqualTo(commitReportExpectedJson);
+
+    // Report a null report
+    reporter.report(null);
+
+    // Verify that no records were sent to Kafka
+    history = mockProducer.history();
+    assertThat(history.size()).isEqualTo(2);
+  }
+
+  @Test
+  public void testInitialize() {
+    // Arrange
+    KafkaMetricsReporter reporter = new KafkaMetricsReporter();
+    Map<String, String> properties =
+        Map.of(
+            KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_KEY,
+            "test-topic",
+            KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY
+                + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            "localhost:9092");
+
+    // Act
+    reporter.initialize(properties);
+
+    // Assert
+    assertThat(reporter).extracting("topic").isEqualTo("test-topic");
+
+    Properties producerProps = reporter.toProducerProperties(properties);
+    assertThat(producerProps.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
+        .isEqualTo("localhost:9092");
+    assertThat(producerProps.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG))
+        .isEqualTo(StringSerializer.class.getName());
+    assertThat(producerProps.getProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG))
+        .isEqualTo(StringSerializer.class.getName());
+  }
+
+  @Test
+  public void testToProducerProperties() {
+    AtomicReference<Properties> capturedProps = new AtomicReference<>();
+
+    String topic = "iceberg-metrics-topic";
+    Map<String, String> props =
+        Map.of(
+            ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            "localhost:9092",
+            ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY + ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+            BytesSerializer.class.getName(),
+            ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY + ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+            BytesSerializer.class.getName(),
+            ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY
+                + KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_KEY,
+            topic,
+            "iceberg.x.y.test",
+            "test-value");
+
+    Map<String, String> expectedProps =
+        Map.of(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName(),
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+    KafkaMetricsReporter reporter = new KafkaMetricsReporter();
+    Properties actualProps = reporter.toProducerProperties(props);
+
+    assertThat(actualProps).isEqualTo(expectedProps);
+  }
+
+  @Test
+  public void testToProducerRecord() throws InstantiationException, IllegalAccessException {
+    // Set up mock Kafka producer
+    MockProducer<String, String> mockProducer =
+        new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+
+    KafkaMetricsReporter reporter = new KafkaMetricsReporter(mockProducer);
+
+    MetricsReport scanReport =
+        ImmutableScanReport.builder()
+            .tableName("test-table")
+            .schemaId(4)
+            .addProjectedFieldIds(1, 2, 3)
+            .addProjectedFieldNames("c1", "c2", "c3")
+            .snapshotId(23L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
+            .build();
+
+    ProducerRecord<String, String> scanReportRecord =
+        reporter.toProducerRecord(
+            scanReport, KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT);
+
+    String scanReportExpectedJson =
+        "{\"table-name\":\"test-table\",\"snapshot-id\":23,\"filter\":true,\"schema-id\":4,"
+            + "\"projected-field-ids\":[1,2,3],"
+            + "\"projected-field-names\":[\"c1\",\"c2\",\"c3\"],\"metrics\":{}}";
+
+    assertThat(scanReportRecord.topic())
+        .isEqualTo(KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT);
+    assertThat(scanReportRecord.key()).isEqualTo(ImmutableScanReport.class.getName());
+    assertThat(scanReportRecord.value()).isEqualTo(scanReportExpectedJson);
+
+    CommitReport commitReport =
+        ImmutableCommitReport.builder()
+            .tableName("roundTripTableName")
+            .snapshotId(23L)
+            .operation("DELETE")
+            .sequenceNumber(4L)
+            .commitMetrics(CommitMetricsResult.from(CommitMetrics.noop(), Map.of()))
+            .build();
+
+    ProducerRecord<String, String> commitReportRecord =
+        reporter.toProducerRecord(
+            commitReport, KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT);
+
+    String commitReportExpectedJson =
+        "{\"table-name\":\"roundTripTableName\",\"snapshot-id\":23,\"sequence-number\":4,"
+            + "\"operation\":\"DELETE\",\"metrics\":{}}";
+
+    assertThat(commitReportRecord.topic())
+        .isEqualTo(KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT);
+    assertThat(commitReportRecord.key()).isEqualTo(ImmutableCommitReport.class.getName());
+    assertThat(commitReportRecord.value()).isEqualTo(commitReportExpectedJson);
+
+    MetricsReport report = new MetricsReport() {};
+    assertThatThrownBy(
+            () ->
+                reporter.toProducerRecord(
+                    report, KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_TOPIC_DEFAULT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported MetricsReport type: " + report.getClass().getName());
+  }
+
+  @Test
+  void testClose() throws InstantiationException, IllegalAccessException {
+    // Set up mock Kafka producer
+    MockProducer<String, String> mockProducer =
+        new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+
+    KafkaMetricsReporter reporter = new KafkaMetricsReporter(mockProducer);
+
+    // Close the reporter
+    reporter.close();
+
+    // Verify that the producer was closed
+    assertThat(mockProducer.closed()).isTrue();
+
+    // test non-initialized reporter
+    KafkaMetricsReporter nullReporter = new KafkaMetricsReporter();
+
+    reporter.close();
+  }
+
+  @Test
+  void testLoadMetricsReporter() throws NoSuchMethodException {
+    Map<String, String> properties =
+        Map.of(
+            CatalogProperties.METRICS_REPORTER_IMPL,
+            KafkaMetricsReporter.class.getName(),
+            KafkaMetricsReporter.ICEBERG_EXPERIMENTAL_KAFKA_PREFIX_KEY
+                + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+            "localhost:9092");
+
+    MetricsReporter metricsReporter = CatalogUtil.loadMetricsReporter(properties);
+    assertThat(metricsReporter).isInstanceOf(KafkaMetricsReporter.class);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -194,4 +194,7 @@ if (kafkaVersions.contains("3")) {
   include ":iceberg-kafka-connect:kafka-connect-transforms"
   project(":iceberg-kafka-connect:kafka-connect-transforms").projectDir = file('kafka-connect/kafka-connect-transforms')
   project(":iceberg-kafka-connect:kafka-connect-transforms").name = "iceberg-kafka-connect-transforms"
+
+  include 'iceberg-experimental:iceberg-kafka-metrics-reporter'
+  project(':iceberg-experimental:iceberg-kafka-metrics-reporter').projectDir = file('experimental/kafka-metrics-reporter')
 }


### PR DESCRIPTION
## Description
The `KafkaMetricsReporter` is a custom implementation of the `MetricsReporter` interface that allows reporting Iceberg metrics to a Kafka topic. This reporter is designed to serialize metrics reports into JSON format and send them as Kafka messages.

## Motivation
This change introduces to address that gap by enabling:
-  **Observable Metrics Pipeline**s: Metrics like `ScanReport` and `CommitReport` can now be serialized and emitted to a Kafka topic in real-time, making them consumable by monitoring systems, dashboards, or alerting tools.
- **Event-Driven Integration**: By pushing metrics into Kafka, Iceberg actions  can now trigger downstream workflows, such as audits, data lineage tracking, or compaction jobs via Kafka consumers.

## Usage
To use the KafkaMetricsReporter, configure the following properties in your catalog:
```bash
metrics-reporter-impl=org.apache.iceberg.experimental.KafkaMetricsReporter
metrics-reporter.kafka.bootstrap.servers=localhost:9092
metrics-reporter.kafka.topic=iceberg-metrics
```
