### PR TITLE
Spark: option to set predicate for filtering files in compaction

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.actions;
 
 import java.util.List;
+import java.util.function.Predicate;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
@@ -198,6 +200,16 @@ public interface RewriteDataFiles
    * @return this for chaining
    */
   RewriteDataFiles filter(Expression expression);
+
+  /**
+   * A user-defined predicate for filtering out data files to include in the rewrite.
+   *
+   * @param predicate A predicate that returns true to include a file, false otherwise
+   * @return this for chaining
+   */
+  default RewriteDataFiles fileFilter(Predicate<DataFile> predicate) {
+    throw new UnsupportedOperationException("File filter not implemented for this framework");
+  }
 
   /**
    * A map of file group information to the results of rewriting that file group. If the results are

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewritePlanner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewritePlanner.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark.actions;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.BinPackRewriteFilePlanner;
 import org.apache.iceberg.expressions.Expression;
@@ -49,8 +51,12 @@ class SparkShufflingDataRewritePlanner extends BinPackRewriteFilePlanner {
   private double compressionFactor;
 
   SparkShufflingDataRewritePlanner(
-      Table table, Expression filter, Long snapshotId, boolean caseSensitive) {
-    super(table, filter, snapshotId, caseSensitive);
+      Table table,
+      Expression filter,
+      Predicate<DataFile> fileFilter,
+      Long snapshotId,
+      boolean caseSensitive) {
+    super(table, filter, fileFilter, snapshotId, caseSensitive);
   }
 
   @Override

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkShufflingDataRewritePlanner.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkShufflingDataRewritePlanner.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.base.Predicates;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.spark.TestBase;
@@ -59,7 +60,11 @@ public class TestSparkShufflingDataRewritePlanner extends TestBase {
     Table table = catalog.createTable(TABLE_IDENT, SCHEMA);
     SparkShufflingDataRewritePlanner planner =
         new SparkShufflingDataRewritePlanner(
-            table, Expressions.alwaysTrue(), null, false /* caseSensitive */);
+            table,
+            Expressions.alwaysTrue(),
+            Predicates.alwaysTrue(),
+            null,
+            false /* caseSensitive */);
 
     assertThat(planner.validOptions())
         .as("Planner must report all supported options")
@@ -83,7 +88,11 @@ public class TestSparkShufflingDataRewritePlanner extends TestBase {
     Table table = catalog.createTable(TABLE_IDENT, SCHEMA);
     SparkShufflingDataRewritePlanner planner =
         new SparkShufflingDataRewritePlanner(
-            table, Expressions.alwaysTrue(), null, false /* caseSensitive */);
+            table,
+            Expressions.alwaysTrue(),
+            Predicates.alwaysTrue(),
+            null,
+            false /* caseSensitive */);
 
     Map<String, String> invalidCompressionFactorOptions =
         ImmutableMap.of(SparkShufflingDataRewritePlanner.COMPRESSION_FACTOR, "0");


### PR DESCRIPTION
This PR adds an option to `RewriteDataFiles` to set a predicate for filtering out data files by attributes. You can already specify an expression to filter out data files, but there is currently no way to filter out data files by attributes such as the data file location.

We have tables with data landing in multiple regions in S3. When new data is committed, we trigger various processes, such as moving data in remote regions to the table location, as well as running rewrite data files to compact the data. This new file filter option allows us to filter out data files in remote regions (based on the location) so we only compact data local to the table location. This prevents concurrency issues (moving data while compacting), and also allows the server-side file move to take precedence over loading files in remote regions.

Another use case we have is to optimize sort compaction. We can filter out files we know are already sorted by some data file attributes, to avoid re-sorting.