### PR TITLE
Core: Allow reading metadata table when scanning table with dropped partition source field

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -80,6 +80,9 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable implements Ser
       int newFieldId = reassignedFields.getOrDefault(field.fieldId(), field.fieldId());
       builder.add(newFieldId, newFieldId, field.name(), Transforms.identity());
     }
+
+    // Enable allowMissingFields for allowing the spec to have missing
+    // source fields in void partition fields
     return builder.build(true);
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -80,7 +80,7 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable implements Ser
       int newFieldId = reassignedFields.getOrDefault(field.fieldId(), field.fieldId());
       builder.add(newFieldId, newFieldId, field.name(), Transforms.identity());
     }
-    return builder.build();
+    return builder.build(true);
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -214,6 +214,22 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
   }
 
   @TestTemplate
+  public void testPartitionSpecEvolutionSourceFieldMissing() throws IOException {
+    // Drop partition field
+    table.updateSpec().removeField("id").commit();
+
+    // Drop the source field
+    table.updateSchema().deleteColumn("id").commit();
+
+    BaseFilesTable filesTable = new AllFilesTable(table);
+    TableScan scan = filesTable.newScan();
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      assertThat(tasks).hasSize(2);
+    }
+  }
+
+  @TestTemplate
   public void testPartitionSpecEvolutionToUnpartitioned() throws IOException {
     // Remove all the partition fields
     table.updateSpec().removeField("id").removeField("nested.id").commit();


### PR DESCRIPTION
To replicate this issue run the following spark queries:
```sql
CREATE TABLE ns.barfoo (dateint INT,hour INT, data STRING) USING iceberg PARTITIONED BY (dateint, hour);
INSERT INTO ns.barfoo (dateint, hour, data) VALUES (20250101, 1, 'a'), (20250102, 1, 'a'), (20250102, 2, 'a');
ALTER TABLE ns.barfoo DROP PARTITION FIELD dateint;
ALTER TABLE ns.barfoo DROP COLUMN dateint;
SELECT * FROM ns.barfoo.files;
```