### PR TITLE
Core: make SnapshotRefType public

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotRefType.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRefType.java
@@ -21,7 +21,7 @@ package org.apache.iceberg;
 import java.util.Locale;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-enum SnapshotRefType {
+public enum SnapshotRefType {
   BRANCH,
   TAG;
 


### PR DESCRIPTION
Hi!

It seems that this enum should be `public` to be able to create instance for this update: https://github.com/apache/iceberg/blob/378479bd21ddc5de7c08dcfec1595196dd8f4a78/core/src/main/java/org/apache/iceberg/MetadataUpdate.java#L378-L390 otherwise it requires to use some kind of reflection / shadowing to be able to create instance of SnapshotRefType.

Or maybe there is another way to create MetadataUpdate.SetSnapshotRef?


