### PR TITLE
ADLSFileIO: support service principal authentication

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
@@ -61,6 +61,7 @@ public class AzureProperties implements Serializable {
   private Long adlsWriteBlockSize;
   private String adlsRefreshCredentialsEndpoint;
   private boolean adlsRefreshCredentialsEnabled;
+  private String token;
   private Map<String, String> allProperties;
 
   public AzureProperties() {}


### PR DESCRIPTION
Closes #13819

Add `adls.tenant-id`, `adls.client-id`, and `adls.client-secret` as configuration properties for ADLSFileIO. 
These are passed to the `DataLakeFileSystemClient` builder using ClientSecretCredential from the Azure Identity SDK:
```
TokenCredential credential = new ClientSecretCredentialBuilder()
    .tenantId(conf.get("adls.tenant-id"))
    .clientId(conf.get("adls.client-id"))
    .clientSecret(conf.get("adls.client-secret"))
    .build();
```
This credential would then be passed into the DataLakeFileSystemClientBuilder instead of DefaultAzureCredential.

This PR needs to rebase #13825



