### PR TITLE
Spark 4.0: Properly handle UUID in partition field

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -78,6 +78,8 @@ public class SparkValueConverter {
         return ByteBuffer.wrap((byte[]) object);
       case INTEGER:
         return ((Number) object).intValue();
+      case UUID:
+        return java.util.UUID.fromString((String) object);
       case BOOLEAN:
       case LONG:
       case FLOAT:

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestUUIDPartitionRewriteManifests.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestUUIDPartitionRewriteManifests.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestUUIDPartitionRewriteManifests extends TestBase {
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(2, "uuid_col", Types.UUIDType.get()),
+          Types.NestedField.optional(3, "data", Types.StringType.get()));
+
+  private String tableLocation = null;
+
+  @TempDir private Path temp;
+  @TempDir private File tableDir;
+
+  @BeforeEach
+  public void setupTableLocation() throws Exception {
+    this.tableLocation = tableDir.toURI().toString();
+  }
+
+  @Test
+  public void testRewriteManifestsWithUUIDPartition() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("uuid_col").build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, "2");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    // Create test data with UUID partition values
+    UUID uuid1 = UUID.randomUUID();
+    UUID uuid2 = UUID.randomUUID();
+
+    // Write first batch of records
+    Dataset<Row> df1 =
+        spark.sql(
+            String.format(
+                "SELECT 1 as id, cast('%s' as string) as uuid_col, 'data1' as data",
+                uuid1.toString()));
+    df1.write().format("iceberg").mode("append").save(tableLocation);
+
+    // Write second batch of records
+    Dataset<Row> df2 =
+        spark.sql(
+            String.format(
+                "SELECT 2 as id, cast('%s' as string) as uuid_col, 'data2' as data",
+                uuid2.toString()));
+    df2.write().format("iceberg").mode("append").save(tableLocation);
+
+    table.refresh();
+
+    List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifests).as("Should have 2 manifests before rewrite").hasSize(2);
+
+    SparkActions actions = SparkActions.get();
+
+    // This should not throw an exception with our fix
+    RewriteManifests.Result result =
+        actions.rewriteManifests(table).rewriteIf(manifest -> true).execute();
+
+    assertThat(result.rewrittenManifests()).as("Action should rewrite 2 manifests").hasSize(2);
+    assertThat(result.addedManifests()).as("Action should add 1 manifest").hasSize(1);
+
+    table.refresh();
+
+    List<ManifestFile> newManifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(newManifests).as("Should have 1 manifest after rewrite").hasSize(1);
+
+    // Verify data is still readable
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<Row> actualRecords = resultDF.orderBy("id").collectAsList();
+
+    assertThat(actualRecords).hasSize(2);
+    assertThat(actualRecords.get(0).getInt(0)).isEqualTo(1);
+    assertThat(actualRecords.get(0).getString(2)).isEqualTo("data1");
+    assertThat(actualRecords.get(1).getInt(0)).isEqualTo(2);
+    assertThat(actualRecords.get(1).getString(2)).isEqualTo("data2");
+  }
+}

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestUUIDArrayStructInternalRow.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestUUIDArrayStructInternalRow.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestUUIDArrayStructInternalRow extends TestBase {
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(
+              2, "uuid_array", Types.ListType.ofOptional(3, Types.UUIDType.get())),
+          Types.NestedField.optional(4, "data", Types.StringType.get()));
+
+  private String tableLocation = null;
+
+  @TempDir private Path temp;
+  @TempDir private File tableDir;
+
+  @BeforeEach
+  public void setupTableLocation() throws Exception {
+    this.tableLocation = tableDir.toURI().toString();
+  }
+
+  @Test
+  public void testUUIDArrayConversion() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    var options = Maps.<String, String>newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, "2");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    // Create test data with UUID arrays
+    UUID uuid1 = UUID.randomUUID();
+    UUID uuid2 = UUID.randomUUID();
+    UUID uuid3 = UUID.randomUUID();
+
+    Record record = GenericRecord.create(SCHEMA);
+    record.set(0, 1);
+    record.set(1, Arrays.asList(uuid1, uuid2, uuid3));
+    record.set(2, "test_data");
+
+    // Create StructInternalRow and test array conversion
+    StructInternalRow structRow = new StructInternalRow(SCHEMA.asStruct());
+    structRow.setStruct(record);
+
+    ArrayData arrayData = structRow.getArray(1);
+
+    assertThat(arrayData).isNotNull();
+    assertThat(arrayData.numElements()).isEqualTo(3);
+
+    UTF8String firstElement = arrayData.getUTF8String(0);
+    UTF8String secondElement = arrayData.getUTF8String(1);
+    UTF8String thirdElement = arrayData.getUTF8String(2);
+
+    assertThat(firstElement.toString()).isEqualTo(uuid1.toString());
+    assertThat(secondElement.toString()).isEqualTo(uuid2.toString());
+    assertThat(thirdElement.toString()).isEqualTo(uuid3.toString());
+  }
+
+  @Test
+  public void testUUIDArrayWithNulls() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    var options = Maps.<String, String>newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, "2");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    UUID uuid1 = UUID.randomUUID();
+    UUID uuid2 = UUID.randomUUID();
+
+    // Create a record with UUID array containing nulls
+    Record record = GenericRecord.create(SCHEMA);
+    record.set(0, 1);
+    record.set(1, Arrays.asList(uuid1, null, uuid2));
+    record.set(2, "test_data");
+
+    StructInternalRow structRow = new StructInternalRow(SCHEMA.asStruct());
+    structRow.setStruct(record);
+
+    ArrayData arrayData = structRow.getArray(1);
+
+    assertThat(arrayData).isNotNull();
+    assertThat(arrayData.numElements()).isEqualTo(3);
+
+    UTF8String firstElement = arrayData.getUTF8String(0);
+    assertThat(arrayData.isNullAt(1)).isTrue();
+    UTF8String thirdElement = arrayData.getUTF8String(2);
+
+    assertThat(firstElement.toString()).isEqualTo(uuid1.toString());
+    assertThat(thirdElement.toString()).isEqualTo(uuid2.toString());
+  }
+
+  @Test
+  public void testUUIDArrayIntegrationWithSpark() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    var options = Maps.<String, String>newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, "2");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    UUID uuid1 = UUID.randomUUID();
+    UUID uuid2 = UUID.randomUUID();
+
+    Dataset<Row> df =
+        spark.sql(
+            String.format(
+                "SELECT 1 as id, array(cast('%s' as string), cast('%s' as string)) as uuid_array, 'data1' as data",
+                uuid1.toString(), uuid2.toString()));
+
+    df.write().format("iceberg").mode("append").save(tableLocation);
+
+    table.refresh();
+
+    // Verify data can be read back
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<Row> actualRecords = resultDF.collectAsList();
+
+    assertThat(actualRecords).hasSize(1);
+    Row row = actualRecords.get(0);
+    assertThat(row.getInt(0)).isEqualTo(1);
+    assertThat(row.getString(2)).isEqualTo("data1");
+
+    // Verify UUID array
+    List<String> uuidArray = row.getList(1);
+    assertThat(uuidArray).hasSize(2);
+    assertThat(uuidArray.get(0)).isEqualTo(uuid1.toString());
+    assertThat(uuidArray.get(1)).isEqualTo(uuid2.toString());
+  }
+}


