### PR TITLE
Core: Batch load new files when validating replaced partitions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
+++ b/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.exceptions.CherrypickAncestorCommitException;
@@ -30,8 +31,6 @@ import org.apache.iceberg.util.PartitionSet;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.WapUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Cherry-picks or fast-forwards the current state to a snapshot.
@@ -46,8 +45,6 @@ class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
   private Snapshot cherrypickSnapshot = null;
   private boolean requireFastForward = false;
   private PartitionSet replacedPartitions = null;
-
-  private static final Logger LOG = LoggerFactory.getLogger(CherryPickOperation.class);
 
   CherryPickOperation(String tableName, TableOperations ops) {
     super(tableName, ops);
@@ -230,7 +227,7 @@ class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
               newFile.partition());
         }
       } catch (IOException ioe) {
-        LOG.warn("Failed to close task iterable", ioe);
+        throw new UncheckedIOException("Failed to validate replaced partitions", ioe);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -283,7 +283,8 @@ public class SnapshotUtil {
   }
 
   /**
-   * @deprecated please use `newFilesBetween`
+   * @deprecated will be removed in 2.0.0, use {@link #newFilesBetween(Long, long, Function,
+   *     FileIO)} instead.
    */
   @Deprecated
   public static List<DataFile> newFiles(

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -310,24 +310,25 @@ public class SnapshotUtil {
   }
 
   public static CloseableIterable<DataFile> newFilesBetween(
-      Long baseSnapshotId, long latestSnapshotId, Function<Long, Snapshot> lookup, FileIO io) {
+      Long startSnapshotId, long endSnapshotId, Function<Long, Snapshot> lookup, FileIO io) {
 
     List<Snapshot> snapshots = Lists.newArrayList();
     Snapshot lastSnapshot = null;
-    for (Snapshot currentSnapshot : ancestorsOf(latestSnapshotId, lookup)) {
+    for (Snapshot currentSnapshot : ancestorsOf(endSnapshotId, lookup)) {
       lastSnapshot = currentSnapshot;
-      if (Objects.equals(currentSnapshot.snapshotId(), baseSnapshotId)) {
+      if (Objects.equals(currentSnapshot.snapshotId(), startSnapshotId)) {
         break;
       }
+
       snapshots.add(currentSnapshot);
     }
 
     if (lastSnapshot != null) {
       ValidationException.check(
-          Objects.equals(lastSnapshot.snapshotId(), baseSnapshotId)
-              || Objects.equals(lastSnapshot.parentId(), baseSnapshotId),
+          Objects.equals(lastSnapshot.snapshotId(), startSnapshotId)
+              || Objects.equals(lastSnapshot.parentId(), startSnapshotId),
           "Cannot determine history between read snapshot %s and the last known ancestor %s",
-          baseSnapshotId,
+          startSnapshotId,
           lastSnapshot.snapshotId());
     }
 


### PR DESCRIPTION
These changes ensures that data files are not loaded all into memory at once when validating replaced partitions. Instead it uses `ParallelIterable` to load new files in batches with a hard limit of 30k files in memory at a time.

This PR deprecates `SnapshotUtil.newFiles` in favor of `SnapshotUtil.newFilesBetween`