### PR TITLE
Docs: Document `max-files-to-rewrite` in Spark `rewrite_data_files`

### DIFF
--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -414,6 +414,7 @@ Iceberg can compact data files in parallel using Spark with the `rewriteDataFile
 | `delete-ratio-threshold` | 0.3 | Minimum deletion ratio that needs to be associated with a data file for it to be considered for rewriting |
 | `output-spec-id` | current partition spec id | Identifier of the output partition spec. Data will be reorganized during the rewrite to align with the output partitioning. |
 | `remove-dangling-deletes` | false | Remove dangling position and equality deletes after rewriting. A delete file is considered dangling if it does not apply to any live data files. Enabling this will generate an additional commit for the removal. |
+| `max-files-to-rewrite` | null | This option sets an upper limit on the number of eligible files that will be rewritten. If this option is not specified, all eligible files will be rewritten. |
 
 !!! info
     Dangling delete files are removed based solely on data sequence numbers. This action does not apply to global 


### PR DESCRIPTION
Add documentation for the `max-files-to-rewrite` parameter in Spark `rewrite_data_files`.

This parameter was added in https://github.com/apache/iceberg/pull/12824 and https://github.com/apache/iceberg/pull/13082 but is listed in the general options of the `rewrite_data_files` Spark procedure.