### PR TITLE
Core: Allow date to timestamp promotion

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -422,6 +422,17 @@ public class TypeUtil {
         Types.DecimalType toDecimal = (Types.DecimalType) to;
         return fromDecimal.scale() == toDecimal.scale()
             && fromDecimal.precision() <= toDecimal.precision();
+
+      case DATE:
+        if (to.typeId() == Type.TypeID.TIMESTAMP) {
+          Types.TimestampType toTimestamp = (Types.TimestampType) to;
+          return Types.TimestampType.withoutZone().equals(toTimestamp);
+        }
+        if (to.typeId() == Type.TypeID.TIMESTAMP_NANO) {
+          Types.TimestampNanoType toTimestampNano = (Types.TimestampNanoType) to;
+          return Types.TimestampNanoType.withoutZone().equals(toTimestampNano);
+        }
+        return false;
     }
 
     return false;

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
@@ -361,6 +361,29 @@ public class TestSchemaUnionByFieldName {
   }
 
   @Test
+  // date -> Can promote to timestamp without timezone
+  public void testTypePromoteDateToTimestamp() {
+    Schema currentSchema = new Schema(required(1, "aCol", DateType.get()));
+    Schema newSchema = new Schema(required(1, "aCol", TimestampType.withoutZone()));
+
+    Schema applied = new SchemaUpdate(currentSchema, 1).unionByNameWith(newSchema).apply();
+    assertThat(applied.asStruct().fields()).hasSize(1);
+    assertThat(applied.asStruct().fields().get(0).type()).isEqualTo(TimestampType.withoutZone());
+  }
+
+  @Test
+  // date -> Can promote to timestamp nano without timezone
+  public void testTypePromoteDateToTimestampNano() {
+    Schema currentSchema = new Schema(required(1, "aCol", DateType.get()));
+    Schema newSchema = new Schema(required(1, "aCol", TimestampNanoType.withoutZone()));
+
+    Schema applied = new SchemaUpdate(currentSchema, 1).unionByNameWith(newSchema).apply();
+    assertThat(applied.asStruct().fields()).hasSize(1);
+    assertThat(applied.asStruct().fields().get(0).type())
+        .isEqualTo(TimestampNanoType.withoutZone());
+  }
+
+  @Test
   // float 32-bit IEEE 754 floating point -> Can promote to double
   public void testTypePromoteFloatToDouble() {
     Schema currentSchema = new Schema(required(1, "aCol", FloatType.get()));

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -77,11 +77,13 @@ public class TestSchemaUpdate {
               7,
               "properties",
               Types.MapType.ofOptional(18, 19, Types.StringType.get(), Types.StringType.get()),
-              "string map of properties"));
+              "string map of properties"),
+          optional(24, "date", Types.DateType.get()),
+          optional(25, "date2", Types.DateType.get()));
 
   private static final Set<Integer> ALL_IDS = ImmutableSet.copyOf(TypeUtil.getProjectedIds(SCHEMA));
 
