### PR TITLE
Flink: Fix flaky tests for Iceberg sink

### DIFF
--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -323,7 +323,11 @@ public class SimpleDataUtil {
     Snapshot snapshot = latestSnapshot(table, branch);
 
     if (snapshot == null) {
-      assertThat(expected).isEmpty();
+      assertThat(expected)
+          .as(
+              "No snapshot for table '%s', assuming expected data is empty. If that's not the case, the Flink job most likely did not checkpoint.",
+              table.name())
+          .isEmpty();
       return;
     }
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
@@ -134,7 +134,7 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
 
     List<Row> leftRows = createRows("left-");
     DataStream<Row> leftStream =
-        env.fromCollection(leftRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(leftRows), ROW_TYPE_INFO)
             .name("leftCustomSource")
             .uid("leftCustomSource");
     if (isTableSchema) {
@@ -157,7 +157,7 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
 
     List<Row> rightRows = createRows("right-");
     DataStream<Row> rightStream =
-        env.fromCollection(rightRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(rightRows), ROW_TYPE_INFO)
             .name("rightCustomSource")
             .uid("rightCustomSource");
     if (isTableSchema) {

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
@@ -236,7 +236,7 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
 
     List<Row> leftRows = createRows("left-");
     DataStream<Row> leftStream =
-        env.fromCollection(leftRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(leftRows), ROW_TYPE_INFO)
             .name("leftCustomSource")
             .uid("leftCustomSource");
 
@@ -260,7 +260,7 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
 
     List<Row> rightRows = createRows("right-");
     DataStream<Row> rightStream =
-        env.fromCollection(rightRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(rightRows), ROW_TYPE_INFO)
             .name("rightCustomSource")
             .uid("rightCustomSource");
 


### PR DESCRIPTION
The tests https://github.com/apache/iceberg/blob/720ef99720a1c59e4670db983c951243dffc4f3e/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java#L98 and https://github.com/apache/iceberg/blob/720ef99720a1c59e4670db983c951243dffc4f3e/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java#L200 are often flaky, especially in the context of parallel test execution in #13675 where it almost always fails.

The reason is that it uses a bounded source (`env.fromCollection(..)`) which does not wait for a checkpoint to get triggered before shutting down. If no checkpoint gets triggered before the job shuts down, no Iceberg snapshot gets created for the test table and it remains empty. The test then fails with the following exception:

```
TestIcebergSink > testTwoSinksInDisjointedDAG() > format=AVRO, parallelism=1, partitioned=true, isTableSchema=true FAILED
    java.lang.AssertionError: 
    Expecting empty but was: [Record(1, right-aaa),
        Record(1, right-bbb),
        Record(1, right-ccc),
        Record(2, right-aaa),
        Record(2, right-bbb),
        Record(2, right-ccc),
        Record(3, right-aaa),
        Record(3, right-bbb),
        Record(3, right-ccc)]
        at org.apache.iceberg.flink.SimpleDataUtil.assertTableRecords(SimpleDataUtil.java:326)
        at org.apache.iceberg.flink.SimpleDataUtil.assertTableRows(SimpleDataUtil.java:264)
        at org.apache.iceberg.flink.sink.TestIcebergSink.testTwoSinksInDisjointedDAG(TestIcebergSink.java:295)
```

The exception is slightly misleading, which is why I'm changing the assert description alongside with the flaky test. The test has been tested also with #13675.