### PR TITLE
Docs: remove redundant build directive from spark-iceberg service in quickstart docker-compose.yml

### DIFF
--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -41,7 +41,6 @@ services:
   spark-iceberg:
     image: tabulario/spark-iceberg
     container_name: spark-iceberg
-    build: spark/
     networks:
       iceberg_net:
     depends_on:


### PR DESCRIPTION
when I following the quickstart guide and running `docker-compse up`, I encountered the following error:
```
ERROR: build path /path/to/iceberg/spark either does not exist, is not accessible, or is not a valid URL.
```
To work around this, I manually create the `spark` directory and run `docker-compse up` again. However, this resulted in another error: 
```
Building spark-iceberg
[+] Building 0.1s (1/2)                                                                                                                                                                                               
 => [internal] load build definition from Dockerfile                                                                                                                                                             0.0s
 => => transferring dockerfile: 2B                                                                                                                                                                               0.0s
failed to solve with frontend dockerfile.v0: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount457218145/Dockerfile: no such file or directory
ERROR: Service 'spark-iceberg' failed to build : Build failed
```
After removing the `build` directive from the `spark-iceberg` service in docker-compose.yml, the container started successfully.
This PR removes the redundant `build` directive to prevent the above errors and allow the quickstart to work out of the box.