### PR TITLE
AWS: Add Retries to Analytics Stream

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -27,6 +27,7 @@ project(":iceberg-aws-bundle") {
     implementation platform(libs.awssdk.bom)
     implementation libs.awssdk.s3accessgrants
     implementation "software.amazon.awssdk:apache-client"
+    implementation "software.amazon.awssdk:netty-nio-client"
     implementation "software.amazon.awssdk:auth"
     implementation "software.amazon.awssdk:crt-core"
     implementation "software.amazon.awssdk:http-auth-aws-crt"

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.glue;
 
+import static org.apache.iceberg.aws.s3.S3TestUtil.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -28,6 +29,7 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.aws.AwsIntegTestUtil;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.aws.s3.S3TestUtil;
 import org.apache.iceberg.aws.util.RetryDetector;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -160,6 +162,9 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   public void testNoRetryAwarenessCorruptsTable() {
     // This test exists to replicate the issue the prior test validates the fix for
     // See https://github.com/apache/iceberg/issues/7151
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(),
+        "Analytics Accelerator Library does not support custom Iceberg exception: NotFoundException");
     String namespace = createNamespace();
     String tableName = createTable(namespace);
     TableIdentifier tableId = TableIdentifier.of(namespace, tableName);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -41,6 +41,8 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -158,12 +160,13 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
         .isEqualTo(2);
   }
 
