### PR TITLE
Spark,Core: Refactor Delete OrphanFiles by moving common code from Spark to core

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/FileURI.java
+++ b/core/src/main/java/org/apache/iceberg/actions/FileURI.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import java.net.URI;
+import java.util.Map;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+
+public class FileURI {
+
+  private String scheme;
+  private String authority;
+  private String path;
+  private String uriAsString;
+
+  public FileURI(
+      String uriAsString, Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    URI uri = new Path(uriAsString).toUri();
+    this.scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
+    this.authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
+    this.path = uri.getPath();
+    this.uriAsString = uriAsString;
+  }
+
+  public FileURI(String scheme, String authority, String path, String uriAsString) {
+    this.scheme = scheme;
+    this.authority = authority;
+    this.path = path;
+    this.uriAsString = uriAsString;
+  }
+
+  public FileURI() {}
+
+  public String getScheme() {
+    return scheme;
+  }
+
+  public void setScheme(String scheme) {
+    this.scheme = scheme;
+  }
+
+  public String getAuthority() {
+    return authority;
+  }
+
+  public void setAuthority(String authority) {
+    this.authority = authority;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getUriAsString() {
+    return uriAsString;
+  }
+
+  public void setUriAsString(String uriAsString) {
+    this.uriAsString = uriAsString;
+  }
+
+  public boolean schemeMatch(FileURI another) {
+    return uriComponentMatch(scheme, another.getScheme());
+  }
+
+  public boolean authorityMatch(FileURI another) {
+    return uriComponentMatch(authority, another.getAuthority());
+  }
+
+  private boolean uriComponentMatch(String valid, String actual) {
+    return Strings.isNullOrEmpty(valid) || valid.equalsIgnoreCase(actual);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("scheme", scheme)
+        .add("authority", authority)
+        .add("path", path)
+        .add("uriAsString", uriAsString)
+        .toString();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/FileURI.java
+++ b/core/src/main/java/org/apache/iceberg/actions/FileURI.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.actions;
 
 import java.net.URI;
 import java.util.Map;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 
@@ -31,20 +30,18 @@ public class FileURI {
   private String path;
   private String uriAsString;
 
-  public FileURI(
-      String uriAsString, Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
-    URI uri = new Path(uriAsString).toUri();
-    this.scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
-    this.authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
-    this.path = uri.getPath();
-    this.uriAsString = uriAsString;
-  }
-
   public FileURI(String scheme, String authority, String path, String uriAsString) {
     this.scheme = scheme;
     this.authority = authority;
     this.path = path;
     this.uriAsString = uriAsString;
+  }
+
+  public FileURI(URI uri, Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    this.scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
+    this.authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
+    this.path = uri.getPath();
+    this.uriAsString = uri.toString();
   }
 
   public FileURI() {}

--- a/core/src/main/java/org/apache/iceberg/util/FileSystemWalker.java
+++ b/core/src/main/java/org/apache/iceberg/util/FileSystemWalker.java
@@ -50,10 +50,11 @@ public class FileSystemWalker {
    * Recursively lists files in the specified directory that satisfy the given conditions. Use
    * {@link PartitionAwareHiddenPathFilter} to filter out hidden paths.
    *
-   * @param io File system interface supporting prefix operations
+   * @param io FileIO implementation interface supporting prefix operations
    * @param dir Base directory to start recursive listing
-   * @param specs Map of {@link PartitionSpec partition specs} for this table.
-   * @param filter Additional filter condition for files
+   * @param specs Map of {@link PartitionSpec partition specs} for this table. Used to prevent
+   *     partition directories from being filtered as hidden paths.
+   * @param filter File filter condition, only files satisfying this condition will be collected.
    * @param fileConsumer Consumer to accept matching file locations
    */
   public static void listDirRecursivelyWithFileIO(
@@ -78,8 +79,8 @@ public class FileSystemWalker {
   }
 
   /**
-   * Recursively traverses the specified directory using Hadoop API to collect file paths that meet
-   * the conditions.
+   * Recursively traverses the specified directory using Hadoop FileSystem API to collect file paths
+   * that meet the conditions.
    *
    * <p>This method provides depth control and subdirectory quantity limitation:
    *
@@ -91,9 +92,10 @@ public class FileSystemWalker {
    * </ul>
    *
    * @param dir The starting directory path to traverse
-   * @param specs Map of {@link PartitionSpec partition specs} for this table.
+   * @param specs Map of {@link PartitionSpec partition specs} for this table. Used to prevent *
+   *     partition directories from being filtered as hidden paths.
    * @param filter File filter condition, only files satisfying this condition will be collected
-   * @param conf Hadoop conf
+   * @param conf Hadoop's configuration used to load the FileSystem
    * @param maxDepth Maximum recursion depth limit
    * @param maxDirectSubDirs Upper limit of subdirectories that can be processed directly
    * @param directoryConsumer Consumer for collecting parameter for storing unprocessed directory

--- a/core/src/main/java/org/apache/iceberg/util/FileSystemWalker.java
+++ b/core/src/main/java/org/apache/iceberg/util/FileSystemWalker.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.hadoop.HiddenPathFilter;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.SupportsPrefixOperations;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * Utility class for recursively traversing file systems and identifying hidden paths. Provides
+ * methods to list files recursively while filtering out hidden paths based on specified criteria.
+ */
+public class FileSystemWalker {
+
+  private FileSystemWalker() {}
+
+  /**
+   * Recursively lists files in the specified directory that satisfy the given conditions. Use
+   * {@link PartitionAwareHiddenPathFilter} to filter out hidden paths.
+   *
+   * @param io File system interface supporting prefix operations
+   * @param dir Base directory to start recursive listing
+   * @param specs Map of {@link PartitionSpec partition specs} for this table.
+   * @param predicate Additional filter condition for files
+   * @param consumer Consumer to accept matching file locations
+   */
+  public static void listDirRecursivelyWithFileIO(
+      SupportsPrefixOperations io,
+      String dir,
+      Map<Integer, PartitionSpec> specs,
+      Predicate<FileInfo> predicate,
+      Consumer<String> consumer) {
+    PathFilter pathFilter = PartitionAwareHiddenPathFilter.forSpecs(specs);
+    String listPath = dir;
+    if (!dir.endsWith("/")) {
+      listPath = dir + "/";
+    }
+
+    Iterable<FileInfo> files = io.listPrefix(listPath);
+    for (FileInfo file : files) {
+      Path path = new Path(file.location());
+      if (!isHiddenPath(dir, path, pathFilter) && predicate.test(file)) {
+        consumer.accept(file.location());
+      }
+    }
+  }
+
+  /**
+   * Recursively traverses the specified directory using Hadoop API to collect file paths that meet
+   * the conditions.
+   *
+   * <p>This method provides depth control and subdirectory quantity limitation:
+   *
+   * <ul>
+   *   <li>Stops traversal when maximum recursion depth is reached and adds current directory to
+   *       pending list
+   *   <li>Stops traversal when number of direct subdirectories exceeds threshold and adds
+   *       subdirectories to pending list
+   * </ul>
+   *
+   * @param dir The starting directory path to traverse
+   * @param specs Map of {@link PartitionSpec partition specs} for this table.
+   * @param predicate File filter condition, only files satisfying this condition will be collected
+   * @param conf Hadoop conf
+   * @param maxDepth Maximum recursion depth limit
+   * @param maxDirectSubDirs Upper limit of subdirectories that can be processed directly
+   * @param remainingSubDirs Consumer for collecting parameter for storing unprocessed directory
+   *     paths
+   * @param files Consumer for collecting qualified file paths
+   */
+  public static void listDirRecursivelyWithHadoop(
+      String dir,
+      Map<Integer, PartitionSpec> specs,
+      Predicate<FileStatus> predicate,
+      Configuration conf,
+      int maxDepth,
+      int maxDirectSubDirs,
+      Consumer<String> remainingSubDirs,
+      Consumer<String> files) {
+    PathFilter pathFilter = PartitionAwareHiddenPathFilter.forSpecs(specs);
+    if (maxDepth <= 0) {
+      remainingSubDirs.accept(dir);
+      return;
+    }
+
+    try {
+      Path path = new Path(dir);
+      FileSystem fs = path.getFileSystem(conf);
+      List<String> subDirs = Lists.newArrayList();
+
+      for (FileStatus file : fs.listStatus(path, pathFilter)) {
+        if (file.isDirectory()) {
+          subDirs.add(file.getPath().toString());
+        } else if (file.isFile() && predicate.test(file)) {
+          files.accept(file.getPath().toString());
+        }
+      }
+
+      if (subDirs.size() > maxDirectSubDirs) {
+        subDirs.forEach(remainingSubDirs);
+        return;
+      }
+
+      for (String subDir : subDirs) {
+        listDirRecursivelyWithHadoop(
+            subDir,
+            specs,
+            predicate,
+            conf,
+            maxDepth - 1,
+            maxDirectSubDirs,
+            remainingSubDirs,
+            files);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * Determines if a path is hidden by checking its hierarchy against the base directory.
+   *
+   * @param baseDir The root directory to use as the stopping point for recursion
+   * @param path The path to check for hidden status
+   * @param pathFilter Filter used to evaluate path visibility
+   * @return {@code true} if the path is hidden, {@code false} otherwise
+   */
+  private static boolean isHiddenPath(String baseDir, Path path, PathFilter pathFilter) {
+    boolean isHiddenPath = false;
+    Path currentPath = path;
+    while (currentPath.getParent().toString().contains(baseDir)) {
+      if (!pathFilter.accept(currentPath)) {
+        isHiddenPath = true;
+        break;
+      }
+
+      currentPath = currentPath.getParent();
+    }
+
+    return isHiddenPath;
+  }
+
+  /**
+   * A {@link PathFilter} that filters out hidden path, but does not filter out paths that would be
+   * marked as hidden by {@link HiddenPathFilter} due to a partition field that starts with one of
+   * the characters that indicate a hidden path.
+   */
+  private static class PartitionAwareHiddenPathFilter implements PathFilter, Serializable {
+
+    private final Set<String> hiddenPathPartitionNames;
+
+    private PartitionAwareHiddenPathFilter(Set<String> hiddenPathPartitionNames) {
+      this.hiddenPathPartitionNames = hiddenPathPartitionNames;
+    }
+
+    @Override
+    public boolean accept(Path path) {
+      return isHiddenPartitionPath(path) || HiddenPathFilter.get().accept(path);
+    }
+
+    private boolean isHiddenPartitionPath(Path path) {
+      return hiddenPathPartitionNames.stream().anyMatch(path.getName()::startsWith);
+    }
+
+    public static PathFilter forSpecs(Map<Integer, PartitionSpec> specs) {
+      if (specs == null) {
+        return HiddenPathFilter.get();
+      }
+
+      Set<String> partitionNames =
+          specs.values().stream()
+              .map(PartitionSpec::fields)
+              .flatMap(List::stream)
+              .filter(field -> field.name().startsWith("_") || field.name().startsWith("."))
+              .map(field -> field.name() + "=")
+              .collect(Collectors.toSet());
+
+      if (partitionNames.isEmpty()) {
+        return HiddenPathFilter.get();
+      } else {
+        return new PartitionAwareHiddenPathFilter(partitionNames);
+      }
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/actions/TestFileURI.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestFileURI.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.Test;
 
@@ -30,9 +31,15 @@ public class TestFileURI {
   @Test
   public void testSchemeMatchWithSameScheme() {
     FileURI uri1 =
-        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
     FileURI uri2 =
-        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
 
     assertThat(uri1.schemeMatch(uri2)).isTrue();
   }
@@ -40,8 +47,13 @@ public class TestFileURI {
   @Test
   public void testSchemeMatchWithDifferentScheme() {
     FileURI uri1 =
-        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
-    FileURI uri2 = new FileURI("file:///path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    FileURI uri2 =
+        new FileURI(
+            new Path("file:///path").toUri(), Collections.emptyMap(), Collections.emptyMap());
 
     assertThat(uri1.schemeMatch(uri2)).isFalse();
   }
@@ -49,8 +61,12 @@ public class TestFileURI {
   @Test
   public void testSchemeMatchWithEmptyScheme() {
     FileURI uri1 =
-        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
-    FileURI uri2 = new FileURI("/path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    FileURI uri2 =
+        new FileURI(new Path("/path").toUri(), Collections.emptyMap(), Collections.emptyMap());
 
     assertThat(uri1.schemeMatch(uri2)).isFalse();
   }
@@ -68,9 +84,15 @@ public class TestFileURI {
   @Test
   public void testAuthorityMatchWithSameAuthority() {
     FileURI uri1 =
-        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
     FileURI uri2 =
-        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
 
     assertThat(uri1.authorityMatch(uri2)).isTrue();
   }
@@ -78,9 +100,15 @@ public class TestFileURI {
   @Test
   public void testAuthorityMatchWithDifferentAuthority() {
     FileURI uri1 =
-        new FileURI("hdfs://namenode1/path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode1/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
     FileURI uri2 =
-        new FileURI("hdfs://namenode2/path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode2/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
 
     assertThat(uri1.authorityMatch(uri2)).isFalse();
   }
@@ -88,8 +116,13 @@ public class TestFileURI {
   @Test
   public void testAuthorityMatchWithEmptyAuthority() {
     FileURI uri1 =
-        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
-    FileURI uri2 = new FileURI("file:///path", Collections.emptyMap(), Collections.emptyMap());
+        new FileURI(
+            new Path("hdfs://namenode/path").toUri(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    FileURI uri2 =
+        new FileURI(
+            new Path("file:///path").toUri(), Collections.emptyMap(), Collections.emptyMap());
 
     assertThat(uri1.authorityMatch(uri2)).isFalse();
   }
@@ -109,8 +142,10 @@ public class TestFileURI {
     Map<String, String> schemeMap = Maps.newHashMap();
     schemeMap.put("HDFS", "hdfs");
 
-    FileURI uri1 = new FileURI("HDFS://namenode/path", schemeMap, Collections.emptyMap());
-    FileURI uri2 = new FileURI("hdfs://namenode/path", schemeMap, Collections.emptyMap());
+    FileURI uri1 =
+        new FileURI(new Path("HDFS://namenode/path").toUri(), schemeMap, Collections.emptyMap());
+    FileURI uri2 =
+        new FileURI(new Path("hdfs://namenode/path").toUri(), schemeMap, Collections.emptyMap());
 
     assertThat(uri1.schemeMatch(uri2)).isTrue();
   }
@@ -120,8 +155,10 @@ public class TestFileURI {
     Map<String, String> authorityMap = Maps.newHashMap();
     authorityMap.put("OLD-NODE", "new-node");
 
-    FileURI uri1 = new FileURI("hdfs://OLD-NODE/path", Collections.emptyMap(), authorityMap);
-    FileURI uri2 = new FileURI("hdfs://new-node/path", Collections.emptyMap(), authorityMap);
+    FileURI uri1 =
+        new FileURI(new Path("hdfs://OLD-NODE/path").toUri(), Collections.emptyMap(), authorityMap);
+    FileURI uri2 =
+        new FileURI(new Path("hdfs://new-node/path").toUri(), Collections.emptyMap(), authorityMap);
 
     assertThat(uri1.authorityMatch(uri2)).isTrue();
   }

--- a/core/src/test/java/org/apache/iceberg/actions/TestFileURI.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestFileURI.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestFileURI {
+
+  @Test
+  public void testSchemeMatchWithSameScheme() {
+    FileURI uri1 =
+        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+    FileURI uri2 =
+        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+
+    assertThat(uri1.schemeMatch(uri2)).isTrue();
+  }
+
+  @Test
+  public void testSchemeMatchWithDifferentScheme() {
+    FileURI uri1 =
+        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+    FileURI uri2 = new FileURI("file:///path", Collections.emptyMap(), Collections.emptyMap());
+
+    assertThat(uri1.schemeMatch(uri2)).isFalse();
+  }
+
+  @Test
+  public void testSchemeMatchWithEmptyScheme() {
+    FileURI uri1 =
+        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+    FileURI uri2 = new FileURI("/path", Collections.emptyMap(), Collections.emptyMap());
+
+    assertThat(uri1.schemeMatch(uri2)).isFalse();
+  }
+
+  @Test
+  public void testSchemeMatchWithNullScheme() {
+    FileURI uri1 = new FileURI();
+    uri1.setScheme(null);
+    FileURI uri2 = new FileURI();
+    uri2.setScheme("hdfs");
+
+    assertThat(uri1.schemeMatch(uri2)).isTrue();
+  }
+
+  @Test
+  public void testAuthorityMatchWithSameAuthority() {
+    FileURI uri1 =
+        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+    FileURI uri2 =
+        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+
+    assertThat(uri1.authorityMatch(uri2)).isTrue();
+  }
+
+  @Test
+  public void testAuthorityMatchWithDifferentAuthority() {
+    FileURI uri1 =
+        new FileURI("hdfs://namenode1/path", Collections.emptyMap(), Collections.emptyMap());
+    FileURI uri2 =
+        new FileURI("hdfs://namenode2/path", Collections.emptyMap(), Collections.emptyMap());
+
+    assertThat(uri1.authorityMatch(uri2)).isFalse();
+  }
+
+  @Test
+  public void testAuthorityMatchWithEmptyAuthority() {
+    FileURI uri1 =
+        new FileURI("hdfs://namenode/path", Collections.emptyMap(), Collections.emptyMap());
+    FileURI uri2 = new FileURI("file:///path", Collections.emptyMap(), Collections.emptyMap());
+
+    assertThat(uri1.authorityMatch(uri2)).isFalse();
+  }
+
+  @Test
+  public void testAuthorityMatchWithNullAuthority() {
+    FileURI uri1 = new FileURI();
+    uri1.setAuthority(null);
+    FileURI uri2 = new FileURI();
+    uri2.setAuthority("namenode");
+
+    assertThat(uri1.authorityMatch(uri2)).isTrue();
+  }
+
+  @Test
+  public void testSchemeMapping() {
+    Map<String, String> schemeMap = Maps.newHashMap();
+    schemeMap.put("HDFS", "hdfs");
+
+    FileURI uri1 = new FileURI("HDFS://namenode/path", schemeMap, Collections.emptyMap());
+    FileURI uri2 = new FileURI("hdfs://namenode/path", schemeMap, Collections.emptyMap());
+
+    assertThat(uri1.schemeMatch(uri2)).isTrue();
+  }
+
+  @Test
+  public void testAuthorityMapping() {
+    Map<String, String> authorityMap = Maps.newHashMap();
+    authorityMap.put("OLD-NODE", "new-node");
+
+    FileURI uri1 = new FileURI("hdfs://OLD-NODE/path", Collections.emptyMap(), authorityMap);
+    FileURI uri2 = new FileURI("hdfs://new-node/path", Collections.emptyMap(), authorityMap);
+
+    assertThat(uri1.authorityMatch(uri2)).isTrue();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestFileSystemWalker.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestFileSystemWalker.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -35,6 +34,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,8 +73,8 @@ public class TestFileSystemWalker {
 
   @Test
   public void testListDirRecursivelyWithHadoop() {
-    List<String> foundFiles = new ArrayList<>();
-    List<String> remainingDirs = new ArrayList<>();
+    List<String> foundFiles = Lists.newArrayList();
+    List<String> remainingDirs = Lists.newArrayList();
     Predicate<FileStatus> fileFilter =
         fileStatus -> fileStatus.getPath().getName().endsWith(".txt");
     FileSystemWalker.listDirRecursivelyWithHadoop(
@@ -98,8 +98,8 @@ public class TestFileSystemWalker {
 
   @Test
   public void testListDirRecursivelyWithHadoopMaxDepth() {
-    List<String> foundFiles = new ArrayList<>();
-    List<String> remainingDirs = new ArrayList<>();
+    List<String> foundFiles = Lists.newArrayList();
+    List<String> remainingDirs = Lists.newArrayList();
     Predicate<FileStatus> fileFilter =
         fileStatus -> fileStatus.getPath().getName().endsWith(".txt");
     FileSystemWalker.listDirRecursivelyWithHadoop(
@@ -123,7 +123,7 @@ public class TestFileSystemWalker {
 
   @Test
   public void testListDirRecursivelyWithFileIO() {
-    List<String> foundFiles = new ArrayList<>();
+    List<String> foundFiles = Lists.newArrayList();
     Predicate<FileInfo> fileFilter = fileInfo -> fileInfo.location().endsWith(".txt");
     FileSystemWalker.listDirRecursivelyWithFileIO(
         fileIO, basePath, specs, fileFilter, foundFiles::add);

--- a/core/src/test/java/org/apache/iceberg/util/TestFileSystemWalker.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestFileSystemWalker.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestFileSystemWalker {
+
+  @TempDir private Path tempDir;
+  private String basePath;
+  private Configuration hadoopConf;
+  private Map<Integer, PartitionSpec> specs;
+  private HadoopFileIO fileIO;
+
+  @BeforeEach
+  public void before() throws IOException {
+    this.basePath = tempDir.toAbsolutePath().toString();
+    this.hadoopConf = new Configuration();
+    this.fileIO = new HadoopFileIO(hadoopConf);
+
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "data", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("id").build();
+    specs = ImmutableMap.of(0, spec);
+
+    Files.createDirectories(Paths.get(basePath, "normal_dir"));
+    Files.createDirectories(Paths.get(basePath, "normal_dir/dep1"));
+    Files.createDirectories(Paths.get(basePath, "hidden_dir/_partition"));
+    Files.createFile(Paths.get(basePath, "file1.txt"));
+    Files.createFile(Paths.get(basePath, "normal_dir/file2.txt"));
+    Files.createFile(Paths.get(basePath, "normal_dir/dep1/file3.txt"));
+    Files.createFile(Paths.get(basePath, "hidden_dir/.hidden_file.txt"));
+    Files.createFile(Paths.get(basePath, "hidden_dir/_partition/file3.txt"));
+  }
+
+  @Test
+  public void testListDirRecursivelyWithHadoop() {
+    List<String> foundFiles = new ArrayList<>();
+    List<String> remainingDirs = new ArrayList<>();
+    Predicate<FileStatus> fileFilter =
+        fileStatus -> fileStatus.getPath().getName().endsWith(".txt");
+    FileSystemWalker.listDirRecursivelyWithHadoop(
+        basePath,
+        specs,
+        fileFilter,
+        hadoopConf,
+        Integer.MAX_VALUE,
+        Integer.MAX_VALUE,
+        remainingDirs::add,
+        foundFiles::add);
+
+    assertThat(foundFiles).hasSize(3);
+    assertThat(foundFiles).contains(Paths.get("file://", basePath, "file1.txt").toString());
+    assertThat(foundFiles)
+        .contains(Paths.get("file://", basePath, "normal_dir/file2.txt").toString());
+    assertThat(foundFiles)
+        .contains(Paths.get("file://", basePath, "normal_dir/dep1/file3.txt").toString());
+    assertThat(remainingDirs).isEmpty();
+  }
+
+  @Test
+  public void testListDirRecursivelyWithHadoopMaxDepth() {
+    List<String> foundFiles = new ArrayList<>();
+    List<String> remainingDirs = new ArrayList<>();
+    Predicate<FileStatus> fileFilter =
+        fileStatus -> fileStatus.getPath().getName().endsWith(".txt");
+    FileSystemWalker.listDirRecursivelyWithHadoop(
+        basePath,
+        specs,
+        fileFilter,
+        hadoopConf,
+        2, // maxDepth
+        10, // maxDirectSubDirs
+        remainingDirs::add,
+        foundFiles::add);
+
+    assertThat(foundFiles).hasSize(2);
+    assertThat(foundFiles).contains(Paths.get("file://", basePath, "file1.txt").toString());
+    assertThat(foundFiles)
+        .contains(Paths.get("file://", basePath, "normal_dir/file2.txt").toString());
+    assertThat(remainingDirs).hasSize(1);
+    assertThat(remainingDirs)
+        .contains(Paths.get("file://", basePath, "normal_dir/dep1").toString());
+  }
+
+  @Test
+  public void testListDirRecursivelyWithFileIO() {
+    List<String> foundFiles = new ArrayList<>();
+    Predicate<FileInfo> fileFilter = fileInfo -> fileInfo.location().endsWith(".txt");
+    FileSystemWalker.listDirRecursivelyWithFileIO(
+        fileIO, basePath, specs, fileFilter, foundFiles::add);
+
+    assertThat(foundFiles).hasSize(3);
+    assertThat(foundFiles).contains(Paths.get("file://", basePath, "file1.txt").toString());
+    assertThat(foundFiles)
+        .contains(Paths.get("file://", basePath, "normal_dir/file2.txt").toString());
+    assertThat(foundFiles)
+        .contains(Paths.get("file://", basePath, "normal_dir/dep1/file3.txt").toString());
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -21,9 +21,6 @@ package org.apache.iceberg.spark.actions;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.sql.Timestamp;
 import java.util.Collections;
@@ -31,23 +28,19 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathFilter;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileURI;
 import org.apache.iceberg.actions.ImmutableDeleteOrphanFiles;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.hadoop.HiddenPathFilter;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.io.SupportsPrefixOperations;
@@ -59,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.util.FileSystemWalker;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
@@ -123,6 +117,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
   private boolean usePrefixListing = false;
+  private static final Encoder<FileURI> FILE_URI_ENCODER = Encoders.bean(FileURI.class);
 
   DeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -310,8 +305,6 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     List<String> subDirs = Lists.newArrayList();
     List<String> matchingFiles = Lists.newArrayList();
 
-    PathFilter pathFilter = PartitionAwareHiddenPathFilter.forSpecs(table.specs());
-
     if (usePrefixListing) {
       Preconditions.checkArgument(
           table.io() instanceof SupportsPrefixOperations,
@@ -320,8 +313,12 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
       Predicate<org.apache.iceberg.io.FileInfo> predicate =
           fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;
-      listDirRecursivelyWithFileIO(
-          (SupportsPrefixOperations) table.io(), location, predicate, pathFilter, matchingFiles);
+      FileSystemWalker.listDirRecursivelyWithFileIO(
+          (SupportsPrefixOperations) table.io(),
+          location,
+          table.specs(),
+          predicate,
+          matchingFiles::add);
 
       JavaRDD<String> matchingFileRDD = sparkContext().parallelize(matchingFiles, 1);
       return spark().createDataset(matchingFileRDD.rdd(), Encoders.STRING());
@@ -329,15 +326,15 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       Predicate<FileStatus> predicate = file -> file.getModificationTime() < olderThanTimestamp;
       // list at most MAX_DRIVER_LISTING_DEPTH levels and only dirs that have
       // less than MAX_DRIVER_LISTING_DIRECT_SUB_DIRS direct sub dirs on the driver
-      listDirRecursivelyWithHadoop(
+      FileSystemWalker.listDirRecursivelyWithHadoop(
           location,
+          table.specs(),
           predicate,
           hadoopConf.value(),
           MAX_DRIVER_LISTING_DEPTH,
           MAX_DRIVER_LISTING_DIRECT_SUB_DIRS,
-          subDirs,
-          pathFilter,
-          matchingFiles);
+          subDirs::add,
+          matchingFiles::add);
 
       JavaRDD<String> matchingFileRDD = sparkContext().parallelize(matchingFiles, 1);
 
@@ -349,99 +346,12 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       JavaRDD<String> subDirRDD = sparkContext().parallelize(subDirs, parallelism);
 
       Broadcast<SerializableConfiguration> conf = sparkContext().broadcast(hadoopConf);
-      ListDirsRecursively listDirs = new ListDirsRecursively(conf, olderThanTimestamp, pathFilter);
+      ListDirsRecursively listDirs =
+          new ListDirsRecursively(conf, olderThanTimestamp, table.specs());
       JavaRDD<String> matchingLeafFileRDD = subDirRDD.mapPartitions(listDirs);
 
       JavaRDD<String> completeMatchingFileRDD = matchingFileRDD.union(matchingLeafFileRDD);
       return spark().createDataset(completeMatchingFileRDD.rdd(), Encoders.STRING());
-    }
-  }
-
-  private static void listDirRecursivelyWithFileIO(
-      SupportsPrefixOperations io,
-      String dir,
-      Predicate<org.apache.iceberg.io.FileInfo> predicate,
-      PathFilter pathFilter,
-      List<String> matchingFiles) {
-    String listPath = dir;
-    if (!dir.endsWith("/")) {
-      listPath = dir + "/";
-    }
-
-    Iterable<org.apache.iceberg.io.FileInfo> files = io.listPrefix(listPath);
-    for (org.apache.iceberg.io.FileInfo file : files) {
-      Path path = new Path(file.location());
-      if (!isHiddenPath(dir, path, pathFilter) && predicate.test(file)) {
-        matchingFiles.add(file.location());
-      }
-    }
-  }
-
-  private static boolean isHiddenPath(String baseDir, Path path, PathFilter pathFilter) {
-    boolean isHiddenPath = false;
-    Path currentPath = path;
-    while (currentPath.getParent().toString().contains(baseDir)) {
-      if (!pathFilter.accept(currentPath)) {
-        isHiddenPath = true;
-        break;
-      }
-
-      currentPath = currentPath.getParent();
-    }
-
-    return isHiddenPath;
-  }
-
-  @VisibleForTesting
-  static void listDirRecursivelyWithHadoop(
-      String dir,
-      Predicate<FileStatus> predicate,
-      Configuration conf,
-      int maxDepth,
-      int maxDirectSubDirs,
-      List<String> remainingSubDirs,
-      PathFilter pathFilter,
-      List<String> matchingFiles) {
-
-    // stop listing whenever we reach the max depth
-    if (maxDepth <= 0) {
-      remainingSubDirs.add(dir);
-      return;
-    }
-
-    try {
-      Path path = new Path(dir);
-      FileSystem fs = path.getFileSystem(conf);
-
-      List<String> subDirs = Lists.newArrayList();
-
-      for (FileStatus file : fs.listStatus(path, pathFilter)) {
-        if (file.isDirectory()) {
-          subDirs.add(file.getPath().toString());
-        } else if (file.isFile() && predicate.test(file)) {
-          matchingFiles.add(file.getPath().toString());
-        }
-      }
-
-      // stop listing if the number of direct sub dirs is bigger than maxDirectSubDirs
-      if (subDirs.size() > maxDirectSubDirs) {
-        remainingSubDirs.addAll(subDirs);
-        return;
-      }
-
-      for (String subDir : subDirs) {
-        listDirRecursivelyWithHadoop(
-            subDir,
-            predicate,
-            conf,
-            maxDepth - 1,
-            maxDirectSubDirs,
-            remainingSubDirs,
-            pathFilter,
-            matchingFiles);
-      }
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
     }
   }
 
@@ -496,16 +406,16 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
     private final Broadcast<SerializableConfiguration> hadoopConf;
     private final long olderThanTimestamp;
-    private final PathFilter pathFilter;
+    private final Map<Integer, PartitionSpec> specs;
 
     ListDirsRecursively(
         Broadcast<SerializableConfiguration> hadoopConf,
         long olderThanTimestamp,
-        PathFilter pathFilter) {
+        Map<Integer, PartitionSpec> specs) {
 
       this.hadoopConf = hadoopConf;
       this.olderThanTimestamp = olderThanTimestamp;
-      this.pathFilter = pathFilter;
+      this.specs = specs;
     }
 
     @Override
@@ -516,15 +426,15 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       Predicate<FileStatus> predicate = file -> file.getModificationTime() < olderThanTimestamp;
 
       while (dirs.hasNext()) {
-        listDirRecursivelyWithHadoop(
+        FileSystemWalker.listDirRecursivelyWithHadoop(
             dirs.next(),
+            specs,
             predicate,
             hadoopConf.value().value(),
             MAX_EXECUTOR_LISTING_DEPTH,
             MAX_EXECUTOR_LISTING_DIRECT_SUB_DIRS,
-            subDirs,
-            pathFilter,
-            files);
+            subDirs::add,
+            files::add);
       }
 
       if (!subDirs.isEmpty()) {
@@ -558,21 +468,21 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       FileURI valid = row._2;
 
       if (valid == null) {
-        return actual.uriAsString;
+        return actual.getUriAsString();
       }
 
-      boolean schemeMatch = uriComponentMatch(valid.scheme, actual.scheme);
-      boolean authorityMatch = uriComponentMatch(valid.authority, actual.authority);
+      boolean schemeMatch = valid.schemeMatch(actual);
+      boolean authorityMatch = valid.authorityMatch(actual);
 
       if ((!schemeMatch || !authorityMatch) && mode == PrefixMismatchMode.DELETE) {
-        return actual.uriAsString;
+        return actual.getUriAsString();
       } else {
         if (!schemeMatch) {
-          conflicts.add(Pair.of(valid.scheme, actual.scheme));
+          conflicts.add(Pair.of(valid.getScheme(), actual.getScheme()));
         }
 
         if (!authorityMatch) {
-          conflicts.add(Pair.of(valid.authority, actual.authority));
+          conflicts.add(Pair.of(valid.getAuthority(), actual.getAuthority()));
         }
 
         return null;
@@ -621,7 +531,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     protected abstract String uriAsString(I input);
 
     Dataset<FileURI> apply(Dataset<I> ds) {
-      return ds.mapPartitions(this, FileURI.ENCODER);
+      return ds.mapPartitions(this, FILE_URI_ENCODER);
     }
 
     @Override
@@ -635,100 +545,6 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       String scheme = equalSchemes.getOrDefault(uri.getScheme(), uri.getScheme());
       String authority = equalAuthorities.getOrDefault(uri.getAuthority(), uri.getAuthority());
       return new FileURI(scheme, authority, uri.getPath(), uriAsString);
-    }
-  }
-
-  /**
-   * A {@link PathFilter} that filters out hidden path, but does not filter out paths that would be
-   * marked as hidden by {@link HiddenPathFilter} due to a partition field that starts with one of
-   * the characters that indicate a hidden path.
-   */
-  @VisibleForTesting
-  static class PartitionAwareHiddenPathFilter implements PathFilter, Serializable {
-
-    private final Set<String> hiddenPathPartitionNames;
-
-    PartitionAwareHiddenPathFilter(Set<String> hiddenPathPartitionNames) {
-      this.hiddenPathPartitionNames = hiddenPathPartitionNames;
-    }
-
-    @Override
-    public boolean accept(Path path) {
-      return isHiddenPartitionPath(path) || HiddenPathFilter.get().accept(path);
-    }
-
-    private boolean isHiddenPartitionPath(Path path) {
-      return hiddenPathPartitionNames.stream().anyMatch(path.getName()::startsWith);
-    }
-
-    static PathFilter forSpecs(Map<Integer, PartitionSpec> specs) {
-      if (specs == null) {
-        return HiddenPathFilter.get();
-      }
-
-      Set<String> partitionNames =
-          specs.values().stream()
-              .map(PartitionSpec::fields)
-              .flatMap(List::stream)
-              .filter(field -> field.name().startsWith("_") || field.name().startsWith("."))
-              .map(field -> field.name() + "=")
-              .collect(Collectors.toSet());
-
-      if (partitionNames.isEmpty()) {
-        return HiddenPathFilter.get();
-      } else {
-        return new PartitionAwareHiddenPathFilter(partitionNames);
-      }
-    }
-  }
-
-  public static class FileURI {
-    public static final Encoder<FileURI> ENCODER = Encoders.bean(FileURI.class);
-
-    private String scheme;
-    private String authority;
-    private String path;
-    private String uriAsString;
-
-    public FileURI(String scheme, String authority, String path, String uriAsString) {
-      this.scheme = scheme;
-      this.authority = authority;
-      this.path = path;
-      this.uriAsString = uriAsString;
-    }
-
-    public FileURI() {}
-
-    public void setScheme(String scheme) {
-      this.scheme = scheme;
-    }
-
-    public void setAuthority(String authority) {
-      this.authority = authority;
-    }
-
-    public void setPath(String path) {
-      this.path = path;
-    }
-
-    public void setUriAsString(String uriAsString) {
-      this.uriAsString = uriAsString;
-    }
-
-    public String getScheme() {
-      return scheme;
-    }
-
-    public String getAuthority() {
-      return authority;
-    }
-
-    public String getPath() {
-      return path;
-    }
-
-    public String getUriAsString() {
-      return uriAsString;
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 
 import java.io.File;
@@ -49,7 +49,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathFilter;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.GenericBlobMetadata;
 import org.apache.iceberg.GenericStatisticsFile;
@@ -84,6 +83,7 @@ import org.apache.iceberg.spark.actions.DeleteOrphanFilesSparkAction.StringToFil
 import org.apache.iceberg.spark.source.FilePathLastModifiedRecord;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.FileSystemWalker;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
@@ -1159,20 +1159,19 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     DeleteOrphanFilesSparkAction deleteOrphanFilesSparkAction =
         SparkActions.get().deleteOrphanFiles(table);
     DeleteOrphanFilesSparkAction spyAction = Mockito.spy(deleteOrphanFilesSparkAction);
-    try (MockedStatic<DeleteOrphanFilesSparkAction> mockedStatic =
-        Mockito.mockStatic(DeleteOrphanFilesSparkAction.class)) {
+    try (MockedStatic<FileSystemWalker> mockedStatic = Mockito.mockStatic(FileSystemWalker.class)) {
       spyAction.execute();
       mockedStatic.verify(
           () ->
-              DeleteOrphanFilesSparkAction.listDirRecursivelyWithHadoop(
+              FileSystemWalker.listDirRecursivelyWithHadoop(
                   anyString(),
+                  anyMap(),
                   any(Predicate.class),
                   any(Configuration.class),
                   anyInt(),
                   anyInt(),
-                  anyList(),
-                  any(PathFilter.class),
-                  anyList()));
+                  any(),
+                  any()));
     }
   }
 


### PR DESCRIPTION
Currently, Flink may support DeleteOrphans (https://github.com/apache/iceberg/pull/13302), and some of the code can be reused from Spark.  
The main goal of this PR is to refactor the commonly used code out of the Spark code into the core, so that Flink can reuse it.