### PR TITLE
Spec, Core: mark 503 as non retryable error code for Update Table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -138,6 +138,7 @@ public class ErrorHandlers {
           throw new CommitFailedException("Commit failed: %s", error.message());
         case 500:
         case 502:
+        case 503:
         case 504:
           throw new CommitStateUnknownException(
               new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));

--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -94,6 +94,7 @@ public class ErrorHandlers {
           throw new CommitFailedException("Commit failed: %s", error.message());
         case 500:
         case 502:
+        case 503:
         case 504:
           throw new CommitStateUnknownException(
               new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -61,7 +61,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  *
  * <ul>
  *   <li>SC_TOO_MANY_REQUESTS (429)
- *   <li>SC_SERVICE_UNAVAILABLE (503)
  * </ul>
  *
  * The following retriable HTTP status codes are defined for idempotent requests:
@@ -90,8 +89,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
     Preconditions.checkArgument(
         maximumRetries > 0, "Cannot set retries to %s, the value must be positive", maximumRetries);
     this.maxRetries = maximumRetries;
-    this.retriableCodes =
-        ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS, HttpStatus.SC_SERVICE_UNAVAILABLE);
+    this.retriableCodes = ImmutableSet.of(HttpStatus.SC_TOO_MANY_REQUESTS);
     this.idempotentRetriableCodes =
         ImmutableSet.of(
             HttpStatus.SC_TOO_MANY_REQUESTS,

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -37,6 +37,8 @@ import org.apache.hc.client5.http.utils.DateUtils;
 import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.apache.hc.core5.http.message.BasicHttpResponse;
 import org.junit.jupiter.api.Test;
@@ -208,6 +210,15 @@ public class TestExponentialHttpRequestRetryStrategy {
   public void testRetryDoesNotHappenOnUnacceptableStatusCodes(int statusCode) {
     BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
     assertThat(retryStrategy.retryRequest(response, 3, null)).isFalse();
+  }
+
+  @Test
+  public void testRetryHappensWith503WithRetryAfterHeader() {
+    BasicHttpResponse response =
+        new BasicHttpResponse(HttpStatus.SC_SERVICE_UNAVAILABLE, "Service Unavailable");
+    response.addHeader(new BasicHeader(HttpHeaders.RETRY_AFTER, "60"));
+
+    assertThat(retryStrategy.retryRequest(response, 3, null)).isTrue();
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -82,9 +82,6 @@ public class TestExponentialHttpRequestRetryStrategy {
 
   @Test
   public void basicRetry() {
-    BasicHttpResponse response503 = new BasicHttpResponse(503, "Oopsie");
-    assertThat(retryStrategy.retryRequest(response503, 3, null)).isTrue();
-
     BasicHttpResponse response429 = new BasicHttpResponse(429, "Oopsie");
     assertThat(retryStrategy.retryRequest(response429, 3, null)).isTrue();
 
@@ -200,14 +197,14 @@ public class TestExponentialHttpRequestRetryStrategy {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {429, 503})
+  @ValueSource(ints = 429)
   public void testRetryHappensOnAcceptableStatusCodes(int statusCode) {
     BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
     assertThat(retryStrategy.retryRequest(response, 3, null)).isTrue();
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {500, 502, 504})
+  @ValueSource(ints = {500, 502, 503, 504})
   public void testRetryDoesNotHappenOnUnacceptableStatusCodes(int statusCode) {
     BasicHttpResponse response = new BasicHttpResponse(statusCode, String.valueOf(statusCode));
     assertThat(retryStrategy.retryRequest(response, 3, null)).isFalse();

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1064,7 +1064,19 @@ paths:
                   }
                 }
         503:
-          $ref: '#/components/responses/ServiceUnavailableResponse'
+          description:
+            Service Unavailable; the commit state is unknown.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              example: {
+                "error": {
+                  "message": "Service Unavailable",
+                  "type": "CommitStateUnknownException",
+                  "code": 503
+                }
+              }
         502:
           description:
             A gateway or proxy received an invalid response from the upstream server; the commit state is unknown.

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1064,19 +1064,7 @@ paths:
                   }
                 }
         503:
-          description:
-            Service Unavailable; the commit state is unknown.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IcebergErrorResponse'
-              example: {
-                "error": {
-                  "message": "Service Unavailable",
-                  "type": "CommitStateUnknownException",
-                  "code": 503
-                }
-              }
+          $ref: '#/components/responses/ServiceUnavailableResponse'
         502:
           description:
             A gateway or proxy received an invalid response from the upstream server; the commit state is unknown.
@@ -4659,10 +4647,10 @@ components:
 
     ServiceUnavailableResponse:
       description:
-        The service is not ready to handle the request. The client should wait and retry.
+        The service is not ready to handle the request, request could have been partially processed.
 
-
-        The service may additionally send a Retry-After header to indicate when to retry.
+        The service may additionally send a Retry-After header to indicate when to retry, a non idempotent
+        request should only be retried when the Retry-After header is present.
       content:
         application/json:
           schema:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4650,7 +4650,7 @@ components:
         The service is not ready to handle the request, request could have been partially processed.
 
         The service may additionally send a Retry-After header to indicate when to retry, a non idempotent
-        request should only be retried when the Retry-After header is present.
+        request should only be retried by the client when the Retry-After header is present.
       content:
         application/json:
           schema:


### PR DESCRIPTION
### About the change

Mark 503 as non retryable in update table, as pointed some of the very common services like Envoy 
details : https://lists.apache.org/thread/oqonscy1b4qlmovnjtbcohz38kgprgmq

There seems to be a general alignment on the direction to treat 503 as commit state unknown as the outcomes are severe as if leading to table corruption. 

