### PR TITLE
spark 4: add tests to verify Arrow Support for Row lineage when using the Parquet Vectorized reader

### DIFF
--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -73,11 +73,15 @@ public class GenericsHelpers {
   }
 
   public static void assertEqualsBatch(
-      Types.StructType struct, Iterator<Record> expectedRecords, ColumnarBatch batch) {
-    for (int rowId = 0; rowId < batch.numRows(); rowId++) {
-      InternalRow row = batch.getRow(rowId);
+      Types.StructType struct,
+      Iterator<Record> expectedRecords,
+      ColumnarBatch batch,
+      Map<Integer, Object> idToConstant,
+      Integer batchFirstRowPos) {
+    for (int rowPos = 0; rowPos < batch.numRows(); rowPos++) {
+      InternalRow row = batch.getRow(rowPos);
       Record expectedRecord = expectedRecords.next();
-      assertEqualsUnsafe(struct, expectedRecord, row);
+      assertEqualsUnsafe(struct, expectedRecord, row, idToConstant, batchFirstRowPos + rowPos);
     }
   }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -113,33 +113,6 @@ public class TestHelpers {
     }
   }
 
-  public static void assertEqualsBatch(
-      Types.StructType struct, Iterator<Record> expected, ColumnarBatch batch) {
-    for (int rowId = 0; rowId < batch.numRows(); rowId++) {
-      InternalRow row = batch.getRow(rowId);
-      Record rec = expected.next();
-
-      List<Types.NestedField> fields = struct.fields();
-      for (int readPos = 0; readPos < fields.size(); readPos += 1) {
-        Types.NestedField field = fields.get(readPos);
-        Field writeField = rec.getSchema().getField(field.name());
-
-        Type fieldType = field.type();
-        Object actualValue = row.isNullAt(readPos) ? null : row.get(readPos, convert(fieldType));
-
-        Object expectedValue;
-        if (writeField != null) {
-          int writePos = writeField.pos();
-          expectedValue = rec.get(writePos);
-        } else {
-          expectedValue = field.initialDefault();
-        }
-
-        assertEqualsUnsafe(fieldType, expectedValue, actualValue);
-      }
-    }
-  }
-
   public static void assertEqualsBatchWithRows(
       Types.StructType struct, Iterator<Row> expected, ColumnarBatch batch) {
     for (int rowId = 0; rowId < batch.numRows(); rowId++) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -27,6 +27,8 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.RandomGenericData;
@@ -37,6 +39,7 @@ import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Function;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -78,6 +81,13 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
   }
 
   @Override
+  protected void writeAndValidate(Schema writeSchema, Schema expectedSchema, List<Record> records)
+      throws IOException {
+    writeAndValidate(
+        writeSchema, expectedSchema, true, BATCH_SIZE, records.size(), records, ID_TO_CONSTANT);
+  }
+
+  @Override
   protected boolean supportsDefaultValues() {
     return true;
   }
@@ -85,6 +95,11 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
   @Override
   protected boolean supportsNestedTypes() {
     return false;
+  }
+
+  @Override
+  protected boolean supportsRowLineage() {
+    return true;
   }
 
   private void writeAndValidate(
@@ -104,6 +119,29 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       int batchSize,
       Function<Record, Record> transform)
       throws IOException {
+    writeAndValidate(
+        writeSchema,
+        expectedSchema,
+        numRecords,
+        seed,
+        nullPercentage,
+        reuseContainers,
+        batchSize,
+        transform,
+        ImmutableMap.of());
+  }
+
+  private void writeAndValidate(
+      Schema writeSchema,
+      Schema expectedSchema,
+      int numRecords,
+      long seed,
+      float nullPercentage,
+      boolean reuseContainers,
+      int batchSize,
+      Function<Record, Record> transform,
+      Map<Integer, Object> idToConstant)
+      throws IOException {
     // Write test data
     assumeThat(
             TypeUtil.find(
@@ -115,6 +153,25 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
     Iterable<Record> expected =
         generateData(writeSchema, numRecords, seed, nullPercentage, transform);
 
+    writeAndValidate(
+        writeSchema,
+        expectedSchema,
+        reuseContainers,
+        batchSize,
+        numRecords,
+        expected,
+        idToConstant);
+  }
+
+  private void writeAndValidate(
+      Schema writeSchema,
+      Schema expectedSchema,
+      boolean reuseContainers,
+      int batchSize,
+      int numRecords,
+      Iterable<Record> expected,
+      Map<Integer, Object> idToConstant)
+      throws IOException {
     // write a test parquet file using iceberg writer
     File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
@@ -123,7 +180,8 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       writer.addAll(expected);
     }
 
-    assertRecordsMatch(expectedSchema, numRecords, expected, testFile, reuseContainers, batchSize);
+    assertRecordsMatch(
+        expectedSchema, numRecords, expected, testFile, reuseContainers, batchSize, idToConstant);
   }
 
   protected int getNumRows() {
@@ -165,14 +223,26 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       boolean reuseContainers,
       int batchSize)
       throws IOException {
+    assertRecordsMatch(
+        schema, expectedSize, expected, testFile, reuseContainers, batchSize, ImmutableMap.of());
+  }
+
+  void assertRecordsMatch(
+      Schema schema,
+      int expectedSize,
+      Iterable<Record> expected,
+      File testFile,
+      boolean reuseContainers,
+      int batchSize,
+      Map<Integer, Object> idToConstant)
+      throws IOException {
     Parquet.ReadBuilder readBuilder =
         Parquet.read(Files.localInput(testFile))
             .project(schema)
             .recordsPerBatch(batchSize)
             .createBatchedReaderFunc(
                 type ->
-                    VectorizedSparkParquetReaders.buildReader(
-                        schema, type, Maps.newHashMap(), null));
+                    VectorizedSparkParquetReaders.buildReader(schema, type, idToConstant, null));
     if (reuseContainers) {
       readBuilder.reuseContainers();
     }
@@ -182,8 +252,9 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       int numRowsRead = 0;
       while (batches.hasNext()) {
         ColumnarBatch batch = batches.next();
+        GenericsHelpers.assertEqualsBatch(
+            schema.asStruct(), expectedIter, batch, idToConstant, numRowsRead);
         numRowsRead += batch.numRows();
-        GenericsHelpers.assertEqualsBatch(schema.asStruct(), expectedIter, batch);
       }
       assertThat(numRowsRead).isEqualTo(expectedSize);
     }


### PR DESCRIPTION
Add v3.5 tests from https://github.com/apache/iceberg/pull/12928 to v4.0
