### PR TITLE
Add "stop signs" for sensitive information/issues to all issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -22,6 +22,12 @@ name: Iceberg Bug report 🐞
 description: Problems, bugs and issues with Apache Iceberg
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        * Verify that the issue is not already reported, looking at the [currently open issues](https://github.com/apache/iceberg/issues), use the `Filter` field to narrow down your search.
+        * **Possible security vulnerabilities**: STOP here and contact `security@apache.org` instead!
+        * Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
   - type: dropdown
     attributes:
       label: Apache Iceberg version

--- a/.github/ISSUE_TEMPLATE/iceberg_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_improvement.yml
@@ -22,6 +22,10 @@ name: Iceberg Improvement / Feature Request
 description: New features with Apache Iceberg
 labels: ["improvement"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
   - type: textarea
     attributes:
       label: Feature Request / Improvement

--- a/.github/ISSUE_TEMPLATE/iceberg_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_proposal.yml
@@ -24,7 +24,10 @@ labels: ["proposal"]
 body:
   - type: markdown
     attributes:
-      value: "Please see documentation site for information on [contributing proposals](https://iceberg.apache.org/contribute/#apache-iceberg-improvement-proposals)"
+      value: |
+        Please see documentation site for information on [contributing proposals](https://iceberg.apache.org/contribute/#apache-iceberg-improvement-proposals)
+        
+        Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
   - type: textarea
     attributes:
       label: Proposed Change

--- a/.github/ISSUE_TEMPLATE/iceberg_question.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_question.yml
@@ -24,7 +24,10 @@ labels: ["question"]
 body:
   - type: markdown
     attributes:
-      value: "Feel free to ask your question on [Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-2561tq9qr-UtISlHgsdY3Virs3Z2_btQ) as well."
+      value: |
+        Feel free to ask your question on [Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-2561tq9qr-UtISlHgsdY3Virs3Z2_btQ) as well.
+
+        Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
   - type: textarea
     attributes:
       label: Query engine


### PR DESCRIPTION
External contributors are usually not very familiar with all the procedures and rules and such at Apache.

Important "stop signs" should be added to the issue templates, highlighting to not share sensitive information and particularly to report potential vulnerabilities and security issues via security@apache.org.