### PR TITLE
Flink: Dynamic Sink: Allow updating table properties

### DIFF
--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -43,6 +43,7 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
   private final int cacheMaximumSize;
   private final long cacheRefreshMs;
   private final int inputSchemasPerTableCacheMaximumSize;
+  private final TablePropertiesUpdater tablePropertiesUpdater;
 
   private transient TableMetadataCache tableCache;
   private transient HashKeyGenerator hashKeyGenerator;
@@ -57,13 +58,15 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
       boolean immediateUpdate,
       int cacheMaximumSize,
       long cacheRefreshMs,
-      int inputSchemasPerTableCacheMaximumSize) {
+      int inputSchemasPerTableCacheMaximumSize,
+      TablePropertiesUpdater tablePropertiesUpdater) {
     this.generator = generator;
     this.catalogLoader = catalogLoader;
     this.immediateUpdate = immediateUpdate;
     this.cacheMaximumSize = cacheMaximumSize;
     this.cacheRefreshMs = cacheRefreshMs;
     this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
+    this.tablePropertiesUpdater = tablePropertiesUpdater;
   }
 
   @Override
@@ -77,7 +80,7 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
         new HashKeyGenerator(
             cacheMaximumSize, getRuntimeContext().getTaskInfo().getMaxNumberOfParallelSubtasks());
     if (immediateUpdate) {
-      updater = new TableUpdater(tableCache, catalog);
+      updater = new TableUpdater(tableCache, catalog, tablePropertiesUpdater);
     } else {
       updateStream =
           new OutputTag<>(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
+import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.RichMapFunction;
@@ -42,17 +43,21 @@ class DynamicTableUpdateOperator
   private final long cacheRefreshMs;
   private final int inputSchemasPerTableCacheMaximumSize;
 
+  @Nullable private final TablePropertiesUpdater tablePropertiesUpdater;
+
   private transient TableUpdater updater;
 
   DynamicTableUpdateOperator(
       CatalogLoader catalogLoader,
       int cacheMaximumSize,
       long cacheRefreshMs,
-      int inputSchemasPerTableCacheMaximumSize) {
+      int inputSchemasPerTableCacheMaximumSize,
+      @Nullable TablePropertiesUpdater tablePropertiesUpdater) {
     this.catalogLoader = catalogLoader;
     this.cacheMaximumSize = cacheMaximumSize;
     this.cacheRefreshMs = cacheRefreshMs;
     this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
+    this.tablePropertiesUpdater = tablePropertiesUpdater;
   }
 
   @Override
@@ -63,7 +68,8 @@ class DynamicTableUpdateOperator
         new TableUpdater(
             new TableMetadataCache(
                 catalog, cacheMaximumSize, cacheRefreshMs, inputSchemasPerTableCacheMaximumSize),
-            catalog);
+            catalog,
+            tablePropertiesUpdater);
   }
 
   @Override

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TablePropertiesUpdater.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TablePropertiesUpdater.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.io.Serializable;
+import java.util.Map;
+
+@FunctionalInterface
+public interface TablePropertiesUpdater extends Serializable {
+
+  /**
+   * Updates table properties based on the current properties and the fully-qualified table name.
+   *
+   * @param tableName the fully-qualified name of the table being updated
+   * @param currentProperties the current table properties
+   * @return the updated table properties
+   */
+  Map<String, String> apply(String tableName, Map<String, String> currentProperties);
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
@@ -61,7 +61,8 @@ class TestDynamicTableUpdateOperator {
             CATALOG_EXTENSION.catalogLoader(),
             cacheMaximumSize,
             cacheRefreshMs,
-            inputSchemaCacheMaximumSize);
+            inputSchemaCacheMaximumSize,
+            null);
     operator.open(null);
 
     DynamicRecordInternal input =
@@ -93,7 +94,8 @@ class TestDynamicTableUpdateOperator {
             CATALOG_EXTENSION.catalogLoader(),
             cacheMaximumSize,
             cacheRefreshMs,
-            inputSchemaCacheMaximumSize);
+            inputSchemaCacheMaximumSize,
+            null);
     operator.open(null);
 
     catalog.createTable(table, SCHEMA1);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
@@ -20,12 +20,14 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.sink.TestFlinkIcebergSinkBase;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +45,7 @@ public class TestTableMetadataCache extends TestFlinkIcebergSinkBase {
           Types.NestedField.optional(3, "extra", Types.StringType.get()));
 
   @Test
