### PR TITLE
Flink: Backport LRUCache usage to Flink 1.19/1.20

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,7 +54,7 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
 
   private static final Logger LOG = LoggerFactory.getLogger(DynamicWriter.class);
 
-  private final Cache<WriteTarget, RowDataTaskWriterFactory> taskWriterFactories;
+  private final Map<WriteTarget, RowDataTaskWriterFactory> taskWriterFactories;
   private final Map<WriteTarget, TaskWriter<RowData>> writers;
   private final DynamicWriterMetrics metrics;
   private final int subTaskId;
@@ -82,7 +80,7 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
     this.metrics = metrics;
     this.subTaskId = subTaskId;
     this.attemptId = attemptId;
-    this.taskWriterFactories = Caffeine.newBuilder().maximumSize(cacheMaximumSize).build();
+    this.taskWriterFactories = new LRUCache<>(cacheMaximumSize);
     this.writers = Maps.newHashMap();
 
     LOG.debug("DynamicIcebergSinkWriter created for subtask {} attemptId {}", subTaskId, attemptId);
@@ -102,7 +100,7 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
                 element.equalityFields()),
             writerKey -> {
               RowDataTaskWriterFactory taskWriterFactory =
-                  taskWriterFactories.get(
+                  taskWriterFactories.computeIfAbsent(
                       writerKey,
                       factoryKey -> {
                         Table table =

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/LRUCache.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/LRUCache.java
@@ -42,6 +42,10 @@ class LRUCache<K, V> extends LinkedHashMap<K, V> {
   private final int maximumSize;
   private final Consumer<Map.Entry<K, V>> evictionCallback;
 
+  LRUCache(int maximumSize) {
+    this(maximumSize, ignored -> {});
+  }
+
   LRUCache(int maximumSize, Consumer<Map.Entry<K, V>> evictionCallback) {
     super(Math.min(maximumSize, DEFAULT_INITIAL_CAPACITY), DEFAULT_LOAD_FACTOR, true);
     this.maximumSize = maximumSize;

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -20,8 +20,8 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -302,7 +302,7 @@ class TestHashKeyGenerator {
     int writeParallelism = 2;
     int maxWriteParallelism = 8;
     HashKeyGenerator generator = new HashKeyGenerator(maxCacheSize, maxWriteParallelism);
-    Cache<HashKeyGenerator.SelectorKey, KeySelector<RowData, Integer>> keySelectorCache =
+    Map<HashKeyGenerator.SelectorKey, KeySelector<RowData, Integer>> keySelectorCache =
         generator.getKeySelectorCache();
 
     PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
@@ -317,18 +317,14 @@ class TestHashKeyGenerator {
             writeParallelism);
 
     int writeKey1 = generator.generateKey(record);
-    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+    assertThat(keySelectorCache).hasSize(1);
 
     int writeKey2 = generator.generateKey(record);
     assertThat(writeKey2).isNotEqualTo(writeKey1);
-    // Manually clean up because the cleanup is not always triggered
-    keySelectorCache.cleanUp();
-    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+    assertThat(keySelectorCache).hasSize(1);
 
     int writeKey3 = generator.generateKey(record);
-    // Manually clean up because the cleanup is not always triggered
-    keySelectorCache.cleanUp();
-    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+    assertThat(keySelectorCache).hasSize(1);
     // We create a new key selector which will start off at the same position
     assertThat(writeKey1).isEqualTo(writeKey3);
   }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
@@ -89,8 +89,6 @@ public class TestTableMetadataCache extends TestFlinkIcebergSinkBase {
     catalog.createTable(tableIdentifier, SCHEMA);
     TableMetadataCache cache = new TableMetadataCache(catalog, 0, Long.MAX_VALUE, 10);
 
-    // Cleanup routine doesn't run after every write
-    cache.getInternalCache().cleanUp();
-    assertThat(cache.getInternalCache().estimatedSize()).isEqualTo(0);
+    assertThat(cache.getInternalCache()).isEmpty();
   }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
@@ -111,7 +111,7 @@ public class TestTableSerializerCache {
     RowDataSerializer serializer1 = creator1.get();
     RowDataSerializer serializer2 = creator2.get();
 
-    cache.getCache().cleanUp();
+    cache.getCache().clear();
     assertThat(serializer1).isNotSameAs(creator1.get());
     assertThat(serializer2).isNotSameAs(creator2.get());
   }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableUpdater.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableUpdater.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -85,11 +86,11 @@ public class TestTableUpdater extends TestFlinkIcebergSinkBase {
 
     catalog.createTable(tableIdentifier, SCHEMA);
     tableUpdater.update(tableIdentifier, "myBranch", SCHEMA, PartitionSpec.unpartitioned());
-    TableMetadataCache.CacheItem cacheItem = cache.getInternalCache().getIfPresent(tableIdentifier);
+    TableMetadataCache.CacheItem cacheItem = cache.getInternalCache().get(tableIdentifier);
     assertThat(cacheItem).isNotNull();
 
     tableUpdater.update(tableIdentifier, "myBranch", SCHEMA, PartitionSpec.unpartitioned());
-    assertThat(cache.getInternalCache().getIfPresent(tableIdentifier)).isEqualTo(cacheItem);
+    assertThat(cache.getInternalCache()).contains(Map.entry(tableIdentifier, cacheItem));
   }
 
   @Test
@@ -153,7 +154,7 @@ public class TestTableUpdater extends TestFlinkIcebergSinkBase {
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
 
     // Last result cache should be cleared
-    assertThat(cache.getInternalCache().getIfPresent(tableIdentifier).inputSchemas().get(SCHEMA2))
-        .isNull();
+    assertThat(cache.getInternalCache().get(tableIdentifier).inputSchemas())
+        .doesNotContainKey(SCHEMA2);
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,7 +54,7 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
 
   private static final Logger LOG = LoggerFactory.getLogger(DynamicWriter.class);
 
-  private final Cache<WriteTarget, RowDataTaskWriterFactory> taskWriterFactories;
+  private final Map<WriteTarget, RowDataTaskWriterFactory> taskWriterFactories;
   private final Map<WriteTarget, TaskWriter<RowData>> writers;
   private final DynamicWriterMetrics metrics;
   private final int subTaskId;
@@ -82,7 +80,7 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
     this.metrics = metrics;
     this.subTaskId = subTaskId;
     this.attemptId = attemptId;
-    this.taskWriterFactories = Caffeine.newBuilder().maximumSize(cacheMaximumSize).build();
+    this.taskWriterFactories = new LRUCache<>(cacheMaximumSize);
     this.writers = Maps.newHashMap();
 
     LOG.debug("DynamicIcebergSinkWriter created for subtask {} attemptId {}", subTaskId, attemptId);
@@ -102,7 +100,7 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
                 element.equalityFields()),
             writerKey -> {
               RowDataTaskWriterFactory taskWriterFactory =
-                  taskWriterFactories.get(
+                  taskWriterFactories.computeIfAbsent(
                       writerKey,
                       factoryKey -> {
                         Table table =

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/LRUCache.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/LRUCache.java
@@ -42,6 +42,10 @@ class LRUCache<K, V> extends LinkedHashMap<K, V> {
   private final int maximumSize;
   private final Consumer<Map.Entry<K, V>> evictionCallback;
 
+  LRUCache(int maximumSize) {
+    this(maximumSize, ignored -> {});
+  }
+
   LRUCache(int maximumSize, Consumer<Map.Entry<K, V>> evictionCallback) {
     super(Math.min(maximumSize, DEFAULT_INITIAL_CAPACITY), DEFAULT_LOAD_FACTOR, true);
     this.maximumSize = maximumSize;

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -20,8 +20,8 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -302,7 +302,7 @@ class TestHashKeyGenerator {
     int writeParallelism = 2;
     int maxWriteParallelism = 8;
     HashKeyGenerator generator = new HashKeyGenerator(maxCacheSize, maxWriteParallelism);
-    Cache<HashKeyGenerator.SelectorKey, KeySelector<RowData, Integer>> keySelectorCache =
+    Map<HashKeyGenerator.SelectorKey, KeySelector<RowData, Integer>> keySelectorCache =
         generator.getKeySelectorCache();
 
     PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
@@ -317,18 +317,14 @@ class TestHashKeyGenerator {
             writeParallelism);
 
     int writeKey1 = generator.generateKey(record);
-    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+    assertThat(keySelectorCache).hasSize(1);
 
     int writeKey2 = generator.generateKey(record);
     assertThat(writeKey2).isNotEqualTo(writeKey1);
-    // Manually clean up because the cleanup is not always triggered
-    keySelectorCache.cleanUp();
-    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+    assertThat(keySelectorCache).hasSize(1);
 
     int writeKey3 = generator.generateKey(record);
-    // Manually clean up because the cleanup is not always triggered
-    keySelectorCache.cleanUp();
-    assertThat(keySelectorCache.estimatedSize()).isEqualTo(1);
+    assertThat(keySelectorCache).hasSize(1);
     // We create a new key selector which will start off at the same position
     assertThat(writeKey1).isEqualTo(writeKey3);
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
@@ -89,8 +89,6 @@ public class TestTableMetadataCache extends TestFlinkIcebergSinkBase {
     catalog.createTable(tableIdentifier, SCHEMA);
     TableMetadataCache cache = new TableMetadataCache(catalog, 0, Long.MAX_VALUE, 10);
 
-    // Cleanup routine doesn't run after every write
-    cache.getInternalCache().cleanUp();
-    assertThat(cache.getInternalCache().estimatedSize()).isEqualTo(0);
+    assertThat(cache.getInternalCache()).isEmpty();
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
@@ -111,7 +111,7 @@ public class TestTableSerializerCache {
     RowDataSerializer serializer1 = creator1.get();
     RowDataSerializer serializer2 = creator2.get();
 
-    cache.getCache().cleanUp();
+    cache.getCache().clear();
     assertThat(serializer1).isNotSameAs(creator1.get());
     assertThat(serializer2).isNotSameAs(creator2.get());
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableUpdater.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableUpdater.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -85,11 +86,11 @@ public class TestTableUpdater extends TestFlinkIcebergSinkBase {
 
     catalog.createTable(tableIdentifier, SCHEMA);
     tableUpdater.update(tableIdentifier, "myBranch", SCHEMA, PartitionSpec.unpartitioned());
-    TableMetadataCache.CacheItem cacheItem = cache.getInternalCache().getIfPresent(tableIdentifier);
+    TableMetadataCache.CacheItem cacheItem = cache.getInternalCache().get(tableIdentifier);
     assertThat(cacheItem).isNotNull();
 
     tableUpdater.update(tableIdentifier, "myBranch", SCHEMA, PartitionSpec.unpartitioned());
-    assertThat(cache.getInternalCache().getIfPresent(tableIdentifier)).isEqualTo(cacheItem);
+    assertThat(cache.getInternalCache()).contains(Map.entry(tableIdentifier, cacheItem));
   }
 
   @Test
@@ -153,7 +154,7 @@ public class TestTableUpdater extends TestFlinkIcebergSinkBase {
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
 
     // Last result cache should be cleared
-    assertThat(cache.getInternalCache().getIfPresent(tableIdentifier).inputSchemas().get(SCHEMA2))
-        .isNull();
+    assertThat(cache.getInternalCache().get(tableIdentifier).inputSchemas())
+        .doesNotContainKey(SCHEMA2);
   }
 }


### PR DESCRIPTION
This PR backports changes in https://github.com/apache/iceberg/pull/13382 to Flink 1.19/1.20. 