### PR TITLE
Spark: Support Trigger AvailableNow in SS

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -64,11 +64,11 @@ import org.apache.spark.sql.connector.read.streaming.Offset;
 import org.apache.spark.sql.connector.read.streaming.ReadLimit;
 import org.apache.spark.sql.connector.read.streaming.ReadMaxFiles;
 import org.apache.spark.sql.connector.read.streaming.ReadMaxRows;
-import org.apache.spark.sql.connector.read.streaming.SupportsAdmissionControl;
+import org.apache.spark.sql.connector.read.streaming.SupportsTriggerAvailableNow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SparkMicroBatchStream implements MicroBatchStream, SupportsAdmissionControl {
+public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerAvailableNow {
   private static final Joiner SLASH = Joiner.on("/");
   private static final Logger LOG = LoggerFactory.getLogger(SparkMicroBatchStream.class);
   private static final Types.StructType EMPTY_GROUPING_KEY_TYPE = Types.StructType.of();
@@ -521,6 +521,11 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsAdmissio
     } else {
       return ReadLimit.allAvailable();
     }
+  }
+
+  @Override
+  public void prepareForTriggerAvailableNow() {
+    LOG.info("The streaming query reports to use Trigger.AvailableNow");
   }
 
   private static class InitialOffsetStore {


### PR DESCRIPTION
Addresses #13823 

## About the change
Changing SparkMicroBatchStream to implement SupportsTriggerAvailableNow instead of SupportsAdmissionControl, so MultiBatchExecution can use the configured `streaming-max-files-per-micro-batch` or `streaming-max-rows-per-micro-batch` instead of ignoring and overriding to `ReadLimit.AllAvailable`.

## Testing
Added Rate Limit UTs using AvailableNow trigger and tests asserting self-termination & no reprocessing of data