### PR TITLE
Core: Make deprecated method package-private in PartitionStats

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1416,6 +1416,18 @@ acceptedBreaks:
         \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String,\
         \ java.lang.String)"
         justification: "Removing deprecated code for 1.11.0"
+      - code: "java.method.visibilityReduced"
+        old: "method void org.apache.iceberg.PartitionStats::liveEntry(org.apache.iceberg.ContentFile<?>, org.apache.iceberg.Snapshot)"
+        new: "method void org.apache.iceberg.PartitionStats::liveEntry(org.apache.iceberg.ContentFile<?>, org.apache.iceberg.Snapshot)"
+        justification: "Changing deprecated code"
+      - code: "java.method.visibilityReduced"
+        old: "method void org.apache.iceberg.PartitionStats::appendStats(org.apache.iceberg.PartitionStats)"
+        new: "method void org.apache.iceberg.PartitionStats::appendStats(org.apache.iceberg.PartitionStats)"
+        justification: "Changing deprecated code"
+      - code: "java.method.visibilityReduced"
+        old: "method void org.apache.iceberg.PartitionStats::deletedEntry(org.apache.iceberg.Snapshot)"
+        new: "method void org.apache.iceberg.PartitionStats::deletedEntry(org.apache.iceberg.Snapshot)"
+        justification: "Changing deprecated code"
     org.apache.iceberg:iceberg-data:
       - code: "java.class.removed"
         old: "class org.apache.iceberg.data.PartitionStatsHandler"

--- a/core/src/main/java/org/apache/iceberg/PartitionStats.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStats.java
@@ -100,10 +100,8 @@ public class PartitionStats implements StructLike {
    *
    * @param file the {@link ContentFile} from the manifest entry.
    * @param snapshot the snapshot corresponding to the live entry.
-   * @deprecated since 1.10.0, visibility will be reduced in 1.11.0
    */
-  @Deprecated // will become package-private
-  public void liveEntry(ContentFile<?> file, Snapshot snapshot) {
+  void liveEntry(ContentFile<?> file, Snapshot snapshot) {
     Preconditions.checkArgument(specId == file.specId(), "Spec IDs must match");
 
     switch (file.content()) {
@@ -140,10 +138,8 @@ public class PartitionStats implements StructLike {
    * Updates the modified time and snapshot ID for the deleted manifest entry.
    *
    * @param snapshot the snapshot corresponding to the deleted manifest entry.
-   * @deprecated since 1.10.0, visibility will be reduced in 1.11.0
    */
-  @Deprecated // will become package-private
-  public void deletedEntry(Snapshot snapshot) {
+  void deletedEntry(Snapshot snapshot) {
     if (snapshot != null) {
       updateSnapshotInfo(snapshot.snapshotId(), snapshot.timestampMillis());
     }
@@ -190,10 +186,8 @@ public class PartitionStats implements StructLike {
    * Appends statistics from given entry to current entry.
    *
    * @param entry the entry from which statistics will be sourced.
-   * @deprecated since 1.10.0, visibility will be reduced in 1.11.0
    */
-  @Deprecated // will become package-private
-  public void appendStats(PartitionStats entry) {
+  void appendStats(PartitionStats entry) {
     Preconditions.checkArgument(specId == entry.specId(), "Spec IDs must match");
 
     this.dataRecordCount += entry.dataRecordCount;


### PR DESCRIPTION
Follow-up #14059

The last remaining deprecated code in core module is RefreshingAuthManager, which is referenced by OAuth2Manager. 