### PR TITLE
Core: Add Schema evolution test with partition transform on a field with default values

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -26,8 +26,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import org.apache.avro.generic.GenericData;
@@ -64,7 +62,7 @@ public class TestScansAndSchemaEvolution {
 
   @Parameter private int formatVersion;
 
-  @TempDir private Path temp;
+  @TempDir private File temp;
 
   private DataFile createDataFile(String partValue) throws IOException {
     List<GenericData.Record> expected = RandomAvroData.generate(SCHEMA, 100, 0L);
@@ -95,10 +93,7 @@ public class TestScansAndSchemaEvolution {
 
   @TestTemplate
   public void testPartitionSourceRename() throws IOException {
-    File location = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(location.delete()).isTrue(); // should be created by table create
-
-    Table table = TestTables.create(location, "test", SCHEMA, SPEC, formatVersion);
+    Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);
 
     DataFile fileOne = createDataFile("one");
     DataFile fileTwo = createDataFile("two");
@@ -121,10 +116,7 @@ public class TestScansAndSchemaEvolution {
   @TestTemplate
   public void testAddColumnWithDefaultValueAndQuery() throws IOException {
     assumeThat(V3_AND_ABOVE).as("Default values require v3+").contains(formatVersion);
-    File location = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(location.delete()).isTrue(); // should be created by table create
-
-    Table table = TestTables.create(location, "test", SCHEMA, SPEC, formatVersion);
+    Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);
 
     // Write initial data
     DataFile fileOne = createDataFile("one");
@@ -187,10 +179,7 @@ public class TestScansAndSchemaEvolution {
   @TestTemplate
   public void testAddColumnWithDefaultValueAndPartitionTransform() throws IOException {
     assumeThat(V3_AND_ABOVE).as("Default values require v3+").contains(formatVersion);
-    File location = Files.createTempDirectory(temp, "junit").toFile();
-    assertThat(location.delete()).isTrue(); // should be created by table create
-
-    Table table = TestTables.create(location, "test", SCHEMA, SPEC, formatVersion);
+    Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);
 
     // Write initial data
     DataFile fileOne = createDataFile("one");

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -167,6 +168,79 @@ public class TestScansAndSchemaEvolution {
         .hasSize(2); // Files are returned, filtering happens during read
 
     // Write new data after schema evolution
+    DataFile fileThree = createDataFile("three");
+    table.newAppend().appendFile(fileThree).commit();
+
+    // Test that all tasks have access to the column with default value
+    assertThat(table.newScan().planFiles())
+        .hasSize(3)
+        .allSatisfy(
+            task -> {
+              Schema taskSchema = task.schema();
+              Types.NestedField categoryFieldInTask = taskSchema.findField("category");
+              assertThat(categoryFieldInTask).isNotNull();
+              assertThat(categoryFieldInTask.initialDefault()).isEqualTo(defaultValue);
+              assertThat(categoryFieldInTask.writeDefault()).isEqualTo(defaultValue);
+            });
+  }
+
+  @TestTemplate
+  public void testAddColumnWithDefaultValueAndPartitionTransform() throws IOException {
+    assumeThat(V3_AND_ABOVE).as("Default values require v3+").contains(formatVersion);
+    File location = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(location.delete()).isTrue(); // should be created by table create
+
+    Table table = TestTables.create(location, "test", SCHEMA, SPEC, formatVersion);
+
+    // Write initial data
+    DataFile fileOne = createDataFile("one");
+    DataFile fileTwo = createDataFile("two");
+    table.newAppend().appendFile(fileOne).appendFile(fileTwo).commit();
+
+    // Add a new column with an initial default value
+    String defaultValue = "default_category";
+    table
+        .updateSchema()
+        .addColumn("category", Types.StringType.get(), "Product category", Literal.of(defaultValue))
+        .commit();
+
+    // Add bucket transform on the new column with default value
+    table.updateSpec().addField(Expressions.bucket("category", 8)).commit();
+
+    // Verify the updated partition spec includes the new column with bucket transform
+    PartitionSpec updatedSpec = table.spec();
+    assertThat(updatedSpec.fields())
+        .hasSize(2); // original "part" (identity) + new "category_bucket_8"
+
+    // Verify original identity partition field is preserved
+    PartitionField partPartitionField = updatedSpec.fields().get(0);
+    assertThat(partPartitionField.name()).isEqualTo("part");
+    assertThat(partPartitionField.transform()).isEqualTo(Transforms.identity());
+
+    // Verify new bucket partition field
+    PartitionField categoryPartitionField = updatedSpec.fields().get(1);
+    assertThat(categoryPartitionField.name()).isEqualTo("category_bucket_8");
+    assertThat(categoryPartitionField.transform()).isEqualTo(Transforms.bucket(8));
+
+    // Verify scan planning works with the new partition column
+    assertThat(table.newScan().planFiles()).hasSize(2);
+
+    // Test that scan with projection includes the new column with default value
+    Schema projectionSchema = table.schema().select("id", "data", "category");
+    assertThat(table.newScan().project(projectionSchema).planFiles())
+        .hasSize(2)
+        .allSatisfy(
+            task -> {
+              assertThat(task.schema().findField("category")).isNotNull();
+              assertThat(task.schema().findField("category").initialDefault())
+                  .isEqualTo(defaultValue);
+            });
+
+    // Test scan with filter on the partitioned default column
+    assertThat(table.newScan().filter(Expressions.equal("category", defaultValue)).planFiles())
+        .hasSize(2); // All files should match since default applies to all
+
+    // Write new data after schema and partition evolution
     DataFile fileThree = createDataFile("three");
     table.newAppend().appendFile(fileThree).commit();
 


### PR DESCRIPTION
Ensures default values work correctly with bucket partitioning.