### PR TITLE
Reuse vectors across encoding switches in VectorizedArrowReader

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -217,6 +217,10 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
   }
 
   private void allocateFieldVector(boolean dictionaryEncodedVector) {
+    // Allocate-only: caller must ensure there is no active vector in use.
+    Preconditions.checkState(
+        vec == null,
+        "allocateFieldVector must be called only when no active vector is in use (vec == null)");
     if (dictionaryEncodedVector) {
       allocateDictEncodedVector();
     } else {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetDictionaryEncodedVectorizedReads.java
@@ -116,15 +116,15 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
     File mixedFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(mixedFile.delete()).as("Delete should succeed").isTrue();
     Parquet.concat(
-        ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile),
+        ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile, plainEncodingFile),
         mixedFile,
         rowGroupSize,
         schema,
         ImmutableMap.of());
     assertRecordsMatch(
         schema,
-        30000,
-        FluentIterable.concat(dictionaryEncodableData, nonDictionaryData, dictionaryEncodableData),
+        40000,
+        FluentIterable.concat(dictionaryEncodableData, nonDictionaryData, dictionaryEncodableData, nonDictionaryData),
         mixedFile,
         true,
         BATCH_SIZE);


### PR DESCRIPTION
Address this comment: https://github.com/apache/iceberg/pull/13935/files#r2308812199

- Add a precondition in `allocateFieldVector` that it’s allocate-only and must be called with `vec == null`.
- reuse vectors across encoding switches