### PR TITLE
Core, Spark: Deprecate `write.metadata.path` and use `location` to customize view location

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
@@ -25,7 +25,12 @@ public class ViewProperties {
 
   public static final String METADATA_COMPRESSION = "write.metadata.compression-codec";
   public static final String METADATA_COMPRESSION_DEFAULT = "gzip";
-  public static final String WRITE_METADATA_LOCATION = "write.metadata.path";
+
+  /**
+   * @deprecated will be removed in 2.0.0, use location instead.
+   */
+  @Deprecated public static final String WRITE_METADATA_LOCATION = "write.metadata.path";
+
   public static final String COMMENT = "comment";
   public static final String REPLACE_DROP_DIALECT_ALLOWED = "replace.drop-dialect.allowed";
   public static final boolean REPLACE_DROP_DIALECT_ALLOWED_DEFAULT = false;

--- a/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
@@ -27,7 +27,7 @@ public class ViewProperties {
   public static final String METADATA_COMPRESSION_DEFAULT = "gzip";
 
   /**
-   * @deprecated will be removed in 2.0.0, use location instead.
+   * @deprecated will be removed in 2.0.0, use {@link ViewBuilder#withLocation} instead.
    */
   @Deprecated public static final String WRITE_METADATA_LOCATION = "write.metadata.path";
 

--- a/docs/docs/spark-ddl.md
+++ b/docs/docs/spark-ddl.md
@@ -619,6 +619,18 @@ Display view properties:
 SHOW TBLPROPERTIES <viewName>
 ```
 
+#### Creating a view with location
+
+To specify the view metadata location, use `TBLPROPERTIES ('location'='fully-qualified-uri')`:
+
+```sql
+CREATE VIEW <viewName>
+    TBLPROPERTIES ('location' = '/path/to/custom-location')
+AS SELECT * FROM <tableName>
+```
+
+The view metadata is stored in the specified location with `/metadata` appended, such as `/path/to/custom-location/metadata`.
+
 #### Dropping a view
 
 Drop an existing view:

--- a/docs/docs/view-configuration.md
+++ b/docs/docs/view-configuration.md
@@ -28,7 +28,7 @@ Iceberg views support properties to configure view behavior. Below is an overvie
 | Property                         | Default                   | Description                                                                        |
 |----------------------------------|---------------------------|------------------------------------------------------------------------------------|
 | write.metadata.compression-codec | gzip                      | Metadata compression codec: `none` or `gzip`                                       |
-| write.metadata.path              | view location + /metadata | Base location for metadata files                                                   |
+| location                         | view location + /metadata | Base location for metadata files                                                   |
 | version.history.num-entries      | 10                        | Controls the number of `versions` to retain                                        |
 | replace.drop-dialect.allowed     | false                     | Controls whether a SQL dialect is allowed to be dropped during a replace operation |
 

--- a/docs/docs/view-configuration.md
+++ b/docs/docs/view-configuration.md
@@ -28,7 +28,6 @@ Iceberg views support properties to configure view behavior. Below is an overvie
 | Property                         | Default                   | Description                                                                        |
 |----------------------------------|---------------------------|------------------------------------------------------------------------------------|
 | write.metadata.compression-codec | gzip                      | Metadata compression codec: `none` or `gzip`                                       |
-| location                         | view location + /metadata | Base location for metadata files                                                   |
 | version.history.num-entries      | 10                        | Controls the number of `versions` to retain                                        |
 | replace.drop-dialect.allowed     | false                     | Controls whether a SQL dialect is allowed to be dropped during a replace operation |
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -2120,18 +2120,14 @@ public class TestViews extends ExtensionsTestBase {
     String customMetadataLocation =
         Paths.get(temp.toUri().toString(), "custom-metadata-location").toString();
     sql(
-        "CREATE VIEW %s TBLPROPERTIES ('%s'='%s') AS SELECT * FROM %s",
-        viewName, "location", customMetadataLocation, tableName);
-    String location = viewCatalog().loadView(TableIdentifier.of(NAMESPACE, viewName)).location();
+        "CREATE VIEW %s TBLPROPERTIES ('location'='%s') AS SELECT * FROM %s",
+        viewName, customMetadataLocation, tableName);
 
-    assertThat(sql("DESCRIBE EXTENDED %s", viewName))
-        .contains(
-            row(
-                "View Properties",
-                String.format(
-                    "['format-version' = '1', 'location' = '%s', 'provider' = 'iceberg']",
-                    customMetadataLocation),
-                ""));
+    assertThat(sql("SHOW TBLPROPERTIES %s", viewName))
+        .contains(row("location", customMetadataLocation));
+
+    String location = viewCatalog().loadView(TableIdentifier.of(NAMESPACE, viewName)).location();
+    assertThat(location).isEqualTo(customMetadataLocation);
   }
 
   private void insertRows(int numRows) throws NoSuchTableException {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -2114,6 +2114,26 @@ public class TestViews extends ExtensionsTestBase {
                 ""));
   }
 
+  @TestTemplate
+  public void createViewWithCustomMetadataLocationWithLocation() {
+    String viewName = viewName("v");
+    String customMetadataLocation =
+        Paths.get(temp.toUri().toString(), "custom-metadata-location").toString();
+    sql(
+        "CREATE VIEW %s TBLPROPERTIES ('%s'='%s') AS SELECT * FROM %s",
+        viewName, "location", customMetadataLocation, tableName);
+    String location = viewCatalog().loadView(TableIdentifier.of(NAMESPACE, viewName)).location();
+
+    assertThat(sql("DESCRIBE EXTENDED %s", viewName))
+        .contains(
+            row(
+                "View Properties",
+                String.format(
+                    "['format-version' = '1', 'location' = '%s', 'provider' = 'iceberg']",
+                    customMetadataLocation),
+                ""));
+  }
+
   private void insertRows(int numRows) throws NoSuchTableException {
     List<SimpleRecord> records = Lists.newArrayListWithCapacity(numRows);
     for (int i = 1; i <= numRows; i++) {

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -2119,18 +2119,14 @@ public class TestViews extends ExtensionsTestBase {
     String customMetadataLocation =
         Paths.get(temp.toUri().toString(), "custom-metadata-location").toString();
     sql(
-        "CREATE VIEW %s TBLPROPERTIES ('%s'='%s') AS SELECT * FROM %s",
-        viewName, "location", customMetadataLocation, tableName);
-    String location = viewCatalog().loadView(TableIdentifier.of(NAMESPACE, viewName)).location();
+        "CREATE VIEW %s TBLPROPERTIES ('location'='%s') AS SELECT * FROM %s",
+        viewName, customMetadataLocation, tableName);
 
-    assertThat(sql("DESCRIBE EXTENDED %s", viewName))
-        .contains(
-            row(
-                "View Properties",
-                String.format(
-                    "['format-version' = '1', 'location' = '%s', 'provider' = 'iceberg']",
-                    customMetadataLocation),
-                ""));
+    assertThat(sql("SHOW TBLPROPERTIES %s", viewName))
+        .contains(row("location", customMetadataLocation));
+
+    String location = viewCatalog().loadView(TableIdentifier.of(NAMESPACE, viewName)).location();
+    assertThat(location).isEqualTo(customMetadataLocation);
   }
 
   private void insertRows(int numRows) throws NoSuchTableException {

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -2113,6 +2113,26 @@ public class TestViews extends ExtensionsTestBase {
                 ""));
   }
 
+  @TestTemplate
+  public void createViewWithCustomMetadataLocationWithLocation() {
+    String viewName = viewName("v");
+    String customMetadataLocation =
+        Paths.get(temp.toUri().toString(), "custom-metadata-location").toString();
+    sql(
+        "CREATE VIEW %s TBLPROPERTIES ('%s'='%s') AS SELECT * FROM %s",
+        viewName, "location", customMetadataLocation, tableName);
+    String location = viewCatalog().loadView(TableIdentifier.of(NAMESPACE, viewName)).location();
+
+    assertThat(sql("DESCRIBE EXTENDED %s", viewName))
+        .contains(
+            row(
+                "View Properties",
+                String.format(
+                    "['format-version' = '1', 'location' = '%s', 'provider' = 'iceberg']",
+                    customMetadataLocation),
+                ""));
+  }
+
   private void insertRows(int numRows) throws NoSuchTableException {
     List<SimpleRecord> records = Lists.newArrayListWithCapacity(numRows);
     for (int i = 1; i <= numRows; i++) {


### PR DESCRIPTION
The context of this PR is https://github.com/apache/iceberg/pull/12017#issuecomment-3238253488.

## Changes

This PR tries to deprecate the `write.metadata.path` property which was added in [PR#12017](https://github.com/apache/iceberg/pull/12017), and use `location` instead to for the view location configuration.

## Background

That PR#12017 added `write.metadata.path` to customize the View location. However, the [Iceberg View Spec](https://iceberg.apache.org/view-spec/#view-metadata) defines `location` as its view location. Using `write.metadata.path` is confusing because it specifies two view locations in its view properties, along with `location`. 

## Behavior difference between `location` and `write.metadata.path`

Both properties can configure the view location, however, 

* if `write.metadata.path` is specified, the view metadata is put in the path defined `write.metadata.path`
    * (e.g.) When `'write.metadata.path'='custom-location/path/to` is specified, the view metadata is put in `custom-location/path/to`
* if `location` is specified, the view metadata is put in the path defined `location` with `/metadata` path
    * (e.g.) When `'location='custom-location/path/to` is specified, the view metadata is put in `custom-location/path/to/metadata`