### PR TITLE
Spark: Fix not delete data files of hive tables without purge #12790

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -282,10 +282,11 @@ public class SparkSessionCatalog<
 
   @Override
   public boolean dropTable(Identifier ident) {
-    // no need to check table existence to determine which catalog to use. if a table doesn't exist
-    // then both are
-    // required to return false.
-    return icebergCatalog.dropTable(ident) || getSessionCatalog().dropTable(ident);
+    if (icebergCatalog.tableExists(ident)) {
+      return icebergCatalog.dropTable(ident);
+    } else {
+      return getSessionCatalog().dropTable(ident);
+    }
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -282,10 +282,11 @@ public class SparkSessionCatalog<
 
   @Override
   public boolean dropTable(Identifier ident) {
-    // no need to check table existence to determine which catalog to use. if a table doesn't exist
-    // then both are
-    // required to return false.
-    return icebergCatalog.dropTable(ident) || getSessionCatalog().dropTable(ident);
+    if (icebergCatalog.tableExists(ident)) {
+      return icebergCatalog.dropTable(ident);
+    } else {
+      return getSessionCatalog().dropTable(ident);
+    }
   }
 
   @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -283,10 +283,11 @@ public class SparkSessionCatalog<
 
   @Override
   public boolean dropTable(Identifier ident) {
-    // no need to check table existence to determine which catalog to use. if a table doesn't exist
-    // then both are
-    // required to return false.
-    return icebergCatalog.dropTable(ident) || getSessionCatalog().dropTable(ident);
+    if (icebergCatalog.tableExists(ident)) {
+      return icebergCatalog.dropTable(ident);
+    } else {
+      return getSessionCatalog().dropTable(ident);
+    }
   }
 
   @Override


### PR DESCRIPTION
Addresses #12790

# About the Change
This change updates the `dropTable` method to keep the behavior consistent with Hive tables. Instead of attempting to drop from both catalogs, it now checks whether the table exists in `icebergCatalog` and only calls `icebergCatalog.dropTable` in that case; otherwise it delegates to `sessionCatalog`.