### PR TITLE
AWS: exclude logging dependencies from bundle

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -53,7 +53,9 @@ project(":iceberg-aws-bundle") {
     }
 
     dependencies {
-      exclude(dependency('org.slf4j:slf4j-api'))
+      exclude(dependency('org.slf4j:.*'))
+      exclude(dependency('org.apache.logging.log4j:.*'))
+      exclude(dependency('org.apache.logging.slf4j:.*'))
     }
 
     // relocate AWS-specific versions


### PR DESCRIPTION
A recent AWS SDK version update introduced Log4j version that are incompatible with some environments (like Spark 4.x).  This results in class conflicts if the bundle jar is resolved before other logging jars.

The bom should not include the logging libraries and the existing exclusions don't cover all of the artifacts.  This PR expands the exclusions to remove the conflicting dependencies.