### PR TITLE
Spark: Test `StringStartsWith` expression conversion

### DIFF
--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -42,6 +42,7 @@ import org.apache.spark.sql.sources.IsNull;
 import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
+import org.apache.spark.sql.sources.StringStartsWith;
 import org.junit.jupiter.api.Test;
 
 public class TestSparkFilters {
@@ -122,6 +123,14 @@ public class TestSparkFilters {
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkFilters.convert(in);
           assertThat(actualIn).asString().as("In must match").isEqualTo(expectedIn.toString());
+
+          StringStartsWith startsWith = StringStartsWith.apply(quoted, "a");
+          Expression expectedStartsWith = Expressions.startsWith(unquoted, "a");
+          Expression actualStartsWith = SparkFilters.convert(startsWith);
+          assertThat(actualStartsWith)
+              .asString()
+              .as("StringStartsWith must match")
+              .isEqualTo(expectedStartsWith.toString());
         });
   }
 


### PR DESCRIPTION
`TestSparkFilters` has unit tests for Spark filter to Iceberg expression conversions, but misses testing for Spark's `StringStartsWith` filter that translates to Iceberg's `STARTS_WITH` expression. This PR adds that.