-  void testCaching() {
+  void testSchemaCaching() {
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");
     catalog.createTable(tableIdentifier, SCHEMA);
@@ -61,6 +63,64 @@ public class TestTableMetadataCache extends TestFlinkIcebergSinkBase {
     assertThat(
             cache.schema(tableIdentifier, SerializationUtils.clone(SCHEMA)).resolvedTableSchema())
         .isEqualTo(schema1);
+  }
+
+  @Test
+  void testSpecCaching() {
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");
+
+    // Create table with initial partition spec
+    PartitionSpec initialSpec = PartitionSpec.builderFor(SCHEMA).bucket("data", 10).build();
+    catalog.createTable(tableIdentifier, SCHEMA, initialSpec);
+    TableMetadataCache cache = new TableMetadataCache(catalog, 10, Long.MAX_VALUE, 10);
+
+    // Test spec caching - first call should load from catalog
+    PartitionSpec cachedSpec1 = cache.spec(tableIdentifier, initialSpec);
+    assertThat(cachedSpec1).isNotNull();
+    assertThat(cachedSpec1).isEqualTo(initialSpec);
+
+    // Second call should return cached result
+    PartitionSpec cachedSpec2 = cache.spec(tableIdentifier, initialSpec);
+    assertThat(cachedSpec2).isSameAs(cachedSpec1);
+
+    // Test with different but compatible spec
+    PartitionSpec compatibleSpec = PartitionSpec.builderFor(SCHEMA).bucket("data", 10).build();
+    PartitionSpec cachedCompatibleSpec = cache.spec(tableIdentifier, compatibleSpec);
+    assertThat(cachedCompatibleSpec).isEqualTo(initialSpec);
+
+    // Test with incompatible spec - should return null
+    PartitionSpec incompatibleSpec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
+    PartitionSpec cachedIncompatibleSpec = cache.spec(tableIdentifier, incompatibleSpec);
+    assertThat(cachedIncompatibleSpec).isNull();
+  }
+
+  @Test
+  void testPropertiesCaching() {
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");
+
+    // Create table with some properties
+    Map<String, String> initialProperties = Maps.newHashMap();
+    initialProperties.put("write.format.default", "parquet");
+    initialProperties.put("write.parquet.compression-codec", "snappy");
+    catalog.createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned(), initialProperties);
+
+    TableMetadataCache cache = new TableMetadataCache(catalog, 10, Long.MAX_VALUE, 10);
+
+    // Test properties caching - first call should load from catalog
+    Map<String, String> cachedProperties = cache.properties(tableIdentifier);
+    assertThat(cachedProperties).isNotNull();
+    assertThat(cachedProperties).containsAllEntriesOf(initialProperties);
+
+    // Second call should return cached result
+    Map<String, String> cachedProperties2 = cache.properties(tableIdentifier);
+    assertThat(cachedProperties2).isSameAs(cachedProperties);
+
+    // Test with non-existent table
+    TableIdentifier nonExistentTable = TableIdentifier.parse("default.nonExistentTable");
+    Map<String, String> nonExistentProperties = cache.properties(nonExistentTable);
+    assertThat(nonExistentProperties).isNull();
   }
 
   @Test


### PR DESCRIPTION
This feature allows modifying table properties on the fly. Users have reported that they need to update table properties of both new and existing tables. Some catalogues even check for certain properties and reject table changes if those properties are not present.

Below the doc added as part of this PR:

---
#### Dynamic Table Properties

The Dynamic Sink supports dynamically updating table properties. This feature allows you to:

- Set different properties for different tables based on table names
- Apply properties during table creation
- Update properties for existing tables

#### TablePropertiesUpdater Interface

The `TablePropertiesUpdater` is an interface that receives the fully-qualified table name and current properties, then returns the updated properties:

```java
interface TablePropertiesUpdater extends Serializable {
    Map<String, String> apply(String tableName, Map<String, String> currentProperties);
}
```

#### Usage Example

```java
TablePropertiesUpdater updater = (tableName, currentProps) -> {
    Map<String, String> updatedProps = new HashMap<>(currentProps);

    // Set compression based on table name
    if (tableName.contains("logs")) {
        updatedProps.put("write.parquet.compression-codec", "gzip");
    } else {
        updatedProps.put("write.parquet.compression-codec", "snappy");
    }

    // Set format properties
    updatedProps.put("write.format.default", "parquet");

    // Add custom metadata
    updatedProps.put("created.by", "dynamic-sink");
    updatedProps.put("table.identifier", tableName);

    // Remove table properties
    updatedProps.remove("to.be.removed.prop");

    return updatedProps;
};

DynamicIcebergSink.forInput(dataStream)
    .generator(new CustomRecordGenerator())
    .catalogLoader(catalogLoader)
    .tablePropertiesUpdater(updater)
    .append();
```