### PR TITLE
update REST spec to clarify `AssertRefSnapshotId`'s `snapshot-id` field as required

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -441,8 +441,8 @@ class AssertTableUUID(TableRequirement):
 class AssertRefSnapshotId(TableRequirement):
     """
     The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`.
-    The `snapshot-id` field is required in this object, but its value may be `null` or missing.
-    If `snapshot-id` is `null` or missing, the ref must not already exist.
+    The `snapshot-id` field is required in this object, but in the case of a `null`
+    the ref must not already exist.
 
     """
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -440,7 +440,10 @@ class AssertTableUUID(TableRequirement):
 
 class AssertRefSnapshotId(TableRequirement):
     """
-    The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
+    The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`.
+    The `snapshot-id` field is required in this object, but its value may be `null` or missing.
+    If `snapshot-id` is `null` or missing, the ref must not already exist.
+
     """
 
     type: str = Field('assert-ref-snapshot-id', const=True)

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3138,8 +3138,8 @@ components:
     AssertRefSnapshotId:
       description: |
         The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`.
-        The `snapshot-id` field is required in this object, but its value may be `null` or missing.
-        If `snapshot-id` is `null` or missing, the ref must not already exist.
+        The `snapshot-id` field is required in this object, but in the case of a `null`
+        the ref must not already exist.
       allOf:
         - $ref: '#/components/schemas/TableRequirement'
       required:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3136,9 +3136,10 @@ components:
           type: string
 
     AssertRefSnapshotId:
-      description:
-        The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; 
-        if `snapshot-id` is `null` or missing, the ref must not already exist
+      description: |
+        The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`.
+        The `snapshot-id` field is required in this object, but its value may be `null` or missing.
+        If `snapshot-id` is `null` or missing, the ref must not already exist.
       allOf:
         - $ref: '#/components/schemas/TableRequirement'
       required:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3154,6 +3154,7 @@ components:
         snapshot-id:
           type: integer
           format: int64
+          nullable: true
 
     AssertLastAssignedFieldId:
       description:


### PR DESCRIPTION
Closes #13901

this is the only case of required but null/missing in the REST spec

