### PR TITLE
Hive: Throw `NoSuchViewException` when loading an Iceberg table as a view

### DIFF
--- a/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
@@ -87,6 +87,27 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
   }
 
   @Test
+  public void loadViewThatAlreadyExistsAsTable() {
+    assumeThat(tableCatalog()).as("Only valid for catalogs that support tables").isNotNull();
+
+    TableIdentifier tableIdentifier = TableIdentifier.of("ns", "table");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(tableIdentifier.namespace());
+    }
+
+    assertThat(tableCatalog().tableExists(tableIdentifier)).as("Table should not exist").isFalse();
+
+    tableCatalog().buildTable(tableIdentifier, SCHEMA).create();
+
+    assertThat(tableCatalog().tableExists(tableIdentifier)).as("Table should exist").isTrue();
+
+    assertThatThrownBy(() -> catalog().loadView(tableIdentifier))
+        .isInstanceOf(NoSuchViewException.class)
+        .hasMessageStartingWith("View does not exist");
+  }
+
+  @Test
   public void basicCreateView() {
     TableIdentifier identifier = TableIdentifier.of("ns", "view");
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -90,6 +90,10 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
 
     try {
       table = metaClients.run(client -> client.getTable(database, viewName));
+
+      // Check if we are trying to load an Iceberg Table as a View
+      HiveOperationsBase.validateLoadIcebergTableAsIcebergView(table, fullName);
+      // Check if it is a valid Iceberg View
       HiveOperationsBase.validateTableIsIcebergView(table, fullName);
 
       metadataLocation =


### PR DESCRIPTION
This change adds a new helper method `validateLoadIcebergTableAsIcebergView` that throws a `NoSuchViewException` when `HiveViewOperations` tries to load a Table instead of a View. This will make `HiveCatalog` behave the same as all the other catalog implementations.

Additionally, I added a missing test in `ViewCatalogTest` to test for this specific scenario