### PR TITLE
Flink: Ensure DynamicCommitter idempotence in the presence of failures

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -71,7 +71,6 @@ import org.slf4j.LoggerFactory;
 class DynamicCommitter implements Committer<DynamicCommittable> {
 
   private static final String MAX_COMMITTED_CHECKPOINT_ID = "flink.max-committed-checkpoint-id";
-  private static final String MAX_WRITE_RESULT_INDEX = "flink.max-write-result-index";
   private static final Logger LOG = LoggerFactory.getLogger(DynamicCommitter.class);
   private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
   private static final WriteResult EMPTY_WRITE_RESULT =
@@ -81,7 +80,6 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
           .build();
 
   private static final long INITIAL_CHECKPOINT_ID = -1L;
-  private static final int INITIAL_WRITE_RESULT_INDEX = -1;
 
   @VisibleForTesting
   static final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
@@ -139,54 +137,28 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
         commitRequestMap.entrySet()) {
       Table table = catalog.loadTable(TableIdentifier.parse(entry.getKey().tableName()));
       DynamicCommittable last = entry.getValue().lastEntry().getValue().get(0).getCommittable();
-
-      CheckpointInfo maxCommittedCheckpointIds =
+      long maxCommittedCheckpointId =
           getMaxCommittedCheckpointId(
               table, last.jobId(), last.operatorId(), entry.getKey().branch());
       // Mark the already committed FilesCommittable(s) as finished
       entry
           .getValue()
-          .headMap(maxCommittedCheckpointIds.maxProcessedCheckpointId, false)
+          .headMap(maxCommittedCheckpointId, true)
           .values()
           .forEach(list -> list.forEach(CommitRequest::signalAlreadyCommitted));
-      // Filter out all committables until the last checkpoint id, which may be partially committed.
       NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> uncommitted =
-          entry.getValue().tailMap(maxCommittedCheckpointIds.maxProcessedCheckpointId, true);
-
+          entry.getValue().tailMap(maxCommittedCheckpointId, false);
       if (!uncommitted.isEmpty()) {
         commitPendingRequests(
-            table,
-            entry.getKey().branch(),
-            uncommitted,
-            last.jobId(),
-            last.operatorId(),
-            maxCommittedCheckpointIds);
+            table, entry.getKey().branch(), uncommitted, last.jobId(), last.operatorId());
       }
     }
   }
 
