### PR TITLE
Spark: add new args:only_metadata for remove_orphan_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ coverage.xml
 .project
 .settings
 bin/
+.vscode/
+.vercel/
 
 # Hive/metastore files
 metastore_db/

--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -319,6 +319,7 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 | `equal_authorities` |    | map<string, string> | Mapping of file system authorities to be considered equal. Key is a comma-separated list of authorities and value is an authority. |
 | `prefix_mismatch_mode` |    | string | Action behavior when location prefixes (schemes/authorities) mismatch: <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files.</li></ul> |  
 | `prefix_listing` |    | boolean   | When true, use prefix-based file listing via the `SupportsPrefixOperations` interface. The Table FileIO implementation must support `SupportsPrefixOperations` when this flag is enabled (defaults to false) |
+| `only_metadata` |    | boolean   | When set to true, only metadata files will be deleted. (defaults to false) |
 
 #### Output
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -64,7 +64,9 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         ProcedureParameter.optional("equal_authorities", STRING_MAP),
         ProcedureParameter.optional("prefix_mismatch_mode", DataTypes.StringType),
         // List files with prefix operations. Default is false.
-        ProcedureParameter.optional("prefix_listing", DataTypes.BooleanType)
+        ProcedureParameter.optional("prefix_listing", DataTypes.BooleanType),
+        // Only delete metadata files. Default is false.
+        ProcedureParameter.optional("only_metadata", DataTypes.BooleanType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -140,6 +142,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
     boolean prefixListing = args.isNullAt(9) ? false : args.getBoolean(9);
 
+    boolean onlyMetadata = args.isNullAt(10) ? false : args.getBoolean(10);
+
     return withIcebergTable(
         tableIdent,
         table -> {
@@ -187,6 +191,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
           }
 
           action.usePrefixListing(prefixListing);
+
+          action.setOnlyMetadata(onlyMetadata);
 
           DeleteOrphanFiles.Result result = action.execute();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -110,6 +110,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private static final int MAX_DRIVER_LISTING_DIRECT_SUB_DIRS = 10;
   private static final int MAX_EXECUTOR_LISTING_DEPTH = 2000;
   private static final int MAX_EXECUTOR_LISTING_DIRECT_SUB_DIRS = Integer.MAX_VALUE;
+  private static final String METADATA_FOLDER_NAME = "metadata";
 
   private final SerializableConfiguration hadoopConf;
   private final int listingParallelism;
@@ -123,6 +124,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
   private boolean usePrefixListing = false;
+  private boolean onlyMetadata = false;
 
   DeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -210,6 +212,11 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
   public DeleteOrphanFilesSparkAction usePrefixListing(boolean newUsePrefixListing) {
     this.usePrefixListing = newUsePrefixListing;
+    return this;
+  }
+
+  public DeleteOrphanFilesSparkAction setOnlyMetadata(boolean onlyMetadataFlag) {
+    this.onlyMetadata = onlyMetadataFlag;
     return this;
   }
 
@@ -307,6 +314,11 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private Dataset<String> listedFileDS() {
+    String scanLocation = location;
+    if (onlyMetadata) {
+      scanLocation = table.location() + "/" + METADATA_FOLDER_NAME;
+    }
+
     List<String> subDirs = Lists.newArrayList();
     List<String> matchingFiles = Lists.newArrayList();
 
@@ -321,16 +333,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       Predicate<org.apache.iceberg.io.FileInfo> predicate =
           fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;
       listDirRecursivelyWithFileIO(
-          (SupportsPrefixOperations) table.io(), location, predicate, pathFilter, matchingFiles);
+          (SupportsPrefixOperations) table.io(), scanLocation, predicate, pathFilter, matchingFiles);
 
       JavaRDD<String> matchingFileRDD = sparkContext().parallelize(matchingFiles, 1);
       return spark().createDataset(matchingFileRDD.rdd(), Encoders.STRING());
     } else {
       Predicate<FileStatus> predicate = file -> file.getModificationTime() < olderThanTimestamp;
+
       // list at most MAX_DRIVER_LISTING_DEPTH levels and only dirs that have
       // less than MAX_DRIVER_LISTING_DIRECT_SUB_DIRS direct sub dirs on the driver
       listDirRecursivelyWithHadoop(
-          location,
+          scanLocation,
           predicate,
           hadoopConf.value(),
           MAX_DRIVER_LISTING_DEPTH,

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -64,7 +64,9 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         ProcedureParameter.optional("equal_authorities", STRING_MAP),
         ProcedureParameter.optional("prefix_mismatch_mode", DataTypes.StringType),
         // List files with prefix operations. Default is false.
-        ProcedureParameter.optional("prefix_listing", DataTypes.BooleanType)
+        ProcedureParameter.optional("prefix_listing", DataTypes.BooleanType),
+        // Only delete metadata files. Default is false.
+        ProcedureParameter.optional("only_metadata", DataTypes.BooleanType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -140,6 +142,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
     boolean prefixListing = args.isNullAt(9) ? false : args.getBoolean(9);
 
+    boolean onlyMetadata = args.isNullAt(10) ? false : args.getBoolean(10);
+
     return withIcebergTable(
         tableIdent,
         table -> {
@@ -187,6 +191,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
           }
 
           action.usePrefixListing(prefixListing);
+
+          action.setOnlyMetadata(onlyMetadata);
 
           DeleteOrphanFiles.Result result = action.execute();
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -110,6 +110,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private static final int MAX_DRIVER_LISTING_DIRECT_SUB_DIRS = 10;
   private static final int MAX_EXECUTOR_LISTING_DEPTH = 2000;
   private static final int MAX_EXECUTOR_LISTING_DIRECT_SUB_DIRS = Integer.MAX_VALUE;
+  private static final String METADATA_FOLDER_NAME = "metadata";
 
   private final SerializableConfiguration hadoopConf;
   private final int listingParallelism;
@@ -123,6 +124,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Consumer<String> deleteFunc = null;
   private ExecutorService deleteExecutorService = null;
   private boolean usePrefixListing = false;
+  private boolean onlyMetadata = false;
 
   DeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -210,6 +212,11 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
 
   public DeleteOrphanFilesSparkAction usePrefixListing(boolean newUsePrefixListing) {
     this.usePrefixListing = newUsePrefixListing;
+    return this;
+  }
+
+  public DeleteOrphanFilesSparkAction setOnlyMetadata(boolean onlyMetadataFlag) {
+    this.onlyMetadata = onlyMetadataFlag;
     return this;
   }
 
@@ -307,6 +314,11 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private Dataset<String> listedFileDS() {
+    String scanLocation = location;
+    if (onlyMetadata) {
+      scanLocation = table.location() + "/" + METADATA_FOLDER_NAME;
+    }
+
     List<String> subDirs = Lists.newArrayList();
     List<String> matchingFiles = Lists.newArrayList();
 
@@ -321,16 +333,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       Predicate<org.apache.iceberg.io.FileInfo> predicate =
           fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;
       listDirRecursivelyWithFileIO(
-          (SupportsPrefixOperations) table.io(), location, predicate, pathFilter, matchingFiles);
+          (SupportsPrefixOperations) table.io(), scanLocation, predicate, pathFilter, matchingFiles);
 
       JavaRDD<String> matchingFileRDD = sparkContext().parallelize(matchingFiles, 1);
       return spark().createDataset(matchingFileRDD.rdd(), Encoders.STRING());
     } else {
       Predicate<FileStatus> predicate = file -> file.getModificationTime() < olderThanTimestamp;
+
       // list at most MAX_DRIVER_LISTING_DEPTH levels and only dirs that have
       // less than MAX_DRIVER_LISTING_DIRECT_SUB_DIRS direct sub dirs on the driver
       listDirRecursivelyWithHadoop(
-          location,
+          scanLocation,
           predicate,
           hadoopConf.value(),
           MAX_DRIVER_LISTING_DEPTH,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -70,7 +70,9 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         optionalInParameter("equal_authorities", STRING_MAP),
         optionalInParameter("prefix_mismatch_mode", DataTypes.StringType),
         // List files with prefix operations. Default is false.
-        optionalInParameter("prefix_listing", DataTypes.BooleanType)
+        optionalInParameter("prefix_listing", DataTypes.BooleanType),
+        // Only delete metadata files. Default is false.
+        optionalInParameter("only_metadata", DataTypes.BooleanType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -146,6 +148,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
     boolean prefixListing = args.isNullAt(9) ? false : args.getBoolean(9);
 
+    boolean onlyMetadata = args.isNullAt(10) ? false : args.getBoolean(10);
+
     return withIcebergTable(
         tableIdent,
         table -> {
@@ -193,6 +197,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
           }
 
           action.usePrefixListing(prefixListing);
+
+          action.setOnlyMetadata(onlyMetadata);
 
           DeleteOrphanFiles.Result result = action.execute();
 


### PR DESCRIPTION
Our streaming jobs generate a significant volume of metadata files. To remove old metadata files, enabling `write.metadata.delete-after-commit.enabled=true` represents a recommended practice. However, ​​this will only delete metadata files that are tracked in the metadata log and will not delete orphaned metadata files.

While executing `remove_orphan_files` would theoretically address such files, traversing the entire data directory imposes substantial performance overhead. Given that streaming jobs follow an append-only pattern, orphaned data rarely occurs in practice. ​Therefore, we introduce an `only_metadata` option to exclusively clean the metadata directory, reducing overall processing latency – particularly for developers who only require metadata directory cleanup.​​