### PR TITLE
Exclude org.apache.arrow.c.** from shading

### DIFF
--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -309,7 +309,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
     // relocate Arrow and related deps to shade Iceberg specific version
     relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
-    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+    relocate ('org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow') {
+      exclude 'org.apache.arrow.c.**'
+    }
     relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -309,7 +309,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
     // relocate Arrow and related deps to shade Iceberg specific version
     relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
-    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+    relocate ('org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow') {
+      exclude 'org.apache.arrow.c.**'
+    }
     relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -314,7 +314,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.apache.hc.core5', 'org.apache.iceberg.shaded.org.apache.hc.core5'
     // relocate Arrow and related deps to shade Iceberg specific version
     relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
-    relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+    relocate ('org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow') {
+      exclude 'org.apache.arrow.c.**'
+    }
     relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'


### PR DESCRIPTION
Comet relies on native Arrow JNI classes (org.apache.arrow.c.jni), which must remain unshaded. This change excludes them from relocation so Comet can interoperate with Iceberg.
This does not affect Iceberg functionality, as Iceberg does not use org.apache.arrow.c.* directly.