### PR TITLE
Docs: Hardcode BSD sed if running on MacOS (Closes #13499)

### DIFF
--- a/site/dev/common.sh
+++ b/site/dev/common.sh
@@ -177,8 +177,8 @@ update_version () {
   # Update version information within the mkdocs.yml file using sed commands
   if [ "$(uname)" == "Darwin" ]
   then
-    sed -i '' -E "s/(^site\_name:[[:space:]]+docs\/).*$/\1${ICEBERG_VERSION}/" ${ICEBERG_VERSION}/mkdocs.yml
-    sed -i '' -E "s/(^[[:space:]]*-[[:space:]]+Javadoc:.*\/javadoc\/).*$/\1${ICEBERG_VERSION}/" ${ICEBERG_VERSION}/mkdocs.yml
+    /usr/bin/sed -i '' -E "s/(^site\_name:[[:space:]]+docs\/).*$/\1${ICEBERG_VERSION}/" ${ICEBERG_VERSION}/mkdocs.yml
+    /usr/bin/sed -i '' -E "s/(^[[:space:]]*-[[:space:]]+Javadoc:.*\/javadoc\/).*$/\1${ICEBERG_VERSION}/" ${ICEBERG_VERSION}/mkdocs.yml
   elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]
   then
     sed -i'' -E "s/(^site_name:[[:space:]]+docs\/)[^[:space:]]+/\1${ICEBERG_VERSION}/" "${ICEBERG_VERSION}/mkdocs.yml"


### PR DESCRIPTION
Fixes #13499 

At the moment the [script checks for MacOS](https://github.com/apache/iceberg/blob/9faf4311d71ce313e81dea07290b3aea9298422c/site/dev/common.sh#L178) and uses a different syntax for `sed`, assuming that it will be BSD sed. This assumption is invalid if the user has changed their default `sed` to be GNU sed.

This PR hardcodes the script to, if on the MacOS, use the built-in BSD sed.