### PR TITLE
Core: Use time-travel schema when resolving partition spec in scan

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -300,7 +300,7 @@ abstract class BaseDistributedDataScan
     }
 
     return builder
-        .specsById(table().specs())
+        .specsById(specs())
         .filterData(filter())
         .caseSensitive(isCaseSensitive())
         .scanMetrics(scanMetrics())

--- a/core/src/main/java/org/apache/iceberg/DataScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataScan.java
@@ -53,7 +53,7 @@ abstract class DataScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
             .caseSensitive(isCaseSensitive())
             .select(withColumnStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS)
             .filterData(filter())
-            .specsById(table().specs())
+            .specsById(specs())
             .scanMetrics(scanMetrics())
             .ignoreDeleted()
             .columnsToKeepStats(columnsToKeepStats());

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -74,7 +74,7 @@ public class DataTableScan extends BaseTableScan {
             .caseSensitive(isCaseSensitive())
             .select(scanColumns())
             .filterData(filter())
-            .specsById(table().specs())
+            .specsById(specs())
             .scanMetrics(scanMetrics())
             .ignoreDeleted()
             .columnsToKeepStats(columnsToKeepStats());

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -79,6 +79,22 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
     return scanMetrics;
   }
 
+  protected Map<Integer, PartitionSpec> specs() {
+    Map<Integer, PartitionSpec> specs = table().specs();
+    // requires latest schema
+    if (!useSnapshotSchema() || snapshotId() == null) {
+      return specs;
+    }
+
+    // this is a time travel request
+    Schema snapshotSchema = tableSchema();
+    Map<Integer, PartitionSpec> newSpecs = Maps.newHashMapWithExpectedSize(specs.size());
+    for (Map.Entry<Integer, PartitionSpec> entry : specs.entrySet()) {
+      newSpecs.put(entry.getKey(), entry.getValue().toUnbound().bindUnchecked(snapshotSchema));
+    }
+    return newSpecs;
+  }
+
   public ThisT useSnapshot(long scanSnapshotId) {
     Preconditions.checkArgument(
         snapshotId() == null, "Cannot override snapshot, already set snapshot id=%s", snapshotId());

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import org.apache.avro.generic.GenericData;
@@ -60,24 +59,29 @@ public class TestScansAndSchemaEvolution {
 
   @Parameter private int formatVersion;
 
-  @TempDir private Path temp;
+  @TempDir private File temp;
 
   private DataFile createDataFile(String partValue) throws IOException {
-    List<GenericData.Record> expected = RandomAvroData.generate(SCHEMA, 100, 0L);
+    return createDataFile(partValue, SCHEMA, SPEC);
+  }
+
+  private DataFile createDataFile(String partValue, Schema schema, PartitionSpec spec)
+      throws IOException {
+    List<GenericData.Record> expected = RandomAvroData.generate(schema, 100, 0L);
 
     OutputFile dataFile =
         new InMemoryOutputFile(FileFormat.AVRO.addExtension(UUID.randomUUID().toString()));
     try (FileAppender<GenericData.Record> writer =
-        Avro.write(dataFile).schema(SCHEMA).named("test").build()) {
+        Avro.write(dataFile).schema(schema).named("test").build()) {
       for (GenericData.Record rec : expected) {
         rec.put("part", partValue); // create just one partition
         writer.add(rec);
       }
     }
 
-    PartitionData partition = new PartitionData(SPEC.partitionType());
+    PartitionData partition = new PartitionData(spec.partitionType());
     partition.set(0, partValue);
-    return DataFiles.builder(SPEC)
+    return DataFiles.builder(spec)
         .withInputFile(dataFile.toInputFile())
         .withPartition(partition)
         .withRecordCount(100)
@@ -91,8 +95,7 @@ public class TestScansAndSchemaEvolution {
 
   @TestTemplate
   public void testPartitionSourceRename() throws IOException {
-    File location = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(location.delete()).isTrue(); // should be created by table create
+    File location = Files.createTempDirectory(temp.toPath(), "junit").toFile();
 
     Table table = TestTables.create(location, "test", SCHEMA, SPEC, formatVersion);
 
@@ -100,6 +103,7 @@ public class TestScansAndSchemaEvolution {
     DataFile fileTwo = createDataFile("two");
 
     table.newAppend().appendFile(fileOne).appendFile(fileTwo).commit();
+    long firstSnapshotId = table.currentSnapshot().snapshotId();
 
     List<FileScanTask> tasks =
         Lists.newArrayList(table.newScan().filter(Expressions.equal("part", "one")).planFiles());
@@ -112,5 +116,62 @@ public class TestScansAndSchemaEvolution {
     tasks = Lists.newArrayList(table.newScan().filter(Expressions.equal("p", "one")).planFiles());
 
     assertThat(tasks).hasSize(1);
+
+    // create a new commit
+    table.newAppend().appendFile(createDataFile("three")).commit();
+
+    // use fiter with previous partition name
+    tasks =
+        Lists.newArrayList(
+            table
+                .newScan()
+                .useSnapshot(firstSnapshotId)
+                .filter(Expressions.equal("part", "one"))
+                .planFiles());
+
+    assertThat(tasks).hasSize(1);
+  }
+
+  @TestTemplate
+  public void testColumnRenameOrDrop() throws IOException {
+    File location = Files.createTempDirectory(temp.toPath(), "junit").toFile();
+
+    Table table = TestTables.create(location, "test", SCHEMA, SPEC, formatVersion);
+
+    DataFile fileOne = createDataFile("one");
+    DataFile fileTwo = createDataFile("two");
+
+    table.newAppend().appendFile(fileOne).appendFile(fileTwo).commit();
+    long firstSnapshotId = table.currentSnapshot().snapshotId();
+
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    DataFile fileThree = createDataFile("three", table.schema(), table.spec());
+    table.newAppend().appendFile(fileThree).commit();
+    long secondSnapshotId = table.currentSnapshot().snapshotId();
+
+    // running successfully with the new filter on previous column name
+    List<FileScanTask> tasks =
+        Lists.newArrayList(
+            table
+                .newScan()
+                .useSnapshot(firstSnapshotId)
+                .filter(Expressions.equal("data", "xyz"))
+                .planFiles());
+    assertThat(tasks).hasSize(2);
+
+    table.updateSchema().deleteColumn("renamed_data").commit();
+    DataFile fileFour = createDataFile("four", table.schema(), table.spec());
+    table.newAppend().appendFile(fileFour).commit();
+
+    // running successfully with the new filter on previous column name
+    tasks =
+        Lists.newArrayList(
+            table
+                .newScan()
+                .useSnapshot(secondSnapshotId)
+                .filter(Expressions.equal("renamed_data", "xyz"))
+                .planFiles());
+    assertThat(tasks).hasSize(3);
   }
 }


### PR DESCRIPTION
Slack: https://apache-iceberg.slack.com/archives/C03LG1D563F/p1749201124409489

Fixes : https://github.com/apache/iceberg/issues/11162

Fix table scan with filter when doing time-travel