### PR TITLE
Flink:RewriteDataFiles support filter in plan

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.iceberg.actions.BinPackRewriteFilePlanner;
 import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.maintenance.operator.DataFileRewriteCommitter;
 import org.apache.iceberg.flink.maintenance.operator.DataFileRewritePlanner;
 import org.apache.iceberg.flink.maintenance.operator.DataFileRewriteRunner;
@@ -56,6 +57,7 @@ public class RewriteDataFiles {
         org.apache.iceberg.actions.RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS_DEFAULT;
     private final Map<String, String> rewriteOptions = Maps.newHashMapWithExpectedSize(6);
     private long maxRewriteBytes = Long.MAX_VALUE;
+    private Expression filter = null;
 
     @Override
     String maintenanceTaskName() {
@@ -191,6 +193,18 @@ public class RewriteDataFiles {
     }
 
     /**
+     * A user provided filter for determining which files will be considered by the rewrite
+     * strategy.
+     *
+     * @param newFilter the filter expression to apply
+     * @return this for method chaining
+     */
+    public Builder filter(Expression newFilter) {
+      this.filter = newFilter;
+      return this;
+    }
+
+    /**
      * Configures the properties for the rewriter.
      *
      * @param rewriteDataFilesConfig properties for the rewriter
@@ -233,7 +247,8 @@ public class RewriteDataFiles {
                       tableLoader(),
                       partialProgressEnabled ? partialProgressMaxCommits : 1,
                       maxRewriteBytes,
-                      rewriteOptions))
+                      rewriteOptions,
+                      filter))
               .name(operatorName(PLANNER_TASK_NAME))
               .uid(PLANNER_TASK_NAME + uidSuffix())
               .slotSharingGroup(slotSharingGroup())

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
@@ -33,6 +33,8 @@ import org.apache.iceberg.actions.BinPackRewriteFilePlanner;
 import org.apache.iceberg.actions.FileRewritePlan;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewriteFileGroup;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
 import org.apache.iceberg.io.CloseableIterator;
@@ -60,6 +62,7 @@ public class DataFileRewritePlanner
   private final long maxRewriteBytes;
   private final Map<String, String> rewriterOptions;
   private transient Counter errorCounter;
+  private final Expression filter;
 
   public DataFileRewritePlanner(
       String tableName,
@@ -69,6 +72,27 @@ public class DataFileRewritePlanner
       int newPartialProgressMaxCommits,
       long maxRewriteBytes,
       Map<String, String> rewriterOptions) {
+    this(
+        tableName,
+        taskName,
+        taskIndex,
+        tableLoader,
+        newPartialProgressMaxCommits,
+        maxRewriteBytes,
+        rewriterOptions,
+        Expressions.alwaysTrue());
+  }
+
+  public DataFileRewritePlanner(
+      String tableName,
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      int newPartialProgressMaxCommits,
+      long maxRewriteBytes,
+      Map<String, String> rewriterOptions,
+      Expression filter) {
+
     Preconditions.checkNotNull(tableName, "Table name should no be null");
     Preconditions.checkNotNull(taskName, "Task name should no be null");
     Preconditions.checkNotNull(tableLoader, "Table loader should no be null");
@@ -81,6 +105,7 @@ public class DataFileRewritePlanner
     this.partialProgressMaxCommits = newPartialProgressMaxCommits;
     this.maxRewriteBytes = maxRewriteBytes;
     this.rewriterOptions = rewriterOptions;
+    this.filter = filter;
   }
 
   @Override
@@ -113,7 +138,8 @@ public class DataFileRewritePlanner
         return;
       }
 
-      BinPackRewriteFilePlanner planner = new BinPackRewriteFilePlanner(table);
+      BinPackRewriteFilePlanner planner =
+          new BinPackRewriteFilePlanner(table, null == filter ? Expressions.alwaysTrue() : filter);
       planner.init(rewriterOptions);
 
       FileRewritePlan<RewriteDataFiles.FileGroupInfo, FileScanTask, DataFile, RewriteFileGroup>

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -34,6 +34,7 @@ import java.util.stream.StreamSupport;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.maintenance.operator.MetricsReporterFactoryForTests;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -371,6 +372,44 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
                     REMOVED_DATA_FILE_SIZE_METRIC),
                 -1L)
             .build());
+  }
+
+  @Test
+  void testRewriteUnPartitionedWithFilter() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+
+    assertFileNum(table, 4, 0);
+
+    appendRewriteDataFiles(
+        RewriteDataFiles.builder()
+            .parallelism(2)
+            .deleteFileThreshold(10)
+            .targetFileSizeBytes(1_000_000L)
+            .maxFileGroupSizeBytes(10_000_000L)
+            .maxFileSizeBytes(2_000_000L)
+            .minFileSizeBytes(500_000L)
+            .minInputFiles(2)
+            .filter(Expressions.in("id", 1, 2))
+            .partialProgressEnabled(true)
+            .partialProgressMaxCommits(1)
+            .maxRewriteBytes(100_000L)
+            .rewriteAll(false));
+
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    assertFileNum(table, 3, 0);
+
+    SimpleDataUtil.assertTableRecords(
+        table,
+        ImmutableList.of(
+            createRecord(1, "a"),
+            createRecord(2, "b"),
+            createRecord(3, "c"),
+            createRecord(4, "d")));
   }
 
   private void appendRewriteDataFiles() {


### PR DESCRIPTION
## Background
When an existing table is migrated to the Flink implementation of RewriteDataFiles and its historical data has not been compacted thoroughly,or modify the targetFileSize, the Flink maintenance job must first rewrite the entire table before it can follow the user’s intended schedule. This initial compaction can run for a very long time, while new data cannot trigger compaction, resulting in degraded query performance.

## Purpose
This PR introduces an optional filter parameter to Flink’s RewriteDataFiles. Users can define predicates (e.g. data whose time is greater than a given timestamp) so that only the necessary subset of data is compacted, allowing historical data to be skipped.