### PR TITLE
Flink: Fix DynamicCommitter use ThreadPools deprecated method

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -108,7 +108,8 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     this.maxContinuousEmptyCommitsMap = Maps.newHashMap();
     this.continuousEmptyCheckpointsMap = Maps.newHashMap();
 
-    this.workerPool = ThreadPools.newWorkerPool("iceberg-committer-pool-" + sinkId, workerPoolSize);
+    this.workerPool =
+        ThreadPools.newFixedThreadPool("iceberg-committer-pool-" + sinkId, workerPoolSize);
   }
 
   @Override

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -108,7 +108,8 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     this.maxContinuousEmptyCommitsMap = Maps.newHashMap();
     this.continuousEmptyCheckpointsMap = Maps.newHashMap();
 
-    this.workerPool = ThreadPools.newWorkerPool("iceberg-committer-pool-" + sinkId, workerPoolSize);
+    this.workerPool =
+        ThreadPools.newFixedThreadPool("iceberg-committer-pool-" + sinkId, workerPoolSize);
   }
 
   @Override

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -108,7 +108,8 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     this.maxContinuousEmptyCommitsMap = Maps.newHashMap();
     this.continuousEmptyCheckpointsMap = Maps.newHashMap();
 
-    this.workerPool = ThreadPools.newWorkerPool("iceberg-committer-pool-" + sinkId, workerPoolSize);
+    this.workerPool =
+        ThreadPools.newFixedThreadPool("iceberg-committer-pool-" + sinkId, workerPoolSize);
   }
 
   @Override


### PR DESCRIPTION
In https://github.com/apache/iceberg/pull/11073 we have changed the `newWorkerPool` method in Flink to `newFixedThreadPool` and marked `newWorkerPool` as a deprecated method. During this process, we found that `DynamicCommitter` still uses `newWorkerPool`. 

The main purpose of this PR is to update it to use the correct method.