### PR TITLE
Core: Fix loading for missing tables with metadata table names

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -103,7 +103,8 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
       TableIdentifier baseTableIdentifier = TableIdentifier.of(identifier.namespace().levels());
       TableOperations ops = newTableOps(baseTableIdentifier);
       if (ops.current() == null) {
-        throw new NoSuchTableException("Table does not exist: %s", baseTableIdentifier);
+        throw new NoSuchTableException(
+            "Tables do not exist: %s, %s", identifier, baseTableIdentifier);
       }
 
       return MetadataTableUtils.createMetadataTableInstance(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -403,6 +403,10 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       if (metadataType != null) {
         // attempt to load a metadata table using the identifier's namespace as the base table
         TableIdentifier baseIdent = TableIdentifier.of(identifier.namespace().levels());
+        if (!baseIdent.hasNamespace()) {
+          throw original;
+        }
+
         try {
           response = loadInternal(context, baseIdent, snapshotMode);
           loadedIdent = baseIdent;

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -960,6 +960,18 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void testLoadMissingTableWithMetadataName() {
+    C catalog = catalog();
+
+    TableIdentifier table = TableIdentifier.of("ns", "entries");
+
+    assertThat(catalog.tableExists(table)).as("Table should not exist").isFalse();
+    assertThatThrownBy(() -> catalog.loadTable(table))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessageStartingWith("Tables do not exist: ns.entries, ns");
+  }
+
+  @Test
   public void testRenameTable() {
     C catalog = catalog();
 


### PR DESCRIPTION
Fix bug where creating a table with a metadata table name fails in Spark using the REST Catalog fails. Closes #13388 