### PR TITLE
Build: Fix error-prone warning

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
@@ -47,6 +47,8 @@ public class ParserContext {
   static class Builder {
     private final Map<String, Object> data = Maps.newHashMap();
 
+    private Builder() {}
+
     public Builder add(String key, Object value) {
       Preconditions.checkNotNull(key, "Key cannot be null");
       Preconditions.checkNotNull(value, "Value cannot be null");


### PR DESCRIPTION
Summary:

Closes https://github.com/apache/iceberg/issues/13178

Details:

- ParserContext: Make Builder constructor private to avoid ImplicitPublicBuilderConstructor

Verification:

Run ./gradlew clean build -x test -x integrationTest --no-build-cache to ensure no ErrorProne warnings
Run ./gradlew :iceberg-core:test to verify modifications don't break existing functionality
