### PR TITLE
JDBC: Do not pass catalog props to JDBC driver

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
@@ -83,8 +83,9 @@ public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
 
   @Override
   protected Connection newClient() {
+    Properties dbProps = JdbcUtil.prepareJdbcDriverProperties(properties);
+
     try {
-      Properties dbProps = JdbcUtil.filterAndRemovePrefix(properties, JdbcCatalog.PROPERTY_PREFIX);
       return DriverManager.getConnection(dbUrl, dbProps);
     } catch (SQLException e) {
       throw new UncheckedSQLException(e, "Failed to connect: %s", dbUrl);

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
@@ -41,13 +41,16 @@ public class TestJdbcUtil {
     input.put("jdbc.user", "bar");
     input.put("jdbc.pass", "secret");
     input.put("jdbc.jdbc.abcxyz", "abcxyz");
+    input.put("jdbc.strict-mode", "foo");
+    input.put("jdbc.schema-version", "bar");
+    input.put("jdbc.init-catalog-tables", "baz");
 
     Properties expected = new Properties();
     expected.put("user", "bar");
     expected.put("pass", "secret");
     expected.put("jdbc.abcxyz", "abcxyz");
 
-    Properties actual = JdbcUtil.filterAndRemovePrefix(input, "jdbc.");
+    Properties actual = JdbcUtil.prepareJdbcDriverProperties(input);
 
     assertThat(actual).isEqualTo(expected);
   }


### PR DESCRIPTION
The `filterAndRemovePrefix` method is not used elsewhere and was already fairly specific to this use-case given it returns `Properties` to pass to a JDBC driver rather than operating generally on a `Map`.

This change renames the method to `prepareJdbcDriverProperties` and adds the additional behavior of filtering-out the three properties specific to JdbcCatalog.

Closes #13672

Could I get a second opinion on if any of these three properties might ever need to be passed down to the JDBC driver?