### PR TITLE
OpenAPI: Correct type annotation in TableMetadat#encryption-keys field

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2554,7 +2554,7 @@ components:
           type: integer
         # encryption
         encryption-keys:
-          type: list
+          type: array
           items:
             $ref: '#/components/schemas/EncryptedKey'
         # snapshot tracking


### PR DESCRIPTION
The `TableMetadata#encryption-keys` field from the REST spec seems to be accidentally setting the type to `list`, rather than an `array`. As far as I can tell, swagger only supports an [`array` type](https://swagger.io/docs/specification/v3_0/data-models/data-types/). 

This was causing code generator issues when generating code for a `jaxrs-spec` generator, until I manually corrected the YAML to an `array` type. Every other array-like field is properly set to `array`.

The swagger [online documentation](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/apache/iceberg/main/open-api/rest-catalog-open-api.yaml) seems to be properly converting this to an array. Did `list` used to be a synonym for `array` in older swagger versions? Didn't dig hard on this one.

<img width="493" height="176" alt="Screenshot 2025-08-07 at 12 01 58 PM" src="https://github.com/user-attachments/assets/0091535a-b3d2-445d-9abb-b57f02fa4ee7" />
