### PR TITLE
Parquet: Update Variant reader test to generate shared test cases.

### DIFF
--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReaders.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReaders.java
@@ -270,10 +270,10 @@ public class TestVariantReaders {
 
   private String writeVariantFile(int rowId, Variant variant) throws IOException {
     String variantFile =
-        String.format("%s/case-%03d_row-%d.variant.bin", CASE_LOCATION, caseNumber, rowId);
+        String.format("case-%03d_row-%d.variant.bin", caseNumber, rowId);
 
     ByteBuffer buffer = ParquetVariantUtil.toByteBuffer(variant.metadata(), variant.value());
-    try (OutputStream out = IO.newOutputFile(variantFile).createOrOverwrite()) {
+    try (OutputStream out = IO.newOutputFile(CASE_LOCATION + "/" + variantFile).createOrOverwrite()) {
       out.write(buffer.array());
     }
 
@@ -281,7 +281,7 @@ public class TestVariantReaders {
   }
 
   private String parquetFile() {
-    return String.format("%s/case-%03d.parquet", CASE_LOCATION, caseNumber);
+    return String.format("case-%03d.parquet", caseNumber);
   }
 
   private void writeParquetFile(InputFile file) throws IOException {
@@ -289,7 +289,7 @@ public class TestVariantReaders {
       return;
     }
 
-    try (OutputStream out = IO.newOutputFile(parquetFile()).createOrOverwrite();
+    try (OutputStream out = IO.newOutputFile(CASE_LOCATION + "/" + parquetFile()).createOrOverwrite();
         InputStream in = file.newStream()) {
       IOUtils.copyBytes(in, out, 1000);
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReaders.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReaders.java
@@ -171,7 +171,7 @@ public class TestVariantReaders {
   }
 
   // TO GENERATE TEST CASES, SET THIS TO A LOCATION
-  private static final String CASE_LOCATION = "/tmp/variant_examples";
+  private static final String CASE_LOCATION = null;
   private static final FileIO IO = new TestTables.LocalFileIO();
   private static final StringWriter JSON_STRING_WRITER = new StringWriter();
   private static final AtomicInteger caseAssignment = new AtomicInteger(0);

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReaders.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReaders.java
@@ -229,6 +229,7 @@ public class TestVariantReaders {
     }
 
     CASE_JSON_GENERATOR.writeStringField("test", testName);
+    CASE_JSON_GENERATOR.writeStringField("parquet_file", parquetFile());
     CASE_JSON_GENERATOR.writeStringField("error_message", errorMessage);
   }
 
@@ -269,11 +270,11 @@ public class TestVariantReaders {
   }
 
   private String writeVariantFile(int rowId, Variant variant) throws IOException {
-    String variantFile =
-        String.format("case-%03d_row-%d.variant.bin", caseNumber, rowId);
+    String variantFile = String.format("case-%03d_row-%d.variant.bin", caseNumber, rowId);
 
     ByteBuffer buffer = ParquetVariantUtil.toByteBuffer(variant.metadata(), variant.value());
-    try (OutputStream out = IO.newOutputFile(CASE_LOCATION + "/" + variantFile).createOrOverwrite()) {
+    try (OutputStream out =
+        IO.newOutputFile(CASE_LOCATION + "/" + variantFile).createOrOverwrite()) {
       out.write(buffer.array());
     }
 
@@ -289,7 +290,8 @@ public class TestVariantReaders {
       return;
     }
 
-    try (OutputStream out = IO.newOutputFile(CASE_LOCATION + "/" + parquetFile()).createOrOverwrite();
+    try (OutputStream out =
+            IO.newOutputFile(CASE_LOCATION + "/" + parquetFile()).createOrOverwrite();
         InputStream in = file.newStream()) {
       IOUtils.copyBytes(in, out, 1000);
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReadsFromFile.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReadsFromFile.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.hadoop.thirdparty.com.google.common.collect.Streams;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TestTables;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.InternalReader;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantTestUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestVariantReadsFromFile {
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.required(2, "var", Types.VariantType.get()));
+
+  private static final String CASE_LOCATION = null;
+  private static final FileIO IO = new TestTables.LocalFileIO();
+
+  private static Stream<JsonNode> cases() throws IOException {
+    if (CASE_LOCATION == null) {
+      return Stream.empty();
+    }
+
+    InputFile caseJsonInput = IO.newInputFile(CASE_LOCATION + "/cases.json");
+    JsonNode cases = JsonUtil.mapper().readValue(caseJsonInput.newStream(), JsonNode.class);
+    Preconditions.checkArgument(
+        cases != null && cases.isArray(), "Invalid case JSON, not an array: %s", caseJsonInput);
+
+    return Streams.stream(cases);
+  }
+
+  private static Stream<Arguments> errorCases() throws IOException {
+    return cases()
+        .filter(caseNode -> caseNode.has("error_message"))
+        .map(
+            caseNode -> {
+              int caseNumber = JsonUtil.getInt("case_number", caseNode);
+              String testName = JsonUtil.getString("test", caseNode);
+              String parquetFile = JsonUtil.getStringOrNull("parquet_file", caseNode);
+              String errorMessage = JsonUtil.getString("error_message", caseNode);
+              return Arguments.of(caseNumber, testName, parquetFile, errorMessage);
+            });
+  }
+
+  private static Stream<Arguments> singleVariantCases() throws IOException {
+    return cases()
+        .filter(caseNode -> caseNode.has("variant_file"))
+        .map(
+            caseNode -> {
+              int caseNumber = JsonUtil.getInt("case_number", caseNode);
+              String testName = JsonUtil.getString("test", caseNode);
+              String variant = JsonUtil.getString("variant", caseNode);
+              String parquetFile = JsonUtil.getString("parquet_file", caseNode);
+              String variantFile = JsonUtil.getString("variant_file", caseNode);
+              return Arguments.of(caseNumber, testName, variant, parquetFile, variantFile);
+            });
+  }
+
+  private static Stream<Arguments> multiVariantCases() throws IOException {
+    return cases()
+        .filter(caseNode -> caseNode.has("variant_files"))
+        .map(
+            caseNode -> {
+              int caseNumber = JsonUtil.getInt("case_number", caseNode);
+              String testName = JsonUtil.getString("test", caseNode);
+              String parquetFile = JsonUtil.getString("parquet_file", caseNode);
+              List<String> variantFiles =
+                  Lists.newArrayList(
+                      Iterables.transform(
+                          caseNode.get("variant_files"),
+                          node -> node == null || node.isNull() ? null : node.asText()));
+              String variants = JsonUtil.getString("variants", caseNode);
+              return Arguments.of(caseNumber, testName, variants, parquetFile, variantFiles);
+            });
+  }
+
+  @ParameterizedTest
+  @MethodSource("errorCases")
+  public void testError(int caseNumber, String testName, String parquetFile, String errorMessage) {
+    Assertions.assertThatThrownBy(() -> readParquet(parquetFile))
+        .as("Test case %s: %s", caseNumber, testName)
+        .hasMessageContaining(errorMessage);
+  }
+
+  @ParameterizedTest
+  @MethodSource("singleVariantCases")
+  public void testSingleVariant(
+      int caseNumber, String testName, String variant, String parquetFile, String variantFile)
+      throws IOException {
+    Variant expected = readVariant(variantFile);
+
+    Record record = readParquetRecord(parquetFile);
+    Assertions.assertThat(record.getField("var")).isInstanceOf(Variant.class);
+    Variant actual = (Variant) record.getField("var");
+    VariantTestUtil.assertEqual(expected.metadata(), actual.metadata());
+    VariantTestUtil.assertEqual(expected.value(), actual.value());
+  }
+
+  @ParameterizedTest
+  @MethodSource("multiVariantCases")
+  public void testMultiVariant(
+      int caseNumber,
+      String testName,
+      String variants,
+      String parquetFile,
+      List<String> variantFiles)
+      throws IOException {
+    List<Record> records = readParquet(parquetFile);
+
+    for (int i = 0; i < records.size(); i += 1) {
+      Record record = records.get(i);
+      String variantFile = variantFiles.get(i);
+
+      if (variantFile != null) {
+        Variant expected = readVariant(variantFile);
+        Assertions.assertThat(record.getField("var")).isInstanceOf(Variant.class);
+        Variant actual = (Variant) record.getField("var");
+        VariantTestUtil.assertEqual(expected.metadata(), actual.metadata());
+        VariantTestUtil.assertEqual(expected.value(), actual.value());
+      } else {
+        Assertions.assertThat(record.getField("var")).isNull();
+      }
+    }
+  }
+
+  private Variant readVariant(String variantFile) throws IOException {
+    try (InputStream in = IO.newInputFile(CASE_LOCATION + "/" + variantFile).newStream()) {
+      byte[] variantBytes = in.readAllBytes();
+      return Variant.from(ByteBuffer.wrap(variantBytes).order(ByteOrder.LITTLE_ENDIAN));
+    }
+  }
+
+  private Record readParquetRecord(String parquetFile) throws IOException {
+    return Iterables.getOnlyElement(readParquet(parquetFile));
+  }
+
+  private List<Record> readParquet(String parquetFile) throws IOException {
+    try (CloseableIterable<Record> reader =
+        Parquet.read(IO.newInputFile(CASE_LOCATION + "/" + parquetFile))
+            .project(SCHEMA)
+            .createReaderFunc(fileSchema -> InternalReader.create(SCHEMA, fileSchema))
+            .build()) {
+      return Lists.newArrayList(reader);
+    }
+  }
+}


### PR DESCRIPTION
This PR updates the reader tests for Parquet so that the Parquet files and matching variants can be saved for cross-language tests.