### PR TITLE
API, Flink: fix typos in javadoc

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -348,7 +348,7 @@ public interface Catalog {
   }
 
   /**
-   * /** Instantiate a builder to either create a table or start a create/replace transaction.
+   * Instantiate a builder to either create a table or start a create/replace transaction.
    *
    * @param identifier a table identifier
    * @param schema a schema

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -48,7 +48,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 
 /**
- * /** Flink source builder for old {@link SourceFunction} implementation.
+ * Flink source builder for old {@link SourceFunction} implementation.
  *
  * @deprecated since 1.7.0, will be removed in 2.0.0. Use {@link IcebergSource} instead, which
  *     implement the newer FLIP-27 source interface. This class implements the old {@link

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -48,7 +48,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 
 /**
- * /** Flink source builder for old {@link SourceFunction} implementation.
+ * Flink source builder for old {@link SourceFunction} implementation.
  *
  * @deprecated since 1.7.0, will be removed in 2.0.0. Use {@link IcebergSource} instead, which
  *     implement the newer FLIP-27 source interface. This class implements the old {@link


### PR DESCRIPTION
Remove superfluous `/**` string inside javadoc section