### PR TITLE
Kafka Connect: Add manifests for the transformations

### DIFF
--- a/kafka-connect/kafka-connect-transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/kafka-connect/kafka-connect-transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.iceberg.connect.transforms.CopyValue
+org.apache.iceberg.connect.transforms.DebeziumTransform
+org.apache.iceberg.connect.transforms.DmsTransform
+org.apache.iceberg.connect.transforms.JsonToMapTransform
+org.apache.iceberg.connect.transforms.KafkaMetadataTransform
+org.apache.iceberg.connect.transforms.MongoDebeziumTransform


### PR DESCRIPTION
Iceberg has a service loader manifest for `IcebergSinkConnector` but does not have a manifest for the Kafka Connect transformations.
Transformations also need a manifest, otherwise by default, with `plugin.discovery=hybrid_warn` you get a warning at startup. Without a manifest, if the `plugin.discovery` configuration is set to `service_load` in the Kafka Connect cluster, then the transformations are not loaded.