### PR TITLE
Tables/Commit: Return updated snapshot

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -37,7 +37,7 @@ import java.util.function.Consumer;
  *
  * <p>{@link #apply()} returns a list of the snapshots that will be removed.
  */
-public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
+public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>, Snapshot> {
 
   /**
    * Expires a specific {@link Snapshot} identified by id.

--- a/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
@@ -41,7 +41,7 @@ import org.apache.iceberg.exceptions.ValidationException;
  *
  * <p>
  */
-public interface ManageSnapshots extends PendingUpdate<Snapshot> {
+public interface ManageSnapshots extends PendingUpdate<Snapshot, Snapshot> {
 
   /**
    * Roll this table's data back to a specific {@link Snapshot} identified by id.

--- a/api/src/main/java/org/apache/iceberg/PendingUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/PendingUpdate.java
@@ -26,8 +26,9 @@ import org.apache.iceberg.exceptions.ValidationException;
  * API for table metadata changes.
  *
  * @param <T> Java class of changes from this update; returned by {@link #apply} for validation.
+ * @param <R> Result type of the commit operation; returned by {@link #commit()}.
  */
-public interface PendingUpdate<T> {
+public interface PendingUpdate<T, R> {
 
   /**
    * Apply the pending changes and return the uncommitted changes for validation.
@@ -47,12 +48,14 @@ public interface PendingUpdate<T> {
    *
    * <p>Once the commit is successful, the updated table will be refreshed.
    *
+   * @return the snapshot created by this commit, or the current snapshot if no new snapshot was
+   *     created
    * @throws ValidationException If the update cannot be applied to the current table metadata.
    * @throws CommitFailedException If the update cannot be committed due to conflicts.
    * @throws CommitStateUnknownException If the update success or failure is unknown, no cleanup
    *     should be done in this case.
    */
-  void commit();
+  R commit();
 
   /**
    * Generates update event to notify about metadata changes

--- a/api/src/main/java/org/apache/iceberg/ReplaceSortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/ReplaceSortOrder.java
@@ -29,4 +29,4 @@ package org.apache.iceberg;
  * will be resolved by applying the pending changes to the new table metadata.
  */
 public interface ReplaceSortOrder
-    extends PendingUpdate<SortOrder>, SortOrderBuilder<ReplaceSortOrder> {}
+    extends PendingUpdate<SortOrder, Snapshot>, SortOrderBuilder<ReplaceSortOrder> {}

--- a/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
  *
  * @param <ThisT> the child Java API class, returned by method chaining.
  */
-public interface SnapshotUpdate<ThisT> extends PendingUpdate<Snapshot> {
+public interface SnapshotUpdate<ThisT> extends PendingUpdate<Snapshot, Snapshot> {
   /**
    * Set a summary property in the snapshot produced by this update.
    *

--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -182,5 +182,5 @@ public interface Transaction {
    * @throws ValidationException If any update cannot be applied to the current table metadata.
    * @throws CommitFailedException If the updates cannot be committed due to conflicts.
    */
-  void commitTransaction();
+  Snapshot commitTransaction();
 }

--- a/api/src/main/java/org/apache/iceberg/UpdatePartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/UpdatePartitionSpec.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.expressions.Term;
  * <p>When committing, these changes will be applied to the current table metadata. Commit conflicts
  * will not be resolved and will result in a {@link CommitFailedException}.
  */
-public interface UpdatePartitionSpec extends PendingUpdate<PartitionSpec> {
+public interface UpdatePartitionSpec extends PendingUpdate<PartitionSpec, Snapshot> {
   /**
    * Set whether column resolution in the source schema should be case sensitive.
    *

--- a/api/src/main/java/org/apache/iceberg/UpdatePartitionStatistics.java
+++ b/api/src/main/java/org/apache/iceberg/UpdatePartitionStatistics.java
@@ -21,7 +21,8 @@ package org.apache.iceberg;
 import java.util.List;
 
 /** API for updating partition statistics files in a table. */
-public interface UpdatePartitionStatistics extends PendingUpdate<List<PartitionStatisticsFile>> {
+public interface UpdatePartitionStatistics
+    extends PendingUpdate<List<PartitionStatisticsFile>, Snapshot> {
   /**
    * Set the table's partition statistics file for given snapshot, replacing the previous partition
    * statistics file for the snapshot if any exists. No-op if the provided file is null.

--- a/api/src/main/java/org/apache/iceberg/UpdateProperties.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateProperties.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * <p>When committing, these changes will be applied to the current table metadata. Commit conflicts
  * will be resolved by applying the pending changes to the new table metadata.
  */
-public interface UpdateProperties extends PendingUpdate<Map<String, String>> {
+public interface UpdateProperties extends PendingUpdate<Map<String, String>, Snapshot> {
 
   /**
    * Add a key/value property to the table.

--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -31,7 +31,7 @@ import org.apache.iceberg.types.Type;
  * <p>When committing, these changes will be applied to the current table metadata. Commit conflicts
  * will not be resolved and will result in a {@link CommitFailedException}.
  */
-public interface UpdateSchema extends PendingUpdate<Schema> {
+public interface UpdateSchema extends PendingUpdate<Schema, Snapshot> {
 
   /**
    * Allow incompatible changes to the schema.

--- a/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateStatistics.java
@@ -21,7 +21,7 @@ package org.apache.iceberg;
 import java.util.List;
 
 /** API for updating statistics files in a table. */
-public interface UpdateStatistics extends PendingUpdate<List<StatisticsFile>> {
+public interface UpdateStatistics extends PendingUpdate<List<StatisticsFile>, Snapshot> {
   /**
    * Set the table's statistics file for given snapshot, replacing the previous statistics file for
    * the snapshot if any exists.

--- a/api/src/main/java/org/apache/iceberg/view/ReplaceViewVersion.java
+++ b/api/src/main/java/org/apache/iceberg/view/ReplaceViewVersion.java
@@ -29,4 +29,4 @@ import org.apache.iceberg.PendingUpdate;
  * will be resolved by applying the pending changes to the new view metadata.
  */
 public interface ReplaceViewVersion
-    extends PendingUpdate<ViewVersion>, VersionBuilder<ReplaceViewVersion> {}
+    extends PendingUpdate<ViewVersion, Void>, VersionBuilder<ReplaceViewVersion> {}

--- a/api/src/main/java/org/apache/iceberg/view/UpdateViewLocation.java
+++ b/api/src/main/java/org/apache/iceberg/view/UpdateViewLocation.java
@@ -16,15 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg;
+package org.apache.iceberg.view;
 
-/** API for setting a table's or view's base location. */
-public interface UpdateLocation extends PendingUpdate<String, Snapshot> {
+import org.apache.iceberg.PendingUpdate;
+
+public interface UpdateViewLocation extends PendingUpdate<String, Void> {
   /**
-   * Set the table's location.
+   * Set the view's location.
    *
    * @param location a String location
    * @return this for method chaining
    */
-  UpdateLocation setLocation(String location);
+  UpdateViewLocation setLocation(String location);
 }

--- a/api/src/main/java/org/apache/iceberg/view/UpdateViewProperties.java
+++ b/api/src/main/java/org/apache/iceberg/view/UpdateViewProperties.java
@@ -29,7 +29,7 @@ import org.apache.iceberg.PendingUpdate;
  * <p>When committing, these changes will be applied to the current view metadata. Commit conflicts
  * will be resolved by applying the pending changes to the new view metadata.
  */
-public interface UpdateViewProperties extends PendingUpdate<Map<String, String>> {
+public interface UpdateViewProperties extends PendingUpdate<Map<String, String>, Void> {
 
   /**
    * Add a key/value property to the view.

--- a/api/src/main/java/org/apache/iceberg/view/View.java
+++ b/api/src/main/java/org/apache/iceberg/view/View.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.UpdateLocation;
 
 /** Interface for view definition. */
 public interface View {
@@ -105,11 +104,11 @@ public interface View {
   }
 
   /**
-   * Create a new {@link UpdateLocation} to set the view's location.
+   * Create a new {@link UpdateViewLocation} to set the view's location.
    *
-   * @return a new {@link UpdateLocation}
+   * @return a new {@link UpdateViewLocation}
    */
-  default UpdateLocation updateLocation() {
+  default UpdateViewLocation updateLocation() {
     throw new UnsupportedOperationException("Updating a view's location is not supported");
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -251,7 +251,7 @@ public class BaseTransaction implements Transaction {
   }
 
   @Override
-  public void commitTransaction() {
+  public Snapshot commitTransaction() {
     Preconditions.checkState(
         hasLastOpCommitted, "Cannot commit transaction: last operation has not committed");
 
@@ -272,6 +272,7 @@ public class BaseTransaction implements Transaction {
         commitSimpleTransaction();
         break;
     }
+    return current.currentSnapshot();
   }
 
   private void commitCreateTransaction() {

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -335,7 +335,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
   }
 
   @Override
-  public void commit() {
+  public Snapshot commit() {
     TableMetadata update;
     if (setAsDefault) {
       update = base.updatePartitionSpec(apply());
@@ -343,6 +343,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
       update = base.addPartitionSpec(apply());
     }
     ops.commit(base, update);
+    return update.currentSnapshot();
   }
 
   private Pair<Integer, Transform<?, ?>> resolve(Term term) {

--- a/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
@@ -122,8 +122,9 @@ class CommitCallbackTransaction implements Transaction {
   }
 
   @Override
-  public void commitTransaction() {
-    wrapped.commitTransaction();
+  public Snapshot commitTransaction() {
+    Snapshot result = wrapped.commitTransaction();
     callback.run();
+    return result;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -468,9 +468,10 @@ class SchemaUpdate implements UpdateSchema {
   }
 
   @Override
-  public void commit() {
+  public Snapshot commit() {
     TableMetadata update = applyChangesToMetadata(base.updateSchema(apply()));
     ops.commit(base, update);
+    return update.currentSnapshot();
   }
 
   private int assignNewColumnId() {

--- a/core/src/main/java/org/apache/iceberg/SetPartitionStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetPartitionStatistics.java
@@ -55,10 +55,12 @@ public class SetPartitionStatistics implements UpdatePartitionStatistics {
   }
 
   @Override
-  public void commit() {
+  public Snapshot commit() {
     TableMetadata base = ops.current();
     TableMetadata newMetadata = internalApply(base);
     ops.commit(base, newMetadata);
+    // Return the current snapshot from the updated metadata
+    return newMetadata.currentSnapshot();
   }
 
   private TableMetadata internalApply(TableMetadata base) {

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -49,10 +49,12 @@ public class SetStatistics implements UpdateStatistics {
   }
 
   @Override
-  public void commit() {
+  public Snapshot commit() {
     TableMetadata base = ops.current();
     TableMetadata newMetadata = internalApply(base);
     ops.commit(base, newMetadata);
+    // Return the current snapshot from the updated metadata
+    return newMetadata.currentSnapshot();
   }
 
   private TableMetadata internalApply(TableMetadata base) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotManager.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotManager.java
@@ -164,10 +164,13 @@ public class SnapshotManager implements ManageSnapshots {
     return updateSnapshotReferencesOperation;
   }
 
-  private void commitIfRefUpdatesExist() {
+  private Snapshot commitIfRefUpdatesExist() {
     if (updateSnapshotReferencesOperation != null) {
-      updateSnapshotReferencesOperation.commit();
+      Snapshot result = updateSnapshotReferencesOperation.commit();
       updateSnapshotReferencesOperation = null;
+      return result;
+    } else {
+      return null;
     }
   }
 
@@ -177,10 +180,11 @@ public class SnapshotManager implements ManageSnapshots {
   }
 
   @Override
-  public void commit() {
-    commitIfRefUpdatesExist();
+  public Snapshot commit() {
+    Snapshot result = commitIfRefUpdatesExist();
     if (!isExternalTransaction) {
-      transaction.commitTransaction();
+      result = transaction.commitTransaction();
     }
+    return result;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -421,7 +421,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   @Override
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
-  public void commit() {
+  public Snapshot commit() {
     // this is always set to the latest commit attempt's snapshot
     AtomicReference<Snapshot> stagedSnapshot = new AtomicReference<>();
     try (Timed ignore = commitMetrics().totalDuration().start()) {
@@ -505,6 +505,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     } catch (Throwable e) {
       LOG.warn("Failed to notify event listeners", e);
     }
+    return stagedSnapshot.get();
   }
 
   private void notifyListeners() {

--- a/core/src/main/java/org/apache/iceberg/UpdateSnapshotReferencesOperation.java
+++ b/core/src/main/java/org/apache/iceberg/UpdateSnapshotReferencesOperation.java
@@ -27,7 +27,8 @@ import org.apache.iceberg.util.SnapshotUtil;
  * ToDo: Add SetSnapshotOperation operations such as setCurrentSnapshot, rollBackTime, rollbackTo to
  * this class so that we can support those operations for refs.
  */
-class UpdateSnapshotReferencesOperation implements PendingUpdate<Map<String, SnapshotRef>> {
+class UpdateSnapshotReferencesOperation
+    implements PendingUpdate<Map<String, SnapshotRef>, Snapshot> {
 
   private final TableOperations ops;
   private final Map<String, SnapshotRef> updatedRefs;
@@ -45,9 +46,11 @@ class UpdateSnapshotReferencesOperation implements PendingUpdate<Map<String, Sna
   }
 
   @Override
-  public void commit() {
+  public Snapshot commit() {
     TableMetadata updated = internalApply();
     ops.commit(base, updated);
+    // Return the current snapshot from the updated metadata
+    return updated.currentSnapshot();
   }
 
   public UpdateSnapshotReferencesOperation createBranch(String name, long snapshotId) {

--- a/core/src/main/java/org/apache/iceberg/view/BaseView.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseView.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.UpdateLocation;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public class BaseView implements View, Serializable {
@@ -96,7 +95,7 @@ public class BaseView implements View, Serializable {
   }
 
   @Override
-  public UpdateLocation updateLocation() {
+  public UpdateViewLocation updateLocation() {
     return new SetViewLocation(ops);
   }
 

--- a/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
@@ -59,7 +59,7 @@ class PropertiesUpdate implements UpdateViewProperties {
   }
 
   @Override
-  public void commit() {
+  public Void commit() {
     Tasks.foreach(ops)
         .retry(
             PropertyUtil.propertyAsInt(
@@ -74,6 +74,7 @@ class PropertiesUpdate implements UpdateViewProperties {
             2.0 /* exponential */)
         .onlyRetryOn(CommitFailedException.class)
         .run(taskOps -> taskOps.commit(base, internalApply()));
+    return null;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
+++ b/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
@@ -27,13 +27,12 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
-import org.apache.iceberg.UpdateLocation;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 
-class SetViewLocation implements UpdateLocation {
+class SetViewLocation implements UpdateViewLocation {
   private final ViewOperations ops;
   private String newLocation = null;
 
@@ -48,7 +47,7 @@ class SetViewLocation implements UpdateLocation {
   }
 
   @Override
-  public void commit() {
+  public Void commit() {
     ViewMetadata base = ops.refresh();
     Tasks.foreach(ops)
         .retry(
@@ -66,10 +65,11 @@ class SetViewLocation implements UpdateLocation {
         .run(
             taskOps ->
                 taskOps.commit(base, ViewMetadata.buildFrom(base).setLocation(apply()).build()));
+    return null;
   }
 
   @Override
-  public UpdateLocation setLocation(String location) {
+  public UpdateViewLocation setLocation(String location) {
     this.newLocation = location;
     return this;
   }

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
@@ -86,7 +86,7 @@ class ViewVersionReplace implements ReplaceViewVersion {
   }
 
   @Override
-  public void commit() {
+  public Void commit() {
     Tasks.foreach(ops)
         .retry(
             PropertyUtil.propertyAsInt(
@@ -101,6 +101,7 @@ class ViewVersionReplace implements ReplaceViewVersion {
             2.0 /* exponential */)
         .onlyRetryOn(CommitFailedException.class)
         .run(taskOps -> taskOps.commit(base, internalApply()));
+    return null;
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
@@ -28,7 +28,6 @@ import java.nio.file.Paths;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Transaction;
-import org.apache.iceberg.UpdateLocation;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -1698,7 +1697,7 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Invalid view location: null");
 
-    UpdateLocation updateViewLocation = view.updateLocation();
+    UpdateViewLocation updateViewLocation = view.updateLocation();
 
     catalog().dropView(identifier);
     assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();


### PR DESCRIPTION
Allows users to get information about the committed snapshot, like snapshotId, without calling 'refresh' which would incur an extra network request.