### PR TITLE
Update build.gradle to include awssdk:utils

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -38,6 +38,7 @@ project(":iceberg-aws-bundle") {
     implementation "software.amazon.awssdk:sts"
     implementation "software.amazon.awssdk:dynamodb"
     implementation "software.amazon.awssdk:lakeformation"
+    implementation "software.amazon.awssdk:utils"
 
     implementation libs.analyticsaccelerator.s3
   }


### PR DESCRIPTION
I am running into compatibility issues when using the Iceberg JAR with AWS EMR 7.2 - it seems to be trying to use the Spark included version of `awssdk.utils` rather than the one matching the shaded packages included with `aws-bundle`.

`ERROR SparkUncaughtExceptionHandler: Uncaught exception in thread Thread[block-manager-storage-async-thread-pool-154,5,main]
java.lang.NoSuchMethodError: 'void software.amazon.awssdk.utils.IoUtils.closeQuietlyV2(java.lang.AutoCloseable, software.amazon.awssdk.utils.Logger)'`

This is an attempt to fix that discrepancy.