### PR TITLE
Handle NPE on null vector columns

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/NullabilityHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/NullabilityHolder.java
@@ -27,6 +27,14 @@ import java.util.Arrays;
  * with monotonically increasing values for the index parameter.
  */
 public class NullabilityHolder {
+  /** Sentinel instance that reports every position as null. */
+  public static final NullabilityHolder ALL_NULLS = new NullabilityHolder() {
+    @Override public byte isNullAt(int index) { return (byte) 1; }
+    @Override public boolean hasNulls() { return true; }
+    @Override public int numNulls() { return Integer.MAX_VALUE; }
+    @Override public int size() { return Integer.MAX_VALUE; }
+  };
+
   private final byte[] isNull;
   private int numNulls;
   private final byte[] nonNulls;
@@ -38,6 +46,13 @@ public class NullabilityHolder {
     Arrays.fill(nonNulls, (byte) 0);
     this.nulls = new byte[size];
     Arrays.fill(nulls, (byte) 1);
+  }
+
+  private NullabilityHolder() {
+    // Private constructor for ALL_NULLS sentinel
+    this.isNull = null;
+    this.nonNulls = null;
+    this.nulls = null;
   }
 
   public int size() {

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestNullVectorAccessor.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestNullVectorAccessor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized;
+
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestNullVectorAccessor {
+
+  @Test
+  public void testNullVectorYieldsNullAccessor() {
+    Types.NestedField field =
+        Types.NestedField.optional(1, "gm_dp_identifier", Types.LongType.get());
+
+    ArrowVectorAccessor<?, String, ?, ?> acc =
+        GenericArrowVectorAccessorFactory.getPlainVectorAccessor(/*vector=*/null, field);
+
+    ColumnVector cv = new ColumnVector(field, acc, /*nullability*/ null);
+
+    // Should not throw and must report nulls
+    Assert.assertTrue(cv.isNullAt(0));
+    Assert.assertTrue(cv.isNullAt(42));
+
+    // Accessor should gracefully return nulls
+    Assert.assertNull(acc.getLong(0));
+    Assert.assertNull(acc.getUTF8String(0));
+  }
+}


### PR DESCRIPTION
Currently there is a null pointer exception being thrown when there is a null vector

```
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "vector" is null
        at org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.getPlainVectorAccessor(GenericArrowVectorAccessorFactory.java:224)
        at org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.getVectorAccessor(GenericArrowVectorAccessorFactory.java:110)
        at org.apache.iceberg.arrow.vectorized.ArrowVectorAccessors.getVectorAccessor(ArrowVectorAccessors.java:54)
        at org.apache.iceberg.arrow.vectorized.ColumnVector.getVectorAccessor(ColumnVector.java:136)
        at org.apache.iceberg.arrow.vectorized.ColumnVector.<init>(ColumnVector.java:56)
        at org.apache.iceberg.arrow.vectorized.ArrowBatchReader.read(ArrowBatchReader.java:54)
        at org.apache.iceberg.arrow.vectorized.ArrowBatchReader.read(ArrowBatchReader.java:29)
        at org.apache.iceberg.parquet.VectorizedParquetReader$FileIterator.next(VectorizedParquetReader.java:145)
        at org.apache.iceberg.arrow.vectorized.ArrowReader$VectorizedCombinedScanIterator.next(ArrowReader.java:314)
        at org.apache.iceberg.arrow.vectorized.ArrowReader$VectorizedCombinedScanIterator.next(ArrowReader.java:190)
```

This only happens when I'm using the vectorized stream reading. This might fix the issue here