### PR TITLE
ADLSFileIO: support access token authentication via the new `adls.token` property

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
@@ -61,6 +61,7 @@ public class AzureProperties implements Serializable {
   private Long adlsWriteBlockSize;
   private String adlsRefreshCredentialsEndpoint;
   private boolean adlsRefreshCredentialsEnabled;
+  private String token;
   private Map<String, String> allProperties;
 
   public AzureProperties() {}


### PR DESCRIPTION
Closes #13818

This PR adds support for passing Microsoft Entra access token to `ADLSFileIO` using the new `ADLS_TOKEN` property. 

The [TokenCredential](https://learn.microsoft.com/en-us/java/api/com.azure.core.credential.tokencredential?view=azure-java-stable) is then used to configure the [DataLakeFileSystemClientBuilder](https://learn.microsoft.com/en-us/java/api/com.azure.storage.file.datalake.datalakefilesystemclientbuilder?view=azure-java-stable#com-azure-storage-file-datalake-datalakefilesystemclientbuilder-credential(com-azure-core-credential-tokencredential)).

See a [similar implementation in apache doris](https://github.com/apache/doris/blob/a6343d75527758434e0c37026c8948b83cfcdc7e/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/AzureRemote.java#L238-L254)

The token expiration is set for 1 hour for now, which is the [default lifetime of an access token](https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens?utm_source=chatgpt.com#token-lifetime). We can make this configurable in the future. 