### PR TITLE
AWS: Add dot as supported character for DB in Glue

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -59,7 +59,7 @@ class IcebergToGlueConverter {
 
   private IcebergToGlueConverter() {}
 
-  private static final Pattern GLUE_DB_PATTERN = Pattern.compile("^[a-z0-9_]{1,252}$");
+  private static final Pattern GLUE_DB_PATTERN = Pattern.compile("^[a-z0-9_.]{1,252}$");
   private static final Pattern GLUE_TABLE_PATTERN = Pattern.compile("^[a-z0-9_]{1,255}$");
   public static final String GLUE_DB_LOCATION_KEY = "location";
   // Utilized for defining descriptions at both the Glue database and table levels.
@@ -85,7 +85,7 @@ class IcebergToGlueConverter {
 
   /**
    * A Glue database name cannot be longer than 252 characters. The only acceptable characters are
-   * lowercase letters, numbers, and the underscore character. More details:
+   * lowercase letters, numbers, the underscore and dot characters. More details:
    * https://docs.aws.amazon.com/athena/latest/ug/glue-best-practices.html
    *
    * @param namespace namespace
@@ -109,7 +109,7 @@ class IcebergToGlueConverter {
     ValidationException.check(
         isValidNamespace(namespace),
         "Cannot convert namespace %s to Glue database name, "
-            + "because it must be 1-252 chars of lowercase letters, numbers, underscore",
+            + "because it must be 1-252 chars of lowercase letters, numbers, underscore, dot",
         namespace);
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -423,7 +423,7 @@ public class TestGlueCatalog {
           .hasMessageStartingWith("Cannot convert namespace")
           .hasMessageEndingWith(
               "to Glue database name, "
-                  + "because it must be 1-252 chars of lowercase letters, numbers, underscore");
+                  + "because it must be 1-252 chars of lowercase letters, numbers, underscore, dot");
     }
   }
 
@@ -485,7 +485,7 @@ public class TestGlueCatalog {
         .isInstanceOf(ValidationException.class)
         .hasMessage(
             "Cannot convert namespace db-1 to Glue database name, "
-                + "because it must be 1-252 chars of lowercase letters, numbers, underscore");
+                + "because it must be 1-252 chars of lowercase letters, numbers, underscore, dot");
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -52,7 +52,16 @@ public class TestIcebergToGlueConverter {
 
   @Test
   public void testToDatabaseName() {
-    assertThat(IcebergToGlueConverter.toDatabaseName(Namespace.of("db"), false)).isEqualTo("db");
+    List<Object[]> goodNames =
+        Lists.newArrayList(
+            new Object[] {Namespace.of("db"), "db"},
+            new Object[] {Namespace.of("db_1"), "db_1"},
+            new Object[] {Namespace.of("db.1"), "db.1"});
+    for (Object[] name : goodNames) {
+
+      assertThat(IcebergToGlueConverter.toDatabaseName((Namespace) name[0], false))
+          .isEqualTo(name[1]);
+    }
   }
 
   @Test
@@ -71,7 +80,7 @@ public class TestIcebergToGlueConverter {
           .hasMessageStartingWith("Cannot convert namespace")
           .hasMessageEndingWith(
               "to Glue database name, "
-                  + "because it must be 1-252 chars of lowercase letters, numbers, underscore");
+                  + "because it must be 1-252 chars of lowercase letters, numbers, underscore, dot");
     }
   }
 


### PR DESCRIPTION
## Description
On AWS Glue it's possible to create namespaces with a dot character however in iceberg this is not considered a valid namespace. Therefore this PR adds the . "dot" as a valid character on the DB pattern.

This is done by changing the `GLUE_DB_PATTERN` variable in `IcebergToGlueConverter`. Also updates the error message.

## Testing
Added more success cases to positive test on `testToDatabaseName`.

## Questions
Do you think this can cause bad interoperability with the existing code, since we are also splitting namespaces with a dot character? 
Any reason why not do this?