### PR TITLE
Flink: Backport #14044: Fix flaky tests for Iceberg sink

### DIFF
--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -323,7 +323,11 @@ public class SimpleDataUtil {
     Snapshot snapshot = latestSnapshot(table, branch);
 
     if (snapshot == null) {
-      assertThat(expected).isEmpty();
+      assertThat(expected)
+          .as(
+              "No snapshot for table '%s', assuming expected data is empty. If that's not the case, the Flink job most likely did not checkpoint.",
+              table.name())
+          .isEmpty();
       return;
     }
 

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
@@ -134,7 +134,7 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
 
     List<Row> leftRows = createRows("left-");
     DataStream<Row> leftStream =
-        env.fromCollection(leftRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(leftRows), ROW_TYPE_INFO)
             .name("leftCustomSource")
             .uid("leftCustomSource");
     if (isTableSchema) {
@@ -157,7 +157,7 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
 
     List<Row> rightRows = createRows("right-");
     DataStream<Row> rightStream =
-        env.fromCollection(rightRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(rightRows), ROW_TYPE_INFO)
             .name("rightCustomSource")
             .uid("rightCustomSource");
     if (isTableSchema) {

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
@@ -236,7 +236,7 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
 
     List<Row> leftRows = createRows("left-");
     DataStream<Row> leftStream =
-        env.fromCollection(leftRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(leftRows), ROW_TYPE_INFO)
             .name("leftCustomSource")
             .uid("leftCustomSource");
 
@@ -260,7 +260,7 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
 
     List<Row> rightRows = createRows("right-");
     DataStream<Row> rightStream =
-        env.fromCollection(rightRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(rightRows), ROW_TYPE_INFO)
             .name("rightCustomSource")
             .uid("rightCustomSource");
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -323,7 +323,11 @@ public class SimpleDataUtil {
     Snapshot snapshot = latestSnapshot(table, branch);
 
     if (snapshot == null) {
-      assertThat(expected).isEmpty();
+      assertThat(expected)
+          .as(
+              "No snapshot for table '%s', assuming expected data is empty. If that's not the case, the Flink job most likely did not checkpoint.",
+              table.name())
+          .isEmpty();
       return;
     }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkExtended.java
@@ -134,7 +134,7 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
 
     List<Row> leftRows = createRows("left-");
     DataStream<Row> leftStream =
-        env.fromCollection(leftRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(leftRows), ROW_TYPE_INFO)
             .name("leftCustomSource")
             .uid("leftCustomSource");
     if (isTableSchema) {
@@ -157,7 +157,7 @@ public class TestFlinkIcebergSinkExtended extends TestFlinkIcebergSinkBase {
 
     List<Row> rightRows = createRows("right-");
     DataStream<Row> rightStream =
-        env.fromCollection(rightRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(rightRows), ROW_TYPE_INFO)
             .name("rightCustomSource")
             .uid("rightCustomSource");
     if (isTableSchema) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSink.java
@@ -236,7 +236,7 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
 
     List<Row> leftRows = createRows("left-");
     DataStream<Row> leftStream =
-        env.fromCollection(leftRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(leftRows), ROW_TYPE_INFO)
             .name("leftCustomSource")
             .uid("leftCustomSource");
 
@@ -260,7 +260,7 @@ public class TestIcebergSink extends TestFlinkIcebergSinkBase {
 
     List<Row> rightRows = createRows("right-");
     DataStream<Row> rightStream =
-        env.fromCollection(rightRows, ROW_TYPE_INFO)
+        env.addSource(createBoundedSource(rightRows), ROW_TYPE_INFO)
             .name("rightCustomSource")
             .uid("rightCustomSource");
 


### PR DESCRIPTION
This is a clean backport of #14044.