### PR TITLE
Spark 4.0: Add Support for PartitionStatistics Files in RewriteTablePath.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -129,8 +129,8 @@ public class RewriteTablePathUtil {
         metadataLogEntries,
         metadata.refs(),
         updatePathInStatisticsFiles(metadata.statisticsFiles(), sourcePrefix, targetPrefix),
-        // TODO: update partition statistics file paths
-        metadata.partitionStatisticsFiles(),
+        updatePathInPartitionStatisticsFiles(
+            metadata.partitionStatisticsFiles(), sourcePrefix, targetPrefix),
         metadata.nextRowId(),
         metadata.encryptionKeys(),
         metadata.changes());
@@ -172,6 +172,31 @@ public class RewriteTablePathUtil {
                     existing.fileSizeInBytes(),
                     existing.fileFooterSizeInBytes(),
                     existing.blobMetadata()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * This method updates the file paths in a list of PartitionStatisticsFile. It replaces the
+   * sourcePrefix in the file paths with the targetPrefix.
+   *
+   * @param partitionStatisticsFiles The list of PartitionStatisticsFile to update.
+   * @param sourcePrefix The prefix to be replaced in the file paths.
+   * @param targetPrefix The new prefix to replace the sourcePrefix in the file paths.
+   * @return A new list of PartitionStatisticsFile with updated file paths.
+   */
+  private static List<PartitionStatisticsFile> updatePathInPartitionStatisticsFiles(
+      List<PartitionStatisticsFile> partitionStatisticsFiles,
+      String sourcePrefix,
+      String targetPrefix) {
+
+    return partitionStatisticsFiles.stream()
+        .map(
+            existing ->
+                ImmutableGenericPartitionStatisticsFile.builder()
+                    .snapshotId(existing.snapshotId())
+                    .path(newPath(existing.path(), sourcePrefix, targetPrefix))
+                    .fileSizeInBytes(existing.fileSizeInBytes())
+                    .build())
         .collect(Collectors.toList());
   }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.RewriteTablePathUtil;
 import org.apache.iceberg.RewriteTablePathUtil.PositionDeleteReaderWriter;
 import org.apache.iceberg.RewriteTablePathUtil.RewriteResult;
@@ -273,11 +274,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     TableMetadata endMetadata =
         ((HasTableOperations) newStaticTable(endVersionName, table.io())).operations().current();
 
-    Preconditions.checkArgument(
-        endMetadata.partitionStatisticsFiles() == null
-            || endMetadata.partitionStatisticsFiles().isEmpty(),
-        "Partition statistics files are not supported yet.");
-
     // rebuild version files
     RewriteResult<Snapshot> rewriteVersionResult = rewriteVersionFiles(endMetadata);
     Set<Snapshot> deltaSnapshots = deltaSnapshots(startMetadata, rewriteVersionResult.toRewrite());
@@ -385,6 +381,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     // include statistics files in copy plan
     result.addAll(
         statsFileCopyPlan(metadata.statisticsFiles(), newTableMetadata.statisticsFiles()));
+    result.addAll(
+        partitionStatsFileCopyPlan(
+            metadata.partitionStatisticsFiles(), newTableMetadata.partitionStatisticsFiles()));
     return result;
   }
 
@@ -404,6 +403,27 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Preconditions.checkArgument(
           before.fileSizeInBytes() == after.fileSizeInBytes(),
           "Before and after path rewrite, statistic file size should be same");
+      result.add(Pair.of(before.path(), after.path()));
+    }
+    return result;
+  }
+
+  private Set<Pair<String, String>> partitionStatsFileCopyPlan(
+      List<PartitionStatisticsFile> beforeStats, List<PartitionStatisticsFile> afterStats) {
+    Set<Pair<String, String>> result = Sets.newHashSet();
+    if (beforeStats.isEmpty()) {
+      return result;
+    }
+
+    Preconditions.checkArgument(
+        beforeStats.size() == afterStats.size(),
+        "Before and after path rewrite, partition statistic files count should be same");
+    for (int i = 0; i < beforeStats.size(); i++) {
+      PartitionStatisticsFile before = beforeStats.get(i);
+      PartitionStatisticsFile after = afterStats.get(i);
+      Preconditions.checkArgument(
+          before.fileSizeInBytes() == after.fileSizeInBytes(),
+          "Before and after path rewrite, partition statistic file size should be same");
       result.add(Pair.of(before.path(), after.path()));
     }
     return result;

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -937,11 +937,14 @@ public class TestRewriteTablePathsAction extends TestBase {
             .findFirst()
             .orElse(null);
 
-    assertThat(statsFilePathPair).as("Should find statistics file in file list").isNotNull();
+    assertThat(statsFilePathPair)
+        .as("Should find Partition statistics file in file list")
+        .isNotNull();
 
     // Verify the source path points to the actual source location, not staging
     assertThat(statsFilePathPair._1())
-        .as("Partition Statistics file source should point to source table location and NOT staging")
+        .as(
+            "Partition Statistics file source should point to source table location and NOT staging")
         .startsWith(sourceTableLocation)
         .contains("/metadata/")
         .doesNotContain("staging");

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -1401,23 +1401,29 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     sql("DROP TABLE IF EXISTS hive.%s.%s", namespace, tableName);
 
-    String sqlStr =
-        String.format(
-            "CREATE TABLE hive.%s.%s (c1 bigint, c2 string, c3 string)", namespace, tableName);
+    StringBuilder createTableSql = new StringBuilder();
+    createTableSql
+        .append("CREATE TABLE hive.")
+        .append(namespace)
+        .append(".")
+        .append(tableName)
+        .append(" (c1 bigint, c2 string, c3 string)");
 
     if (partitionColumn != null && !partitionColumn.isEmpty()) {
-      sqlStr = String.format("%s USING iceberg PARTITIONED BY (%s)", sqlStr, partitionColumn);
+      createTableSql.append(" USING iceberg PARTITIONED BY (").append(partitionColumn).append(")");
+    } else {
+      createTableSql.append(" USING iceberg");
     }
 
     if (!location.isEmpty()) {
-      sqlStr = String.format("%s LOCATION '%s'", sqlStr, location);
+      createTableSql.append(" LOCATION '").append(location).append("'");
     }
 
     if (!tblProperties.isEmpty()) {
-      sqlStr = String.format("%s TBLPROPERTIES (%s)", sqlStr, tblProperties);
+      createTableSql.append(" TBLPROPERTIES (").append(tblProperties).append(")");
     }
 
-    return sqlStr;
+    return createTableSql.toString();
   }
 
   private static String fileName(String path) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -928,10 +928,7 @@ public class TestRewriteTablePathsAction extends TestBase {
         iterations * 2 + 1, iterations, iterations, 0, iterations, iterations * 6 + 1, result);
 
     findAndAssertFileInFileList(
-        result,
-        "partition-stats",
-        sourceTableLocation,
-        targetTableLocation);
+        result, "partition-stats", sourceTableLocation, targetTableLocation);
   }
 
   @Test
@@ -1460,11 +1457,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     Tuple2<String, String> filePathPair =
         filesToMove.stream()
-            .filter(
-                pair ->
-                    pair._1()
-                        .contains(
-                            fileIdentifier)) // Updated to check "contains" instead of "endsWith"
+            .filter(pair -> pair._1().contains(fileIdentifier))
             .findFirst()
             .orElse(null);
 


### PR DESCRIPTION
### Related Issues
- #TODO: update partition statistics file paths (completes the table path rewrite functionality).