### PR TITLE
AWS: Support RangeReadable in Analytics Accelerator Stream

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.glue;
 
+import static org.apache.iceberg.aws.s3.S3TestUtil.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -28,6 +29,7 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.aws.AwsIntegTestUtil;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.aws.s3.S3TestUtil;
 import org.apache.iceberg.aws.util.RetryDetector;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -160,6 +162,9 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   public void testNoRetryAwarenessCorruptsTable() {
     // This test exists to replicate the issue the prior test validates the fix for
     // See https://github.com/apache/iceberg/issues/7151
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(),
+        "Analytics Accelerator Library does not support custom Iceberg exception: NotFoundException");
     String namespace = createNamespace();
     String tableName = createTable(namespace);
     TableIdentifier tableId = TableIdentifier.of(namespace, tableName);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -41,6 +41,8 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -158,12 +160,13 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
         .isEqualTo(2);
   }
 
-  @Test
-  public void testNoRetryAwarenessCorruptsTable() {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNoRetryAwarenessCorruptsTable(Map<String, String> aalProperties) {
     // This test exists to replicate the issue the prior test validates the fix for
     // See https://github.com/apache/iceberg/issues/7151
     skipIfAnalyticsAcceleratorEnabled(
-        new S3FileIOProperties(),
+        new S3FileIOProperties(aalProperties),
         "Analytics Accelerator Library does not support custom Iceberg exception: NotFoundException");
     String namespace = createNamespace();
     String tableName = createTable(namespace);

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
@@ -26,6 +26,8 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
@@ -65,6 +67,18 @@ public class MinioUtil {
     if (legacyMd5PluginEnabled) {
       builder.addPlugin(LegacyMd5Plugin.create());
     }
+    builder.credentialsProvider(
+        StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(container.getUserName(), container.getPassword())));
+    builder.applyMutation(mutator -> mutator.endpointOverride(uri));
+    builder.region(Region.US_EAST_1);
+    builder.forcePathStyle(true); // OSX won't resolve subdomains
+    return builder.build();
+  }
+
+  public static S3AsyncClient createS3AsyncClient(MinIOContainer container) {
+    URI uri = URI.create(container.getS3URL());
+    S3AsyncClientBuilder builder = S3AsyncClient.builder();
     builder.credentialsProvider(
         StaticCredentialsProvider.create(
             AwsBasicCredentials.create(container.getUserName(), container.getPassword())));

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
@@ -18,7 +18,14 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class S3TestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3TestUtil.class);
 
   private S3TestUtil() {}
 
@@ -28,5 +35,19 @@ public class S3TestUtil {
 
   public static String getKeyFromUri(String s3Uri) {
     return new S3URI(s3Uri).key();
+  }
+
+  /**
+   * Skip a test if the Analytics Accelerator Library for Amazon S3 is enabled.
+   *
+   * @param properties properties to probe
+   */
+  public static void skipIfAnalyticsAcceleratorEnabled(
+      S3FileIOProperties properties, String message) {
+    boolean isAcceleratorEnabled = properties.isS3AnalyticsAcceleratorEnabled();
+    if (isAcceleratorEnabled) {
+      LOG.warn(message);
+    }
+    assumeThat(!isAcceleratorEnabled).describedAs(message).isTrue();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
@@ -20,6 +20,11 @@ package org.apache.iceberg.aws.s3;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.params.provider.Arguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,5 +54,25 @@ public class S3TestUtil {
       LOG.warn(message);
     }
     assumeThat(!isAcceleratorEnabled).describedAs(message).isTrue();
+  }
+
+  public static Stream<Arguments> analyticsAcceleratorLibraryProperties() {
+    return listAnalyticsAcceleratorLibraryProperties().stream().map(Arguments::of);
+  }
+
+  public static List<Map<String, String>> listAnalyticsAcceleratorLibraryProperties() {
+    return List.of(
+        ImmutableMap.of(
+            S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, Boolean.toString(true)),
+        ImmutableMap.of(
+            S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, Boolean.toString(false)));
+  }
+
+  public static Map<String, String> mergeProperties(
+      Map<String, String> aalProperties, Map<String, String> testProperties) {
+    return ImmutableMap.<String, String>builder()
+        .putAll(aalProperties)
+        .putAll(testProperties)
+        .build();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
@@ -75,15 +75,16 @@ public class TestFlakyS3InputStream extends TestS3InputStream {
       S3Client s3Client,
       S3AsyncClient s3AsyncClient,
       S3URI uri,
-      Map<String, String> aalProperties) {
+      Map<String, String> aalProperties,
+      MetricsContext metricsContext) {
     final S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(aalProperties);
     if (s3FileIOProperties.isS3AnalyticsAcceleratorEnabled()) {
       PrefixedS3Client client =
           new PrefixedS3Client("s3", aalProperties, () -> s3Client, () -> s3AsyncClient);
       return AnalyticsAcceleratorUtil.newStream(
-          S3InputFile.fromLocation(uri.location(), client, MetricsContext.nullMetrics()));
+          S3InputFile.fromLocation(uri.location(), client, metricsContext));
     }
-    return new S3InputStream(s3Client, uri) {
+    return new S3InputStream(s3Client, uri, s3FileIOProperties, metricsContext) {
       @Override
       void resetForRetry() throws IOException {
         resetForRetryCounter.incrementAndGet();

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestMetricsContext.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestMetricsContext.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * Test implementation of MetricsContext that maintains isolated counters for each test instance.
+ * Used instead of Hadoop metrics to avoid shared state between test runs
+ */
+public class TestMetricsContext implements MetricsContext {
+  private final Map<String, org.apache.iceberg.metrics.Counter> counters = Maps.newConcurrentMap();
+
+  @Override
+  public org.apache.iceberg.metrics.Counter counter(String name, Unit unit) {
+    return counters.computeIfAbsent(name, k -> new LocalCounter());
+  }
+
+  private static class LocalCounter implements org.apache.iceberg.metrics.Counter {
+    private final AtomicLong count = new AtomicLong(0);
+
+    @Override
+    public void increment() {
+      increment(1L);
+    }
+
+    @Override
+    public void increment(long amount) {
+      count.addAndGet(amount);
+    }
+
+    @Override
+    public long value() {
+      return count.get();
+    }
+  }
+}

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.apache.iceberg.aws.s3.S3TestUtil.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -209,8 +210,12 @@ public class TestS3FileIOIntegration {
 
   @Test
   public void testCrossRegionAccessEnabled() throws Exception {
-    clientFactory.initialize(
-        ImmutableMap.of(S3FileIOProperties.CROSS_REGION_ACCESS_ENABLED, "true"));
+    Map<String, String> properties =
+        ImmutableMap.of(S3FileIOProperties.CROSS_REGION_ACCESS_ENABLED, "true");
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(properties),
+        "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access");
+    clientFactory.initialize(properties);
     S3Client s3Client = clientFactory.s3();
     String crossBucketObjectKey = String.format("%s/%s", prefix, UUID.randomUUID());
     String crossBucketObjectUri =
@@ -234,7 +239,12 @@ public class TestS3FileIOIntegration {
   @Test
   public void testNewInputStreamWithCrossRegionAccessPoint() throws Exception {
     requireAccessPointSupport();
-    clientFactory.initialize(ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true"));
+    Map<String, String> properties =
+        ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(properties),
+        "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access Points");
+    clientFactory.initialize(properties);
     S3Client s3Client = clientFactory.s3();
     s3Client.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
@@ -485,14 +495,18 @@ public class TestS3FileIOIntegration {
         new String(encoder.encode(digest.digest(secretKey.getEncoded())), StandardCharsets.UTF_8);
 
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> properties =
         ImmutableMap.of(
             S3FileIOProperties.SSE_TYPE,
             S3FileIOProperties.SSE_TYPE_CUSTOM,
             S3FileIOProperties.SSE_KEY,
             encodedKey,
             S3FileIOProperties.SSE_MD5,
-            md5));
+            md5);
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(properties),
+        "Analytics Accelerator Library does not support Server Side Custom Encryption");
+    s3FileIO.initialize(properties);
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.apache.iceberg.aws.s3.S3TestUtil.mergeProperties;
 import static org.apache.iceberg.aws.s3.S3TestUtil.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,6 +51,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.PartitionMetadata;
 import software.amazon.awssdk.regions.Region;
@@ -160,18 +163,21 @@ public class TestS3FileIOIntegration {
     clientFactory.initialize(Maps.newHashMap());
   }
 
-  @Test
-  public void testNewInputStream() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStream(Map<String, String> aalProperties) throws Exception {
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of());
+    s3FileIO.initialize(aalProperties);
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testS3FileIOWithS3FileIOAwsClientFactoryImpl() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testS3FileIOWithS3FileIOAwsClientFactoryImpl(Map<String, String> aalProperties)
+      throws Exception {
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
@@ -180,38 +186,45 @@ public class TestS3FileIOIntegration {
     properties.put(
         S3FileIOProperties.CLIENT_FACTORY,
         "org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory");
-    s3FileIO.initialize(properties);
+    s3FileIO.initialize(mergeProperties(aalProperties, properties));
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testS3FileIOWithDefaultAwsClientFactoryImpl() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testS3FileIOWithDefaultAwsClientFactoryImpl(Map<String, String> aalProperties)
+      throws Exception {
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO();
-    s3FileIO.initialize(Maps.newHashMap());
+    s3FileIO.initialize(aalProperties);
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testNewInputStreamWithAccessPoint() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStreamWithAccessPoint(Map<String, String> aalProperties)
+      throws Exception {
     requireAccessPointSupport();
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
-            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
+            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testCrossRegionAccessEnabled() throws Exception {
-    Map<String, String> properties =
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testCrossRegionAccessEnabled(Map<String, String> aalProperties) throws Exception {
+    Map<String, String> testProperties =
         ImmutableMap.of(S3FileIOProperties.CROSS_REGION_ACCESS_ENABLED, "true");
+    Map<String, String> properties = mergeProperties(aalProperties, testProperties);
     skipIfAnalyticsAcceleratorEnabled(
         new S3FileIOProperties(properties),
         "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access");
@@ -236,11 +249,14 @@ public class TestS3FileIOIntegration {
     }
   }
 
-  @Test
-  public void testNewInputStreamWithCrossRegionAccessPoint() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStreamWithCrossRegionAccessPoint(Map<String, String> aalProperties)
+      throws Exception {
     requireAccessPointSupport();
-    Map<String, String> properties =
+    Map<String, String> testProperties =
         ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    Map<String, String> properties = mergeProperties(aalProperties, testProperties);
     skipIfAnalyticsAcceleratorEnabled(
         new S3FileIOProperties(properties),
         "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access Points");
@@ -258,38 +274,33 @@ public class TestS3FileIOIntegration {
             .build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> accessPointProperties =
         ImmutableMap.of(
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
-            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
+            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName));
+    s3FileIO.initialize(mergeProperties(aalProperties, accessPointProperties));
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testNewInputStreamWithMultiRegionAccessPoint() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStreamWithMultiRegionAccessPoint(Map<String, String> aalProperties)
+      throws Exception {
     Assumptions.assumeThat(multiRegionAccessPointAlias).isNotEmpty();
-    clientFactory.initialize(ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true"));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    clientFactory.initialize(mergeProperties(aalProperties, testProperties));
     S3Client s3Client = clientFactory.s3();
     s3Client.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> accessPointProperties =
         ImmutableMap.of(
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
             testMultiRegionAccessPointARN(
-                AwsIntegTestUtil.testRegion(), multiRegionAccessPointAlias)));
-    validateRead(s3FileIO);
-  }
-
-  @Test
-  public void testNewInputStreamWithAnalyticsAccelerator() throws Exception {
-    s3.putObject(
-        PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
-        RequestBody.fromBytes(contentBytes));
-    S3FileIO s3FileIO = new S3FileIO();
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, String.valueOf(true)));
+                AwsIntegTestUtil.testRegion(), multiRegionAccessPointAlias));
+    s3FileIO.initialize(mergeProperties(aalProperties, accessPointProperties));
     validateRead(s3FileIO);
   }
 
@@ -407,11 +418,13 @@ public class TestS3FileIOIntegration {
     }
   }
 
-  @Test
-  public void testServerSideS3Encryption() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testServerSideS3Encryption(Map<String, String> aalProperties) throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_S3));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_S3);
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =
@@ -420,16 +433,18 @@ public class TestS3FileIOIntegration {
     assertThat(response.serverSideEncryption()).isEqualTo(ServerSideEncryption.AES256);
   }
 
-  @Test
-  public void testServerSideKmsEncryption() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testServerSideKmsEncryption(Map<String, String> aalProperties) throws Exception {
     requireKMSEncryptionSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
             S3FileIOProperties.SSE_TYPE,
             S3FileIOProperties.SSE_TYPE_KMS,
             S3FileIOProperties.SSE_KEY,
-            kmsKeyArn));
+            kmsKeyArn);
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =
@@ -439,12 +454,15 @@ public class TestS3FileIOIntegration {
     assertThat(kmsKeyArn).isEqualTo(response.ssekmsKeyId());
   }
 
-  @Test
-  public void testServerSideKmsEncryptionWithDefaultKey() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testServerSideKmsEncryptionWithDefaultKey(Map<String, String> aalProperties)
+      throws Exception {
     requireKMSEncryptionSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_KMS));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_KMS);
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =
@@ -461,16 +479,19 @@ public class TestS3FileIOIntegration {
             aliasListEntry -> assertThat(aliasListEntry.aliasName()).isEqualTo("alias/aws/s3"));
   }
 
