### PR TITLE
Translate truncate(col) == value to startsWith(value)

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -143,7 +143,7 @@ public class ExpressionVisitors {
 
     @Override
     public <T> R predicate(BoundPredicate<T> pred) {
-      if (!(pred.term() instanceof BoundReference)) {
+      if (!(pred.term() instanceof BoundReference || (pred.term().ref() != null))) {
         return handleNonReference(pred.term());
       }
 
@@ -163,7 +163,11 @@ public class ExpressionVisitors {
           case NOT_EQ:
             return notEq((BoundReference<T>) pred.term(), literalPred.literal());
           case STARTS_WITH:
-            return startsWith((BoundReference<T>) pred.term(), literalPred.literal());
+            if (pred.term().ref() != null) {
+              return startsWith((BoundReference<T>) pred.term().ref(), literalPred.literal());
+            } else {
+              return startsWith((BoundReference<T>) pred.term(), literalPred.literal());
+            }
           case NOT_STARTS_WITH:
             return notStartsWith((BoundReference<T>) pred.term(), literalPred.literal());
           default:

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -199,7 +199,9 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
       }
     }
 
-    // TODO: translate truncate(col) == value to startsWith(value)
+    if (op() == Operation.EQ && boundTerm instanceof BoundTransform) {
+      return new BoundLiteralPredicate<>(Operation.STARTS_WITH, boundTerm, lit);
+    }
     return new BoundLiteralPredicate<>(op(), boundTerm, lit);
   }
 


### PR DESCRIPTION
Fixes #13802 

equal(truncate(col,width), "value") would be translated as startsWith("value").