### PR TITLE
Docs: Move links to other implementations out of Java docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,14 +35,10 @@ nav:
       - schemas.md
     - Views:
       - view-configuration.md
-  - Libraries:
-    - Java:
-      - Quickstart: java-api-quickstart.md
-      - API: api.md
-      - Javadoc: ../../javadoc/latest/
-    - Python: https://py.iceberg.apache.org/
-    - Rust: https://rust.iceberg.apache.org/
-    - Go: https://pkg.go.dev/github.com/apache/iceberg-go/
+  - API:
+    - Quickstart: java-api-quickstart.md
+    - API: api.md
+    - Javadoc: ../../javadoc/latest/
   - Integrations:
     # Iceberg-maintained integrations come first
     - Apache Spark:

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -35,6 +35,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.path
+    - navigation.sections
     - navigation.top
     - navigation.tracking
     - toc.follow

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -21,26 +21,32 @@ nav:
     - Spark: spark-quickstart.md
     - Hive: hive-quickstart.md
   - Docs:
-    - Nightly: '!include docs/docs/nightly/mkdocs.yml'
-    - Latest (1.9.2): '!include docs/docs/latest/mkdocs.yml'
-    - Previous:
-      - 1.9.1: '!include docs/docs/1.9.1/mkdocs.yml'
-      - 1.9.0: '!include docs/docs/1.9.0/mkdocs.yml'
-      - 1.8.1: '!include docs/docs/1.8.1/mkdocs.yml'
-      - 1.8.0: '!include docs/docs/1.8.0/mkdocs.yml'
-      - 1.7.2: '!include docs/docs/1.7.2/mkdocs.yml'
-      - 1.7.1: '!include docs/docs/1.7.1/mkdocs.yml'
-      - 1.7.0: '!include docs/docs/1.7.0/mkdocs.yml'
-      - 1.6.1: '!include docs/docs/1.6.1/mkdocs.yml'
-      - 1.6.0: '!include docs/docs/1.6.0/mkdocs.yml'
-      - 1.5.2: '!include docs/docs/1.5.2/mkdocs.yml'
-      - 1.5.1: '!include docs/docs/1.5.1/mkdocs.yml'
-      - 1.5.0: '!include docs/docs/1.5.0/mkdocs.yml'
-      - 1.4.3: '!include docs/docs/1.4.3/mkdocs.yml'
-      - 1.4.2: '!include docs/docs/1.4.2/mkdocs.yml'
-      - 1.4.1: '!include docs/docs/1.4.1/mkdocs.yml'
-      - 1.4.0: '!include docs/docs/1.4.0/mkdocs.yml'
-      - archive: archive.md
+    - Java:
+      - Nightly: '!include docs/docs/nightly/mkdocs.yml'
+      - Latest (1.9.2): '!include docs/docs/latest/mkdocs.yml'
+      - Previous:
+        - 1.9.1: '!include docs/docs/1.9.1/mkdocs.yml'
+        - 1.9.0: '!include docs/docs/1.9.0/mkdocs.yml'
+        - 1.8.1: '!include docs/docs/1.8.1/mkdocs.yml'
+        - 1.8.0: '!include docs/docs/1.8.0/mkdocs.yml'
+        - 1.7.2: '!include docs/docs/1.7.2/mkdocs.yml'
+        - 1.7.1: '!include docs/docs/1.7.1/mkdocs.yml'
+        - 1.7.0: '!include docs/docs/1.7.0/mkdocs.yml'
+        - 1.6.1: '!include docs/docs/1.6.1/mkdocs.yml'
+        - 1.6.0: '!include docs/docs/1.6.0/mkdocs.yml'
+        - 1.5.2: '!include docs/docs/1.5.2/mkdocs.yml'
+        - 1.5.1: '!include docs/docs/1.5.1/mkdocs.yml'
+        - 1.5.0: '!include docs/docs/1.5.0/mkdocs.yml'
+        - 1.4.3: '!include docs/docs/1.4.3/mkdocs.yml'
+        - 1.4.2: '!include docs/docs/1.4.2/mkdocs.yml'
+        - 1.4.1: '!include docs/docs/1.4.1/mkdocs.yml'
+        - 1.4.0: '!include docs/docs/1.4.0/mkdocs.yml'
+        - archive: archive.md
+    - Other Implementations:
+      - Python: https://py.iceberg.apache.org/
+      - Rust: https://rust.iceberg.apache.org/
+      - Go: https://go.iceberg.apache.org/
+      - C++: https://github.com/apache/iceberg-cpp/
   - Releases: releases.md
   - Blogs: blogs.md
   - Talks: talks.md


### PR DESCRIPTION
Closes #12910, follow-up #13491

<img width="2934" height="2028" alt="CleanShot 2025-07-21 at 23 24 34@2x" src="https://github.com/user-attachments/assets/14fd30ef-ae8b-4466-bff9-6649e4998231" />

This PR also updates the link to iceberg-go and adds the link to iceberg-cpp.
