### PR TITLE
API,Spark: fix broken metadata table when a column named 'partition' is also the partition key

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -400,6 +400,12 @@ public class PartitionSpec implements Serializable {
     private void checkAndAddPartitionName(String name, Integer sourceColumnId) {
       Types.NestedField schemaField =
           this.caseSensitive ? schema.findField(name) : schema.caseInsensitiveFindField(name);
+      // corner case: extra partition column in metadata table
+      if (name.equalsIgnoreCase("partition") && null!= schemaField && schemaField.fieldId() > 1000) {
+        schemaField =
+                this.caseSensitive ? schema.findField("partition.partition") :
+                        schema.caseInsensitiveFindField("partition.partition");
+      }
       if (checkConflicts) {
         if (sourceColumnId != null) {
           // for identity transform case we allow conflicts between partition and schema field name

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -400,10 +400,10 @@ public class PartitionSpec implements Serializable {
     private void checkAndAddPartitionName(String name, Integer sourceColumnId) {
       Types.NestedField schemaField =
           this.caseSensitive ? schema.findField(name) : schema.caseInsensitiveFindField(name);
-      // corner case: extra partition column in metadata table
+      // corner case: extra partition column in metadata table and whose field id is extremely large
       if (null != schemaField
           && schemaField.name().equals("partition")
-          && schemaField.fieldId() > 1000) {
+          && schemaField.fieldId() > 2000) {
         schemaField = schema.findField("partition.partition");
       }
       if (checkConflicts) {

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -401,10 +401,10 @@ public class PartitionSpec implements Serializable {
       Types.NestedField schemaField =
           this.caseSensitive ? schema.findField(name) : schema.caseInsensitiveFindField(name);
       // corner case: extra partition column in metadata table
-      if (name.equalsIgnoreCase("partition") && null!= schemaField && schemaField.fieldId() > 1000) {
-        schemaField =
-                this.caseSensitive ? schema.findField("partition.partition") :
-                        schema.caseInsensitiveFindField("partition.partition");
+      if (null != schemaField
+          && schemaField.name().equals("partition")
+          && schemaField.fieldId() > 1000) {
+        schemaField = schema.findField("partition.partition");
       }
       if (checkConflicts) {
         if (sourceColumnId != null) {

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -265,6 +265,22 @@ public class TestMetadataTables extends ExtensionsTestBase {
         .containsExactlyElementsOf(expectedRows);
   }
 
+  // test when an iceberg table has a column named partition as the partition key
+  @TestTemplate
+  public void testPositionDeletesTableWithPartColNamedPartition() throws Exception {
+    sql(
+        "CREATE TABLE %s (id int, partition int) USING iceberg PARTITIONED BY (partition) TBLPROPERTIES"
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
+
+    sql("INSERT INTO TABLE %s VALUES (1,1),(2,1),(3,2),(4,2)", tableName);
+
+    sql("DELETE FROM %s WHERE id=1", tableName);
+
+    // check position_deletes table
+    assertThat(sql("SELECT * FROM %s.position_deletes", tableName)).hasSize(1);
+  }
+
   @TestTemplate
   public void testPartitionedTable() throws Exception {
     sql(


### PR DESCRIPTION
with the sql :


```sql
-- ddl
create table db.tst (id int, partition int) USING iceberg PARTITIONED BY (partition) 
TBLPROPERTIES ( 'format-version' = '2', 'write.delete.mode' = 'merge-on-read');
--data initialized
insert into db.tst values (1, 1), (2, 1), (3, 2), (2, 2) ;
--position delete
update db.tst set partition=2 where id=1 ;
--check metadata table but broken before this
select * from db.tst.position_deletes ;
```
the metadata table `db.tst.position_deletes`  is broken under the function `checkAndAddPartitionName`,
since the schema is:
```
schema: table {
  2147483546: file_path: required string (Path of a file in which a deleted row is stored)
  2147483545: pos: required long (Ordinal position of a deleted row in the data file)
  2147483544: row: optional struct<1: id: optional int, 2: partition: optional int> (Deleted row values)
  2147483642: partition: required struct<3: partition: optional int> (Partition that position delete row belongs to)
  2147483643: spec_id: required int (Spec ID used to track the file containing a row)
  2147483646: delete_file_path: required string (Path of the file in which a row is stored)
}
```
we can use fieldID to find the true column ID and fix this problem.

related issue: 
https://github.com/apache/iceberg/issues/14056 
