### PR TITLE
hack to show the latest site super fast

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -21,6 +21,10 @@ help: # Show help for each of the Makefile recipes.
 serve: # Clean, build, and run the docs site locally.
 	dev/serve.sh
 
+.PHONY: serve-local
+serve-local: # Clean, build, and run the docs site locally.
+	dev/serve.sh
+
 .PHONY: build
 build: # Clean and build the docs site locally.
 	dev/build.sh

--- a/site/dev/serve.sh
+++ b/site/dev/serve.sh
@@ -20,4 +20,12 @@ set -e
 
 ./dev/setup_env.sh
 
+# remove all other versions except 1.10.0, nightly, latest, and index.html
+find docs/docs/ docs/javadoc -mindepth 1 -maxdepth 1 \
+  ! -name '1.10.0' \
+  ! -name 'index.html' \
+  ! -name 'nightly' \
+  ! -name 'latest' \
+  -exec rm -rf {} +
+
 mkdocs serve --dirty --watch .

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -24,25 +24,25 @@ nav:
     - Java:
       - Nightly: '!include docs/docs/nightly/mkdocs.yml'
       - Latest (1.10.0): '!include docs/docs/latest/mkdocs.yml'
-      - Previous:
-        - 1.9.2: '!include docs/docs/1.9.2/mkdocs.yml'
-        - 1.9.1: '!include docs/docs/1.9.1/mkdocs.yml'
-        - 1.9.0: '!include docs/docs/1.9.0/mkdocs.yml'
-        - 1.8.1: '!include docs/docs/1.8.1/mkdocs.yml'
-        - 1.8.0: '!include docs/docs/1.8.0/mkdocs.yml'
-        - 1.7.2: '!include docs/docs/1.7.2/mkdocs.yml'
-        - 1.7.1: '!include docs/docs/1.7.1/mkdocs.yml'
-        - 1.7.0: '!include docs/docs/1.7.0/mkdocs.yml'
-        - 1.6.1: '!include docs/docs/1.6.1/mkdocs.yml'
-        - 1.6.0: '!include docs/docs/1.6.0/mkdocs.yml'
-        - 1.5.2: '!include docs/docs/1.5.2/mkdocs.yml'
-        - 1.5.1: '!include docs/docs/1.5.1/mkdocs.yml'
-        - 1.5.0: '!include docs/docs/1.5.0/mkdocs.yml'
-        - 1.4.3: '!include docs/docs/1.4.3/mkdocs.yml'
-        - 1.4.2: '!include docs/docs/1.4.2/mkdocs.yml'
-        - 1.4.1: '!include docs/docs/1.4.1/mkdocs.yml'
-        - 1.4.0: '!include docs/docs/1.4.0/mkdocs.yml'
-        - archive: archive.md
+      # - Previous:
+      #   - 1.9.2: '!include docs/docs/1.9.2/mkdocs.yml'
+      #   - 1.9.1: '!include docs/docs/1.9.1/mkdocs.yml'
+      #   - 1.9.0: '!include docs/docs/1.9.0/mkdocs.yml'
+      #   - 1.8.1: '!include docs/docs/1.8.1/mkdocs.yml'
+      #   - 1.8.0: '!include docs/docs/1.8.0/mkdocs.yml'
+      #   - 1.7.2: '!include docs/docs/1.7.2/mkdocs.yml'
+      #   - 1.7.1: '!include docs/docs/1.7.1/mkdocs.yml'
+      #   - 1.7.0: '!include docs/docs/1.7.0/mkdocs.yml'
+      #   - 1.6.1: '!include docs/docs/1.6.1/mkdocs.yml'
+      #   - 1.6.0: '!include docs/docs/1.6.0/mkdocs.yml'
+      #   - 1.5.2: '!include docs/docs/1.5.2/mkdocs.yml'
+      #   - 1.5.1: '!include docs/docs/1.5.1/mkdocs.yml'
+      #   - 1.5.0: '!include docs/docs/1.5.0/mkdocs.yml'
+      #   - 1.4.3: '!include docs/docs/1.4.3/mkdocs.yml'
+      #   - 1.4.2: '!include docs/docs/1.4.2/mkdocs.yml'
+      #   - 1.4.1: '!include docs/docs/1.4.1/mkdocs.yml'
+      #   - 1.4.0: '!include docs/docs/1.4.0/mkdocs.yml'
+      #   - archive: archive.md
     - Other Implementations:
       - Python: https://py.iceberg.apache.org/
       - Rust: https://rust.iceberg.apache.org/


### PR DESCRIPTION
DO NOT MERGE, We'll find a more permanent solution as part of #14124 and #13661

This is a hack to spin up the iceberg doc site faster locally. The trick is to remove all the previous versions of the doc so mkdocs dont need to render it. 

Use `make serve-local` in the `site/` directory
