### PR TITLE
Spark: (unit test) Order query result deterministically

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -139,7 +139,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
     for (ManifestFile manifest :
         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
@@ -208,7 +208,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -253,7 +253,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -305,7 +305,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -347,7 +347,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -386,7 +386,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -498,7 +498,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<ThreeColumnRecord> actual =
-        result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+        result.orderBy("c1", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -613,7 +613,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -702,7 +702,7 @@ public class TestSparkDataWrite {
     // Since write and commit succeeded, the rows should be readable
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual)
         .hasSize(records.size() + records2.size())
         .containsExactlyInAnyOrder(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -139,7 +139,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
     for (ManifestFile manifest :
         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
@@ -208,7 +208,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -253,7 +253,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -305,7 +305,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -347,7 +347,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -386,7 +386,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -498,7 +498,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<ThreeColumnRecord> actual =
-        result.orderBy("c1", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+        result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -702,7 +702,7 @@ public class TestSparkDataWrite {
     // Since write and commit succeeded, the rows should be readable
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual)
         .hasSize(records.size() + records2.size())
         .containsExactlyInAnyOrder(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -618,7 +618,7 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
             + "FROM %s t1 "
             + "INNER JOIN %s t2 "
             + "ON t1.id = t2.id AND t1.%s = t2.%s "
-            + "ORDER BY t1.id, t1.%s",
+            + "ORDER BY t1.id, t1.%s, t1.salary",
         sourceColumnName,
         tableName,
         tableName(OTHER_TABLE_NAME),

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -139,7 +139,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
     for (ManifestFile manifest :
         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
@@ -208,7 +208,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -253,7 +253,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -305,7 +305,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -347,7 +347,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -386,7 +386,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -498,7 +498,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<ThreeColumnRecord> actual =
-        result.orderBy("c1", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+        result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -701,7 +701,7 @@ public class TestSparkDataWrite {
     // Since write and commit succeeded, the rows should be readable
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual)
         .hasSize(records.size() + records2.size())
         .containsExactlyInAnyOrder(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -139,7 +139,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
     for (ManifestFile manifest :
         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
@@ -208,7 +208,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -253,7 +253,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -305,7 +305,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -347,7 +347,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -386,7 +386,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -498,7 +498,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<ThreeColumnRecord> actual =
-        result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+        result.orderBy("c1", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -613,7 +613,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -701,7 +701,7 @@ public class TestSparkDataWrite {
     // Since write and commit succeeded, the rows should be readable
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual)
         .hasSize(records.size() + records2.size())
         .containsExactlyInAnyOrder(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -616,7 +616,7 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
             + "FROM %s t1 "
             + "INNER JOIN %s t2 "
             + "ON t1.id = t2.id AND t1.%s = t2.%s "
-            + "ORDER BY t1.id, t1.%s",
+            + "ORDER BY t1.id, t1.%s, t1.salary",
         sourceColumnName,
         tableName,
         tableName(OTHER_TABLE_NAME),

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -139,7 +139,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
     for (ManifestFile manifest :
         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
@@ -208,7 +208,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -253,7 +253,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -305,7 +305,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -347,7 +347,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -386,7 +386,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -498,7 +498,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<ThreeColumnRecord> actual =
-        result.orderBy("c1", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+        result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -701,7 +701,7 @@ public class TestSparkDataWrite {
     // Since write and commit succeeded, the rows should be readable
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
     List<SimpleRecord> actual =
-        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual)
         .hasSize(records.size() + records2.size())
         .containsExactlyInAnyOrder(

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -139,7 +139,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
     for (ManifestFile manifest :
         SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io())) {
@@ -208,7 +208,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -253,7 +253,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -305,7 +305,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -347,7 +347,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -386,7 +386,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -498,7 +498,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<ThreeColumnRecord> actual =
-        result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+        result.orderBy("c1", "c3").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
   }
 
@@ -613,7 +613,7 @@ public class TestSparkDataWrite {
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
 
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
 
     List<DataFile> files = Lists.newArrayList();
@@ -701,7 +701,7 @@ public class TestSparkDataWrite {
     // Since write and commit succeeded, the rows should be readable
     Dataset<Row> result = spark.read().format("iceberg").load(targetLocation);
     List<SimpleRecord> actual =
-        result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        result.orderBy("id", "data").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     assertThat(actual)
         .hasSize(records.size() + records2.size())
         .containsExactlyInAnyOrder(

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -816,7 +816,7 @@ public class TestStoragePartitionedJoins extends TestBaseWithCatalog {
             + "FROM %s t1 "
             + "INNER JOIN %s t2 "
             + "ON t1.id = t2.id AND t1.%s = t2.%s "
-            + "ORDER BY t1.id, t1.%s",
+            + "ORDER BY t1.id, t1.%s, t1.salary",
         sourceColumnName,
         tableName,
         tableName(OTHER_TABLE_NAME),


### PR DESCRIPTION
- In `TestStoragePartitionedJoins.java`, most of the query order projected columns except one. That leads to indeterministic result.
- In `TestSparkDataWrite.java`, also order by all projected columns especially when the value of the `id` column in `SimpleRecord` are identical.