### PR TITLE
Flink 1.19, 1.20: Expose cleanExpiredMetadata for snapshot expiration

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
@@ -46,6 +46,7 @@ public class ExpireSnapshots {
     private Integer numSnapshots = null;
     private Integer planningWorkerPoolSize;
     private int deleteBatchSize = DELETE_BATCH_SIZE_DEFAULT;
+    private Boolean cleanExpiredMetadata = null;
 
     @Override
     String maintenanceTaskName() {
@@ -94,6 +95,18 @@ public class ExpireSnapshots {
       return this;
     }
 
+    /**
+     * Expires unused table metadata such as partition specs and schemas.
+     *
+     * @param newCleanExpiredMetadata remove unused partition specs, schemas, or other metadata when
+     *     true
+     * @return this for method chaining
+     */
+    public Builder cleanExpiredMetadata(boolean newCleanExpiredMetadata) {
+      this.cleanExpiredMetadata = newCleanExpiredMetadata;
+      return this;
+    }
+
     @Override
     DataStream<TaskResult> append(DataStream<Trigger> trigger) {
       Preconditions.checkNotNull(tableLoader(), "TableLoader should not be null");
@@ -105,7 +118,8 @@ public class ExpireSnapshots {
                       tableLoader(),
                       maxSnapshotAge == null ? null : maxSnapshotAge.toMillis(),
                       numSnapshots,
-                      planningWorkerPoolSize))
+                      planningWorkerPoolSize,
+                      cleanExpiredMetadata))
               .name(operatorName(EXECUTOR_OPERATOR_NAME))
               .uid(EXECUTOR_OPERATOR_NAME + uidSuffix())
               .slotSharingGroup(slotSharingGroup())

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ExpireSnapshotsProcessor.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ExpireSnapshotsProcessor.java
@@ -52,6 +52,7 @@ public class ExpireSnapshotsProcessor extends ProcessFunction<Trigger, TaskResul
   private final Long maxSnapshotAgeMs;
   private final Integer numSnapshots;
   private final Integer plannerPoolSize;
+  private final Boolean cleanExpiredMetadata;
   private transient ExecutorService plannerPool;
   private transient Table table;
 
@@ -59,13 +60,15 @@ public class ExpireSnapshotsProcessor extends ProcessFunction<Trigger, TaskResul
       TableLoader tableLoader,
       Long maxSnapshotAgeMs,
       Integer numSnapshots,
-      Integer plannerPoolSize) {
-    Preconditions.checkNotNull(tableLoader, "Table loader should no be null");
+      Integer plannerPoolSize,
+      Boolean cleanExpiredMetadata) {
+    Preconditions.checkNotNull(tableLoader, "Table loader should not be null");
 
     this.tableLoader = tableLoader;
     this.maxSnapshotAgeMs = maxSnapshotAgeMs;
     this.numSnapshots = numSnapshots;
     this.plannerPoolSize = plannerPoolSize;
+    this.cleanExpiredMetadata = cleanExpiredMetadata;
   }
 
   @Override
@@ -90,6 +93,10 @@ public class ExpireSnapshotsProcessor extends ProcessFunction<Trigger, TaskResul
 
       if (numSnapshots != null) {
         expireSnapshots = expireSnapshots.retainLast(numSnapshots);
+      }
+
+      if (cleanExpiredMetadata != null) {
+        expireSnapshots.cleanExpiredMetadata(cleanExpiredMetadata);
       }
 
       AtomicLong deleteFileCounter = new AtomicLong(0L);

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -165,6 +165,12 @@ public class OperatorTestBase {
     table.refresh();
   }
 
