### PR TITLE
Docs: fix typo in JdbcLockFactory Javadoc

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -76,7 +76,7 @@ public class JdbcLockFactory implements TriggerLockFactory {
    * same uri.
    *
    * @param uri of the jdbc connection
-   * @param lockId which should indentify the job and the table
+   * @param lockId which should identify the job and the table
    * @param properties used for creating the jdbc connection pool
    */
   public JdbcLockFactory(String uri, String lockId, Map<String, String> properties) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -76,7 +76,7 @@ public class JdbcLockFactory implements TriggerLockFactory {
    * same uri.
    *
    * @param uri of the jdbc connection
-   * @param lockId which should indentify the job and the table
+   * @param lockId which should identify the job and the table
    * @param properties used for creating the jdbc connection pool
    */
   public JdbcLockFactory(String uri, String lockId, Map<String, String> properties) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -76,7 +76,7 @@ public class JdbcLockFactory implements TriggerLockFactory {
    * same uri.
    *
    * @param uri of the jdbc connection
-   * @param lockId which should indentify the job and the table
+   * @param lockId which should identify the job and the table
    * @param properties used for creating the jdbc connection pool
    */
   public JdbcLockFactory(String uri, String lockId, Map<String, String> properties) {


### PR DESCRIPTION
Docs: fix typo in JdbcLockFactory Javadoc.