### PR TITLE
Use decimal precision to determine variant decimal type

### DIFF
--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
@@ -185,7 +185,7 @@ public class TestSerializedPrimitives {
             new byte[] {primitiveHeader(8), 0x04, (byte) 0xD2, 0x02, (byte) 0x96, 0x49});
 
     assertThat(value.type()).isEqualTo(PhysicalType.DECIMAL4);
-    assertThat(value.get()).isEqualTo(new BigDecimal("123456.7890"));
+    assertThat(value.get()).isEqualTo(new BigDecimal("12345.6789"));
   }
 
   @Test
@@ -218,7 +218,7 @@ public class TestSerializedPrimitives {
             });
 
     assertThat(value.type()).isEqualTo(PhysicalType.DECIMAL8);
-    assertThat(value.get()).isEqualTo(new BigDecimal("1234567890.987654321"));
+    assertThat(value.get()).isEqualTo(new BigDecimal("123456789.987654321"));
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
@@ -182,7 +182,7 @@ public class TestSerializedPrimitives {
   public void testDecimal4() {
     VariantPrimitive<?> value =
         SerializedPrimitive.from(
-            new byte[] {primitiveHeader(8), 0x04, (byte) 0xD2, 0x02, (byte) 0x96, 0x49});
+            new byte[] {primitiveHeader(8), 0x04, (byte) 0x15, (byte) 0xCD, (byte) 0x5B, 0x07});
 
     assertThat(value.type()).isEqualTo(PhysicalType.DECIMAL4);
     assertThat(value.get()).isEqualTo(new BigDecimal("12345.6789"));
@@ -208,13 +208,13 @@ public class TestSerializedPrimitives {
               primitiveHeader(9),
               0x09, // scale=9
               (byte) 0xB1,
-              0x1C,
-              0x6C,
-              (byte) 0xB1,
-              (byte) 0xF4,
-              0x10,
-              0x22,
-              0x11
+              (byte) 0xFA,
+              0x52,
+              (byte) 0xE0,
+              (byte) 0x4B,
+              (byte) 0x9B,
+              (byte) 0xB6,
+              0x01
             });
 
     assertThat(value.type()).isEqualTo(PhysicalType.DECIMAL8);

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -186,16 +186,17 @@ public class Variants {
   }
 
   public static VariantPrimitive<BigDecimal> of(BigDecimal value) {
-    int bitLength = value.unscaledValue().bitLength();
-    if (bitLength < 32) {
+    int precision = value.precision();
+
+    if (precision >= 1 && precision <= 9) {
       return new PrimitiveWrapper<>(PhysicalType.DECIMAL4, value);
-    } else if (bitLength < 64) {
+    } else if (precision >= 10 && precision <= 18) {
       return new PrimitiveWrapper<>(PhysicalType.DECIMAL8, value);
-    } else if (bitLength < 128) {
+    } else if (precision <= 38) {
       return new PrimitiveWrapper<>(PhysicalType.DECIMAL16, value);
     }
 
-    throw new UnsupportedOperationException("Unsupported decimal precision: " + value.precision());
+    throw new UnsupportedOperationException("Unsupported decimal precision: " + precision);
   }
 
   public static VariantPrimitive<ByteBuffer> of(ByteBuffer value) {

--- a/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
@@ -52,10 +52,10 @@ public class TestPrimitiveWrapper {
         Variants.ofIsoTimestamptz("1957-11-07T12:33:54.123456+00:00"),
         Variants.ofIsoTimestampntz("2024-11-07T12:33:54.123456"),
         Variants.ofIsoTimestampntz("1957-11-07T12:33:54.123456"),
-        Variants.of(new BigDecimal("123456.7890")), // decimal4
-        Variants.of(new BigDecimal("-123456.7890")), // decimal4
-        Variants.of(new BigDecimal("1234567890.987654321")), // decimal8
-        Variants.of(new BigDecimal("-1234567890.987654321")), // decimal8
+        Variants.of(new BigDecimal("12345.6789")), // decimal4
+        Variants.of(new BigDecimal("-12345.6789")), // decimal4
+        Variants.of(new BigDecimal("123456789.987654321")), // decimal8
+        Variants.of(new BigDecimal("-123456789.987654321")), // decimal8
         Variants.of(new BigDecimal("9876543210.123456789")), // decimal16
         Variants.of(new BigDecimal("-9876543210.123456789")), // decimal16
         Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReaders.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantReaders.java
@@ -122,10 +122,10 @@ public class TestVariantReaders {
         Variants.ofIsoTimestamptz("1957-11-07T12:33:54.123456+00:00"),
         Variants.ofIsoTimestampntz("2024-11-07T12:33:54.123456"),
         Variants.ofIsoTimestampntz("1957-11-07T12:33:54.123456"),
-        Variants.of(new BigDecimal("123456.7890")), // decimal4
-        Variants.of(new BigDecimal("-123456.7890")), // decimal4
-        Variants.of(new BigDecimal("1234567890.987654321")), // decimal8
-        Variants.of(new BigDecimal("-1234567890.987654321")), // decimal8
+        Variants.of(new BigDecimal("12345.6789")), // decimal4
+        Variants.of(new BigDecimal("-12345.6789")), // decimal4
+        Variants.of(new BigDecimal("123456789.987654321")), // decimal8
+        Variants.of(new BigDecimal("-123456789.987654321")), // decimal8
         Variants.of(new BigDecimal("9876543210.123456789")), // decimal16
         Variants.of(new BigDecimal("-9876543210.123456789")), // decimal16
         Variants.of(ByteBuffer.wrap(new byte[] {0x0a, 0x0b, 0x0c, 0x0d})),


### PR DESCRIPTION
**Updated decimal encoding to follow Variant spec**

Aligned the decimal encoding logic with the [Variant spec](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md), selecting the appropriate decimal type based on precision rather than unscaled value range. Updated corresponding tests to reflect the change.