### PR TITLE
 Spark 3.5, 3.4: Add removed_delete_files_count to result of RewriteDataFilesProcedure

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -89,7 +89,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -112,7 +112,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
   public void testRewriteDataFilesInEmptyTable() {
     createTable();
     List<Object[]> output = sql("CALL %s.system.rewrite_data_files('%s')", catalogName, tableIdent);
-    assertEquals("Procedure output must match", ImmutableList.of(row(0, 0, 0L, 0)), output);
+    assertEquals("Procedure output must match", ImmutableList.of(row(0, 0, 0L, 0, 0)), output);
   }
 
   @TestTemplate
@@ -130,7 +130,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 2),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -154,7 +154,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -178,7 +178,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
 
     assertEquals(
         "Action should rewrite 0 data files and add 0 data files",
-        ImmutableList.of(row(0, 0, 0L, 0)),
+        ImmutableList.of(row(0, 0, 0L, 0, 0)),
         output);
 
     List<Object[]> actualRecords = currentData();
@@ -204,7 +204,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -266,7 +266,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -307,7 +307,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         "Action should rewrite 10 data files and add 1 data files",
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(snapshotSummary())
         .containsEntry(SnapshotSummary.REMOVED_FILE_SIZE_PROP, String.valueOf(output.get(0)[2]));
     assertThat(sql("SELECT * FROM %s", tableName))
@@ -379,7 +379,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(5, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -404,7 +404,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -450,7 +450,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(5, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -482,7 +482,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(5, 1),
         row(output.get(0)[0], output.get(0)[1]));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -510,7 +510,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(5, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -772,7 +772,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isEqualTo(
             Long.valueOf(snapshotSummary(identifier).get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -811,7 +811,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(
@@ -851,7 +851,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(
@@ -887,7 +887,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(2, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -73,7 +73,9 @@ class RewriteDataFilesProcedure extends BaseProcedure {
                 "added_data_files_count", DataTypes.IntegerType, false, Metadata.empty()),
             new StructField("rewritten_bytes_count", DataTypes.LongType, false, Metadata.empty()),
             new StructField(
-                "failed_data_files_count", DataTypes.IntegerType, false, Metadata.empty())
+                "failed_data_files_count", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField(
+                "removed_delete_files_count", DataTypes.IntegerType, false, Metadata.empty())
           });
 
   public static ProcedureBuilder builder() {
@@ -198,13 +200,15 @@ class RewriteDataFilesProcedure extends BaseProcedure {
     long rewrittenBytesCount = result.rewrittenBytesCount();
     int addedDataFilesCount = result.addedDataFilesCount();
     int failedDataFilesCount = result.failedDataFilesCount();
+    int removedDeleteFilesCount = result.removedDeleteFilesCount();
 
     InternalRow row =
         newInternalRow(
             rewrittenDataFilesCount,
             addedDataFilesCount,
             rewrittenBytesCount,
-            failedDataFilesCount);
+            failedDataFilesCount,
+            removedDeleteFilesCount);
     return new InternalRow[] {row};
   }
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -98,7 +98,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -121,7 +121,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
   public void testRewriteDataFilesInEmptyTable() {
     createTable();
     List<Object[]> output = sql("CALL %s.system.rewrite_data_files('%s')", catalogName, tableIdent);
-    assertEquals("Procedure output must match", ImmutableList.of(row(0, 0, 0L, 0)), output);
+    assertEquals("Procedure output must match", ImmutableList.of(row(0, 0, 0L, 0, 0)), output);
   }
 
   @TestTemplate
@@ -139,7 +139,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 2),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -206,7 +206,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -230,7 +230,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
 
     assertEquals(
         "Action should rewrite 0 data files and add 0 data files",
-        ImmutableList.of(row(0, 0, 0L, 0)),
+        ImmutableList.of(row(0, 0, 0L, 0, 0)),
         output);
 
     List<Object[]> actualRecords = currentData();
@@ -256,7 +256,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -318,7 +318,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -359,7 +359,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         "Action should rewrite 10 data files and add 1 data files",
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(snapshotSummary())
         .containsEntry(SnapshotSummary.REMOVED_FILE_SIZE_PROP, String.valueOf(output.get(0)[2]));
     assertThat(sql("SELECT * FROM %s", tableName))
@@ -431,7 +431,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(5, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -456,7 +456,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -502,7 +502,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(5, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -534,7 +534,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(5, 1),
         row(output.get(0)[0], output.get(0)[1]));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -562,7 +562,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(5, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -824,7 +824,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isEqualTo(
             Long.valueOf(snapshotSummary(identifier).get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));
@@ -863,7 +863,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(
@@ -903,7 +903,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(10, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(
@@ -939,7 +939,7 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
         row(2, 1),
         Arrays.copyOf(output.get(0), 2));
     // verify rewritten bytes separately
-    assertThat(output.get(0)).hasSize(4);
+    assertThat(output.get(0)).hasSize(5);
     assertThat(output.get(0)[2])
         .isInstanceOf(Long.class)
         .isEqualTo(Long.valueOf(snapshotSummary().get(SnapshotSummary.REMOVED_FILE_SIZE_PROP)));

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -73,7 +73,9 @@ class RewriteDataFilesProcedure extends BaseProcedure {
                 "added_data_files_count", DataTypes.IntegerType, false, Metadata.empty()),
             new StructField("rewritten_bytes_count", DataTypes.LongType, false, Metadata.empty()),
             new StructField(
-                "failed_data_files_count", DataTypes.IntegerType, false, Metadata.empty())
+                "failed_data_files_count", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField(
+                "removed_delete_files_count", DataTypes.IntegerType, false, Metadata.empty())
           });
 
   public static ProcedureBuilder builder() {
@@ -198,13 +200,15 @@ class RewriteDataFilesProcedure extends BaseProcedure {
     long rewrittenBytesCount = result.rewrittenBytesCount();
     int addedDataFilesCount = result.addedDataFilesCount();
     int failedDataFilesCount = result.failedDataFilesCount();
+    int removedDeleteFilesCount = result.removedDeleteFilesCount();
 
     InternalRow row =
         newInternalRow(
             rewrittenDataFilesCount,
             addedDataFilesCount,
             rewrittenBytesCount,
-            failedDataFilesCount);
+            failedDataFilesCount,
+            removedDeleteFilesCount);
     return new InternalRow[] {row};
   }
 


### PR DESCRIPTION
Back-port of https://github.com/apache/iceberg/pull/13657