### PR TITLE
BigQuery: Add table validity check for BigQueryMetastoreCatalog

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
@@ -281,6 +281,16 @@ public class BigQueryMetastoreCatalog extends BaseMetastoreCatalog
   }
 
   @Override
+  protected boolean isValidIdentifier(TableIdentifier identifier) {
+    try {
+      validateNamespace(identifier.namespace());
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
   public String name() {
     return catalogName;
   }

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -22,18 +22,11 @@ import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
 import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE_BIGQUERY;
 import static org.apache.iceberg.gcp.bigquery.BigQueryMetastoreCatalog.PROJECT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.MetadataTableUtils;
-import org.apache.iceberg.Table;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.CatalogTests;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -47,8 +40,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> {
   @TempDir private File tempFolder;

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -154,7 +154,6 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
   @Test
   public void testCreateTableWithDefaultColumnValue() {}
 
-
   @Disabled("BigQuery Metastore does not support rename tables")
   @Test
   public void testRenameTable() {

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -39,6 +39,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableMetadata;
 
 public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> {
   @TempDir private File tempFolder;
@@ -170,5 +181,76 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
   @Test
   public void testRenameTableMissingSourceTable() {
     super.testRenameTableMissingSourceTable();
+  }
+
+  @Test
+  public void testIsValidIdentifierWithValidSingleLevelNamespace() {
+    TableIdentifier validIdentifier = TableIdentifier.of("dataset1", "table1");
+    assertThat(catalog.isValidIdentifier(validIdentifier)).isTrue();
+  }
+
+  @Test
+  public void testIsValidIdentifierWithInvalidMultiLevelNamespace() {
+    TableIdentifier invalidIdentifier = TableIdentifier.of(Namespace.of("level1", "level2"), "table1");
+    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
+  }
+
+  @Test
+  public void testIsValidIdentifierWithThreeLevelNamespace() {
+    TableIdentifier invalidIdentifier = TableIdentifier.of(Namespace.of("level1", "level2", "level3"), "table1");
+    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
+  }
+
+  @Test
+  public void testIsValidIdentifierWithEmptyNamespace() {
+    TableIdentifier invalidIdentifier = TableIdentifier.of(Namespace.empty(), "table1");
+    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
+  }
+
+  @Test
+  public void testLoadMetadataTableIsCalled() {
+    // Create a spy of the catalog to verify method calls
+    BigQueryMetastoreCatalog spyCatalog = spy(catalog);
+
+    // Create mock objects
+    TableOperations mockOps = Mockito.mock(TableOperations.class);
+    TableMetadata mockMetadata = Mockito.mock(TableMetadata.class);
+    Table mockMetadataTable = Mockito.mock(Table.class);
+
+    // Mock the table operations to return metadata (indicating base table exists)
+    when(mockOps.current()).thenReturn(mockMetadata);
+
+    // Create the expected base table identifier that will be extracted from the metadata table identifier
+    TableIdentifier expectedBaseTableId = TableIdentifier.of("dataset1", "table1");
+    when(spyCatalog.newTableOps(expectedBaseTableId)).thenReturn(mockOps);
+
+    // Use MockedStatic to mock the static MetadataTableUtils.createMetadataTableInstance call
+    try (MockedStatic<MetadataTableUtils> mockedUtils = Mockito.mockStatic(MetadataTableUtils.class)) {
+      mockedUtils.when(() -> MetadataTableUtils.createMetadataTableInstance(
+          any(TableOperations.class),
+          any(String.class),
+          any(TableIdentifier.class),
+          any(TableIdentifier.class),
+          any()))
+          .thenReturn(mockMetadataTable);
+
+      // Create a metadata table identifier
+      TableIdentifier metadataTableId = TableIdentifier.of(Namespace.of("dataset1", "table1"), "partitions");
+
+      // Call loadTable which should trigger the metadata table loading path
+      Table result = spyCatalog.loadTable(metadataTableId);
+
+      // Verify that MetadataTableUtils.createMetadataTableInstance was called
+      // This confirms that loadMetadataTable path was taken
+      mockedUtils.verify(() -> MetadataTableUtils.createMetadataTableInstance(
+          any(TableOperations.class),
+          any(String.class),
+          any(TableIdentifier.class),
+          any(TableIdentifier.class),
+          any()));
+
+      // Verify the result is the mocked metadata table
+      assertThat(result).isSameAs(mockMetadataTable);
+    }
   }
 }

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -154,7 +154,6 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
   @Test
   public void testCreateTableWithDefaultColumnValue() {}
 
-  @Test
 
   @Disabled("BigQuery Metastore does not support rename tables")
   @Test

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -155,60 +155,6 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
   public void testCreateTableWithDefaultColumnValue() {}
 
   @Test
-  public void testLoadMetadataTable() {
-
-    // Create a spy of the catalog to verify method calls
-    BigQueryMetastoreCatalog spyCatalog = spy(catalog);
-
-    // Create mock objects
-    TableOperations mockOps = Mockito.mock(TableOperations.class);
-    TableMetadata mockMetadata = Mockito.mock(TableMetadata.class);
-    Table mockMetadataTable = Mockito.mock(Table.class);
-
-    // Mock the table operations to return metadata (indicating base table exists)
-    when(mockOps.current()).thenReturn(mockMetadata);
-
-    // Create the expected base table identifier that will be extracted from the metadata table
-    // identifier
-    TableIdentifier expectedBaseTableId = TableIdentifier.of("dataset1", "table1");
-    when(spyCatalog.newTableOps(expectedBaseTableId)).thenReturn(mockOps);
-
-    // Use MockedStatic to mock the static MetadataTableUtils.createMetadataTableInstance call
-    try (MockedStatic<MetadataTableUtils> mockedUtils =
-        Mockito.mockStatic(MetadataTableUtils.class)) {
-      mockedUtils
-          .when(
-              () ->
-                  MetadataTableUtils.createMetadataTableInstance(
-                      any(TableOperations.class),
-                      any(String.class),
-                      any(TableIdentifier.class),
-                      any(TableIdentifier.class),
-                      any()))
-          .thenReturn(mockMetadataTable);
-
-      // Create a metadata table identifier
-      TableIdentifier metadataTableId =
-          TableIdentifier.of(Namespace.of("dataset1", "table1"), "partitions");
-
-      // Call loadTable which should trigger the metadata table loading path
-      Table result = spyCatalog.loadTable(metadataTableId);
-
-      // Verify that MetadataTableUtils.createMetadataTableInstance was called
-      // This confirms that loadMetadataTable path was taken
-      mockedUtils.verify(
-          () ->
-              MetadataTableUtils.createMetadataTableInstance(
-                  any(TableOperations.class),
-                  any(String.class),
-                  any(TableIdentifier.class),
-                  any(TableIdentifier.class),
-                  any()));
-
-      // Verify the result is the mocked metadata table
-      assertThat(result).isSameAs(mockMetadataTable);
-    }
-  }
 
   @Disabled("BigQuery Metastore does not support rename tables")
   @Test

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -154,62 +154,9 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
   @Test
   public void testCreateTableWithDefaultColumnValue() {}
 
-  @Disabled("BigQuery Metastore does not support multi layer namespaces")
   @Test
-  public void testLoadMetadataTable() {}
+  public void testLoadMetadataTable() {
 
-  @Disabled("BigQuery Metastore does not support rename tables")
-  @Test
-  public void testRenameTable() {
-    super.testRenameTable();
-  }
-
-  @Disabled("BigQuery Metastore does not support rename tables")
-  @Test
-  public void testRenameTableDestinationTableAlreadyExists() {
-    super.testRenameTableDestinationTableAlreadyExists();
-  }
-
-  @Disabled("BigQuery Metastore does not support rename tables")
-  @Test
-  public void renameTableNamespaceMissing() {
-    super.renameTableNamespaceMissing();
-  }
-
-  @Disabled("BigQuery Metastore does not support rename tables")
-  @Test
-  public void testRenameTableMissingSourceTable() {
-    super.testRenameTableMissingSourceTable();
-  }
-
-  @Test
-  public void testIsValidIdentifierWithValidSingleLevelNamespace() {
-    TableIdentifier validIdentifier = TableIdentifier.of("dataset1", "table1");
-    assertThat(catalog.isValidIdentifier(validIdentifier)).isTrue();
-  }
-
-  @Test
-  public void testIsValidIdentifierWithInvalidMultiLevelNamespace() {
-    TableIdentifier invalidIdentifier =
-        TableIdentifier.of(Namespace.of("level1", "level2"), "table1");
-    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
-  }
-
-  @Test
-  public void testIsValidIdentifierWithThreeLevelNamespace() {
-    TableIdentifier invalidIdentifier =
-        TableIdentifier.of(Namespace.of("level1", "level2", "level3"), "table1");
-    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
-  }
-
-  @Test
-  public void testIsValidIdentifierWithEmptyNamespace() {
-    TableIdentifier invalidIdentifier = TableIdentifier.of(Namespace.empty(), "table1");
-    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
-  }
-
-  @Test
-  public void testLoadMetadataTableIsCalled() {
     // Create a spy of the catalog to verify method calls
     BigQueryMetastoreCatalog spyCatalog = spy(catalog);
 
@@ -261,5 +208,55 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
       // Verify the result is the mocked metadata table
       assertThat(result).isSameAs(mockMetadataTable);
     }
+  }
+
+  @Disabled("BigQuery Metastore does not support rename tables")
+  @Test
+  public void testRenameTable() {
+    super.testRenameTable();
+  }
+
+  @Disabled("BigQuery Metastore does not support rename tables")
+  @Test
+  public void testRenameTableDestinationTableAlreadyExists() {
+    super.testRenameTableDestinationTableAlreadyExists();
+  }
+
+  @Disabled("BigQuery Metastore does not support rename tables")
+  @Test
+  public void renameTableNamespaceMissing() {
+    super.renameTableNamespaceMissing();
+  }
+
+  @Disabled("BigQuery Metastore does not support rename tables")
+  @Test
+  public void testRenameTableMissingSourceTable() {
+    super.testRenameTableMissingSourceTable();
+  }
+
+  @Test
+  public void testIsValidIdentifierWithValidSingleLevelNamespace() {
+    TableIdentifier validIdentifier = TableIdentifier.of("dataset1", "table1");
+    assertThat(catalog.isValidIdentifier(validIdentifier)).isTrue();
+  }
+
+  @Test
+  public void testIsValidIdentifierWithInvalidMultiLevelNamespace() {
+    TableIdentifier invalidIdentifier =
+        TableIdentifier.of(Namespace.of("level1", "level2"), "table1");
+    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
+  }
+
+  @Test
+  public void testIsValidIdentifierWithThreeLevelNamespace() {
+    TableIdentifier invalidIdentifier =
+        TableIdentifier.of(Namespace.of("level1", "level2", "level3"), "table1");
+    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
+  }
+
+  @Test
+  public void testIsValidIdentifierWithEmptyNamespace() {
+    TableIdentifier invalidIdentifier = TableIdentifier.of(Namespace.empty(), "table1");
+    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
   }
 }

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -171,27 +171,28 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
 
   @Test
   public void testIsValidIdentifierWithValidSingleLevelNamespace() {
-    TableIdentifier validIdentifier = TableIdentifier.of("dataset1", "table1");
-    assertThat(catalog.isValidIdentifier(validIdentifier)).isTrue();
+    assertThat(catalog.isValidIdentifier(TableIdentifier.of("dataset1", "table1"))).isTrue();
   }
 
   @Test
   public void testIsValidIdentifierWithInvalidMultiLevelNamespace() {
-    TableIdentifier invalidIdentifier =
-        TableIdentifier.of(Namespace.of("level1", "level2"), "table1");
-    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
+    assertThat(
+            catalog.isValidIdentifier(
+                TableIdentifier.of(Namespace.of("level1", "level2"), "table1")))
+        .isFalse();
   }
 
   @Test
   public void testIsValidIdentifierWithThreeLevelNamespace() {
-    TableIdentifier invalidIdentifier =
-        TableIdentifier.of(Namespace.of("level1", "level2", "level3"), "table1");
-    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
+    assertThat(
+            catalog.isValidIdentifier(
+                TableIdentifier.of(Namespace.of("level1", "level2", "level3"), "table1")))
+        .isFalse();
   }
 
   @Test
   public void testIsValidIdentifierWithEmptyNamespace() {
-    TableIdentifier invalidIdentifier = TableIdentifier.of(Namespace.empty(), "table1");
-    assertThat(catalog.isValidIdentifier(invalidIdentifier)).isFalse();
+    assertThat(catalog.isValidIdentifier(TableIdentifier.of(Namespace.empty(), "table1")))
+        .isFalse();
   }
 }


### PR DESCRIPTION
This PR fixes a table validity check for the BigQueryMetastoreCatalog introduced in https://github.com/apache/iceberg/pull/12808. We need this validity check in order to access metadata tables using the syntax documented in: https://iceberg.apache.org/docs/1.10.0/docs/hive/?h=metadata#querying-metadata-tables. For example [inspecting metadata tables](https://iceberg.apache.org/docs/1.10.0/docs/spark-queries/?h=partitions#inspecting-with-dataframes). This is similar to the HiveCatalog [implementation](https://github.com/apache/iceberg/blob/345140e9f7d428fcc3b4fcc639a690084a698b76/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java#L663-L665). Without this check Iceberg will attempt to load a regular table and fail in the BigQueryMetastoreCatalog implementation because the namespace has more than one level. 


Added tests as well. 