### PR TITLE
Docs: Add creating release from passed RC tag

### DIFF
--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -268,6 +268,8 @@ Next, add a release tag to the git repository based on the passing candidate tag
 git tag -am 'Release Apache Iceberg <VERSION>' apache-iceberg-<VERSION> apache-iceberg-<VERSION>-rcN
 ```
 
+Create a new release in the iceberg repository on GitHub, using the tag created above [Steps](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+
 Then release the candidate repository in [Nexus](https://repository.apache.org/#stagingRepositories).
 
 #### Announcing the release


### PR DESCRIPTION
## About the change 

This change adds a step to create a release from tag created in step above explicitly with instructions on how to. 
Adding it here as i missed doing it in 1.9.2. 