### PR TITLE
Core: Throw error for DELETE operations in incremental scan

### DIFF
--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -132,13 +132,15 @@ class IncrementalDataTableScan extends DataTableScan {
     for (Snapshot snapshot :
         SnapshotUtil.ancestorsBetween(toSnapshotId, fromSnapshotId, table::snapshot)) {
       // for now, incremental scan supports only appends
-      if (snapshot.operation().equals(DataOperations.APPEND)) {
+      String operation = snapshot.operation();
+      if (operation.equals(DataOperations.APPEND)) {
         snapshots.add(snapshot);
-      } else if (snapshot.operation().equals(DataOperations.OVERWRITE)) {
+      } else if (operation.equals(DataOperations.OVERWRITE)
+          || operation.equals(DataOperations.DELETE)) {
         throw new UnsupportedOperationException(
             String.format(
                 "Found %s operation, cannot support incremental data in snapshots (%s, %s]",
-                DataOperations.OVERWRITE, fromSnapshotId, toSnapshotId));
+                operation, fromSnapshotId, toSnapshotId));
       }
     }
     return snapshots;


### PR DESCRIPTION
Throw an exception if a DELETE or OVERWRITE snapshot is found in the incremental scan range.

DELETE and OVERWRITE operations change the data, which may cause incorrect results in incremental reads, so they should not be silently ignored. Only REPLACE operations do not change the data and can be safely skipped.

For example, suppose between snapshot A and snapshot B, we append a file containing data with id=1, and then delete this file afterwards. If we perform an incremental scan for changes between snapshot A and B, it is possible to query and retrieve the record with id=1. However, this result is incorrect because the data has already been deleted.