### PR TITLE
AWS: Configure builder for reuse of http connection pool in SDKv2

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/ApacheHttpClientConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/ApacheHttpClientConfigurations.java
@@ -44,7 +44,11 @@ class ApacheHttpClientConfigurations {
   public <T extends AwsSyncClientBuilder> void configureHttpClientBuilder(T awsClientBuilder) {
     ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
     configureApacheHttpClientBuilder(apacheHttpClientBuilder);
-    awsClientBuilder.httpClientBuilder(apacheHttpClientBuilder);
+    // Use httpClient(<client>) method in AWS SDKv2 to prevent shared connection pools from closing
+    // prematurely.
+    // See:
+    // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/client/builder/SdkAsyncClientBuilder.html#httpClient(software.amazon.awssdk.http.async.SdkAsyncHttpClient)
+    awsClientBuilder.httpClient(apacheHttpClientBuilder.build());
   }
 
   private void initialize(Map<String, String> httpClientProperties) {

--- a/aws/src/main/java/org/apache/iceberg/aws/UrlConnectionHttpClientConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/UrlConnectionHttpClientConfigurations.java
@@ -39,7 +39,11 @@ class UrlConnectionHttpClientConfigurations {
     UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
         UrlConnectionHttpClient.builder();
     configureUrlConnectionHttpClientBuilder(urlConnectionHttpClientBuilder);
-    awsClientBuilder.httpClientBuilder(urlConnectionHttpClientBuilder);
+    // Use httpClient(<client>) method in AWS SDKv2 to prevent shared connection pools from closing
+    // prematurely.
+    // See:
+    // https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/client/builder/SdkAsyncClientBuilder.html#httpClient(software.amazon.awssdk.http.async.SdkAsyncHttpClient)
+    awsClientBuilder.httpClient(urlConnectionHttpClientBuilder.build());
   }
 
   private void initialize(Map<String, String> httpClientProperties) {


### PR DESCRIPTION
This is an alternative PR for https://github.com/apache/iceberg/pull/12868 based on the review [comments](https://github.com/apache/iceberg/pull/12868#issuecomment-3164904270). This changes how we configure the http client for shared connection pool.

See: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/client/builder/SdkAsyncClientBuilder.html#httpClient(software.amazon.awssdk.http.async.SdkAsyncHttpClient)
