### PR TITLE
Spark4.0: Implement check for destination table location overlap with source table location.

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -124,10 +124,12 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
     StagedSparkTable stagedTable = stageDestTable();
     Table icebergTable = stagedTable.table();
 
-    // TODO: Check the dest table location does not overlap with the source table location
-
     boolean threw = true;
     try {
+      Preconditions.checkArgument(
+          !sourceTableLocation().equals(icebergTable.location()),
+          "The destination table location overlaps with the source table location");
+
       LOG.info("Ensuring {} has a valid name mapping", destTableIdent());
       ensureNameMappingPresent(icebergTable);
 


### PR DESCRIPTION

This PR addresses the TODO in the code by implementing a check to ensure that the destination table location does not overlap with the source table location. The check will validate that the paths or locations of the destination and source tables are distinct, preventing potential conflicts or data overwrites during operations. The change improves data integrity and enhances error handling.