### PR TITLE
Build: Release with JDK17

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-if (project.hasProperty('release') && jdkVersion != '11') {
-  throw new GradleException("Releases must be built with Java 11")
+if (project.hasProperty('release') && jdkVersion != '17') {
+  throw new GradleException("Releases must be built with Java 17")
 }
 
 subprojects {


### PR DESCRIPTION
Spark requires JDK 17 or 21, so let's bump the JDK needed to release to 17.

Since we set the target at 11 it works with JDK11 and higher:

https://github.com/apache/iceberg/blob/522de0fe839df2f22f4472241bce632995adc01d/build.gradle#L192

https://github.com/apache/iceberg/blob/522de0fe839df2f22f4472241bce632995adc01d/build.gradle#L245-L247