### PR TITLE
Spark4.0: Refactor Spark procedures to consistently use ProcedureInput for parameter handling.

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/CherrypickSnapshotProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/CherrypickSnapshotProcedure.java
@@ -45,11 +45,13 @@ class CherrypickSnapshotProcedure extends BaseProcedure {
 
   static final String NAME = "cherrypick_snapshot";
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter SNAPSHOT_ID_PARAM =
+      requiredInParameter("snapshot_id", DataTypes.LongType);
+
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        requiredInParameter("snapshot_id", DataTypes.LongType)
-      };
+      new ProcedureParameter[] {TABLE_PARAM, SNAPSHOT_ID_PARAM};
 
   private static final StructType OUTPUT_TYPE =
       new StructType(
@@ -83,8 +85,10 @@ class CherrypickSnapshotProcedure extends BaseProcedure {
 
   @Override
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    long snapshotId = args.getLong(1);
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
+    long snapshotId = input.asLong(SNAPSHOT_ID_PARAM);
 
     return asScanIterator(
         OUTPUT_TYPE,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -51,15 +51,30 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExpireSnapshotsProcedure.class);
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter OLDER_THAN_PARAM =
+      optionalInParameter("older_than", DataTypes.TimestampType);
+  private static final ProcedureParameter RETAIN_LAST_PARAM =
+      optionalInParameter("retain_last", DataTypes.IntegerType);
+  private static final ProcedureParameter MAX_CONCURRENT_DELETES_PARAM =
+      optionalInParameter("max_concurrent_deletes", DataTypes.IntegerType);
+  private static final ProcedureParameter STREAM_RESULTS_PARAM =
+      optionalInParameter("stream_results", DataTypes.BooleanType);
+  private static final ProcedureParameter SNAPSHOT_IDS_PARAM =
+      optionalInParameter("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType));
+  private static final ProcedureParameter CLEAN_EXPIRED_METADATA_PARAM =
+      optionalInParameter("clean_expired_metadata", DataTypes.BooleanType);
+
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        optionalInParameter("older_than", DataTypes.TimestampType),
-        optionalInParameter("retain_last", DataTypes.IntegerType),
-        optionalInParameter("max_concurrent_deletes", DataTypes.IntegerType),
-        optionalInParameter("stream_results", DataTypes.BooleanType),
-        optionalInParameter("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType)),
-        optionalInParameter("clean_expired_metadata", DataTypes.BooleanType)
+        TABLE_PARAM,
+        OLDER_THAN_PARAM,
+        RETAIN_LAST_PARAM,
+        MAX_CONCURRENT_DELETES_PARAM,
+        STREAM_RESULTS_PARAM,
+        SNAPSHOT_IDS_PARAM,
+        CLEAN_EXPIRED_METADATA_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -104,26 +119,31 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
   @Override
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    Long olderThanMillis = args.isNullAt(1) ? null : DateTimeUtil.microsToMillis(args.getLong(1));
-    Integer retainLastNum = args.isNullAt(2) ? null : args.getInt(2);
-    Integer maxConcurrentDeletes = args.isNullAt(3) ? null : args.getInt(3);
-    Boolean streamResult = args.isNullAt(4) ? null : args.getBoolean(4);
-    long[] snapshotIds = args.isNullAt(5) ? null : args.getArray(5).toLongArray();
-    Boolean cleanExpiredMetadata = args.isNullAt(6) ? null : args.getBoolean(6);
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
+    Long olderThanMillis = input.asLong(OLDER_THAN_PARAM, null);
+    if (olderThanMillis != null) {
+      olderThanMillis = DateTimeUtil.microsToMillis(olderThanMillis);
+    }
+    Integer retainLastNum = input.asInt(RETAIN_LAST_PARAM, null);
+    Integer maxConcurrentDeletes = input.asInt(MAX_CONCURRENT_DELETES_PARAM, null);
+    Boolean streamResult = input.asBoolean(STREAM_RESULTS_PARAM, null);
+    Long[] snapshotIds = input.asLongArray(SNAPSHOT_IDS_PARAM, null);
+    Boolean cleanExpiredMetadata = input.asBoolean(CLEAN_EXPIRED_METADATA_PARAM, null);
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0, value: %s",
         maxConcurrentDeletes);
 
+    Long finalOlderThanMillis = olderThanMillis;
     return modifyIcebergTable(
         tableIdent,
         table -> {
           ExpireSnapshots action = actions().expireSnapshots(table);
 
-          if (olderThanMillis != null) {
-            action.expireOlderThan(olderThanMillis);
+          if (finalOlderThanMillis != null) {
+            action.expireOlderThan(finalOlderThanMillis);
           }
 
           if (retainLastNum != null) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
@@ -35,12 +35,15 @@ public class FastForwardBranchProcedure extends BaseProcedure {
 
   static final String NAME = "fast_forward";
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter BRANCH_PARAM =
+      requiredInParameter("branch", DataTypes.StringType);
+  private static final ProcedureParameter TO_PARAM =
+      requiredInParameter("to", DataTypes.StringType);
+
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        requiredInParameter("branch", DataTypes.StringType),
-        requiredInParameter("to", DataTypes.StringType)
-      };
+      new ProcedureParameter[] {TABLE_PARAM, BRANCH_PARAM, TO_PARAM};
 
   private static final StructType OUTPUT_TYPE =
       new StructType(
@@ -75,9 +78,11 @@ public class FastForwardBranchProcedure extends BaseProcedure {
 
   @Override
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    String from = args.getString(1);
-    String to = args.getString(2);
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
+    String from = input.asString(BRANCH_PARAM);
+    String to = input.asString(TO_PARAM);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ProcedureInput.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ProcedureInput.java
@@ -92,6 +92,17 @@ class ProcedureInput {
     return args.isNullAt(ordinal) ? defaultValue : (Long) args.getLong(ordinal);
   }
 
+  public Long[] asLongArray(ProcedureParameter param) {
+    Long[] value = asLongArray(param, null);
+    Preconditions.checkArgument(value != null, "Parameter '%s' is not set", param.name());
+    return value;
+  }
+
+  public Long[] asLongArray(ProcedureParameter param, Long[] defaultValue) {
+    validateParamType(param, DataTypes.createArrayType(DataTypes.LongType));
+    return array(param, (array, ordinal) -> array.getLong(ordinal), Long.class, defaultValue);
+  }
+
   public String asString(ProcedureParameter param) {
     String value = asString(param, null);
     Preconditions.checkArgument(value != null, "Parameter '%s' is not set", param.name());

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/PublishChangesProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/PublishChangesProcedure.java
@@ -49,11 +49,13 @@ class PublishChangesProcedure extends BaseProcedure {
 
   static final String NAME = "publish_changes";
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter WAP_ID_PARAM =
+      requiredInParameter("wap_id", DataTypes.StringType);
+
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        requiredInParameter("wap_id", DataTypes.StringType)
-      };
+      new ProcedureParameter[] {TABLE_PARAM, WAP_ID_PARAM};
 
   private static final StructType OUTPUT_TYPE =
       new StructType(
@@ -87,8 +89,10 @@ class PublishChangesProcedure extends BaseProcedure {
 
   @Override
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    String wapId = args.getString(1);
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
+    String wapId = input.asString(WAP_ID_PARAM);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -26,12 +26,11 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.actions.DeleteOrphanFilesSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
-import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -45,7 +44,6 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.runtime.BoxedUnit;
 
 /**
  * A procedure that removes orphan files in a table.
@@ -58,19 +56,40 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoveOrphanFilesProcedure.class);
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter OLDER_THAN_PARAM =
+      optionalInParameter("older_than", DataTypes.TimestampType);
+  private static final ProcedureParameter LOCATION_PARAM =
+      optionalInParameter("location", DataTypes.StringType);
+  private static final ProcedureParameter DRY_RUN_PARAM =
+      optionalInParameter("dry_run", DataTypes.BooleanType);
+  private static final ProcedureParameter MAX_CONCURRENT_DELETES_PARAM =
+      optionalInParameter("max_concurrent_deletes", DataTypes.IntegerType);
+  private static final ProcedureParameter FILE_LIST_VIEW_PARAM =
+      optionalInParameter("file_list_view", DataTypes.StringType);
+  private static final ProcedureParameter EQUAL_SCHEMES_PARAM =
+      optionalInParameter("equal_schemes", STRING_MAP);
+  private static final ProcedureParameter EQUAL_AUTHORITIES_PARAM =
+      optionalInParameter("equal_authorities", STRING_MAP);
+  private static final ProcedureParameter PREFIX_MISMATCH_MODE_PARAM =
+      optionalInParameter("prefix_mismatch_mode", DataTypes.StringType);
+  // List files with prefix operations. Default is false.
+  private static final ProcedureParameter PREFIX_LISTING_PARAM =
+      optionalInParameter("prefix_listing", DataTypes.BooleanType);
+
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        optionalInParameter("older_than", DataTypes.TimestampType),
-        optionalInParameter("location", DataTypes.StringType),
-        optionalInParameter("dry_run", DataTypes.BooleanType),
-        optionalInParameter("max_concurrent_deletes", DataTypes.IntegerType),
-        optionalInParameter("file_list_view", DataTypes.StringType),
-        optionalInParameter("equal_schemes", STRING_MAP),
-        optionalInParameter("equal_authorities", STRING_MAP),
-        optionalInParameter("prefix_mismatch_mode", DataTypes.StringType),
-        // List files with prefix operations. Default is false.
-        optionalInParameter("prefix_listing", DataTypes.BooleanType)
+        TABLE_PARAM,
+        OLDER_THAN_PARAM,
+        LOCATION_PARAM,
+        DRY_RUN_PARAM,
+        MAX_CONCURRENT_DELETES_PARAM,
+        FILE_LIST_VIEW_PARAM,
+        EQUAL_SCHEMES_PARAM,
+        EQUAL_AUTHORITIES_PARAM,
+        PREFIX_MISMATCH_MODE_PARAM,
+        PREFIX_LISTING_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -105,46 +124,28 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
   @Override
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    Long olderThanMillis = args.isNullAt(1) ? null : DateTimeUtil.microsToMillis(args.getLong(1));
-    String location = args.isNullAt(2) ? null : args.getString(2);
-    boolean dryRun = args.isNullAt(3) ? false : args.getBoolean(3);
-    Integer maxConcurrentDeletes = args.isNullAt(4) ? null : args.getInt(4);
-    String fileListView = args.isNullAt(5) ? null : args.getString(5);
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
+    Long olderThanMillis = input.asLong(OLDER_THAN_PARAM, null);
+    String location = input.asString(LOCATION_PARAM, null);
+    boolean dryRun = input.asBoolean(DRY_RUN_PARAM, false);
+    Integer maxConcurrentDeletes = input.asInt(MAX_CONCURRENT_DELETES_PARAM, null);
+    String fileListView = input.asString(FILE_LIST_VIEW_PARAM, null);
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0, value: %s",
         maxConcurrentDeletes);
 
-    Map<String, String> equalSchemes = Maps.newHashMap();
-    if (!args.isNullAt(6)) {
-      args.getMap(6)
-          .foreach(
-              DataTypes.StringType,
-              DataTypes.StringType,
-              (k, v) -> {
-                equalSchemes.put(k.toString(), v.toString());
-                return BoxedUnit.UNIT;
-              });
-    }
+    Map<String, String> equalSchemes = input.asStringMap(EQUAL_SCHEMES_PARAM, ImmutableMap.of());
+    Map<String, String> equalAuthorities =
+        input.asStringMap(EQUAL_AUTHORITIES_PARAM, ImmutableMap.of());
 
-    Map<String, String> equalAuthorities = Maps.newHashMap();
-    if (!args.isNullAt(7)) {
-      args.getMap(7)
-          .foreach(
-              DataTypes.StringType,
-              DataTypes.StringType,
-              (k, v) -> {
-                equalAuthorities.put(k.toString(), v.toString());
-                return BoxedUnit.UNIT;
-              });
-    }
-
+    String modeAsString = input.asString(PREFIX_MISMATCH_MODE_PARAM, null);
     PrefixMismatchMode prefixMismatchMode =
-        args.isNullAt(8) ? null : PrefixMismatchMode.fromString(args.getString(8));
+        (modeAsString == null) ? null : PrefixMismatchMode.fromString(modeAsString);
 
-    boolean prefixListing = args.isNullAt(9) ? false : args.getBoolean(9);
+    boolean prefixListing = input.asBoolean(PREFIX_LISTING_PARAM, false);
 
     return withIcebergTable(
         tableIdent,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -48,12 +48,15 @@ class RewriteManifestsProcedure extends BaseProcedure {
 
   static final String NAME = "rewrite_manifests";
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter USE_CACHING_PARAM =
+      optionalInParameter("use_caching", DataTypes.BooleanType);
+  private static final ProcedureParameter SPEC_ID_PARAM =
+      optionalInParameter("spec_id", DataTypes.IntegerType);
+
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        optionalInParameter("use_caching", DataTypes.BooleanType),
-        optionalInParameter("spec_id", DataTypes.IntegerType)
-      };
+      new ProcedureParameter[] {TABLE_PARAM, USE_CACHING_PARAM, SPEC_ID_PARAM};
 
   // counts are not nullable since the action result is never null
   private static final StructType OUTPUT_TYPE =
@@ -89,9 +92,10 @@ class RewriteManifestsProcedure extends BaseProcedure {
 
   @Override
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    Boolean useCaching = args.isNullAt(1) ? null : args.getBoolean(1);
-    Integer specId = args.isNullAt(2) ? null : args.getInt(2);
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
+    Boolean useCaching = input.asBoolean(USE_CACHING_PARAM, false);
+    Integer specId = input.asInt(SPEC_ID_PARAM, null);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToSnapshotProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToSnapshotProcedure.java
@@ -44,11 +44,13 @@ class RollbackToSnapshotProcedure extends BaseProcedure {
 
   static final String NAME = "rollback_to_snapshot";
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter SNAPSHOT_ID_PARAM =
+      requiredInParameter("snapshot_id", DataTypes.LongType);
+
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        requiredInParameter("snapshot_id", DataTypes.LongType)
-      };
+      new ProcedureParameter[] {TABLE_PARAM, SNAPSHOT_ID_PARAM};
 
   private static final StructType OUTPUT_TYPE =
       new StructType(
@@ -82,8 +84,9 @@ class RollbackToSnapshotProcedure extends BaseProcedure {
 
   @Override
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    long snapshotId = args.getLong(1);
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
+    long snapshotId = input.asInt(SNAPSHOT_ID_PARAM);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
@@ -45,11 +45,13 @@ class RollbackToTimestampProcedure extends BaseProcedure {
 
   static final String NAME = "rollback_to_timestamp";
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter TIMESTAMP_PARAM =
+      requiredInParameter("timestamp", DataTypes.TimestampType);
+
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        requiredInParameter("timestamp", DataTypes.TimestampType)
-      };
+      new ProcedureParameter[] {TABLE_PARAM, TIMESTAMP_PARAM};
 
   private static final StructType OUTPUT_TYPE =
       new StructType(
@@ -83,9 +85,10 @@ class RollbackToTimestampProcedure extends BaseProcedure {
 
   @Override
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
     // timestamps in Spark have microsecond precision so this conversion is lossy
-    long timestampMillis = DateTimeUtil.microsToMillis(args.getLong(1));
+    long timestampMillis = DateTimeUtil.microsToMillis(input.asLong(TIMESTAMP_PARAM));
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java
@@ -48,12 +48,15 @@ class SetCurrentSnapshotProcedure extends BaseProcedure {
 
   static final String NAME = "set_current_snapshot";
 
+  private static final ProcedureParameter TABLE_PARAM =
+      requiredInParameter("table", DataTypes.StringType);
+  private static final ProcedureParameter SNAPSHOT_ID_PARAM =
+      optionalInParameter("snapshot_id", DataTypes.LongType);
+  private static final ProcedureParameter REF_PARAM =
+      optionalInParameter("ref", DataTypes.StringType);
+
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {
-        requiredInParameter("table", DataTypes.StringType),
-        optionalInParameter("snapshot_id", DataTypes.LongType),
-        optionalInParameter("ref", DataTypes.StringType)
-      };
+      new ProcedureParameter[] {TABLE_PARAM, SNAPSHOT_ID_PARAM, REF_PARAM};
 
   private static final StructType OUTPUT_TYPE =
       new StructType(
@@ -87,9 +90,10 @@ class SetCurrentSnapshotProcedure extends BaseProcedure {
 
   @Override
   public Iterator<Scan> call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    Long snapshotId = args.isNullAt(1) ? null : args.getLong(1);
-    String ref = args.isNullAt(2) ? null : args.getString(2);
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+    Identifier tableIdent = toIdentifier(input.asString(TABLE_PARAM), TABLE_PARAM.name());
+    Long snapshotId = input.asLong(SNAPSHOT_ID_PARAM, null);
+    String ref = input.asString(REF_PARAM, null);
     Preconditions.checkArgument(
         (snapshotId != null && ref == null) || (snapshotId == null && ref != null),
         "Either snapshot_id or ref must be provided, not both");


### PR DESCRIPTION
### Description

This pull request refactors the existing Spark procedures to consistently use `ProcedureInput` for parameter handling. Previously, many stored procedures manually handled parameter extraction from `InternalRow`, leading to inconsistent code across the project. By adopting `ProcedureInput`, we improve the code uniformity and ensure that all stored procedures now use a unified approach for parameter handling.

### Changes:
- Replaced manual parameter extraction with `ProcedureInput` in relevant stored procedure code.
- Simplified parameter validation and conversion by using `ProcedureInput` methods like `asString`, `asLong`, `asInt`, etc.
- Enhanced readability and maintainability by consolidating parameter handling logic into a centralized class.

### Benefits:
- **Consistency**: All stored procedures now handle parameters in a consistent and standardized way.
- **Readability**: Code is more readable and easier to maintain by leveraging `ProcedureInput`'s built-in functions.
- **Reduced Duplication**: Avoids repeated parameter extraction and conversion logic throughout the project.
