### PR TITLE
Spark: Reordering partitions via partition evolution can disable SPJ

### DIFF
--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -378,6 +378,54 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testJoinsWhichReorderPartitionsViaSpecEvolution() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (bucket(8, id), int_col, dep) "
+            + "TBLPROPERTIES (%s)",
+        tableName, tablePropsAsString(TABLE_PROPERTIES));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    // evolve the spec in the first table by reordering the final two partition columns by first
+    // removing them and re-adding them
+    table.updateSpec().removeField("int_col").commit();
+    table.updateSpec().removeField("dep").commit();
+
+    table.updateSpec().addField("dep").commit();
+    table.updateSpec().addField("int_col").commit();
+
+    sql("REFRESH TABLE %s", tableName);
+    sql("INSERT INTO %s VALUES (1L, 100, 'software')", tableName);
+    sql("INSERT INTO %s VALUES (2L, 200, 'hr')", tableName);
+
+    // create another table partitioned by `other_dep` partitioned identically to the original
+    // partitioning of the first table but with the last two partition columns reordered (e.g.
+    // the current state of the first table)
+    sql(
+        "CREATE TABLE %s (other_id BIGINT, other_int_col INT, other_dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (bucket(8, other_id), other_dep, other_int_col)"
+            + "TBLPROPERTIES (%s)",
+        tableName(OTHER_TABLE_NAME), tablePropsAsString(TABLE_PROPERTIES));
+
+    sql("INSERT INTO %s VALUES (1L, 100, 'software')", tableName(OTHER_TABLE_NAME));
+    sql("INSERT INTO %s VALUES (2L, 200, 'hr')", tableName(OTHER_TABLE_NAME));
+
+    assertPartitioningAwarePlan(
+        1, /* expected num of shuffles with SPJ */
+        3, /* expected num of shuffles without SPJ */
+        "SELECT * "
+            + "FROM %s "
+            + "INNER JOIN %s "
+            + "ON id = other_id AND int_col = other_int_col AND dep = other_dep "
+            + "ORDER BY id, int_col, dep",
+        tableName,
+        tableName(OTHER_TABLE_NAME));
+  }
+
+  @TestTemplate
   public void testJoinsWithIncompatibleSpecs() {
     sql(
         "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"


### PR DESCRIPTION
This PR fixes a case where tables with current identical partitioning structures where one table was created directly w/ this structure and the other was created, had it's partitions evolved in a way that changed their order to match the partitioning of the other table. 

Currently, partition groupings are reported to Spark with partition fields sorted by fieldId and if two tables have identical partitions but report them in different orders then the storage partitioned join feature is disabled. 

This PR fixes this issue by changing the partition grouping key reported to Spark (and really just used everywhere) to calculate the grouping key sorted by the order of partition fields in the most recent spec ascending rather than by fieldId ascending. 

This change ends up changing how the grouping key is calculated for all of Iceberg by default, so I'm open to feedback on potentially scoping this down to just Spark if you'd like and/or investigating whether a fix is possible on the Spark end of things rather than in Iceberg.

### Testing
I've added some unit tests to verify that an SPJ plan is generated for this case which fail on the current main branch but pass on this feature branch.

Fixes: https://github.com/apache/iceberg/issues/13530