### PR TITLE
Porting custom spark manifest rewrite order to spark 3.4 and 4.0

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -102,7 +102,6 @@ public class RewriteManifestsSparkAction
           .addedManifests(ImmutableList.of())
           .build();
 
-  private static final String CUSTOM_CLUSTERING_COLUMN_NAME = "__clustering_column__";
   private static final String DATA_FILE_PARTITION_COLUMN_NAME = "data_file.partition";
 
   private final Table table;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -19,10 +19,12 @@
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.MetadataTableType.ENTRIES;
+import static org.apache.spark.sql.functions.col;
 
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -37,6 +39,7 @@ import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RollingManifestWriter;
@@ -71,6 +74,7 @@ import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,6 +102,9 @@ public class RewriteManifestsSparkAction
           .addedManifests(ImmutableList.of())
           .build();
 
+  private static final String CUSTOM_CLUSTERING_COLUMN_NAME = "__clustering_column__";
+  private static final String DATA_FILE_PARTITION_COLUMN_NAME = "data_file.partition";
+
   private final Table table;
   private final int formatVersion;
   private final long targetManifestSizeBytes;
@@ -106,6 +113,8 @@ public class RewriteManifestsSparkAction
   private PartitionSpec spec;
   private Predicate<ManifestFile> predicate = manifest -> true;
   private String outputLocation;
+
+  private List<String> partitionFieldClustering = null;
 
   RewriteManifestsSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -158,6 +167,30 @@ public class RewriteManifestsSparkAction
     } else {
       LOG.warn("Ignoring provided staging location as new manifests will be committed directly");
     }
+    return this;
+  }
+
+  @Override
+  public RewriteManifestsSparkAction sortBy(List<String> partitionFields) {
+    // Collect set of available partition columns to cluster on
+    Set<String> availablePartitionNames =
+        spec.fields().stream().map(PartitionField::name).collect(Collectors.toSet());
+
+    // Identify specified partition fields that are not available in the spec
+    List<String> missingFields =
+        partitionFields.stream()
+            .filter(field -> !availablePartitionNames.contains(field))
+            .collect(Collectors.toList());
+
+    // Check if these partition fields are included in the spec
+    Preconditions.checkArgument(
+        missingFields.isEmpty(),
+        "Cannot set manifest sorting because specified field(s) %s were not found in current partition spec %s. Spec ID %s",
+        missingFields,
+        this.spec,
+        this.spec.specId());
+
+    this.partitionFieldClustering = partitionFields;
     return this;
   }
 
@@ -255,8 +288,7 @@ public class RewriteManifestsSparkAction
         manifestEntryDF,
         df -> {
           WriteManifests<?> writeFunc = newWriteManifestsFunc(content, df.schema());
-          Column partitionColumn = df.col("data_file.partition");
-          Dataset<Row> transformedDF = repartitionAndSort(df, partitionColumn, numManifests);
+          Dataset<Row> transformedDF = repartitionAndSort(df, sortColumn(), numManifests);
           return writeFunc.apply(transformedDF).collectAsList();
         });
   }
