### PR TITLE
Docs: Add Memiiso Debezium to third party integrations

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
       - Daft: daft.md
       - Databend: https://docs.databend.com/guides/access-data-lake/iceberg
+      - Debezium: https://memiiso.github.io/debezium-server-iceberg/
       - Dremio: https://docs.dremio.com/data-formats/apache-iceberg/
       - DuckDB: https://duckdb.org/docs/preview/core_extensions/iceberg/overview
       - Estuary: https://docs.estuary.dev/reference/Connectors/materialization-connectors/apache-iceberg/

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,13 +72,13 @@ nav:
       - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
       - Daft: daft.md
       - Databend: https://docs.databend.com/guides/access-data-lake/iceberg
-      - Memiiso Debezium: https://memiiso.github.io/debezium-server-iceberg/
       - Dremio: https://docs.dremio.com/data-formats/apache-iceberg/
       - DuckDB: https://duckdb.org/docs/preview/core_extensions/iceberg/overview
       - Estuary: https://docs.estuary.dev/reference/Connectors/materialization-connectors/apache-iceberg/
       - Firebolt: https://docs.firebolt.io/reference-sql/functions-reference/table-valued/read_iceberg
       - Google BigQuery: https://cloud.google.com/bigquery/docs/iceberg-tables
       - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
+      - Memiiso Debezium: https://memiiso.github.io/debezium-server-iceberg/
       - Presto: https://prestodb.io/docs/current/connector/iceberg.html
       - Redpanda: https://docs.redpanda.com/current/manage/iceberg/about-iceberg-topics
       - RisingWave: risingwave.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,7 +72,7 @@ nav:
       - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
       - Daft: daft.md
       - Databend: https://docs.databend.com/guides/access-data-lake/iceberg
-      - Debezium: https://memiiso.github.io/debezium-server-iceberg/
+      - Memiiso Debezium: https://memiiso.github.io/debezium-server-iceberg/
       - Dremio: https://docs.dremio.com/data-formats/apache-iceberg/
       - DuckDB: https://duckdb.org/docs/preview/core_extensions/iceberg/overview
       - Estuary: https://docs.estuary.dev/reference/Connectors/materialization-connectors/apache-iceberg/


### PR DESCRIPTION
Adding "Memiiso Debezium Iceberg Consumer" project to third party integrations
link: https://memiiso.github.io/debezium-server-iceberg/

There are end user use-cases but the project is not widely known by end users. This could help to get more visibility and reach to correct users. 

The project is not official Debezium repository, however its  known by the debezium project team. I know it might not be ideal(since the project is not official debezoim.io) but opening PR in case its acceptable.

