### PR TITLE
Minor: Use hasSameSizeAs to show more debug info

### DIFF
--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/DataFrameWriteTestBase.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/DataFrameWriteTestBase.java
@@ -100,7 +100,7 @@ public abstract class DataFrameWriteTestBase extends ScanTestBase {
     }
 
     // verify that the dataframe matches
-    assertThat(rows.size()).isEqualTo(records.size());
+    assertThat(rows).hasSameSizeAs(records);
     Iterator<Record> recordIter = records.iterator();
     for (InternalRow row : rows) {
       GenericsHelpers.assertEqualsUnsafe(schema.asStruct(), recordIter.next(), row);


### PR DESCRIPTION
Revert back to use hasSameSizeAs instead of isEqualTo in the test since when the number doesn't match, hasSameSizeAs will show the records for debug.

```
Actual and expected should have same size but actual size is:
  100
while expected size is:
  99
Actual was:
  [[-1853403699951111791,keys: [djhnOE!Q8EcmpHvCXKdCGT1bKPynyUGZ57,MJtC!VHkgou8p!H1!10?RdQBc1e69Os-F
TMEx7tg6cF4Kvk2D3PcPGZUspTDtS9wK?p!qqERhkj?DT3A=CottFHuHPVAGRPlOwVpSWdNbP})]
...
	at org.apache.iceberg.spark.source.DataFrameWriteTestBase.createDataset(DataFrameWriteTestBase.java:104)
	at org.apache.iceberg.spark.source.DataFrameWriteTestBase.writeRecords(DataFrameWriteTestBase.java:69)
	at org.apache.iceberg.spark.source.ScanTestBase.writeAndValidate(ScanTestBase.java:105)
	at org.apache.iceberg.spark.source.ScanTestBase.writeAndValidate(ScanTestBase.java:85)
	at org.apache.iceberg.spark.data.AvroDataTestBase.testMap(AvroDataTestBase.java:277)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```