### PR TITLE
Spark3.5: Support ROW level operation on insert-replace-where

### DIFF
--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.analysis.RewriteMergeIntoTableForRowLineage
 import org.apache.spark.sql.catalyst.analysis.RewriteUpdateTableForRowLineage
 import org.apache.spark.sql.catalyst.optimizer.RemoveRowLineageOutputFromOriginalTable
 import org.apache.spark.sql.catalyst.optimizer.ReplaceStaticInvoke
+import org.apache.spark.sql.catalyst.optimizer.RewriteInsertReplaceWhere
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
 
@@ -48,6 +49,7 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     // optimizer extensions
     extensions.injectOptimizerRule { _ => ReplaceStaticInvoke }
     extensions.injectOptimizerRule { _ => RemoveRowLineageOutputFromOriginalTable}
+    extensions.injectOptimizerRule( _ => RewriteInsertReplaceWhere)
 
     // planner extensions
     extensions.injectPlannerStrategy { spark => ExtendedDataSourceV2Strategy(spark) }

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteInsertReplaceWhere.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteInsertReplaceWhere.scala
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer;
+
+import org.apache.curator.shaded.com.google.common.base.Preconditions
+import org.apache.spark.sql.catalyst.analysis.RewriteRowLevelCommand
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.expressions.EqualNullSafe
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.expressions.MetadataAttribute
+import org.apache.spark.sql.catalyst.expressions.Not
+import org.apache.spark.sql.catalyst.plans.logical.Expand
+import org.apache.spark.sql.catalyst.plans.logical.Filter
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.OverwriteByExpression
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceData
+import org.apache.spark.sql.catalyst.plans.logical.Union
+import org.apache.spark.sql.catalyst.plans.logical.WriteDelta
+import org.apache.spark.sql.catalyst.util.RowDeltaUtils.INSERT_OPERATION
+import org.apache.spark.sql.catalyst.util.RowDeltaUtils.OPERATION_COLUMN
+import org.apache.spark.sql.connector.catalog.SupportsDeleteV2
+import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
+import org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE
+import org.apache.spark.sql.connector.write.RowLevelOperationTable
+import org.apache.spark.sql.connector.write.SupportsDelta
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+
+object RewriteInsertReplaceWhere extends RewriteRowLevelCommand {
+  override def apply(plan : LogicalPlan) : LogicalPlan = plan resolveOperators {
+
+    case RewriteInsertReplaceWhere(r, tbl, deleteExpr, query) =>
+      val table = buildOperationTable(tbl, MERGE, CaseInsensitiveStringMap.empty)
+      table.operation match {
+        case _: SupportsDelta =>
+          buildWriteDeltaPlan(r, table, query, deleteExpr)
+        case _ =>
+          buildReplaceDataPlan(r, table, query, deleteExpr)
+      }
+  }
+
+  type ReturnType = (DataSourceV2Relation, SupportsRowLevelOperations, Expression, LogicalPlan)
+  def unapply(o:OverwriteByExpression):Option[ReturnType] = {
+    o match {
+      case OverwriteByExpression (r@DataSourceV2Relation (tbl: SupportsRowLevelOperations, _, _, _, _),
+      deleteExpr, query, _, _, _, _) if o.resolved && !deleteExpr.equals(TrueLiteral) &&
+        tbl.properties().containsKey("provider") && "iceberg".equals(tbl.properties().get("provider")) =>
+
+        tbl match {
+          case t:SupportsDeleteV2
+            //This table can use metadata to operate delete operation, keep overwriteByExpression plan.
+            if DataSourceV2Strategy.translateFilterV2(deleteExpr).exists(p => t.canDeleteWhere(Array(p))) => None
+          case _ => Some(r, tbl, deleteExpr, query)
+        }
+
+      case _ => None
+    }
+  }
+
+  def buildWriteDeltaPlan(relation: DataSourceV2Relation, operationTable: RowLevelOperationTable,
+                          query: LogicalPlan, deleteExpr:Expression): WriteDelta = {
+    //Plan for delete part
+    val operation = operationTable.operation.asInstanceOf[SupportsDelta]
+    val rowAttrs = relation.output
+    val rowIdAttrs = resolveRowIdAttrs(relation, operation)
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
+
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+    val deletedRowPlan = Filter(deleteExpr, readRelation)
+    val rowDeltaPlan = buildDeletes(deletedRowPlan, rowIdAttrs)
+
+    val writeRelation = relation.copy(table = operationTable)
+    val projections = buildWriteDeltaProjections(rowDeltaPlan, rowAttrs, rowIdAttrs, metadataAttrs)
+
+    //Plan for insert part
+    val insertPlan = buildInsert(query, readRelation)
+
+    //Insert & delete plan
+    val insertAndDeletePlan = Union(Seq(rowDeltaPlan, insertPlan))
+    WriteDelta(writeRelation, deleteExpr, insertAndDeletePlan, relation, projections)
+  }
+
+  private def buildInsert(query: LogicalPlan, readRelation: LogicalPlan) : Expand = {
+    val (metadataAttrs, rowAttrs) = readRelation.output.partition { attr =>
+      MetadataAttribute.isValid(attr.metadata)
+    }
+    // rowAttrs = __row_operation + tbl.schema
+    Preconditions.checkState(query.output.length == rowAttrs.length, "Insert cols num %s doesn't match target table %s",
+      query.output.length.toString, rowAttrs.length.toString)
+
+    val extraNullValues = metadataAttrs.map(e => Literal(null, e.dataType))
+    val insertOutput = Seq(Literal(INSERT_OPERATION)) ++ query.output ++ extraNullValues
+    val outputs = Seq(insertOutput)
+    val operationTypeAttr = AttributeReference(OPERATION_COLUMN, IntegerType, nullable = false)()
+    val attrs = operationTypeAttr +: readRelation.output
+    val expandOutput = generateExpandOutput(attrs, outputs)
+    Expand(outputs, expandOutput, query)
+  }
+
+  private def buildDeletes(matchedRowsPlan: LogicalPlan, rowIdAttrs: Seq[Attribute]): Expand = {
+    val (metadataAttrs, rowAttrs) = matchedRowsPlan.output.partition { attr =>
+      MetadataAttribute.isValid(attr.metadata)
+    }
+    val deleteOutput = deltaDeleteOutput(rowAttrs, rowIdAttrs, metadataAttrs)
+    val outputs = Seq(deleteOutput)
+    val operationTypeAttr = AttributeReference(OPERATION_COLUMN, IntegerType, nullable = false)()
+    val attrs = operationTypeAttr +: matchedRowsPlan.output
+    val expandOutput = generateExpandOutput(attrs, outputs)
+    Expand(outputs, expandOutput, matchedRowsPlan)
+  }
+
+  private def buildReplaceDataPlan(relation: DataSourceV2Relation, operationTable: RowLevelOperationTable,
+                                   query: LogicalPlan, deleteExpr:Expression): ReplaceData = {
+
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+
+    val remainingRowsFilter = Not(EqualNullSafe(deleteExpr, TrueLiteral))
+    val remainingRowsPlan = Filter(remainingRowsFilter, readRelation)
+
+    //Insert data
+    val insertPlan = buildReplaceDataInsertPlan(query, readRelation)
+    Preconditions.checkState(insertPlan.output.length == remainingRowsPlan.output.length,
+      "Insert cols num %s doesn't match target table %s",
+      insertPlan.output.length.toString, remainingRowsPlan.output.length.toString)
+    val insertAndRemainingRowsPlan = Union(Seq(remainingRowsPlan, insertPlan))
+    val writeRelation = relation.copy(table = operationTable)
+
+    ReplaceData(writeRelation, deleteExpr, insertAndRemainingRowsPlan, relation, Some(deleteExpr))
+  }
+
+  private def buildReplaceDataInsertPlan(query: LogicalPlan, readRelation: LogicalPlan): Expand = {
+    val (metadataAttrs, rowAttrs) = readRelation.output.partition { attr =>
+      MetadataAttribute.isValid(attr.metadata)
+    }
+    // rowAttrs = __row_operation + tbl.schema
+    Preconditions.checkState(query.output.length == rowAttrs.length, "Insert cols num %s doesn't match target table %s",
+      query.output.length.toString, rowAttrs.length.toString)
+
+    val extraNullValues = metadataAttrs.map(e => Literal(null, e.dataType))
+    val insertOutput = Seq(query.output ++ extraNullValues)
+    val attrs = readRelation.output
+    val expandOutput = generateExpandOutput(attrs, insertOutput)
+    Expand(insertOutput, expandOutput, query)
+  }
+}

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteReplaceWhere.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteReplaceWhere.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import java.util.Map;
+import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+public class TestCopyOnWriteReplaceWhere extends TestReplaceWhere {
+  @Override
+  protected Map<String, String> extraTableProperties() {
+    return ImmutableMap.of(
+        TableProperties.MERGE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+}

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadReplaceWhere.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadReplaceWhere.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.util.Map;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestMergeOnReadReplaceWhere extends TestReplaceWhere {
+  @Override
+  protected Map<String, String> extraTableProperties() {
+    return ImmutableMap.of(
+        TableProperties.MERGE_MODE, RowLevelOperationMode.MERGE_ON_READ.modeName());
+  }
+
+  @TestTemplate
+  public void testFallBackToOverWriteByExpression() {
+    assumeThat(fileFormat)
+        .as("Avro does not support metadata delete")
+        .isNotEqualTo(FileFormat.AVRO);
+    super.testFallBackToOverWriteByExpression();
+    assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName)).containsExactly(row(0L));
+  }
+}

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceWhere.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceWhere.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.apache.iceberg.TableProperties.MERGE_MODE;
+import static org.apache.iceberg.TableProperties.MERGE_MODE_DEFAULT;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.Table;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+
+public abstract class TestReplaceWhere extends SparkRowLevelOperationsTestBase {
+  @BeforeAll
+  public static void setupSparkConf() {
+    spark.conf().set("spark.sql.shuffle.partitions", "4");
+  }
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS source");
+  }
+
+  @TestTemplate
+  public void testInsertFromTable() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-two\" }\n"
+            + "{ \"id\": 3, \"dep\": \"emp-id-3\" }\n"
+            + "{ \"id\": 4, \"dep\": \"emp-id-4\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
+            + "{ \"id\": 5, \"dep\": \"emp-id-5\" }");
+
+    // Only 1 data file
+    assertThat(sql("SELECT content FROM %s.files", tableName)).containsExactly(row(0));
+    sql("INSERT INTO %s REPLACE WHERE id <= 2 SELECT * FROM source", tableName);
+
+    assertThat(sql("SELECT dep FROM %s ORDER BY id", tableName))
+        .containsExactly(
+            row("emp-id-1"), row("emp-id-2"), row("emp-id-3"), row("emp-id-4"), row("emp-id-5"));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    if (mode(table) == RowLevelOperationMode.COPY_ON_WRITE) {
+      assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName))
+          .containsExactly(row(0L));
+    } else {
+      assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName))
+          .containsExactly(row(2L));
+    }
+  }
+
+  @TestTemplate
+  public void testInsertFromTableWithDifferentCol() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-two\" }\n"
+            + "{ \"id\": 3, \"dep\": \"emp-id-3\" }\n"
+            + "{ \"id\": 4, \"dep\": \"emp-id-4\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING, location STRING    ",
+        "{ \"id\": 1, \"dep\": \"emp-id-1\" , \"location\":\"SH\"}\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-2\" ,\"location\":\"SH\"}\n"
+            + "{ \"id\": 5, \"dep\": \"emp-id-5\" ,\"location\":\"SH\"}");
+
+    // Only 1 data file
+    assertThat(sql("SELECT content FROM %s.files", tableName)).containsExactly(row(0));
+    sql("INSERT INTO %s REPLACE WHERE id <= 2 SELECT id,dep FROM source", tableName);
+
+    assertThat(sql("SELECT dep FROM %s ORDER BY id", tableName))
+        .containsExactly(
+            row("emp-id-1"), row("emp-id-2"), row("emp-id-3"), row("emp-id-4"), row("emp-id-5"));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    if (mode(table) == RowLevelOperationMode.COPY_ON_WRITE) {
+      assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName))
+          .containsExactly(row(0L));
+    } else {
+      assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName))
+          .containsExactly(row(2L));
+    }
+  }
+
+  @TestTemplate
+  public void testInsertFromValues() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-two\" }\n"
+            + "{ \"id\": 3, \"dep\": \"emp-id-3\" }\n"
+            + "{ \"id\": 4, \"dep\": \"emp-id-4\" }");
+
+    // Only 1 data file
+    assertThat(sql("SELECT content FROM %s.files", tableName)).containsExactly(row(0));
+    sql(
+        "INSERT INTO %s REPLACE WHERE id <= 2 VALUES(1, 'emp-id-1'),(2, 'emp-id-2'),(5, 'emp-id-5')",
+        tableName);
+
+    assertThat(sql("SELECT dep FROM %s ORDER BY id", tableName))
+        .containsExactly(
+            row("emp-id-1"), row("emp-id-2"), row("emp-id-3"), row("emp-id-4"), row("emp-id-5"));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    if (mode(table) == RowLevelOperationMode.COPY_ON_WRITE) {
+      assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName))
+          .containsExactly(row(0L));
+    } else {
+      assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName))
+          .containsExactly(row(2L));
+    }
+  }
+
+  @TestTemplate
+  public void testInsertOverwrite() {
+    // Insert overwrite should use OverWriteByExpressionExec, same as before.
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-two\" }\n"
+            + "{ \"id\": 3, \"dep\": \"emp-id-3\" }\n"
+            + "{ \"id\": 4, \"dep\": \"emp-id-4\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING, location STRING    ",
+        "{ \"id\": 1, \"dep\": \"emp-id-1\" , \"location\":\"SH\"}\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-2\" ,\"location\":\"SH\"}\n"
+            + "{ \"id\": 5, \"dep\": \"emp-id-5\" ,\"location\":\"SH\"}");
+
+    // Only 1 data file
+    assertThat(sql("SELECT content FROM %s.files", tableName)).containsExactly(row(0));
+    sql("INSERT OVERWRITE %s  SELECT id,dep FROM source", tableName);
+
+    // insert successfullly
+    assertThat(sql("SELECT dep FROM %s ORDER BY id", tableName))
+        .containsExactly(row("emp-id-1"), row("emp-id-2"), row("emp-id-5"));
+
+    assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName)).containsExactly(row(0L));
+  }
+
+  @TestTemplate
+  public void testFallBackToOverWriteByExpression() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-two\" }\n"
+            + "{ \"id\": 3, \"dep\": \"emp-id-3\" }\n"
+            + "{ \"id\": 4, \"dep\": \"emp-id-4\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING, location STRING    ",
+        "{ \"id\": 1, \"dep\": \"emp-id-1\" , \"location\":\"SH\"}\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-2\" ,\"location\":\"SH\"}\n"
+            + "{ \"id\": 5, \"dep\": \"emp-id-5\" ,\"location\":\"SH\"}");
+
+    // Only 1 data file
+    assertThat(sql("SELECT content FROM %s.files", tableName)).containsExactly(row(0));
+    sql("INSERT INTO %s REPLACE WHERE id <= 4 SELECT id,dep FROM source", tableName);
+
+    assertThat(sql("SELECT dep FROM %s ORDER BY id", tableName))
+        .containsExactly(row("emp-id-1"), row("emp-id-2"), row("emp-id-5"));
+
+    assertThat(sql("SELECT count(*) FROM %s.position_deletes", tableName)).containsExactly(row(0L));
+  }
+
+  @TestTemplate
+  public void testCaseSentitive() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-two\" }\n"
+            + "{ \"id\": 3, \"dep\": \"emp-id-3\" }\n"
+            + "{ \"id\": 4, \"dep\": \"emp-id-4\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING, location STRING    ",
+        "{ \"id\": 1, \"dep\": \"emp-id-1\" , \"location\":\"SH\"}\n"
+            + "{ \"id\": 2, \"dep\": \"emp-id-2\" ,\"location\":\"SH\"}\n"
+            + "{ \"id\": 5, \"dep\": \"emp-id-5\" ,\"location\":\"SH\"}");
+
+    // Only 1 data file
+    assertThat(sql("SELECT content FROM %s.files", tableName)).containsExactly(row(0));
+    sql("INSERT INTO %s REPLACE WHERE ID <= 4 SELECT ID,DEP FROM source", tableName);
+
+    assertThat(sql("SELECT dep FROM %s ORDER BY id", tableName))
+        .containsExactly(row("emp-id-1"), row("emp-id-2"), row("emp-id-5"));
+  }
+
+  private RowLevelOperationMode mode(Table table) {
+    String modeName = table.properties().getOrDefault(MERGE_MODE, MERGE_MODE_DEFAULT);
+    return RowLevelOperationMode.fromName(modeName);
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -343,7 +343,8 @@ public class SparkTable
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       Map<Integer, Evaluator> evaluators = Maps.newHashMap();
       StrictMetricsEvaluator metricsEvaluator =
-          new StrictMetricsEvaluator(SnapshotUtil.schemaFor(table(), branch), deleteExpr);
+          new StrictMetricsEvaluator(
+              SnapshotUtil.schemaFor(table(), branch), deleteExpr, caseSensitive);
 
       return Iterables.all(
           tasks,
@@ -355,7 +356,8 @@ public class SparkTable
                     spec.specId(),
                     specId ->
                         new Evaluator(
-                            spec.partitionType(), Projections.strict(spec).project(deleteExpr)));
+                            spec.partitionType(),
+                            Projections.strict(spec, caseSensitive).project(deleteExpr)));
             return evaluator.eval(file.partition()) || metricsEvaluator.eval(file);
           });
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -101,6 +101,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final boolean useFanoutWriter;
   private final SparkWriteRequirements writeRequirements;
   private final Map<String, String> writeProperties;
