### PR TITLE
fix: NPE with V1 Manifests without existing_rows_count in V3 Tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -101,9 +101,9 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
         return wrapper.wrap(manifest, null);
       } else {
         Preconditions.checkState(
-                manifest.existingRowsCount() != null && manifest.addedRowsCount() != null,
-                "Cannot include manifest with missing existing or added rows count to a Table with row lineage enabled. Manifest path: %s",
-                manifest.path());
+            manifest.existingRowsCount() != null && manifest.addedRowsCount() != null,
+            "Cannot include manifest with missing existing or added rows count to a Table with row lineage enabled. Manifest path: %s",
+            manifest.path());
         // assign first-row-id and update the next to assign
         wrapper.wrap(manifest, nextRowId);
         // leave space for existing and added rows, in case any of the existing data files do not
@@ -163,9 +163,9 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
         return wrapper.wrap(manifest, null);
       } else {
         Preconditions.checkState(
-                manifest.existingRowsCount() != null && manifest.addedRowsCount() != null,
-                "Cannot include v1 manifest with missing existing or added rows count to a Table with row lineage enabled. Manifest path: %s",
-                manifest.path());
+            manifest.existingRowsCount() != null && manifest.addedRowsCount() != null,
+            "Cannot include v1 manifest with missing existing or added rows count to a Table with row lineage enabled. Manifest path: %s",
+            manifest.path());
         // assign first-row-id and update the next to assign
         wrapper.wrap(manifest, nextRowId);
         // leave space for existing and added rows, in case any of the existing data files do not


### PR DESCRIPTION
While implementing V3 support in Rust, I noticed an unhandled case in Java, which, Java beeing Java, can lead to a NPE.

In V1 tables, `existing_rows_count` and `added_rows_count` is optional. When parsed into a `GenericManifestFile`, it is thus [parsed as optional](https://github.com/apache/iceberg/blob/723d0998d69f254822efd6f8939e71c0723aaab2/core/src/main/java/org/apache/iceberg/ManifestFileParser.java#L121).

When this (data) manifest is now added to a new Snapshot in a V3 table, we prepare the manifest:
https://github.com/apache/iceberg/blob/723d0998d69f254822efd6f8939e71c0723aaab2/core/src/main/java/org/apache/iceberg/ManifestListWriter.java#L158-L166

The if condition doesn't match, as `firstRowId` is also null for V1 Manifests.
In the else clause we inevitably hit `this.nextRowId += manifest.existingRowsCount() + manifest.addedRowsCount();`, where both summands can be null, hence leading to a NPE.

I talked with @RussellSpitzer, and we believe the proper thing to do here is to throw an exception, which this PR implements.
