### PR TITLE
API: Add expression factory methods for timestamp literals.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -329,6 +329,36 @@ public class Expressions {
     return Literals.from(value);
   }
 
+  /**
+   * Create a {@link Literal} from a microsecond value.
+   *
+   * @param micros a timestamp in microseconds from the unix epoch
+   * @return a literal representing the timestamp
+   */
+  public static Literal<Long> micros(long micros) {
+    return new Literals.TimestampLiteral(micros);
+  }
+
+  /**
+   * Create a {@link Literal} from a millisecond value.
+   *
+   * @param millis a timestamp in milliseconds from the unix epoch
+   * @return a literal representing the timestamp
+   */
+  public static Literal<Long> millis(long millis) {
+    return new Literals.TimestampLiteral(millis * 1000);
+  }
+
+  /**
+   * Create a {@link Literal} from a nanosecond value.
+   *
+   * @param nanos a timestamp in nanoseconds from the unix epoch
+   * @return a literal representing the timestamp
+   */
+  public static Literal<Long> nanos(long nanos) {
+    return new Literals.TimestampNanoLiteral(nanos);
+  }
+
   public static <T> UnboundAggregate<T> count(String name) {
     return new UnboundAggregate<>(Operation.COUNT, ref(name));
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -60,7 +60,9 @@ class Literals {
     Preconditions.checkNotNull(value, "Cannot create expression literal from null");
     Preconditions.checkArgument(!NaNUtil.isNaN(value), "Cannot create expression literal from NaN");
 
-    if (value instanceof Boolean) {
+    if (value instanceof Literal) {
+      return (Literal<T>) value;
+    } else if (value instanceof Boolean) {
       return (Literal<T>) new Literals.BooleanLiteral((Boolean) value);
     } else if (value instanceof Integer) {
       return (Literal<T>) new Literals.IntegerLiteral((Integer) value);

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -58,6 +58,30 @@ public class TestExpressionHelpers {
   private final UnboundPredicate<?> pred = lessThan("x", 7);
 
   @Test
+  public void testMillisLiteral() {
+    long now = System.currentTimeMillis();
+    Literal<Long> millis = Expressions.millis(now);
+    assertThat(millis.value()).isEqualTo(now * 1000L);
+    assertThat(millis.to(Types.TimestampNanoType.withZone()).value()).isEqualTo(now * 1_000_000L);
+  }
+
+  @Test
+  public void testMicrosLiteal() {
+    long ts = 1510842668000000L;
+    Literal<Long> micros = Expressions.micros(ts);
+    assertThat(micros.value()).isEqualTo(ts);
+    assertThat(micros.to(Types.TimestampNanoType.withZone()).value()).isEqualTo(ts * 1000L);
+  }
+
+  @Test
+  public void testNanosLiteral() {
+    long ts = 1510842668000000001L;
+    Literal<Long> nanos = Expressions.nanos(ts);
+    assertThat(nanos.value()).isEqualTo(ts);
+    assertThat(nanos.to(Types.TimestampType.withoutZone()).value()).isEqualTo(1510842668000000L);
+  }
+
+  @Test
   public void testSimplifyOr() {
     assertThat(or(alwaysTrue(), pred))
         .as("alwaysTrue or pred => alwaysTrue")


### PR DESCRIPTION
This adds factory methods to Expressions that create timestamp literals. This enables creating predicates with the right timestamp precision:

```java
Expressions.equals("ts", nanos(1754434662952357612L));
Expressions.in("ts", nanos(1754434662952357612L), micros(1754434662952357L));
```

This addresses the concerns from #11775.