### PR TITLE
docs: flink: Fix updated link

### DIFF
--- a/docs/docs/flink.md
+++ b/docs/docs/flink.md
@@ -37,7 +37,7 @@ Apache Iceberg supports both [Apache Flink](https://flink.apache.org/)'s DataStr
 | [DataStream append](flink-writes.md#appending-data)                    | ✔️ ️  |                                                                                        |
 | [DataStream overwrite](flink-writes.md#overwrite-data)                 | ✔️ ️  |                                                                                        |
 | [Metadata tables](flink-queries.md#inspecting-tables)                    | ✔️    |                                                                                        |
-| [Rewrite files action](flink-actions.md#rewrite-files-action)           | ✔️ ️  |                                                                                        |
+| [Rewrite files action](flink-maintenance.md#rewrite-files-action)           | ✔️ ️  |                                                                                        |
 
 ## Preparation when using Flink SQL Client
 


### PR DESCRIPTION
`flink-actions.md` got renamed to `flink-maintenance.md` in https://github.com/apache/iceberg/commit/2df7dc760a63622c0ecd884155e471b27989191d

https://github.com/apache/iceberg/blob/main/docs/docs/flink-maintenance.md

cc @manuzhang 