### PR TITLE
Flink:Backport Revise the display of the task name in TableMaintenance to show the specific task name

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
@@ -47,6 +47,11 @@ public class ExpireSnapshots {
     private Integer planningWorkerPoolSize;
     private int deleteBatchSize = DELETE_BATCH_SIZE_DEFAULT;
 
+    @Override
+    String maintenanceTaskName() {
+      return "ExpireSnapshots";
+    }
+
     /**
      * The snapshots older than this age will be removed.
      *

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/MaintenanceTaskBuilder.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/MaintenanceTaskBuilder.java
@@ -41,6 +41,8 @@ public abstract class MaintenanceTaskBuilder<T extends MaintenanceTaskBuilder<?>
 
   abstract DataStream<TaskResult> append(DataStream<Trigger> sourceStream);
 
+  abstract String maintenanceTaskName();
+
   /**
    * After a given number of Iceberg table commits since the last run, starts the downstream job.
    *

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -57,6 +57,11 @@ public class RewriteDataFiles {
     private final Map<String, String> rewriteOptions = Maps.newHashMapWithExpectedSize(6);
     private long maxRewriteBytes = Long.MAX_VALUE;
 
+    @Override
+    String maintenanceTaskName() {
+      return "RewriteDataFiles";
+    }
+
     /**
      * Allows committing compacted data files in batches. See {@link
      * org.apache.iceberg.actions.RewriteDataFiles#PARTIAL_PROGRESS_ENABLED} for more details.

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
@@ -305,8 +305,7 @@ public class TableMaintenance {
     }
 
     private static String nameFor(MaintenanceTaskBuilder<?> streamBuilder, int taskIndex) {
-      return String.format(
-          Locale.ROOT, "%s [%d]", streamBuilder.getClass().getSimpleName(), taskIndex);
+      return String.format(Locale.ROOT, "%s [%d]", streamBuilder.maintenanceTaskName(), taskIndex);
     }
   }
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
@@ -66,11 +66,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class TestTableMaintenance extends OperatorTestBase {
+  private static final String MAINTENANCE_TASK_NAME = "TestTableMaintenance";
   private static final String[] TASKS =
-      new String[] {
-        MaintenanceTaskBuilderForTest.class.getSimpleName() + " [0]",
-        MaintenanceTaskBuilderForTest.class.getSimpleName() + " [1]"
-      };
+      new String[] {MAINTENANCE_TASK_NAME + " [0]", MAINTENANCE_TASK_NAME + " [1]"};
   private static final TableChange DUMMY_CHANGE = TableChange.builder().commitCount(1).build();
   private static final List<Trigger> PROCESSED =
       Collections.synchronizedList(Lists.newArrayListWithCapacity(1));
@@ -321,8 +319,7 @@ class TestTableMaintenance extends OperatorTestBase {
     // Choose an operator from the maintenance task part of the graph
     Transformation<?> scheduledTransformation =
         env.getTransformations().stream()
-            .filter(
-                t -> t.getName().startsWith(MaintenanceTaskBuilderForTest.class.getSimpleName()))
+            .filter(t -> t.getName().startsWith(MAINTENANCE_TASK_NAME))
             .findFirst()
             .orElseThrow();
     assertThat(scheduledTransformation.getUid()).contains(anotherUid);
@@ -417,6 +414,11 @@ class TestTableMaintenance extends OperatorTestBase {
       this.success = success;
       this.id = counter;
       ++counter;
+    }
+
+    @Override
+    String maintenanceTaskName() {
+      return MAINTENANCE_TASK_NAME;
     }
 
     @Override

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
@@ -47,6 +47,11 @@ public class ExpireSnapshots {
     private Integer planningWorkerPoolSize;
     private int deleteBatchSize = DELETE_BATCH_SIZE_DEFAULT;
 
+    @Override
+    String maintenanceTaskName() {
+      return "ExpireSnapshots";
+    }
+
     /**
      * The snapshots older than this age will be removed.
      *

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/MaintenanceTaskBuilder.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/MaintenanceTaskBuilder.java
@@ -41,6 +41,8 @@ public abstract class MaintenanceTaskBuilder<T extends MaintenanceTaskBuilder<?>
 
   abstract DataStream<TaskResult> append(DataStream<Trigger> sourceStream);
 
+  abstract String maintenanceTaskName();
+
   /**
    * After a given number of Iceberg table commits since the last run, starts the downstream job.
    *

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -57,6 +57,11 @@ public class RewriteDataFiles {
     private final Map<String, String> rewriteOptions = Maps.newHashMapWithExpectedSize(6);
     private long maxRewriteBytes = Long.MAX_VALUE;
 
+    @Override
+    String maintenanceTaskName() {
+      return "RewriteDataFiles";
+    }
+
     /**
      * Allows committing compacted data files in batches. See {@link
      * org.apache.iceberg.actions.RewriteDataFiles#PARTIAL_PROGRESS_ENABLED} for more details.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
@@ -305,8 +305,7 @@ public class TableMaintenance {
     }
 
     private static String nameFor(MaintenanceTaskBuilder<?> streamBuilder, int taskIndex) {
-      return String.format(
-          Locale.ROOT, "%s [%d]", streamBuilder.getClass().getSimpleName(), taskIndex);
+      return String.format(Locale.ROOT, "%s [%d]", streamBuilder.maintenanceTaskName(), taskIndex);
     }
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
@@ -66,11 +66,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class TestTableMaintenance extends OperatorTestBase {
+  private static final String MAINTENANCE_TASK_NAME = "TestTableMaintenance";
   private static final String[] TASKS =
-      new String[] {
-        MaintenanceTaskBuilderForTest.class.getSimpleName() + " [0]",
-        MaintenanceTaskBuilderForTest.class.getSimpleName() + " [1]"
-      };
+      new String[] {MAINTENANCE_TASK_NAME + " [0]", MAINTENANCE_TASK_NAME + " [1]"};
   private static final TableChange DUMMY_CHANGE = TableChange.builder().commitCount(1).build();
   private static final List<Trigger> PROCESSED =
       Collections.synchronizedList(Lists.newArrayListWithCapacity(1));
@@ -321,8 +319,7 @@ class TestTableMaintenance extends OperatorTestBase {
     // Choose an operator from the maintenance task part of the graph
     Transformation<?> scheduledTransformation =
         env.getTransformations().stream()
-            .filter(
-                t -> t.getName().startsWith(MaintenanceTaskBuilderForTest.class.getSimpleName()))
+            .filter(t -> t.getName().startsWith(MAINTENANCE_TASK_NAME))
             .findFirst()
             .orElseThrow();
     assertThat(scheduledTransformation.getUid()).contains(anotherUid);
@@ -417,6 +414,11 @@ class TestTableMaintenance extends OperatorTestBase {
       this.success = success;
       this.id = counter;
       ++counter;
+    }
+
+    @Override
+    String maintenanceTaskName() {
+      return MAINTENANCE_TASK_NAME;
     }
 
     @Override


### PR DESCRIPTION
Back port https://github.com/apache/iceberg/pull/13024 to Flink 1.19 and 1.20