### PR TITLE
Implement missing close() method in CompositeMetricsReporter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/metrics/MetricsReporters.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/MetricsReporters.java
@@ -78,6 +78,17 @@ public class MetricsReporters {
       }
     }
 
+    @Override
+    public void close() {
+      for (MetricsReporter reporter : reporters) {
+        try {
+          reporter.close();
+        } catch (Exception e) {
+          LOG.warn("Failed to close metrics reporter {}", reporter.getClass().getName(), e);
+        }
+      }
+    }
+
     Set<MetricsReporter> reporters() {
       return Collections.unmodifiableSet(reporters);
     }


### PR DESCRIPTION
This ensures that when a CompositeMetricsReporter is closed, all of its underlying reporters are properly closed as well, preventing resource leaks.