### PR TITLE
Flink: Backport Fix ResultSet resource leak in JdbcLockFactory.initializeLockTables().

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -127,21 +127,24 @@ public class JdbcLockFactory implements TriggerLockFactory {
       pool.run(
           conn -> {
             DatabaseMetaData dbMeta = conn.getMetaData();
-            ResultSet tableExists =
+            try (ResultSet rs =
                 dbMeta.getTables(
                     null /* catalog name */,
                     null /* schemaPattern */,
                     LOCK_TABLE_NAME /* tableNamePattern */,
-                    null /* types */);
-            if (tableExists.next()) {
-              LOG.debug("Flink maintenance lock table already exists");
-              return true;
+                    null /* types */)) {
+              if (rs.next()) {
+                LOG.debug("Flink maintenance lock table already exists");
+                return true;
+              }
+            }
+            LOG.info("Creating Flink maintenance lock table {}", LOCK_TABLE_NAME);
+            try (PreparedStatement ps = conn.prepareStatement(CREATE_LOCK_TABLE_SQL)) {
+              ps.execute();
             }
 
-            LOG.info("Creating Flink maintenance lock table {}", LOCK_TABLE_NAME);
-            return conn.prepareStatement(CREATE_LOCK_TABLE_SQL).execute();
+            return true;
           });
-
     } catch (SQLTimeoutException e) {
       throw new UncheckedSQLException(
           e, "Cannot initialize JDBC table maintenance lock: Query timed out");

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -127,21 +127,24 @@ public class JdbcLockFactory implements TriggerLockFactory {
       pool.run(
           conn -> {
             DatabaseMetaData dbMeta = conn.getMetaData();
-            ResultSet tableExists =
+            try (ResultSet rs =
                 dbMeta.getTables(
                     null /* catalog name */,
                     null /* schemaPattern */,
                     LOCK_TABLE_NAME /* tableNamePattern */,
-                    null /* types */);
-            if (tableExists.next()) {
-              LOG.debug("Flink maintenance lock table already exists");
-              return true;
+                    null /* types */)) {
+              if (rs.next()) {
+                LOG.debug("Flink maintenance lock table already exists");
+                return true;
+              }
+            }
+            LOG.info("Creating Flink maintenance lock table {}", LOCK_TABLE_NAME);
+            try (PreparedStatement ps = conn.prepareStatement(CREATE_LOCK_TABLE_SQL)) {
+              ps.execute();
             }
 
-            LOG.info("Creating Flink maintenance lock table {}", LOCK_TABLE_NAME);
-            return conn.prepareStatement(CREATE_LOCK_TABLE_SQL).execute();
+            return true;
           });
-
     } catch (SQLTimeoutException e) {
       throw new UncheckedSQLException(
           e, "Cannot initialize JDBC table maintenance lock: Query timed out");


### PR DESCRIPTION
backport #13821.