### PR TITLE
Flink: Dynamic Iceberg Sink: Rename method in DynamicRecordGenerator

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordGenerator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordGenerator.java
@@ -30,5 +30,5 @@ public interface DynamicRecordGenerator<T> extends Serializable {
    * Takes the user-defined input and yields zero, one, or multiple {@link DynamicRecord}s using the
    * {@link Collector}.
    */
-  void convert(T inputRecord, Collector<DynamicRecord> out) throws Exception;
+  void generate(T inputRecord, Collector<DynamicRecord> out) throws Exception;
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -89,7 +89,7 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
       throws Exception {
     this.context = ctx;
     this.collector = out;
-    generator.convert(element, this);
+    generator.generate(element, this);
   }
 
   @Override

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -178,7 +178,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
   private static class Generator implements DynamicRecordGenerator<DynamicIcebergDataImpl> {
 
     @Override
-    public void convert(DynamicIcebergDataImpl row, Collector<DynamicRecord> out) {
+    public void generate(DynamicIcebergDataImpl row, Collector<DynamicRecord> out) {
       TableIdentifier tableIdentifier = TableIdentifier.of(DATABASE, row.tableName);
       String branch = row.branch;
       Schema schema = row.schemaProvided;

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSinkPerf.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSinkPerf.java
@@ -164,7 +164,7 @@ class TestDynamicIcebergSinkPerf {
   private static class IdBasedGenerator implements DynamicRecordGenerator<Integer> {
 
     @Override
-    public void convert(Integer id, Collector<DynamicRecord> out) {
+    public void generate(Integer id, Collector<DynamicRecord> out) {
       out.collect(rows.get(id % SAMPLE_SIZE));
     }
   }


### PR DESCRIPTION
The decided to change the terminology from converter to generator. The interface method still had the old name, despite the class already gotten renamed.