-  @Test
-  public void testNoRetryAwarenessCorruptsTable() {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNoRetryAwarenessCorruptsTable(Map<String, String> aalProperties) {
     // This test exists to replicate the issue the prior test validates the fix for
     // See https://github.com/apache/iceberg/issues/7151
     skipIfAnalyticsAcceleratorEnabled(
-        new S3FileIOProperties(),
+        new S3FileIOProperties(aalProperties),
         "Analytics Accelerator Library does not support custom Iceberg exception: NotFoundException");
     String namespace = createNamespace();
     String tableName = createTable(namespace);

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/MinioUtil.java
@@ -26,6 +26,8 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.LegacyMd5Plugin;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
@@ -65,6 +67,18 @@ public class MinioUtil {
     if (legacyMd5PluginEnabled) {
       builder.addPlugin(LegacyMd5Plugin.create());
     }
+    builder.credentialsProvider(
+        StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(container.getUserName(), container.getPassword())));
+    builder.applyMutation(mutator -> mutator.endpointOverride(uri));
+    builder.region(Region.US_EAST_1);
+    builder.forcePathStyle(true); // OSX won't resolve subdomains
+    return builder.build();
+  }
+
+  public static S3AsyncClient createS3AsyncClient(MinIOContainer container) {
+    URI uri = URI.create(container.getS3URL());
+    S3AsyncClientBuilder builder = S3AsyncClient.builder();
     builder.credentialsProvider(
         StaticCredentialsProvider.create(
             AwsBasicCredentials.create(container.getUserName(), container.getPassword())));

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
@@ -18,7 +18,14 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class S3TestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3TestUtil.class);
 
   private S3TestUtil() {}
 
@@ -28,5 +35,19 @@ public class S3TestUtil {
 
   public static String getKeyFromUri(String s3Uri) {
     return new S3URI(s3Uri).key();
+  }
+
+  /**
+   * Skip a test if the Analytics Accelerator Library for Amazon S3 is enabled.
+   *
+   * @param properties properties to probe
+   */
+  public static void skipIfAnalyticsAcceleratorEnabled(
+      S3FileIOProperties properties, String message) {
+    boolean isAcceleratorEnabled = properties.isS3AnalyticsAcceleratorEnabled();
+    if (isAcceleratorEnabled) {
+      LOG.warn(message);
+    }
+    assumeThat(!isAcceleratorEnabled).describedAs(message).isTrue();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
@@ -20,6 +20,11 @@ package org.apache.iceberg.aws.s3;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.params.provider.Arguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,5 +54,25 @@ public class S3TestUtil {
       LOG.warn(message);
     }
     assumeThat(!isAcceleratorEnabled).describedAs(message).isTrue();
+  }
+
+  public static Stream<Arguments> analyticsAcceleratorLibraryProperties() {
+    return listAnalyticsAcceleratorLibraryProperties().stream().map(Arguments::of);
+  }
+
+  public static List<Map<String, String>> listAnalyticsAcceleratorLibraryProperties() {
+    return List.of(
+        ImmutableMap.of(
+            S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, Boolean.toString(true)),
+        ImmutableMap.of(
+            S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, Boolean.toString(false)));
+  }
+
+  public static Map<String, String> mergeProperties(
+      Map<String, String> aalProperties, Map<String, String> testProperties) {
+    return ImmutableMap.<String, String>builder()
+        .putAll(aalProperties)
+        .putAll(testProperties)
+        .build();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
@@ -75,15 +75,16 @@ public class TestFlakyS3InputStream extends TestS3InputStream {
       S3Client s3Client,
       S3AsyncClient s3AsyncClient,
       S3URI uri,
-      Map<String, String> aalProperties) {
+      Map<String, String> aalProperties,
+      MetricsContext metricsContext) {
     final S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(aalProperties);
     if (s3FileIOProperties.isS3AnalyticsAcceleratorEnabled()) {
       PrefixedS3Client client =
           new PrefixedS3Client("s3", aalProperties, () -> s3Client, () -> s3AsyncClient);
       return AnalyticsAcceleratorUtil.newStream(
-          S3InputFile.fromLocation(uri.location(), client, MetricsContext.nullMetrics()));
+          S3InputFile.fromLocation(uri.location(), client, metricsContext));
     }
-    return new S3InputStream(s3Client, uri) {
+    return new S3InputStream(s3Client, uri, s3FileIOProperties, metricsContext) {
       @Override
       void resetForRetry() throws IOException {
         resetForRetryCounter.incrementAndGet();

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestMetricsContext.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestMetricsContext.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * Test implementation of MetricsContext that maintains isolated counters for each test instance.
+ * Used instead of Hadoop metrics to avoid shared state between test runs
+ */
+public class TestMetricsContext implements MetricsContext {
+  private final Map<String, org.apache.iceberg.metrics.Counter> counters = Maps.newConcurrentMap();
+
+  @Override
+  public org.apache.iceberg.metrics.Counter counter(String name, Unit unit) {
+    return counters.computeIfAbsent(name, k -> new LocalCounter());
+  }
+
+  private static class LocalCounter implements org.apache.iceberg.metrics.Counter {
+    private final AtomicLong count = new AtomicLong(0);
+
+    @Override
+    public void increment() {
+      increment(1L);
+    }
+
+    @Override
+    public void increment(long amount) {
+      count.addAndGet(amount);
+    }
+
+    @Override
+    public long value() {
+      return count.get();
+    }
+  }
+}

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.apache.iceberg.aws.s3.S3TestUtil.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -209,8 +210,12 @@ public class TestS3FileIOIntegration {
 
   @Test
   public void testCrossRegionAccessEnabled() throws Exception {
-    clientFactory.initialize(
-        ImmutableMap.of(S3FileIOProperties.CROSS_REGION_ACCESS_ENABLED, "true"));
+    Map<String, String> properties =
+        ImmutableMap.of(S3FileIOProperties.CROSS_REGION_ACCESS_ENABLED, "true");
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(properties),
+        "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access");
+    clientFactory.initialize(properties);
     S3Client s3Client = clientFactory.s3();
     String crossBucketObjectKey = String.format("%s/%s", prefix, UUID.randomUUID());
     String crossBucketObjectUri =
@@ -234,7 +239,12 @@ public class TestS3FileIOIntegration {
   @Test
   public void testNewInputStreamWithCrossRegionAccessPoint() throws Exception {
     requireAccessPointSupport();
-    clientFactory.initialize(ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true"));
+    Map<String, String> properties =
+        ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(properties),
+        "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access Points");
+    clientFactory.initialize(properties);
     S3Client s3Client = clientFactory.s3();
     s3Client.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
@@ -485,14 +495,18 @@ public class TestS3FileIOIntegration {
         new String(encoder.encode(digest.digest(secretKey.getEncoded())), StandardCharsets.UTF_8);
 
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> properties =
         ImmutableMap.of(
             S3FileIOProperties.SSE_TYPE,
             S3FileIOProperties.SSE_TYPE_CUSTOM,
             S3FileIOProperties.SSE_KEY,
             encodedKey,
             S3FileIOProperties.SSE_MD5,
-            md5));
+            md5);
+    skipIfAnalyticsAcceleratorEnabled(
+        new S3FileIOProperties(properties),
+        "Analytics Accelerator Library does not support Server Side Custom Encryption");
+    s3FileIO.initialize(properties);
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.apache.iceberg.aws.s3.S3TestUtil.mergeProperties;
 import static org.apache.iceberg.aws.s3.S3TestUtil.skipIfAnalyticsAcceleratorEnabled;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,6 +51,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.PartitionMetadata;
 import software.amazon.awssdk.regions.Region;
@@ -160,18 +163,21 @@ public class TestS3FileIOIntegration {
     clientFactory.initialize(Maps.newHashMap());
   }
 
-  @Test
-  public void testNewInputStream() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStream(Map<String, String> aalProperties) throws Exception {
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of());
+    s3FileIO.initialize(aalProperties);
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testS3FileIOWithS3FileIOAwsClientFactoryImpl() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testS3FileIOWithS3FileIOAwsClientFactoryImpl(Map<String, String> aalProperties)
+      throws Exception {
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
@@ -180,38 +186,45 @@ public class TestS3FileIOIntegration {
     properties.put(
         S3FileIOProperties.CLIENT_FACTORY,
         "org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory");
-    s3FileIO.initialize(properties);
+    s3FileIO.initialize(mergeProperties(aalProperties, properties));
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testS3FileIOWithDefaultAwsClientFactoryImpl() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testS3FileIOWithDefaultAwsClientFactoryImpl(Map<String, String> aalProperties)
+      throws Exception {
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO();
-    s3FileIO.initialize(Maps.newHashMap());
+    s3FileIO.initialize(aalProperties);
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testNewInputStreamWithAccessPoint() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStreamWithAccessPoint(Map<String, String> aalProperties)
+      throws Exception {
     requireAccessPointSupport();
     s3.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
-            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
+            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testCrossRegionAccessEnabled() throws Exception {
-    Map<String, String> properties =
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testCrossRegionAccessEnabled(Map<String, String> aalProperties) throws Exception {
+    Map<String, String> testProperties =
         ImmutableMap.of(S3FileIOProperties.CROSS_REGION_ACCESS_ENABLED, "true");
+    Map<String, String> properties = mergeProperties(aalProperties, testProperties);
     skipIfAnalyticsAcceleratorEnabled(
         new S3FileIOProperties(properties),
         "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access");
@@ -236,11 +249,14 @@ public class TestS3FileIOIntegration {
     }
   }
 
-  @Test
-  public void testNewInputStreamWithCrossRegionAccessPoint() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStreamWithCrossRegionAccessPoint(Map<String, String> aalProperties)
+      throws Exception {
     requireAccessPointSupport();
-    Map<String, String> properties =
+    Map<String, String> testProperties =
         ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    Map<String, String> properties = mergeProperties(aalProperties, testProperties);
     skipIfAnalyticsAcceleratorEnabled(
         new S3FileIOProperties(properties),
         "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access Points");
@@ -258,38 +274,33 @@ public class TestS3FileIOIntegration {
             .build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> accessPointProperties =
         ImmutableMap.of(
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
-            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
+            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName));
+    s3FileIO.initialize(mergeProperties(aalProperties, accessPointProperties));
     validateRead(s3FileIO);
   }
 
-  @Test
-  public void testNewInputStreamWithMultiRegionAccessPoint() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testNewInputStreamWithMultiRegionAccessPoint(Map<String, String> aalProperties)
+      throws Exception {
     Assumptions.assumeThat(multiRegionAccessPointAlias).isNotEmpty();
-    clientFactory.initialize(ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true"));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    clientFactory.initialize(mergeProperties(aalProperties, testProperties));
     S3Client s3Client = clientFactory.s3();
     s3Client.putObject(
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> accessPointProperties =
         ImmutableMap.of(
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
             testMultiRegionAccessPointARN(
-                AwsIntegTestUtil.testRegion(), multiRegionAccessPointAlias)));
-    validateRead(s3FileIO);
-  }
-
-  @Test
-  public void testNewInputStreamWithAnalyticsAccelerator() throws Exception {
-    s3.putObject(
-        PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
-        RequestBody.fromBytes(contentBytes));
-    S3FileIO s3FileIO = new S3FileIO();
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, String.valueOf(true)));
+                AwsIntegTestUtil.testRegion(), multiRegionAccessPointAlias));
+    s3FileIO.initialize(mergeProperties(aalProperties, accessPointProperties));
     validateRead(s3FileIO);
   }
 
@@ -407,11 +418,13 @@ public class TestS3FileIOIntegration {
     }
   }
 
-  @Test
-  public void testServerSideS3Encryption() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testServerSideS3Encryption(Map<String, String> aalProperties) throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_S3));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_S3);
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =
@@ -420,16 +433,18 @@ public class TestS3FileIOIntegration {
     assertThat(response.serverSideEncryption()).isEqualTo(ServerSideEncryption.AES256);
   }
 
-  @Test
-  public void testServerSideKmsEncryption() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testServerSideKmsEncryption(Map<String, String> aalProperties) throws Exception {
     requireKMSEncryptionSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
             S3FileIOProperties.SSE_TYPE,
             S3FileIOProperties.SSE_TYPE_KMS,
             S3FileIOProperties.SSE_KEY,
-            kmsKeyArn));
+            kmsKeyArn);
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =
@@ -439,12 +454,15 @@ public class TestS3FileIOIntegration {
     assertThat(kmsKeyArn).isEqualTo(response.ssekmsKeyId());
   }
 
-  @Test
-  public void testServerSideKmsEncryptionWithDefaultKey() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testServerSideKmsEncryptionWithDefaultKey(Map<String, String> aalProperties)
+      throws Exception {
     requireKMSEncryptionSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_KMS));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_KMS);
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =
@@ -461,16 +479,19 @@ public class TestS3FileIOIntegration {
             aliasListEntry -> assertThat(aliasListEntry.aliasName()).isEqualTo("alias/aws/s3"));
   }
 
-  @Test
-  public void testDualLayerServerSideKmsEncryption() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDualLayerServerSideKmsEncryption(Map<String, String> aalProperties)
+      throws Exception {
     requireKMSEncryptionSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
             S3FileIOProperties.SSE_TYPE,
             S3FileIOProperties.DSSE_TYPE_KMS,
             S3FileIOProperties.SSE_KEY,
-            kmsKeyArn));
+            kmsKeyArn);
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     write(s3FileIO);
     validateRead(s3FileIO);
     GetObjectResponse response =
