### PR TITLE
feat: support longer width for long and decimal truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ coverage.xml
 
 # vscode/eclipse files
 .classpath
+.factorypath
 .project
 .settings
 bin/

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1254,6 +1254,59 @@ acceptedBreaks:
       new: "method void org.apache.iceberg.data.parquet.BaseParquetWriter<T>::<init>()"
       justification: "Changing deprecated code"
   "1.9.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <T> org.apache.iceberg.expressions.UnboundTerm<T> org.apache.iceberg.expressions.Expressions::truncate(java.lang.String,\
+        \ ===int===)"
+      new: "parameter <T> org.apache.iceberg.expressions.UnboundTerm<T> org.apache.iceberg.expressions.Expressions::truncate(java.lang.String,\
+        \ ===long===)"
+      justification: "Support longer width for long and decimal truncation"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <T> org.apache.iceberg.transforms.Transform<T, T> org.apache.iceberg.transforms.Transforms::truncate(===int===)"
+      new: "parameter <T> org.apache.iceberg.transforms.Transform<T, T> org.apache.iceberg.transforms.Transforms::truncate(===long===)"
+      justification: "Support longer width for long and decimal truncation"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter <T> org.apache.iceberg.transforms.Transform<T, T> org.apache.iceberg.transforms.Transforms::truncate(org.apache.iceberg.types.Type,\
+        \ ===int===)"
+      new: "parameter <T> org.apache.iceberg.transforms.Transform<T, T> org.apache.iceberg.transforms.Transforms::truncate(org.apache.iceberg.types.Type,\
+        \ ===long===)"
+      justification: "Support longer width for long and decimal truncation"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter T org.apache.iceberg.transforms.PartitionSpecVisitor<T>::truncate(int,\
+        \ java.lang.String, int, ===int===)"
+      new: "parameter T org.apache.iceberg.transforms.PartitionSpecVisitor<T>::truncate(int,\
+        \ java.lang.String, int, ===long===)"
+      justification: "Support longer width for long and decimal truncation"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter T org.apache.iceberg.transforms.PartitionSpecVisitor<T>::truncate(java.lang.String,\
+        \ int, ===int===)"
+      new: "parameter T org.apache.iceberg.transforms.PartitionSpecVisitor<T>::truncate(java.lang.String,\
+        \ int, ===long===)"
+      justification: "Support longer width for long and decimal truncation"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter T org.apache.iceberg.transforms.SortOrderVisitor<T>::truncate(java.lang.String,\
+        \ int, ===int===, org.apache.iceberg.SortDirection, org.apache.iceberg.NullOrder)"
+      new: "parameter T org.apache.iceberg.transforms.SortOrderVisitor<T>::truncate(java.lang.String,\
+        \ int, ===long===, org.apache.iceberg.SortDirection, org.apache.iceberg.NullOrder)"
+      justification: "Support longer width for long and decimal truncation"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter long org.apache.iceberg.util.TruncateUtil::truncateLong(===int===,\
+        \ long)"
+      new: "parameter long org.apache.iceberg.util.TruncateUtil::truncateLong(===long===,\
+        \ long)"
+      justification: "Support longer width for long and decimal truncation"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter org.apache.iceberg.PartitionSpec.Builder org.apache.iceberg.PartitionSpec.Builder::truncate(java.lang.String,\
+        \ ===int===)"
+      new: "parameter org.apache.iceberg.PartitionSpec.Builder org.apache.iceberg.PartitionSpec.Builder::truncate(java.lang.String,\
+        \ ===long===)"
+      justification: "Support longer width for long and decimal truncation"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter org.apache.iceberg.PartitionSpec.Builder org.apache.iceberg.PartitionSpec.Builder::truncate(java.lang.String,\
+        \ ===int===, java.lang.String)"
+      new: "parameter org.apache.iceberg.PartitionSpec.Builder org.apache.iceberg.PartitionSpec.Builder::truncate(java.lang.String,\
+        \ ===long===, java.lang.String)"
+      justification: "Support longer width for long and decimal truncation"
     org.apache.iceberg:iceberg-common:
     - code: "java.method.visibilityReduced"
       old: "method <R> R org.apache.iceberg.common.DynConstructors.Ctor<C>::invokeChecked(java.lang.Object,\

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -569,11 +569,11 @@ public class PartitionSpec implements Serializable {
       return bucket(sourceColumn, numBuckets, columnName + "_bucket");
     }
 
