### PR TITLE
Flink: Backport supports delete orphan files in TableMaintenance to 1.19 and 1.20

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFiles.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFiles.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import java.time.Duration;
+import java.util.Map;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
+import org.apache.iceberg.flink.maintenance.operator.DeleteFilesProcessor;
+import org.apache.iceberg.flink.maintenance.operator.FileNameReader;
+import org.apache.iceberg.flink.maintenance.operator.FileUriKeySelector;
+import org.apache.iceberg.flink.maintenance.operator.ListFileSystemFiles;
+import org.apache.iceberg.flink.maintenance.operator.ListMetadataFiles;
+import org.apache.iceberg.flink.maintenance.operator.MetadataTablePlanner;
+import org.apache.iceberg.flink.maintenance.operator.OrphanFilesDetector;
+import org.apache.iceberg.flink.maintenance.operator.SkipOnError;
+import org.apache.iceberg.flink.maintenance.operator.TaskResultAggregator;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.ThreadPools;
+
+/** Delete orphan files from the file system. */
+public class DeleteOrphanFiles {
+
+  private static final Schema FILE_PATH_SCHEMA = new Schema(DataFile.FILE_PATH);
+  private static final ScanContext FILE_PATH_SCAN_CONTEXT =
+      ScanContext.builder().streaming(true).project(FILE_PATH_SCHEMA).build();
+  private static final Splitter COMMA_SPLITTER = Splitter.on(",");
+
+  @Internal
+  public static final OutputTag<Exception> ERROR_STREAM =
+      new OutputTag<>("error-stream", TypeInformation.of(Exception.class));
+
+  static final String PLANNER_TASK_NAME = "Table Planner";
+  static final String READER_TASK_NAME = "Files Reader";
+  static final String FILESYSTEM_FILES_TASK_NAME = "Filesystem Files";
+  static final String METADATA_FILES_TASK_NAME = "List metadata Files";
+  static final String DELETE_FILES_TASK_NAME = "Delete File";
+  static final String AGGREGATOR_TASK_NAME = "Orphan Files Aggregator";
+  static final String FILTER_FILES_TASK_NAME = "Filter File";
+  static final String SKIP_ON_ERROR_TASK_NAME = "Skip On Error";
+
+  public static DeleteOrphanFiles.Builder builder() {
+    return new DeleteOrphanFiles.Builder();
+  }
+
+  private DeleteOrphanFiles() {
+    // Do not instantiate directly
+  }
+
+  public static class Builder extends MaintenanceTaskBuilder<DeleteOrphanFiles.Builder> {
+    private String location;
+    private Duration minAge = Duration.ofDays(3);
+    private int planningWorkerPoolSize = ThreadPools.WORKER_THREAD_POOL_SIZE;
+    private int deleteBatchSize = 1000;
+    private boolean usePrefixListing = false;
+    private Map<String, String> equalSchemes =
+        Maps.newHashMap(
+            ImmutableMap.of(
+                "s3n", "s3",
+                "s3a", "s3"));
+    private final Map<String, String> equalAuthorities = Maps.newHashMap();
+    private PrefixMismatchMode prefixMismatchMode = PrefixMismatchMode.ERROR;
+
+    @Override
+    String maintenanceTaskName() {
+      return "DeleteOrphanFiles";
+    }
+
+    /**
+     * The location to start the recursive listing the candidate files for removal. By default, the
+     * {@link Table#location()} is used.
+     *
+     * @param newLocation the task will scan
+     * @return for chained calls
+     */
+    public Builder location(String newLocation) {
+      this.location = newLocation;
+      return this;
+    }
+
+    /**
+     * Whether to use prefix listing when listing files from the file system.
+     *
+     * @param newUsePrefixListing true to enable prefix listing, false otherwise
+     * @return for chained calls
+     */
+    public Builder usePrefixListing(boolean newUsePrefixListing) {
+      this.usePrefixListing = newUsePrefixListing;
+      return this;
+    }
+
+    /**
+     * Action behavior when location prefixes (schemes/authorities) mismatch.
+     *
+     * @param newPrefixMismatchMode to action when mismatch
+     * @return for chained calls
+     */
+    public Builder prefixMismatchMode(PrefixMismatchMode newPrefixMismatchMode) {
+      this.prefixMismatchMode = newPrefixMismatchMode;
+      return this;
+    }
+
+    /**
+     * The files newer than this age will not be removed.
+     *
+     * @param newMinAge of the files to be removed
+     * @return for chained calls
+     */
+    public Builder minAge(Duration newMinAge) {
+      this.minAge = newMinAge;
+      return this;
+    }
+
+    /**
+     * The worker pool size used for planning the scan of the {@link MetadataTableType#ALL_FILES}
+     * table. This scan is used for determining the files used by the table.
+     *
+     * @param newPlanningWorkerPoolSize for scanning
+     * @return for chained calls
+     */
+    public Builder planningWorkerPoolSize(int newPlanningWorkerPoolSize) {
+      this.planningWorkerPoolSize = newPlanningWorkerPoolSize;
+      return this;
+    }
+
+    /**
+     * Passes schemes that should be considered equal.
+     *
+     * <p>The key may include a comma-separated list of schemes. For instance,
+     * Map("s3a,s3,s3n","s3").
+     *
+     * @param newEqualSchemes list of equal schemes
+     * @return this for method chaining
+     */
+    public Builder equalSchemes(Map<String, String> newEqualSchemes) {
+      equalSchemes.putAll(flattenMap(newEqualSchemes));
+      return this;
+    }
+
+    /**
+     * Passes authorities that should be considered equal.
+     *
+     * <p>The key may include a comma-separate list of authorities. For instance,
+     * Map("s1name,s2name","servicename").
+     *
+     * @param newEqualAuthorities list of equal authorities
+     * @return this for method chaining
+     */
+    public Builder equalAuthorities(Map<String, String> newEqualAuthorities) {
+      equalAuthorities.putAll(flattenMap(newEqualAuthorities));
+      return this;
+    }
+
+    /**
+     * Size of the batch used to deleting the files.
+     *
+     * @param newDeleteBatchSize number of batch file
+     * @return for chained calls
+     */
+    public Builder deleteBatchSize(int newDeleteBatchSize) {
+      this.deleteBatchSize = newDeleteBatchSize;
+      return this;
+    }
+
+    @Override
+    DataStream<TaskResult> append(DataStream<Trigger> trigger) {
+      tableLoader().open();
+
+      // Collect all data files
+      SingleOutputStreamOperator<MetadataTablePlanner.SplitInfo> splits =
+          trigger
+              .process(
+                  new MetadataTablePlanner(
+                      taskName(),
+                      index(),
+                      tableLoader(),
+                      FILE_PATH_SCAN_CONTEXT,
+                      MetadataTableType.ALL_FILES,
+                      planningWorkerPoolSize))
+              .name(operatorName(PLANNER_TASK_NAME))
+              .uid(PLANNER_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .forceNonParallel();
+
+      // Read the records and get all data files
+      SingleOutputStreamOperator<String> tableDataFiles =
+          splits
+              .rebalance()
+              .process(
+                  new FileNameReader(
+                      taskName(),
+                      index(),
+                      tableLoader(),
+                      FILE_PATH_SCHEMA,
+                      FILE_PATH_SCAN_CONTEXT,
+                      MetadataTableType.ALL_FILES))
+              .name(operatorName(READER_TASK_NAME))
+              .uid(READER_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .setParallelism(parallelism());
+
+      // Collect all meta data files
+      SingleOutputStreamOperator<String> tableMetadataFiles =
+          trigger
+              .process(new ListMetadataFiles(taskName(), index(), tableLoader()))
+              .name(operatorName(METADATA_FILES_TASK_NAME))
+              .uid(METADATA_FILES_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .forceNonParallel();
+
+      // List the all file system files
+      SingleOutputStreamOperator<String> allFsFiles =
+          trigger
+              .process(
+                  new ListFileSystemFiles(
+                      taskName(),
+                      index(),
+                      tableLoader(),
+                      location,
+                      minAge.toMillis(),
+                      usePrefixListing))
+              .name(operatorName(FILESYSTEM_FILES_TASK_NAME))
+              .uid(FILESYSTEM_FILES_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .forceNonParallel();
+
+      SingleOutputStreamOperator<String> filesToDelete =
+          tableMetadataFiles
+              .union(tableDataFiles)
+              .keyBy(new FileUriKeySelector(equalSchemes, equalAuthorities))
+              .connect(allFsFiles.keyBy(new FileUriKeySelector(equalSchemes, equalAuthorities)))
+              .process(new OrphanFilesDetector(prefixMismatchMode, equalSchemes, equalAuthorities))
+              .slotSharingGroup(slotSharingGroup())
+              .name(operatorName(FILTER_FILES_TASK_NAME))
+              .uid(FILTER_FILES_TASK_NAME + uidSuffix())
+              .setParallelism(parallelism());
+
+      DataStream<Exception> errorStream =
+          tableMetadataFiles
+              .getSideOutput(ERROR_STREAM)
+              .union(
+                  allFsFiles.getSideOutput(ERROR_STREAM),
+                  tableDataFiles.getSideOutput(ERROR_STREAM),
+                  splits.getSideOutput(ERROR_STREAM),
+                  filesToDelete.getSideOutput(ERROR_STREAM));
+
+      // Stop deleting the files if there is an error
+      SingleOutputStreamOperator<String> filesOrSkip =
+          filesToDelete
+              .connect(errorStream)
+              .transform(
+                  operatorName(SKIP_ON_ERROR_TASK_NAME),
+                  TypeInformation.of(String.class),
+                  new SkipOnError())
+              .uid(SKIP_ON_ERROR_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .forceNonParallel();
+
+      // delete the files
+      filesOrSkip
+          .rebalance()
+          .transform(
+              operatorName(DELETE_FILES_TASK_NAME),
+              TypeInformation.of(Void.class),
+              new DeleteFilesProcessor(
+                  tableLoader().loadTable(), taskName(), index(), deleteBatchSize))
+          .uid(DELETE_FILES_TASK_NAME + uidSuffix())
+          .slotSharingGroup(slotSharingGroup())
+          .setParallelism(parallelism());
+
+      // Ignore the file deletion result and return the DataStream<TaskResult> directly
+      return trigger
+          .connect(errorStream)
+          .transform(
+              operatorName(AGGREGATOR_TASK_NAME),
+              TypeInformation.of(TaskResult.class),
+              new TaskResultAggregator(tableName(), taskName(), index()))
+          .uid(AGGREGATOR_TASK_NAME + uidSuffix())
+          .slotSharingGroup(slotSharingGroup())
+          .forceNonParallel();
+    }
+  }
+
+  private static Map<String, String> flattenMap(Map<String, String> map) {
+    Map<String, String> flattenedMap = Maps.newHashMap();
+    if (map != null) {
+      for (String key : map.keySet()) {
+        String value = map.get(key);
+        for (String splitKey : COMMA_SPLITTER.split(key)) {
+          flattenedMap.put(splitKey.trim(), value.trim());
+        }
+      }
+    }
+
+    return flattenedMap;
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FileNameReader.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FileNameReader.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.source.ScanContext;
+
+/** A specialized reader implementation that extracts file names from Iceberg table rows. */
+@Internal
+public class FileNameReader extends TableReader<String> {
+
+  public FileNameReader(
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      Schema projectedSchema,
+      ScanContext scanContext,
+      MetadataTableType metadataTableType) {
+    super(taskName, taskIndex, tableLoader, projectedSchema, scanContext, metadataTableType);
+  }
+
+  @Override
+  void extract(RowData rowData, Collector<String> out) {
+    if (rowData != null && rowData.getString(0) != null) {
+      out.collect(rowData.getString(0).toString());
+    }
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FileUriKeySelector.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FileUriKeySelector.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Map;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.actions.FileURI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A key selector implementation that extracts a normalized file path from a file URI string.
+ *
+ * <p>This selector groups file URIs by their normalized path, ignoring differences in scheme and
+ * authority that are considered equivalent according to the provided mappings.
+ */
+@Internal
+public class FileUriKeySelector implements KeySelector<String, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(FileUriKeySelector.class);
+
+  static final String INVALID_URI = "__INVALID_URI__";
+
+  private final Map<String, String> equalSchemes;
+  private final Map<String, String> equalAuthorities;
+
+  public FileUriKeySelector(
+      Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    this.equalSchemes = equalSchemes;
+    this.equalAuthorities = equalAuthorities;
+  }
+
+  @Override
+  public String getKey(String value) throws Exception {
+    try {
+      FileURI fileUri = new FileURI(new Path(value).toUri(), equalSchemes, equalAuthorities);
+      return fileUri.getPath();
+    } catch (Exception e) {
+      LOG.warn("Uri convert to FileURI error! Uri is {}.", value, e);
+      return INVALID_URI;
+    }
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Map;
+import java.util.function.Predicate;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.SupportsPrefixOperations;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.FileSystemWalker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Recursively lists the files in the `location` directory. Hidden files, and files younger than the
+ * `minAgeMs` are omitted in the result.
+ */
+@Internal
+public class ListFileSystemFiles extends ProcessFunction<Trigger, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(ListFileSystemFiles.class);
+
+  private final String taskName;
+  private final int taskIndex;
+
+  private FileIO io;
+  private Map<Integer, PartitionSpec> specs;
+  private String location;
+  private final long minAgeMs;
+  private transient Counter errorCounter;
+  private final TableLoader tableLoader;
+  private final boolean usePrefixListing;
+  private transient Configuration configuration;
+
+  public ListFileSystemFiles(
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      String location,
+      long minAgeMs,
+      boolean usePrefixListing) {
+    Preconditions.checkNotNull(taskName, "Task name should no be null");
+    Preconditions.checkNotNull(tableLoader, "TableLoad should no be null");
+
+    this.tableLoader = tableLoader;
+    this.taskName = taskName;
+    this.taskIndex = taskIndex;
+    this.minAgeMs = minAgeMs;
+    this.location = location;
+    this.usePrefixListing = usePrefixListing;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    tableLoader.open();
+    Table table = tableLoader.loadTable();
+    this.io = table.io();
+    this.location = location != null ? location : table.location();
+    this.specs = table.specs();
+    this.errorCounter =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), table.name(), taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+    this.configuration = new Configuration();
+    table.properties().forEach(configuration::set);
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<String> out) throws Exception {
+    long olderThanTimestamp = trigger.timestamp() - minAgeMs;
+    try {
+      if (usePrefixListing) {
+        Predicate<FileInfo> predicate = fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;
+        Preconditions.checkArgument(
+            io instanceof SupportsPrefixOperations,
+            "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+            io);
+
+        FileSystemWalker.listDirRecursivelyWithFileIO(
+            (SupportsPrefixOperations) io, location, specs, predicate, out::collect);
+      } else {
+        Predicate<FileStatus> predicate = file -> file.getModificationTime() < olderThanTimestamp;
+        FileSystemWalker.listDirRecursivelyWithHadoop(
+            location,
+            specs,
+            predicate,
+            configuration,
+            Integer.MAX_VALUE,
+            Integer.MAX_VALUE,
+            dir -> {},
+            out::collect);
+      }
+    } catch (Exception e) {
+      LOG.warn("Exception listing files for {} at {}", location, ctx.timestamp(), e);
+      ctx.output(DeleteOrphanFiles.ERROR_STREAM, e);
+      errorCounter.inc();
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ReachableFileUtil;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Lists the metadata files referenced by the table. */
+@Internal
+public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(ListMetadataFiles.class);
+
+  private final String taskName;
+  private final int taskIndex;
+  private transient Counter errorCounter;
+  private final TableLoader tableLoader;
+  private transient Table table;
+
+  public ListMetadataFiles(String taskName, int taskIndex, TableLoader tableLoader) {
+    Preconditions.checkNotNull(taskName, "Task name should no be null");
+    Preconditions.checkNotNull(tableLoader, "TableLoader should no be null");
+    this.tableLoader = tableLoader;
+    this.taskName = taskName;
+    this.taskIndex = taskIndex;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    tableLoader.open();
+    this.table = tableLoader.loadTable();
+    this.errorCounter =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), table.name(), taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<String> collector)
+      throws Exception {
+    try {
+      table
+          .snapshots()
+          .forEach(
+              snapshot -> {
+                // Manifest lists
+                collector.collect(snapshot.manifestListLocation());
+                // Snapshot JSONs
+                ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
+                // Statistics files
+                ReachableFileUtil.statisticsFilesLocations(table).forEach(collector::collect);
+                // Version hint file for Hadoop catalogs
+                collector.collect(ReachableFileUtil.versionHintLocation(table));
+
+                // Emit the manifest file locations
+                snapshot.allManifests(table.io()).stream()
+                    .map(ManifestFile::path)
+                    .forEach(collector::collect);
+              });
+    } catch (Exception e) {
+      LOG.error("Exception listing metadata files for {} at {}", table, ctx.timestamp(), e);
+      ctx.output(DeleteOrphanFiles.ERROR_STREAM, e);
+      errorCounter.inc();
+    }
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/MetadataTablePlanner.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/MetadataTablePlanner.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.concurrent.ExecutorService;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.flink.source.FlinkSplitPlanner;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitSerializer;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ThreadPools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Plans the splits to read a metadata table content. */
+@Internal
+public class MetadataTablePlanner extends ProcessFunction<Trigger, MetadataTablePlanner.SplitInfo> {
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataTablePlanner.class);
+
+  private final String taskName;
+  private final int taskIndex;
+  private final TableLoader tableLoader;
+  private final int workerPoolSize;
+  private final ScanContext scanContext;
+  private transient ExecutorService workerPool;
+  private transient Counter errorCounter;
+  private transient Table table;
+  private transient IcebergSourceSplitSerializer splitSerializer;
+  private final MetadataTableType metadataTableType;
+
+  public MetadataTablePlanner(
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      ScanContext scanContext,
+      MetadataTableType metadataTableType,
+      int workerPoolSize) {
+    Preconditions.checkNotNull(taskName, "Task name should no be null");
+    Preconditions.checkNotNull(tableLoader, "Table should no be null");
+    Preconditions.checkArgument(scanContext.isStreaming(), "Streaming should be set to true");
+
+    this.taskName = taskName;
+    this.taskIndex = taskIndex;
+    this.tableLoader = tableLoader;
+    this.scanContext = scanContext;
+    this.workerPoolSize = workerPoolSize;
+    this.metadataTableType = metadataTableType;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    tableLoader.open();
+    Table originalTable = tableLoader.loadTable();
+    this.table = MetadataTableUtils.createMetadataTableInstance(originalTable, metadataTableType);
+    this.workerPool =
+        ThreadPools.newFixedThreadPool(table.name() + "-table-planner", workerPoolSize);
+    this.splitSerializer = new IcebergSourceSplitSerializer(scanContext.caseSensitive());
+    this.errorCounter =
+        TableMaintenanceMetrics.groupFor(
+                getRuntimeContext(), originalTable.name(), taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<SplitInfo> out)
+      throws Exception {
+    try {
+      table.refresh();
+      for (IcebergSourceSplit split :
+          FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, workerPool)) {
+        out.collect(new SplitInfo(splitSerializer.getVersion(), splitSerializer.serialize(split)));
+      }
+    } catch (Exception e) {
+      LOG.warn("Exception planning scan for {} at {}", table, ctx.timestamp(), e);
+      ctx.output(DeleteOrphanFiles.ERROR_STREAM, e);
+      errorCounter.inc();
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+    if (workerPool != null) {
+      workerPool.shutdown();
+    }
+  }
+
+  public static class SplitInfo {
+    private final int version;
+    private final byte[] split;
+
+    public SplitInfo(int version, byte[] split) {
+      this.version = version;
+      this.split = split;
+    }
+
+    public int version() {
+      return version;
+    }
+
+    public byte[] split() {
+      return split;
+    }
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/OrphanFilesDetector.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/OrphanFilesDetector.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileURI;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A specialized co-process function that performs an anti-join between two streams of file URIs.
+ *
+ * <p>Emits every file that exists in the file system but is not referenced in the table metadata,
+ * which are considered orphan files. It also handles URI normalization using provided scheme and
+ * authority equivalence mappings.
+ */
+@Internal
+public class OrphanFilesDetector extends KeyedCoProcessFunction<String, String, String, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(OrphanFilesDetector.class);
+
+  // Use MapState to dedupe the strings found in the table
+  private transient MapState<String, Boolean> foundInTable;
+  private transient ValueState<String> foundInFileSystem;
+  private transient ValueState<Boolean> hasUriError;
+  private final DeleteOrphanFiles.PrefixMismatchMode prefixMismatchMode;
+  private final Map<String, String> equalSchemes;
+  private final Map<String, String> equalAuthorities;
+
+  public OrphanFilesDetector(
+      DeleteOrphanFiles.PrefixMismatchMode prefixMismatchMode,
+      Map<String, String> equalSchemes,
+      Map<String, String> equalAuthorities) {
+    this.prefixMismatchMode = prefixMismatchMode;
+    this.equalSchemes = equalSchemes;
+    this.equalAuthorities = equalAuthorities;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    foundInTable =
+        getRuntimeContext()
+            .getMapState(
+                new MapStateDescriptor<>("antiJoinFoundInTable", Types.STRING, Types.BOOLEAN));
+    hasUriError =
+        getRuntimeContext().getState(new ValueStateDescriptor<>("antiJoinUriError", Types.BOOLEAN));
+    foundInFileSystem =
+        getRuntimeContext()
+            .getState(new ValueStateDescriptor<>("antiJoinFoundInFileSystem", Types.STRING));
+  }
+
+  @Override
+  public void processElement1(String value, Context context, Collector<String> collector)
+      throws Exception {
+    if (shouldSkipElement(value, context)) {
+      return;
+    }
+
+    if (!foundInTable.contains(value)) {
+      foundInTable.put(value, true);
+      context.timerService().registerEventTimeTimer(context.timestamp());
+    }
+  }
+
+  @Override
+  public void processElement2(String value, Context context, Collector<String> collector)
+      throws Exception {
+    if (shouldSkipElement(value, context)) {
+      return;
+    }
+
+    foundInFileSystem.update(value);
+    context.timerService().registerEventTimeTimer(context.timestamp());
+  }
+
+  @Override
+  public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
+    if (Boolean.TRUE.equals(hasUriError.value())) {
+      clearState();
+      return;
+    }
+
+    List<FileURI> foundInTablesList = Lists.newArrayList();
+    foundInTable
+        .keys()
+        .forEach(
+            uri ->
+                foundInTablesList.add(
+                    new FileURI(new Path(uri).toUri(), equalSchemes, equalAuthorities)));
+
+    if (foundInFileSystem.value() != null) {
+      if (foundInTablesList.isEmpty()) {
+        FileURI fileURI =
+            new FileURI(
+                new Path(foundInFileSystem.value()).toUri(), equalSchemes, equalAuthorities);
+        out.collect(fileURI.getUriAsString());
+      } else {
+        FileURI actual =
+            new FileURI(
+                new Path(foundInFileSystem.value()).toUri(), equalSchemes, equalAuthorities);
+        if (hasMismatch(actual, foundInTablesList)) {
+          if (prefixMismatchMode == DeleteOrphanFiles.PrefixMismatchMode.DELETE) {
+            out.collect(foundInFileSystem.value());
+          } else if (prefixMismatchMode == DeleteOrphanFiles.PrefixMismatchMode.ERROR) {
+            ValidationException validationException =
+                new ValidationException(
+                    "Unable to determine whether certain files are orphan. "
+                        + "Metadata references files that match listed/provided files except for authority/scheme. "
+                        + "Please, inspect the conflicting authorities/schemes and provide which of them are equal "
+                        + "by further configuring the action via equalSchemes() and equalAuthorities() methods. "
+                        + "Set the prefix mismatch mode to 'NONE' to ignore remaining locations with conflicting "
+                        + "authorities/schemes or to 'DELETE' if you are ABSOLUTELY confident that remaining conflicting "
+                        + "authorities/schemes are different. It will be impossible to recover deleted files. "
+                        + "Conflicting authorities/schemes");
+            LOG.warn(
+                "Unable to determine whether certain files are orphan. Found in filesystem: {} and in table: {}",
+                actual,
+                StringUtils.join(foundInTablesList, ","),
+                validationException);
+            ctx.output(
+                org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.ERROR_STREAM,
+                validationException);
+          }
+        }
+      }
+    }
+
+    clearState();
+  }
+
+  private boolean hasMismatch(FileURI actual, List<FileURI> foundInTablesList) {
+    return foundInTablesList.stream()
+        .noneMatch(valid -> valid.schemeMatch(actual) && valid.authorityMatch(actual));
+  }
+
+  private boolean shouldSkipElement(String value, Context context) throws IOException {
+    if (Boolean.TRUE.equals(hasUriError.value())) {
+      return true;
+    }
+
+    if (FileUriKeySelector.INVALID_URI.equals(context.getCurrentKey())) {
+      context.output(
+          org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.ERROR_STREAM,
+          new RuntimeException("Invalid URI format detected: " + value));
+      hasUriError.update(true);
+      foundInTable.clear();
+      foundInFileSystem.clear();
+      return true;
+    }
+
+    return false;
+  }
+
+  private void clearState() {
+    hasUriError.clear();
+    foundInTable.clear();
+    foundInFileSystem.clear();
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SkipOnError.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SkipOnError.java
@@ -19,8 +19,8 @@
 package org.apache.iceberg.flink.maintenance.operator;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.state.v2.ListState;
-import org.apache.flink.api.common.state.v2.ListStateDescriptor;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -58,14 +58,14 @@ public class SkipOnError extends AbstractStreamOperator<String>
   }
 
   @Override
-  public void processElement1(StreamRecord<String> element) {
+  public void processElement1(StreamRecord<String> element) throws Exception {
     if (!hasErrorFlag) {
       filesToDelete.add(element.getValue());
     }
   }
 
   @Override
-  public void processElement2(StreamRecord<Exception> element) {
+  public void processElement2(StreamRecord<Exception> element) throws Exception {
     hasError.add(true);
     hasErrorFlag = true;
     filesToDelete.clear();

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SkipOnError.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SkipOnError.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.v2.ListState;
+import org.apache.flink.api.common.state.v2.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Skip file deletion processing when an error is encountered. */
+@Internal
+public class SkipOnError extends AbstractStreamOperator<String>
+    implements TwoInputStreamOperator<String, Exception, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(SkipOnError.class);
+  private transient ListState<String> filesToDelete;
+  private transient ListState<Boolean> hasError;
+  private boolean hasErrorFlag = false;
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    this.filesToDelete =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("blockOnErrorFiles", String.class));
+    this.hasError =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("blockOnErrorHasError", Types.BOOLEAN));
+
+    if (!Iterables.isEmpty(hasError.get())) {
+      hasErrorFlag = true;
+    }
+  }
+
+  @Override
+  public void processElement1(StreamRecord<String> element) {
+    if (!hasErrorFlag) {
+      filesToDelete.add(element.getValue());
+    }
+  }
+
+  @Override
+  public void processElement2(StreamRecord<Exception> element) {
+    hasError.add(true);
+    hasErrorFlag = true;
+    filesToDelete.clear();
+  }
+
+  @Override
+  public void processWatermark(Watermark mark) throws Exception {
+    try {
+      if (!hasErrorFlag) {
+        filesToDelete.get().forEach(file -> output.collect(new StreamRecord<>(file)));
+      } else {
+        LOG.info("Omitting result on failure at {}", mark.getTimestamp());
+      }
+    } finally {
+      filesToDelete.clear();
+      hasError.clear();
+      hasErrorFlag = false;
+    }
+
+    super.processWatermark(mark);
+  }
+}

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableReader.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableReader.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.reader.MetaDataReaderFunction;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitSerializer;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Reads the records from the metadata table splits. */
+abstract class TableReader<R> extends ProcessFunction<MetadataTablePlanner.SplitInfo, R> {
+  private static final Logger LOG = LoggerFactory.getLogger(TableReader.class);
+
+  private final TableLoader tableLoader;
+  private final String taskName;
+  private final int taskIndex;
+  private final Schema projectedSchema;
+  private IcebergSourceSplitSerializer splitSerializer;
+  private final ScanContext scanContext;
+  private final MetadataTableType metadataTableType;
+
+  private transient MetaDataReaderFunction rowDataReaderFunction;
+  private transient Counter errorCounter;
+
+  TableReader(
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      Schema projectedSchema,
+      ScanContext scanContext,
+      MetadataTableType metadataTableType) {
+    Preconditions.checkNotNull(taskName, "Task name should no be null");
+    Preconditions.checkNotNull(tableLoader, "Table should no be null");
+    Preconditions.checkNotNull(projectedSchema, "The projected schema should no be null");
+
+    this.tableLoader = tableLoader;
+    this.taskName = taskName;
+    this.taskIndex = taskIndex;
+    this.projectedSchema = projectedSchema;
+    this.scanContext = scanContext;
+    this.metadataTableType = metadataTableType;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    tableLoader.open();
+    Table table = tableLoader.loadTable();
+    Table metaTable = MetadataTableUtils.createMetadataTableInstance(table, metadataTableType);
+    this.errorCounter =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), table.name(), taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+    this.rowDataReaderFunction =
+        new MetaDataReaderFunction(
+            new Configuration(),
+            metaTable.schema(),
+            projectedSchema,
+            metaTable.io(),
+            metaTable.encryption());
+    this.splitSerializer = new IcebergSourceSplitSerializer(scanContext.caseSensitive());
+  }
+
+  @Override
+  public void processElement(
+      MetadataTablePlanner.SplitInfo splitInfo, Context ctx, Collector<R> out) throws Exception {
+    IcebergSourceSplit split = splitSerializer.deserialize(splitInfo.version(), splitInfo.split());
+    try (DataIterator<RowData> iterator = rowDataReaderFunction.createDataIterator(split)) {
+      iterator.forEachRemaining(rowData -> extract(rowData, out));
+    } catch (Exception e) {
+      LOG.warn("Exception processing split {} at {}", split, ctx.timestamp(), e);
+      ctx.output(DeleteOrphanFiles.ERROR_STREAM, e);
+      errorCounter.inc();
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  /**
+   * Extracts the desired data from the given RowData.
+   *
+   * @param rowData the RowData from which to extract
+   * @param out the Collector to which to output the extracted data
+   */
+  abstract void extract(RowData rowData, Collector<R> out);
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/MaintenanceTaskTestBase.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/MaintenanceTaskTestBase.java
@@ -41,7 +41,13 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       ManualSource<Trigger> triggerSource,
       CollectingSink<TaskResult> collectingSink)
       throws Exception {
-    runAndWaitForResult(env, triggerSource, collectingSink, false, () -> true);
+    runAndWaitForResult(
+        env,
+        triggerSource,
+        collectingSink,
+        false /* generateFailure */,
+        () -> true /* waitForCondition */,
+        true /* resultSuccess */);
   }
 
   void runAndWaitForSuccess(
@@ -50,7 +56,13 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       CollectingSink<TaskResult> collectingSink,
       Supplier<Boolean> waitForCondition)
       throws Exception {
-    runAndWaitForResult(env, triggerSource, collectingSink, false, waitForCondition);
+    runAndWaitForResult(
+        env,
+        triggerSource,
+        collectingSink,
+        false /* generateFailure */,
+        waitForCondition,
+        true /* resultSuccess */);
   }
 
   void runAndWaitForFailure(
@@ -58,7 +70,13 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       ManualSource<Trigger> triggerSource,
       CollectingSink<TaskResult> collectingSink)
       throws Exception {
-    runAndWaitForResult(env, triggerSource, collectingSink, true, () -> true);
+    runAndWaitForResult(
+        env,
+        triggerSource,
+        collectingSink,
+        true /* generateFailure */,
+        () -> true /* waitForCondition */,
+        true /* resultSuccess */);
   }
 
   void runAndWaitForResult(
@@ -66,7 +84,8 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       ManualSource<Trigger> triggerSource,
       CollectingSink<TaskResult> collectingSink,
       boolean generateFailure,
-      Supplier<Boolean> waitForCondition)
+      Supplier<Boolean> waitForCondition,
+      boolean resultSuccess)
       throws Exception {
     JobClient jobClient = null;
     try {
@@ -79,7 +98,7 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       TaskResult result = collectingSink.poll(POLL_DURATION);
 
       assertThat(result.startEpoch()).isEqualTo(time);
-      assertThat(result.success()).isTrue();
+      assertThat(result.success()).isEqualTo(resultSuccess);
       assertThat(result.taskIndex()).isEqualTo(TESTING_TASK_ID);
 
       if (generateFailure) {

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestDeleteOrphanFiles.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestDeleteOrphanFiles.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.DELETE_FILES_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.FILESYSTEM_FILES_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.METADATA_FILES_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.PLANNER_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.READER_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.DELETE_FILE_FAILED_COUNTER;
+import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.DELETE_FILE_SUCCEEDED_COUNTER;
+import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.ERROR_COUNTER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.operator.MetricsReporterFactoryForTests;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+class TestDeleteOrphanFiles extends MaintenanceTaskTestBase {
+
+  private Path relative(Table table, String relativePath) {
+    return FileSystems.getDefault().getPath(table.location().substring(5), relativePath);
+  }
+
+  private void createFiles(Path... paths) throws IOException {
+    for (Path path : paths) {
+      Files.write(path, "DUMMY".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  void testDeleteOrphanFilesUnPartitioned() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+
+    assertFileNum(table, 4, 0);
+
+    Path inData = relative(table, "metadata/in_data");
+    Path inMetadata = relative(table, "metadata/in_metadata");
+
+    createFiles(inData);
+    createFiles(inMetadata);
+    assertThat(inMetadata).exists();
+    assertThat(inData).exists();
+
+    appendDeleteOrphanFiles();
+
+    runAndWaitForSuccess(
+        infra.env(), infra.source(), infra.sink(), () -> checkDeleteFinished(table.name(), 2L));
+    assertThat(inMetadata).doesNotExist();
+    assertThat(inData).doesNotExist();
+    assertFileNum(table, 4, 0);
+
+    // Check the metrics
+    MetricsReporterFactoryForTests.assertCounters(
+        new ImmutableMap.Builder<List<String>, Long>()
+            .put(
+                ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    READER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    FILESYSTEM_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    METADATA_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_FAILED_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_SUCCEEDED_COUNTER),
+                2L)
+            .build());
+  }
+
+  @Test
+  void testDeleteOrphanFilesPartitioned() throws Exception {
+    Table table = createPartitionedTable();
+    insertPartitioned(table, 1, "p1");
+    insertPartitioned(table, 2, "p1");
+    insertPartitioned(table, 3, "p2");
+    insertPartitioned(table, 4, "p2");
+
+    assertFileNum(table, 4, 0);
+
+    Path inMetadata = relative(table, "metadata/in_metadata");
+    Path inData = relative(table, "metadata/in_data");
+
+    createFiles(inMetadata);
+    createFiles(inData);
+    assertThat(inMetadata).exists();
+    assertThat(inData).exists();
+
+    appendDeleteOrphanFiles();
+
+    runAndWaitForSuccess(
+        infra.env(), infra.source(), infra.sink(), () -> checkDeleteFinished(table.name(), 2L));
+    assertThat(inMetadata).doesNotExist();
+    assertThat(inData).doesNotExist();
+
+    assertFileNum(table, 4, 0);
+
+    // Check the metrics
+    MetricsReporterFactoryForTests.assertCounters(
+        new ImmutableMap.Builder<List<String>, Long>()
+            .put(
+                ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    READER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    FILESYSTEM_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    METADATA_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_FAILED_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_SUCCEEDED_COUNTER),
+                2L)
+            .build());
+  }
+
+  @Test
+  void testDeleteOrphanFilesFailure() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+
+    assertFileNum(table, 4, 0);
+
+    Path inData = relative(table, "metadata/in_data");
+    Path inMetadata = relative(table, "metadata/in_metadata");
+
+    createFiles(inData);
+    createFiles(inMetadata);
+    assertThat(inMetadata).exists();
+    assertThat(inData).exists();
+
+    appendDeleteOrphanFiles();
+
+    // Mock error in the delete files operator
+    Long parentId = table.currentSnapshot().parentId();
+    for (ManifestFile manifestFile : table.snapshot(parentId).allManifests(table.io())) {
+      table.io().deleteFile(manifestFile.path());
+    }
+
+    runAndWaitForResult(
+        infra.env(),
+        infra.source(),
+        infra.sink(),
+        false /* generateFailure */,
+        () -> checkDeleteFinished(table.name(), 0L),
+        false /* resultSuccess*/);
+
+    // An error occurred; the file should not be deleted. And the job should not be failed.
+    assertThat(inMetadata).exists();
+    assertThat(inData).exists();
+
+    // Check the metrics
+    MetricsReporterFactoryForTests.assertCounters(
+        new ImmutableMap.Builder<List<String>, Long>()
+            .put(
+                ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    READER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                1L)
+            .put(
+                ImmutableList.of(
+                    FILESYSTEM_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    METADATA_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_FAILED_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_SUCCEEDED_COUNTER),
+                0L)
+            .build());
+  }
+
+  private void appendDeleteOrphanFiles() {
+    appendDeleteOrphanFiles(DeleteOrphanFiles.builder().minAge(Duration.ZERO));
+  }
+
+  private void appendDeleteOrphanFiles(DeleteOrphanFiles.Builder builder) {
+    builder
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+  }
+
+  private static void assertFileNum(
+      Table table, int expectedDataFileNum, int expectedDeleteFileNum) {
+    table.refresh();
+    assertThat(
+            table.currentSnapshot().dataManifests(table.io()).stream()
+                .flatMap(
+                    m ->
+                        StreamSupport.stream(
+                            ManifestFiles.read(m, table.io(), table.specs()).spliterator(), false))
+                .count())
+        .isEqualTo(expectedDataFileNum);
+    assertThat(
+            table.currentSnapshot().deleteManifests(table.io()).stream()
+                .flatMap(
+                    m ->
+                        StreamSupport.stream(
+                            ManifestFiles.readDeleteManifest(m, table.io(), table.specs())
+                                .spliterator(),
+                            false))
+                .count())
+        .isEqualTo(expectedDeleteFileNum);
+  }
+
+  private static boolean checkDeleteFinished(String tableName, Long expectedDeleteNum) {
+    return expectedDeleteNum.equals(
+        MetricsReporterFactoryForTests.counter(
+            ImmutableList.of(
+                DELETE_FILES_TASK_NAME + "[0]",
+                tableName,
+                DUMMY_TASK_NAME,
+                "0",
+                DELETE_FILE_SUCCEEDED_COUNTER)));
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -89,6 +89,10 @@ public class OperatorTestBase {
   protected static final String DUMMY_TASK_NAME = "dummyTask";
   protected static final String DUMMY_TABLE_NAME = "dummyTable";
 
+  static final String FILE_NAME_1 = "fileName1";
+  static final String FILE_NAME_2 = "fileName2";
+  static final Watermark WATERMARK_2 = new Watermark(EVENT_TIME_2);
+
   @RegisterExtension
   protected static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
       new MiniClusterExtension(

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListFileSystemFiles.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListFileSystemFiles.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+class TestListFileSystemFiles extends OperatorTestBase {
+  @Parameter(index = 0)
+  private boolean usePrefixListing;
+
+  @Parameters(name = "usePrefixListing = {0}")
+  private static Object[][] parameters() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @TestTemplate
+  void testMetadataFilesWithTable() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListFileSystemFiles(
+                OperatorTestBase.DUMMY_TABLE_NAME,
+                0,
+                tableLoader(),
+                table.location(),
+                0,
+                usePrefixListing))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+
+      assertThat(testHarness.extractOutputValues()).hasSize(11);
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @TestTemplate
+  void testMetadataFilesWithPartitionTable() throws Exception {
+    Table table = createPartitionedTable();
+    insertPartitioned(table, 1, "p1");
+    insertPartitioned(table, 2, "p1");
+    insertPartitioned(table, 3, "p2");
+    insertPartitioned(table, 4, "p2");
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListFileSystemFiles(
+                OperatorTestBase.DUMMY_TABLE_NAME,
+                0,
+                tableLoader(),
+                table.location(),
+                0,
+                usePrefixListing))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+
+      assertThat(testHarness.extractOutputValues()).hasSize(14);
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @TestTemplate
+  void testMetadataFilesWithEmptyTable() throws Exception {
+    Table table = createTable();
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListFileSystemFiles(
+                OperatorTestBase.DUMMY_TABLE_NAME,
+                0,
+                tableLoader(),
+                table.location(),
+                0,
+                usePrefixListing))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+
+      assertThat(testHarness.extractOutputValues()).hasSize(2);
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.junit.jupiter.api.Test;
+
+class TestListMetadataFiles extends OperatorTestBase {
+
+  @Test
+  void testMetadataFilesWithTable() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+      tableMetadataFiles.forEach(System.out::println);
+      assertThat(tableMetadataFiles).hasSize(24);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMetadataFilesWithPartitionTable() throws Exception {
+    Table table = createPartitionedTable();
+    insertPartitioned(table, 1, "p1");
+    insertPartitioned(table, 2, "p1");
+    insertPartitioned(table, 3, "p2");
+    insertPartitioned(table, 4, "p2");
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+      assertThat(tableMetadataFiles).hasSize(38);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMetadataFilesWithEmptyTable() throws Exception {
+    createTable();
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+      assertThat(tableMetadataFiles).hasSize(0);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestOrphanFilesDetector.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestOrphanFilesDetector.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
+import org.apache.iceberg.actions.FileURI;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestOrphanFilesDetector extends OperatorTestBase {
+  private static final Map<String, String> EQUAL_SCHEMES =
+      Maps.newHashMap(
+          ImmutableMap.of(
+              "s3n", "s3",
+              "s3a", "s3"));
+  private static final Map<String, String> EQUAL_AUTHORITIES = Maps.newHashMap();
+  private static final String SCHEME_FILE_1 = "s3:/fileName1";
+  private static final String AUTHORITY_FILE_1 = "s3://HDFS1002060/fileName1";
+  private static final String ONE_AUTHORITY_SCHEME_FILE_1 = "s3a://HDFS1002060/fileName1";
+  private static final String TWO_AUTHORITY_SCHEME_FILE_1 = "s3b://HDFS1002060/fileName1";
+
+  @Test
+  void testFileSystemFirst() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processWatermark1(WATERMARK);
+      testHarness.processElement1(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processWatermark2(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testTableFirst() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processWatermark1(WATERMARK);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processWatermark2(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testOnlyFileSystem() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEqualTo(ImmutableList.of(SCHEME_FILE_1));
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testOnlyTable() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testFileSystemWithAuthority() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(AUTHORITY_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testTableWithAuthority() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      ConcurrentLinkedQueue<StreamRecord<Exception>> errorList =
+          testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM);
+      assertThat(errorList).hasSize(1);
+      assertThat(errorList.stream().findFirst().get().getValue())
+          .isInstanceOf(ValidationException.class);
+
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void testDiffScheme() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(ONE_AUTHORITY_SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testUnRegisterScheme() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(TWO_AUTHORITY_SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      ConcurrentLinkedQueue<StreamRecord<Exception>> errorList =
+          testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM);
+      assertThat(errorList).hasSize(1);
+      assertThat(errorList.stream().findFirst().get().getValue())
+          .isInstanceOf(ValidationException.class);
+
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void testPrefixMismatchModeDelete() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness(PrefixMismatchMode.DELETE)) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEqualTo(ImmutableList.of(SCHEME_FILE_1));
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testPrefixMismatchModeIgnore() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness(PrefixMismatchMode.IGNORE)) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMultiAuthority() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness(PrefixMismatchMode.IGNORE)) {
+      testHarness.open();
+
+      testHarness.processElement1(TWO_AUTHORITY_SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement1(ONE_AUTHORITY_SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(AUTHORITY_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  private static KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness(
+      PrefixMismatchMode prefixMismatchMode) throws Exception {
+    return ProcessFunctionTestHarnesses.forKeyedCoProcessFunction(
+        new OrphanFilesDetector(prefixMismatchMode, EQUAL_SCHEMES, EQUAL_AUTHORITIES),
+        (KeySelector<String, String>)
+            t -> new FileURI(new Path(t).toUri(), EQUAL_SCHEMES, EQUAL_AUTHORITIES).getPath(),
+        (KeySelector<String, String>)
+            t -> new FileURI(new Path(t).toUri(), EQUAL_SCHEMES, EQUAL_AUTHORITIES).getPath(),
+        BasicTypeInfo.STRING_TYPE_INFO);
+  }
+
+  private static KeyedTwoInputStreamOperatorTestHarness<String, String, String, String>
+      testHarness() throws Exception {
+    return testHarness(PrefixMismatchMode.ERROR);
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestSkipOnError.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestSkipOnError.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TestSkipOnError extends OperatorTestBase {
+
+  private static final Exception EXCEPTION = new Exception("Test error");
+
+  @Test
+  void testNoFailure() throws Exception {
+    try (TwoInputStreamOperatorTestHarness<String, Exception, String> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(new SkipOnError())) {
+      testHarness.open();
+
+      testHarness.processElement1(FILE_NAME_1, EVENT_TIME);
+      testHarness.processElement1(FILE_NAME_2, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues())
+          .isEqualTo(ImmutableList.of(FILE_NAME_1, FILE_NAME_2));
+    }
+  }
+
+  @Test
+  void testFailure() throws Exception {
+    try (TwoInputStreamOperatorTestHarness<String, Exception, String> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(new SkipOnError())) {
+      testHarness.open();
+
+      testHarness.processElement1(FILE_NAME_1, EVENT_TIME);
+      testHarness.processElement2(EXCEPTION, EVENT_TIME);
+      testHarness.processElement1(FILE_NAME_2, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testStateRestore(boolean withError) throws Exception {
+    OperatorSubtaskState state;
+    try (TwoInputStreamOperatorTestHarness<String, Exception, String> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(new SkipOnError())) {
+      testHarness.open();
+
+      testHarness.processElement1(FILE_NAME_1, EVENT_TIME);
+      if (withError) {
+        testHarness.processElement2(EXCEPTION, EVENT_TIME);
+      }
+
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      state = testHarness.snapshot(1L, EVENT_TIME);
+    }
+
+    try (TwoInputStreamOperatorTestHarness<String, Exception, String> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(new SkipOnError())) {
+      testHarness.initializeState(state);
+      testHarness.open();
+
+      testHarness.processElement1(FILE_NAME_2, EVENT_TIME);
+
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      if (withError) {
+        assertThat(testHarness.extractOutputValues()).isEmpty();
+      } else {
+        assertThat(testHarness.extractOutputValues())
+            .isEqualTo(ImmutableList.of(FILE_NAME_1, FILE_NAME_2));
+      }
+    }
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTablePlanerAndReader.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTablePlanerAndReader.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.junit.jupiter.api.Test;
+
+class TestTablePlanerAndReader extends OperatorTestBase {
+  private static final Schema FILE_PATH_SCHEMA = new Schema(DataFile.FILE_PATH);
+  private static final ScanContext FILE_PATH_SCAN_CONTEXT =
+      ScanContext.builder().streaming(true).project(FILE_PATH_SCHEMA).build();
+
+  @Test
+  void testTablePlaneAndRead() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    List<MetadataTablePlanner.SplitInfo> icebergSourceSplits;
+    try (OneInputStreamOperatorTestHarness<Trigger, MetadataTablePlanner.SplitInfo> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new MetadataTablePlanner(
+                OperatorTestBase.DUMMY_TASK_NAME,
+                0,
+                tableLoader(),
+                FILE_PATH_SCAN_CONTEXT,
+                MetadataTableType.ALL_FILES,
+                1))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+      icebergSourceSplits = testHarness.extractOutputValues();
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+
+    try (OneInputStreamOperatorTestHarness<MetadataTablePlanner.SplitInfo, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new FileNameReader(
+                OperatorTestBase.DUMMY_TASK_NAME,
+                0,
+                tableLoader(),
+                FILE_PATH_SCHEMA,
+                FILE_PATH_SCAN_CONTEXT,
+                MetadataTableType.ALL_FILES))) {
+      testHarness.open();
+      for (MetadataTablePlanner.SplitInfo icebergSourceSplit : icebergSourceSplits) {
+        testHarness.processElement(icebergSourceSplit, System.currentTimeMillis());
+      }
+
+      assertThat(testHarness.extractOutputValues()).hasSize(2);
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testTablePlaneAndReadWithPartitionedTable() throws Exception {
+    Table table = createPartitionedTable();
+    insertPartitioned(table, 1, "p1");
+    insertPartitioned(table, 2, "p1");
+    insertPartitioned(table, 3, "p2");
+    insertPartitioned(table, 4, "p2");
+    List<MetadataTablePlanner.SplitInfo> icebergSourceSplits;
+    try (OneInputStreamOperatorTestHarness<Trigger, MetadataTablePlanner.SplitInfo> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new MetadataTablePlanner(
+                OperatorTestBase.DUMMY_TASK_NAME,
+                0,
+                tableLoader(),
+                FILE_PATH_SCAN_CONTEXT,
+                MetadataTableType.ALL_FILES,
+                1))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+      icebergSourceSplits = testHarness.extractOutputValues();
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+
+    try (OneInputStreamOperatorTestHarness<MetadataTablePlanner.SplitInfo, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new FileNameReader(
+                OperatorTestBase.DUMMY_TASK_NAME,
+                0,
+                tableLoader(),
+                FILE_PATH_SCHEMA,
+                FILE_PATH_SCAN_CONTEXT,
+                MetadataTableType.ALL_FILES))) {
+      testHarness.open();
+      for (MetadataTablePlanner.SplitInfo icebergSourceSplit : icebergSourceSplits) {
+        testHarness.processElement(icebergSourceSplit, System.currentTimeMillis());
+      }
+
+      assertThat(testHarness.extractOutputValues()).hasSize(4);
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFiles.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import java.time.Duration;
+import java.util.Map;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
+import org.apache.iceberg.flink.maintenance.operator.DeleteFilesProcessor;
+import org.apache.iceberg.flink.maintenance.operator.FileNameReader;
+import org.apache.iceberg.flink.maintenance.operator.FileUriKeySelector;
+import org.apache.iceberg.flink.maintenance.operator.ListFileSystemFiles;
+import org.apache.iceberg.flink.maintenance.operator.ListMetadataFiles;
+import org.apache.iceberg.flink.maintenance.operator.MetadataTablePlanner;
+import org.apache.iceberg.flink.maintenance.operator.OrphanFilesDetector;
+import org.apache.iceberg.flink.maintenance.operator.SkipOnError;
+import org.apache.iceberg.flink.maintenance.operator.TaskResultAggregator;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.ThreadPools;
+
+/** Delete orphan files from the file system. */
+public class DeleteOrphanFiles {
+
+  private static final Schema FILE_PATH_SCHEMA = new Schema(DataFile.FILE_PATH);
+  private static final ScanContext FILE_PATH_SCAN_CONTEXT =
+      ScanContext.builder().streaming(true).project(FILE_PATH_SCHEMA).build();
+  private static final Splitter COMMA_SPLITTER = Splitter.on(",");
+
+  @Internal
+  public static final OutputTag<Exception> ERROR_STREAM =
+      new OutputTag<>("error-stream", TypeInformation.of(Exception.class));
+
+  static final String PLANNER_TASK_NAME = "Table Planner";
+  static final String READER_TASK_NAME = "Files Reader";
+  static final String FILESYSTEM_FILES_TASK_NAME = "Filesystem Files";
+  static final String METADATA_FILES_TASK_NAME = "List metadata Files";
+  static final String DELETE_FILES_TASK_NAME = "Delete File";
+  static final String AGGREGATOR_TASK_NAME = "Orphan Files Aggregator";
+  static final String FILTER_FILES_TASK_NAME = "Filter File";
+  static final String SKIP_ON_ERROR_TASK_NAME = "Skip On Error";
+
+  public static DeleteOrphanFiles.Builder builder() {
+    return new DeleteOrphanFiles.Builder();
+  }
+
+  private DeleteOrphanFiles() {
+    // Do not instantiate directly
+  }
+
+  public static class Builder extends MaintenanceTaskBuilder<DeleteOrphanFiles.Builder> {
+    private String location;
+    private Duration minAge = Duration.ofDays(3);
+    private int planningWorkerPoolSize = ThreadPools.WORKER_THREAD_POOL_SIZE;
+    private int deleteBatchSize = 1000;
+    private boolean usePrefixListing = false;
+    private Map<String, String> equalSchemes =
+        Maps.newHashMap(
+            ImmutableMap.of(
+                "s3n", "s3",
+                "s3a", "s3"));
+    private final Map<String, String> equalAuthorities = Maps.newHashMap();
+    private PrefixMismatchMode prefixMismatchMode = PrefixMismatchMode.ERROR;
+
+    @Override
+    String maintenanceTaskName() {
+      return "DeleteOrphanFiles";
+    }
+
+    /**
+     * The location to start the recursive listing the candidate files for removal. By default, the
+     * {@link Table#location()} is used.
+     *
+     * @param newLocation the task will scan
+     * @return for chained calls
+     */
+    public Builder location(String newLocation) {
+      this.location = newLocation;
+      return this;
+    }
+
+    /**
+     * Whether to use prefix listing when listing files from the file system.
+     *
+     * @param newUsePrefixListing true to enable prefix listing, false otherwise
+     * @return for chained calls
+     */
+    public Builder usePrefixListing(boolean newUsePrefixListing) {
+      this.usePrefixListing = newUsePrefixListing;
+      return this;
+    }
+
+    /**
+     * Action behavior when location prefixes (schemes/authorities) mismatch.
+     *
+     * @param newPrefixMismatchMode to action when mismatch
+     * @return for chained calls
+     */
+    public Builder prefixMismatchMode(PrefixMismatchMode newPrefixMismatchMode) {
+      this.prefixMismatchMode = newPrefixMismatchMode;
+      return this;
+    }
+
+    /**
+     * The files newer than this age will not be removed.
+     *
+     * @param newMinAge of the files to be removed
+     * @return for chained calls
+     */
+    public Builder minAge(Duration newMinAge) {
+      this.minAge = newMinAge;
+      return this;
+    }
+
+    /**
+     * The worker pool size used for planning the scan of the {@link MetadataTableType#ALL_FILES}
+     * table. This scan is used for determining the files used by the table.
+     *
+     * @param newPlanningWorkerPoolSize for scanning
+     * @return for chained calls
+     */
+    public Builder planningWorkerPoolSize(int newPlanningWorkerPoolSize) {
+      this.planningWorkerPoolSize = newPlanningWorkerPoolSize;
+      return this;
+    }
+
+    /**
+     * Passes schemes that should be considered equal.
+     *
+     * <p>The key may include a comma-separated list of schemes. For instance,
+     * Map("s3a,s3,s3n","s3").
+     *
+     * @param newEqualSchemes list of equal schemes
+     * @return this for method chaining
+     */
+    public Builder equalSchemes(Map<String, String> newEqualSchemes) {
+      equalSchemes.putAll(flattenMap(newEqualSchemes));
+      return this;
+    }
+
+    /**
+     * Passes authorities that should be considered equal.
+     *
+     * <p>The key may include a comma-separate list of authorities. For instance,
+     * Map("s1name,s2name","servicename").
+     *
+     * @param newEqualAuthorities list of equal authorities
+     * @return this for method chaining
+     */
+    public Builder equalAuthorities(Map<String, String> newEqualAuthorities) {
+      equalAuthorities.putAll(flattenMap(newEqualAuthorities));
+      return this;
+    }
+
+    /**
+     * Size of the batch used to deleting the files.
+     *
+     * @param newDeleteBatchSize number of batch file
+     * @return for chained calls
+     */
+    public Builder deleteBatchSize(int newDeleteBatchSize) {
+      this.deleteBatchSize = newDeleteBatchSize;
+      return this;
+    }
+
+    @Override
+    DataStream<TaskResult> append(DataStream<Trigger> trigger) {
+      tableLoader().open();
+
+      // Collect all data files
+      SingleOutputStreamOperator<MetadataTablePlanner.SplitInfo> splits =
+          trigger
+              .process(
+                  new MetadataTablePlanner(
+                      taskName(),
+                      index(),
+                      tableLoader(),
+                      FILE_PATH_SCAN_CONTEXT,
+                      MetadataTableType.ALL_FILES,
+                      planningWorkerPoolSize))
+              .name(operatorName(PLANNER_TASK_NAME))
+              .uid(PLANNER_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .forceNonParallel();
+
+      // Read the records and get all data files
+      SingleOutputStreamOperator<String> tableDataFiles =
+          splits
+              .rebalance()
+              .process(
+                  new FileNameReader(
+                      taskName(),
+                      index(),
+                      tableLoader(),
+                      FILE_PATH_SCHEMA,
+                      FILE_PATH_SCAN_CONTEXT,
+                      MetadataTableType.ALL_FILES))
+              .name(operatorName(READER_TASK_NAME))
+              .uid(READER_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .setParallelism(parallelism());
+
+      // Collect all meta data files
+      SingleOutputStreamOperator<String> tableMetadataFiles =
+          trigger
+              .process(new ListMetadataFiles(taskName(), index(), tableLoader()))
+              .name(operatorName(METADATA_FILES_TASK_NAME))
+              .uid(METADATA_FILES_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .forceNonParallel();
+
+      // List the all file system files
+      SingleOutputStreamOperator<String> allFsFiles =
+          trigger
+              .process(
+                  new ListFileSystemFiles(
+                      taskName(),
+                      index(),
+                      tableLoader(),
+                      location,
+                      minAge.toMillis(),
+                      usePrefixListing))
+              .name(operatorName(FILESYSTEM_FILES_TASK_NAME))
+              .uid(FILESYSTEM_FILES_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .forceNonParallel();
+
+      SingleOutputStreamOperator<String> filesToDelete =
+          tableMetadataFiles
+              .union(tableDataFiles)
+              .keyBy(new FileUriKeySelector(equalSchemes, equalAuthorities))
+              .connect(allFsFiles.keyBy(new FileUriKeySelector(equalSchemes, equalAuthorities)))
+              .process(new OrphanFilesDetector(prefixMismatchMode, equalSchemes, equalAuthorities))
+              .slotSharingGroup(slotSharingGroup())
+              .name(operatorName(FILTER_FILES_TASK_NAME))
+              .uid(FILTER_FILES_TASK_NAME + uidSuffix())
+              .setParallelism(parallelism());
+
+      DataStream<Exception> errorStream =
+          tableMetadataFiles
+              .getSideOutput(ERROR_STREAM)
+              .union(
+                  allFsFiles.getSideOutput(ERROR_STREAM),
+                  tableDataFiles.getSideOutput(ERROR_STREAM),
+                  splits.getSideOutput(ERROR_STREAM),
+                  filesToDelete.getSideOutput(ERROR_STREAM));
+
+      // Stop deleting the files if there is an error
+      SingleOutputStreamOperator<String> filesOrSkip =
+          filesToDelete
+              .connect(errorStream)
+              .transform(
+                  operatorName(SKIP_ON_ERROR_TASK_NAME),
+                  TypeInformation.of(String.class),
+                  new SkipOnError())
+              .uid(SKIP_ON_ERROR_TASK_NAME + uidSuffix())
+              .slotSharingGroup(slotSharingGroup())
+              .forceNonParallel();
+
+      // delete the files
+      filesOrSkip
+          .rebalance()
+          .transform(
+              operatorName(DELETE_FILES_TASK_NAME),
+              TypeInformation.of(Void.class),
+              new DeleteFilesProcessor(
+                  tableLoader().loadTable(), taskName(), index(), deleteBatchSize))
+          .uid(DELETE_FILES_TASK_NAME + uidSuffix())
+          .slotSharingGroup(slotSharingGroup())
+          .setParallelism(parallelism());
+
+      // Ignore the file deletion result and return the DataStream<TaskResult> directly
+      return trigger
+          .connect(errorStream)
+          .transform(
+              operatorName(AGGREGATOR_TASK_NAME),
+              TypeInformation.of(TaskResult.class),
+              new TaskResultAggregator(tableName(), taskName(), index()))
+          .uid(AGGREGATOR_TASK_NAME + uidSuffix())
+          .slotSharingGroup(slotSharingGroup())
+          .forceNonParallel();
+    }
+  }
+
+  private static Map<String, String> flattenMap(Map<String, String> map) {
+    Map<String, String> flattenedMap = Maps.newHashMap();
+    if (map != null) {
+      for (String key : map.keySet()) {
+        String value = map.get(key);
+        for (String splitKey : COMMA_SPLITTER.split(key)) {
+          flattenedMap.put(splitKey.trim(), value.trim());
+        }
+      }
+    }
+
+    return flattenedMap;
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FileNameReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FileNameReader.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.source.ScanContext;
+
+/** A specialized reader implementation that extracts file names from Iceberg table rows. */
+@Internal
+public class FileNameReader extends TableReader<String> {
+
+  public FileNameReader(
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      Schema projectedSchema,
+      ScanContext scanContext,
+      MetadataTableType metadataTableType) {
+    super(taskName, taskIndex, tableLoader, projectedSchema, scanContext, metadataTableType);
+  }
+
+  @Override
+  void extract(RowData rowData, Collector<String> out) {
+    if (rowData != null && rowData.getString(0) != null) {
+      out.collect(rowData.getString(0).toString());
+    }
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FileUriKeySelector.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FileUriKeySelector.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Map;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.actions.FileURI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A key selector implementation that extracts a normalized file path from a file URI string.
+ *
+ * <p>This selector groups file URIs by their normalized path, ignoring differences in scheme and
+ * authority that are considered equivalent according to the provided mappings.
+ */
+@Internal
+public class FileUriKeySelector implements KeySelector<String, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(FileUriKeySelector.class);
+
+  static final String INVALID_URI = "__INVALID_URI__";
+
+  private final Map<String, String> equalSchemes;
+  private final Map<String, String> equalAuthorities;
+
+  public FileUriKeySelector(
+      Map<String, String> equalSchemes, Map<String, String> equalAuthorities) {
+    this.equalSchemes = equalSchemes;
+    this.equalAuthorities = equalAuthorities;
+  }
+
+  @Override
+  public String getKey(String value) throws Exception {
+    try {
+      FileURI fileUri = new FileURI(new Path(value).toUri(), equalSchemes, equalAuthorities);
+      return fileUri.getPath();
+    } catch (Exception e) {
+      LOG.warn("Uri convert to FileURI error! Uri is {}.", value, e);
+      return INVALID_URI;
+    }
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Map;
+import java.util.function.Predicate;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.SupportsPrefixOperations;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.FileSystemWalker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Recursively lists the files in the `location` directory. Hidden files, and files younger than the
+ * `minAgeMs` are omitted in the result.
+ */
+@Internal
+public class ListFileSystemFiles extends ProcessFunction<Trigger, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(ListFileSystemFiles.class);
+
+  private final String taskName;
+  private final int taskIndex;
+
+  private FileIO io;
+  private Map<Integer, PartitionSpec> specs;
+  private String location;
+  private final long minAgeMs;
+  private transient Counter errorCounter;
+  private final TableLoader tableLoader;
+  private final boolean usePrefixListing;
+  private transient Configuration configuration;
+
+  public ListFileSystemFiles(
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      String location,
+      long minAgeMs,
+      boolean usePrefixListing) {
+    Preconditions.checkNotNull(taskName, "Task name should no be null");
+    Preconditions.checkNotNull(tableLoader, "TableLoad should no be null");
+
+    this.tableLoader = tableLoader;
+    this.taskName = taskName;
+    this.taskIndex = taskIndex;
+    this.minAgeMs = minAgeMs;
+    this.location = location;
+    this.usePrefixListing = usePrefixListing;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    tableLoader.open();
+    Table table = tableLoader.loadTable();
+    this.io = table.io();
+    this.location = location != null ? location : table.location();
+    this.specs = table.specs();
+    this.errorCounter =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), table.name(), taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+    this.configuration = new Configuration();
+    table.properties().forEach(configuration::set);
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<String> out) throws Exception {
+    long olderThanTimestamp = trigger.timestamp() - minAgeMs;
+    try {
+      if (usePrefixListing) {
+        Predicate<FileInfo> predicate = fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;
+        Preconditions.checkArgument(
+            io instanceof SupportsPrefixOperations,
+            "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+            io);
+
+        FileSystemWalker.listDirRecursivelyWithFileIO(
+            (SupportsPrefixOperations) io, location, specs, predicate, out::collect);
+      } else {
+        Predicate<FileStatus> predicate = file -> file.getModificationTime() < olderThanTimestamp;
+        FileSystemWalker.listDirRecursivelyWithHadoop(
+            location,
+            specs,
+            predicate,
+            configuration,
+            Integer.MAX_VALUE,
+            Integer.MAX_VALUE,
+            dir -> {},
+            out::collect);
+      }
+    } catch (Exception e) {
+      LOG.warn("Exception listing files for {} at {}", location, ctx.timestamp(), e);
+      ctx.output(DeleteOrphanFiles.ERROR_STREAM, e);
+      errorCounter.inc();
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ReachableFileUtil;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Lists the metadata files referenced by the table. */
+@Internal
+public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(ListMetadataFiles.class);
+
+  private final String taskName;
+  private final int taskIndex;
+  private transient Counter errorCounter;
+  private final TableLoader tableLoader;
+  private transient Table table;
+
+  public ListMetadataFiles(String taskName, int taskIndex, TableLoader tableLoader) {
+    Preconditions.checkNotNull(taskName, "Task name should no be null");
+    Preconditions.checkNotNull(tableLoader, "TableLoader should no be null");
+    this.tableLoader = tableLoader;
+    this.taskName = taskName;
+    this.taskIndex = taskIndex;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    tableLoader.open();
+    this.table = tableLoader.loadTable();
+    this.errorCounter =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), table.name(), taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<String> collector)
+      throws Exception {
+    try {
+      table
+          .snapshots()
+          .forEach(
+              snapshot -> {
+                // Manifest lists
+                collector.collect(snapshot.manifestListLocation());
+                // Snapshot JSONs
+                ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
+                // Statistics files
+                ReachableFileUtil.statisticsFilesLocations(table).forEach(collector::collect);
+                // Version hint file for Hadoop catalogs
+                collector.collect(ReachableFileUtil.versionHintLocation(table));
+
+                // Emit the manifest file locations
+                snapshot.allManifests(table.io()).stream()
+                    .map(ManifestFile::path)
+                    .forEach(collector::collect);
+              });
+    } catch (Exception e) {
+      LOG.error("Exception listing metadata files for {} at {}", table, ctx.timestamp(), e);
+      ctx.output(DeleteOrphanFiles.ERROR_STREAM, e);
+      errorCounter.inc();
+    }
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/MetadataTablePlanner.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/MetadataTablePlanner.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.concurrent.ExecutorService;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.flink.source.FlinkSplitPlanner;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitSerializer;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ThreadPools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Plans the splits to read a metadata table content. */
+@Internal
+public class MetadataTablePlanner extends ProcessFunction<Trigger, MetadataTablePlanner.SplitInfo> {
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataTablePlanner.class);
+
+  private final String taskName;
+  private final int taskIndex;
+  private final TableLoader tableLoader;
+  private final int workerPoolSize;
+  private final ScanContext scanContext;
+  private transient ExecutorService workerPool;
+  private transient Counter errorCounter;
+  private transient Table table;
+  private transient IcebergSourceSplitSerializer splitSerializer;
+  private final MetadataTableType metadataTableType;
+
+  public MetadataTablePlanner(
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      ScanContext scanContext,
+      MetadataTableType metadataTableType,
+      int workerPoolSize) {
+    Preconditions.checkNotNull(taskName, "Task name should no be null");
+    Preconditions.checkNotNull(tableLoader, "Table should no be null");
+    Preconditions.checkArgument(scanContext.isStreaming(), "Streaming should be set to true");
+
+    this.taskName = taskName;
+    this.taskIndex = taskIndex;
+    this.tableLoader = tableLoader;
+    this.scanContext = scanContext;
+    this.workerPoolSize = workerPoolSize;
+    this.metadataTableType = metadataTableType;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    tableLoader.open();
+    Table originalTable = tableLoader.loadTable();
+    this.table = MetadataTableUtils.createMetadataTableInstance(originalTable, metadataTableType);
+    this.workerPool =
+        ThreadPools.newFixedThreadPool(table.name() + "-table-planner", workerPoolSize);
+    this.splitSerializer = new IcebergSourceSplitSerializer(scanContext.caseSensitive());
+    this.errorCounter =
+        TableMaintenanceMetrics.groupFor(
+                getRuntimeContext(), originalTable.name(), taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<SplitInfo> out)
+      throws Exception {
+    try {
+      table.refresh();
+      for (IcebergSourceSplit split :
+          FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, workerPool)) {
+        out.collect(new SplitInfo(splitSerializer.getVersion(), splitSerializer.serialize(split)));
+      }
+    } catch (Exception e) {
+      LOG.warn("Exception planning scan for {} at {}", table, ctx.timestamp(), e);
+      ctx.output(DeleteOrphanFiles.ERROR_STREAM, e);
+      errorCounter.inc();
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+    if (workerPool != null) {
+      workerPool.shutdown();
+    }
+  }
+
+  public static class SplitInfo {
+    private final int version;
+    private final byte[] split;
+
+    public SplitInfo(int version, byte[] split) {
+      this.version = version;
+      this.split = split;
+    }
+
+    public int version() {
+      return version;
+    }
+
+    public byte[] split() {
+      return split;
+    }
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/OrphanFilesDetector.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/OrphanFilesDetector.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.FileURI;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A specialized co-process function that performs an anti-join between two streams of file URIs.
+ *
+ * <p>Emits every file that exists in the file system but is not referenced in the table metadata,
+ * which are considered orphan files. It also handles URI normalization using provided scheme and
+ * authority equivalence mappings.
+ */
+@Internal
+public class OrphanFilesDetector extends KeyedCoProcessFunction<String, String, String, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(OrphanFilesDetector.class);
+
+  // Use MapState to dedupe the strings found in the table
+  private transient MapState<String, Boolean> foundInTable;
+  private transient ValueState<String> foundInFileSystem;
+  private transient ValueState<Boolean> hasUriError;
+  private final DeleteOrphanFiles.PrefixMismatchMode prefixMismatchMode;
+  private final Map<String, String> equalSchemes;
+  private final Map<String, String> equalAuthorities;
+
+  public OrphanFilesDetector(
+      DeleteOrphanFiles.PrefixMismatchMode prefixMismatchMode,
+      Map<String, String> equalSchemes,
+      Map<String, String> equalAuthorities) {
+    this.prefixMismatchMode = prefixMismatchMode;
+    this.equalSchemes = equalSchemes;
+    this.equalAuthorities = equalAuthorities;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    foundInTable =
+        getRuntimeContext()
+            .getMapState(
+                new MapStateDescriptor<>("antiJoinFoundInTable", Types.STRING, Types.BOOLEAN));
+    hasUriError =
+        getRuntimeContext().getState(new ValueStateDescriptor<>("antiJoinUriError", Types.BOOLEAN));
+    foundInFileSystem =
+        getRuntimeContext()
+            .getState(new ValueStateDescriptor<>("antiJoinFoundInFileSystem", Types.STRING));
+  }
+
+  @Override
+  public void processElement1(String value, Context context, Collector<String> collector)
+      throws Exception {
+    if (shouldSkipElement(value, context)) {
+      return;
+    }
+
+    if (!foundInTable.contains(value)) {
+      foundInTable.put(value, true);
+      context.timerService().registerEventTimeTimer(context.timestamp());
+    }
+  }
+
+  @Override
+  public void processElement2(String value, Context context, Collector<String> collector)
+      throws Exception {
+    if (shouldSkipElement(value, context)) {
+      return;
+    }
+
+    foundInFileSystem.update(value);
+    context.timerService().registerEventTimeTimer(context.timestamp());
+  }
+
+  @Override
+  public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
+    if (Boolean.TRUE.equals(hasUriError.value())) {
+      clearState();
+      return;
+    }
+
+    List<FileURI> foundInTablesList = Lists.newArrayList();
+    foundInTable
+        .keys()
+        .forEach(
+            uri ->
+                foundInTablesList.add(
+                    new FileURI(new Path(uri).toUri(), equalSchemes, equalAuthorities)));
+
+    if (foundInFileSystem.value() != null) {
+      if (foundInTablesList.isEmpty()) {
+        FileURI fileURI =
+            new FileURI(
+                new Path(foundInFileSystem.value()).toUri(), equalSchemes, equalAuthorities);
+        out.collect(fileURI.getUriAsString());
+      } else {
+        FileURI actual =
+            new FileURI(
+                new Path(foundInFileSystem.value()).toUri(), equalSchemes, equalAuthorities);
+        if (hasMismatch(actual, foundInTablesList)) {
+          if (prefixMismatchMode == DeleteOrphanFiles.PrefixMismatchMode.DELETE) {
+            out.collect(foundInFileSystem.value());
+          } else if (prefixMismatchMode == DeleteOrphanFiles.PrefixMismatchMode.ERROR) {
+            ValidationException validationException =
+                new ValidationException(
+                    "Unable to determine whether certain files are orphan. "
+                        + "Metadata references files that match listed/provided files except for authority/scheme. "
+                        + "Please, inspect the conflicting authorities/schemes and provide which of them are equal "
+                        + "by further configuring the action via equalSchemes() and equalAuthorities() methods. "
+                        + "Set the prefix mismatch mode to 'NONE' to ignore remaining locations with conflicting "
+                        + "authorities/schemes or to 'DELETE' if you are ABSOLUTELY confident that remaining conflicting "
+                        + "authorities/schemes are different. It will be impossible to recover deleted files. "
+                        + "Conflicting authorities/schemes");
+            LOG.warn(
+                "Unable to determine whether certain files are orphan. Found in filesystem: {} and in table: {}",
+                actual,
+                StringUtils.join(foundInTablesList, ","),
+                validationException);
+            ctx.output(
+                org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.ERROR_STREAM,
+                validationException);
+          }
+        }
+      }
+    }
+
+    clearState();
+  }
+
+  private boolean hasMismatch(FileURI actual, List<FileURI> foundInTablesList) {
+    return foundInTablesList.stream()
+        .noneMatch(valid -> valid.schemeMatch(actual) && valid.authorityMatch(actual));
+  }
+
+  private boolean shouldSkipElement(String value, Context context) throws IOException {
+    if (Boolean.TRUE.equals(hasUriError.value())) {
+      return true;
+    }
+
+    if (FileUriKeySelector.INVALID_URI.equals(context.getCurrentKey())) {
+      context.output(
+          org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.ERROR_STREAM,
+          new RuntimeException("Invalid URI format detected: " + value));
+      hasUriError.update(true);
+      foundInTable.clear();
+      foundInFileSystem.clear();
+      return true;
+    }
+
+    return false;
+  }
+
+  private void clearState() {
+    hasUriError.clear();
+    foundInTable.clear();
+    foundInFileSystem.clear();
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SkipOnError.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SkipOnError.java
@@ -19,8 +19,8 @@
 package org.apache.iceberg.flink.maintenance.operator;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.state.v2.ListState;
-import org.apache.flink.api.common.state.v2.ListStateDescriptor;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -58,14 +58,14 @@ public class SkipOnError extends AbstractStreamOperator<String>
   }
 
   @Override
-  public void processElement1(StreamRecord<String> element) {
+  public void processElement1(StreamRecord<String> element) throws Exception {
     if (!hasErrorFlag) {
       filesToDelete.add(element.getValue());
     }
   }
 
   @Override
-  public void processElement2(StreamRecord<Exception> element) {
+  public void processElement2(StreamRecord<Exception> element) throws Exception {
     hasError.add(true);
     hasErrorFlag = true;
     filesToDelete.clear();

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SkipOnError.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SkipOnError.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.v2.ListState;
+import org.apache.flink.api.common.state.v2.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Skip file deletion processing when an error is encountered. */
+@Internal
+public class SkipOnError extends AbstractStreamOperator<String>
+    implements TwoInputStreamOperator<String, Exception, String> {
+  private static final Logger LOG = LoggerFactory.getLogger(SkipOnError.class);
+  private transient ListState<String> filesToDelete;
+  private transient ListState<Boolean> hasError;
+  private boolean hasErrorFlag = false;
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    this.filesToDelete =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("blockOnErrorFiles", String.class));
+    this.hasError =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("blockOnErrorHasError", Types.BOOLEAN));
+
+    if (!Iterables.isEmpty(hasError.get())) {
+      hasErrorFlag = true;
+    }
+  }
+
+  @Override
+  public void processElement1(StreamRecord<String> element) {
+    if (!hasErrorFlag) {
+      filesToDelete.add(element.getValue());
+    }
+  }
+
+  @Override
+  public void processElement2(StreamRecord<Exception> element) {
+    hasError.add(true);
+    hasErrorFlag = true;
+    filesToDelete.clear();
+  }
+
+  @Override
+  public void processWatermark(Watermark mark) throws Exception {
+    try {
+      if (!hasErrorFlag) {
+        filesToDelete.get().forEach(file -> output.collect(new StreamRecord<>(file)));
+      } else {
+        LOG.info("Omitting result on failure at {}", mark.getTimestamp());
+      }
+    } finally {
+      filesToDelete.clear();
+      hasError.clear();
+      hasErrorFlag = false;
+    }
+
+    super.processWatermark(mark);
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableReader.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.reader.MetaDataReaderFunction;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitSerializer;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Reads the records from the metadata table splits. */
+abstract class TableReader<R> extends ProcessFunction<MetadataTablePlanner.SplitInfo, R> {
+  private static final Logger LOG = LoggerFactory.getLogger(TableReader.class);
+
+  private final TableLoader tableLoader;
+  private final String taskName;
+  private final int taskIndex;
+  private final Schema projectedSchema;
+  private IcebergSourceSplitSerializer splitSerializer;
+  private final ScanContext scanContext;
+  private final MetadataTableType metadataTableType;
+
+  private transient MetaDataReaderFunction rowDataReaderFunction;
+  private transient Counter errorCounter;
+
+  TableReader(
+      String taskName,
+      int taskIndex,
+      TableLoader tableLoader,
+      Schema projectedSchema,
+      ScanContext scanContext,
+      MetadataTableType metadataTableType) {
+    Preconditions.checkNotNull(taskName, "Task name should no be null");
+    Preconditions.checkNotNull(tableLoader, "Table should no be null");
+    Preconditions.checkNotNull(projectedSchema, "The projected schema should no be null");
+
+    this.tableLoader = tableLoader;
+    this.taskName = taskName;
+    this.taskIndex = taskIndex;
+    this.projectedSchema = projectedSchema;
+    this.scanContext = scanContext;
+    this.metadataTableType = metadataTableType;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    tableLoader.open();
+    Table table = tableLoader.loadTable();
+    Table metaTable = MetadataTableUtils.createMetadataTableInstance(table, metadataTableType);
+    this.errorCounter =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), table.name(), taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+    this.rowDataReaderFunction =
+        new MetaDataReaderFunction(
+            new Configuration(),
+            metaTable.schema(),
+            projectedSchema,
+            metaTable.io(),
+            metaTable.encryption());
+    this.splitSerializer = new IcebergSourceSplitSerializer(scanContext.caseSensitive());
+  }
+
+  @Override
+  public void processElement(
+      MetadataTablePlanner.SplitInfo splitInfo, Context ctx, Collector<R> out) throws Exception {
+    IcebergSourceSplit split = splitSerializer.deserialize(splitInfo.version(), splitInfo.split());
+    try (DataIterator<RowData> iterator = rowDataReaderFunction.createDataIterator(split)) {
+      iterator.forEachRemaining(rowData -> extract(rowData, out));
+    } catch (Exception e) {
+      LOG.warn("Exception processing split {} at {}", split, ctx.timestamp(), e);
+      ctx.output(DeleteOrphanFiles.ERROR_STREAM, e);
+      errorCounter.inc();
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  /**
+   * Extracts the desired data from the given RowData.
+   *
+   * @param rowData the RowData from which to extract
+   * @param out the Collector to which to output the extracted data
+   */
+  abstract void extract(RowData rowData, Collector<R> out);
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/MaintenanceTaskTestBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/MaintenanceTaskTestBase.java
@@ -41,7 +41,13 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       ManualSource<Trigger> triggerSource,
       CollectingSink<TaskResult> collectingSink)
       throws Exception {
-    runAndWaitForResult(env, triggerSource, collectingSink, false, () -> true);
+    runAndWaitForResult(
+        env,
+        triggerSource,
+        collectingSink,
+        false /* generateFailure */,
+        () -> true /* waitForCondition */,
+        true /* resultSuccess */);
   }
 
   void runAndWaitForSuccess(
@@ -50,7 +56,13 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       CollectingSink<TaskResult> collectingSink,
       Supplier<Boolean> waitForCondition)
       throws Exception {
-    runAndWaitForResult(env, triggerSource, collectingSink, false, waitForCondition);
+    runAndWaitForResult(
+        env,
+        triggerSource,
+        collectingSink,
+        false /* generateFailure */,
+        waitForCondition,
+        true /* resultSuccess */);
   }
 
   void runAndWaitForFailure(
@@ -58,7 +70,13 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       ManualSource<Trigger> triggerSource,
       CollectingSink<TaskResult> collectingSink)
       throws Exception {
-    runAndWaitForResult(env, triggerSource, collectingSink, true, () -> true);
+    runAndWaitForResult(
+        env,
+        triggerSource,
+        collectingSink,
+        true /* generateFailure */,
+        () -> true /* waitForCondition */,
+        true /* resultSuccess */);
   }
 
   void runAndWaitForResult(
@@ -66,7 +84,8 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       ManualSource<Trigger> triggerSource,
       CollectingSink<TaskResult> collectingSink,
       boolean generateFailure,
-      Supplier<Boolean> waitForCondition)
+      Supplier<Boolean> waitForCondition,
+      boolean resultSuccess)
       throws Exception {
     JobClient jobClient = null;
     try {
@@ -79,7 +98,7 @@ class MaintenanceTaskTestBase extends OperatorTestBase {
       TaskResult result = collectingSink.poll(POLL_DURATION);
 
       assertThat(result.startEpoch()).isEqualTo(time);
-      assertThat(result.success()).isTrue();
+      assertThat(result.success()).isEqualTo(resultSuccess);
       assertThat(result.taskIndex()).isEqualTo(TESTING_TASK_ID);
 
       if (generateFailure) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestDeleteOrphanFiles.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestDeleteOrphanFiles.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.DELETE_FILES_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.FILESYSTEM_FILES_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.METADATA_FILES_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.PLANNER_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles.READER_TASK_NAME;
+import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.DELETE_FILE_FAILED_COUNTER;
+import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.DELETE_FILE_SUCCEEDED_COUNTER;
+import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.ERROR_COUNTER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.operator.MetricsReporterFactoryForTests;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+class TestDeleteOrphanFiles extends MaintenanceTaskTestBase {
+
+  private Path relative(Table table, String relativePath) {
+    return FileSystems.getDefault().getPath(table.location().substring(5), relativePath);
+  }
+
+  private void createFiles(Path... paths) throws IOException {
+    for (Path path : paths) {
+      Files.write(path, "DUMMY".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  void testDeleteOrphanFilesUnPartitioned() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+
+    assertFileNum(table, 4, 0);
+
+    Path inData = relative(table, "metadata/in_data");
+    Path inMetadata = relative(table, "metadata/in_metadata");
+
+    createFiles(inData);
+    createFiles(inMetadata);
+    assertThat(inMetadata).exists();
+    assertThat(inData).exists();
+
+    appendDeleteOrphanFiles();
+
+    runAndWaitForSuccess(
+        infra.env(), infra.source(), infra.sink(), () -> checkDeleteFinished(table.name(), 2L));
+    assertThat(inMetadata).doesNotExist();
+    assertThat(inData).doesNotExist();
+    assertFileNum(table, 4, 0);
+
+    // Check the metrics
+    MetricsReporterFactoryForTests.assertCounters(
+        new ImmutableMap.Builder<List<String>, Long>()
+            .put(
+                ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    READER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    FILESYSTEM_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    METADATA_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_FAILED_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_SUCCEEDED_COUNTER),
+                2L)
+            .build());
+  }
+
+  @Test
+  void testDeleteOrphanFilesPartitioned() throws Exception {
+    Table table = createPartitionedTable();
+    insertPartitioned(table, 1, "p1");
+    insertPartitioned(table, 2, "p1");
+    insertPartitioned(table, 3, "p2");
+    insertPartitioned(table, 4, "p2");
+
+    assertFileNum(table, 4, 0);
+
+    Path inMetadata = relative(table, "metadata/in_metadata");
+    Path inData = relative(table, "metadata/in_data");
+
+    createFiles(inMetadata);
+    createFiles(inData);
+    assertThat(inMetadata).exists();
+    assertThat(inData).exists();
+
+    appendDeleteOrphanFiles();
+
+    runAndWaitForSuccess(
+        infra.env(), infra.source(), infra.sink(), () -> checkDeleteFinished(table.name(), 2L));
+    assertThat(inMetadata).doesNotExist();
+    assertThat(inData).doesNotExist();
+
+    assertFileNum(table, 4, 0);
+
+    // Check the metrics
+    MetricsReporterFactoryForTests.assertCounters(
+        new ImmutableMap.Builder<List<String>, Long>()
+            .put(
+                ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    READER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    FILESYSTEM_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    METADATA_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_FAILED_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_SUCCEEDED_COUNTER),
+                2L)
+            .build());
+  }
+
+  @Test
+  void testDeleteOrphanFilesFailure() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+
+    assertFileNum(table, 4, 0);
+
+    Path inData = relative(table, "metadata/in_data");
+    Path inMetadata = relative(table, "metadata/in_metadata");
+
+    createFiles(inData);
+    createFiles(inMetadata);
+    assertThat(inMetadata).exists();
+    assertThat(inData).exists();
+
+    appendDeleteOrphanFiles();
+
+    // Mock error in the delete files operator
+    Long parentId = table.currentSnapshot().parentId();
+    for (ManifestFile manifestFile : table.snapshot(parentId).allManifests(table.io())) {
+      table.io().deleteFile(manifestFile.path());
+    }
+
+    runAndWaitForResult(
+        infra.env(),
+        infra.source(),
+        infra.sink(),
+        false /* generateFailure */,
+        () -> checkDeleteFinished(table.name(), 0L),
+        false /* resultSuccess*/);
+
+    // An error occurred; the file should not be deleted. And the job should not be failed.
+    assertThat(inMetadata).exists();
+    assertThat(inData).exists();
+
+    // Check the metrics
+    MetricsReporterFactoryForTests.assertCounters(
+        new ImmutableMap.Builder<List<String>, Long>()
+            .put(
+                ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    READER_TASK_NAME + "[0]", table.name(), DUMMY_TASK_NAME, "0", ERROR_COUNTER),
+                1L)
+            .put(
+                ImmutableList.of(
+                    FILESYSTEM_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    METADATA_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    ERROR_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_FAILED_COUNTER),
+                0L)
+            .put(
+                ImmutableList.of(
+                    DELETE_FILES_TASK_NAME + "[0]",
+                    table.name(),
+                    DUMMY_TASK_NAME,
+                    "0",
+                    DELETE_FILE_SUCCEEDED_COUNTER),
+                0L)
+            .build());
+  }
+
+  private void appendDeleteOrphanFiles() {
+    appendDeleteOrphanFiles(DeleteOrphanFiles.builder().minAge(Duration.ZERO));
+  }
+
+  private void appendDeleteOrphanFiles(DeleteOrphanFiles.Builder builder) {
+    builder
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+  }
+
+  private static void assertFileNum(
+      Table table, int expectedDataFileNum, int expectedDeleteFileNum) {
+    table.refresh();
+    assertThat(
+            table.currentSnapshot().dataManifests(table.io()).stream()
+                .flatMap(
+                    m ->
+                        StreamSupport.stream(
+                            ManifestFiles.read(m, table.io(), table.specs()).spliterator(), false))
+                .count())
+        .isEqualTo(expectedDataFileNum);
+    assertThat(
+            table.currentSnapshot().deleteManifests(table.io()).stream()
+                .flatMap(
+                    m ->
+                        StreamSupport.stream(
+                            ManifestFiles.readDeleteManifest(m, table.io(), table.specs())
+                                .spliterator(),
+                            false))
+                .count())
+        .isEqualTo(expectedDeleteFileNum);
+  }
+
+  private static boolean checkDeleteFinished(String tableName, Long expectedDeleteNum) {
+    return expectedDeleteNum.equals(
+        MetricsReporterFactoryForTests.counter(
+            ImmutableList.of(
+                DELETE_FILES_TASK_NAME + "[0]",
+                tableName,
+                DUMMY_TASK_NAME,
+                "0",
+                DELETE_FILE_SUCCEEDED_COUNTER)));
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -89,6 +89,10 @@ public class OperatorTestBase {
   protected static final String DUMMY_TASK_NAME = "dummyTask";
   protected static final String DUMMY_TABLE_NAME = "dummyTable";
 
+  static final String FILE_NAME_1 = "fileName1";
+  static final String FILE_NAME_2 = "fileName2";
+  static final Watermark WATERMARK_2 = new Watermark(EVENT_TIME_2);
+
   @RegisterExtension
   protected static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
       new MiniClusterExtension(

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListFileSystemFiles.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListFileSystemFiles.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+class TestListFileSystemFiles extends OperatorTestBase {
+  @Parameter(index = 0)
+  private boolean usePrefixListing;
+
+  @Parameters(name = "usePrefixListing = {0}")
+  private static Object[][] parameters() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @TestTemplate
+  void testMetadataFilesWithTable() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListFileSystemFiles(
+                OperatorTestBase.DUMMY_TABLE_NAME,
+                0,
+                tableLoader(),
+                table.location(),
+                0,
+                usePrefixListing))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+
+      assertThat(testHarness.extractOutputValues()).hasSize(11);
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @TestTemplate
+  void testMetadataFilesWithPartitionTable() throws Exception {
+    Table table = createPartitionedTable();
+    insertPartitioned(table, 1, "p1");
+    insertPartitioned(table, 2, "p1");
+    insertPartitioned(table, 3, "p2");
+    insertPartitioned(table, 4, "p2");
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListFileSystemFiles(
+                OperatorTestBase.DUMMY_TABLE_NAME,
+                0,
+                tableLoader(),
+                table.location(),
+                0,
+                usePrefixListing))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+
+      assertThat(testHarness.extractOutputValues()).hasSize(14);
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @TestTemplate
+  void testMetadataFilesWithEmptyTable() throws Exception {
+    Table table = createTable();
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListFileSystemFiles(
+                OperatorTestBase.DUMMY_TABLE_NAME,
+                0,
+                tableLoader(),
+                table.location(),
+                0,
+                usePrefixListing))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+
+      assertThat(testHarness.extractOutputValues()).hasSize(2);
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.junit.jupiter.api.Test;
+
+class TestListMetadataFiles extends OperatorTestBase {
+
+  @Test
+  void testMetadataFilesWithTable() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+      tableMetadataFiles.forEach(System.out::println);
+      assertThat(tableMetadataFiles).hasSize(24);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMetadataFilesWithPartitionTable() throws Exception {
+    Table table = createPartitionedTable();
+    insertPartitioned(table, 1, "p1");
+    insertPartitioned(table, 2, "p1");
+    insertPartitioned(table, 3, "p2");
+    insertPartitioned(table, 4, "p2");
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+      assertThat(tableMetadataFiles).hasSize(38);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMetadataFilesWithEmptyTable() throws Exception {
+    createTable();
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+      assertThat(tableMetadataFiles).hasSize(0);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestOrphanFilesDetector.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestOrphanFilesDetector.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
+import org.apache.iceberg.actions.FileURI;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestOrphanFilesDetector extends OperatorTestBase {
+  private static final Map<String, String> EQUAL_SCHEMES =
+      Maps.newHashMap(
+          ImmutableMap.of(
+              "s3n", "s3",
+              "s3a", "s3"));
+  private static final Map<String, String> EQUAL_AUTHORITIES = Maps.newHashMap();
+  private static final String SCHEME_FILE_1 = "s3:/fileName1";
+  private static final String AUTHORITY_FILE_1 = "s3://HDFS1002060/fileName1";
+  private static final String ONE_AUTHORITY_SCHEME_FILE_1 = "s3a://HDFS1002060/fileName1";
+  private static final String TWO_AUTHORITY_SCHEME_FILE_1 = "s3b://HDFS1002060/fileName1";
+
+  @Test
+  void testFileSystemFirst() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processWatermark1(WATERMARK);
+      testHarness.processElement1(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processWatermark2(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testTableFirst() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processWatermark1(WATERMARK);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processWatermark2(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testOnlyFileSystem() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEqualTo(ImmutableList.of(SCHEME_FILE_1));
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testOnlyTable() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testFileSystemWithAuthority() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(AUTHORITY_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testTableWithAuthority() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      ConcurrentLinkedQueue<StreamRecord<Exception>> errorList =
+          testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM);
+      assertThat(errorList).hasSize(1);
+      assertThat(errorList.stream().findFirst().get().getValue())
+          .isInstanceOf(ValidationException.class);
+
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void testDiffScheme() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(ONE_AUTHORITY_SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testUnRegisterScheme() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness()) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(TWO_AUTHORITY_SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      ConcurrentLinkedQueue<StreamRecord<Exception>> errorList =
+          testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM);
+      assertThat(errorList).hasSize(1);
+      assertThat(errorList.stream().findFirst().get().getValue())
+          .isInstanceOf(ValidationException.class);
+
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void testPrefixMismatchModeDelete() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness(PrefixMismatchMode.DELETE)) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEqualTo(ImmutableList.of(SCHEME_FILE_1));
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testPrefixMismatchModeIgnore() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness(PrefixMismatchMode.IGNORE)) {
+      testHarness.open();
+
+      testHarness.processElement1(AUTHORITY_FILE_1, EVENT_TIME);
+      testHarness.processElement2(SCHEME_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMultiAuthority() throws Exception {
+    try (KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness =
+        testHarness(PrefixMismatchMode.IGNORE)) {
+      testHarness.open();
+
+      testHarness.processElement1(TWO_AUTHORITY_SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement1(ONE_AUTHORITY_SCHEME_FILE_1, EVENT_TIME);
+      testHarness.processElement2(AUTHORITY_FILE_1, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      assertThat(testHarness.getSideOutput(DeleteOrphanFiles.ERROR_STREAM)).isNull();
+    }
+  }
+
+  private static KeyedTwoInputStreamOperatorTestHarness<String, String, String, String> testHarness(
+      PrefixMismatchMode prefixMismatchMode) throws Exception {
+    return ProcessFunctionTestHarnesses.forKeyedCoProcessFunction(
+        new OrphanFilesDetector(prefixMismatchMode, EQUAL_SCHEMES, EQUAL_AUTHORITIES),
+        (KeySelector<String, String>)
+            t -> new FileURI(new Path(t).toUri(), EQUAL_SCHEMES, EQUAL_AUTHORITIES).getPath(),
+        (KeySelector<String, String>)
+            t -> new FileURI(new Path(t).toUri(), EQUAL_SCHEMES, EQUAL_AUTHORITIES).getPath(),
+        BasicTypeInfo.STRING_TYPE_INFO);
+  }
+
+  private static KeyedTwoInputStreamOperatorTestHarness<String, String, String, String>
+      testHarness() throws Exception {
+    return testHarness(PrefixMismatchMode.ERROR);
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestSkipOnError.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestSkipOnError.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TestSkipOnError extends OperatorTestBase {
+
+  private static final Exception EXCEPTION = new Exception("Test error");
+
+  @Test
+  void testNoFailure() throws Exception {
+    try (TwoInputStreamOperatorTestHarness<String, Exception, String> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(new SkipOnError())) {
+      testHarness.open();
+
+      testHarness.processElement1(FILE_NAME_1, EVENT_TIME);
+      testHarness.processElement1(FILE_NAME_2, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues())
+          .isEqualTo(ImmutableList.of(FILE_NAME_1, FILE_NAME_2));
+    }
+  }
+
+  @Test
+  void testFailure() throws Exception {
+    try (TwoInputStreamOperatorTestHarness<String, Exception, String> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(new SkipOnError())) {
+      testHarness.open();
+
+      testHarness.processElement1(FILE_NAME_1, EVENT_TIME);
+      testHarness.processElement2(EXCEPTION, EVENT_TIME);
+      testHarness.processElement1(FILE_NAME_2, EVENT_TIME);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+
+      testHarness.processBothWatermarks(WATERMARK);
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testStateRestore(boolean withError) throws Exception {
+    OperatorSubtaskState state;
+    try (TwoInputStreamOperatorTestHarness<String, Exception, String> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(new SkipOnError())) {
+      testHarness.open();
+
+      testHarness.processElement1(FILE_NAME_1, EVENT_TIME);
+      if (withError) {
+        testHarness.processElement2(EXCEPTION, EVENT_TIME);
+      }
+
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      state = testHarness.snapshot(1L, EVENT_TIME);
+    }
+
+    try (TwoInputStreamOperatorTestHarness<String, Exception, String> testHarness =
+        new TwoInputStreamOperatorTestHarness<>(new SkipOnError())) {
+      testHarness.initializeState(state);
+      testHarness.open();
+
+      testHarness.processElement1(FILE_NAME_2, EVENT_TIME);
+
+      assertThat(testHarness.extractOutputValues()).isEmpty();
+      testHarness.processBothWatermarks(WATERMARK);
+      if (withError) {
+        assertThat(testHarness.extractOutputValues()).isEmpty();
+      } else {
+        assertThat(testHarness.extractOutputValues())
+            .isEqualTo(ImmutableList.of(FILE_NAME_1, FILE_NAME_2));
+      }
+    }
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTablePlanerAndReader.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestTablePlanerAndReader.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.junit.jupiter.api.Test;
+
+class TestTablePlanerAndReader extends OperatorTestBase {
+  private static final Schema FILE_PATH_SCHEMA = new Schema(DataFile.FILE_PATH);
+  private static final ScanContext FILE_PATH_SCAN_CONTEXT =
+      ScanContext.builder().streaming(true).project(FILE_PATH_SCHEMA).build();
+
+  @Test
+  void testTablePlaneAndRead() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    List<MetadataTablePlanner.SplitInfo> icebergSourceSplits;
+    try (OneInputStreamOperatorTestHarness<Trigger, MetadataTablePlanner.SplitInfo> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new MetadataTablePlanner(
+                OperatorTestBase.DUMMY_TASK_NAME,
+                0,
+                tableLoader(),
+                FILE_PATH_SCAN_CONTEXT,
+                MetadataTableType.ALL_FILES,
+                1))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+      icebergSourceSplits = testHarness.extractOutputValues();
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+
+    try (OneInputStreamOperatorTestHarness<MetadataTablePlanner.SplitInfo, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new FileNameReader(
+                OperatorTestBase.DUMMY_TASK_NAME,
+                0,
+                tableLoader(),
+                FILE_PATH_SCHEMA,
+                FILE_PATH_SCAN_CONTEXT,
+                MetadataTableType.ALL_FILES))) {
+      testHarness.open();
+      for (MetadataTablePlanner.SplitInfo icebergSourceSplit : icebergSourceSplits) {
+        testHarness.processElement(icebergSourceSplit, System.currentTimeMillis());
+      }
+
+      assertThat(testHarness.extractOutputValues()).hasSize(2);
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testTablePlaneAndReadWithPartitionedTable() throws Exception {
+    Table table = createPartitionedTable();
+    insertPartitioned(table, 1, "p1");
+    insertPartitioned(table, 2, "p1");
+    insertPartitioned(table, 3, "p2");
+    insertPartitioned(table, 4, "p2");
+    List<MetadataTablePlanner.SplitInfo> icebergSourceSplits;
+    try (OneInputStreamOperatorTestHarness<Trigger, MetadataTablePlanner.SplitInfo> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new MetadataTablePlanner(
+                OperatorTestBase.DUMMY_TASK_NAME,
+                0,
+                tableLoader(),
+                FILE_PATH_SCAN_CONTEXT,
+                MetadataTableType.ALL_FILES,
+                1))) {
+      testHarness.open();
+      OperatorTestBase.trigger(testHarness);
+      icebergSourceSplits = testHarness.extractOutputValues();
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+
+    try (OneInputStreamOperatorTestHarness<MetadataTablePlanner.SplitInfo, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new FileNameReader(
+                OperatorTestBase.DUMMY_TASK_NAME,
+                0,
+                tableLoader(),
+                FILE_PATH_SCHEMA,
+                FILE_PATH_SCAN_CONTEXT,
+                MetadataTableType.ALL_FILES))) {
+      testHarness.open();
+      for (MetadataTablePlanner.SplitInfo icebergSourceSplit : icebergSourceSplits) {
+        testHarness.processElement(icebergSourceSplit, System.currentTimeMillis());
+      }
+
+      assertThat(testHarness.extractOutputValues()).hasSize(4);
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+}


### PR DESCRIPTION
This is a backport for https://github.com/apache/iceberg/pull/13302 to Flink 1.19 and 1.20 . 
