### PR TITLE
Core: Use zero-copy wrapper for equalityFieldIds

### DIFF
--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -51,6 +51,7 @@ import com.google.common.io.CountingOutputStream;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -99,5 +100,6 @@ public class GuavaClasses {
     CountingOutputStream.class.getName();
     Suppliers.class.getName();
     Stopwatch.class.getName();
+    Ints.class.getName();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -555,7 +555,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
 
   @Override
   public List<Integer> equalityFieldIds() {
-    return ArrayUtil.toIntList(equalityIds);
+    return ArrayUtil.toUnmodifiableIntList(equalityIds);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
+import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
 import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 
 public class ArrayUtil {
@@ -40,6 +41,14 @@ public class ArrayUtil {
   public static List<Integer> toIntList(int[] ints) {
     if (ints != null) {
       return IntStream.of(ints).boxed().collect(Collectors.toList());
+    } else {
+      return null;
+    }
+  }
+
+  public static List<Integer> toUnmodifiableIntList(int[] ints) {
+    if (ints != null) {
+      return Collections.unmodifiableList(Ints.asList(ints));
     } else {
       return null;
     }


### PR DESCRIPTION
In one of our Trino -> Iceberg use case, which relies on equality deletes, we observed that a lot of time and allocations are being spent in `BaseFile.equalityFieldIds()` (~34% of our overall allocs). 

Checking the implementation, it seems that the current implementation based on streams has to copy and box the data, which is very inefficient.

<img width="1310" height="802" alt="image" src="https://github.com/user-attachments/assets/b82fbd37-80fa-4bdd-9a33-81e8acf91504" />



There is already prior art (https://github.com/apache/iceberg/pull/8336) to use Guava 0-copy wrappers for longs / split offsets in the same class, I'm doing that same change.

Drafted a quick JMH to show the difference, and it clearly makes a huge difference:

```
Benchmark                              (arraySize)  Mode  Cnt        Score         Error  Units
IntListBenchmark.guavaImplementation            10    ss   10     1266.800 ±     199.548  ns/op
IntListBenchmark.guavaImplementation          1000    ss   10     1387.200 ±     531.909  ns/op
IntListBenchmark.guavaImplementation        100000    ss   10     1262.500 ±     188.043  ns/op
IntListBenchmark.guavaImplementation       1000000    ss   10     1600.000 ±    1509.810  ns/op
IntListBenchmark.streamImplementation           10    ss   10     8883.500 ±    1858.339  ns/op
IntListBenchmark.streamImplementation         1000    ss   10    46229.000 ±   25265.952  ns/op
IntListBenchmark.streamImplementation       100000    ss   10   736904.100 ±  299912.894  ns/op
IntListBenchmark.streamImplementation      1000000    ss   10  7321966.800 ± 7146920.166  ns/op

```