### PR TITLE
Spark 3.5, 4.0: ERROR when executing DML queries with identifier fields

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -381,7 +381,7 @@ public class SparkScanBuilder
     AtomicInteger nextId = new AtomicInteger();
     return new Schema(
         metaColumnFields,
-        table.schema().identifierFieldIds(),
+        Set.of(),
         oldId -> {
           if (!idsToReassign.contains(oldId)) {
             return oldId;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
@@ -76,7 +76,7 @@ public class TestSparkMetadataColumns extends TestBase {
   private static final String TABLE_NAME = "test_table";
   private static final Schema SCHEMA =
       new Schema(
-          Types.NestedField.optional(1, "id", Types.LongType.get()),
+          Types.NestedField.required(1, "id", Types.LongType.get()),
           Types.NestedField.optional(2, "category", Types.StringType.get()),
           Types.NestedField.optional(3, "data", Types.StringType.get()));
   private static final PartitionSpec SPEC = PartitionSpec.unpartitioned();
@@ -288,6 +288,42 @@ public class TestSparkMetadataColumns extends TestBase {
         .addColumn(MetadataColumns.SPEC_ID.name(), Types.IntegerType.get())
         .addColumn(MetadataColumns.FILE_PATH.name(), Types.StringType.get())
         .commit();
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a1', 'b1', -1, 'path/to/file')", TABLE_NAME);
+
+    assertEquals(
+        "Rows must match",
+        ImmutableList.of(row(1L, "a1")),
+        sql("SELECT id, category FROM %s", TABLE_NAME));
+
+    assertThatThrownBy(() -> sql("SELECT * FROM %s", TABLE_NAME))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Table column names conflict with names reserved for Iceberg metadata columns: [_spec_id, _file].");
+
+    table.refresh();
+
+    table
+        .updateSchema()
+        .renameColumn(MetadataColumns.SPEC_ID.name(), "_renamed" + MetadataColumns.SPEC_ID.name())
+        .renameColumn(
+            MetadataColumns.FILE_PATH.name(), "_renamed" + MetadataColumns.FILE_PATH.name())
+        .commit();
+
+    assertEquals(
+        "Rows must match",
+        ImmutableList.of(row(0, null, -1)),
+        sql("SELECT _spec_id, _partition, _renamed_spec_id FROM %s", TABLE_NAME));
+  }
+
+  @TestTemplate
+  public void testIdentifierFields() {
+    table
+            .updateSchema()
+            .addColumn(MetadataColumns.SPEC_ID.name(), Types.IntegerType.get())
+            .addColumn(MetadataColumns.FILE_PATH.name(), Types.StringType.get())
+            .setIdentifierFields("id")
+            .commit();
 
     sql("INSERT INTO TABLE %s VALUES (1, 'a1', 'b1', -1, 'path/to/file')", TABLE_NAME);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
@@ -319,11 +319,11 @@ public class TestSparkMetadataColumns extends TestBase {
   @TestTemplate
   public void testIdentifierFields() {
     table
-            .updateSchema()
-            .addColumn(MetadataColumns.SPEC_ID.name(), Types.IntegerType.get())
-            .addColumn(MetadataColumns.FILE_PATH.name(), Types.StringType.get())
-            .setIdentifierFields("id")
-            .commit();
+        .updateSchema()
+        .addColumn(MetadataColumns.SPEC_ID.name(), Types.IntegerType.get())
+        .addColumn(MetadataColumns.FILE_PATH.name(), Types.StringType.get())
+        .setIdentifierFields("id")
+        .commit();
 
     sql("INSERT INTO TABLE %s VALUES (1, 'a1', 'b1', -1, 'path/to/file')", TABLE_NAME);
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -381,7 +381,7 @@ public class SparkScanBuilder
     AtomicInteger nextId = new AtomicInteger();
     return new Schema(
         metaColumnFields,
-        table.schema().identifierFieldIds(),
+        Set.of(),
         oldId -> {
           if (!idsToReassign.contains(oldId)) {
             return oldId;

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
@@ -320,37 +320,37 @@ public class TestSparkMetadataColumns extends TestBase {
   @TestTemplate
   public void testIdentifierFields() {
     table
-            .updateSchema()
-            .addColumn(MetadataColumns.SPEC_ID.name(), Types.IntegerType.get())
-            .addColumn(MetadataColumns.FILE_PATH.name(), Types.StringType.get())
-            .setIdentifierFields("id")
-            .commit();
+        .updateSchema()
+        .addColumn(MetadataColumns.SPEC_ID.name(), Types.IntegerType.get())
+        .addColumn(MetadataColumns.FILE_PATH.name(), Types.StringType.get())
+        .setIdentifierFields("id")
+        .commit();
 
     sql("INSERT INTO TABLE %s VALUES (1, 'a1', 'b1', -1, 'path/to/file')", TABLE_NAME);
 
     assertEquals(
-            "Rows must match",
-            ImmutableList.of(row(1L, "a1")),
-            sql("SELECT id, category FROM %s", TABLE_NAME));
+        "Rows must match",
+        ImmutableList.of(row(1L, "a1")),
+        sql("SELECT id, category FROM %s", TABLE_NAME));
 
     assertThatThrownBy(() -> sql("SELECT * FROM %s", TABLE_NAME))
-            .isInstanceOf(ValidationException.class)
-            .hasMessageStartingWith(
-                    "Table column names conflict with names reserved for Iceberg metadata columns: [_spec_id, _file].");
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Table column names conflict with names reserved for Iceberg metadata columns: [_spec_id, _file].");
 
     table.refresh();
 
     table
-            .updateSchema()
-            .renameColumn(MetadataColumns.SPEC_ID.name(), "_renamed" + MetadataColumns.SPEC_ID.name())
-            .renameColumn(
-                    MetadataColumns.FILE_PATH.name(), "_renamed" + MetadataColumns.FILE_PATH.name())
-            .commit();
+        .updateSchema()
+        .renameColumn(MetadataColumns.SPEC_ID.name(), "_renamed" + MetadataColumns.SPEC_ID.name())
+        .renameColumn(
+            MetadataColumns.FILE_PATH.name(), "_renamed" + MetadataColumns.FILE_PATH.name())
+        .commit();
 
     assertEquals(
-            "Rows must match",
-            ImmutableList.of(row(0, null, -1)),
-            sql("SELECT _spec_id, _partition, _renamed_spec_id FROM %s", TABLE_NAME));
+        "Rows must match",
+        ImmutableList.of(row(0, null, -1)),
+        sql("SELECT _spec_id, _partition, _renamed_spec_id FROM %s", TABLE_NAME));
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkMetadataColumns.java
@@ -77,7 +77,7 @@ public class TestSparkMetadataColumns extends TestBase {
   private static final String TABLE_NAME = "test_table";
   private static final Schema SCHEMA =
       new Schema(
-          Types.NestedField.optional(1, "id", Types.LongType.get()),
+          Types.NestedField.required(1, "id", Types.LongType.get()),
           Types.NestedField.optional(2, "category", Types.StringType.get()),
           Types.NestedField.optional(3, "data", Types.StringType.get()));
   private static final PartitionSpec SPEC = PartitionSpec.unpartitioned();
@@ -315,6 +315,42 @@ public class TestSparkMetadataColumns extends TestBase {
         "Rows must match",
         ImmutableList.of(row(0, null, -1)),
         sql("SELECT _spec_id, _partition, _renamed_spec_id FROM %s", TABLE_NAME));
+  }
+
+  @TestTemplate
+  public void testIdentifierFields() {
+    table
+            .updateSchema()
+            .addColumn(MetadataColumns.SPEC_ID.name(), Types.IntegerType.get())
+            .addColumn(MetadataColumns.FILE_PATH.name(), Types.StringType.get())
+            .setIdentifierFields("id")
+            .commit();
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a1', 'b1', -1, 'path/to/file')", TABLE_NAME);
+
+    assertEquals(
+            "Rows must match",
+            ImmutableList.of(row(1L, "a1")),
+            sql("SELECT id, category FROM %s", TABLE_NAME));
+
+    assertThatThrownBy(() -> sql("SELECT * FROM %s", TABLE_NAME))
+            .isInstanceOf(ValidationException.class)
+            .hasMessageStartingWith(
+                    "Table column names conflict with names reserved for Iceberg metadata columns: [_spec_id, _file].");
+
+    table.refresh();
+
+    table
+            .updateSchema()
+            .renameColumn(MetadataColumns.SPEC_ID.name(), "_renamed" + MetadataColumns.SPEC_ID.name())
+            .renameColumn(
+                    MetadataColumns.FILE_PATH.name(), "_renamed" + MetadataColumns.FILE_PATH.name())
+            .commit();
+
+    assertEquals(
+            "Rows must match",
+            ImmutableList.of(row(0, null, -1)),
+            sql("SELECT _spec_id, _partition, _renamed_spec_id FROM %s", TABLE_NAME));
   }
 
   @TestTemplate


### PR DESCRIPTION
Fixes #11341

This fixes a bug introduced in https://github.com/apache/iceberg/pull/10547, where metadata tables are broken for tables with identifier columns.  Metadata table schemas got the identifier columns of the parent table, but they should not have identifier columns.