### PR TITLE
[REST] Add BasicTLSConfigurer for custom keystore and truststore support

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.auth;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Map;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A TLS configurer that supports custom keystore and truststore configuration.
+ */
+public class BasicTLSConfigurer implements TLSConfigurer {
+
+    public static final String TLS_KEYSTORE_PATH = "rest.client.tls.keystore.path";
+    public static final String TLS_KEYSTORE_PASSWORD = "rest.client.tls.keystore.password";
+    public static final String TLS_KEYSTORE_TYPE = "rest.client.tls.keystore.type";
+    public static final String TLS_TRUSTSTORE_PATH = "rest.client.tls.truststore.path";
+    public static final String TLS_TRUSTSTORE_PASSWORD = "rest.client.tls.truststore.password";
+    public static final String TLS_TRUSTSTORE_TYPE = "rest.client.tls.truststore.type";
+
+    private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
+    private static final String DEFAULT_SSL_PROTOCOL = "TLS";
+
+    private SSLContext sslContext;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        String keystorePath = properties.get(TLS_KEYSTORE_PATH);
+        String keystorePassword = properties.get(TLS_KEYSTORE_PASSWORD);
+        String keystoreType = properties.getOrDefault(TLS_KEYSTORE_TYPE, DEFAULT_KEYSTORE_TYPE);
+        String truststorePath = properties.get(TLS_TRUSTSTORE_PATH);
+        String truststorePassword = properties.get(TLS_TRUSTSTORE_PASSWORD);
+        String truststoreType = properties.getOrDefault(TLS_TRUSTSTORE_TYPE, DEFAULT_KEYSTORE_TYPE);
+
+        try {
+            SSLContext context = SSLContext.getInstance(DEFAULT_SSL_PROTOCOL);
+
+            KeyManagerFactory keyManagerFactory = null;
+            if (keystorePath != null) {
+                KeyStore keyStore = loadKeyStore(keystorePath, keystorePassword, keystoreType);
+                keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                keyManagerFactory.init(keyStore, keystorePassword != null ? keystorePassword.toCharArray() : null);
+            }
+
+            TrustManagerFactory trustManagerFactory = null;
+            if (truststorePath != null) {
+                KeyStore trustStore = loadKeyStore(truststorePath, truststorePassword, truststoreType);
+                trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init(trustStore);
+            }
+
+            context.init(
+                    keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
+                    trustManagerFactory != null ? trustManagerFactory.getTrustManagers() : null,
+                    null);
+
+            this.sslContext = context;
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException | UnrecoverableKeyException e) {
+            throw new IllegalStateException("Failed to create SSL context", e);
+        }
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return sslContext != null ? sslContext : SSLContext.getDefault();
+    }
+
+    private KeyStore loadKeyStore(String path, String password, String type) {
+        try (FileInputStream fis = new FileInputStream(path)) {
+            KeyStore keyStore = KeyStore.getInstance(type);
+            keyStore.load(fis, password != null ? password.toCharArray() : null);
+            return keyStore;
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
+            throw new IllegalStateException(String.format("Failed to load keystore from path: %s", path), e);
+        }
+    }
+}


### PR DESCRIPTION
This is a follow up to https://github.com/apache/iceberg/pull/13190.

Implements a `BasicTLSConfigurer` class that provides TLS configuration with custom keystore and truststore support for REST client authentication.

Property-based configuration with support for:
`rest.client.tls.keystore.path`
`rest.client.tls.keystore.password`
`rest.client.tls.keystore.type` - (default: JKS)
`rest.client.tls.truststore.path`
`rest.client.tls.truststore.password`
`rest.client.tls.truststore.type` - (default: JKS)
