### PR TITLE
Flink: Improve ConfigOption Descriptions for Flink Table Maintenance Configs.

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
@@ -37,7 +37,8 @@ public class FlinkMaintenanceConfig {
           .longType()
           .defaultValue(TableMaintenance.LOCK_CHECK_DELAY_SECOND_DEFAULT)
           .withDescription(
-              "The delay time (in seconds) between each lock check during the rewrite operation.");
+              "The delay time (in seconds) between each lock check during maintenance operations such as "
+                  + "rewriting data files, manifest files, expiring snapshots, and deleting orphan files.");
 
   public static final String PARALLELISM = PREFIX + "parallelism";
   public static final ConfigOption<Integer> PARALLELISM_OPTION =

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
@@ -31,27 +31,50 @@ public class FlinkMaintenanceConfig {
 
   public static final String PREFIX = "flink-maintenance.";
 
+  // Configuration for lock check delay (in seconds)
+  // This setting controls the delay between each lock check during the rewrite operation
   public static final String LOCK_CHECK_DELAY = PREFIX + "lock-check-delay-seconds";
   public static final ConfigOption<Long> LOCK_CHECK_DELAY_OPTION =
       ConfigOptions.key(LOCK_CHECK_DELAY)
           .longType()
-          .defaultValue(TableMaintenance.LOCK_CHECK_DELAY_SECOND_DEFAULT);
+          .defaultValue(TableMaintenance.LOCK_CHECK_DELAY_SECOND_DEFAULT)
+          .withDescription(
+              "The delay time (in seconds) between each lock check during the rewrite operation.");
 
+  // Configuration for parallelism
+  // This setting controls the parallelism level for the maintenance tasks,
+  // determining how many tasks can run concurrently
   public static final String PARALLELISM = PREFIX + "parallelism";
   public static final ConfigOption<Integer> PARALLELISM_OPTION =
-      ConfigOptions.key(PARALLELISM).intType().defaultValue(ExecutionConfig.PARALLELISM_DEFAULT);
+      ConfigOptions.key(PARALLELISM)
+          .intType()
+          .defaultValue(ExecutionConfig.PARALLELISM_DEFAULT)
+          .withDescription(
+              "The parallelism level for the maintenance task. "
+                  + "Determines how many tasks can run concurrently.");
 
+  // Configuration for rate limit (in seconds)
+  // This setting controls the rate at which maintenance operations can occur,
+  // limiting the number of operations per second
   public static final String RATE_LIMIT = PREFIX + "rate-limit-seconds";
   public static final ConfigOption<Long> RATE_LIMIT_OPTION =
       ConfigOptions.key(RATE_LIMIT)
           .longType()
-          .defaultValue(TableMaintenance.RATE_LIMIT_SECOND_DEFAULT);
+          .defaultValue(TableMaintenance.RATE_LIMIT_SECOND_DEFAULT)
+          .withDescription(
+              "The rate limit (in seconds) for maintenance operations. "
+                  + "This controls how many operations can be performed per second.");
 
+  // Configuration for slot sharing group
+  // This setting determines which operators in Flink can share the same slots
   public static final String SLOT_SHARING_GROUP = PREFIX + "slot-sharing-group";
   public static final ConfigOption<String> SLOT_SHARING_GROUP_OPTION =
       ConfigOptions.key(SLOT_SHARING_GROUP)
           .stringType()
-          .defaultValue(StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP);
+          .defaultValue(StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP)
+          .withDescription(
+              "The slot sharing group for maintenance tasks. "
+                  + "Determines which operators can share slots in the Flink execution environment.");
 
   private final FlinkConfParser confParser;
   private final Table table;
@@ -66,6 +89,11 @@ public class FlinkMaintenanceConfig {
     this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
   }
 
+  /**
+   * Gets the rate limit value (in seconds) for maintenance operations.
+   *
+   * @return The rate limit for maintenance operations
+   */
   public long rateLimit() {
     return confParser
         .longConf()
@@ -75,6 +103,11 @@ public class FlinkMaintenanceConfig {
         .parse();
   }
 
+  /**
+   * Gets the parallelism value for maintenance tasks.
+   *
+   * @return The parallelism for maintenance tasks
+   */
   public int parallelism() {
     return confParser
         .intConf()
@@ -84,6 +117,11 @@ public class FlinkMaintenanceConfig {
         .parse();
   }
 
+  /**
+   * Gets the lock check delay value (in seconds).
+   *
+   * @return The lock check delay time (in seconds)
+   */
   public long lockCheckDelay() {
     return confParser
         .longConf()
@@ -93,6 +131,11 @@ public class FlinkMaintenanceConfig {
         .parse();
   }
 
+  /**
+   * Gets the slot sharing group value for maintenance tasks.
+   *
+   * @return The slot sharing group for maintenance tasks
+   */
   public String slotSharingGroup() {
     return confParser
         .stringConf()

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
@@ -31,8 +31,6 @@ public class FlinkMaintenanceConfig {
 
   public static final String PREFIX = "flink-maintenance.";
 
-  // Configuration for lock check delay (in seconds)
-  // This setting controls the delay between each lock check during the rewrite operation
   public static final String LOCK_CHECK_DELAY = PREFIX + "lock-check-delay-seconds";
   public static final ConfigOption<Long> LOCK_CHECK_DELAY_OPTION =
       ConfigOptions.key(LOCK_CHECK_DELAY)
@@ -41,21 +39,13 @@ public class FlinkMaintenanceConfig {
           .withDescription(
               "The delay time (in seconds) between each lock check during the rewrite operation.");
 
-  // Configuration for parallelism
-  // This setting controls the parallelism level for the maintenance tasks,
-  // determining how many tasks can run concurrently
   public static final String PARALLELISM = PREFIX + "parallelism";
   public static final ConfigOption<Integer> PARALLELISM_OPTION =
       ConfigOptions.key(PARALLELISM)
           .intType()
           .defaultValue(ExecutionConfig.PARALLELISM_DEFAULT)
-          .withDescription(
-              "The parallelism level for the maintenance task. "
-                  + "Determines how many tasks can run concurrently.");
+          .withDescription("The number of parallel tasks for the maintenance action.");
 
-  // Configuration for rate limit (in seconds)
-  // This setting controls the rate at which maintenance operations can occur,
-  // limiting the number of operations per second
   public static final String RATE_LIMIT = PREFIX + "rate-limit-seconds";
   public static final ConfigOption<Long> RATE_LIMIT_OPTION =
       ConfigOptions.key(RATE_LIMIT)
@@ -65,8 +55,6 @@ public class FlinkMaintenanceConfig {
               "The rate limit (in seconds) for maintenance operations. "
                   + "This controls how many operations can be performed per second.");
 
-  // Configuration for slot sharing group
-  // This setting determines which operators in Flink can share the same slots
   public static final String SLOT_SHARING_GROUP = PREFIX + "slot-sharing-group";
   public static final ConfigOption<String> SLOT_SHARING_GROUP_OPTION =
       ConfigOptions.key(SLOT_SHARING_GROUP)
@@ -91,8 +79,6 @@ public class FlinkMaintenanceConfig {
 
   /**
    * Gets the rate limit value (in seconds) for maintenance operations.
-   *
-   * @return The rate limit for maintenance operations
    */
   public long rateLimit() {
     return confParser
@@ -105,8 +91,6 @@ public class FlinkMaintenanceConfig {
 
   /**
    * Gets the parallelism value for maintenance tasks.
-   *
-   * @return The parallelism for maintenance tasks
    */
   public int parallelism() {
     return confParser
@@ -119,8 +103,6 @@ public class FlinkMaintenanceConfig {
 
   /**
    * Gets the lock check delay value (in seconds).
-   *
-   * @return The lock check delay time (in seconds)
    */
   public long lockCheckDelay() {
     return confParser
@@ -133,8 +115,6 @@ public class FlinkMaintenanceConfig {
 
   /**
    * Gets the slot sharing group value for maintenance tasks.
-   *
-   * @return The slot sharing group for maintenance tasks
    */
   public String slotSharingGroup() {
     return confParser

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
@@ -77,9 +77,7 @@ public class FlinkMaintenanceConfig {
     this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
   }
 
-  /**
-   * Gets the rate limit value (in seconds) for maintenance operations.
-   */
+  /** Gets the rate limit value (in seconds) for maintenance operations. */
   public long rateLimit() {
     return confParser
         .longConf()
@@ -89,9 +87,7 @@ public class FlinkMaintenanceConfig {
         .parse();
   }
 
-  /**
-   * Gets the parallelism value for maintenance tasks.
-   */
+  /** Gets the parallelism value for maintenance tasks. */
   public int parallelism() {
     return confParser
         .intConf()
@@ -101,9 +97,7 @@ public class FlinkMaintenanceConfig {
         .parse();
   }
 
-  /**
-   * Gets the lock check delay value (in seconds).
-   */
+  /** Gets the lock check delay value (in seconds). */
   public long lockCheckDelay() {
     return confParser
         .longConf()
@@ -113,9 +107,7 @@ public class FlinkMaintenanceConfig {
         .parse();
   }
 
-  /**
-   * Gets the slot sharing group value for maintenance tasks.
-   */
+  /** Gets the slot sharing group value for maintenance tasks. */
   public String slotSharingGroup() {
     return confParser
         .stringConf()

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/LockConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/LockConfig.java
@@ -32,42 +32,87 @@ public class LockConfig {
 
   public static final String PREFIX = FlinkMaintenanceConfig.PREFIX + "lock.";
 
+  // Configuration option for lock type
+  // Specifies the type of lock to use, e.g., jdbc or zookeeper
   public static final ConfigOption<String> LOCK_TYPE_OPTION =
-      ConfigOptions.key(PREFIX + "type").stringType().defaultValue(StringUtils.EMPTY);
+      ConfigOptions.key(PREFIX + "type")
+          .stringType()
+          .defaultValue(StringUtils.EMPTY)
+          .withDescription("The type of lock to use, e.g., jdbc or zookeeper.");
 
+  // Configuration option for lock ID
+  // Specifies the unique identifier for the lock
   public static final ConfigOption<String> LOCK_ID_OPTION =
-      ConfigOptions.key(PREFIX + "lock-id").stringType().defaultValue(StringUtils.EMPTY);
+      ConfigOptions.key(PREFIX + "lock-id")
+          .stringType()
+          .defaultValue(StringUtils.EMPTY)
+          .withDescription("The unique identifier for the lock.");
 
+  // Configuration options for JDBC-based locking
   public static class JdbcLockConfig {
 
     public static final String JDBC = "jdbc";
 
+    // JDBC URI configuration option
+    // Specifies the URI for the JDBC connection used for locking
     public static final ConfigOption<String> JDBC_URI_OPTION =
-        ConfigOptions.key(PREFIX + JDBC + ".uri").stringType().defaultValue(StringUtils.EMPTY);
+        ConfigOptions.key(PREFIX + JDBC + ".uri")
+            .stringType()
+            .defaultValue(StringUtils.EMPTY)
+            .withDescription("The URI of the JDBC connection for acquiring the lock.");
 
+    // Option to initialize the lock table in the JDBC database
     public static final ConfigOption<String> JDBC_INIT_LOCK_TABLE_OPTION =
         ConfigOptions.key(PREFIX + JDBC + ".init-lock-table")
             .stringType()
-            .defaultValue(Boolean.FALSE.toString());
+            .defaultValue(Boolean.FALSE.toString())
+            .withDescription("Whether to initialize the lock table in the JDBC database.");
   }
 
+  // Configuration options for Zookeeper-based locking
   public static class ZkLockConfig {
     public static final String ZK = "zookeeper";
 
+    // Zookeeper URI configuration option
+    // Specifies the URI of the Zookeeper service for acquiring the lock
     public static final ConfigOption<String> ZK_URI_OPTION =
-        ConfigOptions.key(PREFIX + ZK + ".uri").stringType().defaultValue(StringUtils.EMPTY);
+        ConfigOptions.key(PREFIX + ZK + ".uri")
+            .stringType()
+            .defaultValue(StringUtils.EMPTY)
+            .withDescription("The URI of the Zookeeper service for acquiring the lock.");
 
+    // Zookeeper session timeout in milliseconds
+    // Specifies the session timeout for the Zookeeper client
     public static final ConfigOption<Integer> ZK_SESSION_TIMEOUT_MS_OPTION =
-        ConfigOptions.key(PREFIX + ZK + ".session-timeout-ms").intType().defaultValue(60000);
+        ConfigOptions.key(PREFIX + ZK + ".session-timeout-ms")
+            .intType()
+            .defaultValue(60000)
+            .withDescription("The session timeout (in milliseconds) for the Zookeeper client.");
 
+    // Zookeeper connection timeout in milliseconds
+    // Specifies the connection timeout for the Zookeeper client
     public static final ConfigOption<Integer> ZK_CONNECTION_TIMEOUT_MS_OPTION =
-        ConfigOptions.key(PREFIX + ZK + ".connection-timeout-ms").intType().defaultValue(15000);
+        ConfigOptions.key(PREFIX + ZK + ".connection-timeout-ms")
+            .intType()
+            .defaultValue(15000)
+            .withDescription("The connection timeout (in milliseconds) for the Zookeeper client.");
 
+    // Zookeeper base sleep time in milliseconds
+    // Specifies the base sleep time between retries for the Zookeeper client
     public static final ConfigOption<Integer> ZK_BASE_SLEEP_MS_OPTION =
-        ConfigOptions.key(PREFIX + ZK + ".base-sleep-ms").intType().defaultValue(3000);
+        ConfigOptions.key(PREFIX + ZK + ".base-sleep-ms")
+            .intType()
+            .defaultValue(3000)
+            .withDescription(
+                "The base sleep time (in milliseconds) between retries for the Zookeeper client.");
 
+    // Zookeeper maximum retries
+    // Specifies the maximum number of retries for the Zookeeper client in case of failure
     public static final ConfigOption<Integer> ZK_MAX_RETRIES_OPTION =
-        ConfigOptions.key(PREFIX + ZK + ".max-retries").intType().defaultValue(3);
+        ConfigOptions.key(PREFIX + ZK + ".max-retries")
+            .intType()
+            .defaultValue(3)
+            .withDescription("The maximum number of retries for the Zookeeper client.");
   }
 
   private final FlinkConfParser confParser;
@@ -80,6 +125,11 @@ public class LockConfig {
     this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
   }
 
+  /**
+   * Gets the lock type configuration value (e.g., jdbc or zookeeper).
+   *
+   * @return The lock type
+   */
   public String lockType() {
     return confParser
         .stringConf()
@@ -89,6 +139,12 @@ public class LockConfig {
         .parse();
   }
 
+  /**
+   * Gets the lock ID configuration value. If blank, returns the provided default value.
+   *
+   * @param defaultValue The default value to return if lock ID is not provided
+   * @return The lock ID
+   */
   public String lockId(String defaultValue) {
     String lockId =
         confParser
@@ -104,6 +160,11 @@ public class LockConfig {
     return lockId;
   }
 
+  /**
+   * Gets the JDBC URI configuration value.
+   *
+   * @return The JDBC URI
+   */
   public String jdbcUri() {
     return confParser
         .stringConf()
@@ -113,6 +174,11 @@ public class LockConfig {
         .parse();
   }
 
+  /**
+   * Gets the configuration value for initializing the JDBC lock table.
+   *
+   * @return The value indicating whether to initialize the lock table in JDBC
+   */
   public String jdbcInitTable() {
     return confParser
         .stringConf()
@@ -122,6 +188,11 @@ public class LockConfig {
         .parse();
   }
 
+  /**
+   * Gets the Zookeeper URI configuration value.
+   *
+   * @return The Zookeeper URI
+   */
   public String zkUri() {
     return confParser
         .stringConf()
@@ -131,6 +202,11 @@ public class LockConfig {
         .parse();
   }
 
+  /**
+   * Gets the Zookeeper session timeout configuration (in milliseconds).
+   *
+   * @return The session timeout (in milliseconds)
+   */
   public int zkSessionTimeoutMs() {
     return confParser
         .intConf()
@@ -140,6 +216,11 @@ public class LockConfig {
         .parse();
   }
 
+  /**
+   * Gets the Zookeeper connection timeout configuration (in milliseconds).
+   *
+   * @return The connection timeout (in milliseconds)
+   */
   public int zkConnectionTimeoutMs() {
     return confParser
         .intConf()
@@ -149,6 +230,11 @@ public class LockConfig {
         .parse();
   }
 
+  /**
+   * Gets the Zookeeper base sleep time configuration (in milliseconds).
+   *
+   * @return The base sleep time (in milliseconds)
+   */
   public int zkBaseSleepMs() {
     return confParser
         .intConf()
@@ -158,6 +244,11 @@ public class LockConfig {
         .parse();
   }
 
+  /**
+   * Gets the Zookeeper maximum retry count configuration.
+   *
+   * @return The maximum retry count
+   */
   public int zkMaxRetries() {
     return confParser
         .intConf()

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/LockConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/LockConfig.java
@@ -106,9 +106,7 @@ public class LockConfig {
     this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
   }
 
-  /**
-   * Gets the lock type configuration value (e.g., jdbc or zookeeper).
-   */
+  /** Gets the lock type configuration value (e.g., jdbc or zookeeper). */
   public String lockType() {
     return confParser
         .stringConf()
@@ -118,9 +116,7 @@ public class LockConfig {
         .parse();
   }
 
-  /**
-   * Gets the lock ID configuration value. If blank, returns the provided default value.
-   */
+  /** Gets the lock ID configuration value. If blank, returns the provided default value. */
   public String lockId(String defaultValue) {
     String lockId =
         confParser
@@ -136,9 +132,7 @@ public class LockConfig {
     return lockId;
   }
 
-  /**
-   * Gets the JDBC URI configuration value.
-   */
+  /** Gets the JDBC URI configuration value. */
   public String jdbcUri() {
     return confParser
         .stringConf()
@@ -148,9 +142,7 @@ public class LockConfig {
         .parse();
   }
 
-  /**
-   * Gets the configuration value for initializing the JDBC lock table.
-   */
+  /** Gets the configuration value for initializing the JDBC lock table. */
   public String jdbcInitTable() {
     return confParser
         .stringConf()
@@ -160,9 +152,7 @@ public class LockConfig {
         .parse();
   }
 
-  /**
-   * Gets the Zookeeper URI configuration value.
-   */
+  /** Gets the Zookeeper URI configuration value. */
   public String zkUri() {
     return confParser
         .stringConf()
@@ -172,9 +162,7 @@ public class LockConfig {
         .parse();
   }
 
-  /**
-   * Gets the Zookeeper session timeout configuration (in milliseconds).
-   */
+  /** Gets the Zookeeper session timeout configuration (in milliseconds). */
   public int zkSessionTimeoutMs() {
     return confParser
         .intConf()
@@ -184,9 +172,7 @@ public class LockConfig {
         .parse();
   }
 
-  /**
-   * Gets the Zookeeper connection timeout configuration (in milliseconds).
-   */
+  /** Gets the Zookeeper connection timeout configuration (in milliseconds). */
   public int zkConnectionTimeoutMs() {
     return confParser
         .intConf()
@@ -196,9 +182,7 @@ public class LockConfig {
         .parse();
   }
 
-  /**
-   * Gets the Zookeeper base sleep time configuration (in milliseconds).
-   */
+  /** Gets the Zookeeper base sleep time configuration (in milliseconds). */
   public int zkBaseSleepMs() {
     return confParser
         .intConf()
@@ -208,9 +192,7 @@ public class LockConfig {
         .parse();
   }
 
-  /**
-   * Gets the Zookeeper maximum retry count configuration.
-   */
+  /** Gets the Zookeeper maximum retry count configuration. */
   public int zkMaxRetries() {
     return confParser
         .intConf()

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/LockConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/LockConfig.java
@@ -32,36 +32,28 @@ public class LockConfig {
 
   public static final String PREFIX = FlinkMaintenanceConfig.PREFIX + "lock.";
 
-  // Configuration option for lock type
-  // Specifies the type of lock to use, e.g., jdbc or zookeeper
   public static final ConfigOption<String> LOCK_TYPE_OPTION =
       ConfigOptions.key(PREFIX + "type")
           .stringType()
           .defaultValue(StringUtils.EMPTY)
           .withDescription("The type of lock to use, e.g., jdbc or zookeeper.");
 
-  // Configuration option for lock ID
-  // Specifies the unique identifier for the lock
   public static final ConfigOption<String> LOCK_ID_OPTION =
       ConfigOptions.key(PREFIX + "lock-id")
           .stringType()
           .defaultValue(StringUtils.EMPTY)
           .withDescription("The unique identifier for the lock.");
 
-  // Configuration options for JDBC-based locking
   public static class JdbcLockConfig {
 
     public static final String JDBC = "jdbc";
 
-    // JDBC URI configuration option
-    // Specifies the URI for the JDBC connection used for locking
     public static final ConfigOption<String> JDBC_URI_OPTION =
         ConfigOptions.key(PREFIX + JDBC + ".uri")
             .stringType()
             .defaultValue(StringUtils.EMPTY)
             .withDescription("The URI of the JDBC connection for acquiring the lock.");
 
-    // Option to initialize the lock table in the JDBC database
     public static final ConfigOption<String> JDBC_INIT_LOCK_TABLE_OPTION =
         ConfigOptions.key(PREFIX + JDBC + ".init-lock-table")
             .stringType()
@@ -69,36 +61,27 @@ public class LockConfig {
             .withDescription("Whether to initialize the lock table in the JDBC database.");
   }
 
-  // Configuration options for Zookeeper-based locking
   public static class ZkLockConfig {
     public static final String ZK = "zookeeper";
 
-    // Zookeeper URI configuration option
-    // Specifies the URI of the Zookeeper service for acquiring the lock
     public static final ConfigOption<String> ZK_URI_OPTION =
         ConfigOptions.key(PREFIX + ZK + ".uri")
             .stringType()
             .defaultValue(StringUtils.EMPTY)
             .withDescription("The URI of the Zookeeper service for acquiring the lock.");
 
-    // Zookeeper session timeout in milliseconds
-    // Specifies the session timeout for the Zookeeper client
     public static final ConfigOption<Integer> ZK_SESSION_TIMEOUT_MS_OPTION =
         ConfigOptions.key(PREFIX + ZK + ".session-timeout-ms")
             .intType()
             .defaultValue(60000)
             .withDescription("The session timeout (in milliseconds) for the Zookeeper client.");
 
-    // Zookeeper connection timeout in milliseconds
-    // Specifies the connection timeout for the Zookeeper client
     public static final ConfigOption<Integer> ZK_CONNECTION_TIMEOUT_MS_OPTION =
         ConfigOptions.key(PREFIX + ZK + ".connection-timeout-ms")
             .intType()
             .defaultValue(15000)
             .withDescription("The connection timeout (in milliseconds) for the Zookeeper client.");
 
-    // Zookeeper base sleep time in milliseconds
-    // Specifies the base sleep time between retries for the Zookeeper client
     public static final ConfigOption<Integer> ZK_BASE_SLEEP_MS_OPTION =
         ConfigOptions.key(PREFIX + ZK + ".base-sleep-ms")
             .intType()
@@ -106,8 +89,6 @@ public class LockConfig {
             .withDescription(
                 "The base sleep time (in milliseconds) between retries for the Zookeeper client.");
 
-    // Zookeeper maximum retries
-    // Specifies the maximum number of retries for the Zookeeper client in case of failure
     public static final ConfigOption<Integer> ZK_MAX_RETRIES_OPTION =
         ConfigOptions.key(PREFIX + ZK + ".max-retries")
             .intType()
@@ -127,8 +108,6 @@ public class LockConfig {
 
   /**
    * Gets the lock type configuration value (e.g., jdbc or zookeeper).
-   *
-   * @return The lock type
    */
   public String lockType() {
     return confParser
@@ -141,9 +120,6 @@ public class LockConfig {
 
   /**
    * Gets the lock ID configuration value. If blank, returns the provided default value.
-   *
-   * @param defaultValue The default value to return if lock ID is not provided
-   * @return The lock ID
    */
   public String lockId(String defaultValue) {
     String lockId =
@@ -162,8 +138,6 @@ public class LockConfig {
 
   /**
    * Gets the JDBC URI configuration value.
-   *
-   * @return The JDBC URI
    */
   public String jdbcUri() {
     return confParser
@@ -176,8 +150,6 @@ public class LockConfig {
 
   /**
    * Gets the configuration value for initializing the JDBC lock table.
-   *
-   * @return The value indicating whether to initialize the lock table in JDBC
    */
   public String jdbcInitTable() {
     return confParser
@@ -190,8 +162,6 @@ public class LockConfig {
 
   /**
    * Gets the Zookeeper URI configuration value.
-   *
-   * @return The Zookeeper URI
    */
   public String zkUri() {
     return confParser
@@ -204,8 +174,6 @@ public class LockConfig {
 
   /**
    * Gets the Zookeeper session timeout configuration (in milliseconds).
-   *
-   * @return The session timeout (in milliseconds)
    */
   public int zkSessionTimeoutMs() {
     return confParser
@@ -218,8 +186,6 @@ public class LockConfig {
 
   /**
    * Gets the Zookeeper connection timeout configuration (in milliseconds).
-   *
-   * @return The connection timeout (in milliseconds)
    */
   public int zkConnectionTimeoutMs() {
     return confParser
@@ -232,8 +198,6 @@ public class LockConfig {
 
   /**
    * Gets the Zookeeper base sleep time configuration (in milliseconds).
-   *
-   * @return The base sleep time (in milliseconds)
    */
   public int zkBaseSleepMs() {
     return confParser
@@ -246,8 +210,6 @@ public class LockConfig {
 
   /**
    * Gets the Zookeeper maximum retry count configuration.
-   *
-   * @return The maximum retry count
    */
   public int zkMaxRetries() {
     return confParser

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
@@ -101,9 +101,7 @@ public class RewriteDataFilesConfig {
     this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
   }
 
-  /**
-   * Gets the number of commits that trigger a rewrite operation.
-   */
+  /** Gets the number of commits that trigger a rewrite operation. */
   public int scheduleOnCommitCount() {
     return confParser
         .intConf()
@@ -113,9 +111,7 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
-  /**
-   * Gets the number of data files that trigger a rewrite operation.
-   */
+  /** Gets the number of data files that trigger a rewrite operation. */
   public int scheduleOnDataFileCount() {
     return confParser
         .intConf()
@@ -125,9 +121,7 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
-  /**
-   * Gets the total size of data files that trigger a rewrite operation.
-   */
+  /** Gets the total size of data files that trigger a rewrite operation. */
   public long scheduleOnDataFileSize() {
     return confParser
         .longConf()
@@ -137,9 +131,7 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
-  /**
-   * Gets the time interval (in seconds) between two consecutive rewrite operations.
-   */
+  /** Gets the time interval (in seconds) between two consecutive rewrite operations. */
   public long scheduleOnIntervalSecond() {
     return confParser
         .longConf()
@@ -149,9 +141,7 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
-  /**
-   * Gets whether partial progress commits are enabled.
-   */
+  /** Gets whether partial progress commits are enabled. */
   public boolean partialProgressEnable() {
     return confParser
         .booleanConf()
@@ -161,9 +151,7 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
-  /**
-   * Gets the maximum number of commits allowed for partial progress.
-   */
+  /** Gets the maximum number of commits allowed for partial progress. */
   public int partialProgressMaxCommits() {
     return confParser
         .intConf()
@@ -173,9 +161,7 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
-  /**
-   * Gets the maximum rewrite bytes allowed for a single rewrite operation.
-   */
+  /** Gets the maximum rewrite bytes allowed for a single rewrite operation. */
   public long maxRewriteBytes() {
     return confParser
         .longConf()

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
@@ -31,18 +31,16 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 public class RewriteDataFilesConfig {
   public static final String PREFIX = FlinkMaintenanceConfig.PREFIX + "rewrite.";
 
-  // Configuration option for maximum rewrite bytes
   public static final String MAX_BYTES = PREFIX + "max-bytes";
   public static final ConfigOption<Long> MAX_BYTES_OPTION =
       ConfigOptions.key(MAX_BYTES)
           .longType()
           .defaultValue(Long.MAX_VALUE)
           .withDescription(
-              "The maximum number of bytes allowed for the rewrite operation. "
-                  + "If the total size of the data files to be rewritten exceeds this value, "
-                  + "the rewrite operation will be split into multiple parts.");
+              "The maximum number of bytes allowed for a rewrite operation. "
+                  + "If the total size of data files exceeds this limit, the rewrites within one scheduled compaction "
+                  + "will be limited in size to restrict the resources used by the compaction.");
 
-  // Maximum number of commits allowed if partial progress is enabled
   public static final ConfigOption<Integer> PARTIAL_PROGRESS_MAX_COMMITS_OPTION =
       ConfigOptions.key(PREFIX + RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS)
           .intType()
@@ -52,7 +50,6 @@ public class RewriteDataFilesConfig {
                   + "This configuration controls how many file groups "
                   + "are committed per run when partial progress is enabled.");
 
-  // Whether to enable partial progress
   public static final ConfigOption<Boolean> PARTIAL_PROGRESS_ENABLED_OPTION =
       ConfigOptions.key(PREFIX + RewriteDataFiles.PARTIAL_PROGRESS_ENABLED)
           .booleanType()
@@ -62,7 +59,6 @@ public class RewriteDataFilesConfig {
                   + "When enabled, the rewrite operation will commit by file group, "
                   + "allowing progress even if some file groups fail to commit.");
 
-  // The number of commits that should trigger a new rewrite operation
   public static final String SCHEDULE_ON_COMMIT_COUNT = PREFIX + "schedule.commit-count";
   public static final ConfigOption<Integer> SCHEDULE_ON_COMMIT_COUNT_OPTION =
       ConfigOptions.key(SCHEDULE_ON_COMMIT_COUNT)
@@ -72,7 +68,6 @@ public class RewriteDataFilesConfig {
               "The number of commits after which to trigger a new rewrite operation. "
                   + "This setting controls the frequency of rewrite operations.");
 
-  // The number of data files that should trigger a new rewrite operation
   public static final String SCHEDULE_ON_DATA_FILE_COUNT = PREFIX + "schedule.data-file-count";
   public static final ConfigOption<Integer> SCHEDULE_ON_DATA_FILE_COUNT_OPTION =
       ConfigOptions.key(SCHEDULE_ON_DATA_FILE_COUNT)
@@ -80,7 +75,6 @@ public class RewriteDataFilesConfig {
           .defaultValue(1000)
           .withDescription("The number of data files that should trigger a new rewrite operation.");
 
-  // The total size of data files that should trigger a new rewrite operation
   public static final String SCHEDULE_ON_DATA_FILE_SIZE = PREFIX + "schedule.data-file-size";
   public static final ConfigOption<Long> SCHEDULE_ON_DATA_FILE_SIZE_OPTION =
       ConfigOptions.key(SCHEDULE_ON_DATA_FILE_COUNT)
@@ -89,7 +83,6 @@ public class RewriteDataFilesConfig {
           .withDescription(
               "The total size of data files that should trigger a new rewrite operation.");
 
-  // The interval in seconds between triggering rewrite operations
   public static final String SCHEDULE_ON_INTERVAL_SECOND = PREFIX + "schedule.interval-second";
   public static final ConfigOption<Long> SCHEDULE_ON_INTERVAL_SECOND_OPTION =
       ConfigOptions.key(SCHEDULE_ON_INTERVAL_SECOND)
@@ -110,8 +103,6 @@ public class RewriteDataFilesConfig {
 
   /**
    * Gets the number of commits that trigger a rewrite operation.
-   *
-   * @return The number of commits
    */
   public int scheduleOnCommitCount() {
     return confParser
@@ -124,8 +115,6 @@ public class RewriteDataFilesConfig {
 
   /**
    * Gets the number of data files that trigger a rewrite operation.
-   *
-   * @return The number of data files
    */
   public int scheduleOnDataFileCount() {
     return confParser
@@ -138,8 +127,6 @@ public class RewriteDataFilesConfig {
 
   /**
    * Gets the total size of data files that trigger a rewrite operation.
-   *
-   * @return The total size of data files
    */
   public long scheduleOnDataFileSize() {
     return confParser
@@ -152,8 +139,6 @@ public class RewriteDataFilesConfig {
 
   /**
    * Gets the time interval (in seconds) between two consecutive rewrite operations.
-   *
-   * @return The interval in seconds
    */
   public long scheduleOnIntervalSecond() {
     return confParser
@@ -166,8 +151,6 @@ public class RewriteDataFilesConfig {
 
   /**
    * Gets whether partial progress commits are enabled.
-   *
-   * @return True if partial progress is enabled
    */
   public boolean partialProgressEnable() {
     return confParser
@@ -180,8 +163,6 @@ public class RewriteDataFilesConfig {
 
   /**
    * Gets the maximum number of commits allowed for partial progress.
-   *
-   * @return The maximum number of commits
    */
   public int partialProgressMaxCommits() {
     return confParser
@@ -194,8 +175,6 @@ public class RewriteDataFilesConfig {
 
   /**
    * Gets the maximum rewrite bytes allowed for a single rewrite operation.
-   *
-   * @return The maximum rewrite bytes
    */
   public long maxRewriteBytes() {
     return confParser

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
@@ -31,39 +31,73 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 public class RewriteDataFilesConfig {
   public static final String PREFIX = FlinkMaintenanceConfig.PREFIX + "rewrite.";
 
+  // Configuration option for maximum rewrite bytes
   public static final String MAX_BYTES = PREFIX + "max-bytes";
   public static final ConfigOption<Long> MAX_BYTES_OPTION =
-      ConfigOptions.key(MAX_BYTES).longType().defaultValue(Long.MAX_VALUE);
+      ConfigOptions.key(MAX_BYTES)
+          .longType()
+          .defaultValue(Long.MAX_VALUE)
+          .withDescription(
+              "The maximum number of bytes allowed for the rewrite operation. "
+                  + "If the total size of the data files to be rewritten exceeds this value, "
+                  + "the rewrite operation will be split into multiple parts.");
 
+  // Maximum number of commits allowed if partial progress is enabled
   public static final ConfigOption<Integer> PARTIAL_PROGRESS_MAX_COMMITS_OPTION =
       ConfigOptions.key(PREFIX + RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS)
           .intType()
-          .defaultValue(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS_DEFAULT);
+          .defaultValue(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS_DEFAULT)
+          .withDescription(
+              "The maximum number of commits allowed when partial progress is enabled. "
+                  + "This configuration controls how many file groups "
+                  + "are committed per run when partial progress is enabled.");
 
+  // Whether to enable partial progress
   public static final ConfigOption<Boolean> PARTIAL_PROGRESS_ENABLED_OPTION =
       ConfigOptions.key(PREFIX + RewriteDataFiles.PARTIAL_PROGRESS_ENABLED)
           .booleanType()
-          .defaultValue(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED_DEFAULT);
+          .defaultValue(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED_DEFAULT)
+          .withDescription(
+              "Whether to enable partial progress commits. "
+                  + "When enabled, the rewrite operation will commit by file group, "
+                  + "allowing progress even if some file groups fail to commit.");
 
+  // The number of commits that should trigger a new rewrite operation
   public static final String SCHEDULE_ON_COMMIT_COUNT = PREFIX + "schedule.commit-count";
   public static final ConfigOption<Integer> SCHEDULE_ON_COMMIT_COUNT_OPTION =
-      ConfigOptions.key(SCHEDULE_ON_COMMIT_COUNT).intType().defaultValue(10);
+      ConfigOptions.key(SCHEDULE_ON_COMMIT_COUNT)
+          .intType()
+          .defaultValue(10)
+          .withDescription(
+              "The number of commits after which to trigger a new rewrite operation. "
+                  + "This setting controls the frequency of rewrite operations.");
 
+  // The number of data files that should trigger a new rewrite operation
   public static final String SCHEDULE_ON_DATA_FILE_COUNT = PREFIX + "schedule.data-file-count";
   public static final ConfigOption<Integer> SCHEDULE_ON_DATA_FILE_COUNT_OPTION =
-      ConfigOptions.key(SCHEDULE_ON_DATA_FILE_COUNT).intType().defaultValue(1000);
+      ConfigOptions.key(SCHEDULE_ON_DATA_FILE_COUNT)
+          .intType()
+          .defaultValue(1000)
+          .withDescription("The number of data files that should trigger a new rewrite operation.");
 
+  // The total size of data files that should trigger a new rewrite operation
   public static final String SCHEDULE_ON_DATA_FILE_SIZE = PREFIX + "schedule.data-file-size";
   public static final ConfigOption<Long> SCHEDULE_ON_DATA_FILE_SIZE_OPTION =
       ConfigOptions.key(SCHEDULE_ON_DATA_FILE_COUNT)
           .longType()
-          .defaultValue(100L * 1024 * 1024 * 1024); // 100G
+          .defaultValue(100L * 1024 * 1024 * 1024) // Default is 100 GB
+          .withDescription(
+              "The total size of data files that should trigger a new rewrite operation.");
 
+  // The interval in seconds between triggering rewrite operations
   public static final String SCHEDULE_ON_INTERVAL_SECOND = PREFIX + "schedule.interval-second";
   public static final ConfigOption<Long> SCHEDULE_ON_INTERVAL_SECOND_OPTION =
       ConfigOptions.key(SCHEDULE_ON_INTERVAL_SECOND)
           .longType()
-          .defaultValue(10 * 60L); // 10 minutes
+          .defaultValue(10 * 60L) // Default is 10 minutes
+          .withDescription(
+              "The time interval (in seconds) between two consecutive rewrite operations. "
+                  + "This ensures periodic scheduling of rewrite tasks.");
 
   private final FlinkConfParser confParser;
   private final Map<String, String> writeProperties;
@@ -74,6 +108,11 @@ public class RewriteDataFilesConfig {
     this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
   }
 
+  /**
+   * Gets the number of commits that trigger a rewrite operation.
+   *
+   * @return The number of commits
+   */
   public int scheduleOnCommitCount() {
     return confParser
         .intConf()
@@ -83,6 +122,11 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
+  /**
+   * Gets the number of data files that trigger a rewrite operation.
+   *
+   * @return The number of data files
+   */
   public int scheduleOnDataFileCount() {
     return confParser
         .intConf()
@@ -92,6 +136,11 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
+  /**
+   * Gets the total size of data files that trigger a rewrite operation.
+   *
+   * @return The total size of data files
+   */
   public long scheduleOnDataFileSize() {
     return confParser
         .longConf()
@@ -101,6 +150,11 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
+  /**
+   * Gets the time interval (in seconds) between two consecutive rewrite operations.
+   *
+   * @return The interval in seconds
+   */
   public long scheduleOnIntervalSecond() {
     return confParser
         .longConf()
@@ -110,6 +164,11 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
+  /**
+   * Gets whether partial progress commits are enabled.
+   *
+   * @return True if partial progress is enabled
+   */
   public boolean partialProgressEnable() {
     return confParser
         .booleanConf()
@@ -119,6 +178,11 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
+  /**
+   * Gets the maximum number of commits allowed for partial progress.
+   *
+   * @return The maximum number of commits
+   */
   public int partialProgressMaxCommits() {
     return confParser
         .intConf()
@@ -128,6 +192,11 @@ public class RewriteDataFilesConfig {
         .parse();
   }
 
+  /**
+   * Gets the maximum rewrite bytes allowed for a single rewrite operation.
+   *
+   * @return The maximum rewrite bytes
+   */
   public long maxRewriteBytes() {
     return confParser
         .longConf()


### PR DESCRIPTION
This pull request improves the readability and maintainability of the following configuration classes by enhancing the descriptions for ConfigOptions and adding necessary comments:

- FlinkMaintenanceConfig:

Added clear descriptions for configuration options such as `LOCK_CHECK_DELAY_OPTION`, `PARALLELISM_OPTION`, `RATE_LIMIT_OPTION`, and `SLOT_SHARING_GROUP_OPTION`.

Added comments explaining the purpose and function of each configuration option.

- LockConfig:

Added detailed descriptions for configuration options like `LOCK_TYPE_OPTION`, `LOCK_ID_OPTION`, `JdbcLockConfig`, and `ZkLockConfig` related to different locking mechanisms.

Improved code clarity by explaining the role of each configuration option for locking (e.g., `JDBC_URI_OPTION`, `ZK_URI_OPTION`, etc.).

- RewriteDataFilesConfig:

Enhanced the descriptions of configuration options, including `MAX_BYTES_OPTION`, `PARTIAL_PROGRESS_MAX_COMMITS_OPTION`, `SCHEDULE_ON_COMMIT_COUNT_OPTION`, `SCHEDULE_ON_DATA_FILE_COUNT_OPTION`, and more.

Added helpful comments to clarify the purpose of each configuration setting related to data rewriting and its usage in Flink-based maintenance tasks.