### PR TITLE
Flink: Dynamic Sink: Document writeParallelism and fail on invalid configuration

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
@@ -48,8 +48,10 @@ public class DynamicRecord {
    * @param rowData The data matching the provided schema.
    * @param partitionSpec The target table {@link PartitionSpec}.
    * @param distributionMode The {@link DistributionMode}.
-   * @param writeParallelism The number of parallel writers. If set to {@literal <= 0}, will
-   *     automatically configure the maximum available write parallelism.
+   * @param writeParallelism The number of parallel writers. Can be set to any value {@literal > 0},
+   *     but will always be automatically capped by the maximum write parallelism, which is the
+   *     parallelism of the sink. Set to Integer.MAX_VALUE for always using the maximum available
+   *     write parallelism.
    */
   public DynamicRecord(
       TableIdentifier tableIdentifier,

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
@@ -62,14 +62,4 @@ class DynamicSinkUtil {
 
     return -input;
   }
-
-  static int firstPositive(int first, int second) {
-    if (first > 0) {
-      return first;
-    }
-    if (second > 0) {
-      return second;
-    }
-    throw new IllegalArgumentException("None of the supplied ints were positive!");
-  }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -99,8 +99,7 @@ class HashKeyGenerator {
                         dynamicRecord.distributionMode(), DistributionMode.NONE),
                     MoreObjects.firstNonNull(
                         dynamicRecord.equalityFields(), Collections.emptySet()),
-                    DynamicSinkUtil.firstPositive(
-                        dynamicRecord.writeParallelism(), maxWriteParallelism)));
+                    Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism)));
     try {
       return keySelector.getKey(
           overrideRowData != null ? overrideRowData : dynamicRecord.rowData());
@@ -243,15 +242,17 @@ class HashKeyGenerator {
         String tableName,
         int writeParallelism,
         int maxWriteParallelism) {
-      if (writeParallelism > maxWriteParallelism) {
-        LOG.warn(
-            "{}: writeParallelism {} is greater than maxWriteParallelism {}. Capping writeParallelism at {}",
-            tableName,
-            writeParallelism,
-            maxWriteParallelism,
-            maxWriteParallelism);
-        writeParallelism = maxWriteParallelism;
-      }
+      Preconditions.checkArgument(
+          writeParallelism > 0,
+          "%s: writeParallelism must be > 0 (is: %s)",
+          tableName,
+          writeParallelism);
+      Preconditions.checkArgument(
+          writeParallelism <= maxWriteParallelism,
+          "%s: writeParallelism (%s) must be <= maxWriteParallelism (%s)",
+          tableName,
+          writeParallelism,
+          maxWriteParallelism);
       this.wrapped = wrapped;
       this.writeParallelism = writeParallelism;
       this.distinctKeys = new int[writeParallelism];


### PR DESCRIPTION
This documents how to automatically set the write parallelism to the max available write parallelism, i.e. the job parallelism, and add checks for invalid write parallelisms. 