### PR TITLE
AWS: Add Read Vector IO support to AAL

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/ParquetObjectRange.java
+++ b/api/src/main/java/org/apache/iceberg/io/ParquetObjectRange.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
+public class ParquetObjectRange {
+  public CompletableFuture<ByteBuffer> getByteBuffer() {
+    return byteBuffer;
+  }
+
+  public void setByteBuffer(CompletableFuture<ByteBuffer> byteBuffer) {
+    this.byteBuffer = byteBuffer;
+  }
+
+  public long getOffset() {
+    return offset;
+  }
+
+  public void setOffset(long offset) {
+    this.offset = offset;
+  }
+
+  public int getLength() {
+    return length;
+  }
+
+  public void setLength(int length) {
+    this.length = length;
+  }
+
+  private CompletableFuture<ByteBuffer> byteBuffer;
+  private long offset;
+  private int length;
+
+  public ParquetObjectRange(CompletableFuture<ByteBuffer> byteBuffer, long offset, int length) {
+    this.byteBuffer = byteBuffer;
+    this.offset = offset;
+    this.length = length;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/SeekableInputStream.java
+++ b/api/src/main/java/org/apache/iceberg/io/SeekableInputStream.java
@@ -20,6 +20,9 @@ package org.apache.iceberg.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.IntFunction;
 
 /**
  * {@code SeekableInputStream} is an interface with the methods needed to read data from a file or
@@ -43,4 +46,14 @@ public abstract class SeekableInputStream extends InputStream {
    * @throws IOException If the underlying stream throws IOException
    */
   public abstract void seek(long newPos) throws IOException;
+
+  public void readVectored(List<ParquetObjectRange> ranges, IntFunction<ByteBuffer> allocate)
+      throws IOException {
+    throw new UnsupportedOperationException(
+        "Default iceberg stream doesn't support read vector io");
+  }
+
+  public boolean readVectoredAvailable(IntFunction<ByteBuffer> allocate) {
+    return false;
+  }
 }

--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -39,7 +39,7 @@ project(":iceberg-aws-bundle") {
     implementation "software.amazon.awssdk:dynamodb"
     implementation "software.amazon.awssdk:lakeformation"
 
-    implementation libs.analyticsaccelerator.s3
+    implementation(libs.analyticsaccelerator.s3)
   }
 
   shadowJar {
@@ -50,10 +50,6 @@ project(":iceberg-aws-bundle") {
     from(projectDir) {
       include 'LICENSE'
       include 'NOTICE'
-    }
-
-    dependencies {
-      exclude(dependency('org.slf4j:slf4j-api'))
     }
 
     // relocate AWS-specific versions

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.glue;
 
+import static org.apache.iceberg.aws.s3.S3TestUtil.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -28,6 +29,7 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.aws.AwsIntegTestUtil;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.aws.s3.S3TestUtil;
 import org.apache.iceberg.aws.util.RetryDetector;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -160,6 +162,9 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   public void testNoRetryAwarenessCorruptsTable() {
     // This test exists to replicate the issue the prior test validates the fix for
     // See https://github.com/apache/iceberg/issues/7151
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(),
+        "Analytics Accelerator Library does not support custom Iceberg exception: NotFoundException");
     String namespace = createNamespace();
     String tableName = createTable(namespace);
     TableIdentifier tableId = TableIdentifier.of(namespace, tableName);

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
@@ -26,6 +26,8 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
@@ -65,6 +67,18 @@ public class MinioUtil {
     if (legacyMd5PluginEnabled) {
       builder.addPlugin(LegacyMd5Plugin.create());
     }
+    builder.credentialsProvider(
+        StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(container.getUserName(), container.getPassword())));
+    builder.applyMutation(mutator -> mutator.endpointOverride(uri));
+    builder.region(Region.US_EAST_1);
+    builder.forcePathStyle(true); // OSX won't resolve subdomains
+    return builder.build();
+  }
+
+  public static S3AsyncClient createS3AsyncClient(MinIOContainer container) {
+    URI uri = URI.create(container.getS3URL());
+    S3AsyncClientBuilder builder = S3AsyncClient.builder();
     builder.credentialsProvider(
         StaticCredentialsProvider.create(
             AwsBasicCredentials.create(container.getUserName(), container.getPassword())));

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
@@ -18,7 +18,14 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class S3TestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3TestUtil.class);
 
   private S3TestUtil() {}
 
@@ -28,5 +35,19 @@ public class S3TestUtil {
 
   public static String getKeyFromUri(String s3Uri) {
     return new S3URI(s3Uri).key();
+  }
+
+  /**
+   * Skip a test if the Analytics Accelerator Library for Amazon S3 is enabled.
+   *
+   * @param properties properties to probe
+   */
+  public static void skipIfAnalyticsAcceleratorEnabled(
+      S3FileIOProperties properties, String message) {
+    boolean isAcceleratorEnabled = properties.isS3AnalyticsAcceleratorEnabled();
+    if (isAcceleratorEnabled) {
+      LOG.warn(message);
+    }
+    assumeThat(!isAcceleratorEnabled).describedAs(message).isTrue();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -265,10 +265,14 @@ public class TestS3FileIOIntegration {
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testNewInputStreamWithMultiRegionAccessPoint() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStreamWithMultiRegionAccessPoint(Map<String, String> aalProperties)
+      throws Exception {
     assumeThat(multiRegionAccessPointAlias).isNotEmpty();
-    clientFactory.initialize(ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true"));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    clientFactory.initialize(mergeProperties(aalProperties, testProperties));
     S3Client s3Client = clientFactory.s3();
     s3Client.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorInputStreamWrapper.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorInputStreamWrapper.java
@@ -77,6 +77,7 @@ class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream {
   @Override
   public void readVectored(List<ParquetObjectRange> ranges, IntFunction<ByteBuffer> allocate)
       throws IOException {
+    LOG.info("Read vectored ranges: {}", ranges);
     this.delegate.readVectored(convertRanges(ranges), allocate, LOG_BYTE_BUFFER_RELEASED);
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
@@ -27,13 +27,13 @@ import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.s3.analyticsaccelerator.ObjectClientConfiguration;
-import software.amazon.s3.analyticsaccelerator.S3SdkObjectClient;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguration;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
+import software.amazon.s3.analyticsaccelerator.S3SyncSdkObjectClient;
 import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
 import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
@@ -44,13 +44,13 @@ class AnalyticsAcceleratorUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(AnalyticsAcceleratorUtil.class);
 
-  private static final Cache<Pair<S3AsyncClient, S3FileIOProperties>, S3SeekableInputStreamFactory>
+  private static final Cache<Pair<S3Client, S3FileIOProperties>, S3SeekableInputStreamFactory>
       STREAM_FACTORY_CACHE =
           Caffeine.newBuilder()
               .maximumSize(100)
               .removalListener(
                   (RemovalListener<
-                          Pair<S3AsyncClient, S3FileIOProperties>, S3SeekableInputStreamFactory>)
+                          Pair<S3Client, S3FileIOProperties>, S3SeekableInputStreamFactory>)
                       (key, factory, cause) -> close(factory))
               .build();
 
@@ -70,7 +70,7 @@ class AnalyticsAcceleratorUtil {
 
     S3SeekableInputStreamFactory factory =
         STREAM_FACTORY_CACHE.get(
-            Pair.of(inputFile.asyncClient(), inputFile.s3FileIOProperties()),
+            Pair.of(inputFile.client(), inputFile.s3FileIOProperties()),
             AnalyticsAcceleratorUtil::createNewFactory);
 
     try {
@@ -83,7 +83,7 @@ class AnalyticsAcceleratorUtil {
   }
 
   private static S3SeekableInputStreamFactory createNewFactory(
-      Pair<S3AsyncClient, S3FileIOProperties> cacheKey) {
+      Pair<S3Client, S3FileIOProperties> cacheKey) {
     ConnectorConfiguration connectorConfiguration =
         new ConnectorConfiguration(cacheKey.second().s3AnalyticsacceleratorProperties());
     S3SeekableInputStreamConfiguration streamConfiguration =
@@ -91,7 +91,10 @@ class AnalyticsAcceleratorUtil {
     ObjectClientConfiguration objectClientConfiguration =
         ObjectClientConfiguration.fromConfiguration(connectorConfiguration);
 
-    ObjectClient objectClient = new S3SdkObjectClient(cacheKey.first(), objectClientConfiguration);
+    // Use the existing S3Client from the cache key
+    S3Client s3Client = cacheKey.first();
+
+    ObjectClient objectClient = new S3SyncSdkObjectClient(s3Client, objectClientConfiguration);
     return new S3SeekableInputStreamFactory(objectClient, streamConfiguration);
   }
 
@@ -105,8 +108,7 @@ class AnalyticsAcceleratorUtil {
     }
   }
 
-  public static void cleanupCache(
-      S3AsyncClient asyncClient, S3FileIOProperties s3FileIOProperties) {
-    STREAM_FACTORY_CACHE.invalidate(Pair.of(asyncClient, s3FileIOProperties));
+  public static void cleanupCache(S3Client client, S3FileIOProperties s3FileIOProperties) {
+    STREAM_FACTORY_CACHE.invalidate(Pair.of(client, s3FileIOProperties));
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/PrefixedS3Client.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/PrefixedS3Client.java
@@ -109,14 +109,14 @@ class PrefixedS3Client implements AutoCloseable {
   @Override
   public void close() {
     if (null != s3Client) {
+      // cleanup usage in analytics accelerator if any
+      if (s3FileIOProperties().isS3AnalyticsAcceleratorEnabled()) {
+        AnalyticsAcceleratorUtil.cleanupCache(s3Client, s3FileIOProperties);
+      }
       s3Client.close();
     }
 
     if (null != s3AsyncClient) {
-      // cleanup usage in analytics accelerator if any
-      if (s3FileIOProperties().isS3AnalyticsAcceleratorEnabled()) {
-        AnalyticsAcceleratorUtil.cleanupCache(s3AsyncClient, s3FileIOProperties);
-      }
       s3AsyncClient.close();
     }
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 class StaticClientFactory implements AwsClientFactory {
   static S3Client client;
+  static S3AsyncClient asyncClient;
 
   @Override
   public S3Client s3() {
@@ -36,7 +37,7 @@ class StaticClientFactory implements AwsClientFactory {
 
   @Override
   public S3AsyncClient s3Async() {
-    return null;
+    return asyncClient;
   }
 
   @Override

--- a/build.gradle
+++ b/build.gradle
@@ -118,8 +118,8 @@ allprojects {
   group = "org.apache.iceberg"
   version = projectVersion
   repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@
 [versions]
 activation = "1.1.1"
 aliyun-sdk-oss = "3.10.2"
-analyticsaccelerator = "1.2.1"
+analyticsaccelerator = "SNAPSHOT"
 antlr = "4.9.3"
 antlr413 = "4.13.1" # For Spark 4.0 support
 aircompressor = "0.27"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@
 [versions]
 activation = "1.1.1"
 aliyun-sdk-oss = "3.10.2"
-analyticsaccelerator = "1.2.0"
+analyticsaccelerator = "1.2.1"
 antlr = "4.9.3"
 antlr413 = "4.13.1" # For Spark 4.0 support
 aircompressor = "0.27"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@
 [versions]
 activation = "1.1.1"
 aliyun-sdk-oss = "3.10.2"
-analyticsaccelerator = "1.0.0"
+analyticsaccelerator = "1.2.0"
 antlr = "4.9.3"
 antlr413 = "4.13.1" # For Spark 4.0 support
 aircompressor = "0.27"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@
 [versions]
 activation = "1.1.1"
 aliyun-sdk-oss = "3.10.2"
-analyticsaccelerator = "SNAPSHOT"
+analyticsaccelerator = "1.2.2"
 antlr = "4.9.3"
 antlr413 = "4.13.1" # For Spark 4.0 support
 aircompressor = "0.27"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@
 [versions]
 activation = "1.1.1"
 aliyun-sdk-oss = "3.10.2"
-analyticsaccelerator = "1.2.2"
+analyticsaccelerator = "SNAPSHOT"
 antlr = "4.9.3"
 antlr413 = "4.13.1" # For Spark 4.0 support
 aircompressor = "0.27"

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1339,7 +1339,6 @@ public class Parquet {
         if (fileDecryptionProperties != null) {
           optionsBuilder.withDecryption(fileDecryptionProperties);
         }
-        optionsBuilder.withUseHadoopVectoredIo(true);
         ParquetReadOptions options = optionsBuilder.build();
 
         NameMapping mapping;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1339,7 +1339,7 @@ public class Parquet {
         if (fileDecryptionProperties != null) {
           optionsBuilder.withDecryption(fileDecryptionProperties);
         }
-
+        optionsBuilder.withUseHadoopVectoredIo(true);
         ParquetReadOptions options = optionsBuilder.build();
 
         NameMapping mapping;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -21,6 +21,11 @@ package org.apache.iceberg.parquet;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -29,11 +34,14 @@ import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.hadoop.HadoopOutputFile;
 import org.apache.iceberg.io.DelegatingInputStream;
 import org.apache.iceberg.io.DelegatingOutputStream;
+import org.apache.iceberg.io.ParquetObjectRange;
+import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.hadoop.util.HadoopStreams;
 import org.apache.parquet.io.DelegatingPositionOutputStream;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.ParquetFileRange;
 import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.io.SeekableInputStream;
 
@@ -120,6 +128,33 @@ class ParquetIO {
     @Override
     public void seek(long newPos) throws IOException {
       delegate.seek(newPos);
+    }
+
+    @Override
+    public boolean readVectoredAvailable(ByteBufferAllocator allocate) {
+      IntFunction<ByteBuffer> delegateAllocate = (allocate::allocate);
+      return delegate.readVectoredAvailable(delegateAllocate);
+    }
+
+    @Override
+    public void readVectored(List<ParquetFileRange> ranges, ByteBufferAllocator allocate)
+        throws IOException {
+      IntFunction<ByteBuffer> delegateAllocate = (allocate::allocate);
+      List<ParquetObjectRange> delegateRange = convertRanges(ranges);
+
+      delegate.readVectored(delegateRange, delegateAllocate);
+    }
+
+    private static List<ParquetObjectRange> convertRanges(List<ParquetFileRange> ranges) {
+      return ranges.stream()
+          .map(
+              parquetFileRange -> {
+                CompletableFuture<ByteBuffer> result = new CompletableFuture<>();
+                parquetFileRange.setDataReadFuture(result);
+                return new ParquetObjectRange(
+                    result, parquetFileRange.getOffset(), parquetFileRange.getLength());
+              })
+          .collect(Collectors.toList());
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -141,7 +141,6 @@ class ParquetIO {
         throws IOException {
       IntFunction<ByteBuffer> delegateAllocate = (allocate::allocate);
       List<ParquetObjectRange> delegateRange = convertRanges(ranges);
-
       delegate.readVectored(delegateRange, delegateAllocate);
     }
 


### PR DESCRIPTION
### What Am I doing:
https://github.com/apache/iceberg/issues/13254
This is to add in the vectored IO path to Iceberg

### How am I doing this:
Adding the needed methods to Iceberg's Parquet IO implementation. 
Defaulted OFF to the default Iceberg Stream and overrode it for AAL where we support it.
Added a mapping from parquet's object range to an iceberg specific one and then added a mapping from icebergs object range to AAL's

Depends on https://github.com/apache/iceberg/pull/13347

Note this includes commits from another: PR 
this commit: 85afb8914c5d704d695df29eec421f0e1d9c25f4 is the one for read vector.

### How have I tested this
- Tested with and without AAL and could see the default non-read vectored methods being used
- Ran a suite of benchmarks and confirmed the ranges passed through are as expected
- Added integration tests for our read vectored approach