### PR TITLE
API, Core: Preserve original Type for upper/lower bounds in Metrics

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Iceberg file format metrics. */
@@ -37,6 +38,8 @@ public class Metrics implements Serializable {
   private Map<Integer, Long> nanValueCounts = null;
   private Map<Integer, ByteBuffer> lowerBounds = null;
   private Map<Integer, ByteBuffer> upperBounds = null;
+  // this is not serialized with all the other fields
+  private Map<Integer, Type> originalTypes = null;
 
   public Metrics() {}
 
@@ -72,6 +75,25 @@ public class Metrics implements Serializable {
     this.nanValueCounts = nanValueCounts;
     this.lowerBounds = lowerBounds;
     this.upperBounds = upperBounds;
+  }
+
+  public Metrics(
+      Long rowCount,
+      Map<Integer, Long> columnSizes,
+      Map<Integer, Long> valueCounts,
+      Map<Integer, Long> nullValueCounts,
+      Map<Integer, Long> nanValueCounts,
+      Map<Integer, ByteBuffer> lowerBounds,
+      Map<Integer, ByteBuffer> upperBounds,
+      Map<Integer, Type> originalTypes) {
+    this.rowCount = rowCount;
+    this.columnSizes = columnSizes;
+    this.valueCounts = valueCounts;
+    this.nullValueCounts = nullValueCounts;
+    this.nanValueCounts = nanValueCounts;
+    this.lowerBounds = lowerBounds;
+    this.upperBounds = upperBounds;
+    this.originalTypes = originalTypes;
   }
 
   /**
@@ -140,6 +162,15 @@ public class Metrics implements Serializable {
    */
   public Map<Integer, ByteBuffer> upperBounds() {
     return upperBounds;
+  }
+
+  /**
+   * Get the non-null original types for the upper/lower bound for all fields in a file.
+   *
+   * @return A map of fieldId to the original type of the upper/lower bound.
+   */
+  public Map<Integer, Type> originalTypes() {
+    return originalTypes;
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -53,11 +53,7 @@ public class Metrics implements Serializable {
       Map<Integer, Long> valueCounts,
       Map<Integer, Long> nullValueCounts,
       Map<Integer, Long> nanValueCounts) {
-    this.rowCount = rowCount;
-    this.columnSizes = columnSizes;
-    this.valueCounts = valueCounts;
-    this.nullValueCounts = nullValueCounts;
-    this.nanValueCounts = nanValueCounts;
+    this(rowCount, columnSizes, valueCounts, nullValueCounts, nanValueCounts, null, null, null);
   }
 
   public Metrics(
@@ -68,13 +64,15 @@ public class Metrics implements Serializable {
       Map<Integer, Long> nanValueCounts,
       Map<Integer, ByteBuffer> lowerBounds,
       Map<Integer, ByteBuffer> upperBounds) {
-    this.rowCount = rowCount;
-    this.columnSizes = columnSizes;
-    this.valueCounts = valueCounts;
-    this.nullValueCounts = nullValueCounts;
-    this.nanValueCounts = nanValueCounts;
-    this.lowerBounds = lowerBounds;
-    this.upperBounds = upperBounds;
+    this(
+        rowCount,
+        columnSizes,
+        valueCounts,
+        nullValueCounts,
+        nanValueCounts,
+        lowerBounds,
+        upperBounds,
+        null);
   }
 
   public Metrics(

--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -167,7 +167,7 @@ public class Metrics implements Serializable {
    *
    * @return A map of fieldId to the original type of the upper/lower bound.
    */
-  public Map<Integer, Type> originalTypes() {
+  Map<Integer, Type> originalTypes() {
     return originalTypes;
   }
 

--- a/api/src/test/java/org/apache/iceberg/TestMetricsSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/TestMetricsSerialization.java
@@ -27,7 +27,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestMetricsSerialization {
@@ -88,7 +91,9 @@ public class TestMetricsSerialization {
     Map<Integer, ByteBuffer> byteMap2 = Maps.newHashMap();
     byteMap1.put(3, ByteBuffer.wrap(new byte[] {1, 2}));
 
-    return new Metrics(0L, longMap1, longMap2, longMap3, null, byteMap1, byteMap2);
+    Map<Integer, Type> originalTypes =
+        ImmutableMap.of(1, Types.IntegerType.get(), 2, Types.IntegerType.get());
+    return new Metrics(0L, longMap1, longMap2, longMap3, null, byteMap1, byteMap2, originalTypes);
   }
 
   private static Metrics generateMetricsWithNulls() {
@@ -100,7 +105,8 @@ public class TestMetricsSerialization {
     byteMap.put(null, ByteBuffer.wrap(new byte[] {1, 2, 3}));
     byteMap.put(4, null);
 
-    return new Metrics(null, null, longMap, longMap, null, null, byteMap);
+    Map<Integer, Type> originalTypes = ImmutableMap.of(4, Types.IntegerType.get());
+    return new Metrics(null, null, longMap, longMap, null, null, byteMap, originalTypes);
   }
 
   private static void assertEquals(Metrics expected, Metrics actual) {
@@ -111,6 +117,8 @@ public class TestMetricsSerialization {
 
     assertEquals(expected.lowerBounds(), actual.lowerBounds());
     assertEquals(expected.upperBounds(), actual.upperBounds());
+    // originalTypes isn't serialized
+    assertThat(actual.originalTypes()).isNull();
   }
 
   private static void assertEquals(

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.ByteBuffers;
 
 public class DataFiles {
@@ -151,6 +152,7 @@ public class DataFiles {
     private Map<Integer, Long> nanValueCounts = null;
     private Map<Integer, ByteBuffer> lowerBounds = null;
     private Map<Integer, ByteBuffer> upperBounds = null;
+    private Map<Integer, Type> originalTypes = null;
     private ByteBuffer keyMetadata = null;
     private List<Long> splitOffsets = null;
     private Integer sortOrderId = SortOrder.unsorted().orderId();
@@ -290,6 +292,7 @@ public class DataFiles {
       this.nanValueCounts = metrics.nanValueCounts();
       this.lowerBounds = metrics.lowerBounds();
       this.upperBounds = metrics.upperBounds();
+      this.originalTypes = metrics.originalTypes();
       return this;
     }
 
@@ -345,7 +348,8 @@ public class DataFiles {
               nullValueCounts,
               nanValueCounts,
               lowerBounds,
-              upperBounds),
+              upperBounds,
+              originalTypes),
           keyMetadata,
           splitOffsets,
           sortOrderId,

--- a/core/src/main/java/org/apache/iceberg/DoubleFieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/DoubleFieldMetrics.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import org.apache.iceberg.types.Types;
+
 /**
  * Iceberg internally tracked field level metrics, used by Parquet and ORC writers only.
  *
@@ -29,7 +31,7 @@ public class DoubleFieldMetrics extends FieldMetrics<Double> {
 
   private DoubleFieldMetrics(
       int id, long valueCount, long nanValueCount, Double lowerBound, Double upperBound) {
-    super(id, valueCount, 0L, nanValueCount, lowerBound, upperBound);
+    super(id, valueCount, 0L, nanValueCount, lowerBound, upperBound, Types.DoubleType.get());
   }
 
   public static class Builder {

--- a/core/src/main/java/org/apache/iceberg/FieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/FieldMetrics.java
@@ -31,15 +31,15 @@ public class FieldMetrics<T> {
   private final Type originalType;
 
   public FieldMetrics(int id, long valueCount, long nullValueCount) {
-    this(id, valueCount, nullValueCount, -1L, null, null);
+    this(id, valueCount, nullValueCount, -1L, null, null, null);
   }
 
   public FieldMetrics(int id, long valueCount, long nullValueCount, T lowerBound, T upperBound) {
-    this(id, valueCount, nullValueCount, -1L, lowerBound, upperBound);
+    this(id, valueCount, nullValueCount, -1L, lowerBound, upperBound, null);
   }
 
   public FieldMetrics(int id, long valueCount, long nullValueCount, long nanValueCount) {
-    this(id, valueCount, nullValueCount, nanValueCount, null, null);
+    this(id, valueCount, nullValueCount, nanValueCount, null, null, null);
   }
 
   public FieldMetrics(
@@ -54,13 +54,7 @@ public class FieldMetrics<T> {
       long nanValueCount,
       T lowerBound,
       T upperBound) {
-    this.id = id;
-    this.valueCount = valueCount;
-    this.nullValueCount = nullValueCount;
-    this.nanValueCount = nanValueCount;
-    this.lowerBound = lowerBound;
-    this.upperBound = upperBound;
-    this.originalType = null;
+    this(id, valueCount, nullValueCount, nanValueCount, lowerBound, upperBound, null);
   }
 
   public FieldMetrics(

--- a/core/src/main/java/org/apache/iceberg/FieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/FieldMetrics.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import org.apache.iceberg.types.Type;
+
 /** Iceberg internally tracked field level metrics. */
 public class FieldMetrics<T> {
   private final int id;
@@ -26,6 +28,7 @@ public class FieldMetrics<T> {
   private final long nanValueCount;
   private final T lowerBound;
   private final T upperBound;
+  private final Type originalType;
 
   public FieldMetrics(int id, long valueCount, long nullValueCount) {
     this(id, valueCount, nullValueCount, -1L, null, null);
@@ -37,6 +40,11 @@ public class FieldMetrics<T> {
 
   public FieldMetrics(int id, long valueCount, long nullValueCount, long nanValueCount) {
     this(id, valueCount, nullValueCount, nanValueCount, null, null);
+  }
+
+  public FieldMetrics(
+      int id, long valueCount, long nullValueCount, T lowerBound, T upperBound, Type originalType) {
+    this(id, valueCount, nullValueCount, -1L, lowerBound, upperBound, originalType);
   }
 
   public FieldMetrics(
@@ -52,6 +60,24 @@ public class FieldMetrics<T> {
     this.nanValueCount = nanValueCount;
     this.lowerBound = lowerBound;
     this.upperBound = upperBound;
+    this.originalType = null;
+  }
+
+  public FieldMetrics(
+      int id,
+      long valueCount,
+      long nullValueCount,
+      long nanValueCount,
+      T lowerBound,
+      T upperBound,
+      Type originalType) {
+    this.id = id;
+    this.valueCount = valueCount;
+    this.nullValueCount = nullValueCount;
+    this.nanValueCount = nanValueCount;
+    this.lowerBound = lowerBound;
+    this.upperBound = upperBound;
+    this.originalType = originalType;
   }
 
   /** Returns the id of the field that the metrics within this class are associated with. */
@@ -85,6 +111,11 @@ public class FieldMetrics<T> {
   /** Returns the upper bound value of this field. */
   public T upperBound() {
     return upperBound;
+  }
+
+  /** Returns the original type of the upper/lower bound value of this field. */
+  public Type originalType() {
+    return originalType;
   }
 
   /** Returns if the metrics has bounds (i.e. there is at least non-null value for this field) */

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.ByteBuffers;
 
 public class FileMetadata {
@@ -56,6 +57,7 @@ public class FileMetadata {
     private Map<Integer, Long> nanValueCounts = null;
     private Map<Integer, ByteBuffer> lowerBounds = null;
     private Map<Integer, ByteBuffer> upperBounds = null;
+    private Map<Integer, Type> originalTypes = null;
     private ByteBuffer keyMetadata = null;
     private Integer sortOrderId = null;
     private List<Long> splitOffsets = null;
@@ -195,6 +197,7 @@ public class FileMetadata {
       this.nanValueCounts = metrics.nanValueCounts();
       this.lowerBounds = metrics.lowerBounds();
       this.upperBounds = metrics.upperBounds();
+      this.originalTypes = metrics.originalTypes();
       return this;
     }
 
@@ -291,7 +294,8 @@ public class FileMetadata {
               nullValueCounts,
               nanValueCounts,
               lowerBounds,
-              upperBounds),
+              upperBounds,
+              originalTypes),
           equalityFieldIds,
           sortOrderId,
           splitOffsets,

--- a/core/src/main/java/org/apache/iceberg/FloatFieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/FloatFieldMetrics.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import org.apache.iceberg.types.Types;
+
 /**
  * Iceberg internally tracked field level metrics, used by Parquet and ORC writers only.
  *
@@ -29,7 +31,7 @@ public class FloatFieldMetrics extends FieldMetrics<Float> {
 
   private FloatFieldMetrics(
       int id, long valueCount, long nanValueCount, Float lowerBound, Float upperBound) {
-    super(id, valueCount, 0L, nanValueCount, lowerBound, upperBound);
+    super(id, valueCount, 0L, nanValueCount, lowerBound, upperBound, Types.FloatType.get());
   }
 
   public Builder builderFor(int id) {

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -55,7 +55,8 @@ public class MetricsUtil {
         copyWithoutKeys(metrics.nullValueCounts(), excludedFieldIds),
         copyWithoutKeys(metrics.nanValueCounts(), excludedFieldIds),
         metrics.lowerBounds(),
-        metrics.upperBounds());
+        metrics.upperBounds(),
+        metrics.originalTypes());
   }
 
   /**
@@ -73,7 +74,8 @@ public class MetricsUtil {
         copyWithoutKeys(metrics.nullValueCounts(), excludedFieldIds),
         copyWithoutKeys(metrics.nanValueCounts(), excludedFieldIds),
         copyWithoutKeys(metrics.lowerBounds(), excludedFieldIds),
-        copyWithoutKeys(metrics.upperBounds(), excludedFieldIds));
+        copyWithoutKeys(metrics.upperBounds(), excludedFieldIds),
+        copyWithoutKeys(metrics.originalTypes(), excludedFieldIds));
   }
 
   private static <K, V> Map<K, V> copyWithoutKeys(Map<K, V> map, Set<K> keys) {

--- a/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
@@ -174,6 +175,7 @@ public class FileGenerationUtil {
     Map<Integer, Long> nanValueCounts = Maps.newHashMap();
     Map<Integer, ByteBuffer> lowerBounds = Maps.newHashMap();
     Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
+    Map<Integer, Type> originalTypes = Maps.newHashMap();
 
     for (Types.NestedField column : schema.columns()) {
       int fieldId = column.fieldId();
@@ -181,6 +183,7 @@ public class FileGenerationUtil {
       valueCounts.put(fieldId, generateValueCount());
       nullValueCounts.put(fieldId, (long) random().nextInt(5));
       nanValueCounts.put(fieldId, (long) random().nextInt(5));
+      originalTypes.put(fieldId, column.type());
       if (knownLowerBounds.containsKey(fieldId) && knownUpperBounds.containsKey(fieldId)) {
         lowerBounds.put(fieldId, knownLowerBounds.get(fieldId));
         upperBounds.put(fieldId, knownUpperBounds.get(fieldId));
@@ -200,7 +203,8 @@ public class FileGenerationUtil {
         nullValueCounts,
         nanValueCounts,
         lowerBounds,
-        upperBounds);
+        upperBounds,
+        originalTypes);
   }
 
   private static Metrics generatePositionDeleteMetrics(DataFile dataFile) {
@@ -208,6 +212,7 @@ public class FileGenerationUtil {
     Map<Integer, Long> columnSizes = Maps.newHashMap();
     Map<Integer, ByteBuffer> lowerBounds = Maps.newHashMap();
     Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
+    Map<Integer, Type> originalTypes = Maps.newHashMap();
 
     for (Types.NestedField column : DeleteSchemaUtil.pathPosSchema().columns()) {
       int fieldId = column.fieldId();
@@ -216,6 +221,7 @@ public class FileGenerationUtil {
         ByteBuffer bound = Conversions.toByteBuffer(Types.StringType.get(), dataFile.location());
         lowerBounds.put(fieldId, bound);
         upperBounds.put(fieldId, bound);
+        originalTypes.put(fieldId, column.type());
       }
     }
 
@@ -226,7 +232,8 @@ public class FileGenerationUtil {
         null /* no NULL counts */,
         null /* no NaN counts */,
         lowerBounds,
-        upperBounds);
+        upperBounds,
+        originalTypes);
   }
 
   private static Metrics generatePositionDeleteMetrics() {

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -770,6 +770,10 @@ public abstract class TestMetrics {
       int fieldId, Type type, T lowerBound, T upperBound, Metrics metrics) {
     Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
     Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
+    if (null != lowerBound || null != upperBound) {
+      // if there's an expected lower/upper bound, then the original type should be available
+      assertThat(metrics.originalTypes().get(fieldId)).isEqualTo(type);
+    }
 
     if (lowerBounds.containsKey(fieldId)) {
       assertThat((Object) fromByteBuffer(type, lowerBounds.get(fieldId))).isEqualTo(lowerBound);

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
@@ -248,7 +248,8 @@ public class GenericOrcWriters {
               nullValueCount,
               metricsWithoutNullCount.nanValueCount(),
               metricsWithoutNullCount.lowerBound(),
-              metricsWithoutNullCount.upperBound()));
+              metricsWithoutNullCount.upperBound(),
+              metricsWithoutNullCount.originalType()));
     }
   }
 
@@ -281,7 +282,8 @@ public class GenericOrcWriters {
               nullValueCount,
               metricsWithoutNullCount.nanValueCount(),
               metricsWithoutNullCount.lowerBound(),
-              metricsWithoutNullCount.upperBound()));
+              metricsWithoutNullCount.upperBound(),
+              metricsWithoutNullCount.originalType()));
     }
   }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -143,6 +143,7 @@ public class OrcMetrics {
     final Schema schema = ORCSchemaUtil.convert(orcSchemaWithIds);
     Map<Integer, ByteBuffer> lowerBounds = Maps.newHashMap();
     Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
+    Map<Integer, Type> originalTypes = Maps.newHashMap();
 
     Map<Integer, FieldMetrics<?>> fieldMetricsMap =
         Optional.ofNullable(fieldMetricsStream)
@@ -193,6 +194,8 @@ public class OrcMetrics {
                         icebergCol.type(), colStat, metricsMode, fieldMetricsMap.get(fieldId))
                     : Optional.empty();
             orcMax.ifPresent(byteBuffer -> upperBounds.put(icebergCol.fieldId(), byteBuffer));
+
+            originalTypes.put(fieldId, icebergCol.type());
           }
         }
       }
@@ -206,7 +209,8 @@ public class OrcMetrics {
         MetricsUtil.createNanValueCounts(
             fieldMetricsMap.values().stream(), effectiveMetricsConfig, schema),
         lowerBounds,
-        upperBounds);
+        upperBounds,
+        originalTypes);
   }
 
   private static boolean inMapOrList(TypeDescription orcCol) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -456,7 +456,8 @@ public class ParquetValueWriters {
                   nullValueCount,
                   metrics.nanValueCount(),
                   metrics.lowerBound(),
-                  metrics.upperBound()));
+                  metrics.upperBound(),
+                  metrics.originalType()));
         } else {
           throw new IllegalStateException(
               String.format(

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
@@ -140,6 +140,9 @@ public class TestVariantMetrics {
               return bounds.get(ROOT_FIELD);
             })
         .isEqualTo(value);
+
+    assertThat(metrics.originalTypes())
+        .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
   @ParameterizedTest
@@ -181,6 +184,9 @@ public class TestVariantMetrics {
               return bounds.get(ROOT_FIELD);
             })
         .isEqualTo(largerValue);
+
+    assertThat(metrics.originalTypes())
+        .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
   @ParameterizedTest
@@ -204,6 +210,8 @@ public class TestVariantMetrics {
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+
+    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -224,6 +232,8 @@ public class TestVariantMetrics {
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+
+    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -244,6 +254,8 @@ public class TestVariantMetrics {
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+
+    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -263,6 +275,8 @@ public class TestVariantMetrics {
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+
+    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -281,6 +295,8 @@ public class TestVariantMetrics {
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 0L)));
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
+
+    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -333,6 +349,9 @@ public class TestVariantMetrics {
     assertThat(metrics.upperBounds().get(2))
         .extracting(bytes -> Variant.from(bytes).value())
         .isEqualTo(expectedBounds);
+
+    assertThat(metrics.originalTypes())
+        .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
   @Test
@@ -389,6 +408,9 @@ public class TestVariantMetrics {
     assertThat(metrics.upperBounds().get(2))
         .extracting(bytes -> Variant.from(bytes).value())
         .isEqualTo(expectedBounds);
+
+    assertThat(metrics.originalTypes())
+        .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
   @Test
@@ -447,6 +469,9 @@ public class TestVariantMetrics {
     assertThat(metrics.upperBounds().get(2))
         .extracting(bytes -> Variant.from(bytes).value())
         .isEqualTo(expectedBounds);
+
+    assertThat(metrics.originalTypes())
+        .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
   private Metrics writeParquet(VariantShreddingFunction shredding, Variant... variants)

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
@@ -141,7 +141,8 @@ public class TestVariantMetrics {
             })
         .isEqualTo(value);
 
-    assertThat(metrics.originalTypes())
+    assertThat(metrics)
+        .extracting("originalTypes")
         .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
@@ -185,7 +186,8 @@ public class TestVariantMetrics {
             })
         .isEqualTo(largerValue);
 
-    assertThat(metrics.originalTypes())
+    assertThat(metrics)
+        .extracting("originalTypes")
         .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
@@ -211,7 +213,7 @@ public class TestVariantMetrics {
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
 
-    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
+    assertThat(metrics).extracting("originalTypes").isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -233,7 +235,7 @@ public class TestVariantMetrics {
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
 
-    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
+    assertThat(metrics).extracting("originalTypes").isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -255,7 +257,7 @@ public class TestVariantMetrics {
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
 
-    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
+    assertThat(metrics).extracting("originalTypes").isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -276,7 +278,7 @@ public class TestVariantMetrics {
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
 
-    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
+    assertThat(metrics).extracting("originalTypes").isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -296,7 +298,7 @@ public class TestVariantMetrics {
     assertThat(metrics.upperBounds())
         .isEqualTo(Map.of(1, Conversions.toByteBuffer(Type.TypeID.LONG, 1L)));
 
-    assertThat(metrics.originalTypes()).isEqualTo(Map.of(1, Types.LongType.get()));
+    assertThat(metrics).extracting("originalTypes").isEqualTo(Map.of(1, Types.LongType.get()));
   }
 
   @Test
@@ -350,7 +352,8 @@ public class TestVariantMetrics {
         .extracting(bytes -> Variant.from(bytes).value())
         .isEqualTo(expectedBounds);
 
-    assertThat(metrics.originalTypes())
+    assertThat(metrics)
+        .extracting("originalTypes")
         .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
@@ -409,7 +412,8 @@ public class TestVariantMetrics {
         .extracting(bytes -> Variant.from(bytes).value())
         .isEqualTo(expectedBounds);
 
-    assertThat(metrics.originalTypes())
+    assertThat(metrics)
+        .extracting("originalTypes")
         .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 
@@ -470,7 +474,8 @@ public class TestVariantMetrics {
         .extracting(bytes -> Variant.from(bytes).value())
         .isEqualTo(expectedBounds);
 
-    assertThat(metrics.originalTypes())
+    assertThat(metrics)
+        .extracting("originalTypes")
         .isEqualTo(Map.of(1, Types.LongType.get(), 2, Types.VariantType.get()));
   }
 


### PR DESCRIPTION
This preserves the original type of the upper/lower bound of a particular field metric. 
This will be later used to convert from `Metrics` to the new content stats