### PR TITLE
Fix commit idempotence of DynamicIcebergSink

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -631,5 +632,71 @@ abstract class BaseFile<F> extends SupportsIndexProjection
         .add("content_offset", contentOffset == null ? "null" : contentOffset)
         .add("content_size_in_bytes", contentSizeInBytes == null ? "null" : contentSizeInBytes)
         .toString();
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  @Override
+  public boolean equals(Object other) {
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    BaseFile<?> baseFile = (BaseFile<?>) other;
+    return partitionSpecId == baseFile.partitionSpecId
+        && fileSizeInBytes == baseFile.fileSizeInBytes
+        && Objects.equals(partitionType, baseFile.partitionType)
+        && Objects.equals(fileOrdinal, baseFile.fileOrdinal)
+        && Objects.equals(manifestLocation, baseFile.manifestLocation)
+        && content == baseFile.content
+        && Objects.equals(filePath, baseFile.filePath)
+        && format == baseFile.format
+        && Objects.equals(partitionData, baseFile.partitionData)
+        && Objects.equals(recordCount, baseFile.recordCount)
+        && Objects.equals(dataSequenceNumber, baseFile.dataSequenceNumber)
+        && Objects.equals(fileSequenceNumber, baseFile.fileSequenceNumber)
+        && Objects.equals(columnSizes, baseFile.columnSizes)
+        && Objects.equals(valueCounts, baseFile.valueCounts)
+        && Objects.equals(nullValueCounts, baseFile.nullValueCounts)
+        && Objects.equals(nanValueCounts, baseFile.nanValueCounts)
+        && Objects.equals(lowerBounds, baseFile.lowerBounds)
+        && Objects.equals(upperBounds, baseFile.upperBounds)
+        && Objects.deepEquals(splitOffsets, baseFile.splitOffsets)
+        && Objects.deepEquals(equalityIds, baseFile.equalityIds)
+        && Objects.deepEquals(keyMetadata, baseFile.keyMetadata)
+        && Objects.equals(sortOrderId, baseFile.sortOrderId)
+        && Objects.equals(firstRowId, baseFile.firstRowId)
+        && Objects.equals(referencedDataFile, baseFile.referencedDataFile)
+        && Objects.equals(contentOffset, baseFile.contentOffset)
+        && Objects.equals(contentSizeInBytes, baseFile.contentSizeInBytes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        partitionType,
+        fileOrdinal,
+        manifestLocation,
+        partitionSpecId,
+        content,
+        filePath,
+        format,
+        partitionData,
+        recordCount,
+        fileSizeInBytes,
+        dataSequenceNumber,
+        fileSequenceNumber,
+        columnSizes,
+        valueCounts,
+        nullValueCounts,
+        nanValueCounts,
+        lowerBounds,
+        upperBounds,
+        Arrays.hashCode(splitOffsets),
+        Arrays.hashCode(equalityIds),
+        Arrays.hashCode(keyMetadata),
+        sortOrderId,
+        firstRowId,
+        referencedDataFile,
+        contentOffset,
+        contentSizeInBytes);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ContentFileAvroEncoder.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileAvroEncoder.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.inmemory.InMemoryInputFile;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.apache.iceberg.types.Types;
+
+/**
+ * A utility class to encode {@link ContentFile} implementations as Avro in a backwards compatible
+ * way. It uses the same Avro encoding mechanism as {@link ManifestWriter} and {@link
+ * ManifestReader}. *
+ */
+public class ContentFileAvroEncoder {
+  private ContentFileAvroEncoder() {}
+
+  public static <T> byte[] encode(ContentFile<T>[] files) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputStream view = new DataOutputStream(out);
+
+    Map<Types.StructType, List<ContentFile<T>>> filesByPartitionType = Maps.newLinkedHashMap();
+    for (ContentFile<T> dataFile : files) {
+      Types.StructType partitionType = ((PartitionData) dataFile.partition()).getPartitionType();
+      filesByPartitionType
+          .computeIfAbsent(partitionType, ignoredSpec -> Lists.newArrayList())
+          .add(dataFile);
+    }
+    // Number of unique partition types
+    view.writeInt(filesByPartitionType.size());
+
+    for (Map.Entry<Types.StructType, List<ContentFile<T>>> entry :
+        filesByPartitionType.entrySet()) {
+      Types.StructType partitionType = entry.getKey();
+      List<ContentFile<T>> dataFiles = entry.getValue();
+      Schema fileSchema = new Schema(DataFile.getType(partitionType).fields());
+
+      String partitionSchema = SchemaParser.toJson(partitionType.asSchema());
+      view.writeUTF(partitionSchema);
+
+      InMemoryOutputFile outputFile = new InMemoryOutputFile();
+      try (FileAppender<ContentFile<T>> fileAppender =
+          InternalData.write(FileFormat.AVRO, outputFile).schema(fileSchema).build()) {
+        fileAppender.addAll(dataFiles);
+      }
+
+      byte[] serialisedFiles = outputFile.toByteArray();
+      view.writeInt(serialisedFiles.length);
+      view.write(serialisedFiles);
+    }
+
+    return out.toByteArray();
+  }
+
+  public static DataFile[] decodeDataFiles(byte[] serialized) throws IOException {
+    return decode(serialized, GenericDataFile.class);
+  }
+
+  public static DeleteFile[] decodeDeleteFiles(byte[] serialized) throws IOException {
+    return decode(serialized, GenericDeleteFile.class);
+  }
+
+  private static <T extends StructLike> T[] decode(byte[] serialized, Class<T> fileClass)
+      throws IOException {
+    DataInputStream view = new DataInputStream(new ByteArrayInputStream(serialized));
+    List<T> files = Lists.newArrayList();
+
+    int uniqueSpecTypes = view.readInt();
+    for (int i = 0; i < uniqueSpecTypes; i++) {
+      Schema partitionSchema = SchemaParser.fromJson(view.readUTF());
+      Schema fileSchema = new Schema(DataFile.getType(partitionSchema.asStruct()).fields());
+
+      byte[] fileBuffer = new byte[view.readInt()];
+      ByteStreams.readFully(view, fileBuffer);
+
+      try (CloseableIterable<T> reader =
+          InternalData.read(FileFormat.AVRO, new InMemoryInputFile(fileBuffer))
+              .project(fileSchema)
+              .setRootType(fileClass)
+              .setCustomType(DataFile.PARTITION_ID, PartitionData.class)
+              .build()) {
+        reader.forEach(files::add);
+      }
+    }
+
+    return files.toArray((T[]) Array.newInstance(fileClass, files.size()));
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/WriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/WriteResult.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg.io;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.CharSequenceSet;
@@ -133,5 +136,36 @@ public class WriteResult implements Serializable {
     public WriteResult build() {
       return new WriteResult(dataFiles, deleteFiles, referencedDataFiles, rewrittenDeleteFiles);
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("dataFiles", dataFiles)
+        .add("deleteFiles", deleteFiles)
+        .add("referencedDataFiles", referencedDataFiles)
+        .add("rewrittenDeleteFiles", rewrittenDeleteFiles)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    WriteResult that = (WriteResult) other;
+    return Objects.deepEquals(dataFiles, that.dataFiles)
+        && Objects.deepEquals(deleteFiles, that.deleteFiles)
+        && Objects.deepEquals(referencedDataFiles, that.referencedDataFiles)
+        && Objects.deepEquals(rewrittenDeleteFiles, that.rewrittenDeleteFiles);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        Arrays.hashCode(dataFiles),
+        Arrays.hashCode(deleteFiles),
+        Arrays.hashCode(referencedDataFiles),
+        Arrays.hashCode(rewrittenDeleteFiles));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/io/TestWriteResult.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestWriteResult.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import static org.apache.iceberg.TestBase.SPEC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.TestHelpers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestWriteResult {
+  static final DataFile FILE_A =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-a.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_A_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofPositionDeletes()
+          .withPath("/path/to/data-a-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  private static final WriteResult WRITE_RESULT =
+      WriteResult.builder().addDataFiles(FILE_A).addDeleteFiles(FILE_A_DELETES).build();
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void serialization(TestHelpers.RoundTripSerializer<WriteResult> roundTripSerializer)
+      throws IOException, ClassNotFoundException {
+    assertThat(roundTripSerializer.apply(WRITE_RESULT)).isEqualTo(WRITE_RESULT);
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/CommitSummary.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/CommitSummary.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.flink.sink;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.NavigableMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.flink.annotation.Internal;
@@ -43,11 +42,7 @@ public class CommitSummary {
     pendingResults.values().forEach(this::addWriteResult);
   }
 
-  public void addAll(NavigableMap<Long, List<WriteResult>> pendingResults) {
-    pendingResults.values().forEach(writeResults -> writeResults.forEach(this::addWriteResult));
-  }
-
-  private void addWriteResult(WriteResult writeResult) {
+  public void addWriteResult(WriteResult writeResult) {
     dataFilesCount.addAndGet(writeResult.dataFiles().length);
     Arrays.stream(writeResult.dataFiles())
         .forEach(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommittable.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommittable.java
@@ -19,42 +19,41 @@
 package org.apache.iceberg.flink.sink.dynamic;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Objects;
-import org.apache.iceberg.flink.sink.DeltaManifests;
+import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
 /**
  * The aggregated results of a single checkpoint which should be committed. Containing the
- * serialized {@link DeltaManifests} file - which contains the commit data, and the jobId,
- * operatorId, checkpointId triplet to identify the specific commit.
+ * serialized {@link org.apache.iceberg.io.WriteResult} and the jobId, operatorId, checkpointId
+ * triplet to identify the specific commit.
  *
  * <p>{@link DynamicCommittableSerializer} is used to serialize {@link DynamicCommittable} between
  * the {@link DynamicWriter} and the {@link DynamicWriteResultAggregator}.
  */
 class DynamicCommittable implements Serializable {
 
-  private final WriteTarget key;
-  private final byte[] manifest;
+  private final TableKey key;
+  private final WriteResult writeResult;
   private final String jobId;
   private final String operatorId;
   private final long checkpointId;
 
   DynamicCommittable(
-      WriteTarget key, byte[] manifest, String jobId, String operatorId, long checkpointId) {
+      TableKey key, WriteResult writeResult, String jobId, String operatorId, long checkpointId) {
     this.key = key;
-    this.manifest = manifest;
+    this.writeResult = writeResult;
     this.jobId = jobId;
     this.operatorId = operatorId;
     this.checkpointId = checkpointId;
   }
 
-  WriteTarget key() {
+  TableKey key() {
     return key;
   }
 
-  byte[] manifest() {
-    return manifest;
+  WriteResult writeResult() {
+    return writeResult;
   }
 
   String jobId() {
@@ -78,27 +77,24 @@ class DynamicCommittable implements Serializable {
     DynamicCommittable that = (DynamicCommittable) o;
     return checkpointId == that.checkpointId
         && Objects.equals(key, that.key)
-        && Objects.deepEquals(manifest, that.manifest)
+        && Objects.equals(writeResult, that.writeResult)
         && Objects.equals(jobId, that.jobId)
         && Objects.equals(operatorId, that.operatorId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(key, Arrays.hashCode(manifest), jobId, operatorId, checkpointId);
+    return Objects.hash(key, writeResult, jobId, operatorId, checkpointId);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("key", key)
+        .add("writeResult", writeResult)
         .add("jobId", jobId)
         .add("checkpointId", checkpointId)
         .add("operatorId", operatorId)
         .toString();
-  }
-
-  public WriteTarget writeTarget() {
-    return key;
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -168,7 +168,7 @@ public class DynamicIcebergSink
         .transform(
             prefixIfNotNull(uidPrefix, sinkId + " Pre Commit"),
             typeInformation,
-            new DynamicWriteResultAggregator(catalogLoader))
+            new DynamicWriteResultAggregator())
         .uid(prefixIfNotNull(uidPrefix, sinkId + "-pre-commit-topology"));
   }
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResult.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResult.java
@@ -22,15 +22,15 @@ import org.apache.iceberg.io.WriteResult;
 
 class DynamicWriteResult {
 
-  private final WriteTarget key;
+  private final TableKey key;
   private final WriteResult writeResult;
 
-  DynamicWriteResult(WriteTarget key, WriteResult writeResult) {
+  DynamicWriteResult(TableKey key, WriteResult writeResult) {
     this.key = key;
     this.writeResult = writeResult;
   }
 
-  WriteTarget key() {
+  TableKey key() {
     return key;
   }
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -50,7 +50,7 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
   public DynamicWriteResult deserialize(int version, byte[] serialized) throws IOException {
     if (version == 1) {
       DataInputDeserializer view = new DataInputDeserializer(serialized);
-      WriteTarget key = WriteTarget.deserializeFrom(view);
+      TableKey key = TableKey.deserializeFrom(view);
       byte[] resultBuf = new byte[view.available()];
       view.read(resultBuf);
       WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(version, resultBuf);

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -187,7 +187,8 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
           writeResult.dataFiles().length,
           writeResult.deleteFiles().length);
 
-      result.add(new DynamicWriteResult(writeTarget, writeResult));
+      TableKey tableKey = new TableKey(writeTarget.tableName(), writeTarget.branch());
+      result.add(new DynamicWriteResult(tableKey, writeResult));
     }
 
     writers.clear();

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/PartitionSpecEvolution.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/PartitionSpecEvolution.java
@@ -34,9 +34,9 @@ public class PartitionSpecEvolution {
   private PartitionSpecEvolution() {}
 
   /**
-   * Checks whether two PartitionSpecs are compatible with each other. Less strict than {@code
-   * PartitionSpec#compatible} in the sense that it tolerates differently named partition fields, as
-   * long as their transforms and field names corresponding to their source ids match.
+   * Checks whether two PartitionSpecs are compatible with each other. Less strict than {@link
+   * PartitionSpec#compatibleWith} in the sense that it tolerates differently named partition
+   * fields, as long as their transforms and field names corresponding to their source ids match.
    */
   public static boolean checkCompatibility(PartitionSpec spec1, PartitionSpec spec2) {
     if (spec1.equals(spec2)) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableKey.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableKey.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+
+class TableKey implements Serializable {
+  private final String tableName;
+  private final String branch;
+
+  TableKey(String tableName, String branch) {
+    this.tableName = tableName;
+    this.branch = branch;
+  }
+
+  TableKey(DynamicCommittable committable) {
+    this.tableName = committable.key().tableName();
+    this.branch = committable.key().branch();
+  }
+
+  String tableName() {
+    return tableName;
+  }
+
+  String branch() {
+    return branch;
+  }
+
+  void serializeTo(DataOutputView view) throws IOException {
+    view.writeUTF(tableName);
+    view.writeUTF(branch);
+  }
+
+  static TableKey deserializeFrom(DataInputView view) throws IOException {
+    return new TableKey(view.readUTF(), view.readUTF());
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    TableKey that = (TableKey) other;
+    return tableName.equals(that.tableName) && branch.equals(that.branch);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tableName, branch);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("tableName", tableName)
+        .add("branch", branch)
+        .toString();
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestWriteResultSerializer.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestWriteResultSerializer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.apache.iceberg.TestBase.SCHEMA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.io.WriteResult;
+import org.junit.jupiter.api.Test;
+
+public class TestWriteResultSerializer {
+  private static final PartitionSpec SPEC_1 =
+      PartitionSpec.builderFor(SCHEMA).withSpecId(0).bucket("data", 2).build();
+  private static final PartitionSpec SPEC_2 =
+      PartitionSpec.builderFor(SCHEMA).withSpecId(1).bucket("data", 5).build();
+
+  private static final DataFile FILE_1 =
+      DataFiles.builder(SPEC_1)
+          .withPath("/path/to/data-1.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("data_bucket=0")
+          .withRecordCount(1)
+          .build();
+  private static final DataFile FILE_2 =
+      DataFiles.builder(SPEC_2)
+          .withPath("/path/to/data-2.parquet")
+          .withFileSizeInBytes(11)
+          .withPartitionPath("data_bucket=3")
+          .withRecordCount(1)
+          .build();
+
+  private static final DeleteFile FILE_1_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC_1)
+          .ofPositionDeletes()
+          .withPath("/path/to/data-1-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("data_bucket=0")
+          .withRecordCount(1)
+          .build();
+
+  private static final WriteResult WRITE_RESULT =
+      WriteResult.builder()
+          .addDataFiles(FILE_1, FILE_2)
+          .addDeleteFiles(FILE_1_DELETES)
+          .addReferencedDataFiles("foo", "bar")
+          .addRewrittenDeleteFiles(FILE_1_DELETES)
+          .build();
+
+  @Test
+  public void testRoundTripSerialize() throws IOException {
+    WriteResultSerializer serializer = new WriteResultSerializer();
+
+    WriteResult copy =
+        serializer.deserialize(serializer.getVersion(), serializer.serialize(WRITE_RESULT));
+    assertThat(copy).isEqualTo(WRITE_RESULT);
+  }
+
+  @Test
+  void testUnsupportedVersion() {
+    WriteResultSerializer serializer = new WriteResultSerializer();
+
+    assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(WRITE_RESULT)))
+        .hasMessage("Unrecognized version or corrupt state: -1")
+        .isInstanceOf(IOException.class);
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultAggregator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultAggregator.java
@@ -20,42 +20,33 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.hadoop.util.Sets;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.io.WriteResult;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class TestDynamicWriteResultAggregator {
-
-  @RegisterExtension
-  static final HadoopCatalogExtension CATALOG_EXTENSION = new HadoopCatalogExtension("db", "table");
-
   @Test
-  void testAggregator() throws Exception {
-    CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
-    CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table2"), new Schema());
-
-    DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+  void testAggregatesWriteResultsForTwoTables() throws Exception {
     try (OneInputStreamOperatorTestHarness<
             CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>>
-        testHarness = new OneInputStreamOperatorTestHarness<>(aggregator)) {
+        testHarness = new OneInputStreamOperatorTestHarness<>(new DynamicWriteResultAggregator())) {
       testHarness.open();
 
-      WriteTarget writeTarget1 = new WriteTarget("table", "branch", 42, 0, true, Sets.newHashSet());
+      TableKey tableKey1 = new TableKey("table", "branch");
       DynamicWriteResult dynamicWriteResult1 =
-          new DynamicWriteResult(writeTarget1, WriteResult.builder().build());
-      WriteTarget writeTarget2 =
-          new WriteTarget("table2", "branch", 42, 0, true, Sets.newHashSet(1, 2));
+          new DynamicWriteResult(tableKey1, WriteResult.builder().build());
+      TableKey tableKey2 = new TableKey("table2", "branch");
       DynamicWriteResult dynamicWriteResult2 =
-          new DynamicWriteResult(writeTarget2, WriteResult.builder().build());
+          new DynamicWriteResult(tableKey2, WriteResult.builder().build());
 
       CommittableWithLineage<DynamicWriteResult> committable1 =
           new CommittableWithLineage<>(dynamicWriteResult1, 0, 0);
@@ -78,5 +69,83 @@ class TestDynamicWriteResultAggregator {
       // Only contains a CommittableSummary
       assertThat(testHarness.getRecordOutput()).hasSize(4);
     }
+  }
+
+  @Test
+  void testAggregatesWriteResultsForOneTable() throws Exception {
+    long checkpointId = 1L;
+
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>>
+        testHarness = new OneInputStreamOperatorTestHarness<>(new DynamicWriteResultAggregator())) {
+      testHarness.open();
+
+      TableKey tableKey = new TableKey("table", "branch");
+      DataFile dataFile1 =
+          DataFiles.builder(PartitionSpec.unpartitioned())
+              .withPath("/data-1.parquet")
+              .withFileSizeInBytes(10)
+              .withRecordCount(1)
+              .build();
+      DataFile dataFile2 =
+          DataFiles.builder(PartitionSpec.unpartitioned())
+              .withPath("/data-2.parquet")
+              .withFileSizeInBytes(20)
+              .withRecordCount(2)
+              .build();
+
+      testHarness.processElement(createRecord(tableKey, checkpointId, dataFile1));
+      testHarness.processElement(createRecord(tableKey, checkpointId, dataFile2));
+
+      assertThat(testHarness.getOutput()).isEmpty();
+
+      testHarness.prepareSnapshotPreBarrier(checkpointId);
+
+      List<CommittableMessage<DynamicCommittable>> outputValues = testHarness.extractOutputValues();
+      // Contains a CommittableSummary + DynamicCommittable
+      assertThat(outputValues).hasSize(2);
+
+      SinkV2Assertions.assertThat(extractAndAssertCommittableSummary(outputValues.get(0)))
+          .hasOverallCommittables(1)
+          .hasFailedCommittables(0)
+          .hasCheckpointId(checkpointId);
+
+      CommittableWithLineage<DynamicCommittable> committable =
+          extractAndAssertCommittableWithLineage(outputValues.get(1));
+
+      SinkV2Assertions.assertThat(committable).hasCheckpointId(checkpointId);
+
+      DynamicCommittable dynamicCommittable = committable.getCommittable();
+
+      assertThat(dynamicCommittable.writeResult())
+          .isEqualTo(WriteResult.builder().addDataFiles(dataFile1, dataFile2).build());
+      assertThat(dynamicCommittable.key()).isEqualTo(tableKey);
+      assertThat(dynamicCommittable.checkpointId()).isEqualTo(checkpointId);
+      assertThat(dynamicCommittable.jobId())
+          .isEqualTo(testHarness.getEnvironment().getJobID().toString());
+      assertThat(dynamicCommittable.operatorId())
+          .isEqualTo(testHarness.getOperator().getOperatorID().toString());
+    }
+  }
+
+  private static StreamRecord<CommittableMessage<DynamicWriteResult>> createRecord(
+      TableKey tableKey, long checkpointId, DataFile... dataFiles) {
+    return new StreamRecord<>(
+        new CommittableWithLineage<>(
+            new DynamicWriteResult(tableKey, WriteResult.builder().addDataFiles(dataFiles).build()),
+            checkpointId,
+            0));
+  }
+
+  static CommittableSummary<DynamicCommittable> extractAndAssertCommittableSummary(
+      CommittableMessage<DynamicCommittable> message) {
+    assertThat(message).isInstanceOf(CommittableSummary.class);
+    return (CommittableSummary<DynamicCommittable>) message;
+  }
+
+  static CommittableWithLineage<DynamicCommittable> extractAndAssertCommittableWithLineage(
+      CommittableMessage<DynamicCommittable> message) {
+    assertThat(message).isInstanceOf(CommittableWithLineage.class);
+    return (CommittableWithLineage<DynamicCommittable>) message;
   }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import org.apache.hadoop.util.Sets;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Metrics;
@@ -48,13 +47,12 @@ class TestDynamicWriteResultSerializer {
                   ImmutableMap.of(1, ByteBuffer.allocate(1)),
                   ImmutableMap.of(1, ByteBuffer.allocate(1))))
           .build();
+  private static final TableKey TABLE_KEY = new TableKey("table", "branch");
 
   @Test
   void testRoundtrip() throws IOException {
     DynamicWriteResult dynamicWriteResult =
-        new DynamicWriteResult(
-            new WriteTarget("table", "branch", 42, 23, false, Sets.newHashSet(1, 2)),
-            WriteResult.builder().addDataFiles(DATA_FILE).build());
+        new DynamicWriteResult(TABLE_KEY, WriteResult.builder().addDataFiles(DATA_FILE).build());
 
     DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
     DynamicWriteResult copy =
@@ -68,11 +66,9 @@ class TestDynamicWriteResultSerializer {
   }
 
   @Test
-  void testUnsupportedVersion() throws IOException {
+  void testUnsupportedVersion() {
     DynamicWriteResult dynamicWriteResult =
-        new DynamicWriteResult(
-            new WriteTarget("table", "branch", 42, 23, false, Sets.newHashSet(1, 2)),
-            WriteResult.builder().addDataFiles(DATA_FILE).build());
+        new DynamicWriteResult(TABLE_KEY, WriteResult.builder().addDataFiles(DATA_FILE).build());
 
     DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
     assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(dynamicWriteResult)))


### PR DESCRIPTION
Addresses the following issue: https://github.com/apache/iceberg/issues/14090.

Fix the issue by aggregating `WriteResult` objects by table and branch (aka `TableKey`), which would emit a single committable per checkpoint. It requires serialising the aggregated `WriteResult` and saving it in a Flink checkpoint instead of a temporary manifest file, because, according to the Iceberg spec, a single manifest must contain files with only one partition spec, while we may aggregate write results for potentially multiple partition specs.