### PR TITLE
Spark 3.4: Backport row lineage support in spark readers

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -180,7 +180,10 @@ class SparkBatch implements Batch {
   }
 
   private boolean supportsCometBatchReads(Types.NestedField field) {
-    return field.type().isPrimitiveType() && !field.type().typeId().equals(Type.TypeID.UUID);
+    return field.type().isPrimitiveType()
+        && !field.type().typeId().equals(Type.TypeID.UUID)
+        && field.fieldId() != MetadataColumns.ROW_ID.fieldId()
+        && field.fieldId() != MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
   }
 
   // conditions for using ORC batch reads:

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
@@ -64,8 +64,7 @@ public class SparkTestHelperBase {
       Object[] actual = actualRows.get(row);
       assertThat(actual).as("Number of columns should match").hasSameSizeAs(expected);
       for (int col = 0; col < actualRows.get(row).length; col += 1) {
-        String newContext = String.format("%s: row %d col %d", context, row + 1, col + 1);
-        assertEquals(newContext, expected, actual);
+        assertEquals(context + ": row " + (row + 1), expected, actual);
       }
     }
   }
@@ -83,7 +82,9 @@ public class SparkTestHelperBase {
           assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
         }
       } else if (expectedValue != ANY) {
-        assertThat(actualValue).as("%s contents should match", context).isEqualTo(expectedValue);
+        assertThat(actualValue)
+            .as(context + " col " + (col + 1) + " contents should match")
+            .isEqualTo(expectedValue);
       }
     }
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -38,6 +38,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.data.GenericDataUtil;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
@@ -198,12 +200,47 @@ public class GenericsHelpers {
 
   public static void assertEqualsUnsafe(
       Types.StructType struct, Record expected, InternalRow actual) {
-    List<Types.NestedField> fields = struct.fields();
-    for (int i = 0; i < fields.size(); i += 1) {
-      Type fieldType = fields.get(i).type();
+    assertEqualsUnsafe(struct, expected, actual, null, -1);
+  }
 
-      Object expectedValue = expected.get(i);
-      Object actualValue = actual.get(i, convert(fieldType));
+  public static void assertEqualsUnsafe(
+      Types.StructType struct,
+      Record expected,
+      InternalRow actual,
+      Map<Integer, Object> idToConstant,
+      int pos) {
+    Types.StructType expectedType = expected.struct();
+    List<Types.NestedField> fields = struct.fields();
+    for (int readPos = 0; readPos < fields.size(); readPos += 1) {
+      Types.NestedField field = fields.get(readPos);
+      Types.NestedField expectedField = expectedType.field(field.fieldId());
+
+      Type fieldType = field.type();
+      Object actualValue =
+          actual.isNullAt(readPos) ? null : actual.get(readPos, convert(fieldType));
+
+      Object expectedValue;
+      if (expectedField != null) {
+        int id = expectedField.fieldId();
+        if (id == MetadataColumns.ROW_ID.fieldId()) {
+          expectedValue = expected.getField(expectedField.name());
+          if (expectedValue == null && idToConstant != null) {
+            expectedValue = (Long) idToConstant.get(id) + pos;
+          }
+
+        } else if (id == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
+          expectedValue = expected.getField(expectedField.name());
+          if (expectedValue == null && idToConstant != null) {
+            expectedValue = idToConstant.get(id);
+          }
+
+        } else {
+          expectedValue = expected.getField(expectedField.name());
+        }
+      } else {
+        // comparison expects Iceberg's generic representation
+        expectedValue = GenericDataUtil.internalToGeneric(field.type(), field.initialDefault());
+      }
 
       assertEqualsUnsafe(fieldType, expectedValue, actualValue);
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.spark.data;
 
-import static org.apache.iceberg.spark.data.TestHelpers.assertEqualsUnsafe;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +27,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -38,7 +36,9 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
@@ -70,6 +70,13 @@ public class TestSparkParquetReader extends AvroDataTest {
 
   @Override
   protected void writeAndValidate(Schema writeSchema, Schema expectedSchema) throws IOException {
+    List<Record> expected = RandomGenericData.generate(writeSchema, 100, 0L);
+    writeAndValidate(writeSchema, expectedSchema, expected);
+  }
+
+  @Override
+  protected void writeAndValidate(Schema writeSchema, Schema expectedSchema, List<Record> expected)
+      throws IOException {
     assumeThat(
             null
                 == TypeUtil.find(
@@ -79,27 +86,37 @@ public class TestSparkParquetReader extends AvroDataTest {
         .as("Parquet Avro cannot write non-string map keys")
         .isTrue();
 
-    List<GenericData.Record> expected = RandomData.generateList(writeSchema, 100, 0L);
-
-    OutputFile outputFile = new InMemoryOutputFile();
-
-    try (FileAppender<GenericData.Record> writer =
-        Parquet.write(outputFile).schema(writeSchema).named("test").build()) {
+    OutputFile output = new InMemoryOutputFile();
+    try (FileAppender<Record> writer =
+        Parquet.write(output)
+            .schema(writeSchema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .named("test")
+            .build()) {
       writer.addAll(expected);
     }
 
     try (CloseableIterable<InternalRow> reader =
-        Parquet.read(outputFile.toInputFile())
+        Parquet.read(output.toInputFile())
             .project(expectedSchema)
-            .createReaderFunc(type -> SparkParquetReaders.buildReader(expectedSchema, type))
+            .createReaderFunc(
+                type -> SparkParquetReaders.buildReader(expectedSchema, type, ID_TO_CONSTANT))
             .build()) {
       Iterator<InternalRow> rows = reader.iterator();
-      for (GenericData.Record record : expected) {
-        assertThat(rows.hasNext()).as("Should have expected number of rows").isTrue();
-        assertEqualsUnsafe(expectedSchema.asStruct(), record, rows.next());
+      int pos = 0;
+      for (Record record : expected) {
+        assertThat(rows).as("Should have expected number of rows").hasNext();
+        GenericsHelpers.assertEqualsUnsafe(
+            expectedSchema.asStruct(), record, rows.next(), ID_TO_CONSTANT, pos);
+        pos += 1;
       }
-      assertThat(rows.hasNext()).as("Should not have extra rows").isFalse();
+      assertThat(rows).as("Should not have extra rows").isExhausted();
     }
+  }
+
+  @Override
+  protected boolean supportsRowLineage() {
+    return true;
   }
 
   @Override


### PR DESCRIPTION
This PR adds the support added to spark readers for row lineage to spark 3.4. This back port is based on the changes added in #12836, and is 1:1 change no 3.4 specific changes necessary.

cc: @amogh-jahagirdar 