-  @Test
-  public void testDualLayerServerSideKmsEncryption() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDualLayerServerSideKmsEncryption(Map<String, String> aalProperties)
+      throws Exception {
     requireKMSEncryptionSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
             S3FileIOProperties.SSE_TYPE,
             S3FileIOProperties.DSSE_TYPE_KMS,
             S3FileIOProperties.SSE_KEY,
-            kmsKeyArn));
+            kmsKeyArn);
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =
@@ -480,8 +501,9 @@ public class TestS3FileIOIntegration {
     assertThat(response.ssekmsKeyId()).isEqualTo(kmsKeyArn);
   }
 
-  @Test
-  public void testServerSideCustomEncryption() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testServerSideCustomEncryption(Map<String, String> aalProperties) throws Exception {
     requireKMSEncryptionSupport();
     // generate key
     KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
@@ -495,14 +517,12 @@ public class TestS3FileIOIntegration {
         new String(encoder.encode(digest.digest(secretKey.getEncoded())), StandardCharsets.UTF_8);
 
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    Map<String, String> properties =
+    Map<String, String> testProperties =
         ImmutableMap.of(
-            S3FileIOProperties.SSE_TYPE,
-            S3FileIOProperties.SSE_TYPE_CUSTOM,
-            S3FileIOProperties.SSE_KEY,
-            encodedKey,
-            S3FileIOProperties.SSE_MD5,
-            md5);
+            S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_CUSTOM,
+            S3FileIOProperties.SSE_KEY, encodedKey,
+            S3FileIOProperties.SSE_MD5, md5);
+    Map<String, String> properties = mergeProperties(aalProperties, testProperties);
     skipIfAnalyticsAcceleratorEnabled(
         new S3FileIOProperties(properties),
         "Analytics Accelerator Library does not support Server Side Custom Encryption");
@@ -524,13 +544,15 @@ public class TestS3FileIOIntegration {
     assertThat(response.sseCustomerKeyMD5()).isEqualTo(md5);
   }
 
-  @Test
-  public void testACL() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testACL(Map<String, String> aalProperties) throws Exception {
     requireACLSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
-            S3FileIOProperties.ACL, ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL.toString()));
+            S3FileIOProperties.ACL, ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL.toString());
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
 
     write(s3FileIO);
     validateRead(s3FileIO);
