### PR TITLE
Revert "Docker: Pin QEMU version temporarily"

### DIFF
--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -54,9 +54,6 @@ jobs:
         echo "DOCKER_IMAGE_VERSION=`echo ${{ github.ref }} | tr -d -c 0-9.`" >> "$GITHUB_ENV"
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-      with:
-        ## Temporary due to bug in qemu:  https://github.com/docker/setup-qemu-action/issues/198
-        image: tonistiigi/binfmt:qemu-v7.0.0-28
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Build and Push


### PR DESCRIPTION
Reverts apache/iceberg#12262

The issue (https://github.com/docker/setup-qemu-action/issues/198) has been resolved. 
I verified reverting the change is fine in another Trino's testing docker repository (https://github.com/trinodb/docker-images/pull/251). 