### PR TITLE
Docs: Update nessie version

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -80,7 +80,7 @@ markdown_extensions:
 
 extra:
   icebergVersion: '1.9.2'
-  nessieVersion: '0.103.3'
+  nessieVersion: '0.104.5'
   flinkVersion: '1.20.0'
   flinkVersionMajor: '1.20'
   social:


### PR DESCRIPTION
closes #13968


Based on the version in gradle/libs.versions.toml: https://github.com/apache/iceberg/blob/d8767f1b56a4de379d3d49a5c2f02bab4b0e330f/gradle/libs.versions.toml#L76