### PR TITLE
REST: Expose response headers in GET requests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/BaseHTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/BaseHTTPClient.java
@@ -90,6 +90,18 @@ public abstract class BaseHTTPClient implements RESTClient {
   }
 
   @Override
+  public <T extends RESTResponse> T get(
+      String path,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders) {
+    HTTPRequest request = buildRequest(HTTPMethod.GET, path, queryParams, headers, null);
+    return execute(request, responseType, errorHandler, responseHeaders);
+  }
+
+  @Override
   public <T extends RESTResponse> T post(
       String path,
       RESTRequest body,

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -110,6 +110,30 @@ public interface RESTClient extends Closeable {
     return get(path, queryParams, responseType, headers, errorHandler);
   }
 
+  default <T extends RESTResponse> T get(
+      String path,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Supplier<Map<String, String>> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders) {
+    return get(path, queryParams, responseType, headers.get(), errorHandler, responseHeaders);
+  }
+
+  default <T extends RESTResponse> T get(
+      String path,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders) {
+    if (null != responseHeaders) {
+      throw new UnsupportedOperationException("Returning response headers is not supported");
+    }
+
+    return get(path, queryParams, responseType, headers, errorHandler);
+  }
+
   <T extends RESTResponse> T get(
       String path,
       Map<String, String> queryParams,

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -70,7 +70,7 @@ import org.mockserver.verify.VerificationTimes;
 
 /**
  * * Exercises the RESTClient interface, specifically over a mocked-server using the actual
- * HttpRESTClient code.
+ * HTTPClient code.
  */
 public class TestHTTPClient {
 
@@ -602,7 +602,8 @@ public class TestHTTPClient {
       case POST:
         return restClient.post(path, body, Item.class, headers, onError, responseHeaders);
       case GET:
-        return restClient.get(path, Item.class, headers, onError);
+        return restClient.get(
+            path, ImmutableMap.of(), Item.class, headers, onError, responseHeaders);
       case HEAD:
         restClient.head(path, headers, onError);
         return null;

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -205,7 +205,8 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
             eq(RESTCatalogAdapter.Route.LIST_VIEWS),
             eq(ImmutableMap.of("pageToken", "", "pageSize", "10", "namespace", namespaceName)),
             any(),
-            eq(ListTablesResponse.class));
+            eq(ListTablesResponse.class),
+            any());
 
     // verify second request with update pageToken
     Mockito.verify(adapter)
@@ -213,7 +214,8 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
             eq(RESTCatalogAdapter.Route.LIST_VIEWS),
             eq(ImmutableMap.of("pageToken", "10", "pageSize", "10", "namespace", namespaceName)),
             any(),
-            eq(ListTablesResponse.class));
+            eq(ListTablesResponse.class),
+            any());
 
     // verify third request with update pageToken
     Mockito.verify(adapter)
@@ -221,7 +223,8 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
             eq(RESTCatalogAdapter.Route.LIST_VIEWS),
             eq(ImmutableMap.of("pageToken", "20", "pageSize", "10", "namespace", namespaceName)),
             any(),
-            eq(ListTablesResponse.class));
+            eq(ListTablesResponse.class),
+            any());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalogWithAssumedViewSupport.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalogWithAssumedViewSupport.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
@@ -52,13 +53,18 @@ public class TestRESTViewCatalogWithAssumedViewSupport extends TestRESTViewCatal
 
           @Override
           public <T extends RESTResponse> T handleRequest(
-              Route route, Map<String, String> vars, Object body, Class<T> responseType) {
+              Route route,
+              Map<String, String> vars,
+              HTTPRequest httpRequest,
+              Class<T> responseType,
+              Consumer<Map<String, String>> responseHeaders) {
+
             if (CONFIG == route) {
               // simulate a legacy server that doesn't send back supported endpoints
               return castResponse(responseType, ConfigResponse.builder().build());
             }
 
-            return super.handleRequest(route, vars, body, responseType);
+            return super.handleRequest(route, vars, httpRequest, responseType, responseHeaders);
           }
         };
 

--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTServerCatalogAdapter.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTServerCatalogAdapter.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest;
 
 import java.util.Map;
+import java.util.function.Consumer;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
@@ -38,8 +39,12 @@ class RESTServerCatalogAdapter extends RESTCatalogAdapter {
 
   @Override
   public <T extends RESTResponse> T handleRequest(
-      Route route, Map<String, String> vars, Object body, Class<T> responseType) {
-    T restResponse = super.handleRequest(route, vars, body, responseType);
+      Route route,
+      Map<String, String> vars,
+      HTTPRequest httpRequest,
+      Class<T> responseType,
+      Consumer<Map<String, String>> responseHeaders) {
+    T restResponse = super.handleRequest(route, vars, httpRequest, responseType, responseHeaders);
 
     if (restResponse instanceof LoadTableResponse) {
       if (PropertyUtil.propertyAsBoolean(


### PR DESCRIPTION
Attempt to revive #12194 to expose the response header on GET requests in RESTClient

@nastra @danielcweeks can you help take a look? 