### PR TITLE
AWS: Add support to run all integration tests when S3 Analytics Accelerator is enabled

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.glue;
 
+import static org.apache.iceberg.aws.s3.S3TestUtil.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -28,6 +29,7 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.aws.AwsIntegTestUtil;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.aws.s3.S3TestUtil;
 import org.apache.iceberg.aws.util.RetryDetector;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -160,6 +162,9 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   public void testNoRetryAwarenessCorruptsTable() {
     // This test exists to replicate the issue the prior test validates the fix for
     // See https://github.com/apache/iceberg/issues/7151
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(),
+        "Analytics Accelerator Library does not support custom Iceberg exception: NotFoundException");
     String namespace = createNamespace();
     String tableName = createTable(namespace);
     TableIdentifier tableId = TableIdentifier.of(namespace, tableName);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -41,6 +41,8 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -158,12 +160,13 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
         .isEqualTo(2);
   }
 
-  @Test
-  public void testNoRetryAwarenessCorruptsTable() {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNoRetryAwarenessCorruptsTable(Map<String, String> aalProperties) {
     // This test exists to replicate the issue the prior test validates the fix for
     // See https://github.com/apache/iceberg/issues/7151
     skipIfAnalyticsAcceleratorEnabled(
-        new S3FileIOProperties(),
+        new S3FileIOProperties(aalProperties),
         "Analytics Accelerator Library does not support custom Iceberg exception: NotFoundException");
     String namespace = createNamespace();
     String tableName = createTable(namespace);

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
@@ -26,6 +26,8 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
@@ -65,6 +67,18 @@ public class MinioUtil {
     if (legacyMd5PluginEnabled) {
       builder.addPlugin(LegacyMd5Plugin.create());
     }
+    builder.credentialsProvider(
+        StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(container.getUserName(), container.getPassword())));
+    builder.applyMutation(mutator -> mutator.endpointOverride(uri));
+    builder.region(Region.US_EAST_1);
+    builder.forcePathStyle(true); // OSX won't resolve subdomains
+    return builder.build();
+  }
+
+  public static S3AsyncClient createS3AsyncClient(MinIOContainer container) {
+    URI uri = URI.create(container.getS3URL());
+    S3AsyncClientBuilder builder = S3AsyncClient.builder();
     builder.credentialsProvider(
         StaticCredentialsProvider.create(
             AwsBasicCredentials.create(container.getUserName(), container.getPassword())));

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
@@ -18,7 +18,14 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class S3TestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3TestUtil.class);
 
   private S3TestUtil() {}
 
@@ -28,5 +35,19 @@ public class S3TestUtil {
 
   public static String getKeyFromUri(String s3Uri) {
     return new S3URI(s3Uri).key();
+  }
+
+  /**
+   * Skip a test if the Analytics Accelerator Library for Amazon S3 is enabled.
+   *
+   * @param properties properties to probe
+   */
+  public static void skipIfAnalyticsAcceleratorEnabled(
+      S3FileIOProperties properties, String message) {
+    boolean isAcceleratorEnabled = properties.isS3AnalyticsAcceleratorEnabled();
+    if (isAcceleratorEnabled) {
+      LOG.warn(message);
+    }
+    assumeThat(!isAcceleratorEnabled).describedAs(message).isTrue();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
@@ -20,6 +20,11 @@ package org.apache.iceberg.aws.s3;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.params.provider.Arguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,5 +54,25 @@ public class S3TestUtil {
       LOG.warn(message);
     }
     assumeThat(!isAcceleratorEnabled).describedAs(message).isTrue();
+  }
+
+  public static Stream<Arguments> analyticsAcceleratorLibraryProperties() {
+    return listAnalyticsAcceleratorLibraryProperties().stream().map(Arguments::of);
+  }
+
+  public static List<Map<String, String>> listAnalyticsAcceleratorLibraryProperties() {
+    return List.of(
+        ImmutableMap.of(
+            S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, Boolean.toString(true)),
+        ImmutableMap.of(
+            S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, Boolean.toString(false)));
+  }
+
+  public static Map<String, String> mergeProperties(
+      Map<String, String> aalProperties, Map<String, String> testProperties) {
+    return ImmutableMap.<String, String>builder()
+        .putAll(aalProperties)
+        .putAll(testProperties)
+        .build();
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 class StaticClientFactory implements AwsClientFactory {
   static S3Client client;
+  static S3AsyncClient asyncClient;
 
   @Override
   public S3Client s3() {
@@ -36,7 +37,7 @@ class StaticClientFactory implements AwsClientFactory {
 
   @Override
   public S3AsyncClient s3Async() {
-    return null;
+    return asyncClient;
   }
 
   @Override


### PR DESCRIPTION
**Context**
We have integrated [analytics-accelerator-s3](https://github.com/awslabs/analytics-accelerator-s3) into Iceberg in PR #12299. Currently, Iceberg customers need to enable the `s3.analytics-accelerator.enabled` flag in `S3FileIOProperties` to use the library. We plan to make this feature enabled by default in the future and have begun addressing the feature gaps between our current Analytics Accelerator Library (AAL) stream and the existing `S3InputStream`. This PR marks the beginning of our work toward default integration.

**Description of PR**
This PR modifies the existing integration tests to ensure compatibility when AAL is enabled by default. It incorporates all necessary async client setup code and skips integration tests that would currently fail if AAL is enabled in local setups. These skipped tests represent the feature gaps we are actively working to resolve.

**Testing**
- All integration tests function properly with AAL disabled (current default behavior) and also work when AAL is enabled (with the exception of a few skipped tests).
- Note that to enable AAL while running these tests, we just have to update this [flag](https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java#L87) to `true`.