### PR TITLE
kafka-connect: resolve CVE-2025-48734 

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -64,9 +64,14 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
   configurations {
     hive {
       extendsFrom runtimeClasspath
+      // force upgrades for dependencies with known vulnerabilities...
+      resolutionStrategy {
+        force 'commons-beanutils:commons-beanutils:1.11.0'
+      }
     }
     all {
       exclude group: 'javax.activation', module: 'activation'
+      exclude group: 'commons-beanutils'
       // force upgrades for dependencies with known vulnerabilities...
       resolutionStrategy {
         force 'org.codehaus.jettison:jettison:1.5.4'


### PR DESCRIPTION
removes commons-beanutils from non-hive deps, bump version to 1.11.0 to resolve CVE when using hive