### PR TITLE
Flink: Fix table of contents in Flink docs

### DIFF
--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -370,7 +370,7 @@ the state of the Flink job. To avoid that, make sure to keep the last snapshot c
 job (which can be identified by the `flink.job-id` property in the summary), and only delete
 orphan files that are old enough.
 
-# Flink Writes (SinkV2 based implementation)
+## Sink V2 based implementation
 
 At the time when the current default, `FlinkSink` implementation was created, Flink Sink's interface had some
 limitations that were not acceptable for the Iceberg tables purpose. Due to these limitations, `FlinkSink` is based 
@@ -381,14 +381,14 @@ was introduced. This interface is used in the new `IcebergSink` implementation w
 The new implementation is a base for further work on features such as [table maintenance](maintenance.md).
 The SinkV2 based implementation is currently an experimental feature so use it with caution.
 
-## Writing with SQL
+### Writing with SQL
 
 To turn on SinkV2 based implementation in SQL, set this configuration option:
 ```sql
 SET table.exec.iceberg.use-v2-sink = true;
 ```
 
-## Writing with DataStream
+### Writing with DataStream
 
 To use SinkV2 based implementation, replace `FlinkSink` with `IcebergSink` in the provided snippets.
 !!! warning
@@ -398,9 +398,9 @@ To use SinkV2 based implementation, replace `FlinkSink` with `IcebergSink` in th
      - When using `IcebergSink` use `uidSuffix` instead of the `uidPrefix`
 
 
-## Dynamic Iceberg Flink Sink
+## Flink Dynamic Iceberg Sink
 
-Dynamic Flink Iceberg Sink allows:
+The Flink Dynamic Iceberg Sink (Dynamic Sink) allows:
 
 1. **Writing to any number of tables**  
    A single sink can dynamically route records to multiple Iceberg tables.
@@ -515,7 +515,7 @@ Unsupported schema updates:
 Dropping columns is avoided to prevent issues with late or out-of-order data, as removed fields cannot be easily restored without data loss. Renaming is unsupported because schema comparison is name-based, and renames would require additional metadata or hints to resolve.
 
 
-#### Cache
+### Caching
 
 There are two distinct caches involved: the table metadata cache and the input schema cache.
 


### PR DESCRIPTION
Some of the headings in the Flink docs are incorrectly indented, which leads to headings not appearing in the table of contents. The following sections of the docs are off:

1. Sink V2 implementation
2. Flink Dynamic Iceberg Sink

Both of them are submerged in the "Notes" section. See https://iceberg.apache.org/docs/nightly/flink-writes/#notes

This is an example section of the docs alongside with the table of contents:

---
<img width="1004" height="748" alt="image" src="https://github.com/user-attachments/assets/80761eb9-c9c8-40ef-be32-839e701d9bdd" />
