### PR TITLE
Core: Fixed the unpartitioned check in replace partitions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
@@ -111,7 +111,7 @@ public class BaseReplacePartitions extends MergingSnapshotProducer<ReplacePartit
 
   @Override
   public List<ManifestFile> apply(TableMetadata base, Snapshot snapshot) {
-    if (dataSpec().fields().isEmpty()) {
+    if (dataSpec().isUnpartitioned()) {
       // replace all data in an unpartitioned table
       deleteByRowFilter(Expressions.alwaysTrue());
     }


### PR DESCRIPTION
**Summary**

- The logic in [BaseReplacePartitions.apply()](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java#L114) doesn't run unpartitioned table check correctly. It simply counts for the fields in the partition spec without checking if they have void transform applied. This leads to the wrong behavior when `insert overwrite` runs on a table with partition columns removed, where it's supposed to replace the entire partitions instead of overwriting the partitions affected. The expected behavior is described in the public [doc](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java#L114).

**Change**

- Modified the check to use the method in `PartitionSpec`, which includes the void transform check.

**Test Plan**

- Tested locally using Iceberg 1.4 and Spark 3.5.