### PR TITLE
Docs: Fix typo in KafkaConnect docs

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -506,7 +506,7 @@ If `nested` is on:
 `_kafka_metadata.topic`, `_kafka_metadata.partition`, `_kafka_metadata.offset`, `_kafka_metadata.timestamp`
 
 If `nested` is off:
-`_kafka_metdata_topic`, `_kafka_metadata_partition`, `_kafka_metadata_offset`, `_kafka_metadata_timestamp`
+`_kafka_metadata_topic`, `_kafka_metadata_partition`, `_kafka_metadata_offset`, `_kafka_metadata_timestamp`
 
 ### MongoDebeziumTransform
 _(Experimental)_


### PR DESCRIPTION
Fixes a minor typo in the KafkaConnect docs (missing `a` in `kafka_metdata_topic`).