@@ -543,65 +565,81 @@ public class TestS3FileIOIntegration {
         .satisfies(grant -> assertThat(grant.permission()).isEqualTo(Permission.FULL_CONTROL));
   }
 
-  @Test
-  public void testClientFactorySerialization() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testClientFactorySerialization(Map<String, String> aalProperties) throws Exception {
     S3FileIO fileIO = new S3FileIO(clientFactory::s3);
-    fileIO.initialize(ImmutableMap.of());
+    fileIO.initialize(aalProperties);
     write(fileIO);
     byte[] data = TestHelpers.serialize(fileIO);
     S3FileIO fileIO2 = TestHelpers.deserialize(data);
     validateRead(fileIO2);
   }
 
-  @Test
-  public void testDeleteFilesMultipleBatches() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesMultipleBatches(Map<String, String> aalProperties) throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize)));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
 
     testDeleteFiles(deletionBatchSize * 2, s3FileIO);
   }
 
-  @Test
-  public void testDeleteFilesMultipleBatchesWithAccessPoints() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesMultipleBatchesWithAccessPoints(Map<String, String> aalProperties)
+      throws Exception {
     requireAccessPointSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
             S3FileIOProperties.DELETE_BATCH_SIZE,
             Integer.toString(deletionBatchSize),
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
-            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
+            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     testDeleteFiles(deletionBatchSize * 2, s3FileIO);
   }
 
