### PR TITLE
add toString implementations to SparkPositionDeltaWrite

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -266,6 +266,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       }
     }
 
+    @Override
+    public String toString() {
+      return String.format("IcebergDeltaWrite(table=%s)", table);
+    }
+
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {
       Expression filter = Expressions.alwaysTrue();
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -268,7 +268,8 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     @Override
     public String toString() {
-      return String.format("IcebergDeltaWrite(table=%s)", table);
+      long snapshotId = table.currentSnapshot().snapshotId();
+      return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
     }
 
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -268,7 +268,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     @Override
     public String toString() {
-      long snapshotId = table.currentSnapshot().snapshotId();
+      long snapshotId = table.currentSnapshot() != null ? table.currentSnapshot().snapshotId() : -1;
       return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -279,7 +279,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     @Override
     public String toString() {
-      long snapshotId = table.currentSnapshot().snapshotId();
+      long snapshotId = table.currentSnapshot() != null ? table.currentSnapshot().snapshotId() : -1;
       return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -277,6 +277,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       }
     }
 
+    @Override
+    public String toString() {
+      return String.format("IcebergDeltaWrite(table=%s)", table);
+    }
+
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {
       Expression filter = Expressions.alwaysTrue();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -279,7 +279,8 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     @Override
     public String toString() {
-      return String.format("IcebergDeltaWrite(table=%s)", table);
+      long snapshotId = table.currentSnapshot().snapshotId();
+      return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
     }
 
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -279,7 +279,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     @Override
     public String toString() {
-      long snapshotId = table.currentSnapshot().snapshotId();
+      long snapshotId = table.currentSnapshot() != null ? table.currentSnapshot().snapshotId() : -1;
       return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
     }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -277,6 +277,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       }
     }
 
+    @Override
+    public String toString() {
+      return String.format("IcebergDeltaWrite(table=%s)", table);
+    }
+
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {
       Expression filter = Expressions.alwaysTrue();
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -279,7 +279,8 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     @Override
     public String toString() {
-      return String.format("IcebergDeltaWrite(table=%s)", table);
+      long snapshotId = table.currentSnapshot().snapshotId();
+      return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
     }
 
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {


### PR DESCRIPTION
When reading spark event logs that contain the `DeltaWrite` action in them, it is currently printed in the plan description like this:

```
(1) WriteDelta
Input [1]: [_col#1]
Arguments: org.apache.iceberg.spark.source.SparkPositionDeltaWrite@5234f6c5
```

While when parsing `ReplaceData` (that is implemented in [`SparkWrite`](https://github.com/apache/iceberg/blob/8353ac8f80799495cfdc32dd37222ed1b8d8070f/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java#L263-L266)), it looks like this:

```
(1) ReplaceData
Input [1]: [col#1]
Arguments: IcebergWrite(table=iceberg_table, format=PARQUET)
```

This change is about adding a toString method to SparkPositionDeltaWrite for more readable plans.