### PR TITLE
Spark 4.0: Add Configurable Empty Directory Deletion to RemoveOrphanFilesProcedure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -164,4 +164,19 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
       }
     }
   }
+
+  enum DeleteEmptyDirectoriesMode {
+    NONE,
+    ORPHAN,
+    ALL;
+
+    public static DeleteEmptyDirectoriesMode fromString(String modeAsString) {
+      Preconditions.checkArgument(modeAsString != null, "Invalid mode: null");
+      try {
+        return DeleteEmptyDirectoriesMode.valueOf(modeAsString.toUpperCase(Locale.ENGLISH));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(String.format("Invalid mode: %s", modeAsString), e);
+      }
+    }
+  }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.DeleteOrphanFiles.DeleteEmptyDirectoriesMode;
 import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -70,7 +71,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         optionalInParameter("equal_authorities", STRING_MAP),
         optionalInParameter("prefix_mismatch_mode", DataTypes.StringType),
         // List files with prefix operations. Default is false.
-        optionalInParameter("prefix_listing", DataTypes.BooleanType)
+        optionalInParameter("prefix_listing", DataTypes.BooleanType),
+        optionalInParameter("empty_dir_deletion_mode", DataTypes.StringType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -146,6 +148,9 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
     boolean prefixListing = args.isNullAt(9) ? false : args.getBoolean(9);
 
+    DeleteEmptyDirectoriesMode deleteEmptyDirectoriesMode =
+        args.isNullAt(10) ? null : DeleteEmptyDirectoriesMode.fromString(args.getString(10));
+
     return withIcebergTable(
         tableIdent,
         table -> {
@@ -190,6 +195,10 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
           if (prefixMismatchMode != null) {
             action.prefixMismatchMode(prefixMismatchMode);
+          }
+
+          if (deleteEmptyDirectoriesMode != null) {
+            action.deleteEmptyDirectoriesMode(deleteEmptyDirectoriesMode);
           }
 
           action.usePrefixListing(prefixListing);


### PR DESCRIPTION
Background:
RemoveOrphanFilesProcedure currently does not clean up empty directories left by orphan data files. When large amounts of uncommitted partition data are written (e.g., aborted writes), many empty directories may remain with no simple way to clean them up.

This PR adds:
A new parameter empty_dir_deletion_mode:
NONE (default): Do not delete any directories
ORPHAN: Only remove empty directories that become empty as a direct result of this orphan file cleanup (safe option)
ALL: Recursively remove all empty directories under the table location (use with caution: may be expensive and subject to concurrent modification risks)
Associated methods for recursive directory cleanup

Usage example:
`CALL catalog.system.remove_orphan_files('db.tbl', empty_dir_deletion_mode => 'ORPHAN')`

If accepted, I will extend support to other Spark versions and update the documentation.