### PR TITLE
Core: Support Distributed Scan For Partitions Metadata Table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -244,6 +244,12 @@ public class TableProperties {
   public static final String DELETE_PLANNING_MODE = "read.delete-planning-mode";
   public static final String PLANNING_MODE_DEFAULT = PlanningMode.AUTO.modeName();
 
+  public static final String METADATA_PLANNING_MODE = "read.metadata-planning-mode";
+  public static final String METADATA_PLANNING_MODE_DEFAULT = PlanningMode.AUTO.modeName();
+  public static final String METADATA_PLANNING_MODE_AUTO_THRESHOLD =
+      "read.metadata-planning-mode-auto-threshold";
+  public static final long METADATA_PLANNING_MODE_AUTO_THRESHOLD_DEFAULT = 10;
+
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 

--- a/core/src/test/java/org/apache/iceberg/TestDistributedPartitionsTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestDistributedPartitionsTable.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for distributed scanning of PartitionsTable metadata.
+ *
+ * <p>These tests focus on validating the scan mode selection logic that determines when to use
+ * distributed vs local scanning based on table properties.
+ */
+public class TestDistributedPartitionsTable extends TestBase {
+
+  @Test
+  public void testDistributedModeSelection() {
+    // Test that distributed mode is selected when explicitly configured
+    table.updateProperties().set(TableProperties.METADATA_PLANNING_MODE, "distributed").commit();
+
+    PartitionsTable partitionsTable = new PartitionsTable(table);
+
+    // newScan() should return DistributedPartitionsScan when distributed mode is set
+    TableScan scan = partitionsTable.newScan();
+
+    // Verify we get a DistributedPartitionsScan instance
+    assertThat(scan.getClass().getName())
+        .as("Should return DistributedPartitionsScan in distributed mode")
+        .contains("DistributedPartitionsScan");
+  }
+
+  @Test
+  public void testLocalModeSelection() {
+    // Test that local mode is selected when explicitly configured
+    table.updateProperties().set(TableProperties.METADATA_PLANNING_MODE, "local").commit();
+
+    PartitionsTable partitionsTable = new PartitionsTable(table);
+
+    // newScan() should return PartitionsScan when local mode is set
+    TableScan scan = partitionsTable.newScan();
+
+    // Verify we get a PartitionsScan instance (not DistributedPartitionsScan)
+    assertThat(scan.getClass().getName())
+        .as("Should return PartitionsScan in local mode")
+        .contains("PartitionsScan")
+        .as("Should not return DistributedPartitionsScan in local mode")
+        .doesNotContain("DistributedPartitionsScan");
+  }
+
+  @Test
+  public void testAutoModeLogic() {
+    // Test AUTO mode behavior with empty table (should select local)
+    table.updateProperties().set(TableProperties.METADATA_PLANNING_MODE, "auto").commit();
+
+    PartitionsTable partitionsTable = new PartitionsTable(table);
+    TableScan scan = partitionsTable.newScan();
+
+    // With no data, AUTO should select local mode
+    assertThat(scan.getClass().getName())
+        .as("AUTO mode should select local scanning for tables with few manifests")
+        .contains("PartitionsScan")
+        .as("AUTO mode should not select distributed scanning for tables with few manifests")
+        .doesNotContain("DistributedPartitionsScan");
+  }
+
+  @Test
+  public void testDefaultModeIsAuto() {
+    // Test that default behavior works when no explicit configuration is set
+    PartitionsTable partitionsTable = new PartitionsTable(table);
+
+    // Default should be AUTO mode, which should work without errors
+    TableScan scan = partitionsTable.newScan();
+
+    // Should not fail and should return a valid scan
+    assertThat(scan).as("Default scan should not be null").isNotNull();
+
+    // For a table with no data, AUTO should select local mode
+    assertThat(scan.getClass().getName())
+        .as("Default AUTO mode should select local scanning for empty tables")
+        .contains("PartitionsScan");
+  }
+
+  @Test
+  public void testSqlQueryIntegrationFlow() {
+    // This test validates the complete flow that happens when users run:
+    // SELECT max(max_utc_date) FROM dse.session_feature_engagement_f__partitions
+
+    // 1. Spark calls PartitionsTable.newScan() (this is what we're testing)
+    PartitionsTable partitionsTable = new PartitionsTable(table);
+
+    // 2. Configure for distributed mode (like production tables)
+    table.updateProperties().set(TableProperties.METADATA_PLANNING_MODE, "distributed").commit();
+
+    // 3. The scan should automatically use distributed mode
+    TableScan metadataScan = partitionsTable.newScan();
+
+    // 4. Verify distributed scan is selected (this enables cluster distribution)
+    assertThat(metadataScan.getClass().getName())
+        .as("SQL queries on partitions metadata should use distributed scanning")
+        .contains("DistributedPartitionsScan");
+
+    // 5. This scan would then be executed by Spark across the cluster
+    // (In real usage, Spark would call planFiles() and distribute tasks)
+    assertThat(metadataScan).as("Metadata scan should be properly initialized").isNotNull();
+  }
+
+  @Test
+  public void testUnpartitionedTableSupport() {
+    // Test that unpartitioned tables work correctly with both modes
+    PartitionsTable partitionsTable = new PartitionsTable(table);
+
+    // Test distributed mode with unpartitioned table
+    table.updateProperties().set(TableProperties.METADATA_PLANNING_MODE, "distributed").commit();
+
+    TableScan distributedScan = partitionsTable.newScan();
+    assertThat(distributedScan)
+        .as("Distributed scan should work with unpartitioned tables")
+        .isNotNull();
+
+    // Test local mode with unpartitioned table
+    table.updateProperties().set(TableProperties.METADATA_PLANNING_MODE, "local").commit();
+
+    TableScan localScan = partitionsTable.newScan();
+    assertThat(localScan).as("Local scan should work with unpartitioned tables").isNotNull();
+
+    // Scans should be different types
+    assertThat(localScan.getClass())
+        .as("Local and distributed scans should be different types")
+        .isNotEqualTo(distributedScan.getClass());
+  }
+
+  @Test
+  public void testBackwardCompatibility() {
+    // Verify that tables without the new property work exactly as before
+    PartitionsTable partitionsTable = new PartitionsTable(table);
+
+    // Don't set any metadata planning mode property
+    TableScan scan = partitionsTable.newScan();
+
+    // Should default to AUTO mode and work without issues
+    assertThat(scan).as("Scan should work without metadata planning mode property").isNotNull();
+
+    // For small tables, AUTO should behave like the old default (local)
+    assertThat(scan.getClass().getName())
+        .as("Backward compatibility: should use local scanning for small tables")
+        .contains("PartitionsScan");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -483,7 +483,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat(scanNoFilter.schema().asStruct()).isEqualTo(expected);
 
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanNoFilter);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(8);
     } else {
@@ -508,7 +508,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");
     assertThat(scanWithProjection.schema().asStruct()).isEqualTo(expected);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanWithProjection);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanWithProjection);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(8);
     } else {
@@ -527,7 +527,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Table partitionsTable = new PartitionsTable(table);
     CloseableIterable<ManifestEntry<?>> tasksAndEq =
-        PartitionsTable.planEntries((StaticTableScan) partitionsTable.newScan());
+        PartitionsTable.planEntries((BaseMetadataTableScan) partitionsTable.newScan());
     for (ManifestEntry<? extends ContentFile<?>> task : tasksAndEq) {
       assertThat(task.file().columnSizes()).isNull();
       assertThat(task.file().valueCounts()).isNull();
@@ -550,7 +550,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanAndEq);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanAndEq);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(2);
     } else {
@@ -572,7 +572,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.greaterThan("record_count", 0));
     TableScan scanLtAnd = partitionsTable.newScan().filter(ltAnd);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanLtAnd);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanLtAnd);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(4);
     } else {
@@ -596,7 +596,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scanOr = partitionsTable.newScan().filter(or);
 
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanOr);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanOr);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(8);
     } else {
@@ -617,7 +617,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
     TableScan scanNot = partitionsTable.newScan().filter(not);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanNot);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanNot);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(4);
     } else {
@@ -637,7 +637,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     Expression set = Expressions.in("partition.data_bucket", 2, 3);
     TableScan scanSet = partitionsTable.newScan().filter(set);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanSet);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanSet);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(4);
     } else {
@@ -657,7 +657,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     Expression unary = Expressions.notNull("partition.data_bucket");
     TableScan scanUnary = partitionsTable.newScan().filter(unary);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanUnary);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanUnary);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(8);
     } else {
@@ -957,7 +957,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scan);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scan);
     if (formatVersion >= 2) {
       // Four data files and delete files of old spec, one new data file of new spec
       assertThat(entries).hasSize(9);
@@ -971,7 +971,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
-    entries = PartitionsTable.planEntries((StaticTableScan) scan);
+    entries = PartitionsTable.planEntries((BaseMetadataTableScan) scan);
 
     if (formatVersion >= 2) {
       // 1 original data file and delete file written by old spec, plus 1 new data file written by
@@ -1022,7 +1022,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scan);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scan);
 
     if (formatVersion >= 2) {
       // Four data and delete files of original spec, one data file written by new spec
@@ -1039,7 +1039,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
-    entries = PartitionsTable.planEntries((StaticTableScan) scan);
+    entries = PartitionsTable.planEntries((BaseMetadataTableScan) scan);
 
     if (formatVersion == 1) {
       // 1 original data file written by old spec
@@ -1108,7 +1108,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanAndEq);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanAndEq);
     assertThat(entries).hasSize(1);
     validateSingleFieldPartition(entries, 0);
   }
