### PR TITLE
docs: add subpage for REST Catalog Spec in "Specification"

### DIFF
--- a/site/docs/rest-catalog-spec.md
+++ b/site/docs/rest-catalog-spec.md
@@ -21,9 +21,9 @@ title: "REST Catalog Spec"
 ## REST Catalog API Specification
 
 Iceberg defines a REST-based Catalog API for managing table metadata and performing catalog operations. You can find the OpenAPI specification here:
-[REST Catalog OpenAPI YAML](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml)
+[REST Catalog OpenAPI YAML](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml).
 
-You can also explore the API interactively using the [Swagger UI](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml)
+You can also explore the API interactively using the [Swagger UI](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml).
 
 ## REST Catalog Protocol
 

--- a/site/docs/rest-catalog-spec.md
+++ b/site/docs/rest-catalog-spec.md
@@ -21,9 +21,9 @@ title: "REST Catalog Spec"
 ## REST Catalog API Specification
 
 Iceberg defines a REST-based Catalog API for managing table metadata and performing catalog operations. You can find the OpenAPI specification here:
-[REST Catalog OpenAPI YAML][iceberg-rest-spec]
+[REST Catalog OpenAPI YAML](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml)
 
-You can also explore the API interactively using the [Swagger UI][swagger-ui]
+You can also explore the API interactively using the [Swagger UI](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml)
 
 ## REST Catalog Protocol
 
@@ -40,6 +40,3 @@ The REST protocol is important for several reasons:
 - **Security**: The protocol supports secure table sharing using credential vending or remote signing.
 
 You can use the REST catalog protocol with any built-in catalog using translation in the `CatalogHandlers` class, or using the community maintained [`iceberg-rest-fixture`](https://hub.docker.com/r/apache/iceberg-rest-fixture) docker image.
-
-[iceberg-rest-spec]: https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
-[swagger-ui]: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml

--- a/site/docs/rest-catalog-spec.md
+++ b/site/docs/rest-catalog-spec.md
@@ -1,0 +1,45 @@
+---
+title: "REST Catalog Spec"
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+## REST Catalog API Specification
+
+Iceberg defines a REST-based Catalog API for managing table metadata and performing catalog operations. You can find the OpenAPI specification here:
+[REST Catalog OpenAPI YAML][iceberg-rest-spec]
+
+You can also explore the API interactively using the [Swagger UI][swagger-ui]
+
+## REST Catalog Protocol
+
+As the Iceberg project grew to support more languages and engines, pluggable catalogs started to cause some practical problems. Catalogs needed to be implemented in multiple languages and it proved difficult for commercial offerings to support many different catalogs and clients.
+
+To solve compatibility problems and pave a path for new features, the community created the REST catalog protocol, a common API (using the OpenAPI spec) for interacting with any Iceberg catalog. This is analogous to Hive's thrift protocol for HMS.
+
+The REST protocol is important for several reasons:
+
+- **Language and Engine Compatibility**: New languages and engines can support any catalog with just one client implementation.
+- **Improved Reliability**: It uses change-based commits to enable server-side deconfliction and retries — fewer failures!
+- **Simplified Metadata Management**: Metadata version upgrades are easier because root metadata is written by the catalog service.
+- **Advanced Features**: It enables new features such as lazy snapshot loading, multi-table commits, and caching.
+- **Security**: The protocol supports secure table sharing using credential vending or remote signing.
+
+You can use the REST catalog protocol with any built-in catalog using translation in the `CatalogHandlers` class, or using the community maintained [`iceberg-rest-fixture`](https://hub.docker.com/r/apache/iceberg-rest-fixture) docker image.
+
+[iceberg-rest-spec]: https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
+[swagger-ui]: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -65,7 +65,7 @@ nav:
       - Sponsors: https://www.apache.org/foundation/sponsors.html
   - Specification:
     - Terms: terms.md
-    - REST Catalog Spec: https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml
+    - REST Catalog Spec: rest-catalog-spec.md
     - Table Spec: spec.md
     - View spec: view-spec.md
     - Puffin spec: puffin-spec.md


### PR DESCRIPTION
I always access the irc spec through the left pane of https://iceberg.apache.org/spec/  which brings me to the swagger view. 
The swagger view is great but wont allow me to reference and hyperlink a specific section. 
So I end up navigating to the `rest-catalog-open-api.yaml` file manually. 

This PR adds a dedicated page for REST spec
<img width="1108" height="780" alt="Screenshot 2025-07-23 at 10 57 57 PM" src="https://github.com/user-attachments/assets/f5d63a5e-b630-4f1b-8ab3-c8122768e47c" />

I also took a few paragraphs from https://www.tabular.io/apache-iceberg-cookbook/getting-started-catalog-background/ 
