### PR TITLE
[docs] Link “Multi-Engine Support” from Spark Getting Started

### DIFF
--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -24,7 +24,9 @@ The latest version of Iceberg is [{{ icebergVersion }}](../../releases.md).
 
 Spark is currently the most feature-rich compute engine for Iceberg operations.
 We recommend you to get started with Spark to understand Iceberg concepts and features with examples.
-You can also view documentations of using Iceberg with other compute engine under the [Multi-Engine Support](../../multi-engine-support.md) page.
+You can also view documentations of using Iceberg with other compute engine under the
+[Multi-Engine Support page](https://iceberg.apache.org/multi-engine-support/).
+
 
 ## Using Iceberg in Spark 3
 


### PR DESCRIPTION
### What
Turn the plain-text reference to the “Multi-Engine Support” page into a hyperlink
on the Spark Getting Started guide.

### Why
The guide tells readers to see the Multi-Engine Support page but does not link to it.
Adding the link improves navigation and discovery of other engine integrations.

### How
- docs/docs/spark-getting-started.md: add link to
  https://iceberg.apache.org/multi-engine-support/

### Notes
Docs-only change. If a JIRA is preferred, I’m happy to open one.