-  private static final int SCHEMA_LAST_COLUMN_ID = 23;
+  private static final int SCHEMA_LAST_COLUMN_ID = 25;
 
   @Test
   public void testNoChanges() {
@@ -193,7 +195,9 @@ public class TestSchemaUpdate {
                 7,
                 "properties",
                 Types.MapType.ofOptional(18, 19, Types.StringType.get(), Types.StringType.get()),
-                "string map of properties"));
+                "string map of properties"),
+            optional(24, "date", Types.DateType.get()),
+            optional(25, "date2", Types.DateType.get()));
 
     Schema updated =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -326,7 +330,9 @@ public class TestSchemaUpdate {
                 7,
                 "properties",
                 Types.MapType.ofOptional(18, 19, Types.StringType.get(), Types.StringType.get()),
-                "string map of properties"));
+                "string map of properties"),
+            optional(24, "date", Types.DateType.get()),
+            optional(25, "date2", Types.DateType.get()));
 
     Schema updated =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -345,7 +351,9 @@ public class TestSchemaUpdate {
         Sets.newHashSet(
             Pair.of(Types.IntegerType.get(), Types.LongType.get()),
             Pair.of(Types.FloatType.get(), Types.DoubleType.get()),
-            Pair.of(Types.DecimalType.of(9, 2), Types.DecimalType.of(18, 2)));
+            Pair.of(Types.DecimalType.of(9, 2), Types.DecimalType.of(18, 2)),
+            Pair.of(Types.DateType.get(), Types.TimestampType.withoutZone()),
+            Pair.of(Types.DateType.get(), Types.TimestampNanoType.withoutZone()));
 
     List<Type.PrimitiveType> primitives =
         Lists.newArrayList(
@@ -358,6 +366,8 @@ public class TestSchemaUpdate {
             Types.TimeType.get(),
             Types.TimestampType.withZone(),
             Types.TimestampType.withoutZone(),
+            Types.TimestampNanoType.withZone(),
+            Types.TimestampNanoType.withoutZone(),
             Types.StringType.get(),
             Types.UUIDType.get(),
             Types.BinaryType.get(),
@@ -432,7 +442,9 @@ public class TestSchemaUpdate {
                 7,
                 "properties",
                 Types.MapType.ofOptional(18, 19, Types.StringType.get(), Types.StringType.get()),
-                "string map of properties"));
+                "string map of properties"),
+            optional(24, "date", Types.DateType.get()),
+            optional(25, "date2", Types.DateType.get()));
 
     Schema renamed =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -489,7 +501,9 @@ public class TestSchemaUpdate {
                 7,
                 "properties",
                 Types.MapType.ofOptional(18, 19, Types.StringType.get(), Types.StringType.get()),
-                "string map of properties"));
+                "string map of properties"),
+            optional(24, "date", Types.DateType.get()),
+            optional(25, "date2", Types.DateType.get()));
 
     Schema renamed =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -532,7 +546,7 @@ public class TestSchemaUpdate {
                     Types.StructType.of(
                         required(12, "lat", Types.FloatType.get()),
                         required(13, "long", Types.FloatType.get()),
-                        optional(25, "alt", Types.FloatType.get()))),
+                        optional(27, "alt", Types.FloatType.get()))),
                 "map of address to coordinate"),
             optional(
                 5,
@@ -542,8 +556,8 @@ public class TestSchemaUpdate {
                     Types.StructType.of(
                         required(15, "x", Types.LongType.get()),
                         required(16, "y", Types.LongType.get()),
-                        optional(26, "z", Types.LongType.get()),
-                        optional(27, "t.t", Types.LongType.get()))),
+                        optional(28, "z", Types.LongType.get()),
+                        optional(29, "t.t", Types.LongType.get()))),
                 "2-D cartesian points"),
             required(6, "doubles", Types.ListType.ofRequired(17, Types.DoubleType.get())),
             optional(
@@ -551,7 +565,9 @@ public class TestSchemaUpdate {
                 "properties",
                 Types.MapType.ofOptional(18, 19, Types.StringType.get(), Types.StringType.get()),
                 "string map of properties"),
-            optional(24, "toplevel", Types.DecimalType.of(9, 2)));
+            optional(24, "date", Types.DateType.get()),
+            optional(25, "date2", Types.DateType.get()),
+            optional(26, "toplevel", Types.DecimalType.of(9, 2)));
 
     Schema added =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -885,9 +901,9 @@ public class TestSchemaUpdate {
                         required(23, "zip", Types.IntegerType.get())),
                     Types.StructType.of(
                         required(12, "latitude", Types.DoubleType.get(), "latitude"),
-                        optional(25, "alt", Types.FloatType.get()),
+                        optional(27, "alt", Types.FloatType.get()),
                         required(
-                            28, "description", Types.StringType.get(), "Location description"))),
+                            30, "description", Types.StringType.get(), "Location description"))),
                 "map of address to coordinate"),
             optional(
                 5,
@@ -897,11 +913,13 @@ public class TestSchemaUpdate {
                     Types.StructType.of(
                         optional(15, "X", Types.LongType.get()),
                         required(16, "y.y", Types.LongType.get()),
-                        optional(26, "z", Types.LongType.get()),
-                        optional(27, "t.t", Types.LongType.get(), "name with '.'"))),
+                        optional(28, "z", Types.LongType.get()),
+                        optional(29, "t.t", Types.LongType.get(), "name with '.'"))),
                 "2-D cartesian points"),
             required(6, "doubles", Types.ListType.ofRequired(17, Types.DoubleType.get())),
-            optional(24, "toplevel", Types.DecimalType.of(9, 2)));
+            optional(24, "date", Types.DateType.get()),
+            optional(25, "date2", Types.DateType.get()),
+            optional(26, "toplevel", Types.DecimalType.of(9, 2)));
 
     Schema updated =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -986,7 +1004,7 @@ public class TestSchemaUpdate {
                 "preferences",
                 Types.StructType.of(
                     optional(9, "feature2", Types.BooleanType.get()),
-                    optional(24, "feature1", Types.BooleanType.get())),
+                    optional(26, "feature1", Types.BooleanType.get())),
                 "struct of named boolean options"),
             required(
                 4,
@@ -1017,7 +1035,9 @@ public class TestSchemaUpdate {
                 7,
                 "properties",
                 Types.MapType.ofOptional(18, 19, Types.StringType.get(), Types.StringType.get()),
-                "string map of properties"));
+                "string map of properties"),
+            optional(24, "date", Types.DateType.get()),
+            optional(25, "date2", Types.DateType.get()));
 
     Schema updatedNested =
         new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
@@ -2188,8 +2208,8 @@ public class TestSchemaUpdate {
                 new SchemaUpdate(newSchema, SCHEMA_LAST_COLUMN_ID + 2).deleteColumn("out").apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "Cannot delete field 24: out: required struct<25: nested: required string> "
-                + "as it will delete nested identifier field 25: nested: required string");
+            "Cannot delete field 26: out: required struct<27: nested: required string> "
+                + "as it will delete nested identifier field 27: nested: required string");
   }
 
   @Test


### PR DESCRIPTION
It seems that though V3 spec allows date to timestamp/timestamp nano without timezone promotions, it isn't yet implemented.