### PR TITLE
Fix issue 13661

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -15,11 +15,16 @@
 
 .PHONY: help
 help: # Show help for each of the Makefile recipes.
-	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "[1;32m$$(echo $$l | cut -f 1 -d':')[00m:$$(echo $$l | cut -f 2- -d'#')
+"; done
 
 .PHONY: serve
 serve: # Clean, build, and run the docs site locally.
 	dev/serve.sh
+
+.PHONY: serve-local
+serve-local: # Clean, build, and run the docs site locally using local docs.
+	dev/serve.sh --local
 
 .PHONY: build
 build: # Clean and build the docs site locally.

--- a/site/dev/common.sh
+++ b/site/dev/common.sh
@@ -177,12 +177,12 @@ update_version () {
   # Update version information within the mkdocs.yml file using sed commands
   if [ "$(uname)" == "Darwin" ]
   then
-    /usr/bin/sed -i '' -E "s/(^site\_name:[[:space:]]+docs\/).*$/\1${ICEBERG_VERSION}/" ${ICEBERG_VERSION}/mkdocs.yml
-    /usr/bin/sed -i '' -E "s/(^[[:space:]]*-[[:space:]]+Javadoc:.*\/javadoc\/).*$/\1${ICEBERG_VERSION}/" ${ICEBERG_VERSION}/mkdocs.yml
+    /usr/bin/sed -i '' -E "s/(^site\_name:[[:space:]]+docs\/).*$/${ICEBERG_VERSION}/" ${ICEBERG_VERSION}/mkdocs.yml
+    /usr/bin/sed -i '' -E "s/(^[[:space:]]*-[[:space:]]+Javadoc:.*\/javadoc\/).*$/${ICEBERG_VERSION}/" ${ICEBERG_VERSION}/mkdocs.yml
   elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]
   then
-    sed -i'' -E "s/(^site_name:[[:space:]]+docs\/)[^[:space:]]+/\1${ICEBERG_VERSION}/" "${ICEBERG_VERSION}/mkdocs.yml"
-    sed -i'' -E "s/(^[[:space:]]*-[[:space:]]+Javadoc:.*\/javadoc\/).*$/\1${ICEBERG_VERSION}/" "${ICEBERG_VERSION}/mkdocs.yml"
+    sed -i'' -E "s/(^site_name:[[:space:]]+docs\/)[^[:space:]]+/${ICEBERG_VERSION}/" "${ICEBERG_VERSION}/mkdocs.yml"
+    sed -i'' -E "s/(^[[:space:]]*-[[:space:]]+Javadoc:.*\/javadoc\/).*$/${ICEBERG_VERSION}/" "${ICEBERG_VERSION}/mkdocs.yml"
   fi
 
 }
@@ -201,7 +201,9 @@ search_exclude_versioned_docs () {
 
   # Modify .md files to exclude versioned documentation from search indexing
   python3 -c "import os
-for f in filter(lambda x: x.endswith('.md'), os.listdir()): lines = open(f).readlines(); open(f, 'w').writelines(lines[:2] + ['search:\n', '  exclude: true\n'] + lines[2:]);"
+for f in filter(lambda x: x.endswith('.md'), os.listdir()): lines = open(f).readlines(); open(f, 'w').writelines(lines[:2] + ['search:
+', '  exclude: true
+'] + lines[2:]);"
 
   cd -
 }
@@ -231,6 +233,26 @@ pull_versioned_docs () {
 
   # Create the 'nightly' version of documentation
   create_nightly  
+}
+
+# Sets up local worktrees for the documentation and performs operations related to different versions.
+pull_local_docs () {
+  echo " --> pull local docs"
+
+  mkdir -p docs/docs
+  mkdir -p docs/javadoc
+
+  # Retrieve the latest version of documentation for processing
+  local latest_version=$(get_latest_version)
+
+  # Output the latest version for debugging purposes
+  echo "Latest version is: ${latest_version}"
+
+  # Create the 'latest' version of documentation
+  create_latest "${latest_version}"
+
+  # Create the 'nightly' version of documentation
+  create_nightly
 }
 
 # Cleans up artifacts and temporary files generated during documentation management.

--- a/site/dev/serve.sh
+++ b/site/dev/serve.sh
@@ -18,6 +18,6 @@
 
 set -e
 
-./dev/setup_env.sh
+./dev/setup_env.sh "$1"
 
 mkdocs serve --dirty --watch .

--- a/site/dev/setup_env.sh
+++ b/site/dev/setup_env.sh
@@ -24,6 +24,10 @@ clean
 
 install_deps
 
-pull_versioned_docs
+if [ "$1" == "--local" ]; then
+  pull_local_docs
+else
+  pull_versioned_docs
+fi
 
 git show "${REMOTE}/main:../.asf.yaml" > docs/.asf.yaml


### PR DESCRIPTION
closes issue [#13661](https://github.com/apache/iceberg/issues/13661)
docs: improve local editing experience

This commit introduces a new `serve-local` command to the Makefile that allows for a much faster local build of the documentation.

The `serve-local` command works by creating symbolic links to the local `docs` and `javadoc` directories instead of pulling all the versioned documentation from the remote repository. This significantly reduces the build time, making it much easier to edit and preview the documentation locally.

The following changes were made:

- A new `pull_local_docs` function was added to `site/dev/common.sh` that creates symbolic links to the local `docs` and `javadoc` directories.
- The `site/dev/setup_env.sh` script was modified to include a `--local` flag that triggers the use of the `pull_local_docs` function.
- The `site/dev/serve.sh` script was modified to accept and pass on the `--local` flag.
- A new `serve-local` command was added to the `site/Makefile` that executes `serve.sh` with the `--local` flag.