### PR TITLE
Max Inferred columns should consider Sort order columns first

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -90,7 +90,7 @@ public abstract class TestMetrics {
           required(1, "intCol", IntegerType.get()),
           required(2, "nestedStructCol", NESTED_STRUCT_TYPE));
 
-  private static final Schema SIMPLE_SCHEMA =
+  static final Schema SIMPLE_SCHEMA =
       new Schema(
           optional(1, "booleanCol", BooleanType.get()),
           required(2, "intCol", IntegerType.get()),


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/13914

Max Inferred columns limit does not take sort order columns and columns configured explicitly using `write.metadata.metrics.column.` into account. This PR addresses the same and process the columns in the following order:

1. sort order
2. columns configured explicitly 
3. remaining columns in the schema

In case max limit reached at any above step, it doesn't proceed further and return only the columns collected so far.