### PR TITLE
Spec: Add `nullable: true` to LoadTableResult metadata-location

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3309,6 +3309,7 @@ components:
         metadata-location:
           type: string
           description: May be null if the table is staged as part of a transaction
+          nullable: true
         metadata:
           $ref: '#/components/schemas/TableMetadata'
         config:


### PR DESCRIPTION
The description for the `metadata-location` for `LoadTableResult` says the field can be nullable, however, the `nullable` attribute is missing. In DuckDB-iceberg, we generate code to convert Rest objects to c++ classes, and the absence of a nullable field is causing errors when catalogs return null during a table create operation with stage-create = true.

Anyway, opening this PR so the spec is consistent with the description and v.v.