@@ -1183,7 +1183,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                       return thread;
                     }));
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scan);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scan);
     if (formatVersion >= 2) {
       assertThat(entries).hasSize(8);
     } else {

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -149,7 +149,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
     TableScan scanNoFilter = partitionsTable.newScan().select("partition");
     assertThat(scanNoFilter.schema().asStruct()).isEqualTo(idPartition);
     CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
+        PartitionsTable.planEntries((BaseMetadataTableScan) scanNoFilter);
     assertThat(entries).hasSize(4);
     validatePartition(entries, 0, 0);
     validatePartition(entries, 0, 1);
@@ -231,7 +231,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
     assertThat(partitionsTable.schema().findField("partition")).isNotNull();
 
     try (CloseableIterable<ManifestEntry<?>> entries =
-        PartitionsTable.planEntries((StaticTableScan) partitionsTable.newScan())) {
+        PartitionsTable.planEntries((BaseMetadataTableScan) partitionsTable.newScan())) {
       // four partitioned data files and one non-partitioned data file.
       assertThat(entries).hasSize(5);
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributedPartitionsTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributedPartitionsTable.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributedPartitionsTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributedPartitionsTable.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/**
+ * Integration tests for distributed PartitionsTable scanning in Spark.
+ *
+ * <p>Tests the complete flow from SQL queries like: SELECT max(max_utc_date) FROM table__partitions
+ *
+ * <p>Down to the distributed partition metadata scanning implementation.
+ */
+public class TestSparkDistributedPartitionsTable extends CatalogTestBase {
+
+  @AfterEach
+  public void dropTestTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testDistributedPartitionsTableQueryPerformance() {
+
+    // Create table with date partitioning (common in production)
+    sql(
+        "CREATE TABLE %s (id bigint, data string, utc_date date) "
+            + "USING iceberg PARTITIONED BY (days(utc_date)) "
+            + "TBLPROPERTIES ('read.metadata-planning-mode' = 'distributed')",
+        tableName);
+
+    // Insert data into multiple partitions to create realistic metadata volume
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, 'data1', date '2023-01-01'), "
+            + "(2, 'data2', date '2023-01-02'), "
+            + "(3, 'data3', date '2023-01-03'), "
+            + "(4, 'data4', date '2023-01-04'), "
+            + "(5, 'data5', date '2023-01-05')",
+        tableName);
+
+    // This is the key test: Query the partitions metadata table
+    // Equivalent to: SELECT max(max_utc_date) FROM session_feature_engagement_f__partitions
+    List<Object[]> result = sql("SELECT COUNT(*) FROM %s.partitions", tableName);
+
+    // Verify the query executes successfully
+    assertThat(result).as("Partitions metadata query should return results").isNotNull();
+    assertThat(result).as("Should return exactly one row for COUNT query").hasSize(1);
+
+    // Should have exactly 5 partitions (one for each date inserted)
+    Long partitionCount = (Long) result.get(0)[0];
+    assertThat(partitionCount)
+        .as("Should have exactly 5 partitions for 5 different dates")
+        .isEqualTo(5L);
+  }
+
+  @TestTemplate
+  public void testPartitionsTableMetadataColumns() {
+    // Test that all partition metadata columns are available via SQL
+    sql(
+        "CREATE TABLE %s (id bigint, category string) "
+            + "USING iceberg PARTITIONED BY (category) "
+            + "TBLPROPERTIES ('read.metadata-planning-mode' = 'distributed')",
+        tableName);
+
+    // Insert test data
+    sql("INSERT INTO %s VALUES (1, 'A'), (2, 'B'), (3, 'C')", tableName);
+
+    // Query all available metadata columns from partitions table
+    List<Object[]> result =
+        sql(
+            "SELECT partition, record_count, file_count, spec_id "
+                + "FROM %s.partitions "
+                + "ORDER BY partition",
+            tableName);
+
+    // Should have exactly 3 partitions (one for each category: A, B, C)
+    assertThat(result).as("Should have exactly 3 partition metadata rows").hasSize(3);
+
+    // Verify each partition has exactly the expected metadata
+    for (Object[] row : result) {
+      assertThat(row[0]).as("Partition column should not be null").isNotNull();
+      assertThat((Long) row[1]).as("Each partition should have exactly 1 record").isEqualTo(1L);
+      assertThat((Integer) row[2]).as("Each partition should have exactly 1 file").isEqualTo(1);
+      assertThat((Integer) row[3]).as("Spec ID should be 0 for the default spec").isEqualTo(0);
+    }
+  }
+
+  @TestTemplate
+  public void testLocalVsDistributedModeComparison() {
+    // Create a table and compare local vs distributed scanning results
+    sql(
+        "CREATE TABLE %s (id bigint, value string) "
+            + "USING iceberg PARTITIONED BY (bucket(4, value))",
+        tableName);
+
+    // Insert data to create multiple partitions
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, 'A'), (2, 'B'), (3, 'C'), (4, 'D'), "
+            + "(5, 'E'), (6, 'F'), (7, 'G'), (8, 'H')",
+        tableName);
+
+    // Test local mode
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('read.metadata-planning-mode' = 'local')", tableName);
+    List<Object[]> localResult = sql("SELECT count(*) FROM %s.partitions", tableName);
+    Long localCount = (Long) localResult.get(0)[0];
+
+    // Test distributed mode
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('read.metadata-planning-mode' = 'distributed')",
+        tableName);
+    List<Object[]> distributedResult = sql("SELECT count(*) FROM %s.partitions", tableName);
+    Long distributedCount = (Long) distributedResult.get(0)[0];
+
+    // Both modes should return the same results
+    assertThat(distributedCount)
+        .as("Local and distributed modes should return same results")
+        .isEqualTo(localCount);
+
+    // With bucket(4, value), we should have 1-4 partitions (depends on hash distribution)
+    assertThat(distributedCount).as("Should have at least 1 partition").isGreaterThanOrEqualTo(1L);
+    assertThat(distributedCount)
+        .as("Should have at most 4 partitions for bucket(4)")
+        .isLessThanOrEqualTo(4L);
+  }
+
+  @TestTemplate
+  public void testSqlQueryWithAggregations() {
+    // Test basic aggregations that work with distributed scanning
+    sql(
+        "CREATE TABLE %s (id bigint, amount decimal(10,2), region string) "
+            + "USING iceberg PARTITIONED BY (region) "
+            + "TBLPROPERTIES ('read.metadata-planning-mode' = 'distributed')",
+        tableName);
+
+    // Insert data across multiple regions
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, 100.50, 'US'), (2, 200.75, 'EU'), "
+            + "(3, 150.25, 'APAC'), (4, 300.00, 'US')",
+        tableName);
+
+    // Test basic COUNT aggregation (avoiding complex field aggregations for now)
+    List<Object[]> result = sql("SELECT COUNT(*) FROM %s.partitions", tableName);
+
+    assertThat(result).as("Should return one aggregation row").hasSize(1);
+    Object[] row = result.get(0);
+    // Should have exactly 3 partitions: US, EU, APAC (US appears twice but it's the same partition)
+    assertThat((Long) row[0])
+        .as("Should have exactly 3 partitions for 3 distinct regions")
+        .isEqualTo(3L);
+
+    // Test simple partition queries work - should return exactly 3 partition rows
+    List<Object[]> partitionList = sql("SELECT partition FROM %s.partitions", tableName);
+    assertThat(partitionList).as("Should have exactly 3 partition rows").hasSize(3);
+  }
+
+  @TestTemplate
+  public void testAutoModeWithLargeTable() {
+    // Test AUTO mode selection with a table that has many partitions
+    sql(
+        "CREATE TABLE %s (id bigint, timestamp timestamp, user_id bigint) "
+            + "USING iceberg PARTITIONED BY (hours(timestamp)) "
+            + "TBLPROPERTIES ('read.metadata-planning-mode' = 'auto')",
+        tableName);
+
+    // Insert data to create many partitions (AUTO should select distributed)
+    for (int hour = 0; hour < 15; hour++) {
+      sql(
+          "INSERT INTO %s VALUES " + "(%d, timestamp '2023-01-01 %02d:00:00', %d)",
+          tableName, hour, hour, hour * 100);
+    }
+
+    // Query should automatically use distributed scanning
+    List<Object[]> result = sql("SELECT COUNT(*) FROM %s.partitions", tableName);
+
+    assertThat(result).as("Should return exactly one row for COUNT query").hasSize(1);
+    Long partitionCount = (Long) result.get(0)[0];
+    // Should have exactly 15 partitions (one for each hour: 0-14)
+    assertThat(partitionCount)
+        .as("Should have exactly 15 partitions for 15 different hours")
+        .isEqualTo(15L);
+
+    // Verify this triggers AUTO distributed mode (threshold is > 10)
+    assertThat(partitionCount)
+        .as("15 partitions should trigger AUTO distributed mode (threshold > 10)")
+        .isGreaterThan(10L);
+  }
+}

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributedPartitionsTable.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributedPartitionsTable.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/**
+ * Integration tests for distributed PartitionsTable scanning in Spark.
+ *
+ * <p>Tests the complete flow from SQL queries like: SELECT max(max_utc_date) FROM table__partitions
+ *
+ * <p>Down to the distributed partition metadata scanning implementation.
+ */
+public class TestSparkDistributedPartitionsTable extends CatalogTestBase {
+
+  @AfterEach
+  public void dropTestTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testDistributedPartitionsTableQueryPerformance() {
+
+    // Create table with date partitioning (common in production)
+    sql(
+        "CREATE TABLE %s (id bigint, data string, utc_date date) "
+            + "USING iceberg PARTITIONED BY (days(utc_date)) "
+            + "TBLPROPERTIES ('read.metadata-planning-mode' = 'distributed')",
+        tableName);
+
+    // Insert data into multiple partitions to create realistic metadata volume
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, 'data1', date '2023-01-01'), "
+            + "(2, 'data2', date '2023-01-02'), "
+            + "(3, 'data3', date '2023-01-03'), "
+            + "(4, 'data4', date '2023-01-04'), "
+            + "(5, 'data5', date '2023-01-05')",
+        tableName);
+
+    // This is the key test: Query the partitions metadata table
+    // Equivalent to: SELECT max(max_utc_date) FROM session_feature_engagement_f__partitions
+    List<Object[]> result = sql("SELECT COUNT(*) FROM %s.partitions", tableName);
+
+    // Verify the query executes successfully
+    assertThat(result).as("Partitions metadata query should return results").isNotNull();
+    assertThat(result).as("Should return exactly one row for COUNT query").hasSize(1);
+
+    // Should have exactly 5 partitions (one for each date inserted)
+    Long partitionCount = (Long) result.get(0)[0];
+    assertThat(partitionCount)
+        .as("Should have exactly 5 partitions for 5 different dates")
+        .isEqualTo(5L);
+  }
+
+  @TestTemplate
+  public void testPartitionsTableMetadataColumns() {
+    // Test that all partition metadata columns are available via SQL
+    sql(
+        "CREATE TABLE %s (id bigint, category string) "
+            + "USING iceberg PARTITIONED BY (category) "
+            + "TBLPROPERTIES ('read.metadata-planning-mode' = 'distributed')",
+        tableName);
+
+    // Insert test data
+    sql("INSERT INTO %s VALUES (1, 'A'), (2, 'B'), (3, 'C')", tableName);
+
+    // Query all available metadata columns from partitions table
+    List<Object[]> result =
+        sql(
+            "SELECT partition, record_count, file_count, spec_id "
+                + "FROM %s.partitions "
+                + "ORDER BY partition",
+            tableName);
+
+    // Should have exactly 3 partitions (one for each category: A, B, C)
+    assertThat(result).as("Should have exactly 3 partition metadata rows").hasSize(3);
+
+    // Verify each partition has exactly the expected metadata
+    for (Object[] row : result) {
+      assertThat(row[0]).as("Partition column should not be null").isNotNull();
+      assertThat((Long) row[1]).as("Each partition should have exactly 1 record").isEqualTo(1L);
+      assertThat((Integer) row[2]).as("Each partition should have exactly 1 file").isEqualTo(1);
+      assertThat((Integer) row[3]).as("Spec ID should be 0 for the default spec").isEqualTo(0);
+    }
+  }
+
+  @TestTemplate
+  public void testLocalVsDistributedModeComparison() {
+    // Create a table and compare local vs distributed scanning results
+    sql(
+        "CREATE TABLE %s (id bigint, value string) "
+            + "USING iceberg PARTITIONED BY (bucket(4, value))",
+        tableName);
+
+    // Insert data to create multiple partitions
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, 'A'), (2, 'B'), (3, 'C'), (4, 'D'), "
+            + "(5, 'E'), (6, 'F'), (7, 'G'), (8, 'H')",
+        tableName);
+
+    // Test local mode
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('read.metadata-planning-mode' = 'local')", tableName);
+    List<Object[]> localResult = sql("SELECT count(*) FROM %s.partitions", tableName);
+    Long localCount = (Long) localResult.get(0)[0];
+
+    // Test distributed mode
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('read.metadata-planning-mode' = 'distributed')",
+        tableName);
+    List<Object[]> distributedResult = sql("SELECT count(*) FROM %s.partitions", tableName);
+    Long distributedCount = (Long) distributedResult.get(0)[0];
+
+    // Both modes should return the same results
+    assertThat(distributedCount)
+        .as("Local and distributed modes should return same results")
+        .isEqualTo(localCount);
+
+    // With bucket(4, value), we should have 1-4 partitions (depends on hash distribution)
+    assertThat(distributedCount).as("Should have at least 1 partition").isGreaterThanOrEqualTo(1L);
+    assertThat(distributedCount)
+        .as("Should have at most 4 partitions for bucket(4)")
+        .isLessThanOrEqualTo(4L);
+  }
+
+  @TestTemplate
+  public void testSqlQueryWithAggregations() {
+    // Test basic aggregations that work with distributed scanning
+    sql(
+        "CREATE TABLE %s (id bigint, amount decimal(10,2), region string) "
+            + "USING iceberg PARTITIONED BY (region) "
+            + "TBLPROPERTIES ('read.metadata-planning-mode' = 'distributed')",
+        tableName);
+
+    // Insert data across multiple regions
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, 100.50, 'US'), (2, 200.75, 'EU'), "
+            + "(3, 150.25, 'APAC'), (4, 300.00, 'US')",
+        tableName);
+
+    // Test basic COUNT aggregation (avoiding complex field aggregations for now)
+    List<Object[]> result = sql("SELECT COUNT(*) FROM %s.partitions", tableName);
+
+    assertThat(result).as("Should return one aggregation row").hasSize(1);
+    Object[] row = result.get(0);
+    // Should have exactly 3 partitions: US, EU, APAC (US appears twice but it's the same partition)
+    assertThat((Long) row[0])
+        .as("Should have exactly 3 partitions for 3 distinct regions")
+        .isEqualTo(3L);
+
+    // Test simple partition queries work - should return exactly 3 partition rows
+    List<Object[]> partitionList = sql("SELECT partition FROM %s.partitions", tableName);
+    assertThat(partitionList).as("Should have exactly 3 partition rows").hasSize(3);
+  }
+
+  @TestTemplate
+  public void testAutoModeWithLargeTable() {
+    // Test AUTO mode selection with a table that has many partitions
+    sql(
+        "CREATE TABLE %s (id bigint, timestamp timestamp, user_id bigint) "
+            + "USING iceberg PARTITIONED BY (hours(timestamp)) "
+            + "TBLPROPERTIES ('read.metadata-planning-mode' = 'auto')",
+        tableName);
+
+    // Insert data to create many partitions (AUTO should select distributed)
+    for (int hour = 0; hour < 15; hour++) {
+      sql(
+          "INSERT INTO %s VALUES " + "(%d, timestamp '2023-01-01 %02d:00:00', %d)",
+          tableName, hour, hour, hour * 100);
+    }
+
+    // Query should automatically use distributed scanning
+    List<Object[]> result = sql("SELECT COUNT(*) FROM %s.partitions", tableName);
+
+    assertThat(result).as("Should return exactly one row for COUNT query").hasSize(1);
+    Long partitionCount = (Long) result.get(0)[0];
+    // Should have exactly 15 partitions (one for each hour: 0-14)
+    assertThat(partitionCount)
+        .as("Should have exactly 15 partitions for 15 different hours")
+        .isEqualTo(15L);
+
+    // Verify this triggers AUTO distributed mode (threshold is > 10)
+    assertThat(partitionCount)
+        .as("15 partitions should trigger AUTO distributed mode (threshold > 10)")
+        .isGreaterThan(10L);
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces distributed scanning capabilities for the `PartitionsTable` metadata table to improve performance when querying tables with many manifest files.

## Why is this needed?
Today partitions metadata table is processes in a single task/thread which can be limiting for engines like Spark when scanning partitions metadata of very large table with very large number of manifests. Sometimes also leading to the process (Spark driver) going OOM. This PR enables parallel processing of partition metadata scanning for large tables with many manifest files, significantly reducing query latency for partition metadata table operations.

## Key Changes
- **New Planning Modes**: Added `LOCAL`, `DISTRIBUTED`, and `AUTO` modes via `METADATA_PLANNING_MODE` table property
- **Auto-switching**: Automatically uses distributed scanning when manifest count exceeds configurable threshold (default: 10)
- **Enhanced PartitionsTable**: Implements `DistributedPartitionsScan` for parallel manifest processing
- **Comprehensive Testing**: Added tests for core functionality and Spark integration (v3.5, v4.0)
- **Backward Compatibility**: Existing behavior preserved with `AUTO` mode as default