### PR TITLE
Fix concurrency issues in Azure credential refresh.

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
@@ -66,7 +66,7 @@ public class VendedAdlsCredentialProvider implements Serializable, AutoCloseable
     this.catalogEndpoint = properties.get(CatalogProperties.URI);
   }
 
-  String credentialForAccount(String storageAccount) {
+  Mono<String> credentialForAccount(String storageAccount) {
     return sasCredentialByAccount()
         .computeIfAbsent(
             storageAccount,
@@ -74,8 +74,7 @@ public class VendedAdlsCredentialProvider implements Serializable, AutoCloseable
                 new SimpleTokenCache(
                     () -> Mono.fromSupplier(() -> sasTokenForAccount(storageAccount))))
         .getToken()
-        .map(AccessToken::getToken)
-        .block();
+        .map(AccessToken::getToken);
   }
 
   private AccessToken sasTokenForAccount(String storageAccount) {

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
@@ -111,7 +111,7 @@ public class VendedAdlsCredentialProvider implements Serializable, AutoCloseable
     if (this.sasCredentialByAccount == null) {
       synchronized (this) {
         if (this.sasCredentialByAccount == null) {
-          this.sasCredentialByAccount = Maps.newHashMap();
+          this.sasCredentialByAccount = Maps.newConcurrentMap();
         }
       }
     }

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestVendedAdlsCredentialProvider.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestVendedAdlsCredentialProvider.java
@@ -84,7 +84,7 @@ public class TestVendedAdlsCredentialProvider extends VendedCredentialsTestBase 
                 "invalid uri",
                 CatalogProperties.URI,
                 CATALOG_URI))) {
-      assertThatThrownBy(() -> provider.credentialForAccount(STORAGE_ACCOUNT))
+      assertThatThrownBy(() -> provider.credentialForAccount(STORAGE_ACCOUNT).block())
           .isInstanceOf(RESTException.class)
           .hasMessageStartingWith(
               "Failed to create request URI from base %sinvalid uri", CATALOG_URI);
@@ -103,7 +103,7 @@ public class TestVendedAdlsCredentialProvider extends VendedCredentialsTestBase 
     mockServer.when(mockRequest).respond(mockResponse);
 
     try (VendedAdlsCredentialProvider provider = new VendedAdlsCredentialProvider(PROPERTIES)) {
-      assertThatThrownBy(() -> provider.credentialForAccount(STORAGE_ACCOUNT))
+      assertThatThrownBy(() -> provider.credentialForAccount(STORAGE_ACCOUNT).block())
           .isInstanceOf(IllegalStateException.class)
           .hasMessage("Invalid ADLS Credentials for storage-account account1: empty");
     }
@@ -126,7 +126,7 @@ public class TestVendedAdlsCredentialProvider extends VendedCredentialsTestBase 
     mockServer.when(mockRequest).respond(mockResponse);
 
     try (VendedAdlsCredentialProvider provider = new VendedAdlsCredentialProvider(PROPERTIES)) {
-      assertThatThrownBy(() -> provider.credentialForAccount(STORAGE_ACCOUNT))
+      assertThatThrownBy(() -> provider.credentialForAccount(STORAGE_ACCOUNT).block())
           .isInstanceOf(IllegalStateException.class)
           .hasMessage("Invalid ADLS Credentials: adls.sas-token-expires-at-ms.account1 not set");
     }
@@ -152,13 +152,14 @@ public class TestVendedAdlsCredentialProvider extends VendedCredentialsTestBase 
     mockServer.when(mockRequest).respond(mockResponse);
 
     try (VendedAdlsCredentialProvider provider = new VendedAdlsCredentialProvider(PROPERTIES)) {
-      String azureSasCredential = provider.credentialForAccount(STORAGE_ACCOUNT);
+      String azureSasCredential = provider.credentialForAccount(STORAGE_ACCOUNT).block();
       assertThat(azureSasCredential)
           .isEqualTo(credential.config().get(ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT));
 
       for (int i = 0; i < 5; i++) {
         // resolving credentials multiple times should not hit the credentials endpoint again
-        assertThat(provider.credentialForAccount(STORAGE_ACCOUNT)).isSameAs(azureSasCredential);
+        assertThat(provider.credentialForAccount(STORAGE_ACCOUNT).block())
+            .isSameAs(azureSasCredential);
       }
     }
 
@@ -185,12 +186,12 @@ public class TestVendedAdlsCredentialProvider extends VendedCredentialsTestBase 
     mockServer.when(mockRequest).respond(mockResponse);
 
     try (VendedAdlsCredentialProvider provider = new VendedAdlsCredentialProvider(PROPERTIES)) {
-      String azureSasCredential = provider.credentialForAccount(STORAGE_ACCOUNT);
+      String azureSasCredential = provider.credentialForAccount(STORAGE_ACCOUNT).block();
       assertThat(azureSasCredential)
           .isEqualTo(credential.config().get(ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT));
 
       // resolving credentials multiple times should hit the credentials endpoint again
-      String refreshedAzureSasCredential = provider.credentialForAccount(STORAGE_ACCOUNT);
+      String refreshedAzureSasCredential = provider.credentialForAccount(STORAGE_ACCOUNT).block();
       assertThat(refreshedAzureSasCredential)
           .isEqualTo(credential.config().get(ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT));
     }
@@ -228,7 +229,7 @@ public class TestVendedAdlsCredentialProvider extends VendedCredentialsTestBase 
     mockServer.when(mockRequest).respond(mockResponse);
 
     try (VendedAdlsCredentialProvider provider = new VendedAdlsCredentialProvider(PROPERTIES)) {
-      assertThatThrownBy(() -> provider.credentialForAccount(STORAGE_ACCOUNT))
+      assertThatThrownBy(() -> provider.credentialForAccount(STORAGE_ACCOUNT).block())
           .isInstanceOf(IllegalStateException.class)
           .hasMessage(
               "Invalid ADLS Credentials: only one ADLS credential should exist per storage-account");
@@ -265,8 +266,8 @@ public class TestVendedAdlsCredentialProvider extends VendedCredentialsTestBase 
     mockServer.when(mockRequest).respond(mockResponse);
 
     try (VendedAdlsCredentialProvider provider = new VendedAdlsCredentialProvider(PROPERTIES)) {
-      String azureSasCredential1 = provider.credentialForAccount(STORAGE_ACCOUNT);
-      String azureSasCredential2 = provider.credentialForAccount(STORAGE_ACCOUNT_2);
+      String azureSasCredential1 = provider.credentialForAccount(STORAGE_ACCOUNT).block();
+      String azureSasCredential2 = provider.credentialForAccount(STORAGE_ACCOUNT_2).block();
       assertThat(azureSasCredential1).isNotSameAs(azureSasCredential2);
       assertThat(azureSasCredential1)
           .isEqualTo(credential1.config().get(ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT));
@@ -298,13 +299,13 @@ public class TestVendedAdlsCredentialProvider extends VendedCredentialsTestBase 
     mockServer.when(mockRequest).respond(mockResponse);
 
     try (VendedAdlsCredentialProvider provider = new VendedAdlsCredentialProvider(PROPERTIES)) {
-      String azureSasCredential = provider.credentialForAccount(STORAGE_ACCOUNT);
+      String azureSasCredential = provider.credentialForAccount(STORAGE_ACCOUNT).block();
       assertThat(azureSasCredential)
           .isEqualTo(credential.config().get(ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT));
 
       VendedAdlsCredentialProvider deserializedProvider = roundTripSerializer.apply(provider);
       String reGeneratedAzureSasCredential =
-          deserializedProvider.credentialForAccount(STORAGE_ACCOUNT);
+          deserializedProvider.credentialForAccount(STORAGE_ACCOUNT).block();
 
       assertThat(azureSasCredential).isNotSameAs(reGeneratedAzureSasCredential);
     }

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestVendedAzureSasCredentialPolicy.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestVendedAzureSasCredentialPolicy.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.verify.VerificationTimes;
+import reactor.core.publisher.Mono;
 
 public class TestVendedAzureSasCredentialPolicy extends VendedCredentialsTestBase {
 
@@ -78,12 +79,12 @@ public class TestVendedAzureSasCredentialPolicy extends VendedCredentialsTestBas
         .respond(HttpResponse.response().withStatusCode(403));
 
     when(vendedAdlsCredentialProvider.credentialForAccount(STORAGE_ACCOUNT))
-        .thenReturn(validSasToken);
+        .thenReturn(Mono.just(validSasToken));
     assertThat(client.getFileClient(filePath).exists()).isTrue();
     mockServer.verify(mockRequestWithValidSasToken, VerificationTimes.exactly(1));
 
     when(vendedAdlsCredentialProvider.credentialForAccount(STORAGE_ACCOUNT))
-        .thenReturn(expiredSasToken);
+        .thenReturn(Mono.just(expiredSasToken));
 
     // Every new request of the same client fetches latest SasToken credentials from
     // VendedAdlsCredentialProvider to build http request query parameters.


### PR DESCRIPTION
Fixes #13733

The first commit fixes a crash when trying to use the pipeline async on a parallel Reactor thread:
```
Caused by: java.lang.IllegalStateException: block()/blockFirst()/blockLast() are blocking, which is not supported in thread parallel-1
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:83)
	at reactor.core.publisher.Mono.block(Mono.java:1742)
	at org.apache.iceberg.azure.adlsv2.VendedAdlsCredentialProvider.credentialForAccount(VendedAdlsCredentialProvider.java:78)
	at org.apache.iceberg.azure.adlsv2.VendedAzureSasCredentialPolicy.maybeUpdateCredential(VendedAzureSasCredentialPolicy.java:58)
	at org.apache.iceberg.azure.adlsv2.VendedAzureSasCredentialPolicy.process(VendedAzureSasCredentialPolicy.java:46)
	at com.azure.core.http.HttpPipelineNextPolicy.process(HttpPipelineNextPolicy.java:81)
	at com.azure.storage.common.policy.MetadataValidationPolicy.process(MetadataValidationPolicy.java:45)
	at com.azure.core.http.HttpPipelineNextPolicy.process(HttpPipelineNextPolicy.java:81)
	at com.azure.core.http.policy.AddDatePolicy.lambda$process$0(AddDatePolicy.java:43)
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:45)
	... 12 more
```

The second commit fixes some other thread-safety issues I noticed in the relevant code, which indeed caused failures in our tests.

cc @nastra 