### PR TITLE
Docs: Update API docs and remove `iceberg-hive3` reference

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -113,7 +113,7 @@ table.updateSchema()
 Available operations to update a table are:
 
 * `updateSchema` -- update the table schema
-* `updateSpec` -- creates a new `updatePartitionSpec` to modify a table's partition spec and commit the changes
+* `updateSpec` -- modify a table's partition spec
 * `updateStatistics` -- update statistics files of a table
 * `updatePartitionStatistics` -- update statistics for a specific partition in table
 * `updateProperties` -- update table properties
@@ -129,7 +129,7 @@ Available operations to update a table are:
 * `newTransaction` -- create a new table-level transaction
 * `rewriteManifests` -- rewrite manifest data by clustering files, for faster scan planning
 * `replaceSortOrder` -- for replacing table sort order with a newly created order
-* `newReplacePartitions` -- create a new `ReplacePartitions` to dynamically overwrite partitions in the table with new data
+* `newReplacePartitions` -- used to dynamically overwrite partitions in the table with new data
 
 ### Transactions
 


### PR DESCRIPTION
issue #13249 

In this PR I update `docs/docs/api.md` file to update API documentation.

1. Add `newRowDelta`
2. Remove `iceberg-hive3`
3. Add new API 
  - `updateStatistics`
  - `updatePartitionStatistics`
  - `expireSnapshots`
  - `manageSnapshots`



