### PR TITLE
IRC: Use `PrimitiveTypeValue` rather than `object`

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Extra, Field
@@ -1074,19 +1074,18 @@ class SetStatisticsUpdate(BaseUpdate):
 class UnaryExpression(BaseModel):
     type: ExpressionType
     term: Term
-    value: Dict[str, Any]
 
 
 class LiteralExpression(BaseModel):
     type: ExpressionType
     term: Term
-    value: Dict[str, Any]
+    value: PrimitiveTypeValue
 
 
 class SetExpression(BaseModel):
     type: ExpressionType
     term: Term
-    values: List[Dict[str, Any]]
+    values: List[PrimitiveTypeValue]
 
 
 class StructField(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2249,8 +2249,6 @@ components:
           enum: ["is-null", "not-null", "is-nan", "not-nan"]
         term:
           $ref: '#/components/schemas/Term'
-        value:
-          type: object
 
     LiteralExpression:
       type: object
@@ -2265,7 +2263,7 @@ components:
         term:
           $ref: '#/components/schemas/Term'
         value:
-          type: object
+          $ref: '#/components/schemas/PrimitiveTypeValue'
 
     SetExpression:
       type: object
@@ -2282,7 +2280,7 @@ components:
         values:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/PrimitiveTypeValue'
 
     Term:
       oneOf:


### PR DESCRIPTION
I don't think we want to pass in objects as the value. I've changed it to `PrimitiveTypeValue`, but technically you could also compare on complex types.