### PR TITLE
AWS, Aliyun: Fix memory leak by removing deleteOnExit() calls

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSOutputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSOutputStream.java
@@ -73,7 +73,6 @@ public class OSSOutputStream extends PositionOutputStream {
   private static File newStagingFile(String ossStagingDirectory) {
     try {
       File stagingFile = File.createTempFile("oss-file-io-", ".tmp", new File(ossStagingDirectory));
-      stagingFile.deleteOnExit();
       return stagingFile;
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -218,7 +218,6 @@ class S3OutputStream extends PositionOutputStream {
 
     createStagingDirectoryIfNotExists();
     currentStagingFile = File.createTempFile("s3fileio-", ".tmp", stagingDirectory);
-    currentStagingFile.deleteOnExit();
     try {
       currentPartMessageDigest =
           isChecksumEnabled ? MessageDigest.getInstance(digestAlgorithm) : null;


### PR DESCRIPTION
- fix #13738

Remove unnecessary `File.deleteOnExit()` calls from `S3OutputStream` and `OSSOutputStream` that were causing memory leaks in long-running servers. These calls registered files in the global `DeleteOnExitHook` set which never gets cleared during normal operation, leading to unbounded heap growth. The explicit cleanup logic already handles temporary file deletion properly.
