### PR TITLE
Improve test coverage for 1-5 byte header string primitive in Variant

### DIFF
--- a/api/src/test/java/org/apache/iceberg/variants/VariantTestUtil.java
+++ b/api/src/test/java/org/apache/iceberg/variants/VariantTestUtil.java
@@ -94,6 +94,11 @@ public class VariantTestUtil {
     }
   }
 
+  public static void assertVariantString(VariantValue actual, String expected, int offsetSize) {
+    assertVariantString(actual, expected);
+    assertThat(VariantUtil.sizeOf(actual.asPrimitive().sizeInBytes())).isEqualTo(offsetSize);
+  }
+
   private static byte primitiveHeader(int primitiveType) {
     return (byte) (primitiveType << 2);
   }


### PR DESCRIPTION
Improved test coverage to test 1-5 byte header string primitive in Variant

Fixes https://github.com/apache/iceberg/issues/13376