-    public Builder truncate(String sourceName, int width, String targetName) {
+    public Builder truncate(String sourceName, long width, String targetName) {
       return truncate(findSourceColumn(sourceName), width, targetName);
     }
 
-    private Builder truncate(Types.NestedField sourceColumn, int width, String targetName) {
+    private Builder truncate(Types.NestedField sourceColumn, long width, String targetName) {
       checkAndAddPartitionName(targetName);
       fields.add(
           new PartitionField(
@@ -581,7 +581,7 @@ public class PartitionSpec implements Serializable {
       return this;
     }
 
-    public Builder truncate(String sourceName, int width) {
+    public Builder truncate(String sourceName, long width) {
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       String columnName = schema.findColumnName(sourceColumn.fieldId());
       return truncate(sourceColumn, width, columnName + "_trunc");

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -98,7 +98,7 @@ public class Expressions {
     return new UnboundTransform<>(ref(name), (Transform<?, T>) Transforms.hour());
   }
 
-  public static <T> UnboundTerm<T> truncate(String name, int width) {
+  public static <T> UnboundTerm<T> truncate(String name, long width) {
     return new UnboundTransform<>(ref(name), Transforms.truncate(width));
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
@@ -41,11 +41,11 @@ public interface PartitionSpecVisitor<T> {
     throw new UnsupportedOperationException("Bucket transform is not supported");
   }
 
-  default T truncate(int fieldId, String sourceName, int sourceId, int width) {
+  default T truncate(int fieldId, String sourceName, int sourceId, long width) {
     return truncate(sourceName, sourceId, width);
   }
 
-  default T truncate(String sourceName, int sourceId, int width) {
+  default T truncate(String sourceName, int sourceId, long width) {
     throw new UnsupportedOperationException("Truncate transform is not supported");
   }
 
@@ -119,7 +119,7 @@ public interface PartitionSpecVisitor<T> {
       int numBuckets = ((Bucket<?>) transform).numBuckets();
       return visitor.bucket(field.fieldId(), sourceName, field.sourceId(), numBuckets);
     } else if (transform instanceof Truncate) {
-      int width = ((Truncate<?>) transform).width();
+      long width = ((Truncate<?>) transform).width();
       return visitor.truncate(field.fieldId(), sourceName, field.sourceId(), width);
     } else if (transform == Dates.YEAR
         || transform == Timestamps.MICROS_TO_YEAR

--- a/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
@@ -34,7 +34,7 @@ public interface SortOrderVisitor<T> {
       String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder);
 
   T truncate(
-      String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder);
+      String sourceName, int sourceId, long width, SortDirection direction, NullOrder nullOrder);
 
   T year(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder);
 
@@ -80,7 +80,7 @@ public interface SortOrderVisitor<T> {
             visitor.bucket(
                 sourceName, field.sourceId(), numBuckets, field.direction(), field.nullOrder()));
       } else if (transform instanceof Truncate) {
-        int width = ((Truncate<?>) transform).width();
+        long width = ((Truncate<?>) transform).width();
         results.add(
             visitor.truncate(
                 sourceName, field.sourceId(), width, field.direction(), field.nullOrder()));

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -42,11 +42,10 @@ public class Transforms {
     Matcher widthMatcher = HAS_WIDTH.matcher(transform);
     if (widthMatcher.matches()) {
       String name = widthMatcher.group(1);
-      int parsedWidth = Integer.parseInt(widthMatcher.group(2));
       if (name.equalsIgnoreCase("truncate")) {
-        return Truncate.get(parsedWidth);
+        return Truncate.get(Long.parseLong(widthMatcher.group(2)));
       } else if (name.equalsIgnoreCase("bucket")) {
-        return Bucket.get(parsedWidth);
+        return Bucket.get(Integer.parseInt(widthMatcher.group(2)));
       }
     }
 
@@ -75,10 +74,11 @@ public class Transforms {
     Matcher widthMatcher = HAS_WIDTH.matcher(transform);
     if (widthMatcher.matches()) {
       String name = widthMatcher.group(1);
-      int parsedWidth = Integer.parseInt(widthMatcher.group(2));
       if (name.equalsIgnoreCase("truncate")) {
+        long parsedWidth = Long.parseLong(widthMatcher.group(2));
         return (Transform<?, ?>) Truncate.get(type, parsedWidth);
       } else if (name.equalsIgnoreCase("bucket")) {
+        int parsedWidth = Integer.parseInt(widthMatcher.group(2));
         return (Transform<?, ?>) Bucket.get(type, parsedWidth);
       }
     }
@@ -192,10 +192,10 @@ public class Transforms {
    * @param width the width to truncate data values
    * @param <T> Java type passed to this transform
    * @return a transform that truncates the given type to width
-   * @deprecated use {@link #truncate(int)} instead; will be removed in 2.0.0
+   * @deprecated use {@link #truncate(long)} instead; will be removed in 2.0.0
    */
   @Deprecated
-  public static <T> Transform<T, T> truncate(Type type, int width) {
+  public static <T> Transform<T, T> truncate(Type type, long width) {
     return (Transform<T, T>) Truncate.get(type, width);
   }
 
@@ -267,7 +267,7 @@ public class Transforms {
    * @param <T> Java type passed to this transform
    * @return a transform that truncates the given type to width
    */
-  public static <T> Transform<T, T> truncate(int width) {
+  public static <T> Transform<T, T> truncate(long width) {
     return Truncate.get(width);
   }
 

--- a/api/src/main/java/org/apache/iceberg/util/TruncateUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/TruncateUtil.java
@@ -56,7 +56,7 @@ public class TruncateUtil {
     return value - (((value % width) + width) % width);
   }
 
-  public static long truncateLong(int width, long value) {
+  public static long truncateLong(long width, long value) {
     return value - (((value % width) + width) % width);
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -425,7 +425,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     }
 
     @Override
-    public Boolean truncate(int fieldId, String sourceName, int sourceId, int width) {
+    public Boolean truncate(int fieldId, String sourceName, int sourceId, long width) {
       return false;
     }
 
@@ -480,7 +480,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     }
 
     @Override
-    public Boolean truncate(int fieldId, String sourceName, int sourceId, int width) {
+    public Boolean truncate(int fieldId, String sourceName, int sourceId, long width) {
       return false;
     }
 
@@ -531,7 +531,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     }
 
     @Override
-    public String truncate(int fieldId, String sourceName, int sourceId, int width) {
+    public String truncate(int fieldId, String sourceName, int sourceId, long width) {
       return sourceName + "_trunc_" + width;
     }
 

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -63,7 +63,7 @@ public class Partitioning {
               }
 
               @Override
-              public Boolean truncate(int fieldId, String sourceName, int sourceId, int width) {
+              public Boolean truncate(int fieldId, String sourceName, int sourceId, long width) {
                 return false;
               }
 
@@ -161,7 +161,7 @@ public class Partitioning {
     }
 
     @Override
-    public Void truncate(int fieldId, String sourceName, int sourceId, int width) {
+    public Void truncate(int fieldId, String sourceName, int sourceId, long width) {
       builder.asc(Expressions.truncate(sourceName, width));
       return null;
     }

--- a/core/src/main/java/org/apache/iceberg/util/CopySortOrderFields.java
+++ b/core/src/main/java/org/apache/iceberg/util/CopySortOrderFields.java
@@ -50,7 +50,7 @@ class CopySortOrderFields implements SortOrderVisitor<Void> {
 
   @Override
   public Void truncate(
-      String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder) {
+      String sourceName, int sourceId, long width, SortDirection direction, NullOrder nullOrder) {
     builder.sortBy(Expressions.truncate(sourceName, width), direction, nullOrder);
     return null;
   }

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/BucketPartitionerUtil.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/BucketPartitionerUtil.java
@@ -87,7 +87,7 @@ final class BucketPartitionerUtil {
 
     @Override
     public Tuple2<Integer, Integer> truncate(
-        int fieldId, String sourceName, int sourceId, int width) {
+        int fieldId, String sourceName, int sourceId, long width) {
       return null;
     }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/BucketPartitionerUtil.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/BucketPartitionerUtil.java
@@ -87,7 +87,7 @@ final class BucketPartitionerUtil {
 
     @Override
     public Tuple2<Integer, Integer> truncate(
-        int fieldId, String sourceName, int sourceId, int width) {
+        int fieldId, String sourceName, int sourceId, long width) {
       return null;
     }
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/BucketPartitionerUtil.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/BucketPartitionerUtil.java
@@ -87,7 +87,7 @@ final class BucketPartitionerUtil {
 
     @Override
     public Tuple2<Integer, Integer> truncate(
-        int fieldId, String sourceName, int sourceId, int width) {
+        int fieldId, String sourceName, int sourceId, long width) {
       return null;
     }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
@@ -50,7 +50,7 @@ class SortOrderToSpark implements SortOrderVisitor<SortOrder> {
 
   @Override
   public SortOrder truncate(
-      String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
+      String sourceName, int id, long width, SortDirection direction, NullOrder nullOrder) {
     return Expressions.sort(
         Expressions.apply(
             "truncate", Expressions.literal(width), Expressions.column(quotedName(id))),

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -320,7 +320,7 @@ public class Spark3Util {
     }
 
     @Override
-    public Transform truncate(String sourceName, int sourceId, int width) {
+    public Transform truncate(String sourceName, int sourceId, long width) {
       NamedReference column = Expressions.column(quotedName(sourceId));
       return Expressions.apply("truncate", Expressions.literal(width), column);
     }
@@ -393,7 +393,8 @@ public class Spark3Util {
         case "hours":
           return org.apache.iceberg.expressions.Expressions.hour(colName);
         case "truncate":
-          return org.apache.iceberg.expressions.Expressions.truncate(colName, findWidth(transform));
+          return org.apache.iceberg.expressions.Expressions.truncate(
+              colName, findWidthLong(transform));
         case "zorder":
           return new Zorder(
               Stream.of(transform.references())
@@ -458,7 +459,7 @@ public class Spark3Util {
           builder.hour(colName);
           break;
         case "truncate":
-          builder.truncate(colName, findWidth(transform));
+          builder.truncate(colName, findWidthLong(transform));
           break;
         default:
           throw new UnsupportedOperationException("Transform is not supported: " + transform);
@@ -488,6 +489,28 @@ public class Spark3Util {
             throw new IllegalArgumentException();
           }
           return lit.value().intValue();
+        }
+      }
+    }
+
+    throw new IllegalArgumentException("Cannot find width for transform: " + transform.describe());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static long findWidthLong(Transform transform) {
+    for (Expression expr : transform.arguments()) {
+      if (expr instanceof Literal) {
+        if (((Literal) expr).dataType() instanceof IntegerType) {
+          Literal<Integer> lit = (Literal<Integer>) expr;
+          Preconditions.checkArgument(
+              lit.value() > 0, "Unsupported width for transform: %s", transform.describe());
+          return lit.value();
+
+        } else if (((Literal) expr).dataType() instanceof LongType) {
+          Literal<Long> lit = (Literal<Long>) expr;
+          Preconditions.checkArgument(
+              lit.value() > 0, "Unsupported width for transform: %s", transform.describe());
+          return lit.value();
         }
       }
     }
@@ -1014,7 +1037,7 @@ public class Spark3Util {
     public String truncate(
         String sourceName,
         int sourceId,
-        int width,
+        long width,
         org.apache.iceberg.SortDirection direction,
         NullOrder nullOrder) {
       return String.format("truncate(%s, %s) %s %s", sourceName, width, direction, nullOrder);

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -473,8 +473,13 @@ public class SparkV2Filters {
             int numBuckets = (Integer) convertLiteral((Literal<?>) children[0]);
             return bucket(column, numBuckets);
           case "truncate":
-            int width = (Integer) convertLiteral((Literal<?>) children[0]);
-            return truncate(column, width);
+            Object width = convertLiteral((Literal<?>) children[0]);
+            if (width instanceof Integer) {
+              return truncate(column, (Integer) width);
+            } else if (width instanceof Long) {
+              return truncate(column, (Long) width);
+            }
+            throw new IllegalArgumentException("Invalid truncate width: " + width);
         }
       }
     }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -56,7 +56,8 @@ public class TruncateFunction implements UnboundFunction {
   private static final int VALUE_ORDINAL = 1;
 
   private static final Set<DataType> SUPPORTED_WIDTH_TYPES =
-      ImmutableSet.of(DataTypes.ByteType, DataTypes.ShortType, DataTypes.IntegerType);
+      ImmutableSet.of(
+          DataTypes.ByteType, DataTypes.ShortType, DataTypes.IntegerType, DataTypes.LongType);
 
   @Override
   public BoundFunction bind(StructType inputType) {
@@ -69,7 +70,7 @@ public class TruncateFunction implements UnboundFunction {
 
     if (!SUPPORTED_WIDTH_TYPES.contains(widthField.dataType())) {
       throw new UnsupportedOperationException(
-          "Expected truncation width to be tinyint, shortint or int");
+          "Expected truncation width to be tinyint, shortint, int or long");
     }
 
     DataType valueType = valueField.dataType();
@@ -208,13 +209,13 @@ public class TruncateFunction implements UnboundFunction {
 
   public static class TruncateBigInt extends TruncateBase<Long> {
     // magic function for usage with codegen
-    public static long invoke(int width, long value) {
+    public static long invoke(long width, long value) {
       return TruncateUtil.truncateLong(width, value);
     }
 
     @Override
     public DataType[] inputTypes() {
-      return new DataType[] {DataTypes.IntegerType, DataTypes.LongType};
+      return new DataType[] {DataTypes.LongType, DataTypes.LongType};
     }
 
     @Override
@@ -232,7 +233,7 @@ public class TruncateFunction implements UnboundFunction {
       if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
         return null;
       } else {
-        return invoke(input.getInt(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
+        return invoke(input.getLong(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
       }
     }
   }
@@ -318,7 +319,7 @@ public class TruncateFunction implements UnboundFunction {
     }
 
     // magic method used in codegen
-    public static Decimal invoke(int width, Decimal value) {
+    public static Decimal invoke(long width, Decimal value) {
       if (value == null) {
         return null;
       }
@@ -329,7 +330,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public DataType[] inputTypes() {
-      return new DataType[] {DataTypes.IntegerType, DataTypes.createDecimalType(precision, scale)};
+      return new DataType[] {DataTypes.LongType, DataTypes.createDecimalType(precision, scale)};
     }
 
     @Override
@@ -347,7 +348,7 @@ public class TruncateFunction implements UnboundFunction {
       if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
         return null;
       } else {
-        int width = input.getInt(WIDTH_ORDINAL);
+        long width = input.getLong(WIDTH_ORDINAL);
         Decimal value = input.getDecimal(VALUE_ORDINAL, precision, scale);
         return invoke(width, value);
       }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -301,18 +301,18 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
             () -> scalarSql("SELECT system.truncate(CAST('12.34' as DECIMAL(9, 2)), 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (decimal(9,2), int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (decimal(9,2), int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(() -> scalarSql("SELECT system.truncate('5', 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (string, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (string, int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(
             () -> scalarSql("SELECT system.truncate(INTERVAL '100-00' YEAR TO MONTH, 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (interval year to month, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (interval year to month, int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(
             () ->
@@ -320,7 +320,7 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
                     "SELECT system.truncate(CAST('11 23:4:0' AS INTERVAL DAY TO SECOND), 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (interval day to second, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (interval day to second, int): Expected truncation width to be tinyint, shortint, int or long");
   }
 
   @TestTemplate
@@ -378,7 +378,7 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
 
     String smallIntWidth = (String) scalarSql("EXPLAIN EXTENDED SELECT system.truncate(5S, 6L)");
     assertThat(smallIntWidth)
-        .contains("cast(5 as int)")
+        .contains("cast(5 as bigint)")
         .contains(
             "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateBigInt");
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
@@ -50,7 +50,7 @@ class SortOrderToSpark implements SortOrderVisitor<SortOrder> {
 
   @Override
   public SortOrder truncate(
-      String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
+      String sourceName, int id, long width, SortDirection direction, NullOrder nullOrder) {
     return Expressions.sort(
         Expressions.apply(
             "truncate", Expressions.literal(width), Expressions.column(quotedName(id))),

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -473,8 +473,13 @@ public class SparkV2Filters {
             int numBuckets = (Integer) convertLiteral((Literal<?>) children[0]);
             return bucket(column, numBuckets);
           case "truncate":
-            int width = (Integer) convertLiteral((Literal<?>) children[0]);
-            return truncate(column, width);
+            Object width = convertLiteral((Literal<?>) children[0]);
+            if (width instanceof Integer) {
+              return truncate(column, (Integer) width);
+            } else if (width instanceof Long) {
+              return truncate(column, (Long) width);
+            }
+            throw new IllegalArgumentException("Invalid truncate width: " + width);
         }
       }
     }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -56,7 +56,8 @@ public class TruncateFunction implements UnboundFunction {
   private static final int VALUE_ORDINAL = 1;
 
   private static final Set<DataType> SUPPORTED_WIDTH_TYPES =
-      ImmutableSet.of(DataTypes.ByteType, DataTypes.ShortType, DataTypes.IntegerType);
+      ImmutableSet.of(
+          DataTypes.ByteType, DataTypes.ShortType, DataTypes.IntegerType, DataTypes.LongType);
 
   @Override
   public BoundFunction bind(StructType inputType) {
@@ -69,7 +70,7 @@ public class TruncateFunction implements UnboundFunction {
 
     if (!SUPPORTED_WIDTH_TYPES.contains(widthField.dataType())) {
       throw new UnsupportedOperationException(
-          "Expected truncation width to be tinyint, shortint or int");
+          "Expected truncation width to be tinyint, shortint, int or long");
     }
 
     DataType valueType = valueField.dataType();
@@ -208,13 +209,13 @@ public class TruncateFunction implements UnboundFunction {
 
   public static class TruncateBigInt extends TruncateBase<Long> {
     // magic function for usage with codegen
-    public static long invoke(int width, long value) {
+    public static long invoke(long width, long value) {
       return TruncateUtil.truncateLong(width, value);
     }
 
     @Override
     public DataType[] inputTypes() {
-      return new DataType[] {DataTypes.IntegerType, DataTypes.LongType};
+      return new DataType[] {DataTypes.LongType, DataTypes.LongType};
     }
 
     @Override
@@ -232,7 +233,7 @@ public class TruncateFunction implements UnboundFunction {
       if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
         return null;
       } else {
-        return invoke(input.getInt(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
+        return invoke(input.getLong(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
       }
     }
   }
@@ -318,7 +319,7 @@ public class TruncateFunction implements UnboundFunction {
     }
 
     // magic method used in codegen
-    public static Decimal invoke(int width, Decimal value) {
+    public static Decimal invoke(long width, Decimal value) {
       if (value == null) {
         return null;
       }
@@ -329,7 +330,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public DataType[] inputTypes() {
-      return new DataType[] {DataTypes.IntegerType, DataTypes.createDecimalType(precision, scale)};
+      return new DataType[] {DataTypes.LongType, DataTypes.createDecimalType(precision, scale)};
     }
 
     @Override
@@ -347,7 +348,7 @@ public class TruncateFunction implements UnboundFunction {
       if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
         return null;
       } else {
-        int width = input.getInt(WIDTH_ORDINAL);
+        long width = input.getLong(WIDTH_ORDINAL);
         Decimal value = input.getDecimal(VALUE_ORDINAL, precision, scale);
         return invoke(width, value);
       }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -301,18 +301,18 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
             () -> scalarSql("SELECT system.truncate(CAST('12.34' as DECIMAL(9, 2)), 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (decimal(9,2), int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (decimal(9,2), int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(() -> scalarSql("SELECT system.truncate('5', 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (string, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (string, int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(
             () -> scalarSql("SELECT system.truncate(INTERVAL '100-00' YEAR TO MONTH, 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (interval year to month, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (interval year to month, int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(
             () ->
@@ -320,7 +320,7 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
                     "SELECT system.truncate(CAST('11 23:4:0' AS INTERVAL DAY TO SECOND), 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (interval day to second, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (interval day to second, int): Expected truncation width to be tinyint, shortint, int or long");
   }
 
   @TestTemplate
@@ -378,7 +378,7 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
 
     String smallIntWidth = (String) scalarSql("EXPLAIN EXTENDED SELECT system.truncate(5S, 6L)");
     assertThat(smallIntWidth)
-        .contains("cast(5 as int)")
+        .contains("cast(5 as bigint)")
         .contains(
             "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateBigInt");
   }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
@@ -50,7 +50,7 @@ class SortOrderToSpark implements SortOrderVisitor<SortOrder> {
 
   @Override
   public SortOrder truncate(
-      String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
+      String sourceName, int id, long width, SortDirection direction, NullOrder nullOrder) {
     return Expressions.sort(
         Expressions.apply(
             "truncate", Expressions.literal(width), Expressions.column(quotedName(id))),

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -473,8 +473,13 @@ public class SparkV2Filters {
             int numBuckets = (Integer) convertLiteral((Literal<?>) children[0]);
             return bucket(column, numBuckets);
           case "truncate":
-            int width = (Integer) convertLiteral((Literal<?>) children[0]);
-            return truncate(column, width);
+            Object width = convertLiteral((Literal<?>) children[0]);
+            if (width instanceof Integer) {
+              return truncate(column, (Integer) width);
+            } else if (width instanceof Long) {
+              return truncate(column, (Long) width);
+            }
+            throw new IllegalArgumentException("Invalid truncate width: " + width);
         }
       }
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -56,7 +56,8 @@ public class TruncateFunction implements UnboundFunction {
   private static final int VALUE_ORDINAL = 1;
 
   private static final Set<DataType> SUPPORTED_WIDTH_TYPES =
-      ImmutableSet.of(DataTypes.ByteType, DataTypes.ShortType, DataTypes.IntegerType);
+      ImmutableSet.of(
+          DataTypes.ByteType, DataTypes.ShortType, DataTypes.IntegerType, DataTypes.LongType);
 
   @Override
   public BoundFunction bind(StructType inputType) {
@@ -69,7 +70,7 @@ public class TruncateFunction implements UnboundFunction {
 
     if (!SUPPORTED_WIDTH_TYPES.contains(widthField.dataType())) {
       throw new UnsupportedOperationException(
-          "Expected truncation width to be tinyint, shortint or int");
+          "Expected truncation width to be tinyint, shortint, int or long");
     }
 
     DataType valueType = valueField.dataType();
@@ -208,13 +209,13 @@ public class TruncateFunction implements UnboundFunction {
 
   public static class TruncateBigInt extends TruncateBase<Long> {
     // magic function for usage with codegen
-    public static long invoke(int width, long value) {
+    public static long invoke(long width, long value) {
       return TruncateUtil.truncateLong(width, value);
     }
 
     @Override
     public DataType[] inputTypes() {
-      return new DataType[] {DataTypes.IntegerType, DataTypes.LongType};
+      return new DataType[] {DataTypes.LongType, DataTypes.LongType};
     }
 
     @Override
@@ -232,7 +233,7 @@ public class TruncateFunction implements UnboundFunction {
       if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
         return null;
       } else {
-        return invoke(input.getInt(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
+        return invoke(input.getLong(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
       }
     }
   }
@@ -318,7 +319,7 @@ public class TruncateFunction implements UnboundFunction {
     }
 
     // magic method used in codegen
-    public static Decimal invoke(int width, Decimal value) {
+    public static Decimal invoke(long width, Decimal value) {
       if (value == null) {
         return null;
       }
@@ -329,7 +330,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public DataType[] inputTypes() {
-      return new DataType[] {DataTypes.IntegerType, DataTypes.createDecimalType(precision, scale)};
+      return new DataType[] {DataTypes.LongType, DataTypes.createDecimalType(precision, scale)};
     }
 
     @Override
@@ -347,7 +348,7 @@ public class TruncateFunction implements UnboundFunction {
       if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
         return null;
       } else {
-        int width = input.getInt(WIDTH_ORDINAL);
+        long width = input.getLong(WIDTH_ORDINAL);
         Decimal value = input.getDecimal(VALUE_ORDINAL, precision, scale);
         return invoke(width, value);
       }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -301,18 +301,18 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
             () -> scalarSql("SELECT system.truncate(CAST('12.34' as DECIMAL(9, 2)), 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (decimal(9,2), int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (decimal(9,2), int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(() -> scalarSql("SELECT system.truncate('5', 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (string, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (string, int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(
             () -> scalarSql("SELECT system.truncate(INTERVAL '100-00' YEAR TO MONTH, 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (interval year to month, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (interval year to month, int): Expected truncation width to be tinyint, shortint, int or long");
 
     assertThatThrownBy(
             () ->
@@ -320,7 +320,7 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
                     "SELECT system.truncate(CAST('11 23:4:0' AS INTERVAL DAY TO SECOND), 10)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'truncate' cannot process input: (interval day to second, int): Expected truncation width to be tinyint, shortint or int");
+            "Function 'truncate' cannot process input: (interval day to second, int): Expected truncation width to be tinyint, shortint, int or long");
   }
 
   @TestTemplate
@@ -377,7 +377,7 @@ public class TestSparkTruncateFunction extends TestBaseWithCatalog {
 
     String smallIntWidth = (String) scalarSql("EXPLAIN EXTENDED SELECT system.truncate(5S, 6L)");
     assertThat(smallIntWidth)
-        .contains("cast(5 as int)")
+        .contains("cast(5 as bigint)")
         .contains(
             "static_invoke(org.apache.iceberg.spark.functions.TruncateFunction$TruncateBigInt");
   }


### PR DESCRIPTION
This PR expands width argument of truncate function from int to long. In my case I have long ids like `250812686421393265` and I want to use first six digits as a partition key. I've tried `truncate(1000000000000, id)` transform, but it didn't work in 1.9.2 because 1000000000000 is greater than Integer.MAX_VALUE.

Seems like the change is not breaking. I've tested, a table created and partitioned with the patched version of spark 3.5 is still readable by trino 476 if width is less than Integer.MAX_VALUE.

I didn't find in the spec that width must be less than Integer.MAX_VALUE, so I guess it's not a breaking change from that perspective either.