### PR TITLE
Docs: Add Firebolt to list of vendors and blog posts

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - hive.md
   - Trino: https://trino.io/docs/current/connector/iceberg.html
   - Daft: daft.md
+  - Firebolt: https://docs.firebolt.io/reference-sql/functions-reference/table-valued/read_iceberg
   - Estuary: https://docs.estuary.dev/reference/Connectors/materialization-connectors/apache-iceberg/
   - Tinybird: https://www.tinybird.co/docs/forward/get-data-in/table-functions/iceberg
   - Redpanda: https://docs.redpanda.com/current/manage/iceberg/about-iceberg-topics

--- a/site/docs/blogs.md
+++ b/site/docs/blogs.md
@@ -23,6 +23,11 @@ title: "Blogs"
 Here is a list of company blogs that talk about Iceberg. The blogs are ordered from most recent to oldest.
 
 <!-- markdown-link-check-disable-next-line -->
+### [Querying Apache Iceberg with Sub-Second Performance](https://www.firebolt.io/blog/querying-apache-iceberg-with-sub-second-performance)
+**Date:** June 11, 2025, **Company**: Firebolt
+**Author**: [Lorenz Hübschle](https://www.linkedin.com/in/lorenzhs)
+
+<!-- markdown-link-check-disable-next-line -->
 ### [What Are Apache Iceberg Tables? Benefits and challenges](https://www.redpanda.com/blog/apache-iceberg-tables-benefits-challenges)
 **Date:** May 21, 2025, **Company**: Redpanda
 **Author**: [Redpanda](https://redpanda.com)

--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -78,6 +78,14 @@ A low-latency, high-fidelity data movement platform, Estuary lets developers qui
 
 Estuary's catalog of pre-built data connectors provides integrations with databases, APIs, event logs, and more. [Apache Iceberg](https://estuary.dev/solutions/technology/apache-iceberg/) is a primary destination option with two configurable materializations: one that [merges](https://docs.estuary.dev/reference/Connectors/materialization-connectors/apache-iceberg/) new updates and one that simply [appends](https://docs.estuary.dev/reference/Connectors/materialization-connectors/amazon-s3-iceberg/) them.
 
+### [Firebolt](https://www.firebolt.io)
+
+[Firebolt](https://www.firebolt.io) is a cloud data warehouse built to power data-intensive applications that demand low latency and high concurrency. It is optimized for reading Apache Iceberg tables with sub-second performance and integrates seamlessly with major Iceberg catalogs.
+
+Firebolt is also available as [Firebolt Core](https://docs.firebolt.io/firebolt-core), a free, self-hosted edition of its distributed query engine.
+
+Learn more about querying Iceberg with Firebolt [here](https://www.firebolt.io/blog/querying-apache-iceberg-with-sub-second-performance).
+
 ### [IBM watsonx.data](https://www.ibm.com/products/watsonx-data)
 
 [IBM watsonx.data](https://www.ibm.com/products/watsonx-data) is an open data lakehouse for AI and analytics. It uses Apache Iceberg as a core table format, providing features like schema evolution, time travel, and partitioning. This allows developers to easily work with large, complex data sets while ensuring efficient performance and flexibility. watsonx.data simplifies the integration of Iceberg tables, making it easy to manage data across different environments and query historical data without disruption. 


### PR DESCRIPTION
Adds Firebolt to the list of vendors that support Iceberg, with links to Firebolt's documentation and Iceberg blog post.