### PR TITLE
site: reorganize navbar so that "community" is top level

### DIFF
--- a/site/nav.yml
+++ b/site/nav.yml
@@ -48,11 +48,7 @@ nav:
       - Go: https://go.iceberg.apache.org/
       - C++: https://github.com/apache/iceberg-cpp/
   - Releases: releases.md
-  - Blogs: blogs.md
-  - Talks: talks.md
-  - Vendors: vendors.md
   - Project:
-    - Community: community.md
     - Contributing: contribute.md
     - Multi-engine support: multi-engine-support.md
     - How to release: how-to-release.md
@@ -63,6 +59,12 @@ nav:
       - License: https://www.apache.org/licenses/
       - Security: https://www.apache.org/security/
       - Sponsors: https://www.apache.org/foundation/sponsors.html
+  - Community:
+    - Community: community.md
+    - Community Content: 
+      - Blogs: blogs.md
+      - Talks: talks.md
+    - Vendors: vendors.md
   - Specification:
     - Terms: terms.md
     - REST Catalog Spec: rest-catalog-spec.md


### PR DESCRIPTION
Closes #13261

Preview:
<img width="1347" height="495" alt="Screenshot 2025-08-09 at 10 49 55 AM" src="https://github.com/user-attachments/assets/2615b22e-3ce9-4212-83d5-ac44ad9356c8" />
