### PR TITLE
Core: Add Schema evolution test with initial defaults

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -40,7 +40,7 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -117,79 +117,78 @@ public class TestScansAndSchemaEvolution {
     assertThat(tasks).hasSize(1);
   }
 
-  @Test
+  @TestTemplate
   public void testAddColumnWithDefaultValueAndQuery() throws IOException {
-    // Only enable the test for versions above V3 since default values require V3+.
-    for (int version : V3_AND_ABOVE) {
-      File location = Files.createTempDirectory(temp, "junit").toFile();
-      assertThat(location.delete()).isTrue(); // should be created by table create
+    Assumptions.assumeTrue(
+        V3_AND_ABOVE.contains(formatVersion),
+        "Only enable the test for versions above V3 since default values require V3+.");
+    File location = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(location.delete()).isTrue(); // should be created by table create
 
-      Table table = TestTables.create(location, "test_v" + version, SCHEMA, SPEC, version);
+    Table table = TestTables.create(location, "test", SCHEMA, SPEC, formatVersion);
 
-      // Write initial data
-      DataFile fileOne = createDataFile("one");
-      DataFile fileTwo = createDataFile("two");
-      table.newAppend().appendFile(fileOne).appendFile(fileTwo).commit();
+    // Write initial data
+    DataFile fileOne = createDataFile("one");
+    DataFile fileTwo = createDataFile("two");
+    table.newAppend().appendFile(fileOne).appendFile(fileTwo).commit();
 
-      // Add a new column with an initial default value
-      String defaultValue = "default_category";
-      table
-          .updateSchema()
-          .addColumn(
-              "category", Types.StringType.get(), "Product category", Literal.of(defaultValue))
-          .commit();
+    // Add a new column with an initial default value
+    String defaultValue = "default_category";
+    table
+        .updateSchema()
+        .addColumn("category", Types.StringType.get(), "Product category", Literal.of(defaultValue))
+        .commit();
 
-      // Verify the schema includes the new column with default value
-      Schema updatedSchema = table.schema();
-      Types.NestedField categoryField = updatedSchema.findField("category");
-      assertThat(categoryField).isNotNull();
-      assertThat(categoryField.initialDefault()).isEqualTo(defaultValue);
-      assertThat(categoryField.writeDefault()).isEqualTo(defaultValue);
+    // Verify the schema includes the new column with default value
+    Schema updatedSchema = table.schema();
+    Types.NestedField categoryField = updatedSchema.findField("category");
+    assertThat(categoryField).isNotNull();
+    assertThat(categoryField.initialDefault()).isEqualTo(defaultValue);
+    assertThat(categoryField.writeDefault()).isEqualTo(defaultValue);
 
-      // Verify scan planning works with the new column that has default value
-      List<FileScanTask> tasks = Lists.newArrayList(table.newScan().planFiles());
-      assertThat(tasks).hasSize(2);
+    // Verify scan planning works with the new column that has default value
+    List<FileScanTask> tasks = Lists.newArrayList(table.newScan().planFiles());
+    assertThat(tasks).hasSize(2);
 
-      // Test that scan with projection includes the new column with default value
-      Schema projectionSchema = table.schema().select("id", "data", "category");
-      List<FileScanTask> projectionTasks =
-          Lists.newArrayList(table.newScan().project(projectionSchema).planFiles());
-      assertThat(projectionTasks).hasSize(2);
+    // Test that scan with projection includes the new column with default value
+    Schema projectionSchema = table.schema().select("id", "data", "category");
+    List<FileScanTask> projectionTasks =
+        Lists.newArrayList(table.newScan().project(projectionSchema).planFiles());
+    assertThat(projectionTasks).hasSize(2);
 
-      // Verify that each task has the correct schema with the default column
-      for (FileScanTask task : projectionTasks) {
-        assertThat(task.schema().findField("category")).isNotNull();
-        assertThat(task.schema().findField("category").initialDefault()).isEqualTo(defaultValue);
-      }
+    // Verify that each task has the correct schema with the default column
+    for (FileScanTask task : projectionTasks) {
+      assertThat(task.schema().findField("category")).isNotNull();
+      assertThat(task.schema().findField("category").initialDefault()).isEqualTo(defaultValue);
+    }
 
-      // Test scan with filter on the new default column
-      List<FileScanTask> filteredTasks =
-          Lists.newArrayList(
-              table.newScan().filter(Expressions.equal("category", defaultValue)).planFiles());
-      assertThat(filteredTasks).hasSize(2); // All files should match since default applies to all
+    // Test scan with filter on the new default column
+    List<FileScanTask> filteredTasks =
+        Lists.newArrayList(
+            table.newScan().filter(Expressions.equal("category", defaultValue)).planFiles());
+    assertThat(filteredTasks).hasSize(2); // All files should match since default applies to all
 
-      // Test scan with filter on a value that is different than default.
-      List<FileScanTask> nonDefaultTasks =
-          Lists.newArrayList(
-              table.newScan().filter(Expressions.equal("category", "non_default")).planFiles());
-      assertThat(nonDefaultTasks).hasSize(2); // Files are returned, filtering happens during read
+    // Test scan with filter on a value that is different than default.
+    List<FileScanTask> nonDefaultTasks =
+        Lists.newArrayList(
+            table.newScan().filter(Expressions.equal("category", "non_default")).planFiles());
+    assertThat(nonDefaultTasks).hasSize(2); // Files are returned, filtering happens during read
 
-      // Write new data after schema evolution
-      DataFile fileThree = createDataFile("three");
-      table.newAppend().appendFile(fileThree).commit();
+    // Write new data after schema evolution
+    DataFile fileThree = createDataFile("three");
+    table.newAppend().appendFile(fileThree).commit();
 
-      // Verify scan planning works with all files (old and new)
-      List<FileScanTask> allTasks = Lists.newArrayList(table.newScan().planFiles());
-      assertThat(allTasks).hasSize(3);
+    // Verify scan planning works with all files (old and new)
+    List<FileScanTask> allTasks = Lists.newArrayList(table.newScan().planFiles());
+    assertThat(allTasks).hasSize(3);
 
-      // Test that all tasks have access to the column with default value
-      for (FileScanTask task : allTasks) {
-        Schema taskSchema = task.schema();
-        Types.NestedField categoryFieldInTask = taskSchema.findField("category");
-        assertThat(categoryFieldInTask).isNotNull();
-        assertThat(categoryFieldInTask.initialDefault()).isEqualTo(defaultValue);
-        assertThat(categoryFieldInTask.writeDefault()).isEqualTo(defaultValue);
-      }
+    // Test that all tasks have access to the column with default value
+    for (FileScanTask task : allTasks) {
+      Schema taskSchema = task.schema();
+      Types.NestedField categoryFieldInTask = taskSchema.findField("category");
+      assertThat(categoryFieldInTask).isNotNull();
+      assertThat(categoryFieldInTask.initialDefault()).isEqualTo(defaultValue);
+      assertThat(categoryFieldInTask.writeDefault()).isEqualTo(defaultValue);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.TestHelpers.ALL_VERSIONS;
 import static org.apache.iceberg.TestHelpers.V3_AND_ABOVE;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,7 +41,6 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -119,9 +119,10 @@ public class TestScansAndSchemaEvolution {
 
   @TestTemplate
   public void testAddColumnWithDefaultValueAndQuery() throws IOException {
-    Assumptions.assumeTrue(
-        V3_AND_ABOVE.contains(formatVersion),
-        "Only enable the test for versions above V3 since default values require V3+.");
+    assumeThat(V3_AND_ABOVE.contains(formatVersion))
+        .withFailMessage(
+            "Only enable the test for versions above V3 since default values require V3+.")
+        .isTrue();
     File location = Files.createTempDirectory(temp, "junit").toFile();
     assertThat(location.delete()).isTrue(); // should be created by table create
 


### PR DESCRIPTION
Add a test case to the existing schema evolution test case to add new column with an initial default.
