### PR TITLE
Spark: Use native table FileIO instead of Hadoop to save file list in RewriteTablePath

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -324,7 +324,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   private void writeAsCsv(Set<Pair<String, String>> csvRows, OutputFile outputFile) {
     try (BufferedWriter writer = new BufferedWriter(
-            new OutputStreamWriter(outputFile.create(), StandardCharsets.UTF_8))) {
+            new OutputStreamWriter(outputFile.createOrOverwrite(), StandardCharsets.UTF_8))) {
       for (Pair<String, String> pair : csvRows) {
         writer.write(String.join(",", pair.first(), pair.second()));
         writer.newLine();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -59,13 +58,11 @@ import org.apache.iceberg.data.parquet.GenericParquetReaders;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.exceptions.RuntimeIOException;
-import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.io.ResolvingFileIO;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -323,7 +320,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   private void writeAsCsv(Set<Pair<String, String>> rows, OutputFile outputFile) {
-    try (BufferedWriter writer = new BufferedWriter(
+    try (BufferedWriter writer =
+        new BufferedWriter(
             new OutputStreamWriter(outputFile.createOrOverwrite(), StandardCharsets.UTF_8))) {
       for (Pair<String, String> pair : rows) {
         writer.write(String.join(",", pair.first(), pair.second()));

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -322,10 +322,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     return fileListPath;
   }
 
-  private void writeAsCsv(Set<Pair<String, String>> csvRows, OutputFile outputFile) {
+  private void writeAsCsv(Set<Pair<String, String>> rows, OutputFile outputFile) {
     try (BufferedWriter writer = new BufferedWriter(
             new OutputStreamWriter(outputFile.createOrOverwrite(), StandardCharsets.UTF_8))) {
-      for (Pair<String, String> pair : csvRows) {
+      for (Pair<String, String> pair : rows) {
         writer.write(String.join(",", pair.first(), pair.second()));
         writer.newLine();
       }


### PR DESCRIPTION
RewriteTablePath leverages iceberg native table IO for everything except for writing a "file list" file. For this task it currently leverages a Spark writer, which in turn uses Hadoop. This might become a limitation in some cloud environments: for instance, Hadoop does not support [modern auth strategies](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) of Azure, and thus enforces unwanted auth paths where it is not required by the cloud provider itself. Also it requires the user to manage 2 configurations for table IO and for spark IO. We suggest to use native table io instead.

See corresponding issue here:
https://github.com/apache/iceberg/issues/13458