-  @Test
-  public void testDeleteFilesMultipleBatchesWithCrossRegionAccessPoints() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesMultipleBatchesWithCrossRegionAccessPoints(
+      Map<String, String> aalProperties) throws Exception {
     requireKMSEncryptionSupport();
-    clientFactory.initialize(ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true"));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    clientFactory.initialize(mergeProperties(aalProperties, testProperties));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> accessPointProperties =
         ImmutableMap.of(
             S3FileIOProperties.DELETE_BATCH_SIZE,
             Integer.toString(deletionBatchSize),
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
-            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
+            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName));
+    s3FileIO.initialize(mergeProperties(aalProperties, accessPointProperties));
     testDeleteFiles(deletionBatchSize * 2, s3FileIO);
   }
 
-  @Test
-  public void testDeleteFilesLessThanBatchSize() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesLessThanBatchSize(Map<String, String> aalProperties) throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize)));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     testDeleteFiles(deletionBatchSize - 1, s3FileIO);
   }
 
-  @Test
-  public void testDeleteFilesSingleBatchWithRemainder() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesSingleBatchWithRemainder(Map<String, String> aalProperties)
+      throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize)));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     testDeleteFiles(5, s3FileIO);
   }
 
@@ -643,11 +681,12 @@ public class TestS3FileIOIntegration {
             });
   }
 
