### PR TITLE
Core: Avoid removing reused metadata file when registerTable fails

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -152,7 +152,7 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
       }
     } finally {
       try {
-        if (commitStatus == CommitStatus.FAILURE) {
+        if (commitStatus == CommitStatus.FAILURE && !reuseMetadataLocation(newTable, metadata)) {
           // if anything went wrong, clean up the uncommitted metadata file
           io().deleteFile(newMetadataLocation);
         }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import org.apache.iceberg.BaseMetastoreOperations.CommitStatus;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -146,9 +145,13 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
   }
 
   protected String writeNewMetadataIfRequired(boolean newTable, TableMetadata metadata) {
-    return newTable && metadata.metadataFileLocation() != null
+    return reuseMetadataLocation(newTable, metadata)
         ? metadata.metadataFileLocation()
         : writeNewMetadata(metadata, currentVersion() + 1);
+  }
+
+  protected boolean reuseMetadataLocation(boolean newTable, TableMetadata metadata) {
+    return newTable && metadata.metadataFileLocation() != null;
   }
 
   protected String writeNewMetadata(TableMetadata metadata, int newVersion) {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -289,7 +289,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       throw new CommitFailedException(e);
 
     } finally {
-      HiveOperationsBase.cleanupMetadataAndUnlock(io(), commitStatus, newMetadataLocation, lock);
+      if (!reuseMetadataLocation(newTable, metadata)) {
+        HiveOperationsBase.cleanupMetadataAndUnlock(io(), commitStatus, newMetadataLocation, lock);
+      } else {
+        lock.unlock();
+      }
     }
 
     LOG.info(

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -132,7 +132,7 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
       throw NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_TABLE)
           .orElse(ex);
     } finally {
-      if (failure) {
+      if (failure && !reuseMetadataLocation(newTable, metadata)) {
         io().deleteFile(newMetadataLocation);
       }
     }


### PR DESCRIPTION
When executing `registerTable`, some catalog types leverage the existing metadata file of the source table to avoid creating new metadata file. Refer to PR #6591. However, in this scenario, if the `registerTable` operation fails during commit(for example, due to a concurrent transaction that has just created a table with the same target name), it would be problematic to delete the metadata file directly. Since the metadata file is reused from the source table, not newly created.

This PR fixes such problems, only deleting the metadata file if it is not reused from the source table.