@@ -272,6 +304,28 @@ public class RewriteManifestsSparkAction
       return new WriteDataManifests(writers, combinedFileType, fileType, sparkFileType);
     } else {
       return new WriteDeleteManifests(writers, combinedFileType, fileType, sparkFileType);
+    }
+  }
+
+  private Column sortColumn() {
+    if (partitionFieldClustering != null) {
+      LOG.info(
+          "Clustering manifests for specId {} by partition columns by {} ",
+          spec.specId(),
+          partitionFieldClustering);
+
+      // Map the top level partition column names to the column name referenced within the manifest
+      // entry dataframe
+      Column[] partitionColumns =
+          partitionFieldClustering.stream()
+              .map(p -> col(DATA_FILE_PARTITION_COLUMN_NAME + "." + p))
+              .toArray(Column[]::new);
+
+      // Form a new temporary column to cluster manifests on, based on the custom clustering columns
+      // order provided
+      return functions.struct(partitionColumns);
+    } else {
+      return new Column(DATA_FILE_PARTITION_COLUMN_NAME);
     }
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -102,7 +102,6 @@ public class RewriteManifestsSparkAction
           .addedManifests(ImmutableList.of())
           .build();
 
-  private static final String CUSTOM_CLUSTERING_COLUMN_NAME = "__clustering_column__";
   private static final String DATA_FILE_PARTITION_COLUMN_NAME = "data_file.partition";
 
   private final Table table;

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -19,10 +19,12 @@
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.MetadataTableType.ENTRIES;
+import static org.apache.spark.sql.functions.col;
 
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -37,6 +39,7 @@ import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RollingManifestWriter;
@@ -71,6 +74,7 @@ import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,6 +102,8 @@ public class RewriteManifestsSparkAction
           .addedManifests(ImmutableList.of())
           .build();
 
+  private static final String DATA_FILE_PARTITION_COLUMN_NAME = "data_file.partition";
+
   private final Table table;
   private final int formatVersion;
   private final long targetManifestSizeBytes;
@@ -106,6 +112,8 @@ public class RewriteManifestsSparkAction
   private PartitionSpec spec;
   private Predicate<ManifestFile> predicate = manifest -> true;
   private String outputLocation;
+
+  private List<String> partitionFieldClustering = null;
 
   RewriteManifestsSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -166,6 +174,30 @@ public class RewriteManifestsSparkAction
     String desc = String.format("Rewriting manifests in %s", table.name());
     JobGroupInfo info = newJobGroupInfo("REWRITE-MANIFESTS", desc);
     return withJobGroupInfo(info, this::doExecute);
+  }
+
+  @Override
+  public RewriteManifestsSparkAction sortBy(List<String> partitionFields) {
+    // Collect set of available partition columns to cluster on
+    Set<String> availablePartitionNames =
+        spec.fields().stream().map(PartitionField::name).collect(Collectors.toSet());
+
+    // Identify specified partition fields that are not available in the spec
+    List<String> missingFields =
+        partitionFields.stream()
+            .filter(field -> !availablePartitionNames.contains(field))
+            .collect(Collectors.toList());
+
+    // Check if these partition fields are included in the spec
+    Preconditions.checkArgument(
+        missingFields.isEmpty(),
+        "Cannot set manifest sorting because specified field(s) %s were not found in current partition spec %s. Spec ID %s",
+        missingFields,
+        this.spec,
+        this.spec.specId());
+
+    this.partitionFieldClustering = partitionFields;
+    return this;
   }
 
   private RewriteManifests.Result doExecute() {
@@ -255,8 +287,7 @@ public class RewriteManifestsSparkAction
         manifestEntryDF,
         df -> {
           WriteManifests<?> writeFunc = newWriteManifestsFunc(content, df.schema());
-          Column partitionColumn = df.col("data_file.partition");
-          Dataset<Row> transformedDF = repartitionAndSort(df, partitionColumn, numManifests);
+          Dataset<Row> transformedDF = repartitionAndSort(df, sortColumn(), numManifests);
           return writeFunc.apply(transformedDF).collectAsList();
         });
   }
@@ -272,6 +303,28 @@ public class RewriteManifestsSparkAction
       return new WriteDataManifests(writers, combinedFileType, fileType, sparkFileType);
     } else {
       return new WriteDeleteManifests(writers, combinedFileType, fileType, sparkFileType);
+    }
+  }
+
+  private Column sortColumn() {
+    if (partitionFieldClustering != null) {
+      LOG.info(
+          "Clustering manifests for specId {} by partition columns by {} ",
+          spec.specId(),
+          partitionFieldClustering);
+
+      // Map the top level partition column names to the column name referenced within the manifest
+      // entry dataframe
+      Column[] partitionColumns =
+          partitionFieldClustering.stream()
+              .map(p -> col(DATA_FILE_PARTITION_COLUMN_NAME + "." + p))
+              .toArray(Column[]::new);
+
+      // Form a new temporary column to cluster manifests on, based on the custom clustering columns
+      // order provided
+      return functions.struct(partitionColumns);
+    } else {
+      return new Column(DATA_FILE_PARTITION_COLUMN_NAME);
     }
   }
 


### PR DESCRIPTION
This is a follow on to https://github.com/apache/iceberg/pull/12840. Related to https://github.com/apache/iceberg/issues/9615. Ported the exact same functionality and tests to spark 3.4 and 4.0. 