### PR TITLE
Flink: Adds uid-suffix write option to prevent operator UID hash collisions

### DIFF
--- a/docs/docs/flink-configuration.md
+++ b/docs/docs/flink-configuration.md
@@ -159,6 +159,7 @@ INSERT INTO tableName /*+ OPTIONS('upsert-enabled'='true') */
 | compression-level                       | Table write.(fileformat).compression-level | Overrides this table's compression level for Parquet and Avro tables for this write                                                             |
 | compression-strategy                    | Table write.orc.compression-strategy       | Overrides this table's compression strategy for ORC tables for this write                                                                       |
 | write-parallelism                       | Upstream operator parallelism              | Overrides the writer parallelism                                                                                                                |
+| uid-suffix                              | As per table property                      | Overrides the uid suffix used in the underlying IcebergSink for this table                                                                      |
 
 #### Range distribution statistics type
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -209,7 +209,11 @@ public class FlinkWriteConf {
   }
 
   public String uidSuffix() {
-    return confParser.stringConf().option(FlinkWriteOptions.UID_SUFFIX.key()).parseOptional();
+    return confParser
+        .stringConf()
+        .option(FlinkWriteOptions.UID_SUFFIX.key())
+        .defaultValue(FlinkWriteOptions.UID_SUFFIX.defaultValue())
+        .parse();
   }
 
   public Integer writeParallelism() {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -208,6 +208,10 @@ public class FlinkWriteConf {
         .parse();
   }
 
+  public String uidSuffix() {
+    return confParser.stringConf().option(FlinkWriteOptions.UID_SUFFIX.key()).parseOptional();
+  }
+
   public Integer writeParallelism() {
     return confParser.intConf().option(FlinkWriteOptions.WRITE_PARALLELISM.key()).parseOptional();
   }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -90,5 +90,5 @@ public class FlinkWriteOptions {
 
   //  specify the uidSuffix to be used for the underlying IcebergSink
   public static final ConfigOption<String> UID_SUFFIX =
-      ConfigOptions.key("uid-suffix").stringType().noDefaultValue();
+      ConfigOptions.key("uid-suffix").stringType().defaultValue("");
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -87,4 +87,8 @@ public class FlinkWriteOptions {
   @Experimental
   public static final ConfigOption<Duration> TABLE_REFRESH_INTERVAL =
       ConfigOptions.key("table-refresh-interval").durationType().noDefaultValue();
+
+  //  specify the uidSuffix to be used for the underlying IcebergSink
+  public static final ConfigOption<String> UID_SUFFIX =
+      ConfigOptions.key("uid-suffix").stringType().noDefaultValue();
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -663,9 +663,13 @@ public class IcebergSink
           }
         }
       }
-
       FlinkMaintenanceConfig flinkMaintenanceConfig =
           new FlinkMaintenanceConfig(table, writeOptions, readableConfig);
+
+      if (flinkWriteConf.uidSuffix() != null) {
+        uidSuffix = flinkWriteConf.uidSuffix();
+      }
+
       return new IcebergSink(
           tableLoader,
           table,

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -321,7 +321,6 @@ public class IcebergSink
 
   public static class Builder implements IcebergSinkBuilder<Builder> {
     private TableLoader tableLoader;
-    private String uidSuffix = "";
     private Function<String, DataStream<RowData>> inputCreator = null;
     @Deprecated private TableSchema tableSchema;
     private ResolvedSchema resolvedSchema;
@@ -597,7 +596,7 @@ public class IcebergSink
      * @return {@link Builder} to connect the iceberg table.
      */
     public Builder uidSuffix(String newSuffix) {
-      this.uidSuffix = newSuffix;
+      writeOptions.put(FlinkWriteOptions.UID_SUFFIX.key(), newSuffix);
       return this;
     }
 
@@ -667,15 +666,11 @@ public class IcebergSink
       FlinkMaintenanceConfig flinkMaintenanceConfig =
           new FlinkMaintenanceConfig(table, writeOptions, readableConfig);
 
-      if (flinkWriteConf.uidSuffix() != null) {
-        uidSuffix = flinkWriteConf.uidSuffix();
-      }
-
       return new IcebergSink(
           tableLoader,
           table,
           snapshotSummary,
-          uidSuffix,
+          flinkWriteConf.uidSuffix(),
           SinkUtil.writeProperties(flinkWriteConf.dataFileFormat(), flinkWriteConf, table),
           resolvedSchema != null
               ? toFlinkRowType(table.schema(), resolvedSchema)
@@ -696,7 +691,7 @@ public class IcebergSink
     @Override
     public DataStreamSink<RowData> append() {
       IcebergSink sink = build();
-      String suffix = defaultSuffix(uidSuffix, table.name());
+      String suffix = defaultSuffix(sink.uidSuffix, table.name());
       DataStream<RowData> rowDataInput = inputCreator.apply(suffix);
       // Please note that V2 sink framework will apply the uid here to the framework created
       // operators like writer,

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -663,6 +663,7 @@ public class IcebergSink
           }
         }
       }
+
       FlinkMaintenanceConfig flinkMaintenanceConfig =
           new FlinkMaintenanceConfig(table, writeOptions, readableConfig);
 


### PR DESCRIPTION
Introduces a new 'uid-suffix' Flink write option that allows customizing the IcebergSink operator UID suffix.

This is particularly useful for statement sets with multiple INSERT operations targeting the same table. In the `IcebergSink` implementation, we were currently specifying a default UID suffix using the table's name, which led to hash collisions when multiple instances of IcebergSink attempted to register themselves in different DAGs.