### PR TITLE
Build, Flink: Add timeout and print more logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ subprojects {
     jvmArgs += project.property('extraJvmArgs')
 
     testLogging {
-      events "failed"
+      events "started", "passed", "skipped", "failed"
       exceptionFormat "full"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,13 @@ subprojects {
     jvmArgs += project.property('extraJvmArgs')
 
     testLogging {
-      events "started", "passed", "skipped", "failed"
+      // Check if running on CI environment
+      if (System.getenv('CI') != null) {
+        // More verbose logging for CI environments
+        events "started", "passed", "skipped", "failed"
+      } else {
+        events "failed"
+      }
       exceptionFormat "full"
     }
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
@@ -37,7 +37,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(60)
 public class TestFlinkUpsert extends CatalogTestBase {
 
   @Parameter(index = 2)

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
@@ -37,7 +37,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(60)
 public class TestFlinkUpsert extends CatalogTestBase {
 
   @Parameter(index = 2)

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
@@ -37,7 +37,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(60)
 public class TestFlinkUpsert extends CatalogTestBase {
 
   @Parameter(index = 2)


### PR DESCRIPTION
I often face a situation where the Flink test is stuck in an infinite loop.
Last time it happened with `TestFlinkUpsert`.

This PR adds the timeout to the test, and also adds stop/start logs to the CI output, so it is easier to find the stuck tests.