-  private static class CheckpointInfo {
-    private final long maxProcessedCheckpointId;
-    private final int maxCommittedWriteResultIndex;
-
-    private CheckpointInfo(long maxProcessedCheckpointId, int maxCommittedWriteResultIndex) {
-      this.maxProcessedCheckpointId = maxProcessedCheckpointId;
-      this.maxCommittedWriteResultIndex = maxCommittedWriteResultIndex;
-    }
-
-    int writeResultIndexFor(long checkpointId) {
-      if (checkpointId == this.maxProcessedCheckpointId) {
-        return this.maxCommittedWriteResultIndex;
-      }
-      return -1;
-    }
-  }
-
-  private static CheckpointInfo getMaxCommittedCheckpointId(
+  private static long getMaxCommittedCheckpointId(
       Table table, String flinkJobId, String operatorId, String branch) {
     Snapshot snapshot = table.snapshot(branch);
     long lastCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
-    int writeResultIndex = INITIAL_WRITE_RESULT_INDEX;
 
     while (snapshot != null) {
       Map<String, String> summary = snapshot.summary();
@@ -194,13 +166,9 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       String snapshotOperatorId = summary.get(OPERATOR_ID);
       if (flinkJobId.equals(snapshotFlinkJobId)
           && (snapshotOperatorId == null || snapshotOperatorId.equals(operatorId))) {
-        String maxCheckpointIdString = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
-        if (maxCheckpointIdString != null) {
-          lastCommittedCheckpointId = Long.parseLong(maxCheckpointIdString);
-          String writeResultIndexString = summary.get(MAX_WRITE_RESULT_INDEX);
-          if (writeResultIndexString != null) {
-            writeResultIndex = Integer.parseInt(writeResultIndexString);
-          }
+        String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
+        if (value != null) {
+          lastCommittedCheckpointId = Long.parseLong(value);
           break;
         }
       }
@@ -209,7 +177,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
     }
 
-    return new CheckpointInfo(lastCommittedCheckpointId, writeResultIndex);
+    return lastCommittedCheckpointId;
   }
 
   /**
@@ -228,29 +196,24 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       String branch,
       NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> commitRequestMap,
       String newFlinkJobId,
-      String operatorId,
-      CheckpointInfo checkpointInfo)
+      String operatorId)
       throws IOException {
+    long checkpointId = commitRequestMap.lastKey();
     List<ManifestFile> manifests = Lists.newArrayList();
     NavigableMap<Long, List<WriteResult>> pendingResults = Maps.newTreeMap();
     for (Map.Entry<Long, List<CommitRequest<DynamicCommittable>>> e : commitRequestMap.entrySet()) {
-      long currentCheckpointId = e.getKey();
-      List<CommitRequest<DynamicCommittable>> commitRequests = e.getValue();
-      for (int i = checkpointInfo.writeResultIndexFor(currentCheckpointId) + 1;
-          i < commitRequests.size();
-          i++) {
-        CommitRequest<DynamicCommittable> committable = commitRequests.get(i);
-        List<WriteResult> writeResults =
-            pendingResults.computeIfAbsent(e.getKey(), unused -> Lists.newArrayList());
+      for (CommitRequest<DynamicCommittable> committable : e.getValue()) {
         if (Arrays.equals(EMPTY_MANIFEST_DATA, committable.getCommittable().manifest())) {
-          writeResults.add(EMPTY_WRITE_RESULT);
+          pendingResults
+              .computeIfAbsent(e.getKey(), unused -> Lists.newArrayList())
+              .add(EMPTY_WRITE_RESULT);
         } else {
           DeltaManifests deltaManifests =
               SimpleVersionedSerialization.readVersionAndDeSerialize(
                   DeltaManifestsSerializer.INSTANCE, committable.getCommittable().manifest());
-          WriteResult writeResult =
-              FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs());
-          writeResults.add(writeResult);
+          pendingResults
+              .computeIfAbsent(e.getKey(), unused -> Lists.newArrayList())
+              .add(FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs()));
           manifests.addAll(deltaManifests.manifests());
         }
       }
@@ -259,12 +222,11 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     CommitSummary summary = new CommitSummary();
     summary.addAll(pendingResults);
     commitPendingResult(
-        table, branch, pendingResults, summary, newFlinkJobId, operatorId, checkpointInfo);
+        table, branch, pendingResults, summary, newFlinkJobId, operatorId, checkpointId);
     if (committerMetrics != null) {
       committerMetrics.updateCommitSummary(table.name(), summary);
     }
 
-    long checkpointId = commitRequestMap.lastKey();
     FlinkManifestUtil.deleteCommittedManifests(table, manifests, newFlinkJobId, checkpointId);
   }
 
@@ -275,7 +237,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       CommitSummary summary,
       String newFlinkJobId,
       String operatorId,
-      CheckpointInfo checkpointInfo) {
+      long checkpointId) {
     long totalFiles = summary.dataFilesCount() + summary.deleteFilesCount();
     TableKey key = new TableKey(table.name(), branch);
     int continuousEmptyCheckpoints =
@@ -295,13 +257,11 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       if (replacePartitions) {
         replacePartitions(table, branch, pendingResults, summary, newFlinkJobId, operatorId);
       } else {
-        commitDeltaTxn(
-            table, branch, pendingResults, summary, newFlinkJobId, operatorId, checkpointInfo);
+        commitDeltaTxn(table, branch, pendingResults, summary, newFlinkJobId, operatorId);
       }
 
       continuousEmptyCheckpoints = 0;
-    } else if (!pendingResults.isEmpty()) {
-      long checkpointId = pendingResults.lastKey();
+    } else {
       LOG.info("Skip commit for checkpoint {} due to no data files or delete files.", checkpointId);
     }
 
@@ -315,27 +275,25 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       CommitSummary summary,
       String newFlinkJobId,
       String operatorId) {
-    for (Map.Entry<Long, List<WriteResult>> e : pendingResults.entrySet()) {
-      ReplacePartitions dynamicOverwrite = null;
-      for (WriteResult result : e.getValue()) {
-        if (dynamicOverwrite == null) {
-          dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
-        }
+    // Iceberg tables are unsorted. So the order of the append data does not matter.
+    // Hence, we commit everything in one snapshot.
+    ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
+
+    for (List<WriteResult> writeResults : pendingResults.values()) {
+      for (WriteResult result : writeResults) {
         Arrays.stream(result.dataFiles()).forEach(dynamicOverwrite::addFile);
       }
-      if (dynamicOverwrite != null) {
-        commitOperation(
-            table,
-            branch,
-            dynamicOverwrite,
-            summary,
-            "dynamic partition overwrite",
-            newFlinkJobId,
-            operatorId,
-            e.getKey(),
-            INITIAL_WRITE_RESULT_INDEX);
-      }
     }
+
+    commitOperation(
+        table,
+        branch,
+        dynamicOverwrite,
+        summary,
+        "dynamic partition overwrite",
+        newFlinkJobId,
+        operatorId,
+        pendingResults.lastKey());
   }
 
   private void commitDeltaTxn(
@@ -344,23 +302,35 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       NavigableMap<Long, List<WriteResult>> pendingResults,
       CommitSummary summary,
       String newFlinkJobId,
-      String operatorId,
-      CheckpointInfo checkpointInfo) {
+      String operatorId) {
+    // For append-only WriteResults, we commit all append-only WriteResults into a single
+    // transaction.
+    // For WriteResults with delete files, we issue a separate transaction because for the
+    // sequential transactions txn1 and txn2, the equality-delete files of txn2 are required to be
+    // applied to data files from txn1. Committing the merged one will lead to the incorrect delete
+    // semantic.
+    RowDelta rowDelta = null;
+    long checkpointId = -1;
+
     for (Map.Entry<Long, List<WriteResult>> e : pendingResults.entrySet()) {
-      long checkpointId = e.getKey();
       List<WriteResult> writeResults = e.getValue();
-      // For append-only WriteResults, we commit all append-only WriteResults into a single
-      // transaction.
-      // For WriteResults with delete files, we issue a separate transaction because for the
-      // sequential transactions txn1 and txn2, the equality-delete files of txn2 are required to be
-      // applied to data files from txn1. Committing the merged one will lead to the incorrect
-      // delete semantic.
-      boolean deletesPresent;
-      RowDelta rowDelta = null;
-      for (int i = checkpointInfo.writeResultIndexFor(checkpointId) + 1;
-          i < writeResults.size();
-          i++) {
-        WriteResult result = writeResults.get(i);
+
+      // This branch will only get triggered from the second iteration onward.
+      if (rowDelta != null
+          && writeResults.stream().anyMatch(writeResult -> writeResult.deleteFiles().length > 0)) {
+        // Deletes detected with already accumulated append-only WriteResults. We need to commit the
+        // append-only data first.
+        commitOperation(
+            table, branch, rowDelta, summary, "rowDelta", newFlinkJobId, operatorId, checkpointId);
+        rowDelta = null;
+      }
+
+      checkpointId = e.getKey();
+      if (rowDelta == null) {
+        rowDelta = table.newRowDelta().scanManifestsWith(workerPool);
+      }
+
+      for (WriteResult result : writeResults) {
         // Row delta validations are not needed for streaming changes that write equality deletes.
         // Equality deletes are applied to data in all previous sequence numbers, so retries may
         // push deletes further in the future, but do not affect correctness. Position deletes
@@ -368,41 +338,13 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
         // being added in this commit. There is no way for data files added along with the delete
         // files to be concurrently removed, so there is no need to validate the files referenced by
         // the position delete files that are being committed.
-        deletesPresent = result.deleteFiles().length > 0;
-        if (rowDelta == null) {
-          rowDelta = table.newRowDelta().scanManifestsWith(workerPool);
-        } else if (deletesPresent) {
-          commitOperation(
-              table,
-              branch,
-              rowDelta,
-              summary,
-              "rowDelta",
-              newFlinkJobId,
-              operatorId,
-              checkpointId,
-              i);
-          rowDelta = table.newRowDelta().scanManifestsWith(workerPool);
-        }
-
         Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
         Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
-
-        if (i == writeResults.size() - 1) {
-          // Final WriteResult, we need to commit.
-          commitOperation(
-              table,
-              branch,
-              rowDelta,
-              summary,
-              "rowDelta",
-              newFlinkJobId,
-              operatorId,
-              checkpointId,
-              i);
-        }
       }
     }
+    // Final commit which will be the only commit in case of solely append-only WriteResults.
+    commitOperation(
+        table, branch, rowDelta, summary, "rowDelta", newFlinkJobId, operatorId, checkpointId);
   }
 
   @VisibleForTesting
@@ -414,8 +356,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       String description,
       String newFlinkJobId,
       String operatorId,
-      long checkpointId,
-      int maxWriteResultIndex) {
+      long checkpointId) {
 
     LOG.info(
         "Committing {} for checkpoint {} to table {} branch {} with summary: {}",
@@ -428,7 +369,6 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
     // used by the sink.
     operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));
-    operation.set(MAX_WRITE_RESULT_INDEX, Integer.toString(maxWriteResultIndex));
     operation.set(FLINK_JOB_ID, newFlinkJobId);
     operation.set(OPERATOR_ID, operatorId);
     operation.toBranch(branch);

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -221,8 +221,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
 
     CommitSummary summary = new CommitSummary();
     summary.addAll(pendingResults);
-    commitPendingResult(
-        table, branch, pendingResults, summary, newFlinkJobId, operatorId, checkpointId);
+    commitPendingResult(table, branch, pendingResults, summary, newFlinkJobId, operatorId);
     if (committerMetrics != null) {
       committerMetrics.updateCommitSummary(table.name(), summary);
     }
@@ -236,8 +235,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       NavigableMap<Long, List<WriteResult>> pendingResults,
       CommitSummary summary,
       String newFlinkJobId,
-      String operatorId,
-      long checkpointId) {
+      String operatorId) {
     long totalFiles = summary.dataFilesCount() + summary.deleteFilesCount();
     TableKey key = new TableKey(table.name(), branch);
     int continuousEmptyCheckpoints =
@@ -262,6 +260,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
 
       continuousEmptyCheckpoints = 0;
     } else {
+      long checkpointId = pendingResults.lastKey();
       LOG.info("Skip commit for checkpoint {} due to no data files or delete files.", checkpointId);
     }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -373,21 +373,21 @@ class TestDynamicCommitter {
         aggregator.writeToManifest(
             writeTarget2,
             Sets.newHashSet(new DynamicWriteResult(writeTarget2, writeResult2)),
-            checkpointId2);
+            checkpointId1);
 
     CommitRequest<DynamicCommittable> commitRequest2 =
         new MockCommitRequest<>(
-            new DynamicCommittable(writeTarget2, deltaManifest2, jobId, operatorId, checkpointId2));
+            new DynamicCommittable(writeTarget2, deltaManifest2, jobId, operatorId, checkpointId1));
 
     byte[] deltaManifest3 =
         aggregator.writeToManifest(
             writeTarget3,
             Sets.newHashSet(new DynamicWriteResult(writeTarget3, writeResult2)),
-            checkpointId1);
+            checkpointId2);
 
     CommitRequest<DynamicCommittable> commitRequest3 =
         new MockCommitRequest<>(
-            new DynamicCommittable(writeTarget3, deltaManifest3, jobId, operatorId, checkpointId1));
+            new DynamicCommittable(writeTarget3, deltaManifest3, jobId, operatorId, checkpointId2));
 
     boolean overwriteMode = false;
     int workerPoolSize = 1;
@@ -406,7 +406,7 @@ class TestDynamicCommitter {
     dynamicCommitter.commit(Sets.newHashSet(commitRequest1, commitRequest2, commitRequest3));
 
     table.refresh();
-    // Three committables, but only two snapshots! One snapshot for each table / branch.
+    // Two committables, one for each snapshot / table / branch.
     assertThat(table.snapshots()).hasSize(2);
 
     Snapshot snapshot1 = Iterables.getFirst(table.snapshots(), null);
@@ -418,7 +418,7 @@ class TestDynamicCommitter {
                 .put("added-records", "66")
                 .put("changed-partition-count", "1")
                 .put("flink.job-id", jobId)
-                .put("flink.max-committed-checkpoint-id", "" + checkpointId2)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId1)
                 .put("flink.operator-id", operatorId)
                 .put("total-data-files", "2")
                 .put("total-delete-files", "0")
@@ -437,7 +437,7 @@ class TestDynamicCommitter {
                 .put("added-records", "24")
                 .put("changed-partition-count", "1")
                 .put("flink.job-id", jobId)
-                .put("flink.max-committed-checkpoint-id", "" + checkpointId1)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId2)
                 .put("flink.operator-id", operatorId)
                 .put("total-data-files", "1")
                 .put("total-delete-files", "0")

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -19,8 +19,13 @@
 package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
+import java.io.IOException;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Map;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.connector.sink2.Committer.CommitRequest;
@@ -34,15 +39,18 @@ import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.flink.sink.CommitSummary;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -67,6 +75,22 @@ class TestDynamicCommitter {
                   42L,
                   null, // no column sizes
                   ImmutableMap.of(1, 5L), // value count
+                  ImmutableMap.of(1, 0L), // null count
+                  null,
+                  ImmutableMap.of(1, ByteBuffer.allocate(1)), // lower bounds
+                  ImmutableMap.of(1, ByteBuffer.allocate(1)) // upper bounds
+                  ))
+          .build();
+
+  private static final DataFile DATA_FILE_2 =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-2.parquet")
+          .withFileSizeInBytes(0)
+          .withMetrics(
+              new Metrics(
+                  24L,
+                  null, // no column sizes
+                  ImmutableMap.of(1, 3L), // value count
                   ImmutableMap.of(1, 0L), // null count
                   null,
                   ImmutableMap.of(1, ByteBuffer.allocate(1)), // lower bounds
@@ -162,60 +186,57 @@ class TestDynamicCommitter {
     Snapshot first = Iterables.getFirst(table1.snapshots(), null);
     assertThat(first.summary())
         .containsAllEntriesOf(
-            (Map)
-                ImmutableMap.builder()
-                    .put("added-data-files", "1")
-                    .put("added-records", "42")
-                    .put("changed-partition-count", "1")
-                    .put("flink.job-id", jobId)
-                    .put("flink.max-committed-checkpoint-id", "" + checkpointId)
-                    .put("flink.operator-id", operatorId)
-                    .put("total-data-files", "1")
-                    .put("total-delete-files", "0")
-                    .put("total-equality-deletes", "0")
-                    .put("total-files-size", "0")
-                    .put("total-position-deletes", "0")
-                    .put("total-records", "42")
-                    .build());
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "42")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId)
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "42")
+                .build());
     Snapshot second = Iterables.get(table1.snapshots(), 1, null);
     assertThat(second.summary())
         .containsAllEntriesOf(
-            (Map)
-                ImmutableMap.builder()
-                    .put("added-data-files", "1")
-                    .put("added-records", "42")
-                    .put("changed-partition-count", "1")
-                    .put("flink.job-id", jobId)
-                    .put("flink.max-committed-checkpoint-id", "" + checkpointId)
-                    .put("flink.operator-id", operatorId)
-                    .put("total-data-files", "1")
-                    .put("total-delete-files", "0")
-                    .put("total-equality-deletes", "0")
-                    .put("total-files-size", "0")
-                    .put("total-position-deletes", "0")
-                    .put("total-records", "42")
-                    .build());
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "42")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId)
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "42")
+                .build());
 
     table2.refresh();
     assertThat(table2.snapshots()).hasSize(1);
     Snapshot third = Iterables.getFirst(table2.snapshots(), null);
     assertThat(third.summary())
         .containsAllEntriesOf(
-            (Map)
-                ImmutableMap.builder()
-                    .put("added-data-files", "1")
-                    .put("added-records", "42")
-                    .put("changed-partition-count", "1")
-                    .put("flink.job-id", jobId)
-                    .put("flink.max-committed-checkpoint-id", "" + checkpointId)
-                    .put("flink.operator-id", operatorId)
-                    .put("total-data-files", "1")
-                    .put("total-delete-files", "0")
-                    .put("total-equality-deletes", "0")
-                    .put("total-files-size", "0")
-                    .put("total-position-deletes", "0")
-                    .put("total-records", "42")
-                    .build());
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "42")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId)
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "42")
+                .build());
   }
 
   @Test
@@ -277,21 +298,255 @@ class TestDynamicCommitter {
     Snapshot first = Iterables.getFirst(table1.snapshots(), null);
     assertThat(first.summary())
         .containsAllEntriesOf(
-            (Map)
-                ImmutableMap.builder()
-                    .put("added-data-files", "1")
-                    .put("added-records", "42")
-                    .put("changed-partition-count", "1")
-                    .put("flink.job-id", jobId)
-                    .put("flink.max-committed-checkpoint-id", "" + checkpointId)
-                    .put("flink.operator-id", operatorId)
-                    .put("total-data-files", "1")
-                    .put("total-delete-files", "0")
-                    .put("total-equality-deletes", "0")
-                    .put("total-files-size", "0")
-                    .put("total-position-deletes", "0")
-                    .put("total-records", "42")
-                    .build());
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "42")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId)
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "42")
+                .build());
+  }
+
+  @Test
+  void testTableBranchAtomicCommitForAppendOnlyData() throws Exception {
+    Table table = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table.snapshots()).isEmpty();
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    WriteTarget writeTarget1 =
+        new WriteTarget(TABLE1, "branch", 42, 0, true, Sets.newHashSet(1, 2));
+    // writeTarget2 has a different schema
+    WriteTarget writeTarget2 = new WriteTarget(TABLE1, "branch", 23, 0, true, Sets.newHashSet());
+    // Different branch for writeTarget3
+    WriteTarget writeTarget3 = new WriteTarget(TABLE1, "branch2", 23, 0, true, Sets.newHashSet());
+
+    WriteResult writeResult1 = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    WriteResult writeResult2 = WriteResult.builder().addDataFiles(DATA_FILE_2).build();
+
+    final String jobId = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int checkpointId = 10;
+
+    byte[] deltaManifest1 =
+        aggregator.writeToManifest(
+            writeTarget1, Sets.newHashSet(new DynamicWriteResult(writeTarget1, writeResult1)), 0);
+
+    CommitRequest<DynamicCommittable> commitRequest1 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget1, deltaManifest1, jobId, operatorId, checkpointId));
+
+    byte[] deltaManifest2 =
+        aggregator.writeToManifest(
+            writeTarget2, Sets.newHashSet(new DynamicWriteResult(writeTarget2, writeResult2)), 0);
+
+    CommitRequest<DynamicCommittable> commitRequest2 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget2, deltaManifest2, jobId, operatorId, checkpointId));
+
+    byte[] deltaManifest3 =
+        aggregator.writeToManifest(
+            writeTarget3, Sets.newHashSet(new DynamicWriteResult(writeTarget3, writeResult2)), 0);
+
+    CommitRequest<DynamicCommittable> commitRequest3 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget3, deltaManifest3, jobId, operatorId, checkpointId));
+
+    boolean overwriteMode = false;
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+    DynamicCommitter dynamicCommitter =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    dynamicCommitter.commit(Sets.newHashSet(commitRequest1, commitRequest2, commitRequest3));
+
+    table.refresh();
+    // Three committables, but only two snapshots! One snapshot for all append-only WriteResults,
+    // one snapshot for all WriteResults containing delete files.
+    assertThat(table.snapshots()).hasSize(2);
+
+    Snapshot snapshot1 = Iterables.getFirst(table.snapshots(), null);
+    assertThat(snapshot1.summary())
+        .containsAllEntriesOf(
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "2")
+                .put("added-records", "66")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId)
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "2")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "66")
+                .build());
+
+    Snapshot snapshot2 = Iterables.get(table.snapshots(), 1);
+    assertThat(snapshot2.summary())
+        .containsAllEntriesOf(
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "24")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId)
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "24")
+                .build());
+  }
+
+  @Test
+  void testTableBranchAtomicCommitWithFailures() throws Exception {
+    Table table = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table.snapshots()).isEmpty();
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    WriteTarget writeTarget1 =
+        new WriteTarget(TABLE1, "branch", 42, 0, true, Sets.newHashSet(1, 2));
+    // writeTarget2 has a different schema
+    WriteTarget writeTarget2 = new WriteTarget(TABLE1, "branch", 23, 0, true, Sets.newHashSet());
+
+    WriteResult writeResult1 = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    WriteResult writeResult2 = WriteResult.builder().addDataFiles(DATA_FILE_2).build();
+
+    final String jobId = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int checkpointId1 = 1;
+    final int checkpointId2 = 2;
+
+    byte[] deltaManifest1 =
+        aggregator.writeToManifest(
+            writeTarget1,
+            Sets.newHashSet(new DynamicWriteResult(writeTarget1, writeResult1)),
+            checkpointId1);
+
+    CommitRequest<DynamicCommittable> commitRequest1 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget1, deltaManifest1, jobId, operatorId, checkpointId1));
+
+    byte[] deltaManifest2 =
+        aggregator.writeToManifest(
+            writeTarget2,
+            Sets.newHashSet(new DynamicWriteResult(writeTarget2, writeResult2)),
+            checkpointId2);
+
+    CommitRequest<DynamicCommittable> commitRequest2 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget2, deltaManifest2, jobId, operatorId, checkpointId2));
+
+    boolean overwriteMode = false;
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+
+    // Use special hook to fail during various states of the commit operation
+    CommitHook commitHook = new FailBeforeAndAfterCommit();
+    DynamicCommitter dynamicCommitter =
+        new CommitHookEnabledDynamicCommitter(
+            commitHook,
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    ThrowingCallable commitExecutable =
+        () -> dynamicCommitter.commit(Sets.newHashSet(commitRequest1, commitRequest2));
+
+    // First fail pre-commit
+    assertThatThrownBy(commitExecutable);
+    assertThat(FailBeforeAndAfterCommit.failedBeforeCommit).isTrue();
+
+    // Second fail during commit
+    assertThatThrownBy(commitExecutable);
+    assertThat(FailBeforeAndAfterCommit.failedDuringCommit).isTrue();
+
+    // Third fail after commit
+    assertThatThrownBy(commitExecutable);
+    assertThat(FailBeforeAndAfterCommit.failedAfterCommit).isTrue();
+
+    // Finally commit must go through, although it is a NOOP because the third failure is directly
+    // after the commit finished.
+    try {
+      commitExecutable.call();
+    } catch (Throwable e) {
+      fail("Should not have thrown an exception");
+    }
+
+    table.refresh();
+    // Two committables. One per checkpoint.
+    assertThat(table.snapshots()).hasSize(2);
+
+    Snapshot snapshot1 = Iterables.getFirst(table.snapshots(), null);
+    assertThat(snapshot1.summary())
+        .containsAllEntriesOf(
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "42")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId1)
+                .put("flink.max-write-result-index", "0")
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "42")
+                .build());
+
+    Snapshot snapshot2 = Iterables.get(table.snapshots(), 1);
+    assertThat(snapshot2.summary())
+        .containsAllEntriesOf(
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "24")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId2)
+                .put("flink.max-write-result-index", "0")
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "2")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "66")
+                .build());
   }
 
   @Test
@@ -361,21 +616,118 @@ class TestDynamicCommitter {
     Snapshot latestSnapshot = Iterables.getLast(table1.snapshots());
     assertThat(latestSnapshot.summary())
         .containsAllEntriesOf(
-            (Map)
-                ImmutableMap.builder()
-                    .put("replace-partitions", "true")
-                    .put("added-data-files", "1")
-                    .put("added-records", "42")
-                    .put("changed-partition-count", "1")
-                    .put("flink.job-id", jobId)
-                    .put("flink.max-committed-checkpoint-id", String.valueOf(checkpointId + 1))
-                    .put("flink.operator-id", operatorId)
-                    .put("total-data-files", "1")
-                    .put("total-delete-files", "0")
-                    .put("total-equality-deletes", "0")
-                    .put("total-files-size", "0")
-                    .put("total-position-deletes", "0")
-                    .put("total-records", "42")
-                    .build());
+            ImmutableMap.<String, String>builder()
+                .put("replace-partitions", "true")
+                .put("added-data-files", "1")
+                .put("added-records", "42")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", String.valueOf(checkpointId + 1))
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "42")
+                .build());
+  }
+
+  interface CommitHook extends Serializable {
+    void beforeCommit();
+
+    void duringCommit();
+
+    void afterCommit();
+  }
+
+  static class FailBeforeAndAfterCommit implements CommitHook {
+
+    static boolean failedBeforeCommit;
+    static boolean failedDuringCommit;
+    static boolean failedAfterCommit;
+
+    FailBeforeAndAfterCommit() {
+      reset();
+    }
+
+    @Override
+    public void beforeCommit() {
+      if (!failedBeforeCommit) {
+        failedBeforeCommit = true;
+        throw new RuntimeException("Failing before commit");
+      }
+    }
+
+    @Override
+    public void duringCommit() {
+      if (!failedDuringCommit) {
+        failedDuringCommit = true;
+        throw new RuntimeException("Failing during commit");
+      }
+    }
+
+    @Override
+    public void afterCommit() {
+      if (!failedAfterCommit) {
+        failedAfterCommit = true;
+        throw new RuntimeException("Failing before commit");
+      }
+    }
+
+    static void reset() {
+      failedBeforeCommit = false;
+      failedDuringCommit = false;
+      failedAfterCommit = false;
+    }
+  }
+
+  static class CommitHookEnabledDynamicCommitter extends DynamicCommitter {
+    private final CommitHook commitHook;
+
+    CommitHookEnabledDynamicCommitter(
+        CommitHook commitHook,
+        Catalog catalog,
+        Map<String, String> snapshotProperties,
+        boolean replacePartitions,
+        int workerPoolSize,
+        String sinkId,
+        DynamicCommitterMetrics committerMetrics) {
+      super(
+          catalog, snapshotProperties, replacePartitions, workerPoolSize, sinkId, committerMetrics);
+      this.commitHook = commitHook;
+    }
+
+    @Override
+    public void commit(Collection<CommitRequest<DynamicCommittable>> commitRequests)
+        throws IOException, InterruptedException {
+      commitHook.beforeCommit();
+      super.commit(commitRequests);
+      commitHook.afterCommit();
+    }
+
+    @Override
+    void commitOperation(
+        Table table,
+        String branch,
+        SnapshotUpdate<?> operation,
+        CommitSummary summary,
+        String description,
+        String newFlinkJobId,
+        String operatorId,
+        long checkpointId,
+        int maxWriteResultIndex) {
+      super.commitOperation(
+          table,
+          branch,
+          operation,
+          summary,
+          description,
+          newFlinkJobId,
+          operatorId,
+          checkpointId,
+          maxWriteResultIndex);
+      commitHook.duringCommit();
+    }
   }
 }


### PR DESCRIPTION
Previously, the DynamicCommitter could commit duplicate WriteResults when recovering from failures, leading to incorrect data in tables. This change gets rid of the unnecessary commits for each WriteResult, which caused the problems in the first place, and instead commits all the WriteResults for each Flink checkpoint / table / branch together. 

The WriteResults for each checkpoint / table / branch can safely be committed together, even in the presence of delete files. Since we now commit once per Flink checkpoint and table / branch, we can use the already existing max Flink checkpoint id in the snapshot table properties for the table / branch to detect whether we have already committed.

We intentionally chose not to combine WriteResults across Flink checkpoints, which would be possible when a checkpoint only contains append-only data. While technically feasible, it is a premature optimization which complicates the implementation and maintainability for solving a very rare edge case of committing multiple pending checkpoints. Multiple checkpoints can only occur with a very low checkpoint interval or when concurrent checkpointing is enabled. Even in such a situation, it is preferable to keep the commits separately, as this makes it easier to reason about the applied changes.