### PR TITLE
Readable plans for WriteDelta and IcebergScan

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -102,6 +102,11 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
+  public String description() {
+    return toString();
+  }
+
+  @Override
   public NamedReference[] filterAttributes() {
     Set<Integer> partitionFieldSourceIds = Sets.newHashSet();
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -270,6 +270,12 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       }
     }
 
+    @Override
+    public String toString() {
+      long snapshotId = table.currentSnapshot() != null ? table.currentSnapshot().snapshotId() : -1;
+      return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
+    }
+
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {
       Expression filter = Expressions.alwaysTrue();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -102,6 +102,11 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
+  public String description() {
+    return toString();
+  }
+
+  @Override
   public NamedReference[] filterAttributes() {
     Set<Integer> partitionFieldSourceIds = Sets.newHashSet();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -281,6 +281,12 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       }
     }
 
+    @Override
+    public String toString() {
+      long snapshotId = table.currentSnapshot() != null ? table.currentSnapshot().snapshotId() : -1;
+      return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
+    }
+
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {
       Expression filter = Expressions.alwaysTrue();
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -102,6 +102,11 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
+  public String description() {
+    return toString();
+  }
+
+  @Override
   public NamedReference[] filterAttributes() {
     Set<Integer> partitionFieldSourceIds = Sets.newHashSet();
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -283,6 +283,12 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       }
     }
 
+    @Override
+    public String toString() {
+      long snapshotId = table.currentSnapshot() != null ? table.currentSnapshot().snapshotId() : -1;
+      return String.format("IcebergPositionDeltaWrite(table=%s, current_snapshot_id=%d)", table, snapshotId);
+    }
+
     private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {
       Expression filter = Expressions.alwaysTrue();
 


### PR DESCRIPTION
Summary of Proposed Changes

1. Improve readability of DeltaWrite in Spark event logs
Currently, when event logs contain the DeltaWrite action, the plan description is printed as:
```
(1) WriteDelta
Input [1]: [_col#1]
Arguments: org.apache.iceberg.spark.source.SparkPositionDeltaWrite@5234f6c5
```

By comparison, ReplaceData (implemented in [SparkWrite](https://github.com/apache/iceberg/blob/8353ac8f80799495cfdc32dd37222ed1b8d8070f/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java#L263-L266))
is rendered more informatively:
```
(1) ReplaceData
Input [1]: [col#1]
Arguments: IcebergWrite(table=iceberg_table, format=PARQUET)
```

This change introduces a toString implementation for SparkPositionDeltaWrite to produce more descriptive and user-friendly plan output.

2. Expose IcebergScan details in physical plans
In Spark event logs, IcebergScan does not currently appear in the physical plan description. Instead, only the generic BatchScan is shown:
```
== Physical Plan ==
AppendData ...
+- *(1) ColumnarToRow
   +- BatchScan glue_catalog.namespace.table_name[#col1] glue_catalog.namespace.table_name (branch=null) [filters=, groupedBy=] RuntimeFilters: []
```

This change adds a description method to SparkBatchQueryScan, allowing query plans to include Iceberg-specific scan information and making event logs more informative.