### PR TITLE
Core: Clean expired metadata even if there is no snapshot to expire

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -178,7 +178,9 @@ class RemoveSnapshots implements ExpireSnapshots {
 
   private TableMetadata internalApply() {
     this.base = ops.refresh();
-    if (base.snapshots().isEmpty()) {
+    // attempt to clean expired metadata even if there are no snapshots to expire
+    // table metadata builder takes care of the case when this should actually be a no-op
+    if (base.snapshots().isEmpty() && !cleanExpiredMetadata) {
       return base;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1801,6 +1801,16 @@ public class TestRemoveSnapshots extends TestBase {
 
   @TestTemplate
   public void testRemoveMetadataWithNoSnapshots() throws Exception {
+    TableMetadata current = table.ops().current();
+    removeSnapshots(table)
+        .expireOlderThan(System.currentTimeMillis())
+        .retainLast(1)
+        .cleanExpiredMetadata(true)
+        .commit();
+    assertThat(table.ops().current())
+        .as("No snapshot or metadata to remove, should be a no-op")
+        .isSameAs(current);
+
     table.updateSchema().addColumn("extra_col1", Types.StringType.get()).commit();
     table.updateSchema().addColumn("extra_col2", Types.StringType.get()).commit();
     table.updateSpec().addField("extra_col2").commit();
@@ -1815,7 +1825,7 @@ public class TestRemoveSnapshots extends TestBase {
     assertThat(table.schemas()).as("Expired schemas should be removed").hasSize(1);
     assertThat(table.specs()).as("Expired specs should be removed").hasSize(1);
 
-    TableMetadata current = table.ops().current();
+    current = table.ops().current();
     removeSnapshots(table)
         .expireOlderThan(System.currentTimeMillis())
         .retainLast(1)

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1801,16 +1801,6 @@ public class TestRemoveSnapshots extends TestBase {
 
   @TestTemplate
   public void testRemoveMetadataWithNoSnapshots() throws Exception {
-    TableMetadata current = table.ops().current();
-    removeSnapshots(table)
-        .expireOlderThan(System.currentTimeMillis())
-        .retainLast(1)
-        .cleanExpiredMetadata(true)
-        .commit();
-    assertThat(table.ops().current())
-        .as("No snapshot or metadata to remove, should be a no-op")
-        .isSameAs(current);
-
     table.updateSchema().addColumn("extra_col1", Types.StringType.get()).commit();
     table.updateSchema().addColumn("extra_col2", Types.StringType.get()).commit();
     table.updateSpec().addField("extra_col2").commit();
@@ -1824,8 +1814,11 @@ public class TestRemoveSnapshots extends TestBase {
         .commit();
     assertThat(table.schemas()).as("Expired schemas should be removed").hasSize(1);
     assertThat(table.specs()).as("Expired specs should be removed").hasSize(1);
+  }
 
-    current = table.ops().current();
+  @TestTemplate
+  public void testRemoveSnapshotsNoOp() throws Exception {
+    TableMetadata current = table.ops().current();
     removeSnapshots(table)
         .expireOlderThan(System.currentTimeMillis())
         .retainLast(1)

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1799,6 +1799,37 @@ public class TestRemoveSnapshots extends TestBase {
         .isGreaterThan(0);
   }
 
+  @TestTemplate
+  public void testRemoveMetadataWithNoSnapshots() throws Exception {
+    table.updateSchema().addColumn("extra_col1", Types.StringType.get()).commit();
+    table.updateSchema().addColumn("extra_col2", Types.StringType.get()).commit();
+    table.updateSpec().addField("extra_col2").commit();
+    assertThat(table.schemas()).hasSize(3);
+    assertThat(table.specs()).hasSize(2);
+
+    removeSnapshots(table)
+        .expireOlderThan(System.currentTimeMillis())
+        .retainLast(1)
+        .cleanExpiredMetadata(true)
+        .commit();
+    assertThat(table.schemas())
+        .as("Expired schemas should be removed")
+        .hasSize(1);
+    assertThat(table.specs())
+        .as("Expired specs should be removed")
+        .hasSize(1);
+
+    TableMetadata current = table.ops().current();
+    removeSnapshots(table)
+        .expireOlderThan(System.currentTimeMillis())
+        .retainLast(1)
+        .cleanExpiredMetadata(true)
+        .commit();
+    assertThat(table.ops().current())
+        .as("No snapshot or metadata to remove, should be a no-op")
+        .isSameAs(current);
+  }
+
   private Set<String> manifestPaths(Snapshot snapshot, FileIO io) {
     return snapshot.allManifests(io).stream().map(ManifestFile::path).collect(Collectors.toSet());
   }

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1812,12 +1812,8 @@ public class TestRemoveSnapshots extends TestBase {
         .retainLast(1)
         .cleanExpiredMetadata(true)
         .commit();
-    assertThat(table.schemas())
-        .as("Expired schemas should be removed")
-        .hasSize(1);
-    assertThat(table.specs())
-        .as("Expired specs should be removed")
-        .hasSize(1);
+    assertThat(table.schemas()).as("Expired schemas should be removed").hasSize(1);
+    assertThat(table.specs()).as("Expired specs should be removed").hasSize(1);
 
     TableMetadata current = table.ops().current();
     removeSnapshots(table)


### PR DESCRIPTION
This fixes #13294 