### PR TITLE
AWS: Make the number of retries for metadata location refresh configurable

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -172,6 +172,10 @@ public class GlueCatalog extends BaseMetastoreCatalog
       LockManager lock,
       Map<String, String> catalogProps) {
     this.catalogProperties = catalogProps;
+    if (hadoopConf == null) {
+      LOG.warn("No Hadoop Configuration was set, using the default environment Configuration");
+      this.hadoopConf = new Configuration();
+    }
     initialize(name, path, properties, s3Properties, client, lock);
   }
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -178,6 +178,7 @@ The HMS table locking is a 2-step process:
 | iceberg.hive.metadata-refresh-max-retries | 2               | Maximum number of retries when the metadata file is missing                  |
 | iceberg.hive.table-level-lock-evict-ms    | 600000 (10 min) | The timeout for the JVM table lock is                                        |
 | iceberg.engine.hive.lock-enabled          | true            | Use HMS locks to ensure atomicity of commits                                 |
+| iceberg.glue.metadata-refresh-max-retries | 20              | Maximum number of retries when the metadata file is missing                  |
 
 Note: `iceberg.hive.lock-check-max-wait-ms` and `iceberg.hive.lock-heartbeat-interval-ms` should be less than the [transaction timeout](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.txn.timeout) 
 of the Hive Metastore (`hive.txn.timeout` or `metastore.txn.timeout` in the newer versions). Otherwise, the heartbeats on the lock (which happens during the lock checks) would end up expiring in the 


### PR DESCRIPTION
Basically I copied the mechanism of https://github.com/apache/iceberg/blob/369fe89138ca52ef9437fe657324c659889a8d88/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L85-L88

Closes: #13529