### PR TITLE
Table registration to nonexistent target namespace leads to metadata deletion in HiveCatalog

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
@@ -22,6 +22,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.Spark3Util;
@@ -86,6 +87,12 @@ class RegisterTableProcedure extends BaseProcedure {
         "Cannot handle an empty argument metadata_file");
 
     Catalog icebergCatalog = ((HasIcebergCatalog) tableCatalog()).icebergCatalog();
+    if (tableName.hasNamespace() && icebergCatalog instanceof SupportsNamespaces) {
+      Preconditions.checkArgument(
+          ((SupportsNamespaces) icebergCatalog).namespaceExists(tableName.namespace()),
+          "Cannot register table to nonexistent target namespace %s",
+          tableName.namespace());
+    }
     Table table = icebergCatalog.registerTable(tableName, metadataFile);
     Long currentSnapshotId = null;
     Long totalDataFiles = null;

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
@@ -28,8 +28,12 @@ public enum SparkCatalogConfig {
       "testhive",
       SparkCatalog.class.getName(),
       ImmutableMap.of(
-          "type", "hive",
-          "default-namespace", "default")),
+          "type",
+          "hive",
+          "default-namespace",
+          "default",
+          CatalogProperties.CACHE_ENABLED,
+          "false")),
   HADOOP(
       "testhadoop",
       SparkCatalog.class.getName(),


### PR DESCRIPTION
Related to: https://github.com/apache/iceberg/issues/1533

### Context
- We're registering existing Iceberg tables to `HiveCatalog` and realize that the `metadata.json` files used are deleted when the target namespace doesn't exist.
- When the target namespace doesn't exist, an `ValidationException` is thrown from the `doCommit()` method of `HiveTableOperations`, as https://github.com/apache/iceberg/issues/1533 indicated. The `finally` block of the `doCommit` method will therefore delete the `metadata.json`.
```java
    finally {
      HiveOperationsBase.cleanupMetadataAndUnlock(io(), commitStatus, newMetadataLocation, lock);
    }
```

### Proposed changes
 - In `RegisterTableProcedure`, if the catalog used implements `SupportsNamespaces`, we fails the `register_table` procedure when the target namespace doesn't exist.