### PR TITLE
test: validate partition and schema field name conflicts on schema evolution

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -79,6 +79,12 @@ public class Expressions {
   }
 
   @SuppressWarnings("unchecked")
+  public static <T> UnboundTerm<T> identity(String name) {
+    Transform<?, T> transform = (Transform<?, T>) Transforms.identity();
+    return new UnboundTransform<>(ref(name), transform);
+  }
+
+  @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> year(String name) {
     return new UnboundTransform<>(ref(name), (Transform<?, T>) Transforms.year());
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -79,12 +79,6 @@ public class Expressions {
   }
 
   @SuppressWarnings("unchecked")
-  public static <T> UnboundTerm<T> identity(String name) {
-    Transform<?, T> transform = (Transform<?, T>) Transforms.identity();
-    return new UnboundTransform<>(ref(name), transform);
-  }
-
-  @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> year(String name) {
     return new UnboundTransform<>(ref(name), (Transform<?, T>) Transforms.year());
   }

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.expressions.Expressions.bucket;
-import static org.apache.iceberg.expressions.Expressions.identity;
 import static org.apache.iceberg.expressions.Expressions.truncate;
 import static org.apache.iceberg.expressions.Expressions.year;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -308,8 +307,7 @@ public class TestTableUpdatePartitionSpec extends TestBase {
     table.updateSchema().addColumn("new_field", Types.StringType.get()).commit();
 
     // Add a new partition field referencing 'new_field' and name it 'new_field_partition'
-    // table.updateSpec().addField("new_field_partition", bucket("new_field", 8)).commit();
-    table.updateSpec().addField("new_field_partition", identity("new_field")).commit();
+    table.updateSpec().addField("new_field_partition", bucket("new_field", 8)).commit();
 
     // Assert that adding a column named 'new_field_partition' throws due to name collision
     assertThatThrownBy(

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -19,9 +19,11 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.expressions.Expressions.bucket;
+import static org.apache.iceberg.expressions.Expressions.identity;
 import static org.apache.iceberg.expressions.Expressions.truncate;
 import static org.apache.iceberg.expressions.Expressions.year;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
@@ -298,5 +300,26 @@ public class TestTableUpdatePartitionSpec extends TestBase {
                 .bucket("data", 16)
                 .identity("id")
                 .build());
+  }
+
+  @TestTemplate
+  public void testAddNewSchemaFieldCollidesWithPartitionFieldName() {
+    // Add a new schema column
+    table.updateSchema().addColumn("new_field", Types.StringType.get()).commit();
+
+    // Add a new partition field referencing 'new_field' and name it 'new_field_partition'
+    // table.updateSpec().addField("new_field_partition", bucket("new_field", 8)).commit();
+    table.updateSpec().addField("new_field_partition", identity("new_field")).commit();
+
+    // Assert that adding a column named 'new_field_partition' throws due to name collision
+    assertThatThrownBy(
+            () ->
+                table
+                    .updateSchema()
+                    .addColumn("new_field_partition", Types.StringType.get())
+                    .commit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot create identity partition sourced from different field in schema: new_field_partition");
   }
 }


### PR DESCRIPTION
Closes #13833

Add a test case for field name collision when a new column is added that conflicts with existing partition name