### PR TITLE
[iceberg-rest-fixture] fix sqlite error under high concurrent load

### DIFF
--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /usr/lib/iceberg-rest
 COPY --chown=iceberg:iceberg open-api/build/libs/iceberg-open-api-test-fixtures-runtime-*.jar /usr/lib/iceberg-rest/iceberg-rest-adapter.jar
 
 ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
-ENV CATALOG_URI=jdbc:sqlite::memory:
+ENV CATALOG_URI=jdbc:sqlite:file::memory:?cache=shared
 ENV CATALOG_JDBC_USER=user
 ENV CATALOG_JDBC_PASSWORD=password
 ENV REST_PORT=8181


### PR DESCRIPTION
Closes #13366

Use `file::memory:` to explicitly indicate an in-memory database that supports URI parameters.
Add the `?cache=shared` parameter to allow SQLite to use a shared in-memory cache so that all connections will access the same underlying in-memory database.

Tested locally by explicitly overriding the `CATALOG_URL` parameters in [pyiceberg's integration test setup](https://github.com/apache/iceberg-python/blob/e937f6a1811c9e090552a4ae2015a8032e7ea910/dev/docker-compose-integration.yml#L42-L55)
```
      - CATALOG_URI=jdbc:sqlite:file::memory:?cache=shared
```
and then running the "Reproduce" code in #13366