### PR TITLE
Core: Deprecate TableMetadataParser.read with unused file io parameter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -85,7 +85,7 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
 
     TableOperations ops = newTableOps(identifier);
     InputFile metadataFile = ops.io().newInputFile(metadataFileLocation);
-    TableMetadata metadata = TableMetadataParser.read(ops.io(), metadataFile);
+    TableMetadata metadata = TableMetadataParser.read(metadataFile);
     ops.commit(null, metadata);
 
     return new BaseTable(ops, fullTableName(name(), identifier), metricsReporter());

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -295,7 +295,7 @@ public class TableMetadataParser {
   }
 
   /**
-   * @deprecated use {@link #read(InputFile)} instead.
+   * @deprecated since 1.10.0, will be removed in 1.11.0; use {@link #read(InputFile)} instead.
    */
   @Deprecated
   public static TableMetadata read(FileIO io, InputFile file) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -291,10 +291,18 @@ public class TableMetadataParser {
   }
 
   public static TableMetadata read(FileIO io, String path) {
-    return read(io, io.newInputFile(path));
+    return read(io.newInputFile(path));
   }
 
+  /**
+   * @deprecated use {@link #read(InputFile)} instead.
+   */
+  @Deprecated
   public static TableMetadata read(FileIO io, InputFile file) {
+    return read(file);
+  }
+
+  public static TableMetadata read(InputFile file) {
     Codec codec = Codec.fromFileName(file.location());
     try (InputStream is =
         codec == Codec.GZIP ? new GZIPInputStream(file.newStream()) : file.newStream()) {

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadataParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadataParser.java
@@ -67,8 +67,7 @@ public class TestTableMetadataParser {
     TableMetadata metadata = newTableMetadata(SCHEMA, unpartitioned(), location, properties);
     TableMetadataParser.write(metadata, outputFile);
     assertThat(isCompressed(fileName)).isEqualTo(codec == Codec.GZIP);
-    TableMetadata actualMetadata =
-        TableMetadataParser.read(null, Files.localInput(new File(fileName)));
+    TableMetadata actualMetadata = TableMetadataParser.read(Files.localInput(new File(fileName)));
     verifyMetadata(metadata, actualMetadata);
   }
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
@@ -43,7 +43,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
-import org.apache.iceberg.TestTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.io.Files;
@@ -140,8 +139,7 @@ public class HadoopTableTestBase {
   }
 
   TableMetadata readMetadataVersion(int version) {
-    return TableMetadataParser.read(
-        new TestTables.TestTableOperations("table", tableDir).io(), localInput(version(version)));
+    return TableMetadataParser.read(localInput(version(version)));
   }
 
   int readVersionHint() throws IOException {


### PR DESCRIPTION
The file io parameter is never used in  `TableMetadataParser#read(org.apache.iceberg.io.FileIO, org.apache.iceberg.io.InputFile)` and can be removed.