### PR TITLE
Make 'Drop table' behavior same in hive4 and spark3.5 when use hiveca…

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -64,7 +64,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.LocationUtil;
-mport org.apache.iceberg.util.PropertyUtil;											
+import org.apache.iceberg.util.PropertyUtil;											
 import org.apache.iceberg.view.BaseMetastoreViewCatalog;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
@@ -252,10 +252,7 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
       }
     }
 
-    LOG.info("externalTablePurge: {}", externalTablePurge);
-    LOG.info("gcEnabled: {}", gcEnabled);
     final boolean deleteData = (externalTablePurge || gcEnabled) && this.deleteTableRootDir;
-    LOG.info("deleteData: {}", deleteData);
 
     try {
       clients.run(
@@ -263,7 +260,6 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
             client.dropTable(
                 database,
                 identifier.name(),
-                // false /* do not delete data */,
                 deleteData,
                 false /* throw NoSuchObjectException if the table doesn't exist */);
             return null;

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -84,7 +84,7 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
   public static final String HMS_DB_OWNER_TYPE = "hive.metastore.database.owner-type";
 
   public static final String DELETE_TABLE_ROOTDIR = "delete-table-rootdir";
-  public static final String DELETE_TABLE_ROOTDIR_DEFAULT = "true";																		   
+  public static final String DELETE_TABLE_ROOTDIR_DEFAULT = "false";																		   
   // MetastoreConf is not available with current Hive version
   static final String HIVE_CONF_CATALOG = "metastore.catalog.default";
 


### PR DESCRIPTION
1. add catalog property "delete-table-rootdir",default  value: true. if want to make behavior as before, set this to fasle.
2. if delete-table-rootdir = true and external.table.purge = true, it will call hive metastore method  to delete hive table's root directory , so it will be same as hive4.
