### PR TITLE
Docs: Add Ryft to list of vendors and blog posts

### DIFF
--- a/site/docs/blogs.md
+++ b/site/docs/blogs.md
@@ -21,6 +21,15 @@ title: "Blogs"
 ## Iceberg Blogs
 
 Here is a list of company blogs that talk about Iceberg. The blogs are ordered from most recent to oldest.
+<!-- markdown-link-check-disable-next-line -->
+### [Athena vs. Snowflake on Iceberg: Performance and Cost Comparison on TPC-H](https://www.ryft.io/blog/athena-vs-snowflake-on-iceberg-tpch-comparison)
+**Date:** July 9, 2025, **Company**: Ryft
+**Author**: [Yuval Yogev](https://www.linkedin.com/in/yuvalyogev)
+
+<!-- markdown-link-check-disable-next-line -->
+### [Making Sense of Apache Iceberg Statistics](https://www.ryft.io/blog/making-sense-of-apache-iceberg-statistics)
+**Date:** July 9, 2025, **Company**: Ryft
+**Author**: [Guy Yasoor](https://www.linkedin.com/in/guy-yasoor/)
 
 <!-- markdown-link-check-disable-next-line -->
 ### [Querying Apache Iceberg with Sub-Second Performance](https://www.firebolt.io/blog/querying-apache-iceberg-with-sub-second-performance)

--- a/site/docs/blogs.md
+++ b/site/docs/blogs.md
@@ -21,10 +21,6 @@ title: "Blogs"
 ## Iceberg Blogs
 
 Here is a list of company blogs that talk about Iceberg. The blogs are ordered from most recent to oldest.
-<!-- markdown-link-check-disable-next-line -->
-### [Athena vs. Snowflake on Iceberg: Performance and Cost Comparison on TPC-H](https://www.ryft.io/blog/athena-vs-snowflake-on-iceberg-tpch-comparison)
-**Date:** July 9, 2025, **Company**: Ryft
-**Author**: [Yuval Yogev](https://www.linkedin.com/in/yuvalyogev)
 
 <!-- markdown-link-check-disable-next-line -->
 ### [Making Sense of Apache Iceberg Statistics](https://www.ryft.io/blog/making-sense-of-apache-iceberg-statistics)

--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -108,6 +108,11 @@ Redpanda is both a cloud-native and self-hosted streaming platform whose [Iceber
 
 [RisingWave](https://risingwave.com/) is a cloud-native streaming database for real-time data ingestion, processing, and management. It integrates with Iceberg to [read from](https://docs.risingwave.com/integrations/sources/apache-iceberg) and [write to](https://docs.risingwave.com/integrations/destinations/apache-iceberg) Iceberg tables, enabling efficient file compaction across sources like message queues, databases (via Change Data Capture), data lakes, and files. RisingWave is available as [open source](https://github.com/risingwavelabs/risingwave), a managed cloud service ([RisingWave Cloud](https://cloud.risingwave.com/auth/signin/)) with BYOC support, and an enterprise on-premises edition ([RisingWave Premium](https://docs.risingwave.com/get-started/rw-premium-edition-intro)).
 
+### [Ryft](https://ryft.io/)
+
+[Ryft](https://ryft.io/) is a fully automated Iceberg management platform. Ryft helps data teams create an open, automated and cost-effective Iceberg lakehouse, by maintaining and optimizing Iceberg tables in real time, handling compaction, all based on actual usage patterns. Ryft engine customizes compaction intelligently to fit different use cases like streaming, CDC, batch jobs etc'. Ryft also automates governance, GDPR compliance for Iceberg tables and data lifecycle so data stays secure and compliant. It integrates directly with existing lakehouses using the catalog and storage so users don't need to replace any part of their stack.
+
+
 ### [SingleStore](https://singlestore.com/)
 
 SingleStore is a high‑performance, scalable, distributed SQL platform that makes real‑time analytics and transactional processing available at scale. Its native Apache Iceberg integration removes costly ETL steps and powers intelligent, millisecond‑response applications.

--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -110,7 +110,7 @@ Redpanda is both a cloud-native and self-hosted streaming platform whose [Iceber
 
 ### [Ryft](https://ryft.io/)
 
-[Ryft](https://ryft.io/) is a fully automated Iceberg management platform. Ryft helps data teams create an open, automated and cost-effective Iceberg lakehouse, by maintaining and optimizing Iceberg tables in real time, handling compaction, all based on actual usage patterns. Ryft engine customizes compaction intelligently to fit different use cases like streaming, CDC, batch jobs etc'. Ryft also automates governance, GDPR compliance for Iceberg tables and data lifecycle so data stays secure and compliant. It integrates directly with existing lakehouses using the catalog and storage so users don't need to replace any part of their stack.
+[Ryft](https://ryft.io/) is a fully automated Iceberg management platform. Ryft helps data teams create an open, automated and cost-effective Iceberg lakehouse, by maintaining and optimizing Iceberg tables in real time, based on actual usage patterns. The Ryft engine runs compaction intelligently, adapting to different use cases like streaming, batch jobs, CDC, and more. Ryft also automates compliance, disaster recovery and data lifecycle for Iceberg tables, to ensure your lakeehouse stays secure and compliant. It directly integrates with your existing catalog, storage and query engines, allowing for a very simple deployment.
 
 
 ### [SingleStore](https://singlestore.com/)

--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -110,7 +110,7 @@ Redpanda is both a cloud-native and self-hosted streaming platform whose [Iceber
 
 ### [Ryft](https://ryft.io/)
 
-[Ryft](https://ryft.io/) is a fully automated Iceberg management platform. Ryft helps data teams create an open, automated and cost-effective Iceberg lakehouse, by maintaining and optimizing Iceberg tables in real time, based on actual usage patterns. The Ryft engine runs compaction intelligently, adapting to different use cases like streaming, batch jobs, CDC, and more. Ryft also automates compliance, disaster recovery and data lifecycle for Iceberg tables, to ensure your lakeehouse stays secure and compliant. It directly integrates with your existing catalog, storage and query engines, allowing for a very simple deployment.
+[Ryft](https://ryft.io/) is a fully automated Iceberg management platform. Ryft helps data teams create an open, automated and cost-effective Iceberg lakehouse, by maintaining and optimizing Iceberg tables in real time, based on actual usage patterns. The Ryft engine runs compaction intelligently, adapting to different use cases like streaming, batch jobs, CDC, and more. Ryft also automates compliance, disaster recovery and data lifecycle management for Iceberg tables, to ensure your lakehouse stays secure and compliant. It directly integrates with your existing catalog, storage and query engines, allowing for a very simple deployment.
 
 
 ### [SingleStore](https://singlestore.com/)


### PR DESCRIPTION
Added Ryft to the list of vendors, as well as links to the Iceberg blog posts.