### PR TITLE
Core: Fix case-insensitive validation of fields in schema evolution

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -567,7 +567,7 @@ class SchemaUpdate implements UpdateSchema {
             .asStructType();
 
     // validate identifier requirements based on the latest schema
-    Map<String, Integer> nameToId = TypeUtil.indexByName(struct);
+    Map<String, Integer> nameToId = caseSensitive ? TypeUtil.indexByName(struct) : TypeUtil.indexByLowerCaseName(struct);
     Set<Integer> freshIdentifierFieldIds = Sets.newHashSet();
     for (String name : identifierFieldNames) {
       Preconditions.checkArgument(

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -567,7 +567,8 @@ class SchemaUpdate implements UpdateSchema {
             .asStructType();
 
     // validate identifier requirements based on the latest schema
-    Map<String, Integer> nameToId = caseSensitive ? TypeUtil.indexByName(struct) : TypeUtil.indexByLowerCaseName(struct);
+    Map<String, Integer> nameToId =
+        caseSensitive ? TypeUtil.indexByName(struct) : TypeUtil.indexByLowerCaseName(struct);
     Set<Integer> freshIdentifierFieldIds = Sets.newHashSet();
     for (String name : identifierFieldNames) {
       Preconditions.checkArgument(

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -792,7 +792,7 @@ public class TestSchemaUpdate {
                     .addRequiredColumn("DATA", Types.StringType.get())
                     .apply())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot add column, name already exists: DATA");
+        .hasMessage("Cannot build lower case index: data and DATA collide");
   }
 
   @Test


### PR DESCRIPTION
Closes #13696 

The case sensitivity settings are ignored during the final validation step when committing the `UpdateSchema`.