### PR TITLE
[PoC] Core: Support Table Metadata caching

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -66,6 +66,60 @@ public class CatalogProperties {
   public static final long CACHE_EXPIRATION_INTERVAL_MS_OFF = -1;
 
   /**
+   * Controls whether to use caching during table metadata reads or not.
+   *
+   * <p>Enabling table metadata file caching require the following configuration constraints to be true:
+   *
+   * <ul>
+   *   <li>{@link #IO_TABLE_METADATA_CACHE_EXPIRATION_INTERVAL_MS} must be a non-negative value.
+   *   <li>{@link #IO_TABLE_METADATA_CACHE_MAX_TOTAL_BYTES} must be a positive value.
+   *   <li>{@link #IO_TABLE_METADATA_CACHE_MAX_CONTENT_LENGTH} must be a positive value.
+   * </ul>
+   */
+  public static final String IO_TABLE_METADATA_CACHE_ENABLED = "io.table-metadata.cache-enabled";
+
+  public static final boolean IO_TABLE_METADATA_CACHE_ENABLED_DEFAULT = false;
+
+  /**
+   * Controls the maximum duration for which an entry stays in the table metadata cache.
+   *
+   * <p>Must be a non-negative value. Following are specific behaviors of this config:
+   *
+   * <ul>
+   *   <li>Zero - Cache entries expires only if it gets evicted due to memory pressure from {@link
+   *       #IO_TABLE_METADATA_CACHE_MAX_TOTAL_BYTES} setting.
+   *   <li>Positive Values - Cache entries expire if not accessed via the cache after this many
+   *       milliseconds
+   * </ul>
+   */
+  public static final String IO_TABLE_METADATA_CACHE_EXPIRATION_INTERVAL_MS =
+          "io.table-metadata.cache.expiration-interval-ms";
+
+  public static final long IO_TABLE_METADATA_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT =
+          TimeUnit.MINUTES.toMillis(10);
+
+  /**
+   * Controls the maximum total amount of bytes to cache in the table metadata cache.
+   *
+   * <p>Must be a positive value.
+   */
+  public static final String IO_TABLE_METADATA_CACHE_MAX_TOTAL_BYTES =
+          "io.table-metadata.cache.max-total-bytes";
+
+  public static final long IO_TABLE_METADATA_CACHE_MAX_TOTAL_BYTES_DEFAULT = 100 * 1024 * 1024;
+
+  /**
+   * Controls the maximum length of file to be considered for caching a table metadata file.
+   *
+   * <p>An {@link org.apache.iceberg.io.InputFile} will not be cached if the length is longer than
+   * this limit. Must be a positive value.
+   */
+  public static final String IO_TABLE_METADATA_CACHE_MAX_CONTENT_LENGTH =
+          "io.table-metadata.cache.max-content-length";
+
+  public static final long IO_TABLE_METADATA_CACHE_MAX_CONTENT_LENGTH_DEFAULT = 8 * 1024 * 1024;
+
+  /**
    * Controls whether to use caching during manifest reads or not.
    *
    * <p>Enabling manifest file caching require the following configuration constraints to be true:
@@ -109,7 +163,7 @@ public class CatalogProperties {
   public static final long IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT = 100 * 1024 * 1024;
 
   /**
-   * Controls the maximum length of file to be considered for caching.
+   * Controls the maximum length of file to be considered for caching a manifest file.
    *
    * <p>An {@link org.apache.iceberg.io.InputFile} will not be cached if the length is longer than
    * this limit. Must be a positive value.

--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -71,7 +71,20 @@ public class SystemConfigs {
 
   /**
    * Maximum number of distinct {@link org.apache.iceberg.io.FileIO} that is allowed to have
-   * associated {@link org.apache.iceberg.io.ContentCache} in memory at a time.
+   * associated {@link org.apache.iceberg.io.ContentCache} in memory at a time in the table metadata
+   * cache.
+   */
+  public static final ConfigEntry<Integer> IO_TABLE_METADATA_CACHE_MAX_FILEIO =
+          new ConfigEntry<>(
+                  "iceberg.io.table-metadata.cache.fileio-max",
+                  "ICEBERG_IO_TABLE_METADATA_CACHE_FILEIO_MAX",
+                  8,
+                  Integer::parseUnsignedInt);
+
+  /**
+   * Maximum number of distinct {@link org.apache.iceberg.io.FileIO} that is allowed to have
+   * associated {@link org.apache.iceberg.io.ContentCache} in memory at a time in the manifest
+   * cache.
    */
   public static final ConfigEntry<Integer> IO_MANIFEST_CACHE_MAX_FILEIO =
       new ConfigEntry<>(

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -318,8 +318,16 @@ public class TableMetadataParser {
     return read(io.newInputFile(path));
   }
 
-  public static TableMetadata read(FileIO io, InputFile input) {
-    InputFile file = newInputFile(io, input);
+  public static TableMetadata read(FileIO io, InputFile file) {
+    InputFile wrapped = newInputFile(io, file);
+    return read(wrapped);
+  }
+
+  /**
+   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link #read(FileIO, InputFile)} instead.
+   */
+  @Deprecated
+  public static TableMetadata read(InputFile file) {
     Codec codec = Codec.fromFileName(file.location());
     try (InputStream is =
         codec == Codec.GZIP ? new GZIPInputStream(file.newStream()) : file.newStream()) {


### PR DESCRIPTION
Allows TableMetadataParser to cache the content of `metadata.json`.

Iceberg REST Catalog is expected to serve table metadata of the same table to various clients concurrently. Therefore, caching them would improve average latency and reduce S3 cost. Here, I assume each metadata.json is totally immutable, and I may be overlooking something.

# Related PR

https://github.com/apache/hive/pull/6022