### PR TITLE
AWS: use aws client region for StsClient if available

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -161,6 +161,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private StsClient sts() {
     return StsClient.builder()
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
         .build();
   }
 


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/13524