### PR TITLE
Docs: Fix style of row-level deletes in spec

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -102,9 +102,11 @@ Inheriting the sequence number from manifest metadata allows writing a new manif
 
 Row-level deletes are stored in delete files.
 
-There are two types of row-level deletes:
-* _Position deletes_ mark a row deleted by data file path and the row position in the data file. Position deletes are encoded in a [_position delete file_](#position-delete-files) (V2) or [_deletion vector_](#deletion-vectors) (V3 or above).
-* _Equality deletes_ mark a row deleted by one or more column values, like `id = 5`. Equality deletes are encoded in [_equality delete file_](#equality-delete-files).
+There are two types of row-level deletes: 
+
+* **Position deletes** -- Mark a row deleted by data file path and the row position in the data file. Position deletes are encoded in a [_position delete file_](#position-delete-files) (V2) or [_deletion vector_](#deletion-vectors) (V3 or above).
+
+* **Equality deletes** -- Mark a row deleted by one or more column values, like id = 5. Equality deletes are encoded in [_equality delete file_](#equality-delete-files).
 
 Like data files, delete files are tracked by partition. In general, a delete file must be applied to older data files with the same partition; see [Scan Planning](#scan-planning) for details. Column metrics can be used to determine whether a delete file's rows overlap the contents of a data file or a scan range.
 


### PR DESCRIPTION
Fix Row-level Deletes Rendering in Spec [#13813](https://github.com/apache/iceberg/issues/13813)

This PR fixes the rendering issue of row-level deletes in the Apache Iceberg specification.

- Ensures that Position deletes and Equality deletes are correctly displayed as bulleted list items.
- Removes duplicate entries and adds necessary line breaks for proper Markdown rendering.
- Verified local build to confirm that the spec renders correctly at [Row-level Deletes](https://iceberg.apache.org/spec/#row-level-deletes).

<img width="914" height="351" alt="image" src="https://github.com/user-attachments/assets/a8a42f46-74e8-48f4-ab07-ed67fac8ae3f" />

Closes #13813
