### PR TITLE
Spark: use Bulk deletion for manifests when import files to an iceberg table

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -64,6 +64,7 @@ import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -930,11 +931,15 @@ public class SparkTableUtil {
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {
-    Tasks.foreach(manifests)
-        .executeWith(ThreadPools.getWorkerPool())
-        .noRetry()
-        .suppressFailureWhenFinished()
-        .run(item -> io.deleteFile(item.path()));
+    if (io instanceof SupportsBulkOperations) {
+      ((SupportsBulkOperations) io).deleteFiles(Lists.transform(manifests, ManifestFile::path));
+    } else {
+      Tasks.foreach(manifests)
+              .executeWith(ThreadPools.getWorkerPool())
+              .noRetry()
+              .suppressFailureWhenFinished()
+              .run(item -> io.deleteFile(item.path()));
+    }
   }
 
   public static Dataset<Row> loadTable(SparkSession spark, Table table, long snapshotId) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -935,10 +935,10 @@ public class SparkTableUtil {
       ((SupportsBulkOperations) io).deleteFiles(Lists.transform(manifests, ManifestFile::path));
     } else {
       Tasks.foreach(manifests)
-              .executeWith(ThreadPools.getWorkerPool())
-              .noRetry()
-              .suppressFailureWhenFinished()
-              .run(item -> io.deleteFile(item.path()));
+          .executeWith(ThreadPools.getWorkerPool())
+          .noRetry()
+          .suppressFailureWhenFinished()
+          .run(item -> io.deleteFile(item.path()));
     }
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -64,6 +64,7 @@ import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -930,11 +931,15 @@ public class SparkTableUtil {
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {
-    Tasks.foreach(manifests)
-        .executeWith(ThreadPools.getWorkerPool())
-        .noRetry()
-        .suppressFailureWhenFinished()
-        .run(item -> io.deleteFile(item.path()));
+    if (io instanceof SupportsBulkOperations) {
+      ((SupportsBulkOperations) io).deleteFiles(Lists.transform(manifests, ManifestFile::path));
+    } else {
+      Tasks.foreach(manifests)
+              .executeWith(ThreadPools.getWorkerPool())
+              .noRetry()
+              .suppressFailureWhenFinished()
+              .run(item -> io.deleteFile(item.path()));
+    }
   }
 
   public static Dataset<Row> loadTable(SparkSession spark, Table table, long snapshotId) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -935,10 +935,10 @@ public class SparkTableUtil {
       ((SupportsBulkOperations) io).deleteFiles(Lists.transform(manifests, ManifestFile::path));
     } else {
       Tasks.foreach(manifests)
-              .executeWith(ThreadPools.getWorkerPool())
-              .noRetry()
-              .suppressFailureWhenFinished()
-              .run(item -> io.deleteFile(item.path()));
+          .executeWith(ThreadPools.getWorkerPool())
+          .noRetry()
+          .suppressFailureWhenFinished()
+          .run(item -> io.deleteFile(item.path()));
     }
   }
 


### PR DESCRIPTION
Leverage bulk deletion if IO supports, helpful to speed up the table import with many files. 

Existing `TestAddFilesProcedure` have many unit tests cover this code path for both hive and hadoop catalog (hadoop fileIO) in  
- addFilteredPartitionsToPartitionedWithNullValueFilteringOnDept
- addPartitionsWithNullValueShouldAddFilesToNullPartition
- addAllPartitionsToPartitionedWithNullValue
- addFilteredPartitionsToPartitioned2
- addDataUnpartitioned
- addPartitionToPartitionedHive
- testAddFilesToTableWithManySpecs


