### PR TITLE
Flink: Update Flink 1.18 status to 'End of Life' / Add note for Flink 2.1

### DIFF
--- a/site/docs/multi-engine-support.md
+++ b/site/docs/multi-engine-support.md
@@ -92,10 +92,11 @@ Users should continuously upgrade their Flink version to stay up-to-date.
 | 1.15    | End of Life     | 0.14.0                  | 1.4.3                  | [iceberg-flink-runtime-1.15](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.15/1.4.3/iceberg-flink-runtime-1.15-1.4.3.jar)                               |
 | 1.16    | End of Life     | 1.1.0                   | 1.5.0                  | [iceberg-flink-runtime-1.16](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.16/1.5.0/iceberg-flink-runtime-1.16-1.5.0.jar)                               |
 | 1.17    | End of Life     | 1.3.0                   | 1.6.1                  | [iceberg-flink-runtime-1.17](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.17/1.6.1/iceberg-flink-runtime-1.17-1.6.1.jar) |
-| 1.18    | Maintained      | 1.5.0                   | 1.9.2                  | [iceberg-flink-runtime-1.18](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.18/{{ icebergVersion }}/iceberg-flink-runtime-1.18-{{ icebergVersion }}.jar) |
+| 1.18    | End of Life     | 1.5.0                   | 1.9.2                  | [iceberg-flink-runtime-1.18](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.18/{{ icebergVersion }}/iceberg-flink-runtime-1.18-{{ icebergVersion }}.jar) |
 | 1.19    | Maintained      | 1.6.0                   | {{ icebergVersion }}   | [iceberg-flink-runtime-1.19](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.19/{{ icebergVersion }}/iceberg-flink-runtime-1.19-{{ icebergVersion }}.jar) |
 | 1.20    | Maintained      | 1.7.0                   | {{ icebergVersion }}   | [iceberg-flink-runtime-1.20](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.20/{{ icebergVersion }}/iceberg-flink-runtime-1.20-{{ icebergVersion }}.jar) |
 | 2.0     | Maintained      | 1.10.0                  | {{ icebergVersion }}   | [iceberg-flink-runtime-2.0](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-2.0/{{ icebergVersion }}/iceberg-flink-runtime-2.0-{{ icebergVersion }}.jar)    |
+| 2.1     | To-be-released  | 1.11.0                  |   | |
 
 <!-- markdown-link-check-enable -->
 


### PR DESCRIPTION
Updating the page of supported Flink versions after merging #13714, which added support for Flink 2.1 and removed support for Flink 1.18. 

I've added a placeholder for Flink 2.1 to denote the upcoming support.