### PR TITLE
Core: Allow retries for Idempotent Requests with Certain Codes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -38,6 +38,7 @@ import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -63,6 +64,17 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  *   <li>SC_SERVICE_UNAVAILABLE (503)
  * </ul>
  *
+ * The following retriable HTTP status codes are defined for idempotent requests:
+ * <ul>
+ *   <li>SC_TOO_MANY_REQUESTS (429)
+ *   <li>SC_SERVICE_UNAVAILABLE (503)
+ *   <li>SC_INTERNAL_SERVER_ERROR (500)
+ *   <li>SC_BAD_GATEWAY (502)
+ *   <li>SC_GATEWAY_TIMEOUT (504)
+ *   <li>SC_REQUEST_TIMEOUT (408)
+ *   <li>SC_SERVICE_UNAVAILABLE (503)
+ * </ul>
+ *
  * Most code and behavior is taken from {@link
  * org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy}, with minor modifications to
  * {@link #getRetryInterval(HttpResponse, int, HttpContext)} to achieve exponential backoff.
@@ -71,6 +83,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
   private final int maxRetries;
   private final Set<Class<? extends IOException>> nonRetriableExceptions;
   private final Set<Integer> retriableCodes;
+  private final Set<Integer> idempotentRetriableCodes;
 
   ExponentialHttpRequestRetryStrategy(int maximumRetries) {
     Preconditions.checkArgument(
@@ -78,6 +91,15 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     this.maxRetries = maximumRetries;
     this.retriableCodes =
         ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS, HttpStatus.SC_SERVICE_UNAVAILABLE);
+    this.idempotentRetriableCodes =
+        ImmutableSet.of(
+          HttpStatus.SC_TOO_MANY_REQUESTS,
+          HttpStatus.SC_SERVICE_UNAVAILABLE,
+          HttpStatus.SC_INTERNAL_SERVER_ERROR,
+          HttpStatus.SC_SERVICE_UNAVAILABLE,
+          HttpStatus.SC_BAD_GATEWAY,
+          HttpStatus.SC_GATEWAY_TIMEOUT,
+          HttpStatus.SC_REQUEST_TIMEOUT);
     this.nonRetriableExceptions =
         ImmutableSet.of(
             InterruptedIOException.class,
@@ -117,8 +139,17 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
 
   @Override
   public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
-    return execCount <= maxRetries && retriableCodes.contains(response.getCode());
+    HttpRequest request = context instanceof HttpCoreContext ?
+      ((HttpCoreContext) context).getRequest() : null;
+
+    boolean shouldRetry =
+      execCount <= maxRetries &&
+        (retriableCodes.contains(response.getCode()) ||
+          shouldRetryIdempotent(request, response.getCode()));
+
+    return shouldRetry;
   }
+
 
   @Override
   public TimeValue getRetryInterval(HttpResponse response, int execCount, HttpContext context) {
@@ -131,8 +162,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       try {
         retryAfter = TimeValue.ofSeconds(Long.parseLong(value));
       } catch (NumberFormatException ignore) {
-        Instant retryAfterDate = DateUtils.parseStandardDate(value);
-        if (retryAfterDate != null) {
+        Instant retryAfterDate = DateUtils.parseStandardDate(value); if (retryAfterDate != null) {
           retryAfter =
               TimeValue.ofMilliseconds(retryAfterDate.toEpochMilli() - System.currentTimeMillis());
         }
@@ -147,5 +177,15 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayMillis * 0.1)));
 
     return TimeValue.ofMilliseconds(delayMillis + jitter);
+  }
+
+  private boolean shouldRetryIdempotent(HttpRequest request, int responseCode) {
+    if (request == null) {
+      return false;
+    }
+
+    // Check if the request is idempotent
+    return Method.isIdempotent(request.getMethod()) &&
+      idempotentRetriableCodes.contains(responseCode);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -65,6 +65,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  * </ul>
  *
  * The following retriable HTTP status codes are defined for idempotent requests:
+ *
  * <ul>
  *   <li>SC_TOO_MANY_REQUESTS (429)
  *   <li>SC_SERVICE_UNAVAILABLE (503)
@@ -93,13 +94,13 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
         ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS, HttpStatus.SC_SERVICE_UNAVAILABLE);
     this.idempotentRetriableCodes =
         ImmutableSet.of(
-          HttpStatus.SC_TOO_MANY_REQUESTS,
-          HttpStatus.SC_SERVICE_UNAVAILABLE,
-          HttpStatus.SC_INTERNAL_SERVER_ERROR,
-          HttpStatus.SC_SERVICE_UNAVAILABLE,
-          HttpStatus.SC_BAD_GATEWAY,
-          HttpStatus.SC_GATEWAY_TIMEOUT,
-          HttpStatus.SC_REQUEST_TIMEOUT);
+            HttpStatus.SC_TOO_MANY_REQUESTS,
+            HttpStatus.SC_SERVICE_UNAVAILABLE,
+            HttpStatus.SC_INTERNAL_SERVER_ERROR,
+            HttpStatus.SC_SERVICE_UNAVAILABLE,
+            HttpStatus.SC_BAD_GATEWAY,
+            HttpStatus.SC_GATEWAY_TIMEOUT,
+            HttpStatus.SC_REQUEST_TIMEOUT);
     this.nonRetriableExceptions =
         ImmutableSet.of(
             InterruptedIOException.class,
@@ -139,17 +140,16 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
 
   @Override
   public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
-    HttpRequest request = context instanceof HttpCoreContext ?
-      ((HttpCoreContext) context).getRequest() : null;
+    HttpRequest request =
+        context instanceof HttpCoreContext ? ((HttpCoreContext) context).getRequest() : null;
 
     boolean shouldRetry =
-      execCount <= maxRetries &&
-        (retriableCodes.contains(response.getCode()) ||
-          shouldRetryIdempotent(request, response.getCode()));
+        execCount <= maxRetries
+            && (retriableCodes.contains(response.getCode())
+                || shouldRetryIdempotent(request, response.getCode()));
 
     return shouldRetry;
   }