-  @Test
-  public void testFileRecoveryHappyPath() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testFileRecoveryHappyPath(Map<String, String> aalProperties) throws Exception {
     requireVersioningSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of());
+    s3FileIO.initialize(aalProperties);
     String filePath = String.format("s3://%s/%s/%s", bucketName, prefix, "someFile.parquet");
     write(s3FileIO, filePath);
     s3FileIO.deleteFile(filePath);
@@ -655,13 +694,15 @@ public class TestS3FileIOIntegration {
 
     assertThat(s3FileIO.recoverFile(filePath)).isTrue();
     assertThat(s3FileIO.newInputFile(filePath).exists()).isTrue();
+    s3FileIO.deleteFile(filePath);
   }
 
-  @Test
-  public void testFileRecoveryFailsToRecover() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testFileRecoveryFailsToRecover(Map<String, String> aalProperties) throws Exception {
     requireVersioningSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of());
+    s3FileIO.initialize(aalProperties);
     s3.putBucketVersioning(
         PutBucketVersioningRequest.builder()
             .bucket(bucketName)

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -141,9 +141,6 @@ public class TestS3InputStream {
   @ParameterizedTest
   @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
   public void testRangeRead(Map<String, String> aalProperties) throws Exception {
-    final S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(aalProperties);
-    skipIfAnalyticsAcceleratorEnabled(
-        s3FileIOProperties, "Analytics Accelerator Library does not support range reads");
     testRangeRead(s3, s3Async, aalProperties);
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorInputStreamWrapper.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorInputStreamWrapper.java
@@ -20,13 +20,14 @@ package org.apache.iceberg.aws.s3;
 
 import java.io.IOException;
 import org.apache.iceberg.io.FileIOMetricsContext;
+import org.apache.iceberg.io.RangeReadable;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.Counter;
 import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
 
 /** A wrapper to convert {@link S3SeekableInputStream} to Iceberg {@link SeekableInputStream} */
-class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream {
+class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream implements RangeReadable {
 
   private final S3SeekableInputStream delegate;
   private final Counter readBytes;
@@ -60,6 +61,16 @@ class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream {
     }
     readOperations.increment();
     return bytesRead;
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+    this.delegate.readFully(position, buffer, offset, length);
+  }
+
+  @Override
+  public int readTail(byte[] buffer, int offset, int length) throws IOException {
+    return this.delegate.readTail(buffer, offset, length);
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
@@ -75,7 +75,7 @@ class AnalyticsAcceleratorUtil {
 
     try {
       S3SeekableInputStream seekableInputStream = factory.createStream(uri, openStreamInfo);
-      return new AnalyticsAcceleratorInputStreamWrapper(seekableInputStream);
+      return new AnalyticsAcceleratorInputStreamWrapper(seekableInputStream, inputFile.metrics());
     } catch (IOException e) {
       throw new RuntimeIOException(
           e, "Failed to create S3 analytics accelerator input stream for: %s", inputFile.uri());

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 class StaticClientFactory implements AwsClientFactory {
   static S3Client client;
+  static S3AsyncClient asyncClient;
 
   @Override
   public S3Client s3() {
@@ -36,7 +37,7 @@ class StaticClientFactory implements AwsClientFactory {
 
   @Override
   public S3AsyncClient s3Async() {
-    return null;
+    return asyncClient;
   }
 
   @Override

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@
 [versions]
 activation = "1.1.1"
 aliyun-sdk-oss = "3.10.2"
-analyticsaccelerator = "1.0.0"
+analyticsaccelerator = "1.2.1"
 antlr = "4.9.3"
 antlr413 = "4.13.1" # For Spark 4.0 support
 aircompressor = "0.27"


### PR DESCRIPTION
**Description**
This PR is a follow-up to the existing PRs [#13347](https://github.com/apache/iceberg/pull/13347) and [#13348](https://github.com/apache/iceberg/pull/13348) in the series addressing feature gaps in the stream powered by [analytics-accelerator-s3](https://github.com/awslabs/analytics-accelerator-s3). It's part of our ongoing effort towards default-on integration. This PR specifically adds support for range-based reads.

**Testing**
When `s3.analytics-accelerator.enabled` is set to `true`, previously skipped integration test `testRangeRead` works now.