### PR TITLE
Flink: Fix flaky test in testTwoSinksInDisjointedDAG

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
@@ -151,12 +151,13 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
     // Execute the program.
     env.execute("Test Iceberg DataStream.");
 
+    leftTable.refresh();
+    rightTable.refresh();
+
     SimpleDataUtil.assertTableRows(leftTable, convertToRowData(leftRows));
     SimpleDataUtil.assertTableRows(rightTable, convertToRowData(rightRows));
 
-    leftTable.refresh();
     assertThat(leftTable.currentSnapshot().summary()).doesNotContainKeys("flink.test", "direction");
-    rightTable.refresh();
     assertThat(rightTable.currentSnapshot().summary())
         .containsEntry("flink.test", TestFlinkIcebergSink.class.getName())
         .containsEntry("direction", "rightTable");

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
@@ -247,10 +247,11 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
     // Execute the program.
     env.execute("Test Iceberg DataStream.");
 
+    leftTable.refresh();
+    rightTable.refresh();
+
     SimpleDataUtil.assertTableRows(leftTable, convertToRowData(leftRows));
     SimpleDataUtil.assertTableRows(rightTable, convertToRowData(rightRows));
-
-    leftTable.refresh();
 
     assertThat(leftTable.currentSnapshot().summary().get("flink.test")).isNull();
     assertThat(leftTable.currentSnapshot().summary().get("direction")).isNull();

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
@@ -151,12 +151,13 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
     // Execute the program.
     env.execute("Test Iceberg DataStream.");
 
+    leftTable.refresh();
+    rightTable.refresh();
+
     SimpleDataUtil.assertTableRows(leftTable, convertToRowData(leftRows));
     SimpleDataUtil.assertTableRows(rightTable, convertToRowData(rightRows));
 
-    leftTable.refresh();
     assertThat(leftTable.currentSnapshot().summary()).doesNotContainKeys("flink.test", "direction");
-    rightTable.refresh();
     assertThat(rightTable.currentSnapshot().summary())
         .containsEntry("flink.test", TestFlinkIcebergSink.class.getName())
         .containsEntry("direction", "rightTable");

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
@@ -247,10 +247,11 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
     // Execute the program.
     env.execute("Test Iceberg DataStream.");
 
+    leftTable.refresh();
+    rightTable.refresh();
+
     SimpleDataUtil.assertTableRows(leftTable, convertToRowData(leftRows));
     SimpleDataUtil.assertTableRows(rightTable, convertToRowData(rightRows));
-
-    leftTable.refresh();
 
     assertThat(leftTable.currentSnapshot().summary().get("flink.test")).isNull();
     assertThat(leftTable.currentSnapshot().summary().get("direction")).isNull();

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
@@ -151,12 +151,13 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
     // Execute the program.
     env.execute("Test Iceberg DataStream.");
 
+    leftTable.refresh();
+    rightTable.refresh();
+
     SimpleDataUtil.assertTableRows(leftTable, convertToRowData(leftRows));
     SimpleDataUtil.assertTableRows(rightTable, convertToRowData(rightRows));
 
-    leftTable.refresh();
     assertThat(leftTable.currentSnapshot().summary()).doesNotContainKeys("flink.test", "direction");
-    rightTable.refresh();
     assertThat(rightTable.currentSnapshot().summary())
         .containsEntry("flink.test", TestFlinkIcebergSink.class.getName())
         .containsEntry("direction", "rightTable");

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
@@ -247,10 +247,11 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
     // Execute the program.
     env.execute("Test Iceberg DataStream.");
 
+    leftTable.refresh();
+    rightTable.refresh();
+
     SimpleDataUtil.assertTableRows(leftTable, convertToRowData(leftRows));
     SimpleDataUtil.assertTableRows(rightTable, convertToRowData(rightRows));
-
-    leftTable.refresh();
 
     assertThat(leftTable.currentSnapshot().summary().get("flink.test")).isNull();
     assertThat(leftTable.currentSnapshot().summary().get("direction")).isNull();


### PR DESCRIPTION
In https://github.com/apache/iceberg/issues/13338 , I think the main reason here is that the table metadata has not been updated yet. 

The `leftTable.refresh()` in the code can be called earlier, and a refresh for the rightTable should be added as well. 