### PR TITLE
Remove JSpecify annotations from bundled-guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,6 +260,7 @@ project(':iceberg-bundled-guava') {
       // may be LGPL - use ALv2 findbugs-annotations instead
       exclude group: 'com.google.errorprone'
       exclude group: 'com.google.j2objc'
+      exclude group: 'org.jspecify'
     }
   }
 


### PR DESCRIPTION
These classes are not shaded and cause duplicate class conflicts.