### PR TITLE
Only warn if OAuth2 server URI is not set

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Manager.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Manager.java
@@ -70,7 +70,7 @@ public class OAuth2Manager extends RefreshingAuthManager {
 
   @Override
   public OAuth2Util.AuthSession initSession(RESTClient initClient, Map<String, String> properties) {
-    warnIfDeprecatedTokenEndpointUsed(properties);
+    warnIfOAuthServerUriNotSet(properties);
     AuthConfig config =
         ImmutableAuthConfig.builder()
             .from(AuthConfig.fromProperties(properties))
@@ -272,7 +272,7 @@ public class OAuth2Manager extends RefreshingAuthManager {
         refreshClient, refreshExecutor(), response, System.currentTimeMillis(), parent);
   }
 
-  private static void warnIfDeprecatedTokenEndpointUsed(Map<String, String> properties) {
+  private static void warnIfOAuthServerUriNotSet(Map<String, String> properties) {
     if (!properties.containsKey(OAuth2Properties.OAUTH2_SERVER_URI)) {
       String credential = properties.get(OAuth2Properties.CREDENTIAL);
       String initToken = properties.get(OAuth2Properties.TOKEN);


### PR DESCRIPTION
Closes #13732 

```
WARN OAuth2Manager: Iceberg REST client is missing the OAuth2 server URI configuration and defaults ... 
This warning will disappear if the OAuth2 endpoint is explicitly configured. See https://github.com/apache/iceberg/issues/10537
```
Above warning was shown for 2 scenarios. Updated behavior:
- Warn if OAuth2Properties.OAUTH2_SERVER_URI is not set.
- ~Also warn if OAuth2Properties.OAUTH2_SERVER_URI is set but ends with [v1/oauth/tokens](https://github.com/apache/iceberg/blob/4ae61621c1b5e7f245961b3de48d6d8a3856d012/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java#L57-L59)~

