### PR TITLE
Core: Added {} and null support for default values within SchemaParser

### DIFF
--- a/api/src/main/java/org/apache/iceberg/EmptyStructLike.java
+++ b/api/src/main/java/org/apache/iceberg/EmptyStructLike.java
@@ -20,13 +20,13 @@ package org.apache.iceberg;
 
 import java.io.Serializable;
 
-class EmptyStructLike implements StructLike, Serializable {
+public class EmptyStructLike implements StructLike, Serializable {
 
   private static final EmptyStructLike INSTANCE = new EmptyStructLike();
 
   private EmptyStructLike() {}
 
-  static EmptyStructLike get() {
+  public static EmptyStructLike get() {
     return INSTANCE;
   }
 

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -49,7 +49,7 @@ import org.apache.iceberg.types.Types.StructType;
  * The schema of a data table.
  *
  * <p>Schema ID will only be populated when reading from/writing to table metadata, otherwise it
- * will be default to 0.
+ * will default to 0.
  */
 public class Schema implements Serializable {
   private static final Joiner NEWLINE = Joiner.on('\n');

--- a/api/src/main/java/org/apache/iceberg/expressions/Literal.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literal.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.UUID;
+import org.apache.iceberg.EmptyStructLike;
 import org.apache.iceberg.types.Type;
 
 /**
@@ -69,6 +70,10 @@ public interface Literal<T> extends Serializable {
 
   static Literal<BigDecimal> of(BigDecimal value) {
     return new Literals.DecimalLiteral(value);
+  }
+
+  static Literal<EmptyStructLike> of(EmptyStructLike value) {
+    return new Literals.EmptyStructLiteral(value);
   }
 
   /** Returns the value wrapped by this literal. */

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -883,7 +883,7 @@ public class Types {
     }
 
     private static Literal<?> castDefault(Literal<?> defaultValue, Type type) {
-      if (type.isNestedType() && defaultValue != null) {
+      if (type.isNestedType() && !type.isStructType() && defaultValue != null) {
         throw new IllegalArgumentException(
             String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
       } else if (defaultValue != null) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.util.UUID;
+import org.apache.iceberg.EmptyStructLike;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,7 @@ public class TestLiteralSerialization {
           Literal.of(new byte[] {1, 2, 3}).to(Types.FixedType.ofLength(3)),
           Literal.of(new byte[] {3, 4, 5, 6}).to(Types.BinaryType.get()),
           Literal.of(new BigDecimal("122.50")),
+          Literal.of(EmptyStructLike.get()),
         };
 
     for (Literal<?> lit : literals) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestMiscLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestMiscLiteralConversions.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import org.apache.iceberg.EmptyStructLike;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -125,7 +126,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -141,7 +143,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -152,7 +155,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -171,7 +175,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -190,7 +195,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -211,7 +217,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -232,7 +239,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -249,7 +257,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -266,7 +275,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -287,7 +297,8 @@ public class TestMiscLiteralConversions {
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -302,7 +313,8 @@ public class TestMiscLiteralConversions {
         Types.FloatType.get(),
         Types.DoubleType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -323,7 +335,8 @@ public class TestMiscLiteralConversions {
         Types.DecimalType.of(9, 2),
         Types.StringType.get(),
         Types.FixedType.ofLength(1),
-        Types.BinaryType.get());
+        Types.BinaryType.get(),
+        Types.StructType.of());
   }
 
   @Test
@@ -344,7 +357,8 @@ public class TestMiscLiteralConversions {
         Types.DecimalType.of(9, 2),
         Types.StringType.get(),
         Types.UUIDType.get(),
-        Types.FixedType.ofLength(1));
+        Types.FixedType.ofLength(1),
+        Types.StructType.of());
   }
 
   @Test
@@ -365,7 +379,30 @@ public class TestMiscLiteralConversions {
         Types.DecimalType.of(9, 2),
         Types.StringType.get(),
         Types.UUIDType.get(),
-        Types.FixedType.ofLength(1));
+        Types.FixedType.ofLength(1),
+        Types.StructType.of());
+  }
+
+  @Test
+  public void testInvalidEmptyStructConversions() {
+    testInvalidConversions(
+        Literal.of(EmptyStructLike.get()),
+        Types.BooleanType.get(),
+        Types.IntegerType.get(),
+        Types.LongType.get(),
+        Types.FloatType.get(),
+        Types.DoubleType.get(),
+        Types.DateType.get(),
+        Types.TimeType.get(),
+        Types.TimestampType.withZone(),
+        Types.TimestampType.withoutZone(),
+        Types.TimestampNanoType.withoutZone(),
+        Types.TimestampNanoType.withZone(),
+        Types.DecimalType.of(9, 2),
+        Types.StringType.get(),
+        Types.UUIDType.get(),
+        Types.FixedType.ofLength(1),
+        Types.BinaryType.get());
   }
 
   private void testInvalidConversions(Literal<?> lit, Type... invalidTypes) {

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -196,18 +196,26 @@ public class SchemaParser {
   }
 
   private static Literal<?> defaultFromJson(String defaultField, Type type, JsonNode json) {
-    if (json.has(defaultField)) {
-      Object value = SingleValueParser.fromJson(type, json.get(defaultField));
-      if (type instanceof Types.TimestampNanoType) {
-        // Call Expressions.nanos instead of Expressions.lit to prevent overflow
-        // https://github.com/apache/iceberg/issues/13160
-        return Expressions.nanos((long) value);
-      }
-
-      return Expressions.lit(value);
+    JsonNode defaultValue = json.get(defaultField);
+    if (defaultValue == null || defaultValue.isNull()) {
+      return null;
     }
 
-    return null;
+    // Always parse non-null default values from json to ensure types match up
+    Object javaDefaultValue = SingleValueParser.fromJson(type, defaultValue);
+    if (type instanceof Types.TimestampNanoType) {
+      // Call Expressions.nanos instead of Expressions.lit to prevent overflow
+      // https://github.com/apache/iceberg/issues/13160
+      return Expressions.nanos((long) javaDefaultValue);
+    }
+
+    if (type.isStructType()) {
+      Preconditions.checkArgument(
+          defaultValue.isEmpty(), "Cannot parse non-empty struct default value: %s", defaultValue);
+      return Expressions.lit(EmptyStructLike.get());
+    }
+
+    return Expressions.lit(javaDefaultValue);
   }
 
   private static Types.NestedField.Builder fieldBuilder(boolean isRequired, String name) {

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -21,10 +21,12 @@ package org.apache.iceberg;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.iceberg.data.DataTestBase;
@@ -154,5 +156,92 @@ public class TestSchemaParser extends DataTestBase {
         .isEqualTo(defaultValue.value());
     assertThat(serialized.findField("col_with_default").writeDefault())
         .isEqualTo(defaultValue.value());
+  }
+
+  @Test
+  public void testNullDefaultValueParsing() {
+    String schemaAsJson =
+        "{"
+            + "  \"type\" : \"struct\","
+            + "  \"schema-id\" : 0,"
+            + "  \"fields\" : [ {"
+            + "    \"id\" : 1,"
+            + "    \"name\" : \"id\","
+            + "    \"required\" : true,"
+            + "    \"type\" : \"long\""
+            + "  }, {"
+            + "    \"id\" : 2,"
+            + "    \"name\" : \"col_with_no_default\","
+            + "    \"required\" : true,"
+            + "    \"type\" : \"string\","
+            + "    \"initial-default\" : null,"
+            + "    \"write-default\" : null"
+            + "  } ]"
+            + "}";
+
+    Schema serialized = SchemaParser.fromJson(schemaAsJson);
+    assertThat(serialized.findField("col_with_no_default").initialDefault()).isNull();
+    assertThat(serialized.findField("col_with_no_default").writeDefault()).isNull();
+  }
+
+  @Test
+  public void testEmptyStructDefaultValueParsing() {
+    Types.NestedField xField =
+        Types.NestedField.optional("x")
+            .ofType(new Types.IntegerType())
+            .withId(3)
+            .withWriteDefault(Literal.of(1))
+            .build();
+
+    Types.NestedField yField =
+        Types.NestedField.optional("y")
+            .ofType(new Types.IntegerType())
+            .withId(2)
+            .withWriteDefault(Literal.of(2))
+            .build();
+
+    Types.NestedField structType =
+        Types.NestedField.optional("point")
+            .ofType(Types.StructType.of(List.of(xField, yField)))
+            .withId(1)
+            .withInitialDefault(Literal.of(EmptyStructLike.get()))
+            .withWriteDefault(Literal.of(EmptyStructLike.get()))
+            .build();
+
+    Schema schema = new Schema(structType);
+    String schemaAsJson = SchemaParser.toJson(schema);
+    assertThat(schemaAsJson).contains("\"initial-default\":{}").contains("\"write-default\":{}");
+
+    Schema serialized = SchemaParser.fromJson(schemaAsJson);
+    assertThat(serialized.findField("point").initialDefault()).isEqualTo(EmptyStructLike.get());
+    assertThat(serialized.findField("point").writeDefault()).isEqualTo(EmptyStructLike.get());
+  }
+
+  @Test
+  public void testNonEmptyStructDefaultValueParsing() {
+    String invalidSchemaAsJson =
+        "{\"type\":\"struct\",\"schema-id\":0,\"fields\":["
+            + "{\"id\":1,\"name\":\"partialPoint\",\"required\":false,\"type\":{\"type\":\"struct\",\"fields\":"
+            + "[{\"id\":2,\"name\":\"x\",\"required\":false,\"type\":\"int\"}]},"
+            // invalid nonEmpty struct default set here
+            + "\"initial-default\":{\"2\": 2},\"write-default\":null}]}";
+
+    assertThatThrownBy(() -> SchemaParser.fromJson(invalidSchemaAsJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot parse non-empty struct default value: {\"2\":2}");
+  }
+
+  @Test
+  public void testInvalidStructDefaultValueParsing() {
+    String invalidSchemaAsJson =
+        "{\"type\":\"struct\",\"schema-id\":0,\"fields\":["
+            + "{\"id\":1,\"name\":\"partialPoint\",\"required\":false,\"type\":{\"type\":\"struct\",\"fields\":"
+            + "[{\"id\":2,\"name\":\"x\",\"required\":false,\"type\":\"int\"}]},"
+            // invalid default type (boolean) set here
+            + "\"initial-default\":null,\"write-default\":true}]}";
+
+    assertThatThrownBy(() -> SchemaParser.fromJson(invalidSchemaAsJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot parse default as a struct<2: x: optional int> value: true");
   }
 }


### PR DESCRIPTION
### Overview
`SchemaParser` does not support parsing schema's default values containing `{}` (structs) or explicit `null`s (any supported data type).  From the [spec](https://iceberg.apache.org/spec/#default-values):
- When an optional field is added, the defaults may be null and should be explicitly set
- The default value of a struct can be either `null` or `{}`

#### Struct Change
This PR adds a new `Literal` for specifically `EmptyStructLike` to represent `{}` values.  I reused the existing `EmptyStructLike`, but made it public which will expose to the class to consumers of `iceberg-api` and by extension `iceberg-core`.

I did not tether the Literal to the generic `StructLike` interface as:
- A non-empty StructLike Literal has no functional use at the moment.
- A non-empty StructLike Literal seemed riskier for potential side effects, given Literal is used outside of default values.
- Determining if a StructLike is empty appeared to require a recursive search for non-null values, which is unnecessary complexity.

I did not add conversions between String / EmptyStructLike `Literal`s as that conversion is unrelated to this PR and _probably_ undesired.

#### Null Change
This PR is leaving existing behavior around nulls default values for Schema -> JSON parsing.  A small refactor was done to support null default values in metadata.json files when parsing JSON -> Schema.  

Additional changes (if needed) around Schema -> JSON parsing can be done in another PR.

### Asides
- Assumed `boolean supportsDefaultValues()` method of `DataTestBase` is N/A for `TestSchemaParser` as the underlying implementation defers to a `writeAndValidate` method.  My changes are unrelated to writing the actual default data.
- Assuming the goal of `{}` is for a writer engine to be able to determine if a default struct value is null or Empty.  I.e. using `EmptyStructType` as a flag for this scenario, so writers can react appropriately.
- Related thread on [slack](https://apache-iceberg.slack.com/archives/C03LG1D563F/p1754414031608039)