### PR TITLE
docs: use * for path expansion instead of hardcoding version

### DIFF
--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -410,14 +410,10 @@ shasum -a 512 --check apache-iceberg-*.tar.gz.sha512
 
 ### Verifying License Documentation
 
-Untar the archive.
+Untar the archive and change into the source directory.
 ```bash
 tar xzf apache-iceberg-*.tar.gz
-```
-
-Navigate into the source directory.
-```bash
-cd apache-iceberg-{{ icebergVersion }}
+cd apache-iceberg-*/
 ```
 
 Run RAT checks to validate license headers.


### PR DESCRIPTION
quality of life improvement when verifying a release. 

The [docs to verify release](https://iceberg.apache.org/how-to-release/#verifying-signatures) is always 1 version behind what we're actually trying to verify. For example, right now the docs shows `apache-iceberg-1.9.2.tar.gz.asc` and we're verifying 1.10. 

This change gets rid of the version and let path expansion takes care of the work 