### PR DESCRIPTION
Closes #13703

Previously getUTF8StringInternal and collectionToArrayData assumed CharSequence was the only class it would have to handle. Now allow either CharSequence or UUID. 

Added test to reproduce error case from issue. Below is output from one of these new tests failing against the existing code base:

```
testRewriteManifestsWithUUIDPartition()
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 7.0 failed 1 times, most recent failure: Lost task 0.0 in stage 7.0 (TID 6) (192.168.0.97 executor driver): java.lang.IllegalArgumentException: Wrong class, expected java.lang.CharSequence, but was java.util.UUID, for object: 849d9bcd-ed84-4bf2-8019-35b001ece9a3
	at org.apache.iceberg.PartitionData.get(PartitionData.java:126)
	at org.apache.iceberg.util.StructProjection.get(StructProjection.java:214)
	at org.apache.iceberg.spark.source.StructInternalRow.getUTF8StringInternal(StructInternalRow.java:178)
	at org.apache.iceberg.spark.source.StructInternalRow.getUTF8String(StructInternalRow.java:174)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.project_writeFields_1_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:50)
	at scala.collection.Iterator$$anon$9.hasNext(Iterator.scala:583)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:143)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:57)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:111)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:54)
	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:171)
	at org.apache.spark.scheduler.Task.run(Task.scala:147)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$5(Executor.scala:647)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:80)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:77)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:650)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

Driver stacktrace:
	at app//org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$3(DAGScheduler.scala:2935)
	at app//scala.Option.getOrElse(Option.scala:201)
	at app//org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:2935)
	at app//org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:2927)
	at app//scala.collection.immutable.List.foreach(List.scala:334)
	at app//org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:2927)
	at app//org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1295)
	at app//org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1295)
	at app//scala.Option.foreach(Option.scala:437)
	at app//org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1295)
	at app//org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:3207)
	at app//org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:3141)
	at app//org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:3130)
	at app//org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:50)
Caused by: java.lang.IllegalArgumentException: Wrong class, expected java.lang.CharSequence, but was java.util.UUID, for object: 849d9bcd-ed84-4bf2-8019-35b001ece9a3
	at org.apache.iceberg.PartitionData.get(PartitionData.java:126)
	at org.apache.iceberg.util.StructProjection.get(StructProjection.java:214)
	at org.apache.iceberg.spark.source.StructInternalRow.getUTF8StringInternal(StructInternalRow.java:178)
	at org.apache.iceberg.spark.source.StructInternalRow.getUTF8String(StructInternalRow.java:174)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.project_writeFields_1_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$WholeStageCodegenPartitionEvaluator$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:50)
	at scala.collection.Iterator$$anon$9.hasNext(Iterator.scala:583)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:143)
	at org.apache.spark.shuffle.ShuffleWriteProcessor.write(ShuffleWriteProcessor.scala:57)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:111)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:54)
	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:171)
	at org.apache.spark.scheduler.Task.run(Task.scala:147)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$5(Executor.scala:647)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:80)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:77)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:650)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)


```

After the fix all tests pass including these new tests.