### PR TITLE
Backport #13639: Flink: Dynamic Sink: Ensure parent for newly added struct is resolved from current schema

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -168,7 +168,7 @@ public class EvolveSchemaVisitor extends SchemaWithPartnerVisitor<Integer, Boole
   }
 
   private void addColumn(int parentId, Types.NestedField field) {
-    String parentName = targetSchema.findColumnName(parentId);
+    String parentName = existingSchema.findColumnName(parentId);
     api.addColumn(parentName, field.name(), field.type(), field.doc());
   }
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
@@ -246,6 +246,8 @@ public class TestEvolveSchemaVisitor {
 
   @Test
   public void testAddNestedStruct() {
+    Schema currentSchema =
+        new Schema(optional(1, "struct1", StructType.of(optional(2, "struct2", StructType.of()))));
     Schema targetSchema =
         new Schema(
             optional(
@@ -276,8 +278,8 @@ public class TestEvolveSchemaVisitor {
                                                                 7,
                                                                 "aString",
                                                                 StringType.get()))))))))))))));
-    UpdateSchema updateApi = loadUpdateApi(new Schema(), 0);
-    EvolveSchemaVisitor.visit(updateApi, new Schema(), targetSchema);
+    UpdateSchema updateApi = loadUpdateApi(currentSchema, 2);
+    EvolveSchemaVisitor.visit(updateApi, currentSchema, targetSchema);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -168,7 +168,7 @@ public class EvolveSchemaVisitor extends SchemaWithPartnerVisitor<Integer, Boole
   }
 
   private void addColumn(int parentId, Types.NestedField field) {
-    String parentName = targetSchema.findColumnName(parentId);
+    String parentName = existingSchema.findColumnName(parentId);
     api.addColumn(parentName, field.name(), field.type(), field.doc());
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
@@ -246,6 +246,8 @@ public class TestEvolveSchemaVisitor {
 
   @Test
   public void testAddNestedStruct() {
+    Schema currentSchema =
+        new Schema(optional(1, "struct1", StructType.of(optional(2, "struct2", StructType.of()))));
     Schema targetSchema =
         new Schema(
             optional(
@@ -276,8 +278,8 @@ public class TestEvolveSchemaVisitor {
                                                                 7,
                                                                 "aString",
                                                                 StringType.get()))))))))))))));
-    UpdateSchema updateApi = loadUpdateApi(new Schema(), 0);
-    EvolveSchemaVisitor.visit(updateApi, new Schema(), targetSchema);
+    UpdateSchema updateApi = loadUpdateApi(currentSchema, 2);
+    EvolveSchemaVisitor.visit(updateApi, currentSchema, targetSchema);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 


### PR DESCRIPTION
This is a clean backport of #13639  to Flink 1.19 and Flink 1.20.