### PR TITLE
Spark: Avoid using `Object.hashCode()` for equality of `SparkScan` implementations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/DigestUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/DigestUtil.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+
+public class DigestUtil {
+  private static final byte[] MAGIC_DELIMITER =
+      "0c1d0aaa-b115-42e0-bfa5-38495d6b3f5b".getBytes(Charset.defaultCharset());
+
+  private DigestUtil() {}
+
+  /** Computes a digest string that can be used for equality check of the input object array. */
+  public static String computeDigest(Object... objects) {
+    final MessageDigest md5;
+    try {
+      md5 = MessageDigest.getInstance("MD5");
+    } catch (NoSuchAlgorithmException e) {
+      throw new UnsupportedOperationException("Failed to create MD5 instance", e);
+    }
+    try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      for (Object object : objects) {
+        writeObject(oos, object);
+        writeObject(oos, MAGIC_DELIMITER);
+      }
+      oos.flush();
+      final byte[] objectsMd5 = md5.digest(baos.toByteArray());
+      return Base64.getEncoder().encodeToString(objectsMd5);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to write objects: " + Arrays.toString(objects), e);
+    }
+  }
+
+  private static void writeObject(ObjectOutputStream oos, Object object) throws IOException {
+    if (object == null) {
+      oos.writeObject(null);
+    } else if (object instanceof Integer) {
+      oos.writeInt((Integer) object);
+    } else if (object instanceof Long) {
+      oos.writeLong((Long) object);
+    } else if (object instanceof Short) {
+      oos.writeShort((Short) object);
+    } else if (object instanceof Byte) {
+      oos.writeByte((Byte) object);
+    } else if (object instanceof Float) {
+      oos.writeFloat((Float) object);
+    } else if (object instanceof Double) {
+      oos.writeDouble((Double) object);
+    } else if (object instanceof Character) {
+      oos.writeChar((Character) object);
+    } else if (object instanceof Boolean) {
+      oos.writeBoolean((Boolean) object);
+    } else if (object instanceof String) {
+      oos.writeUTF((String) object);
+    } else if (object instanceof byte[]) {
+      oos.write((byte[]) object);
+    } else {
+      // We don't write objects that are of unknown types to the stream
+      // for digest computation. Because serialization process can be
+      // customizable so doesn't essentially represent the identity of
+      // that object.
+      throw new UnsupportedOperationException(
+          "Digest computation not supported for object type: " + object.getClass());
+    }
+  }
+}

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -55,7 +55,7 @@ class SparkBatch implements Batch {
   private final boolean caseSensitive;
   private final boolean localityEnabled;
   private final boolean executorCacheLocalityEnabled;
-  private final int scanHashCode;
+  private final String scanDigest;
 
   SparkBatch(
       JavaSparkContext sparkContext,
@@ -64,7 +64,7 @@ class SparkBatch implements Batch {
       Types.StructType groupingKeyType,
       List<? extends ScanTaskGroup<?>> taskGroups,
       Schema expectedSchema,
-      int scanHashCode) {
+      String scanDigest) {
     this.sparkContext = sparkContext;
     this.table = table;
     this.branch = readConf.branch();
@@ -75,7 +75,7 @@ class SparkBatch implements Batch {
     this.caseSensitive = readConf.caseSensitive();
     this.localityEnabled = readConf.localityEnabled();
     this.executorCacheLocalityEnabled = readConf.executorCacheLocalityEnabled();
-    this.scanHashCode = scanHashCode;
+    this.scanDigest = scanDigest;
   }
 
   @Override
@@ -219,11 +219,11 @@ class SparkBatch implements Batch {
     }
 
     SparkBatch that = (SparkBatch) o;
-    return table.name().equals(that.table.name()) && scanHashCode == that.scanHashCode;
+    return table.name().equals(that.table.name()) && scanDigest.equals(that.scanDigest);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(table.name(), scanHashCode);
+    return Objects.hash(table.name(), scanDigest);
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
 import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.DeleteFileSet;
+import org.apache.iceberg.util.DigestUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.expressions.NamedReference;
@@ -270,6 +271,22 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
         table().name(),
         branch(),
         readSchema(),
+        filterExpressions().toString(),
+        runtimeFilterExpressions.toString(),
+        snapshotId,
+        startSnapshotId,
+        endSnapshotId,
+        asOfTimestamp,
+        tag);
+  }
+
+  @Override
+  protected String digest() {
+    return DigestUtil.computeDigest(
+        getClass().getName(),
+        table().name(),
+        branch(),
+        readSchema().toString(),
         filterExpressions().toString(),
         runtimeFilterExpressions.toString(),
         snapshotId,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DigestUtil;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.read.Batch;
@@ -109,7 +110,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
         EMPTY_GROUPING_KEY_TYPE,
         taskGroups(),
         expectedSchema,
-        hashCode());
+        digest());
   }
 
   private List<ScanTaskGroup<ChangelogScanTask>> taskGroups() {
@@ -164,5 +165,15 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
   public int hashCode() {
     return Objects.hash(
         table.name(), readSchema(), filters.toString(), startSnapshotId, endSnapshotId);
+  }
+
+  protected String digest() {
+    return DigestUtil.computeDigest(
+        getClass().getName(),
+        table.name(),
+        readSchema().toString(),
+        filters.toString(),
+        startSnapshotId,
+        endSnapshotId);
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.util.DigestUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.expressions.Expressions;
@@ -171,6 +172,17 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
     return Objects.hash(
         table().name(),
         readSchema(),
+        filterExpressions().toString(),
+        snapshotId(),
+        filteredLocations);
+  }
+
+  @Override
+  protected String digest() {
+    return DigestUtil.computeDigest(
+        getClass().getName(),
+        table().name(),
+        readSchema().toString(),
         filterExpressions().toString(),
         snapshotId(),
         filteredLocations);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -159,10 +159,17 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
 
   protected abstract List<? extends ScanTaskGroup<?>> taskGroups();
 
+  /**
+   * A string digest summarizing all the comparable components in this SparkScan. This is used for
+   * equality checks. The instances that are not equal must return different values of digests to
+   * distinguish them from each other.
+   */
+  protected abstract String digest();
+
   @Override
   public Batch toBatch() {
     return new SparkBatch(
-        sparkContext, table, readConf, groupingKeyType(), taskGroups(), expectedSchema, hashCode());
+        sparkContext, table, readConf, groupingKeyType(), taskGroups(), expectedSchema, digest());
   }
 
   @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.util.DigestUtil;
 import org.apache.iceberg.util.TableScanUtil;
 import org.apache.spark.sql.SparkSession;
 
@@ -86,7 +87,7 @@ class SparkStagedScan extends SparkScan {
   @Override
   public int hashCode() {
     return Objects.hash(
-        table().name(), taskSetId, readSchema(), splitSize, splitSize, openFileCost);
+        table().name(), taskSetId, readSchema().toString(), splitSize, splitSize, openFileCost);
   }
 
   @Override
@@ -94,5 +95,17 @@ class SparkStagedScan extends SparkScan {
     return String.format(
         "IcebergStagedScan(table=%s, type=%s, taskSetID=%s, caseSensitive=%s)",
         table(), expectedSchema().asStruct(), taskSetId, caseSensitive());
+  }
+
+  @Override
+  protected String digest() {
+    return DigestUtil.computeDigest(
+        getClass().getName(),
+        table().name(),
+        taskSetId,
+        readSchema(),
+        splitSize,
+        splitSize,
+        openFileCost);
   }
 }


### PR DESCRIPTION
Currently `SparkBatch` relies on the parent instance of `SparkScan`'s `hashCode()` for checking the equality.

https://github.com/apache/iceberg/blob/28b90ea1870643fcdb3afca5426656ab6caa8163/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java#L164-L165

https://github.com/apache/iceberg/blob/28b90ea1870643fcdb3afca5426656ab6caa8163/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java#L211-L223

This is an anti-pattern which could easily cause the objects that are not equal to be incorrectly considered equal by the program.

More specifically, Spark relies on the `SparkBatch`'s equality to determine whether the two `BatchScanExec` are equal. 

https://github.com/apache/spark/blob/fdd7f6fb491e4e52898d884db887cd0a8a707ec3/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala#L46-L56

The equality of `BatchScanExec` can be relied by the exchange / subquery substitution processes in Spark. An incorrect implementation of `equals()` method could result in unexpected behavior of Spark's query planner.

The patch adds a checksum-based algorithm through a newly added utility `DigestUtil` to ensure the sanity of the equality comparison.