### PR TITLE
Flink: Fix hash code comparison for requesting global statistics in DataStatisticsCoordinator

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -279,7 +279,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
           () -> {
             if (event.signature() != null && event.signature() == globalStatistics.hashCode()) {
               LOG.debug(
-                  "Skip responding to statistics request from subtask {}, as hashCode matches or not included in the request",
+                  "Skip responding to statistics request from subtask {}, as the operator task already holds the same global statistics",
                   subtask);
             } else {
               LOG.info(

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsCoordinator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsCoordinator.java
@@ -309,12 +309,14 @@ public class TestDataStatisticsCoordinator {
           .atMost(Duration.ofSeconds(10))
           .until(() -> receivingTasks.getSentEventsForSubtask(0).size() == 2);
 
-      //  signature is right
+      // Simulate the scenario where a subtask send global statistics request with the same hash
+      // code. The coordinator would skip the response after comparing the request contained hash
+      // code with latest global statistics hash code.
       int correctSignature = dataStatisticsCoordinator.globalStatistics().hashCode();
       dataStatisticsCoordinator.handleEventFromOperator(
           0, 0, new RequestGlobalStatisticsEvent(correctSignature));
 
-      Thread.sleep(200);
+      waitForCoordinatorToProcessActions(dataStatisticsCoordinator);
       // Checkpoint StatisticEvent + RequestGlobalStatisticsEvent
       assertThat(receivingTasks.getSentEventsForSubtask(0).size()).isEqualTo(2);
 


### PR DESCRIPTION
In `DataStatisticsCoordinator`, when handling the `RequestGlobalStatisticsEvent`, the coordinator should skip responding to the subtask if the event's signature matches the `hashCode` of the current `globalStatistics`.

The current implementation is incorrect—this PR fixes that behavior.