### PR TITLE
Fixes #13857  Use SqlApiConf.CASE_SENSITIVE_KEY() instead of hard-coded spark.sql.caseSensitive

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -88,6 +88,7 @@ import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.execution.datasources.FileStatusCache;
 import org.apache.spark.sql.execution.datasources.InMemoryFileIndex;
 import org.apache.spark.sql.execution.datasources.PartitionDirectory;
+import org.apache.spark.sql.internal.StaticSQLConf;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StructType;
@@ -538,7 +539,7 @@ public class Spark3Util {
   }
 
   public static boolean extensionsEnabled(SparkSession spark) {
-    String extensions = spark.conf().get("spark.sql.extensions", "");
+    String extensions = spark.conf().get(StaticSQLConf.SPARK_SESSION_EXTENSIONS().key(), "");
     return extensions.contains("IcebergSparkSessionExtensions");
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -53,6 +53,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
@@ -290,7 +291,7 @@ public class SparkUtil {
   }
 
   public static boolean caseSensitive(SparkSession spark) {
-    return Boolean.parseBoolean(spark.conf().get(SqlApiConf.CASE_SENSITIVE_KEY()));
+    return Boolean.parseBoolean(spark.conf().get(SQLConf.CASE_SENSITIVE().key()));
   }
 
   public static List<String> executorLocations() {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -290,7 +290,7 @@ public class SparkUtil {
   }
 
   public static boolean caseSensitive(SparkSession spark) {
-    return Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
+    return Boolean.parseBoolean(spark.conf().get(SqlApiConf.CASE_SENSITIVE_KEY()));
   }
 
   public static List<String> executorLocations() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -88,6 +88,7 @@ import org.apache.spark.sql.execution.datasources.FileStatusCache;
 import org.apache.spark.sql.execution.datasources.FileStatusWithMetadata;
 import org.apache.spark.sql.execution.datasources.InMemoryFileIndex;
 import org.apache.spark.sql.execution.datasources.PartitionDirectory;
+import org.apache.spark.sql.internal.StaticSQLConf;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StructType;
@@ -538,7 +539,7 @@ public class Spark3Util {
   }
 
   public static boolean extensionsEnabled(SparkSession spark) {
-    String extensions = spark.conf().get("spark.sql.extensions", "");
+    String extensions = spark.conf().get(StaticSQLConf.SPARK_SESSION_EXTENSIONS().key(), "");
     return extensions.contains("IcebergSparkSessionExtensions");
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -51,6 +51,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.internal.SqlApiConf;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -254,7 +254,7 @@ public class SparkUtil {
   }
 
   public static boolean caseSensitive(SparkSession spark) {
-    return Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
+    return Boolean.parseBoolean(spark.conf().get(SqlApiConf.CASE_SENSITIVE_KEY()));
   }
 
   public static List<String> executorLocations() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -51,7 +51,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
-import org.apache.spark.sql.internal.SqlApiConf;
+import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
@@ -255,7 +255,7 @@ public class SparkUtil {
   }
 
   public static boolean caseSensitive(SparkSession spark) {
-    return Boolean.parseBoolean(spark.conf().get(SqlApiConf.CASE_SENSITIVE_KEY()));
+    return Boolean.parseBoolean(spark.conf().get(SQLConf.CASE_SENSITIVE().key()));
   }
 
   public static List<String> executorLocations() {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -88,6 +88,7 @@ import org.apache.spark.sql.execution.datasources.FileStatusCache;
 import org.apache.spark.sql.execution.datasources.FileStatusWithMetadata;
 import org.apache.spark.sql.execution.datasources.InMemoryFileIndex;
 import org.apache.spark.sql.execution.datasources.PartitionDirectory;
+import org.apache.spark.sql.internal.StaticSQLConf;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StructType;
@@ -538,7 +539,7 @@ public class Spark3Util {
   }
 
   public static boolean extensionsEnabled(SparkSession spark) {
-    String extensions = spark.conf().get("spark.sql.extensions", "");
+    String extensions = spark.conf().get(StaticSQLConf.SPARK_SESSION_EXTENSIONS().key(), "");
     return extensions.contains("IcebergSparkSessionExtensions");
   }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -51,6 +51,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.internal.SqlApiConf;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
@@ -255,7 +256,7 @@ public class SparkUtil {
   }
 
   public static boolean caseSensitive(SparkSession spark) {
-    return Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
+    return Boolean.parseBoolean(spark.conf().get(SqlApiConf.CASE_SENSITIVE_KEY()));
   }
 
   public static List<String> executorLocations() {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -51,7 +51,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
-import org.apache.spark.sql.internal.SqlApiConf;
+import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
@@ -256,7 +256,7 @@ public class SparkUtil {
   }
 
   public static boolean caseSensitive(SparkSession spark) {
-    return Boolean.parseBoolean(spark.conf().get(SqlApiConf.CASE_SENSITIVE_KEY()));
+    return Boolean.parseBoolean(spark.conf().get(SQLConf.CASE_SENSITIVE().key()));
   }
 
   public static List<String> executorLocations() {


### PR DESCRIPTION
Use SqlApiConf.CASE_SENSITIVE_KEY() instead of hard-coded spark.sql.caseSensitive #13857
