### PR TITLE
[docs] Add EOS note to Flink docs

### DIFF
--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -19,7 +19,9 @@ title: "Flink Writes"
  -->
 # Flink Writes
 
-Iceberg support batch and streaming writes With [Apache Flink](https://flink.apache.org/)'s DataStream API and Table API.
+Iceberg support batch and streaming writes with [Apache Flink](https://flink.apache.org/)'s DataStream API and Table API.
+
+The Flink Iceberg sink guarantees exactly-once semantics.
 
 ## Writing with SQL
 


### PR DESCRIPTION
also fix a typo `s/With/with` in the current text.