### PR TITLE
Spark: Log failed catalog load in Spark3Util::catalogAndIdentifier

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -92,11 +92,15 @@ import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Option;
 import scala.collection.JavaConverters;
 import scala.collection.immutable.Seq;
 
 public class Spark3Util {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Spark3Util.class);
 
   private static final Set<String> RESERVED_PROPERTIES =
       ImmutableSet.of(TableCatalog.PROP_LOCATION, TableCatalog.PROP_PROVIDER);
@@ -810,6 +814,7 @@ public class Spark3Util {
               try {
                 return catalogManager.catalog(catalogName);
               } catch (Exception e) {
+                LOG.info("Failed to load catalog", e);
                 return null;
               }
             },


### PR DESCRIPTION
We were running into issues where our catalog defined in `catalog-impl` failed to load. The error was swallowed by `Spark3Util`.

We instead get errors related to `HiveCatalog`  due to `IcebergSource` falling back to `DEFAULT_CATALOG_NAME` which defaults to `HiveCatalog` if no extra configs are set.

This change logs the failed catalog load.

Also serious if we should get rid of the fallback to `DEFAULT_CATALOG_NAME`.