### PR TITLE
Flink: Fix schedule data file size incorrect in RewriteDataFilesConfig

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
@@ -55,7 +55,7 @@ public class RewriteDataFilesConfig {
 
   public static final String SCHEDULE_ON_DATA_FILE_SIZE = PREFIX + "schedule.data-file-size";
   public static final ConfigOption<Long> SCHEDULE_ON_DATA_FILE_SIZE_OPTION =
-      ConfigOptions.key(SCHEDULE_ON_DATA_FILE_COUNT)
+      ConfigOptions.key(SCHEDULE_ON_DATA_FILE_SIZE)
           .longType()
           .defaultValue(100L * 1024 * 1024 * 1024); // 100G
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
@@ -55,7 +55,7 @@ public class RewriteDataFilesConfig {
 
   public static final String SCHEDULE_ON_DATA_FILE_SIZE = PREFIX + "schedule.data-file-size";
   public static final ConfigOption<Long> SCHEDULE_ON_DATA_FILE_SIZE_OPTION =
-      ConfigOptions.key(SCHEDULE_ON_DATA_FILE_COUNT)
+      ConfigOptions.key(SCHEDULE_ON_DATA_FILE_SIZE)
           .longType()
           .defaultValue(100L * 1024 * 1024 * 1024); // 100G
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFilesConfig.java
@@ -55,7 +55,7 @@ public class RewriteDataFilesConfig {
 
   public static final String SCHEDULE_ON_DATA_FILE_SIZE = PREFIX + "schedule.data-file-size";
   public static final ConfigOption<Long> SCHEDULE_ON_DATA_FILE_SIZE_OPTION =
-      ConfigOptions.key(SCHEDULE_ON_DATA_FILE_COUNT)
+      ConfigOptions.key(SCHEDULE_ON_DATA_FILE_SIZE)
           .longType()
           .defaultValue(100L * 1024 * 1024 * 1024); // 100G
 


### PR DESCRIPTION
Fixed incorrect schedule data file size in RewriteDataFilesConfig. This is a mirror fix, so I have applied it to all versions.