### PR TITLE
docs: Add link to BladePipe

### DIFF
--- a/site/nav.yml
+++ b/site/nav.yml
@@ -63,7 +63,7 @@ nav:
         - Apache Amoro: integrations/amoro.md
         - Apache Doris: https://doris.apache.org/docs/dev/lakehouse/catalogs/iceberg-catalog
         - Apache Druid: https://druid.apache.org/docs/latest/development/extensions-contrib/iceberg/
-        - BladePipe: https://www.bladepipe.com/
+        - BladePipe: https://www.bladepipe.com/docs/dataMigrationAndSync/datasource_func/Iceberg/props_for_iceberg_ds
         - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
         - Daft: integrations/daft.md
         - Databend: https://docs.databend.com/guides/access-data-lake/iceberg


### PR DESCRIPTION
Follow up on https://github.com/apache/iceberg/pull/14033

I thought the BladePipe website was down, but it is only the images that are used on the website. Instead, I think it is better to just add the link to the website.