### PR TITLE
[Core] Add mergeAppendTest to ensure consist distribution of data files in manifests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -784,16 +785,32 @@ public class TestBase {
     return Iterators.forArray(statuses);
   }
 
+  static Iterator<ManifestEntry.Status> statusesRepeat(ManifestEntry.Status status, int count) {
+    return Iterators.limit(Iterators.cycle(Collections.singletonList(status)), count);
+  }
+
   static Iterator<Long> dataSeqs(Long... seqs) {
     return Iterators.forArray(seqs);
+  }
+
+  static Iterator<Long> dataSeqsRepeat(Long value, int count) {
+    return Iterators.limit(Iterators.cycle(Collections.singletonList(value)), count);
   }
 
   static Iterator<Long> fileSeqs(Long... seqs) {
     return Iterators.forArray(seqs);
   }
 
+  static Iterator<Long> fileSeqsRepeat(Long value, int count) {
+    return Iterators.limit(Iterators.cycle(Collections.singletonList(value)), count);
+  }
+
   static Iterator<Long> ids(Long... ids) {
     return Iterators.forArray(ids);
+  }
+
+  static Iterator<Long> idsRepeat(Long value, int count) {
+    return Iterators.limit(Iterators.cycle(Collections.singletonList(value)), count);
   }
 
   static Iterator<DataFile> files(DataFile... files) {


### PR DESCRIPTION
#13411 help maintain passed in ordering of files in manifest lists and this help ensure this ordering guarantee

@stevenzwu @RussellSpitzer @aokolnychyi if you want to take a look.