### PR TITLE
Connect: Fix dynamic class detection

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynClasses.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynClasses.java
@@ -66,7 +66,7 @@ public class DynClasses {
 
       try {
         this.foundClass = Class.forName(className, true, loader);
-      } catch (ClassNotFoundException e) {
+      } catch (ClassNotFoundException | NoClassDefFoundError e) {
         // not the right implementation
       }
 


### PR DESCRIPTION
While trying to deploy the Kafka connector on Confluent Cloud it fails with:

```
java.lang.NoClassDefFoundError: org/apache/hadoop/conf/Configuration
  at java.base/java.lang.ClassLoader.defineClass1(Native Method)
  at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
  at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
  at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
  at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
  at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
  at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
  at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:579)
  at org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader.loadClass(DelegatingClassLoader.java:129)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:579)
  at org.apache.kafka.connect.runtime.isolation.PluginClassLoader.loadClass(PluginClassLoader.java:124)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
  at java.base/java.lang.Class.forName0(Native Method)
  at java.base/java.lang.Class.forName(Class.java:467)
  at org.apache.iceberg.common.DynClasses$Builder.impl(DynClasses.java:68)
  at org.apache.iceberg.connect.CatalogUtils.loadHadoopConfig(CatalogUtils.java:52)
  at org.apache.iceberg.connect.CatalogUtils.loadCatalog(CatalogUtils.java:45)
  at org.apache.iceberg.connect.IcebergSinkTask.start(IcebergSinkTask.java:48)
  at org.apache.kafka.connect.runtime.WorkerSinkTask.initializeAndStart(WorkerSinkTask.java:328)
  at org.apache.kafka.connect.runtime.WorkerTask.doStart(WorkerTask.java:188)
  at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:248)
  at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:304)
  at org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$7(Plugins.java:341)
  at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
  at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.conf.Configuration
  at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
  at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
... 29 more
```

while trying to load `org.apache.hadoop.hdfs.HdfsConfiguration` even though the `hadoop-common` package is present in the artifact.