### PR TITLE
Docs: Fix indentation of 1.9.2 release note

### DIFF
--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -74,7 +74,7 @@ Apache Iceberg 1.9.2 was released on Jul 16, 2025.
 The 1.9.2 release contains bug fixes. For full release notes visit [Github](https://github.com/apache/iceberg/releases/tag/apache-iceberg-1.9.2)
 
 * Core
-    - Core: Stop retrying on 502 / 504 to avoid table corruption due to self conflicts [\#12818](https://github.com/apache/iceberg/pull/12818), [\#13352](https://github.com/apache/iceberg/pull/13352)
+    - Stop retrying on 502 / 504 to avoid table corruption due to self conflicts [\#12818](https://github.com/apache/iceberg/pull/12818), [\#13352](https://github.com/apache/iceberg/pull/13352)
 
 ## Past releases
 


### PR DESCRIPTION
<img width="1562" height="254" alt="Screenshot 2025-07-17 at 16 17 41" src="https://github.com/user-attachments/assets/e3eea60b-1084-4fec-960c-cc4e8edddae6" />
↓
<img width="1646" height="258" alt="Screenshot 2025-07-17 at 16 21 31" src="https://github.com/user-attachments/assets/7730ef3a-dc6a-48c3-80f8-f092d65bdab3" />
