### PR TITLE
[Core] Use Bulk deletion for cleaning up uncommitted files in BaseTransaction

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -44,7 +44,6 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.PositionOutputStream;
-import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.Puffin;
 import org.apache.iceberg.puffin.PuffinWriter;
@@ -1535,7 +1534,7 @@ public class TestRemoveSnapshots extends TestBase {
 
   @TestTemplate
   public void testRemoveFromTableWithBulkIO() {
-    TestBulkLocalFileIO spyFileIO = Mockito.spy(new TestBulkLocalFileIO());
+    TestTables.TestBulkLocalFileIO spyFileIO = Mockito.spy(new TestTables.TestBulkLocalFileIO());
 
     Mockito.doNothing().when(spyFileIO).deleteFiles(any());
 
@@ -1544,7 +1543,7 @@ public class TestRemoveSnapshots extends TestBase {
 
   @TestTemplate
   public void testBulkDeletionWithBulkDeletionFailureException() {
-    TestBulkLocalFileIO spyFileIO = Mockito.spy(new TestBulkLocalFileIO());
+    TestTables.TestBulkLocalFileIO spyFileIO = Mockito.spy(new TestTables.TestBulkLocalFileIO());
 
     Mockito.doThrow(new BulkDeletionFailureException(2))
         .doNothing()
@@ -1556,7 +1555,7 @@ public class TestRemoveSnapshots extends TestBase {
 
   @TestTemplate
   public void testBulkDeletionWithRuntimeException() {
-    TestBulkLocalFileIO spyFileIO = Mockito.spy(new TestBulkLocalFileIO());
+    TestTables.TestBulkLocalFileIO spyFileIO = Mockito.spy(new TestTables.TestBulkLocalFileIO());
 
     Mockito.doThrow(new RuntimeException("Exception when bulk deleting"))
         .doNothing()
@@ -1566,7 +1565,7 @@ public class TestRemoveSnapshots extends TestBase {
     runBulkDeleteTest(spyFileIO);
   }
 
-  private void runBulkDeleteTest(TestBulkLocalFileIO spyFileIO) {
+  private void runBulkDeleteTest(TestTables.TestBulkLocalFileIO spyFileIO) {
     String tableName = "tableWithBulkIO";
     Table tableWithBulkIO =
         TestTables.create(
@@ -1908,19 +1907,5 @@ public class TestRemoveSnapshots extends TestBase {
 
   private static void commitPartitionStats(Table table, PartitionStatisticsFile statisticsFile) {
     table.updatePartitionStatistics().setPartitionStatistics(statisticsFile).commit();
-  }
-
-  private static class TestBulkLocalFileIO extends TestTables.LocalFileIO
-      implements SupportsBulkOperations {
-
-    @Override
-    public void deleteFile(String path) {
-      throw new RuntimeException("Expected to call the bulk delete interface.");
-    }
-
-    @Override
-    public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
-      throw new RuntimeException("Expected to mock this function");
-    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -26,10 +26,12 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -390,6 +392,20 @@ public class TestTables {
       if (!new File(path).delete()) {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
+    }
+  }
+
+  static class TestBulkLocalFileIO extends TestTables.LocalFileIO
+      implements SupportsBulkOperations {
+
+    @Override
+    public void deleteFile(String path) {
+      throw new RuntimeException("Expected to call the bulk delete interface.");
+    }
+
+    @Override
+    public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
+      throw new RuntimeException("Expected to mock this function");
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -242,21 +242,21 @@ public class TestTransaction extends TestBase {
   }
 
   @TestTemplate
-  public void testTransactionFailureBulkDeletionCleanup() {
-    cleanupTables();
+  public void testTransactionFailureBulkDeletionCleanup() throws IOException {
     TestTables.TestBulkLocalFileIO spyFileIO = Mockito.spy(new TestTables.TestBulkLocalFileIO());
-
     Mockito.doNothing().when(spyFileIO).deleteFiles(any());
-    String tableName = "test";
+
+    File location = java.nio.file.Files.createTempDirectory(temp, "junit").toFile();
+    String tableName = "txnFailureBulkDeleteTest";
     TestTables.TestTable tableWithBulkIO =
         TestTables.create(
-            tableDir,
+            location,
             tableName,
             SCHEMA,
             SPEC,
             SortOrder.unsorted(),
             formatVersion,
-            new TestTables.TestTableOperations(tableName, tableDir, spyFileIO));
+            new TestTables.TestTableOperations(tableName, location, spyFileIO));
 
     // set retries to 0 to catch the failure
     tableWithBulkIO.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "0").commit();


### PR DESCRIPTION
Leverage the bulk deletion in FileIO to clean up uncommitted files in BaseTransactions