### PR TITLE
Spark 3.5, 3.4: Fix source location in stats file copy plan in RewriteTablePathSparkAction

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -404,10 +404,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Preconditions.checkArgument(
           before.fileSizeInBytes() == after.fileSizeInBytes(),
           "Before and after path rewrite, statistic file size should be same");
-      result.add(
-          Pair.of(
-              RewriteTablePathUtil.stagingPath(before.path(), sourcePrefix, stagingDir),
-              after.path()));
+      result.add(Pair.of(before.path(), after.path()));
     }
     return result;
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -404,10 +404,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Preconditions.checkArgument(
           before.fileSizeInBytes() == after.fileSizeInBytes(),
           "Before and after path rewrite, statistic file size should be same");
-      result.add(
-          Pair.of(
-              RewriteTablePathUtil.stagingPath(before.path(), sourcePrefix, stagingDir),
-              after.path()));
+      result.add(Pair.of(before.path(), after.path()));
     }
     return result;
   }


### PR DESCRIPTION
Backport of https://github.com/apache/iceberg/pull/13881 for Spark 3.4 and Spark 3.5