### PR TITLE
Site: Bump up mkdocs-monorepo-plugin to 1.1.2

### DIFF
--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -19,5 +19,5 @@ mkdocs-awesome-pages-plugin==2.10.1
 mkdocs-macros-plugin==1.3.9
 mkdocs-material==9.6.18
 mkdocs-material-extensions==1.3.1
-mkdocs-monorepo-plugin @ git+https://github.com/bitsondatadev/mkdocs-monorepo-plugin@url-fix
+mkdocs-monorepo-plugin==1.1.2 
 mkdocs-redirects==1.2.2


### PR DESCRIPTION
https://github.com/bitsondatadev/mkdocs-monorepo-plugin/commit/6cef2431f99f8b68ca472376d3ada79ec912958c has been [committed in upstream](https://github.com/backstage/mkdocs-monorepo-plugin/pull/140/files#diff-a4e8ad01beb5a9b33f939926810cf6d661132f85e1c4f4ec9882222cfa45281c), so the forked mkdocs-monorepo-plugin is no longer needed.

cc @bitsondatadev @Fokko 