### PR TITLE
Build: Allow overriding the default test parallelism of 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,13 @@ subprojects {
     }
   }
 
+  def testParallelism = project.findProperty('testParallelism')
+  if (testParallelism != null) {
+    tasks.withType(Test).configureEach {
+      maxParallelForks = testParallelism as int
+    }
+  }
+
   configurations {
     testImplementation.extendsFrom compileOnly
 


### PR DESCRIPTION
This adds the `testParallelism` property which allows to set the number of Gradle workers for test tasks. The default remains 1 worker (no concurrency).

I found myself frequently editing the `test` section of the Flink builds to speed up the build. The speedup is linear to the number of workers used, given that the machine can keep up.

Example:
```
./gradlew :iceberg-flink:iceberg-flink-2.0:check -PtestParallelism=8
```

Initially, I was planning to add this only to the Flink build files, but I think all other modules of Iceberg can benefit from this build setting.