### PR TITLE
REST: Fix already in use problem for RESTCatalogServer

### DIFF
--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.rest;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
@@ -29,6 +28,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
@@ -121,11 +121,9 @@ public class RESTCatalogServer {
         new Server(
             PropertyUtil.propertyAsInt(catalogContext.configuration, REST_PORT, REST_PORT_DEFAULT));
     httpServer.setHandler(context);
-    Arrays.stream(httpServer.getConnectors())
-        .forEach(
-            connector -> {
-              ((ServerConnector) connector).setReusePort(true);
-            });
+    for (Connector connector : httpServer.getConnectors()) {
+      ((ServerConnector) connector).setReusePort(true);
+    }
     httpServer.start();
 
     if (join) {


### PR DESCRIPTION
In our environments, Iceberg unit tests frequently fail due to `java.net.BindException: Address already in use`, caused by ports lingering in the `TIME_WAIT` state. Although our `findFreePort()` method selects an available port and releases it immediatel, the OS may not release it quickly enough for reuse. To fix this, we enable port reuse, allowing ports in `TIME_WAIT` to be rebound immediately—significantly reducing test flakiness.