+  protected void insert(Table table, Integer id, String data, String extra) throws IOException {
+    new GenericAppenderHelper(table, FileFormat.PARQUET, warehouseDir)
+        .appendToTable(Lists.newArrayList(SimpleDataUtil.createRecord(id, data, extra)));
+    table.refresh();
+  }
+
   /**
    * For the same identifier column id this methods simulate the following row operations: <tr>
    * <li>add an equality delete on oldData

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
@@ -46,6 +46,7 @@ public class ExpireSnapshots {
     private Integer numSnapshots = null;
     private Integer planningWorkerPoolSize;
     private int deleteBatchSize = DELETE_BATCH_SIZE_DEFAULT;
+    private Boolean cleanExpiredMetadata = null;
 
     @Override
     String maintenanceTaskName() {
@@ -94,6 +95,18 @@ public class ExpireSnapshots {
       return this;
     }
 
+    /**
+     * Expires unused table metadata such as partition specs and schemas.
+     *
+     * @param newCleanExpiredMetadata remove unused partition specs, schemas, or other metadata when
+     *     true
+     * @return this for method chaining
+     */
+    public Builder cleanExpiredMetadata(boolean newCleanExpiredMetadata) {
+      this.cleanExpiredMetadata = newCleanExpiredMetadata;
+      return this;
+    }
+
     @Override
     DataStream<TaskResult> append(DataStream<Trigger> trigger) {
       Preconditions.checkNotNull(tableLoader(), "TableLoader should not be null");
@@ -105,7 +118,8 @@ public class ExpireSnapshots {
                       tableLoader(),
                       maxSnapshotAge == null ? null : maxSnapshotAge.toMillis(),
                       numSnapshots,
-                      planningWorkerPoolSize))
+                      planningWorkerPoolSize,
+                      cleanExpiredMetadata))
               .name(operatorName(EXECUTOR_OPERATOR_NAME))
               .uid(EXECUTOR_OPERATOR_NAME + uidSuffix())
               .slotSharingGroup(slotSharingGroup())

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ExpireSnapshotsProcessor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ExpireSnapshotsProcessor.java
@@ -52,6 +52,7 @@ public class ExpireSnapshotsProcessor extends ProcessFunction<Trigger, TaskResul
   private final Long maxSnapshotAgeMs;
   private final Integer numSnapshots;
   private final Integer plannerPoolSize;
+  private final Boolean cleanExpiredMetadata;
   private transient ExecutorService plannerPool;
   private transient Table table;
 
@@ -59,13 +60,15 @@ public class ExpireSnapshotsProcessor extends ProcessFunction<Trigger, TaskResul
       TableLoader tableLoader,
       Long maxSnapshotAgeMs,
       Integer numSnapshots,
-      Integer plannerPoolSize) {
-    Preconditions.checkNotNull(tableLoader, "Table loader should no be null");
+      Integer plannerPoolSize,
+      Boolean cleanExpiredMetadata) {
+    Preconditions.checkNotNull(tableLoader, "Table loader should not be null");
 
     this.tableLoader = tableLoader;
     this.maxSnapshotAgeMs = maxSnapshotAgeMs;
     this.numSnapshots = numSnapshots;
     this.plannerPoolSize = plannerPoolSize;
+    this.cleanExpiredMetadata = cleanExpiredMetadata;
   }
 
   @Override
@@ -90,6 +93,10 @@ public class ExpireSnapshotsProcessor extends ProcessFunction<Trigger, TaskResul
 
       if (numSnapshots != null) {
         expireSnapshots = expireSnapshots.retainLast(numSnapshots);
+      }
+
+      if (cleanExpiredMetadata != null) {
+        expireSnapshots.cleanExpiredMetadata(cleanExpiredMetadata);
       }
 
       AtomicLong deleteFileCounter = new AtomicLong(0L);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -165,6 +165,12 @@ public class OperatorTestBase {
     table.refresh();
   }
 
+  protected void insert(Table table, Integer id, String data, String extra) throws IOException {
+    new GenericAppenderHelper(table, FileFormat.PARQUET, warehouseDir)
+        .appendToTable(Lists.newArrayList(SimpleDataUtil.createRecord(id, data, extra)));
+    table.refresh();
+  }
+
   /**
    * For the same identifier column id this methods simulate the following row operations: <tr>
    * <li>add an equality delete on oldData


### PR DESCRIPTION
Backport of #13569