### PR TITLE
Test: Avoid running redundant tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -259,6 +259,7 @@ public abstract class DeleteFileIndexTestBase<
 
   @TestTemplate
   public void testUnpartitionedTableScan() throws IOException {
+    assumeThat(formatVersion).as("Requires V2 position deletes").isEqualTo(2);
     Table unpartitioned =
         TestTables.create(tableDir, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), 2);
 
@@ -450,6 +451,7 @@ public abstract class DeleteFileIndexTestBase<
 
   @TestTemplate
   public void testUnpartitionedTableSequenceNumbers() throws IOException {
+    assumeThat(formatVersion).as("Requires V2 position deletes").isEqualTo(2);
     Table unpartitioned =
         TestTables.create(tableDir, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), 2);
 


### PR DESCRIPTION
We don't need to run this test 3 times (v2, v3, v4) with `@TestTemplate` because it always uses v2:
```java
TestTables.create(tableDir, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), 2);
```
