### PR TITLE
Fix S3InputStream.readFully connection leak

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -165,7 +165,9 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
 
     String range = String.format("bytes=%s-%s", position, position + length - 1);
 
-    IOUtil.readFully(readRange(range), buffer, offset, length);
+    try (InputStream stream = readRange(range)) {
+      IOUtil.readFully(stream, buffer, offset, length);
+    }
   }
 
   @Override

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+public final class TestS3InputStream {
+
+  @Test
+  void testReadFullyClosesTheStream() throws IOException {
+    S3Client s3Client = mock(S3Client.class);
+    InputStream inputStream = mock(InputStream.class);
+    when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class)))
+        .thenReturn(inputStream);
+    when(inputStream.read(any(), anyInt(), anyInt())).thenReturn(-1);
+
+    S3InputStream s3InputStream = new S3InputStream(s3Client, new S3URI("http://dummy_host:9000"));
+    s3InputStream.readFully(0, new byte[0]);
+    verify(inputStream).close();
+  }
+}


### PR DESCRIPTION
When S3InputStreamReadFully is called it does not expose the underlying InputStream to the caller and does not close it on its own. This leads to connection leak in S3Client since the underlying connection is not returned to connection pool in Apace HTTP client.