### PR TITLE
Flink: Re-enable test range distribution statistics migration

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkDistributionMode.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkDistributionMode.java
@@ -475,13 +475,13 @@ public class TestFlinkIcebergSinkDistributionMode extends TestFlinkIcebergSinkBa
         .commit();
     table.replaceSortOrder().asc("id").commit();
 
-    int numOfCheckpoints = 4;
+    int numOfCheckpoints = 6;
     List<List<Row>> rowsPerCheckpoint = Lists.newArrayListWithCapacity(numOfCheckpoints);
     for (int checkpointId = 0; checkpointId < numOfCheckpoints; ++checkpointId) {
       // checkpointId 2 would emit 11_000 records which is larger than
       // the OPERATOR_SKETCH_SWITCH_THRESHOLD of 10_000.
       // This should trigger the stats migration.
-      int maxId = checkpointId < 1 ? 1_000 : 11_000;
+      int maxId = checkpointId < 2 ? 1_000 : 11_000;
       List<Row> rows = Lists.newArrayListWithCapacity(maxId);
       for (int j = 0; j < maxId; ++j) {
         // fixed value "a" for the data (possible partition column)

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2DistributionMode.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2DistributionMode.java
@@ -490,13 +490,13 @@ public class TestFlinkIcebergSinkV2DistributionMode extends TestFlinkIcebergSink
         .commit();
     table.replaceSortOrder().asc("id").commit();
 
-    int numOfCheckpoints = 4;
+    int numOfCheckpoints = 6;
     List<List<Row>> rowsPerCheckpoint = Lists.newArrayListWithCapacity(numOfCheckpoints);
     for (int checkpointId = 0; checkpointId < numOfCheckpoints; ++checkpointId) {
       // checkpointId 2 would emit 11_000 records which is larger than
       // the OPERATOR_SKETCH_SWITCH_THRESHOLD of 10_000.
       // This should trigger the stats migration.
-      int maxId = checkpointId < 1 ? 1_000 : 11_000;
+      int maxId = checkpointId < 2 ? 1_000 : 11_000;
       List<Row> rows = Lists.newArrayListWithCapacity(maxId);
       for (int j = 0; j < maxId; ++j) {
         // fixed value "a" for the data (possible partition column)

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkDistributionMode.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkDistributionMode.java
@@ -475,13 +475,13 @@ public class TestFlinkIcebergSinkDistributionMode extends TestFlinkIcebergSinkBa
         .commit();
     table.replaceSortOrder().asc("id").commit();
 
-    int numOfCheckpoints = 4;
+    int numOfCheckpoints = 6;
     List<List<Row>> rowsPerCheckpoint = Lists.newArrayListWithCapacity(numOfCheckpoints);
     for (int checkpointId = 0; checkpointId < numOfCheckpoints; ++checkpointId) {
       // checkpointId 2 would emit 11_000 records which is larger than
       // the OPERATOR_SKETCH_SWITCH_THRESHOLD of 10_000.
       // This should trigger the stats migration.
-      int maxId = checkpointId < 1 ? 1_000 : 11_000;
+      int maxId = checkpointId < 2 ? 1_000 : 11_000;
       List<Row> rows = Lists.newArrayListWithCapacity(maxId);
       for (int j = 0; j < maxId; ++j) {
         // fixed value "a" for the data (possible partition column)

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2DistributionMode.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2DistributionMode.java
@@ -490,13 +490,13 @@ public class TestFlinkIcebergSinkV2DistributionMode extends TestFlinkIcebergSink
         .commit();
     table.replaceSortOrder().asc("id").commit();
 
-    int numOfCheckpoints = 4;
+    int numOfCheckpoints = 6;
     List<List<Row>> rowsPerCheckpoint = Lists.newArrayListWithCapacity(numOfCheckpoints);
     for (int checkpointId = 0; checkpointId < numOfCheckpoints; ++checkpointId) {
       // checkpointId 2 would emit 11_000 records which is larger than
       // the OPERATOR_SKETCH_SWITCH_THRESHOLD of 10_000.
       // This should trigger the stats migration.
-      int maxId = checkpointId < 1 ? 1_000 : 11_000;
+      int maxId = checkpointId < 2 ? 1_000 : 11_000;
       List<Row> rows = Lists.newArrayListWithCapacity(maxId);
       for (int j = 0; j < maxId; ++j) {
         // fixed value "a" for the data (possible partition column)

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkDistributionMode.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkDistributionMode.java
@@ -475,13 +475,13 @@ public class TestFlinkIcebergSinkDistributionMode extends TestFlinkIcebergSinkBa
         .commit();
     table.replaceSortOrder().asc("id").commit();
 
-    int numOfCheckpoints = 4;
+    int numOfCheckpoints = 6;
     List<List<Row>> rowsPerCheckpoint = Lists.newArrayListWithCapacity(numOfCheckpoints);
     for (int checkpointId = 0; checkpointId < numOfCheckpoints; ++checkpointId) {
       // checkpointId 2 would emit 11_000 records which is larger than
       // the OPERATOR_SKETCH_SWITCH_THRESHOLD of 10_000.
       // This should trigger the stats migration.
-      int maxId = checkpointId < 1 ? 1_000 : 11_000;
+      int maxId = checkpointId < 2 ? 1_000 : 11_000;
       List<Row> rows = Lists.newArrayListWithCapacity(maxId);
       for (int j = 0; j < maxId; ++j) {
         // fixed value "a" for the data (possible partition column)

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2DistributionMode.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2DistributionMode.java
@@ -490,13 +490,13 @@ public class TestFlinkIcebergSinkV2DistributionMode extends TestFlinkIcebergSink
         .commit();
     table.replaceSortOrder().asc("id").commit();
 
-    int numOfCheckpoints = 4;
+    int numOfCheckpoints = 6;
     List<List<Row>> rowsPerCheckpoint = Lists.newArrayListWithCapacity(numOfCheckpoints);
     for (int checkpointId = 0; checkpointId < numOfCheckpoints; ++checkpointId) {
       // checkpointId 2 would emit 11_000 records which is larger than
       // the OPERATOR_SKETCH_SWITCH_THRESHOLD of 10_000.
       // This should trigger the stats migration.
-      int maxId = checkpointId < 1 ? 1_000 : 11_000;
+      int maxId = checkpointId < 2 ? 1_000 : 11_000;
       List<Row> rows = Lists.newArrayListWithCapacity(maxId);
       for (int j = 0; j < maxId; ++j) {
         // fixed value "a" for the data (possible partition column)


### PR DESCRIPTION
Tuned the setup similar to `numOfCheckpoints = 6` like other test methods. I have run the two test classes 450 times locally. they all passed.

This can be merged as `rebase and merge` to preserve the two commits separately.

```
for index in {00..149}; do
  echo “Iteration $index”;

  ./gradlew -DflinkVersions=1.19  :iceberg-flink:iceberg-flink-1.19:test --tests org.apache.iceberg.flink.sink.TestFlinkIcebergSinkDistributionMode  --tests org.apache.iceberg.flink.sink.TestFlinkIcebergSinkV2DistributionMode >std-$index-v1.19.log 2>&1;

  ./gradlew -DflinkVersions=1.20  :iceberg-flink:iceberg-flink-1.20:test --tests org.apache.iceberg.flink.sink.TestFlinkIcebergSinkDistributionMode  --tests org.apache.iceberg.flink.sink.TestFlinkIcebergSinkV2DistributionMode >std-$index-v1.20.log 2>&1;

  ./gradlew -DflinkVersions=2.0  :iceberg-flink:iceberg-flink-2.0:test --tests org.apache.iceberg.flink.sink.TestFlinkIcebergSinkDistributionMode  --tests org.apache.iceberg.flink.sink.TestFlinkIcebergSinkV2DistributionMode >std-$index-v2.0.log 2>&1

done
```