-
 
   @Override
   public TimeValue getRetryInterval(HttpResponse response, int execCount, HttpContext context) {
@@ -162,7 +162,8 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       try {
         retryAfter = TimeValue.ofSeconds(Long.parseLong(value));
       } catch (NumberFormatException ignore) {
-        Instant retryAfterDate = DateUtils.parseStandardDate(value); if (retryAfterDate != null) {
+        Instant retryAfterDate = DateUtils.parseStandardDate(value);
+        if (retryAfterDate != null) {
           retryAfter =
               TimeValue.ofMilliseconds(retryAfterDate.toEpochMilli() - System.currentTimeMillis());
         }
@@ -185,7 +186,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     }
 
     // Check if the request is idempotent
-    return Method.isIdempotent(request.getMethod()) &&
-      idempotentRetriableCodes.contains(responseCode);
+    return Method.isIdempotent(request.getMethod())
+        && idempotentRetriableCodes.contains(responseCode);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -41,6 +41,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
@@ -51,6 +52,7 @@ import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.reactor.ssl.SSLBufferMode;
 import org.apache.iceberg.IcebergBuild;
@@ -312,7 +314,8 @@ public class HTTPClient extends BaseHTTPClient {
       request.setEntity(new StringEntity(encodedBody));
     }
 
-    try (CloseableHttpResponse response = httpClient.execute(request)) {
+    HttpContext context = HttpClientContext.create();
+    try (CloseableHttpResponse response = httpClient.execute(request, context)) {
       Map<String, String> respHeaders = Maps.newHashMap();
       for (Header header : response.getHeaders()) {
         respHeaders.put(header.getName(), header.getValue());

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -39,8 +39,6 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.apache.hc.core5.http.message.BasicHttpResponse;
-import org.apache.hc.core5.http.protocol.BasicHttpContext;
-import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -32,11 +32,15 @@ import java.time.temporal.ChronoUnit;
 import javax.net.ssl.SSLException;
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -209,5 +213,14 @@ public class TestExponentialHttpRequestRetryStrategy {
   public void testRetryDoesNotHappenOnUnacceptableStatusCodes(int statusCode) {
     BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
     assertThat(retryStrategy.retryRequest(response, 3, null)).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {429, 503, 500, 502, 504, 408})
+  public void testRetryHappensWithIdempotentMethods(int statusCode) {
+    BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
+    HttpClientContext context = HttpClientContext.create();
+    context.setRequest(new BasicHttpRequest("GET", "/"));
+    assertThat(retryStrategy.retryRequest(response, 3, context)).isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -472,10 +472,10 @@ public class TestHTTPClient {
     Item loadTableRequestBody = new Item(0L, "load table");
 
     // First request will respond with a 504 (Gateway Timeout)
-    addRequestTestCaseAndGetPath( path, method, loadTableRequestBody, HttpStatus.SC_GATEWAY_TIMEOUT);
+    addRequestTestCaseAndGetPath(path, method, loadTableRequestBody, HttpStatus.SC_GATEWAY_TIMEOUT);
 
     // Second request will respond with a 200 (OK)
-    addRequestTestCaseAndGetPath( path, method, loadTableRequestBody, HttpStatus.SC_OK);
+    addRequestTestCaseAndGetPath(path, method, loadTableRequestBody, HttpStatus.SC_OK);
 
     // No exception should be thrown, and the second request should succeed
     doExecuteRequest(method, path, loadTableRequestBody, errorHandler, headers -> {});
@@ -534,7 +534,8 @@ public class TestHTTPClient {
    * <p>Note: This will only add one exact request test case, i.e., the response will only be
    * returned for the next matching invocation of the path.
    */
-  private static String addRequestTestCaseAndGetPath(HttpMethod method, Item body, int statusCode) throws JsonProcessingException {
+  private static String addRequestTestCaseAndGetPath(HttpMethod method, Item body, int statusCode)
+      throws JsonProcessingException {
 
     // Build the path route, which must be unique per test case.
     boolean isSuccess = statusCode == 200;
@@ -545,7 +546,6 @@ public class TestHTTPClient {
     return addRequestTestCaseAndGetPath(path, method, body, statusCode);
   }
 
-
   /**
    * Adds a request that the mock server can match against, using the provided path, method, body,
    * and status code. This version allows custom control over the path used in the test, e.g., in
@@ -555,7 +555,7 @@ public class TestHTTPClient {
    * returned for the next matching invocation of the path.
    */
   private static String addRequestTestCaseAndGetPath(
-    String path, HttpMethod method, Item body, int statusCode) throws JsonProcessingException {
+      String path, HttpMethod method, Item body, int statusCode) throws JsonProcessingException {
     boolean isSuccess = statusCode == 200;
 
     // Build the expected request

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.rest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -48,6 +49,7 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.IcebergBuild;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.TLSConfigurer;
@@ -57,9 +59,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockserver.configuration.Configuration;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.matchers.Times;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.verify.VerificationTimes;
@@ -456,6 +460,27 @@ public class TestHTTPClient {
         .doesNotThrowAnyException();
   }
 
+  @ParameterizedTest
+  @EnumSource(HttpMethod.class)
+  public void testRetryIdemmpotentMethods(HttpMethod method) throws JsonProcessingException {
+    assumeThat(method.name().equals("GET") || method.name().equals("HEAD"))
+        .as("Only GET and HEAD methods are idempotent")
+        .isTrue();
+    ResourcePaths paths = ResourcePaths.forCatalogProperties(Map.of());
+    ErrorHandler errorHandler = (ErrorHandler) ErrorHandlers.defaultErrorHandler();
+    String path = paths.table(TableIdentifier.of("ns", "table"));
+    Item loadTableRequestBody = new Item(0L, "load table");
+
+    // First request will respond with a 504 (Gateway Timeout)
+    addRequestTestCaseAndGetPath( path, method, loadTableRequestBody, HttpStatus.SC_GATEWAY_TIMEOUT);
+
+    // Second request will respond with a 200 (OK)
+    addRequestTestCaseAndGetPath( path, method, loadTableRequestBody, HttpStatus.SC_OK);
+
+    // No exception should be thrown, and the second request should succeed
+    doExecuteRequest(method, path, loadTableRequestBody, errorHandler, headers -> {});
+  }
+
   public static void testHttpMethodOnSuccess(HttpMethod method) throws JsonProcessingException {
     Item body = new Item(0L, "hank");
     int statusCode = 200;
@@ -501,18 +526,37 @@ public class TestHTTPClient {
     verify(onError).accept(any());
   }
 
-  // Adds a request that the mock-server can match against, based on the method, path, body, and
-  // headers.
-  // Return the path generated for the test case, so that the client can call that path to exercise
-  // it.
-  private static String addRequestTestCaseAndGetPath(HttpMethod method, Item body, int statusCode)
-      throws JsonProcessingException {
+  /**
+   * Adds a request that the mock server can match against, using the HTTP method, request body, and
+   * status code to define behavior. This method generates a unique path (based on the method and
+   * success/failure outcome) so the client can call it during tests.
+   *
+   * <p>Note: This will only add one exact request test case, i.e., the response will only be
+   * returned for the next matching invocation of the path.
+   */
+  private static String addRequestTestCaseAndGetPath(HttpMethod method, Item body, int statusCode) throws JsonProcessingException {
 
     // Build the path route, which must be unique per test case.
     boolean isSuccess = statusCode == 200;
     // Using different paths keeps the expectations unique for the test's mock server
     String pathName = isSuccess ? "success" : "failure";
     String path = String.format("%s_%s", method, pathName);
+
+    return addRequestTestCaseAndGetPath(path, method, body, statusCode);
+  }
+
+
+  /**
+   * Adds a request that the mock server can match against, using the provided path, method, body,
+   * and status code. This version allows custom control over the path used in the test, e.g., in
+   * the retry scenario, we need to return different responses for the same path and request.
+   *
+   * <p>Note: This will only add one exact request test case, i.e., the response will only be
+   * returned for the next matching invocation of the path.
+   */
+  private static String addRequestTestCaseAndGetPath(
+    String path, HttpMethod method, Item body, int statusCode) throws JsonProcessingException {
+    boolean isSuccess = statusCode == 200;
 
     // Build the expected request
     String asJson = body != null ? MAPPER.writeValueAsString(body) : null;
@@ -542,7 +586,7 @@ public class TestHTTPClient {
       }
     }
 
-    mockServer.when(mockRequest).respond(mockResponse);
+    mockServer.when(mockRequest, Times.exactly(1)).respond(mockResponse);
 
     return path;
   }


### PR DESCRIPTION
Was thinking that we should allow for retries for Idempotent Requests from the HTTP Client for 50X issues. 