### PR TITLE
Replace `assertThrows` with `assertThatThrownBy` for better readability.

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -93,6 +93,10 @@
         <property name="message" value="assertThatThrownBy() should be statically imported from org.assertj.core.api.Assertions"/>
     </module>
     <module name="RegexpMultiline">
+        <property name="format" value="^\s*import\s+static\s+(?!\Qorg.junit.jupiter.api.Assertions.\E).*\.*;"/>
+        <property name="message" value="Avoid static imports of JUnit 5 assertions. Use methods from org.assertj.core.api.Assertions instead."/>
+    </module>
+    <module name="RegexpMultiline">
         <property name="id" value="AssertThatThrownByWithMessageCheck"/>
         <property name="fileExtensions" value="java"/>
         <property name="matchAcrossLines" value="true"/>

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -93,8 +93,8 @@
         <property name="message" value="assertThatThrownBy() should be statically imported from org.assertj.core.api.Assertions"/>
     </module>
     <module name="RegexpMultiline">
-        <property name="format" value="^\s*import\s+static\s+(?!\Qorg.junit.jupiter.api.Assertions.\E).*\.*;"/>
-        <property name="message" value="Avoid static imports of JUnit 5 assertions. Use methods from org.assertj.core.api.Assertions instead."/>
+        <property name="format" value="^\s*import\s+static\s+org\.junit\.jupiter\.api\.Assertions\.\w+;"/>
+        <property name="message" value="Static import of JUnit 5 assertions (org.junit.jupiter.api.Assertions) is prohibited. Use org.assertj.core.api.Assertions methods instead (e.g., import static org.assertj.core.api.Assertions.assertThat)."/>
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="AssertThatThrownByWithMessageCheck"/>

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -94,7 +94,7 @@
     </module>
     <module name="RegexpMultiline">
         <property name="format" value="^\s*import\s+static\s+org\.junit\.jupiter\.api\.Assertions\.\w+;"/>
-        <property name="message" value="Static import of JUnit 5 assertions (org.junit.jupiter.api.Assertions) is prohibited. Use org.assertj.core.api.Assertions methods instead (e.g., import static org.assertj.core.api.Assertions.assertThat)."/>
+        <property name="message" value="Prefer using org.assertj.core.api.Assertions instead."/>
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="AssertThatThrownByWithMessageCheck"/>

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import org.apache.flink.table.data.DecimalData;
@@ -81,9 +81,9 @@ class TestRowDataConverter {
             Types.NestedField.optional(1, "id", Types.IntegerType.get()),
             required(2, "data", Types.StringType.get()));
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> convert(GenericRowData.of(42), currentSchema, targetSchema));
+    assertThatThrownBy(() -> convert(GenericRowData.of(42), currentSchema, targetSchema))
+        .isInstanceOf(IllegalArgumentException.class);
+        .hasMessageContaining("is non-nullable but does not exist in source schema");
   }
 
   @Test
@@ -207,7 +207,9 @@ class TestRowDataConverter {
                     required(103, "required", Types.StringType.get()),
                     required(102, "name", Types.StringType.get()))));
 
-    assertThrows(IllegalArgumentException.class, () -> convert(oldData, oldSchema, newSchema));
+    assertThatThrownBy(() -> convert(oldData, oldSchema, newSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is non-nullable but does not exist in source schema");
   }
 
   @Test

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
@@ -82,7 +82,7 @@ class TestRowDataConverter {
             required(2, "data", Types.StringType.get()));
 
     assertThatThrownBy(() -> convert(GenericRowData.of(42), currentSchema, targetSchema))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("is non-nullable but does not exist in source schema");
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import org.apache.flink.table.data.DecimalData;
@@ -81,9 +81,9 @@ class TestRowDataConverter {
             Types.NestedField.optional(1, "id", Types.IntegerType.get()),
             required(2, "data", Types.StringType.get()));
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> convert(GenericRowData.of(42), currentSchema, targetSchema));
+    assertThatThrownBy(() -> convert(GenericRowData.of(42), currentSchema, targetSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is non-nullable but does not exist in source schema");
   }
 
   @Test
@@ -207,7 +207,9 @@ class TestRowDataConverter {
                     required(103, "required", Types.StringType.get()),
                     required(102, "name", Types.StringType.get()))));
 
-    assertThrows(IllegalArgumentException.class, () -> convert(oldData, oldSchema, newSchema));
+    assertThatThrownBy(() -> convert(oldData, oldSchema, newSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is non-nullable but does not exist in source schema");
   }
 
   @Test

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestRowDataConverter.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import org.apache.flink.table.data.DecimalData;
@@ -81,9 +81,9 @@ class TestRowDataConverter {
             Types.NestedField.optional(1, "id", Types.IntegerType.get()),
             required(2, "data", Types.StringType.get()));
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> convert(GenericRowData.of(42), currentSchema, targetSchema));
+    assertThatThrownBy(() -> convert(GenericRowData.of(42), currentSchema, targetSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is non-nullable but does not exist in source schema");
   }
 
   @Test
@@ -207,7 +207,9 @@ class TestRowDataConverter {
                     required(103, "required", Types.StringType.get()),
                     required(102, "name", Types.StringType.get()))));
 
-    assertThrows(IllegalArgumentException.class, () -> convert(oldData, oldSchema, newSchema));
+    assertThatThrownBy(() -> convert(oldData, oldSchema, newSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("is non-nullable but does not exist in source schema");
   }
 
   @Test


### PR DESCRIPTION
While reviewing the Flink code in the Iceberg project, I noticed the use of JUnit 5's assertThrows. Since the Iceberg project uses AssertJ for unit tests consistently, I have replaced this with AssertJ's assertThatThrownBy to maintain consistency.