### PR TITLE
Core: make BaseRowDelta public

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.DataFileSet;
 import org.apache.iceberg.util.SnapshotUtil;
 
-class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta {
+public class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta {
   private Long startingSnapshotId = null; // check all versions by default
   private final CharSequenceSet referencedDataFiles = CharSequenceSet.empty();
   private final DataFileSet removedDataFiles = DataFileSet.create();
@@ -37,7 +37,7 @@ class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta
   private boolean validateNewDataFiles = false;
   private boolean validateNewDeleteFiles = false;
 
-  BaseRowDelta(String tableName, TableOperations ops) {
+  protected BaseRowDelta(String tableName, TableOperations ops) {
     super(tableName, ops);
   }
 


### PR DESCRIPTION
Similar to other base class extends MergingSnapshotProducer
- https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
- https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
- https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/StreamingDelete.java


we want to make BaseRowDelta public to allow for customization in validation logic and reuse the rest of the logic in the base class.

