### PR TITLE
Revert "Coerce UUID to String in `readable-metrics` (#13087)"

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -174,29 +174,21 @@ public class MetricsUtil {
               "Lower bound",
               DataFile.LOWER_BOUNDS,
               Types.NestedField::type,
-              (file, field) -> {
-                if (file.lowerBounds() == null) {
-                  return null;
-                }
-                Object value =
-                    Conversions.fromByteBuffer(
-                        field.type(), file.lowerBounds().get(field.fieldId()));
-                return (value instanceof java.util.UUID) ? value.toString() : value;
-              }),
+              (file, field) ->
+                  file.lowerBounds() == null
+                      ? null
+                      : Conversions.fromByteBuffer(
+                          field.type(), file.lowerBounds().get(field.fieldId()))),
           new ReadableMetricColDefinition(
               "upper_bound",
               "Upper bound",
               DataFile.UPPER_BOUNDS,
               Types.NestedField::type,
-              (file, field) -> {
-                if (file.upperBounds() == null) {
-                  return null;
-                }
-                Object value =
-                    Conversions.fromByteBuffer(
-                        field.type(), file.upperBounds().get(field.fieldId()));
-                return (value instanceof java.util.UUID) ? value.toString() : value;
-              }));
+              (file, field) ->
+                  file.upperBounds() == null
+                      ? null
+                      : Conversions.fromByteBuffer(
+                          field.type(), file.upperBounds().get(field.fieldId()))));
 
   public static final String READABLE_METRICS = "readable_metrics";
 


### PR DESCRIPTION
This reverts commit 7fefc46e95040e96f199d1c8e4d025047ac1bbc6 which caused downstream issues in Trino, see https://github.com/apache/iceberg/pull/13087