### PR TITLE
Parquet: Fix incorrect JavaDoc parameter descriptions in TripleWriter

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/TripleWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TripleWriter.java
@@ -45,7 +45,7 @@ public interface TripleWriter<T> {
    * Write a triple.
    *
    * @param rl repetition level
-   * @param value the boolean value
+   * @param value the integer value
    */
   default void writeInteger(int rl, int value) {
     throw new UnsupportedOperationException("Not an integer column");
@@ -55,7 +55,7 @@ public interface TripleWriter<T> {
    * Write a triple.
    *
    * @param rl repetition level
-   * @param value the boolean value
+   * @param value the long value
    */
   default void writeLong(int rl, long value) {
     throw new UnsupportedOperationException("Not an long column");
@@ -65,7 +65,7 @@ public interface TripleWriter<T> {
    * Write a triple.
    *
    * @param rl repetition level
-   * @param value the boolean value
+   * @param value the float value
    */
   default void writeFloat(int rl, float value) {
     throw new UnsupportedOperationException("Not an float column");
@@ -75,7 +75,7 @@ public interface TripleWriter<T> {
    * Write a triple.
    *
    * @param rl repetition level
-   * @param value the boolean value
+   * @param value the double value
    */
   default void writeDouble(int rl, double value) {
     throw new UnsupportedOperationException("Not an double column");
@@ -85,7 +85,7 @@ public interface TripleWriter<T> {
    * Write a triple.
    *
    * @param rl repetition level
-   * @param value the boolean value
+   * @param value the binary value
    */
   default void writeBinary(int rl, Binary value) {
     throw new UnsupportedOperationException("Not an binary column");


### PR DESCRIPTION

  ### Description

  This PR fixes incorrect JavaDoc `@param` descriptions in the
  `TripleWriter` interface that have been present since the initial
  commit in 2018.

  The issue was caused by copy-paste errors where all type-specific
  write methods incorrectly described their `value` parameter as "the
   boolean value", which was only correct for the `writeBoolean()`
  method. This inconsistency could confuse developers implementing or
   using the `TripleWriter` interface.

  ### Background

  The `TripleWriter` interface is used internally in Parquet column
  writers to handle different data types. Each write method accepts a
   repetition level and a value of a specific type, but the JavaDoc
  incorrectly described all values as boolean.

  ### Changes

  Fixed JavaDoc `@param` descriptions for the following methods in `p
  arquet/src/main/java/org/apache/iceberg/parquet/TripleWriter.java`:

  - `writeInteger(int rl, int value)` - changed from "the boolean
  value" to "the integer value"
  - `writeLong(int rl, long value)` - changed from "the boolean
  value" to "the long value"
  - `writeFloat(int rl, float value)` - changed from "the boolean
  value" to "the float value"
  - `writeDouble(int rl, double value)` - changed from "the boolean
  value" to "the double value"
  - `writeBinary(int rl, Binary value)` - changed from "the boolean
  value" to "the binary value"

  ### Tests

  This is a documentation-only change with no functional impact. No
  new tests are required as the code behavior remains unchanged.

  ### Notes

  - This is my first contribution to Apache Iceberg
  - The issue has been present since commit d972f45d93 (June 2018)
  - All changes follow the existing JavaDoc style and conventions in
  the codebase