@@ -480,8 +501,9 @@ public class TestS3FileIOIntegration {
     assertThat(response.ssekmsKeyId()).isEqualTo(kmsKeyArn);
   }
 
-  @Test
-  public void testServerSideCustomEncryption() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testServerSideCustomEncryption(Map<String, String> aalProperties) throws Exception {
     requireKMSEncryptionSupport();
     // generate key
     KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
@@ -495,14 +517,12 @@ public class TestS3FileIOIntegration {
         new String(encoder.encode(digest.digest(secretKey.getEncoded())), StandardCharsets.UTF_8);
 
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    Map<String, String> properties =
+    Map<String, String> testProperties =
         ImmutableMap.of(
-            S3FileIOProperties.SSE_TYPE,
-            S3FileIOProperties.SSE_TYPE_CUSTOM,
-            S3FileIOProperties.SSE_KEY,
-            encodedKey,
-            S3FileIOProperties.SSE_MD5,
-            md5);
+            S3FileIOProperties.SSE_TYPE, S3FileIOProperties.SSE_TYPE_CUSTOM,
+            S3FileIOProperties.SSE_KEY, encodedKey,
+            S3FileIOProperties.SSE_MD5, md5);
+    Map<String, String> properties = mergeProperties(aalProperties, testProperties);
     skipIfAnalyticsAcceleratorEnabled(
         new S3FileIOProperties(properties),
         "Analytics Accelerator Library does not support Server Side Custom Encryption");
@@ -524,13 +544,15 @@ public class TestS3FileIOIntegration {
     assertThat(response.sseCustomerKeyMD5()).isEqualTo(md5);
   }
 
-  @Test
-  public void testACL() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testACL(Map<String, String> aalProperties) throws Exception {
     requireACLSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
-            S3FileIOProperties.ACL, ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL.toString()));
+            S3FileIOProperties.ACL, ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL.toString());
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
 
     write(s3FileIO);
     validateRead(s3FileIO);
@@ -543,65 +565,81 @@ public class TestS3FileIOIntegration {
         .satisfies(grant -> assertThat(grant.permission()).isEqualTo(Permission.FULL_CONTROL));
   }
 
-  @Test
-  public void testClientFactorySerialization() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testClientFactorySerialization(Map<String, String> aalProperties) throws Exception {
     S3FileIO fileIO = new S3FileIO(clientFactory::s3);
-    fileIO.initialize(ImmutableMap.of());
+    fileIO.initialize(aalProperties);
     write(fileIO);
     byte[] data = TestHelpers.serialize(fileIO);
     S3FileIO fileIO2 = TestHelpers.deserialize(data);
     validateRead(fileIO2);
   }
 
-  @Test
-  public void testDeleteFilesMultipleBatches() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesMultipleBatches(Map<String, String> aalProperties) throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize)));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
 
     testDeleteFiles(deletionBatchSize * 2, s3FileIO);
   }
 
-  @Test
-  public void testDeleteFilesMultipleBatchesWithAccessPoints() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesMultipleBatchesWithAccessPoints(Map<String, String> aalProperties)
+      throws Exception {
     requireAccessPointSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> testProperties =
         ImmutableMap.of(
             S3FileIOProperties.DELETE_BATCH_SIZE,
             Integer.toString(deletionBatchSize),
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
-            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
+            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     testDeleteFiles(deletionBatchSize * 2, s3FileIO);
   }
 
-  @Test
-  public void testDeleteFilesMultipleBatchesWithCrossRegionAccessPoints() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesMultipleBatchesWithCrossRegionAccessPoints(
+      Map<String, String> aalProperties) throws Exception {
     requireKMSEncryptionSupport();
-    clientFactory.initialize(ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true"));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    clientFactory.initialize(mergeProperties(aalProperties, testProperties));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
+    Map<String, String> accessPointProperties =
         ImmutableMap.of(
             S3FileIOProperties.DELETE_BATCH_SIZE,
             Integer.toString(deletionBatchSize),
             S3FileIOProperties.ACCESS_POINTS_PREFIX + bucketName,
-            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
+            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName));
+    s3FileIO.initialize(mergeProperties(aalProperties, accessPointProperties));
     testDeleteFiles(deletionBatchSize * 2, s3FileIO);
   }
 
-  @Test
-  public void testDeleteFilesLessThanBatchSize() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesLessThanBatchSize(Map<String, String> aalProperties) throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize)));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     testDeleteFiles(deletionBatchSize - 1, s3FileIO);
   }
 
-  @Test
-  public void testDeleteFilesSingleBatchWithRemainder() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testDeleteFilesSingleBatchWithRemainder(Map<String, String> aalProperties)
+      throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(
-        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize)));
+    Map<String, String> testProperties =
+        ImmutableMap.of(S3FileIOProperties.DELETE_BATCH_SIZE, Integer.toString(deletionBatchSize));
+    s3FileIO.initialize(mergeProperties(aalProperties, testProperties));
     testDeleteFiles(5, s3FileIO);
   }
 
@@ -643,11 +681,12 @@ public class TestS3FileIOIntegration {
             });
   }
 
-  @Test
-  public void testFileRecoveryHappyPath() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testFileRecoveryHappyPath(Map<String, String> aalProperties) throws Exception {
     requireVersioningSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of());
+    s3FileIO.initialize(aalProperties);
     String filePath = String.format("s3://%s/%s/%s", bucketName, prefix, "someFile.parquet");
     write(s3FileIO, filePath);
     s3FileIO.deleteFile(filePath);
@@ -655,13 +694,15 @@ public class TestS3FileIOIntegration {
 
     assertThat(s3FileIO.recoverFile(filePath)).isTrue();
     assertThat(s3FileIO.newInputFile(filePath).exists()).isTrue();
+    s3FileIO.deleteFile(filePath);
   }
 