+  private final boolean caseSensitive;
 
   private boolean cleanupOnAbort = false;
 
@@ -130,6 +131,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.writeRequirements = writeRequirements;
     this.outputSpecId = writeConf.outputSpecId();
     this.writeProperties = writeConf.writeProperties();
+    this.caseSensitive = writeConf.caseSensitive();
   }
 
   @Override
@@ -351,6 +353,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     public void commit(WriterCommitMessage[] messages) {
       OverwriteFiles overwriteFiles = table.newOverwrite();
       overwriteFiles.overwriteByRowFilter(overwriteExpr);
+      overwriteFiles.caseSensitive(caseSensitive);
 
       int numFiles = 0;
       for (DataFile file : files(messages)) {


### PR DESCRIPTION
Spark has insert-replace-where query  since version 3.5. 

Current Iceberg only has metadata-level support, this pr will contribute a row-level support.
If table could use metadata to achieve the insert-replace-where, then will keep the original overwrite logical plan.

Original logical plan is
```
== Analyzed Logical Plan ==
OverwriteByExpression RelationV2[name#141, age#142, job#143] spark_catalog.aorakili.person spark_catalog.aorakili.person, (age#142 > 22), false
+- Project [cast(col1#144 as string) AS name#147, cast(col2#145 as int) AS age#148, cast(col3#146 as string) AS job#149]
   +- LocalRelation [col1#144, col2#145, col3#146]
```
For Copy-On-Write mode, the logical plan is 
```
== Optimized Logical Plan ==
ReplaceData RelationV2[name#13, age#14, job#15] spark_catalog.aorakili.person spark_catalog.aorakili.person, IcebergWrite(table=spark_catalog.aorakili.person, format=PARQUET)
+- Union false, false
   :- Project [name#13, age#14, job#15]
   :  +- Filter (dynamicpruningexpression(_file#24 IN (list#43 [])) AND NOT ((age#14 > 22) <=> true))
   :     :  +- Aggregate [_file#42], [_file#42]
   :     :     +- Project [_file#42]
   :     :        +- Filter (isnotnull(age#40) AND (age#40 > 22))
   :     :           +- RelationV2[age#40, _file#42] spark_catalog.aorakili.person
   :     +- RelationV2[name#13, age#14, job#15, _file#24] spark_catalog.aorakili.person
   +- Expand [[name#19, age#20, job#21]], [name#27, age#28, job#29]
      +- LocalRelation [name#19, age#20, job#21]
```

For Merge-On-Read mode, the logical plan is 
```
== Optimized Logical Plan ==
WriteDelta RelationV2[name#54, age#55, job#56] spark_catalog.aorakili.person spark_catalog.aorakili.person, org.apache.iceberg.spark.source.SparkPositionDeltaWrite@77d5395a
+- RebalancePartitions [_spec_id#75, _partition#76, _file#73], 402653184
   +- Union false, false
      :- Expand [[1, null, null, null, _file#65, _pos#66L, _spec_id#63, _partition#64]], [__row_operation#69, name#70, age#71, job#72, _file#73, _pos#74L, _spec_id#75, _partition#76]
      :  +- Project [_file#65, _pos#66L, _spec_id#63, _partition#64]
      :     +- Filter (isnotnull(age#55) AND (age#55 > 22))
      :        +- RelationV2[age#55, _file#65, _pos#66L, _spec_id#63, _partition#64] spark_catalog.aorakili.person
      +- Expand [[3, name#60, age#61, job#62, null, null, null, null]], [__row_operation#78, name#79, age#80, job#81, _file#82, _pos#83L, _spec_id#84, _partition#85]
         +- LocalRelation [name#60, age#61, job#62]
```