### PR TITLE
Use URI string for default Iceberg warehouse location

### DIFF
--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
@@ -89,7 +89,7 @@ public class RESTCatalogServer {
     if (warehouseLocation == null) {
       File tmp = java.nio.file.Files.createTempDirectory("iceberg_warehouse").toFile();
       tmp.deleteOnExit();
-      warehouseLocation = new File(tmp, "iceberg_data").getAbsolutePath();
+      warehouseLocation = new File(tmp, "iceberg_data").toURI().toString();
       catalogProperties.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation);
 
       LOG.info("No warehouse location set. Defaulting to temp location: {}", warehouseLocation);


### PR DESCRIPTION
### Summary
When no warehouse location is set, the code previously used  `getAbsolutePath()` to configure the default Iceberg warehouse directory.   This change switches to using `toURI().toString()`, ensuring the warehouse 
location is represented as a standardized URI (e.g., `file:/.../iceberg_data/`).