### PR TITLE
Bug fix: Observing the extra forward / after the /data/ in the s3 after ingesting the data to non-partitioned iceberg

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -327,7 +327,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     }
 
     private void openCurrent() {
-      if (partitionKey == null) {
+      if (spec.isUnpartitioned() || partitionKey == null) {
         // unpartitioned
         this.currentFile = fileFactory.newOutputFile();
       } else {


### PR DESCRIPTION
Please find the details in the issue: https://github.com/apache/iceberg/issues/13999