### PR TITLE
GCS: Add Iceberg version to UserAgent in GCS requests

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.SerializableSupplier;
 
 class PrefixedStorage implements AutoCloseable {
-  // User Agent Prefix set by the GCS client.
   private static final String GCS_FILE_IO_USER_AGENT = "gcsfileio/" + EnvironmentContext.get();
   private final String storagePrefix;
   private final GCPProperties gcpProperties;

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.gcp.gcs;
 
+import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.OAuth2CredentialsWithRefresh;
@@ -25,12 +26,16 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Map;
+import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.SerializableSupplier;
 
 class PrefixedStorage implements AutoCloseable {
+  // User Agent Prefix set by the GCS client.
+  private static final String GCS_FILE_IO_USER_AGENT = "gcsfileio/" + EnvironmentContext.get();
   private final String storagePrefix;
   private final GCPProperties gcpProperties;
   private SerializableSupplier<Storage> storage;
@@ -49,7 +54,11 @@ class PrefixedStorage implements AutoCloseable {
     if (null == storage) {
       this.storage =
           () -> {
-            StorageOptions.Builder builder = StorageOptions.newBuilder();
+            StorageOptions.Builder builder =
+                StorageOptions.newBuilder()
+                    .setHeaderProvider(
+                        FixedHeaderProvider.create(
+                            ImmutableMap.of("User-agent", GCS_FILE_IO_USER_AGENT)));
 
             gcpProperties.projectId().ifPresent(builder::setProjectId);
             gcpProperties.clientLibToken().ifPresent(builder::setClientLibToken);

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
+import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
@@ -54,5 +55,18 @@ public class TestPrefixedStorage {
     assertThat(storage.storage()).isNotNull();
     assertThat(storage.storagePrefix()).isEqualTo("gs://bucket");
     assertThat(storage.gcpProperties().properties()).isEqualTo(properties);
+  }
+
+  @Test
+  public void userAgentPrefix() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID, "myProject",
+            GCPProperties.GCS_OAUTH2_TOKEN, "token",
+            GCPProperties.GCS_USER_PROJECT, "myUserProject");
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+
+    assertThat(storage.storage().getOptions().getUserAgent())
+        .isEqualTo("gcsfileio/" + EnvironmentContext.get());
   }
 }


### PR DESCRIPTION
Currently the user-agent for traffic from GCSFileIO to GCS is unknown, having an user-agent will help in analyzing and prioritizing the performance improvements for Iceberg FileIO integration with GCS.

Fixes #13393 