### PR TITLE
Remove block spacing guideline in contribute.md

### DIFF
--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -422,49 +422,6 @@ Use `this` when assigning values to instance variables, making it clear when the
 2. Use `.` to create a hierarchy of config groups
     * For example, `s3` in `s3.access-key-id`, `s3.secret-access-key`
 
-#### Block Spacing
-
-To improve readability and maintain consistency, always place a newline after control blocks (if, for, while, switch, etc.). 
-This helps separate logical sections of the code, making it easier to read and debug.
-
-```java
-  // BAD: No newline separator after `if` block
-  public static WriteBuilder write(OutputFile file) {
-     if (file instanceof EncryptedOutputFile) {
-        return write((EncryptedOutputFile) file);
-     }
-     return new WriteBuilder(file);
-  }
-
-  // GOOD: newline separator after `if` block
-  public static WriteBuilder write(OutputFile file) {
-     if (file instanceof EncryptedOutputFile) {
-        return write((EncryptedOutputFile) file);
-     }
-     
-     return new WriteBuilder(file);
-  }
-
-  // BAD: No newline separator after `for` block
-  public static Schema convert(Schema schema) {
-     ImmutableList.Builder<Field> fields = ImmutableList.builder();
-     for (NestedField f : schema.columns()) {
-        fields.add(convert(f));
-     }
-     return new Schema(fields.build());
-  }
-
-  // GOOD: newline separator after `for` block
-  public static Schema convert(Schema schema) {
-     ImmutableList.Builder<Field> fields = ImmutableList.builder();
-     for (NestedField f : schema.columns()) {
-        fields.add(convert(f));
-     }
-
-     return new Schema(fields.build());
-  }
-```
-
 ## Testing
 
 ### AssertJ


### PR DESCRIPTION
The current block spacing code style, as described [here](https://iceberg.apache.org/contribute/#accessing-instance-variables), seems too verbose and unnecessary for many simple cases. For example, even in the doc example in [contributing.md](https://github.com/apache/iceberg/blob/444fb9518ce4437fd901d9d9442a415391ade295/site/docs/contribute.md?plain=1#L425), it's questionable if the code is more readable with an extra newline:
```java
  // BAD: No newline separator after `if` block
  // Why is it that bad??
  public static WriteBuilder write(OutputFile file) {
     if (file instanceof EncryptedOutputFile) {
        return write((EncryptedOutputFile) file);
     }
     return new WriteBuilder(file);
  }

  // GOOD: newline separator after `if` block
  // Seems unnecessary...
  public static WriteBuilder write(OutputFile file) {
     if (file instanceof EncryptedOutputFile) {
        return write((EncryptedOutputFile) file);
     }
     
     return new WriteBuilder(file);
  }
```

Let's remove this and let developers and reviewers decide when to add an extra new line.
If there are strong opinions on this, let's then enforce this code style using static analysis tools like checkstyle, spotless, etc. Rather than relying on the visibility of the guideline.

This PR reverts changes in https://github.com/apache/iceberg/pull/12641.