### PR TITLE
REST-Fixture: Ensure strict mode on jdbc catalog for rest fixture

### DIFF
--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -37,7 +37,7 @@ ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
 ENV CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db
 ENV CATALOG_JDBC_USER=user
 ENV CATALOG_JDBC_PASSWORD=password
-ENV CATALOG_JDBC_STRICT__MODE=password
+ENV CATALOG_JDBC_STRICT__MODE=true
 ENV REST_PORT=8181
 
 # Healthcheck for the iceberg rest service

--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -37,6 +37,7 @@ ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
 ENV CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db
 ENV CATALOG_JDBC_USER=user
 ENV CATALOG_JDBC_PASSWORD=password
+ENV CATALOG_JDBC_STRICT__MODE=password
 ENV REST_PORT=8181
 
 # Healthcheck for the iceberg rest service


### PR DESCRIPTION
When adding common catalog [integration tests in pyiceberg](https://github.com/apache/iceberg-python/pull/2090), we noticed that the rest catalog test, which tests against the rest fixture was failing to throw a `NoSuchNamespaceError` when attempting to create a table in a namespace that does not exist.  @kevinjqliu spotted the issue and we are able to resolve downstream by setting `CATALOG_JDBC_STRICT__MODE=true` in the `docker-compose-integration.yml`, but I think it makes sense to set that variable here to ensure we have consistent behavior wherever this fixture is used.

Tests are now passing downstream with the environment variable set, and the rest catalog is behaving in line with other catalog implementations in the integration tests, which I believe is proof enough that it is safe to make this change here.