### PR TITLE
Site: change default remote name back to origin. otherwise, site CI could fail

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -147,7 +147,7 @@ Deploying the docs is a two-step process:
     ```
  1. Build and push the generated site to the `asf-site` branch of [remote repo](https://github.com/apache/iceberg). This requires committer write permission.
     ```sh
-    # Default remote name is 'apache'
+    # Default remote name is 'origin'
     make deploy
     # Or specify a different remote
     make deploy remote_name=apache

--- a/site/dev/deploy.sh
+++ b/site/dev/deploy.sh
@@ -18,7 +18,7 @@
 
 set -e
 
-remote_name="${1:-apache}"
+remote_name="${1:-origin}"
 
 ./dev/setup_env.sh
 


### PR DESCRIPTION

PR CI was successful. but site CI post merge failed.
https://github.com/apache/iceberg/actions/runs/17750692363