### PR TITLE
AWS: Make `S3FileIO` token expiration property public

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -270,7 +270,7 @@ public class S3FileIOProperties implements Serializable {
    * This expiration time is currently only used in {@link VendedCredentialsProvider} for refreshing
    * vended credentials.
    */
-  static final String SESSION_TOKEN_EXPIRES_AT_MS = "s3.session-token-expires-at-ms";
+  public static final String SESSION_TOKEN_EXPIRES_AT_MS = "s3.session-token-expires-at-ms";
 
   /**
    * Enable to make S3FileIO, to make cross-region call to the region specified in the ARN of an


### PR DESCRIPTION
I see https://github.com/apache/iceberg/pull/11389#discussion_r1815402086 - but was curious if folks would be open to making this public so that REST catalogs implemented in Java can use `S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS` instead of hard-coding the string constant when returning token expirations. 