### PR TITLE
FLINK: clear globalStatisticsState and only keep the state of subtask 0 to avoid duplication

### DIFF
--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
@@ -204,9 +204,9 @@ public class DataStatisticsOperator extends AbstractStreamOperator<StatisticsOrR
 
     // Only subtask 0 saves the state so that globalStatisticsState(UnionListState) stores
     // an exact copy of globalStatistics
+    globalStatisticsState.clear();
     if (globalStatistics != null
         && getRuntimeContext().getTaskInfo().getIndexOfThisSubtask() == 0) {
-      globalStatisticsState.clear();
       LOG.info(
           "Operator {} subtask {} saving global statistics to state", operatorName, subtaskIndex);
       globalStatisticsState.add(globalStatistics);

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
@@ -204,9 +204,9 @@ public class DataStatisticsOperator extends AbstractStreamOperator<StatisticsOrR
 
     // Only subtask 0 saves the state so that globalStatisticsState(UnionListState) stores
     // an exact copy of globalStatistics
+    globalStatisticsState.clear();
     if (globalStatistics != null
         && getRuntimeContext().getTaskInfo().getIndexOfThisSubtask() == 0) {
-      globalStatisticsState.clear();
       LOG.info(
           "Operator {} subtask {} saving global statistics to state", operatorName, subtaskIndex);
       globalStatisticsState.add(globalStatistics);

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
@@ -207,9 +207,9 @@ public class DataStatisticsOperator extends AbstractStreamOperator<StatisticsOrR
 
     // Only subtask 0 saves the state so that globalStatisticsState(UnionListState) stores
     // an exact copy of globalStatistics
+    globalStatisticsState.clear();
     if (globalStatistics != null
         && getRuntimeContext().getTaskInfo().getIndexOfThisSubtask() == 0) {
-      globalStatisticsState.clear();
       LOG.info(
           "Operator {} subtask {} saving global statistics to state", operatorName, subtaskIndex);
       globalStatisticsState.add(globalStatistics);


### PR DESCRIPTION
When using range distribution mode, after a few cycles of running, stopping with a savepoint, and then restarting from that savepoint, the range shuffle operator eventually gets stuck in the INITIALIZING state. 

The root cause is that the globalStatisticsState of all subtasks except subtask 0 is not cleared.

fix  #14079