### PR TITLE
Build: Run CI actions with JDK 17

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
       - run: |
           echo "Using the old version tag, as per git describe, of $(git describe)";
       - run: ./gradlew revapi --rerun-tasks

--- a/.github/workflows/jmh-benchmarks.yml
+++ b/.github/workflows/jmh-benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 11
+        java-version: 17
     - uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/recurring-jmh-benchmarks.yml
+++ b/.github/workflows/recurring-jmh-benchmarks.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
#13381 added a check that makes sure Spark 4.0 is built using JDK 17+, however, this causes other CI actions to fail as they are running with JDK 11 only.

An alternative would be to set `-DsparkVersions=` in those CI actions but I think using JDK 17 instead is probably better