-  @Test
-  public void testFileRecoveryFailsToRecover() throws Exception {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
+  public void testFileRecoveryFailsToRecover(Map<String, String> aalProperties) throws Exception {
     requireVersioningSupport();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of());
+    s3FileIO.initialize(aalProperties);
     s3.putBucketVersioning(
         PutBucketVersioningRequest.builder()
             .bucket(bucketName)

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -225,9 +225,6 @@ public class TestS3FileIOIntegration {
     Map<String, String> testProperties =
         ImmutableMap.of(S3FileIOProperties.CROSS_REGION_ACCESS_ENABLED, "true");
     Map<String, String> properties = mergeProperties(aalProperties, testProperties);
-    skipIfAnalyticsAcceleratorEnabled(
-        new S3FileIOProperties(properties),
-        "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access");
     clientFactory.initialize(properties);
     S3Client s3Client = clientFactory.s3();
     String crossBucketObjectKey = String.format("%s/%s", prefix, UUID.randomUUID());
@@ -241,7 +238,7 @@ public class TestS3FileIOIntegration {
               .build(),
           RequestBody.fromBytes(contentBytes));
       // make a copy in cross-region bucket
-      S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
+      S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, clientFactory::s3Async);
       validateRead(s3FileIO, crossBucketObjectUri);
     } finally {
       AwsIntegTestUtil.cleanS3GeneralPurposeBucket(
@@ -257,9 +254,6 @@ public class TestS3FileIOIntegration {
     Map<String, String> testProperties =
         ImmutableMap.of(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
     Map<String, String> properties = mergeProperties(aalProperties, testProperties);
-    skipIfAnalyticsAcceleratorEnabled(
-        new S3FileIOProperties(properties),
-        "S3 Async Clients needed for Analytics Accelerator Library does not support Cross Region Access Points");
     clientFactory.initialize(properties);
     S3Client s3Client = clientFactory.s3();
     s3Client.putObject(

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -141,9 +141,6 @@ public class TestS3InputStream {
   @ParameterizedTest
   @MethodSource("org.apache.iceberg.aws.s3.S3TestUtil#analyticsAcceleratorLibraryProperties")
   public void testRangeRead(Map<String, String> aalProperties) throws Exception {
-    final S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(aalProperties);
-    skipIfAnalyticsAcceleratorEnabled(
-        s3FileIOProperties, "Analytics Accelerator Library does not support range reads");
     testRangeRead(s3, s3Async, aalProperties);
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -95,12 +95,14 @@ public class AwsClientFactories {
     private AwsClientProperties awsClientProperties;
     private S3FileIOProperties s3FileIOProperties;
     private HttpClientProperties httpClientProperties;
+    private HttpAsyncClientProperties httpAsyncClientProperties;
 
     DefaultAwsClientFactory() {
       awsProperties = new AwsProperties();
       awsClientProperties = new AwsClientProperties();
       s3FileIOProperties = new S3FileIOProperties();
       httpClientProperties = new HttpClientProperties();
+      httpAsyncClientProperties = new HttpAsyncClientProperties();
     }
 
     @Override
@@ -125,18 +127,25 @@ public class AwsClientFactories {
       if (s3FileIOProperties.isS3CRTEnabled()) {
         return S3AsyncClient.crtBuilder()
             .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+            .applyMutation(httpAsyncClientProperties::applyHttpAsyncClientConfigurations)
+            .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+            .applyMutation(s3FileIOProperties::applyServiceConfigurations)
             .applyMutation(
                 b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
-            .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
-            .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
             .build();
       }
       return S3AsyncClient.builder()
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
+          .applyMutation(httpAsyncClientProperties::applyHttpAsyncClientConfigurations)
+          .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyServiceConfigurations)
           .applyMutation(
               b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
-          .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applySignerConfiguration)
+          .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
+          .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
+          .applyMutation(s3FileIOProperties::applyRetryConfigurations)
           .build();
     }
 
@@ -176,6 +185,7 @@ public class AwsClientFactories {
       this.awsClientProperties = new AwsClientProperties(properties);
       this.s3FileIOProperties = new S3FileIOProperties(properties);
       this.httpClientProperties = new HttpClientProperties(properties);
+      this.httpAsyncClientProperties = new HttpAsyncClientProperties(properties);
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -180,21 +180,6 @@ public class AwsClientProperties implements Serializable {
   }
 
   /**
-   * Configure the credential provider for S3 CRT clients.
-   *
-   * <p>Sample usage:
-   *
-   * <pre>
-   *     S3AsyncClient.crtBuilder().applyMutation(awsClientProperties::applyClientCredentialConfigurations)
-   * </pre>
-   */
-  public <T extends S3CrtAsyncClientBuilder> void applyClientCredentialConfigurations(T builder) {
-    if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
-      builder.credentialsProvider(credentialsProvider(this.clientCredentialsProvider));
-    }
-  }
-
-  /**
    * Returns a credentials provider instance. If {@link #refreshCredentialsEndpoint} is set, an
    * instance of {@link VendedCredentialsProvider} is returned. If params were set, we return a new
    * credentials instance. If none of the params are set, we try to dynamically load the provided

--- a/aws/src/main/java/org/apache/iceberg/aws/CrtHttpAsyncClientConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/CrtHttpAsyncClientConfigurations.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.time.Duration;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
+
+class CrtHttpAsyncClientConfigurations {
+  private Integer maxConcurrency;
+  private Long connectionTimeoutMs;
+
+  private CrtHttpAsyncClientConfigurations() {}
+
+  public <T extends S3CrtAsyncClientBuilder> void configureHttpAsyncClientBuilder(
+      T s3CrtAsyncClientBuilder) {
+    configureCrtHttpAsyncClientBuilder(s3CrtAsyncClientBuilder);
+  }
+
+  private void initialize(Map<String, String> httpAsyncClientProperties) {
+    this.maxConcurrency =
+        PropertyUtil.propertyAsInt(
+            httpAsyncClientProperties,
+            HttpAsyncClientProperties.CRT_MAX_CONCURRENCY,
+            HttpAsyncClientProperties.CRT_MAX_CONCURRENCY_DEFAULT);
+    this.connectionTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpAsyncClientProperties, HttpAsyncClientProperties.CRT_CONNECTION_TIMEOUT_MS);
+  }
+
+  @VisibleForTesting
+  void configureCrtHttpAsyncClientBuilder(S3CrtAsyncClientBuilder crtBuilder) {
+    if (connectionTimeoutMs != null) {
+      crtBuilder.httpConfiguration(
+          S3CrtHttpConfiguration.builder()
+              .connectionTimeout(Duration.ofMillis(connectionTimeoutMs))
+              .build());
+    }
+    if (maxConcurrency != null) {
+      crtBuilder.maxConcurrency(maxConcurrency);
+    }
+  }
+
+  public static CrtHttpAsyncClientConfigurations create(Map<String, String> properties) {
+    CrtHttpAsyncClientConfigurations configurations = new CrtHttpAsyncClientConfigurations();
+    configurations.initialize(properties);
+    return configurations;
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/HttpAsyncClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/HttpAsyncClientProperties.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+
+/**
+ * Configuration properties for HTTP async clients used by AWS services.
+ *
+ * <p>The client type (Netty vs CRT) is determined by the {@code s3.crt-enabled} property in
+ * S3FileIOProperties. When CRT is enabled, CRT-specific properties are used; when disabled,
+ * Netty-specific properties are used.
+ */
+public class HttpAsyncClientProperties implements Serializable {
+
+  private static final String CLIENT_PREFIX = "http-async-client.";
+
+  /**
+   * Used to configure the connection timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_CONNECTION_TIMEOUT_MS =
+      "http-async-client.netty.connection-timeout-ms";
+
+  /**
+   * Used to configure the socket timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_SOCKET_TIMEOUT_MS = "http-async-client.netty.socket-timeout-ms";
+
+  /**
+   * Used to configure the connection acquisition timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_CONNECTION_ACQUISITION_TIMEOUT_MS =
+      "http-async-client.netty.connection-acquisition-timeout-ms";
+
+  /**
+   * Used to configure the connection max idle time in milliseconds for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_CONNECTION_MAX_IDLE_TIME_MS =
+      "http-async-client.netty.connection-max-idle-time-ms";
+
+  /**
+   * Used to configure the connection time to live in milliseconds for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_CONNECTION_TIME_TO_LIVE_MS =
+      "http-async-client.netty.connection-time-to-live-ms";
+
+  /**
+   * Used to configure the max connections number for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_MAX_CONNECTIONS = "http-async-client.netty.max-connections";
+
+  /**
+   * Used to configure whether to enable the tcp keep alive setting for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}.
+   *
+   * <p>In default, this is disabled.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_TCP_KEEP_ALIVE_ENABLED =
+      "http-async-client.netty.tcp-keep-alive-enabled";
+
+  /**
+   * Used to configure whether to use idle connection reaper for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}.
+   *
+   * <p>In default, this is enabled.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_USE_IDLE_CONNECTION_REAPER_ENABLED =
+      "http-async-client.netty.use-idle-connection-reaper-enabled";
+
+  /**
+   * Used to configure the proxy endpoint for {@link
+   * software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient.Builder}. This flag only works
+   * when {@code s3.crt-enabled} is {@code false}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/nio/netty/NettyNioAsyncHttpClient.Builder.html
+   */
+  public static final String NETTY_PROXY_ENDPOINT = "http-async-client.netty.proxy-endpoint";
+
+  /**
+   * Used to configure the connection timeout in milliseconds for {@link
+   * software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncHttpClient.Builder}. This flag only
+   * works when {@code s3.crt-enabled} is {@code true}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.Builder.html
+   */
+  public static final String CRT_CONNECTION_TIMEOUT_MS =
+      "http-async-client.crt.connection-timeout-ms";
+
+  /**
+   * Used to configure the max concurrency for {@link
+   * software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncHttpClient.Builder}. This flag only
+   * works when {@code s3.crt-enabled} is {@code true}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.Builder.html
+   */
+  public static final String CRT_MAX_CONCURRENCY = "http-async-client.crt.max-concurrency";
+
+  /**
+   * To fully benefit from the analytics-accelerator-s3 library where this S3 CRT client is used, it
+   * is recommended to initialize with higher concurrency.
+   *
+   * <p>For more details, see: https://github.com/awslabs/analytics-accelerator-s3
+   */
+  public static final int CRT_MAX_CONCURRENCY_DEFAULT = 500;
+
+  private final Map<String, String> httpAsyncClientProperties;
+
+  public HttpAsyncClientProperties() {
+    this.httpAsyncClientProperties = Collections.emptyMap();
+  }
+
+  public HttpAsyncClientProperties(Map<String, String> properties) {
+    this.httpAsyncClientProperties =
+        PropertyUtil.filterProperties(properties, key -> key.startsWith(CLIENT_PREFIX));
+  }
+
+  public <T extends S3AsyncClientBuilder> void applyHttpAsyncClientConfigurations(T builder) {
+    NettyHttpAsyncClientConfigurations nettyConfigurations =
+        loadHttpAsyncClientConfigurations(NettyHttpAsyncClientConfigurations.class.getName());
+    nettyConfigurations.configureHttpAsyncClientBuilder(builder);
+  }
+
+  public <T extends S3CrtAsyncClientBuilder> void applyHttpAsyncClientConfigurations(T builder) {
+    CrtHttpAsyncClientConfigurations crtConfigurations =
+        loadHttpAsyncClientConfigurations(CrtHttpAsyncClientConfigurations.class.getName());
+    crtConfigurations.configureHttpAsyncClientBuilder(builder);
+  }
+
+  private <T> T loadHttpAsyncClientConfigurations(String impl) {
+    try {
+      Object httpAsyncClientConfigurations =
+          DynMethods.builder("create")
+              .hiddenImpl(impl, Map.class)
+              .buildStaticChecked()
+              .invoke(httpAsyncClientProperties);
+      return (T) httpAsyncClientConfigurations;
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot create %s to generate and configure the http client builder", impl),
+          e);
+    }
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/NettyHttpAsyncClientConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/NettyHttpAsyncClientConfigurations.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+
+class NettyHttpAsyncClientConfigurations {
+  private Long connectionTimeoutMs;
+  private Long socketTimeoutMs;
+  private Long acquisitionTimeoutMs;
+  private Long connectionMaxIdleTimeMs;
+  private Long connectionTimeToLiveMs;
+  private Integer maxConnections;
+  private Boolean tcpKeepAliveEnabled;
+  private Boolean useIdleConnectionReaperEnabled;
+  private String proxyEndpoint;
+
+  private NettyHttpAsyncClientConfigurations() {}
+
+  public <T extends S3AsyncClientBuilder> void configureHttpAsyncClientBuilder(
+      T s3AsyncClientBuilder) {
+    NettyNioAsyncHttpClient.Builder nettyBuilder = NettyNioAsyncHttpClient.builder();
+    configureNettyHttpAsyncClientBuilder(nettyBuilder);
+    s3AsyncClientBuilder.httpClientBuilder(nettyBuilder);
+  }
+
+  private void initialize(Map<String, String> httpAsyncClientProperties) {
+    this.connectionTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpAsyncClientProperties, HttpAsyncClientProperties.NETTY_CONNECTION_TIMEOUT_MS);
+    this.socketTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpAsyncClientProperties, HttpAsyncClientProperties.NETTY_SOCKET_TIMEOUT_MS);
+    this.acquisitionTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpAsyncClientProperties,
+            HttpAsyncClientProperties.NETTY_CONNECTION_ACQUISITION_TIMEOUT_MS);
+    this.connectionMaxIdleTimeMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpAsyncClientProperties, HttpAsyncClientProperties.NETTY_CONNECTION_MAX_IDLE_TIME_MS);
+    this.connectionTimeToLiveMs =
+        PropertyUtil.propertyAsNullableLong(
+            httpAsyncClientProperties, HttpAsyncClientProperties.NETTY_CONNECTION_TIME_TO_LIVE_MS);
+    this.maxConnections =
+        PropertyUtil.propertyAsNullableInt(
+            httpAsyncClientProperties, HttpAsyncClientProperties.NETTY_MAX_CONNECTIONS);
+    this.tcpKeepAliveEnabled =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpAsyncClientProperties, HttpAsyncClientProperties.NETTY_TCP_KEEP_ALIVE_ENABLED);
+    this.useIdleConnectionReaperEnabled =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpAsyncClientProperties,
+            HttpAsyncClientProperties.NETTY_USE_IDLE_CONNECTION_REAPER_ENABLED);
+    this.proxyEndpoint =
+        PropertyUtil.propertyAsString(
+            httpAsyncClientProperties, HttpAsyncClientProperties.NETTY_PROXY_ENDPOINT, null);
+  }
+
+  @VisibleForTesting
+  void configureNettyHttpAsyncClientBuilder(NettyNioAsyncHttpClient.Builder nettyBuilder) {
+    if (connectionTimeoutMs != null) {
+      nettyBuilder.connectionTimeout(Duration.ofMillis(connectionTimeoutMs));
+    }
+    if (socketTimeoutMs != null) {
+      nettyBuilder.readTimeout(Duration.ofMillis(socketTimeoutMs));
+      nettyBuilder.writeTimeout(Duration.ofMillis(socketTimeoutMs));
+    }
+    if (acquisitionTimeoutMs != null) {
+      nettyBuilder.connectionAcquisitionTimeout(Duration.ofMillis(acquisitionTimeoutMs));
+    }
+    if (connectionMaxIdleTimeMs != null) {
+      nettyBuilder.connectionMaxIdleTime(Duration.ofMillis(connectionMaxIdleTimeMs));
+    }
+    if (connectionTimeToLiveMs != null) {
+      nettyBuilder.connectionTimeToLive(Duration.ofMillis(connectionTimeToLiveMs));
+    }
+    if (maxConnections != null) {
+      nettyBuilder.maxConcurrency(maxConnections);
+    }
+    if (tcpKeepAliveEnabled != null) {
+      nettyBuilder.tcpKeepAlive(tcpKeepAliveEnabled);
+    }
+    if (useIdleConnectionReaperEnabled != null) {
+      nettyBuilder.useIdleConnectionReaper(useIdleConnectionReaperEnabled);
+    }
+    if (proxyEndpoint != null) {
+      nettyBuilder.proxyConfiguration(
+          ProxyConfiguration.builder()
+              .host(URI.create(proxyEndpoint).getHost())
+              .port(URI.create(proxyEndpoint).getPort())
+              .build());
+    }
+  }
+
+  public static NettyHttpAsyncClientConfigurations create(Map<String, String> properties) {
+    NettyHttpAsyncClientConfigurations configurations = new NettyHttpAsyncClientConfigurations();
+    configurations.initialize(properties);
+    return configurations;
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorInputStreamWrapper.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorInputStreamWrapper.java
@@ -20,13 +20,14 @@ package org.apache.iceberg.aws.s3;
 
 import java.io.IOException;
 import org.apache.iceberg.io.FileIOMetricsContext;
+import org.apache.iceberg.io.RangeReadable;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.Counter;
 import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
 
 /** A wrapper to convert {@link S3SeekableInputStream} to Iceberg {@link SeekableInputStream} */
-class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream {
+class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream implements RangeReadable {
 
   private final S3SeekableInputStream delegate;
   private final Counter readBytes;
@@ -60,6 +61,16 @@ class AnalyticsAcceleratorInputStreamWrapper extends SeekableInputStream {
     }
     readOperations.increment();
     return bytesRead;
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+    this.delegate.readFully(position, buffer, offset, length);
+  }
+
+  @Override
+  public int readTail(byte[] buffer, int offset, int length) throws IOException {
+    return this.delegate.readTail(buffer, offset, length);
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
@@ -75,7 +75,7 @@ class AnalyticsAcceleratorUtil {
 
     try {
       S3SeekableInputStream seekableInputStream = factory.createStream(uri, openStreamInfo);
-      return new AnalyticsAcceleratorInputStreamWrapper(seekableInputStream);
+      return new AnalyticsAcceleratorInputStreamWrapper(seekableInputStream, inputFile.metrics());
     } catch (IOException e) {
       throw new RuntimeIOException(
           e, "Failed to create S3 analytics accelerator input stream for: %s", inputFile.uri());

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
@@ -85,7 +85,7 @@ class AnalyticsAcceleratorUtil {
   private static S3SeekableInputStreamFactory createNewFactory(
       Pair<S3AsyncClient, S3FileIOProperties> cacheKey) {
     ConnectorConfiguration connectorConfiguration =
-        new ConnectorConfiguration(cacheKey.second().s3AnalyticsacceleratorProperties());
+        new ConnectorConfiguration(cacheKey.second().s3AnalyticsAcceleratorProperties());
     S3SeekableInputStreamConfiguration streamConfiguration =
         S3SeekableInputStreamConfiguration.fromConfiguration(connectorConfiguration);
     ObjectClientConfiguration objectClientConfiguration =

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3AccessGrantsPluginConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3AccessGrantsPluginConfigurations.java
@@ -21,14 +21,14 @@ package org.apache.iceberg.aws.s3;
 import java.util.Map;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.s3accessgrants.plugin.S3AccessGrantsPlugin;
-import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 
 class S3AccessGrantsPluginConfigurations {
   private boolean isS3AccessGrantsFallbackToIamEnabled;
 
   private S3AccessGrantsPluginConfigurations() {}
 
-  public <T extends S3ClientBuilder> void configureS3ClientBuilder(T builder) {
+  public <T extends S3BaseClientBuilder<T, ?>> void configureS3ClientBuilder(T builder) {
     S3AccessGrantsPlugin s3AccessGrantsPlugin =
         S3AccessGrantsPlugin.builder().enableFallback(isS3AccessGrantsFallbackToIamEnabled).build();
     builder.addPlugin(s3AccessGrantsPlugin);

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -513,7 +513,7 @@ public class S3FileIOProperties implements Serializable {
   private final String endpoint;
   private final boolean isRemoteSigningEnabled;
   private final boolean isS3AnalyticsAcceleratorEnabled;
-  private final Map<String, String> s3AnalyticsacceleratorProperties;
+  private final Map<String, String> s3AnalyticsAcceleratorProperties;
   private final boolean isS3CRTEnabled;
   private String writeStorageClass;
   private int s3RetryNumRetries;
@@ -560,7 +560,7 @@ public class S3FileIOProperties implements Serializable {
     this.s3DirectoryBucketListPrefixAsDirectory =
         S3_DIRECTORY_BUCKET_LIST_PREFIX_AS_DIRECTORY_DEFAULT;
     this.isS3AnalyticsAcceleratorEnabled = S3_ANALYTICS_ACCELERATOR_ENABLED_DEFAULT;
-    this.s3AnalyticsacceleratorProperties = Maps.newHashMap();
+    this.s3AnalyticsAcceleratorProperties = Maps.newHashMap();
     this.isS3CRTEnabled = S3_CRT_ENABLED_DEFAULT;
     this.allProperties = Maps.newHashMap();
 
@@ -677,7 +677,7 @@ public class S3FileIOProperties implements Serializable {
     this.isS3AnalyticsAcceleratorEnabled =
         PropertyUtil.propertyAsBoolean(
             properties, S3_ANALYTICS_ACCELERATOR_ENABLED, S3_ANALYTICS_ACCELERATOR_ENABLED_DEFAULT);
-    this.s3AnalyticsacceleratorProperties =
+    this.s3AnalyticsAcceleratorProperties =
         PropertyUtil.propertiesWithPrefix(properties, S3_ANALYTICS_ACCELERATOR_PROPERTIES_PREFIX);
     this.isS3CRTEnabled =
         PropertyUtil.propertyAsBoolean(properties, S3_CRT_ENABLED, S3_CRT_ENABLED_DEFAULT);
@@ -799,8 +799,8 @@ public class S3FileIOProperties implements Serializable {
     return isS3AnalyticsAcceleratorEnabled;
   }
 
-  public Map<String, String> s3AnalyticsacceleratorProperties() {
-    return s3AnalyticsacceleratorProperties;
+  public Map<String, String> s3AnalyticsAcceleratorProperties() {
+    return s3AnalyticsAcceleratorProperties;
   }
 
   public boolean isS3CRTEnabled() {

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -95,7 +95,7 @@ public class TestAwsClientFactories {
   }
 
   @Test
-  public void testS3AsyncClientDefaultIsCrt() {
+  public void testS3AsyncClientDefaultIsNotCrt() {
     assertThat(
             AwsClientFactories.from(
                     ImmutableMap.of(
@@ -106,7 +106,7 @@ public class TestAwsClientFactories {
                         AwsClientProperties.CLIENT_REGION,
                         "us-east-1"))
                 .s3Async())
-        .isInstanceOf(DefaultS3CrtAsyncClient.class);
+        .isNotInstanceOf(DefaultS3CrtAsyncClient.class);
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/TestHttpAsyncClientConfigurations.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestHttpAsyncClientConfigurations.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.time.Duration;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.crt.S3CrtHttpConfiguration;
+
+public class TestHttpAsyncClientConfigurations {
+
+  @Test
+  public void testNettyOverrideConfigurations() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpAsyncClientProperties.NETTY_CONNECTION_TIMEOUT_MS, "200");
+    properties.put(HttpAsyncClientProperties.NETTY_SOCKET_TIMEOUT_MS, "100");
+    properties.put(HttpAsyncClientProperties.NETTY_CONNECTION_ACQUISITION_TIMEOUT_MS, "101");
+    properties.put(HttpAsyncClientProperties.NETTY_CONNECTION_MAX_IDLE_TIME_MS, "102");
+    properties.put(HttpAsyncClientProperties.NETTY_CONNECTION_TIME_TO_LIVE_MS, "103");
+    properties.put(HttpAsyncClientProperties.NETTY_MAX_CONNECTIONS, "104");
+    properties.put(HttpAsyncClientProperties.NETTY_TCP_KEEP_ALIVE_ENABLED, "true");
+    properties.put(HttpAsyncClientProperties.NETTY_USE_IDLE_CONNECTION_REAPER_ENABLED, "false");
+    properties.put(HttpAsyncClientProperties.NETTY_PROXY_ENDPOINT, "http://proxy:8080");
+
+    NettyHttpAsyncClientConfigurations nettyConfigurations =
+        NettyHttpAsyncClientConfigurations.create(properties);
+    NettyNioAsyncHttpClient.Builder nettyBuilder = NettyNioAsyncHttpClient.builder();
+    NettyNioAsyncHttpClient.Builder spyNettyBuilder = Mockito.spy(nettyBuilder);
+
+    nettyConfigurations.configureNettyHttpAsyncClientBuilder(spyNettyBuilder);
+
+    Mockito.verify(spyNettyBuilder).connectionTimeout(Duration.ofMillis(200));
+    Mockito.verify(spyNettyBuilder).readTimeout(Duration.ofMillis(100));
+    Mockito.verify(spyNettyBuilder).writeTimeout(Duration.ofMillis(100));
+    Mockito.verify(spyNettyBuilder).connectionAcquisitionTimeout(Duration.ofMillis(101));
+    Mockito.verify(spyNettyBuilder).connectionMaxIdleTime(Duration.ofMillis(102));
+    Mockito.verify(spyNettyBuilder).connectionTimeToLive(Duration.ofMillis(103));
+    Mockito.verify(spyNettyBuilder).maxConcurrency(104);
+    Mockito.verify(spyNettyBuilder).tcpKeepAlive(true);
+    Mockito.verify(spyNettyBuilder).useIdleConnectionReaper(false);
+    Mockito.verify(spyNettyBuilder).proxyConfiguration(Mockito.any(ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testNettyDefaultConfigurations() {
+    NettyHttpAsyncClientConfigurations nettyConfigurations =
+        NettyHttpAsyncClientConfigurations.create(Maps.newHashMap());
+    NettyNioAsyncHttpClient.Builder nettyBuilder = NettyNioAsyncHttpClient.builder();
+    NettyNioAsyncHttpClient.Builder spyNettyBuilder = Mockito.spy(nettyBuilder);
+
+    nettyConfigurations.configureNettyHttpAsyncClientBuilder(spyNettyBuilder);
+
+    Mockito.verify(spyNettyBuilder, Mockito.never()).connectionTimeout(Mockito.any(Duration.class));
+    Mockito.verify(spyNettyBuilder, Mockito.never()).readTimeout(Mockito.any(Duration.class));
+    Mockito.verify(spyNettyBuilder, Mockito.never()).writeTimeout(Mockito.any(Duration.class));
+    Mockito.verify(spyNettyBuilder, Mockito.never())
+        .connectionAcquisitionTimeout(Mockito.any(Duration.class));
+    Mockito.verify(spyNettyBuilder, Mockito.never())
+        .connectionMaxIdleTime(Mockito.any(Duration.class));
+    Mockito.verify(spyNettyBuilder, Mockito.never())
+        .connectionTimeToLive(Mockito.any(Duration.class));
+    Mockito.verify(spyNettyBuilder, Mockito.never()).maxConcurrency(Mockito.anyInt());
+    Mockito.verify(spyNettyBuilder, Mockito.never()).tcpKeepAlive(Mockito.anyBoolean());
+    Mockito.verify(spyNettyBuilder, Mockito.never()).useIdleConnectionReaper(Mockito.anyBoolean());
+    Mockito.verify(spyNettyBuilder, Mockito.never())
+        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testCrtOverrideConfigurations() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpAsyncClientProperties.CRT_CONNECTION_TIMEOUT_MS, "200");
+    properties.put(HttpAsyncClientProperties.CRT_MAX_CONCURRENCY, "50");
+
+    CrtHttpAsyncClientConfigurations crtConfigurations =
+        CrtHttpAsyncClientConfigurations.create(properties);
+    S3CrtAsyncClientBuilder crtBuilder = Mockito.mock(S3CrtAsyncClientBuilder.class);
+
+    crtConfigurations.configureCrtHttpAsyncClientBuilder(crtBuilder);
+
+    Mockito.verify(crtBuilder).httpConfiguration(Mockito.any(S3CrtHttpConfiguration.class));
+    Mockito.verify(crtBuilder).maxConcurrency(50);
+  }
+
+  @Test
+  public void testCrtDefaultConfigurations() {
+    CrtHttpAsyncClientConfigurations crtConfigurations =
+        CrtHttpAsyncClientConfigurations.create(Maps.newHashMap());
+    S3CrtAsyncClientBuilder crtBuilder = Mockito.mock(S3CrtAsyncClientBuilder.class);
+
+    crtConfigurations.configureCrtHttpAsyncClientBuilder(crtBuilder);
+
+    Mockito.verify(crtBuilder, Mockito.never())
+        .httpConfiguration(Mockito.any(S3CrtHttpConfiguration.class));
+    Mockito.verify(crtBuilder)
+        .maxConcurrency(HttpAsyncClientProperties.CRT_MAX_CONCURRENCY_DEFAULT);
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/TestHttpAsyncClientProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestHttpAsyncClientProperties.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+
+public class TestHttpAsyncClientProperties {
+
+  @Test
+  public void testNettyAsyncClientConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpAsyncClientProperties.NETTY_CONNECTION_TIMEOUT_MS, "200");
+    properties.put(HttpAsyncClientProperties.NETTY_MAX_CONNECTIONS, "100");
+
+    HttpAsyncClientProperties httpAsyncClientProperties = new HttpAsyncClientProperties(properties);
+    S3AsyncClientBuilder s3AsyncClientBuilder = Mockito.mock(S3AsyncClientBuilder.class);
+
+    httpAsyncClientProperties.applyHttpAsyncClientConfigurations(s3AsyncClientBuilder);
+
+    Mockito.verify(s3AsyncClientBuilder).httpClientBuilder(Mockito.any());
+  }
+
+  @Test
+  public void testCrtAsyncClientConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpAsyncClientProperties.CRT_CONNECTION_TIMEOUT_MS, "200");
+    properties.put(HttpAsyncClientProperties.CRT_MAX_CONCURRENCY, "50");
+
+    HttpAsyncClientProperties httpAsyncClientProperties = new HttpAsyncClientProperties(properties);
+    S3CrtAsyncClientBuilder s3CrtAsyncClientBuilder = Mockito.mock(S3CrtAsyncClientBuilder.class);
+
+    httpAsyncClientProperties.applyHttpAsyncClientConfigurations(s3CrtAsyncClientBuilder);
+
+    Mockito.verify(s3CrtAsyncClientBuilder).maxConcurrency(Mockito.any());
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 class StaticClientFactory implements AwsClientFactory {
   static S3Client client;
+  static S3AsyncClient asyncClient;
 
   @Override
   public S3Client s3() {
@@ -36,7 +37,7 @@ class StaticClientFactory implements AwsClientFactory {
 
   @Override
   public S3AsyncClient s3Async() {
-    return null;
+    return asyncClient;
   }
 
   @Override

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -126,9 +126,6 @@ public class TestS3FileIOProperties {
 
     assertThat(Collections.emptyMap()).isEqualTo(s3FileIOProperties.bucketToAccessPointMapping());
 
-    assertThat(S3FileIOProperties.S3_CRT_MAX_CONCURRENCY_DEFAULT)
-        .isEqualTo(s3FileIOProperties.s3CrtMaxConcurrency());
-
     assertThat(S3FileIOProperties.S3_CRT_ENABLED_DEFAULT)
         .isEqualTo(s3FileIOProperties.isS3CRTEnabled());
 
@@ -278,11 +275,6 @@ public class TestS3FileIOProperties {
             String.valueOf(s3FileIOProperties.isRemoteSigningEnabled()));
 
     assertThat(map).containsEntry(S3FileIOProperties.WRITE_STORAGE_CLASS, "INTELLIGENT_TIERING");
-
-    assertThat(map)
-        .containsEntry(
-            S3FileIOProperties.S3_CRT_MAX_CONCURRENCY,
-            String.valueOf(s3FileIOProperties.s3CrtMaxConcurrency()));
 
     assertThat(map)
         .containsEntry(
@@ -439,7 +431,6 @@ public class TestS3FileIOProperties {
     map.put(S3FileIOProperties.PRELOAD_CLIENT_ENABLED, "true");
     map.put(S3FileIOProperties.REMOTE_SIGNING_ENABLED, "true");
     map.put(S3FileIOProperties.WRITE_STORAGE_CLASS, "INTELLIGENT_TIERING");
-    map.put(S3FileIOProperties.S3_CRT_MAX_CONCURRENCY, "200");
     map.put(S3FileIOProperties.S3_CRT_ENABLED, "false");
     map.put(S3FileIOProperties.S3_ANALYTICS_ACCELERATOR_ENABLED, "true");
     return map;
@@ -541,17 +532,6 @@ public class TestS3FileIOProperties {
 
     Mockito.verify(mockS3ClientBuilder)
         .overrideConfiguration(Mockito.any(ClientOverrideConfiguration.class));
-  }
-
-  @Test
-  public void testApplyS3CrtConfigurations() {
-    Map<String, String> properties = Maps.newHashMap();
-    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
-    S3CrtAsyncClientBuilder mockS3CrtAsyncClientBuilder =
-        Mockito.mock(S3CrtAsyncClientBuilder.class);
-    s3FileIOProperties.applyS3CrtConfigurations(mockS3CrtAsyncClientBuilder);
-
-    Mockito.verify(mockS3CrtAsyncClientBuilder).maxConcurrency(Mockito.any(Integer.class));
   }
 
   @Test

--- a/build.gradle
+++ b/build.gradle
@@ -472,6 +472,7 @@ project(':iceberg-aws') {
     compileOnly(libs.awssdk.s3accessgrants)
     compileOnly("software.amazon.awssdk:url-connection-client")
     compileOnly("software.amazon.awssdk:apache-client")
+    compileOnly("software.amazon.awssdk:netty-nio-client")
     compileOnly("software.amazon.awssdk:auth")
     compileOnly("software.amazon.awssdk:http-auth-aws-crt")
     compileOnly("software.amazon.awssdk:s3")

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -589,8 +589,7 @@ The Analytics Accelerator Library can work with either the [S3 CRT client](https
 
 | Property               | Default | Description                                                  |
 |------------------------|---------|--------------------------------------------------------------|
-| s3.crt.enabled         | `true`  | Controls if the S3 Async clients should be created using CRT |
-| s3.crt.max-concurrency | `500`   | Max concurrency for S3 CRT clients                           |
+| s3.crt.enabled         | `false` | Controls if the S3 Async clients should be created using CRT |
 
 Additional library specific configurations are organized into the following sections:
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@
 [versions]
 activation = "1.1.1"
 aliyun-sdk-oss = "3.10.2"
-analyticsaccelerator = "1.0.0"
+analyticsaccelerator = "1.2.1"
 antlr = "4.9.3"
 antlr413 = "4.13.1" # For Spark 4.0 support
 aircompressor = "0.27"

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -114,6 +114,7 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
     implementation project(':iceberg-aws')
     implementation platform(libs.awssdk.bom)
     implementation 'software.amazon.awssdk:apache-client'
+    implementation 'software.amazon.awssdk:netty-nio-client'
     implementation 'software.amazon.awssdk:auth'
     implementation "software.amazon.awssdk:http-auth-aws-crt"
     implementation 'software.amazon.awssdk:iam'


### PR DESCRIPTION
**Context**
We have integrated [analytics-accelerator-s3](https://github.com/awslabs/analytics-accelerator-s3) into Iceberg in PR https://github.com/apache/iceberg/pull/12299. Currently, Iceberg customers need to enable the s3.analytics-accelerator.enabled flag in S3FileIOProperties to use the library. There is a proposal to make Analytics stream the default input stream: https://docs.google.com/document/d/13shy0RWotwfWC_qQksb95PXdi-vSUCKQyDzjoExQEN0

**Description of Change**
Starting from 1.2.2 AAL will allow consumers to pass Retry strategy to execute on Input Stream from S3 to AAL. (https://github.com/awslabs/analytics-accelerator-s3/pull/340)

With this change we are using that stream to ensure parity with S3SeekableInputStream and Analytics Stream on Iceberg.

Unlike current retries where stream has to be re-opened from the last-read position, in these retries, we do not need to do anything on the stream level as AAL will ensure reads are idempotent. 

**Testing**
Extended FlakyInputStream tests to AAL and confirmed all tests are passing in the presence of exceptions and non-retriable exceptions are not retries. 

