### PR TITLE
Build: Use Java 17 to publish snapshot to Maven

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 21
       - run: |
           ./gradlew printVersion
           ./gradlew -DallModules publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
       - run: |
           ./gradlew printVersion
           ./gradlew -DallModules publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}


### PR DESCRIPTION
Use the higher supported JDK version to publish snapshot to Maven, to fix https://github.com/apache/iceberg/actions/runs/15812361048/job/44565434608.

Both Java and Scala are configured with `-release:11`, it means even use a higher version of JDK to build, the output jars still compatible with Java 11.

```
  tasks.withType(JavaCompile.class).configureEach {
    options.encoding = "UTF-8"
    options.release = 11
  }
```

```
    tasks.withType(ScalaCompile.class) {
      scalaCompileOptions.keepAliveMode.set(KeepAliveMode.DAEMON)
      // `options.release` doesn't seem to work for ScalaCompile :(
      sourceCompatibility = "11"
      targetCompatibility = "11"
      scalaCompileOptions.additionalParameters.add("-release:11")
    }
```

