### PR TITLE
Docs: Update testing guidelines to reflect full JUnit 5 migration and AssertJ usage.

### DIFF
--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -566,6 +566,7 @@ Please refer to the [usage guide](https://github.com/awaitility/awaitility/wiki/
 
 ### JUnit 5 / AssertJ
 
+
 Iceberg has now fully migrated to JUnit 5 (org.junit.jupiter.api imports) for all tests. Any new test classes should be written using JUnit 5, 
 and assertions should follow the AssertJ style to ensure consistency and readability.
 


### PR DESCRIPTION
### Summary
Iceberg has now fully migrated to JUnit 5 (`org.junit.jupiter.api` imports) for all tests. This PR updates the testing guidelines to:
- Specify that any new test classes should be written using JUnit 5 only.
- Require assertions to follow the AssertJ style for consistency and readability.