### PR TITLE
Flink: DynamicSink: Convert existing required fields to optional

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -87,6 +87,15 @@ public class CompareSchemasVisitor
       return Result.SCHEMA_UPDATE_NEEDED;
     }
 
+    for (Types.NestedField tableField : tableSchemaType.asStructType().fields()) {
+      if (tableField.isRequired() && struct.field(tableField.name()) == null) {
+        // If a field from the table schema does not exist in the input schema, then we won't visit
+        // it and check for required/optional compatibility. The only choice is to make the table
+        // field optional.
+        return Result.SCHEMA_UPDATE_NEEDED;
+      }
+    }
+
     if (struct.fields().size() != tableSchemaType.asStructType().fields().size()) {
       return Result.DATA_CONVERSION_NEEDED;
     }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
@@ -112,7 +112,7 @@ class TestCompareSchemasVisitor {
   }
 
   @Test
-  void testWithRequiredChange() {
+  void testRequiredChangeForMatchingField() {
     Schema dataSchema =
         new Schema(optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()));
     Schema tableSchema =
@@ -121,6 +121,26 @@ class TestCompareSchemasVisitor {
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
     assertThat(CompareSchemasVisitor.visit(tableSchema, dataSchema))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testRequiredChangeForNonMatchingField() {
+    Schema dataSchema = new Schema(optional(1, "id", IntegerType.get()));
+    Schema tableSchema =
+        new Schema(optional(1, "id", IntegerType.get()), required(2, "extra", StringType.get()));
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+    assertThat(CompareSchemasVisitor.visit(tableSchema, dataSchema))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+  }
+
+  @Test
+  void testNoRequiredChangeForNonMatchingField() {
+    Schema dataSchema = new Schema(required(1, "id", IntegerType.get()));
+    Schema tableSchema =
+        new Schema(required(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()));
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema))
+        .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
   @Test

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -354,19 +354,40 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
   }
 
   @Test
-  void testSchemaEvolutionNonBackwardsCompatible() throws Exception {
-    Schema backwardsIncompatibleSchema =
+  void testRowEvolutionMakeMissingRequiredFieldOptional() throws Exception {
+    Schema existingSchemaWithRequiredField =
         new Schema(
-            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
             Types.NestedField.required(2, "data", Types.StringType.get()));
-    // Required column is missing in this schema
-    Schema erroringSchema =
-        new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+    CATALOG_EXTENSION
+        .catalog()
+        .createTable(TableIdentifier.of(DATABASE, "t1"), existingSchemaWithRequiredField);
+
+    Schema writeSchemaWithoutRequiredField =
+        new Schema(Types.NestedField.optional(1, "id", Types.IntegerType.get()));
 
     List<DynamicIcebergDataImpl> rows =
         Lists.newArrayList(
             new DynamicIcebergDataImpl(
-                backwardsIncompatibleSchema, "t1", "main", PartitionSpec.unpartitioned()),
+                writeSchemaWithoutRequiredField,
+                existingSchemaWithRequiredField,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned()));
+
+    runTest(rows, this.env, 1);
+  }
+
+  @Test
+  void testSchemaEvolutionNonBackwardsCompatible() throws Exception {
+    Schema initialSchema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    // Type change is not allowed
+    Schema erroringSchema = new Schema(Types.NestedField.required(1, "id", Types.StringType.get()));
+
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(initialSchema, "t1", "main", PartitionSpec.unpartitioned()),
             new DynamicIcebergDataImpl(
                 erroringSchema, "t1", "main", PartitionSpec.unpartitioned()));
 
@@ -376,11 +397,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     } catch (JobExecutionException e) {
       assertThat(
               ExceptionUtils.findThrowable(
-                  e,
-                  t ->
-                      t.getMessage()
-                          .contains(
-                              "Field 2 in target schema ROW<`id` INT NOT NULL, `data` STRING NOT NULL> is non-nullable but does not exist in source schema.")))
+                  e, t -> t.getMessage().contains("Cannot change column type: id: int -> string")))
           .isNotEmpty();
     }
   }


### PR DESCRIPTION
This fix converts existing required fields to optional which allows writing data with schemas missing the required field. Prior this change, the field had to exist in both write schema and table schema. Now it can be absent from the write schema.