### PR TITLE
Spec: Add content stats to spec

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -758,7 +758,7 @@ Each stats struct holds statistics for one table field. It may contain the follo
 | _optional_  | 4      | `value_count`             | `long`                    | all                                           | Number of values in the column (including null and NaN values) |
 | _optional_  | 5      | `null_value_count`        | `long`                    | optional fields                               | Number of null values in the column |
 | _optional_  | 6      | `nan_value_count`         | `long`                    | `float`, `double`                             | Number of NaN values in the column |
-| _optional_  | 7      | `avg_value_size_in_bytes` | `int`                     | `string`, `binary`, `variant`                 | Avg value size (uncompressed) in bytes to estimate memory consumption |
+| _optional_  | 7      | `avg_value_size_in_bytes` | `int`                     | `string`, `binary`, `variant`                 | Avg value size in memory (uncompressed) in bytes over non-null values to estimate memory consumption |
 
 For example, stats for a `required` `int` field named `id` with field-id `2` are stored using:
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -710,26 +710,26 @@ For `geography` only, xmin (X value of `lower_bounds`) may be greater than xmax 
 
 When calculating upper and lower bounds for `geometry` and `geography`, null or NaN values in a coordinate dimension are skipped; for example, POINT (1 NaN) contributes a value to X but no values to Y, Z, or M dimension bounds. If a dimension has only null or NaN values, that dimension is omitted from the bounding box. If either the X or Y dimension is missing then the bounding box itself is not produced.
 
-#### Content Stats
+##### Content Stats
 
-Iceberg v4 introduces content stats which represent stats in a `struct<struct<...>>` where each nested struct holds the stats for an individual field of a table. The different field stats types are defined in the next section.
+Iceberg v4 introduces content stats which represent stats in a `struct<struct<...>>`. The statistics for fields are tracked inside a nested struct of value counts and bounds (described in the next section). Each field-level statistics struct is a field of the `content_stats` struct, which holds all statistics for table fields.
 
-##### Field Stats Types
+###### Field Stats Types
 
-The struct that holds individual stats for a particular field of a table consists of the following fields:
+Each stats struct holds stats for a field of the table. It may contain the following metrics:
 
-| Name             | Type                | Offset from field ID of base struct | required | Description                                                                                                                                                                    |
-|------------------|---------------------|-------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| value_count      | `long`              | 1                                   | false    | Number of values in the column (including null and NaN values)                                                                                                                 |
-| null_value_count | `long`              | 2                                   | false    | Number of null values in the column                                                                                                                                            |
-| nan_value_count  | `long`              | 3                                   | false    | Number of NaN values in the column                                                                                                                                             |
-| avg_value_count  | `int`               | 4                                   | false    | The avg value count for variable-length types (string/binary)                                                                                                                  |
-| max_value_count  | `long`              | 5                                   | false    | The max value count for variable-length types (string/binary)                                                                                                                  |
-| lower_bound      | type of table field | 6                                   | false    | Lower bound in the column serialized as the type of the column itself. Each value must be less than or equal to all non-null, non-NaN values in the column for the file [2]    |
-| upper_bound      | type of table field | 7                                   | false    | Upper bound in the column serialized as the type of the column itself. Each value must be greater than or equal to all non-null, non-NaN values in the column for the file [2] |
-| exact_bounds     | `boolean`           | 8                                   | false    | Whether the `upper_bound` / `lower_bound` is exact or not. Defaults to true. Types such as string/binary can't have exact bounds. Additionally, if a DV or an equality delete matches a given data file, then `exact_bounds` must be treated as `false` |
+| required/optional | Offset from field ID of base struct | Name                    | Type                | Description                                                                                                                                                                                                                                             |
+|-------------------|-------------------------------------|-------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _optional_        | 1                                   | value_count             | `long`              | Number of values in the column (including null and NaN values)                                                                                                                                                                                          |
+| _optional_        | 2                                   | null_value_count        | `long`              | Number of null values in the column. Only included for optional columns                                                                                                                                                                                 |
+| _optional_        | 3                                   | nan_value_count         | `long`              | Number of NaN values in the column. Only included for float/double types                                                                                                                                                                                |
+| _optional_        | 4                                   | avg_value_size_in_bytes | `int`               | The avg stored (compressed, encoded) value size in bytes for variable-length types (string/binary)                                                                                                                                                      |
+| _optional_        | 5                                   | max_value_size_in_bytes | `int`               | The max stored (compressed, encoded) value size in bytes for variable-length types (string/binary)                                                                                                                                                      |
+| _optional_        | 6                                   | lower_bound             | type of table field | Lower bound in the column serialized as the type of the column itself. Each value must be less than or equal to all non-null, non-NaN values in the column for the file [2]                                                                             |
+| _optional_        | 7                                   | upper_bound             | type of table field | Upper bound in the column serialized as the type of the column itself. Each value must be greater than or equal to all non-null, non-NaN values in the column for the file [2]                                                                          |
+| _optional_        | 8                                   | exact_bounds            | `boolean`           | Whether the `upper_bound` / `lower_bound` is exact or not. Defaults to true. Types such as string/binary can't have exact bounds. Additionally, if a DV or an equality delete matches a given data file, then `exact_bounds` must be treated as `false` |
 
-#### ID Assignment for Stats fields
+####### ID Assignment for Stats fields
 
 ID assignment follows a deterministic transform that maps from the **table ID space** to the **metadata ID space**. For a given field ID from the **table ID space** each nested stats struct gets an ID assigned from the **metadata ID space**.
 Offsets defined in the [field stats types section](#field-stats-types) are then applied to the stats ID of the enclosing stats struct to calculate IDs for each individual field stats type.
@@ -751,7 +751,7 @@ Note that stats field IDs are only calculated for an assigned field ID:
 
 The stats ID range is defined from `10_000` to `200_010_000`, which effectively means that the highest supported data field ID is `1_000_000`.
 
-#### Stats projection
+###### Stats projection
 
 To retrieve stats for a particular table field ID, one would always project by stats ID, whereas the stats ID for a given table field ID can be calculated by applying the reverse calculation.
 This would be `(stats_field_id - stats_space_field_id_start_for_data_fields) / num_supported_stats_per_column` for normal table field IDs and `stats_field_id - num_reserved_field_ids + (Integer.MAX_VALUE - stats_field_id) + (stats_field_id - stats_space_field_id_start_for_metadata_fields) / num_supported_stats_per_column` for [reserved field IDs](#reserved-field-ids).
@@ -777,24 +777,24 @@ Below are examples for some table field ID -> stats field ID calculations.
 
 The below table shows the stats IDs of individual field statistics, which are calculated based on the offset that is described in the [field stats types section](#field-stats-types).
 
-| Table Field ID | Stats ID of Stats struct | Stats Type       | Stats ID of individual statistic |
-|----------------|--------------------------|------------------|----------------------------------|
-| 2              | 10_400                   | value_count      | 10_401                           |
-|                |                          | null_value_count | 10_402                           |
-|                |                          | nan_value_count  | 10_403                           |
-|                |                          | avg_value_size   | 10_404                           |
-|                |                          | max_value_size   | 10_405                           |
-|                |                          | lower_bound      | 10_406                           |
-|                |                          | upper_bound      | 10_407                           |
-|                |                          | exact_bounds     | 10_408                           |
-| 5              | 11_000                   | value_count      | 11_001                           |
-|                |                          | null_value_count | 11_002                           |
-|                |                          | nan_value_count  | 11_003                           |
-|                |                          | avg_value_size   | 11_004                           |
-|                |                          | max_value_size   | 11_005                           |
-|                |                          | lower_bound      | 11_006                           |
-|                |                          | upper_bound      | 11_007                           |
-|                |                          | upper_bound      | 11_008                           |
+| Table Field ID | Stats ID of Stats struct | Stats Type              | Stats ID of individual statistic |
+|----------------|--------------------------|-------------------------|----------------------------------|
+| 2              | 10_400                   | value_count             | 10_401                           |
+|                |                          | null_value_count        | 10_402                           |
+|                |                          | nan_value_count         | 10_403                           |
+|                |                          | avg_value_size_in_bytes | 10_404                           |
+|                |                          | max_value_size_in_bytes | 10_405                           |
+|                |                          | lower_bound             | 10_406                           |
+|                |                          | upper_bound             | 10_407                           |
+|                |                          | exact_bounds            | 10_408                           |
+| 5              | 11_000                   | value_count             | 11_001                           |
+|                |                          | null_value_count        | 11_002                           |
+|                |                          | nan_value_count         | 11_003                           |
+|                |                          | avg_value_size_in_bytes | 11_004                           |
+|                |                          | max_value_size_in_bytes | 11_005                           |
+|                |                          | lower_bound             | 11_006                           |
+|                |                          | upper_bound             | 11_007                           |
+|                |                          | upper_bound             | 11_008                           |
 
 #### Sequence Number Inheritance
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -686,6 +686,13 @@ Notes:
 5. The `content_offset` and `content_size_in_bytes` fields are used to reference a specific blob for direct access to a deletion vector. For deletion vectors, these values are required and must exactly match the `offset` and `length` stored in the Puffin footer for the deletion vector blob.
 6. The following field ids are reserved on `data_file`: 141.
 
+###### File-level column statistics
+
+Per-column metrics used for filtering and planning are stored at **file** granularity on the `data_file` struct.
+In v3, implementations use maps such as `value_counts`, `lower_bounds`, and `upper_bounds`, keyed by column id, with bounds serialized as binary (see note 1 under [Data File Fields](#data-file-fields)).
+Iceberg v4 adds the optional `content_stats` struct, which holds the same *logical* metrics for primitive leaf columns using nested structs and typed bounds (see [Content Stats](#content-stats)).
+The subsections below define shared bound serialization for variant, geometry, and geography, and then define v4 `content_stats`; the same bound rules apply whether values are read from v3 maps or from v4 field stats.
+
 ###### Bounds for Variant, Geometry, and Geography
 
 For Variant, values in the `lower_bounds` and `upper_bounds` maps store serialized Variant objects that contain lower or upper bounds respectively. The object keys for the bound-variants are normalized JSON path expressions that uniquely identify a field. The object values are primitive Variant representations of the lower or upper bound for that field. Including bounds for any field is optional and upper and lower bounds must have the same Variant type.
@@ -714,49 +721,67 @@ When calculating upper and lower bounds for `geometry` and `geography`, null or 
 
 Iceberg v4 introduces content stats which represent stats in a `struct<struct<...>>`. The statistics for fields are tracked inside a nested struct of value counts and bounds (described in the next section). Each field-level statistics struct is a field of the `content_stats` struct, which holds all statistics for table fields.
 
-###### Field Stats Types
-
-Each stats struct holds stats for a field of the table. It may contain the following metrics:
-
-| required/optional | Offset from field ID of base struct | Name                    | Type                | Description                                                                                                                                                                                                                                             |
-|-------------------|-------------------------------------|-------------------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _optional_        | 1                                   | value_count             | `long`              | Number of values in the column (including null and NaN values)                                                                                                                                                                                          |
-| _optional_        | 2                                   | null_value_count        | `long`              | Number of null values in the column. Only included for optional columns                                                                                                                                                                                 |
-| _optional_        | 3                                   | nan_value_count         | `long`              | Number of NaN values in the column. Only included for float/double types                                                                                                                                                                                |
-| _optional_        | 4                                   | avg_value_size_in_bytes | `int`               | The avg stored (compressed, encoded) value size in bytes for variable-length types (string/binary)                                                                                                                                                      |
-| _optional_        | 5                                   | max_value_size_in_bytes | `int`               | The max stored (compressed, encoded) value size in bytes for variable-length types (string/binary)                                                                                                                                                      |
-| _optional_        | 6                                   | lower_bound             | type of table field | Lower bound in the column serialized as the type of the column itself. Each value must be less than or equal to all non-null, non-NaN values in the column for the file [2]                                                                             |
-| _optional_        | 7                                   | upper_bound             | type of table field | Upper bound in the column serialized as the type of the column itself. Each value must be greater than or equal to all non-null, non-NaN values in the column for the file [2]                                                                          |
-| _optional_        | 8                                   | exact_bounds            | `boolean`           | Whether the `upper_bound` / `lower_bound` is exact or not. Defaults to true. Types such as string/binary can't have exact bounds. Additionally, if a DV or an equality delete matches a given data file, then `exact_bounds` must be treated as `false` |
-
-####### ID Assignment for Stats fields
+###### ID assignment for stats fields
 
 ID assignment follows a deterministic transform that maps from the **table ID space** to the **metadata ID space**. For a given field ID from the **table ID space** each nested stats struct gets an ID assigned from the **metadata ID space**.
-Offsets defined in the [field stats types section](#field-stats-types) are then applied to the stats ID of the enclosing stats struct to calculate IDs for each individual field stats type.
-The calculation is: `stats_space_field_id_start_for_data_fields + (num_supported_stats_per_column * table_field_id`)
+The offset defined in the [field stats types section](#field-stats-types) is added to the stats ID of the enclosing stats struct to calculate IDs for each individual field stats type.
 
-If the table field ID is a [reserved field ID](#reserved-field-ids) then a slightly adjusted calculation is used: `stats_space_field_id_start_for_metadata_fields + (num_supported_stats_per_column * (num_reserved_field_ids - (Integer.MAX_VALUE - metadata_field_id))`)
+**Data columns (normal table field ids)**
 
-The individual variables are defined as following:
+Let `table_field_id` be the column's id in the table schema. Allocate a contiguous block of **200** ids per column (`num_supported_stats_per_column = 200`). The stats struct for that column starts at:
 
-* `stats_space_field_id_start_for_data_fields = 10_000`
-* `stats_space_field_id_start_for_metadata_fields = 2_147_000_000`
-* `num_supported_stats_per_column = 200`, thus supporting a range of **200** potential stats fields for a single table field
-* `num_reserved_field_ids = 200` as defined in [reserved field ID](#reserved-field-ids)
+`stats_struct_id = 10_000 + (200 * table_field_id)`
 
-Note that stats field IDs are only calculated for an assigned field ID:
+Each field statistic listed under [Field stats types](#field-stats-types) has a fixed **offset** within that block. The field id for an individual field statistic is:
 
-* that is defined in the table field ID space
-* that is defined in the [reserved field ID](#reserved-field-ids) space
+`stats_field_id = stats_struct_id + offset`
 
-The stats ID range is defined from `10_000` to `200_010_000`, which effectively means that the highest supported data field ID is `1_000_000`.
+The constant `10_000` is `stats_space_field_id_start_for_data_fields`. The value **200** is both the width of each column's stats block and `num_reserved_field_ids` from [Reserved field ids](#reserved-field-ids).
+
+**Reserved table field ids.**
+
+Columns whose ids fall in the [reserved field ID](#reserved-field-ids) space use a different base so their stats ids do not overlap data columns:
+
+`stats_struct_id = 2_147_000_000 + (200 * (200 - (Integer.MAX_VALUE - table_field_id)))`
+
+Here `2_147_000_000` is `stats_space_field_id_start_for_metadata_fields`. This separate base is required because reserved ids are near `Integer.MAX_VALUE` and cannot use the same linear mapping as data field ids.
+
+Valid data field ids support stats structs with ids from `10_000` through `200_010_000`, so the highest supported **data** field id is `1_000_000`.
+
+###### Name assignment for `content_stats` fields
+
+Each nested stats struct is a **child field** of the root `content_stats` struct. Its **name** is the numerical string of the table column's field id (for example id `103` uses the name `"103"`).
+Its **field id** is deterministically calculated as defined in the previous section.
+
+###### Field stats types
+
+Each stats struct holds statistics for one table column. It may contain the following metrics:
+
+| required/optional | Offset | Name                    | Type                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|-------------------|--------|-------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _optional_        | 1      | value_count             | `long`              | Number of values in the column (including null and NaN values)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| _optional_        | 2      | null_value_count        | `long`              | Number of null values in the column. Only included for optional columns                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| _optional_        | 3      | nan_value_count         | `long`              | Number of NaN values in the column. Only included for float/double types. NaN rules follow note 2 under [Data File Fields](#data-file-fields)                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| _optional_        | 4      | avg_value_size_in_bytes | `int`               | Avg stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| _optional_        | 5      | max_value_size_in_bytes | `int`               | Max stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| _optional_        | 6      | lower_bound             | type of table field | Lower bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography)                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| _optional_        | 7      | upper_bound             | type of table field | Upper bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography)                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| _optional_        | 8      | exact_bounds            | `boolean`           | Whether the `lower_bound` / `upper_bound` are exact (`true`) or may be truncated or otherwise inexact (`false`). Defaults to `true`. Types such as `string` / `binary` often use `false` when bounds are truncated. For types with inherently exact bounds when written (for example boolean, integer, floating-point, date, time, timestamp, decimal, uuid, `geometry`, `geography`), writers should use `true` when bounds are present. If a deletion vector or equality delete file can match rows in the data file, implementations must treat bounds as inexact for pruning (`exact_bounds` as `false`) |
 
 ###### Stats projection
 
-To retrieve stats for a particular table field ID, one would always project by stats ID, whereas the stats ID for a given table field ID can be calculated by applying the reverse calculation.
-This would be `(stats_field_id - stats_space_field_id_start_for_data_fields) / num_supported_stats_per_column` for normal table field IDs and `stats_field_id - num_reserved_field_ids + (Integer.MAX_VALUE - stats_field_id) + (stats_field_id - stats_space_field_id_start_for_metadata_fields) / num_supported_stats_per_column` for [reserved field IDs](#reserved-field-ids).
+To retrieve stats for a particular table field ID, one would always project by stats ID, where the stats ID for a given table field ID can be calculated by applying the reverse calculation.
+For data columns the reverse calculation would be:
 
-Below are examples for some table field ID -> stats field ID calculations.
+`table_field_id = (stats_struct_id - 10_000) / 200`
+
+For [reserved field IDs](#reserved-field-ids), the reverse calculation would be:
+
+`table_field_id = stats_struct_id - num_reserved_field_ids + (Integer.MAX_VALUE - stats_struct_id) + (stats_struct_id - stats_space_field_id_start_for_metadata_fields) / num_supported_stats_per_column`
+
+using `num_reserved_field_ids = 200`, `stats_space_field_id_start_for_metadata_fields = 2_147_000_000`, and `num_supported_stats_per_column = 200` (see [ID assignment for stats fields](#id-assignment-for-stats-fields)).
+
+Below are examples for some table field ID -> stats struct id calculations.
 
 | Table Field ID      | Stats ID of Stats struct  |
 |---------------------|---------------------------|
@@ -775,7 +800,7 @@ Below are examples for some table field ID -> stats field ID calculations.
 | 2_147_483_645       | 2_147_039_600             |
 | 2_147_483_646       | 2_147_039_800             |
 
-The below table shows the stats IDs of individual field statistics, which are calculated based on the offset that is described in the [field stats types section](#field-stats-types).
+The below table shows the stats IDs of individual field statistics, which are calculated based on the offset that is described in the [Field stats types section](#field-stats-types)
 
 | Table Field ID | Stats ID of Stats struct | Stats Type              | Stats ID of individual statistic |
 |----------------|--------------------------|-------------------------|----------------------------------|
@@ -794,7 +819,16 @@ The below table shows the stats IDs of individual field statistics, which are ca
 |                |                          | max_value_size_in_bytes | 11_005                           |
 |                |                          | lower_bound             | 11_006                           |
 |                |                          | upper_bound             | 11_007                           |
-|                |                          | upper_bound             | 11_008                           |
+|                |                          | exact_bounds            | 11_008                           |
+
+###### Manifest schema and `content_stats` typing
+
+The `content_stats` type is dynamically derived from the table schema and produces one nested stats struct per table column, which is then combined into the root `content_stats` struct.
+That derived type is embedded in the manifest for `data_file` at the field reserved for `content_stats` in v4.
+Writers and readers must use this **same** manifest schema both when writing and when reading manifest files for the table.
+
+Using one schema for read and write is what allows **type promotion** on stats: if an `int` column `x` is promoted to `long`, the nested stats struct changes from `struct<..., lower_bound int, upper_bound int, ...>` to `struct<..., lower_bound long, upper_bound long, ...>`.
+Reading an older manifest applies normal Iceberg type promotion to those bound fields; writing after promotion then uses the promoted struct type, so round-trips stay consistent.
 
 #### Sequence Number Inheritance
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -735,7 +735,7 @@ In Iceberg v4, statistics are stored in typed fields grouped in a struct that co
 
 Field-level structs in `content_stats` are based on the corresponding table field's type, requirement, and ID (`field-id`).
 
-Field stats structs are assigned a range of 200 IDs, starting at `10_000 + 200 * field-id`. The first ID in the range (`base-id`) is the ID of the struct field in `content_stats`. Fields within the stats struct are assigned IDs from the range by adding an offset to the `base-id`. For example, the stats struct for table field 2 uses IDs in the range `[10_400, 10_599]`, the field within `content_stats` has uses the `base-id`, ID `10_400`, and its `lower_bound` field (offset 1) uses ID `10_401`.
+Field stats structs are assigned a range of 200 IDs, starting at `10_000 + 200 * field-id`. The first ID in the range (`base-id`) is the ID of the struct field in `content_stats`. Fields within the stats struct are assigned IDs from the range by adding an offset to the `base-id`. For example, the stats struct for table field 2 uses IDs in the range `[10_400, 10_599]`, the field within `content_stats` uses the `base-id`, ID `10_400`, and its `lower_bound` field (offset 1) uses ID `10_401`.
 
 Content stats must be resovled by ID; field names used for stats structs are informational. The recommended name for each field is the full name of the field in the table schema.
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -737,7 +737,7 @@ Field-level structs in `content_stats` are based on the corresponding table fiel
 
 Field stats structs are assigned a range of 200 IDs, starting at `10_000 + 200 * field-id`. The first ID in the range (`base-id`) is the ID of the struct field in `content_stats`. Fields within the stats struct are assigned IDs from the range by adding an offset to the `base-id`. For example, the stats struct for table field 2 uses IDs in the range `[10_400, 10_599]`, the field within `content_stats` uses the `base-id`, ID `10_400`, and its `lower_bound` field (offset 1) uses ID `10_401`.
 
-Content stats must be resovled by ID; field names used for stats structs are informational. The recommended name for each field is the full name of the field in the table schema.
+Content stats must be resolved by ID; field names used for stats structs are informational. The recommended name for each field is the full name of the field in the table schema.
 
 IDs in the range `10_000` (inclusive) to `200_000_000` (exclusive) are reserved for column stats structs in `content_stats`. Stats for table fields with IDs outside that range cannot be stored in `content_stats`.
 
@@ -777,7 +777,7 @@ For example, stats for a `required` `int` field named `id` with field-id `2` are
 
 If any field is missing from the struct, readers must assume that it is unknown.
 
-Lower and upper bounds for `geometry` and `geography` columns are XYZM points that define a bounding box, stored in `geo_lower` and `geo_upper` structs (see [Bounds for Geometry and Geography](#bounds-for-geometry-and-geography). IDs used by geo structs are assigned using offsets in the table field's stats ID range.
+Lower and upper bounds for `geometry` and `geography` columns are XYZM points that define a bounding box, stored in `geo_lower` and `geo_upper` structs (see [Bounds for Geometry and Geography](#bounds-for-geometry-and-geography)). IDs used by geo structs are assigned using offsets in the table field's stats ID range.
 
 The `geo_lower` struct is defined as:
 
@@ -792,7 +792,7 @@ The `geo_upper` struct is defined as:
 
 | Requirement | Offset | Name | Type     | Description |
 |-------------|--------|------|----------|-------------|
-| _required_  | 14     | `x`  | `double` | Bounding box eastermost/xmax; [-180..180] |
+| _required_  | 14     | `x`  | `double` | Bounding box easternmost/xmax; [-180..180] |
 | _required_  | 15     | `y`  | `double` | Bounding box northernmost/ymax; [-90..90] |
 | _optional_  | 16     | `z`  | `double` | Bounding box zmax |
 | _optional_  | 17     | `m`  | `double` | Bounding box mmax |

--- a/format/spec.md
+++ b/format/spec.md
@@ -710,6 +710,91 @@ For `geography` only, xmin (X value of `lower_bounds`) may be greater than xmax 
 
 When calculating upper and lower bounds for `geometry` and `geography`, null or NaN values in a coordinate dimension are skipped; for example, POINT (1 NaN) contributes a value to X but no values to Y, Z, or M dimension bounds. If a dimension has only null or NaN values, that dimension is omitted from the bounding box. If either the X or Y dimension is missing then the bounding box itself is not produced.
 
+#### Content Stats
+
+Content stats have been introduced with v4 and hold stats in a `struct<struct<...>>` where each nested struct holds the stats for an individual field of a table. The different field stats types are defined in the next section.
+
+##### Field Stats Types
+
+The struct that holds individual stats for a particular field of a table consists of the following fields:
+
+| Name             | Type                | Offset from field ID of base struct | required | Description                                                                                                                                                                    |
+|------------------|---------------------|-------------------------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| value_count      | `long`              | 1                                   | false    | Number of values in the column (including null and NaN values)                                                                                                                 |
+| null_value_count | `long`              | 2                                   | false    | Number of null values in the column                                                                                                                                            |
+| nan_value_count  | `long`              | 3                                   | false    | Number of NaN values in the column                                                                                                                                             |
+| avg_value_count  | `int`               | 4                                   | false    | The avg value count for variable-length types (string/binary)                                                                                                                  |
+| max_value_count  | `long`              | 5                                   | false    | The max value count for variable-length types (string/binary)                                                                                                                  |
+| lower_bound      | type of table field | 6                                   | false    | Lower bound in the column serialized as the type of the column itself. Each value must be less than or equal to all non-null, non-NaN values in the column for the file [2]    |
+| upper_bound      | type of table field | 7                                   | false    | Upper bound in the column serialized as the type of the column itself. Each value must be greater than or equal to all non-null, non-NaN values in the column for the file [2] |
+| exact_bounds     | `boolean`           | 8                                   | false    | Whether the `upper_bound` / `lower_bound` is exact or not                                                                                                                      |
+
+#### ID Assignment for Stats fields
+
+ID assignment follows a deterministic transform that maps from the **table ID space** to the **metadata ID space**. For a given field ID from the **table ID space** each nested stats struct gets an ID assigned from the **metadata ID space**.
+The calculation is: `stats_space_field_id_start_for_data_fields + (num_supported_stats_per_column * table_field_id`)
+
+If the table field ID is a [reserved field ID](#reserved-field-ids) then a slightly adjusted calculation is used: `stats_space_field_id_start_for_metadata_fields + (num_supported_stats_per_column * (num_reserved_field_ids - (Integer.MAX_VALUE - metadata_field_id))`)
+
+The individual variables are defined as following:
+
+* `stats_space_field_id_start_for_data_fields = 10_000`
+* `stats_space_field_id_start_for_metadata_fields = 2_147_000_000`
+* `num_supported_stats_per_column = 200`, thus supporting a range of **200** potential stats fields for a single table field
+* `num_reserved_field_ids = 200` as defined in [reserved field ID](#reserved-field-ids)
+
+Note that stats field IDs are only calculated for an assigned field ID:
+
+* that is defined in the table field ID space
+* that is defined in the [reserved field ID](#reserved-field-ids) space
+
+The stats ID range is defined from `10_000` to `200_010_000`, which effectively means that the highest supported data field ID is `1_000_000`.
+
+#### Stats projection
+
+To retrieve stats for a particular table field ID, one would always project by stats ID, whereas the stats ID for a given table field ID can be calculated by applying the reverse calculation.
+This would be `(stats_field_id - stats_space_field_id_start_for_data_fields) / num_supported_stats_per_column` for normal table field IDs and `stats_field_id - num_reserved_field_ids + (Integer.MAX_VALUE - stats_field_id) + (stats_field_id - stats_space_field_id_start_for_metadata_fields) / num_supported_stats_per_column` for [reserved field IDs](#reserved-field-ids).
+
+Below are examples for some table field ID -> stats field ID calculations.
+
+| Table Field ID      | Stats ID of Stats struct  |
+|---------------------|---------------------------|
+| 0                   | 10_000                    |
+| 1                   | 10_200                    |
+| 2                   | 10_400                    |
+| 5                   | 11_000                    |
+| 100                 | 30_000                    |
+| 1_000_000           | 200_010_000               |
+
+| Reserved Field ID   | Stats ID of Stats struct  |
+|---------------------|---------------------------|
+| 2_147_483_447       | 2_147_000_000             |
+| 2_147_483_448       | 2_147_000_200             |
+| 2_147_483_541       | 2_147_018_800             |
+| 2_147_483_645       | 2_147_039_600             |
+| 2_147_483_646       | 2_147_039_800             |
+
+The below table shows the stats IDs of individual field statistics, which are calculated based on the offset that is described in the [field stats types section](#field-stats-types).
+
+| Table Field ID | Stats ID of Stats struct | Stats Type       | Stats ID of individual statistic |
+|----------------|--------------------------|------------------|----------------------------------|
+| 2              | 10_400                   | value_count      | 10_401                           |
+|                |                          | null_value_count | 10_402                           |
+|                |                          | nan_value_count  | 10_403                           |
+|                |                          | avg_value_size   | 10_404                           |
+|                |                          | max_value_size   | 10_405                           |
+|                |                          | lower_bound      | 10_406                           |
+|                |                          | upper_bound      | 10_407                           |
+|                |                          | exact_bounds     | 10_408                           |
+| 5              | 11_000                   | value_count      | 11_001                           |
+|                |                          | null_value_count | 11_002                           |
+|                |                          | nan_value_count  | 11_003                           |
+|                |                          | avg_value_size   | 11_004                           |
+|                |                          | max_value_size   | 11_005                           |
+|                |                          | lower_bound      | 11_006                           |
+|                |                          | upper_bound      | 11_007                           |
+|                |                          | upper_bound      | 11_008                           |
+
 #### Sequence Number Inheritance
 
 Manifests track the sequence number when a data or delete file was added to the table.

--- a/format/spec.md
+++ b/format/spec.md
@@ -739,7 +739,7 @@ Field stats structs are assigned a range of 200 IDs, starting at `10_000 + 200 *
 
 Content stats must be resolved by ID; field names used for stats structs are informational. The recommended name for each field is the full name of the field in the table schema.
 
-IDs in the range `10_000` (inclusive) to `200_000_000` (exclusive) are reserved for column stats structs in `content_stats`. Stats for table fields with IDs outside that range cannot be stored in `content_stats`.
+IDs in the range `10_000` (inclusive) to `200_000_000` (exclusive) are reserved for column stats structs in `content_stats`. Stats for table fields with stats IDs outside that range cannot be stored in `content_stats`.
 
 [Reserved metadata fields](#reserved-field-ids) must use the stats ID ranges from the following table. Stats for metadata fields not in the table are not tracked.
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -773,19 +773,6 @@ Types such as `string` / `binary` often use `tight_bounds=false` when bounds are
 ###### Stats projection
 
 To retrieve stats for a particular table field ID, one would always project by stats ID, where the stats ID for a given table field ID can be calculated by applying the reverse calculation.
-For data columns the reverse calculation would be:
-
-`table_field_id = (stats_struct_id - 10_000) / 200`
-
-For [reserved field IDs](#reserved-field-ids), the reverse calculation would be:
-
-`table_field_id = stats_struct_id - 200 + (Integer.MAX_VALUE - stats_struct_id) + (stats_struct_id - 2_147_000_000) / 200`
-
-using `num_reserved_field_ids = 200`, `stats_space_field_id_start_for_metadata_fields = 2_147_000_000`, and `num_supported_stats_per_column = 200` (see [ID assignment for stats fields](#id-assignment-for-stats-fields)).
-
-The formula is defined as:
-`table_field_id = stats_struct_id - num_reserved_field_ids + (Integer.MAX_VALUE - stats_struct_id) + (stats_struct_id - stats_space_field_id_start_for_metadata_fields) / num_supported_stats_per_column`
-
 Below are examples for some table field ID -> stats struct id calculations.
 
 | Table Field ID      | Stats ID of Stats struct  |
@@ -827,11 +814,8 @@ The below table shows the stats IDs of individual field statistics, which are ca
 
 ###### Manifest schema and `content_stats` typing
 
-The `content_stats` type is dynamically derived from the table schema and produces one nested stats struct per table column, which is then combined into the root `content_stats` struct.
-That derived type is embedded in the manifest for `data_file` at the field reserved for `content_stats` in v4.
-Writers and readers must use this **same** manifest schema both when writing and when reading manifest files for the table.
-
-Using one schema for read and write is what allows **type promotion** on stats: if an `int` column `x` is promoted to `long`, the nested stats struct changes from `struct<..., lower_bound int, upper_bound int, ...>` to `struct<..., lower_bound long, upper_bound long, ...>`.
+The `content_stats` type is dynamically derived and embedded in the manifest for `data_file` at the field reserved for `content_stats` in v4.
+Using one `content_stats` schema for read and write is what allows **type promotion** on stats: if an `int` column `x` is promoted to `long`, the nested stats struct changes from `struct<..., lower_bound int, upper_bound int, ...>` to `struct<..., lower_bound long, upper_bound long, ...>`.
 Reading an older manifest applies normal Iceberg type promotion to those bound fields; writing after promotion then uses the promoted struct type, so round-trips stay consistent.
 
 ###### Content stats aggregation

--- a/format/spec.md
+++ b/format/spec.md
@@ -675,7 +675,11 @@ The `data_file` struct consists of the following fields:
 
 The `partition` struct stores the tuple of partition values for each file. Its type is derived from the partition fields of the partition spec used to write the manifest file. In v2, the partition struct's field ids must match the ids from the partition spec.
 
-The column metrics maps are used when filtering to select both data and delete files. For delete files, the metrics must store bounds and counts for all deleted rows, or must be omitted. Storing metrics for deleted rows ensures that the values can be used during job planning to find delete files that must be merged during a scan.
+The column metrics maps are used when filtering to select both data and delete files.
+In v3, implementations use maps such as `value_counts`, `lower_bounds`, and `upper_bounds`, keyed by column id, with bounds serialized as binary (see note 1 under [Data File Fields](#data-file-fields)).
+Iceberg v4 adds the optional `content_stats` struct, which tracks the same metrics using nested structs and typed bounds (see [Content Stats](#content-stats)).
+Metrics information held in v1-v3 and v4 are both equivalent. A `null` in a v4 `lower_bound` has the same meaning as if the `lower_bounds` map is missing or if an entry is missing from that map.
+For delete files, the metrics must store bounds and counts for all deleted rows, or must be omitted. Storing metrics for deleted rows ensures that the values can be used during job planning to find delete files that must be merged during a scan.
 
 Notes:
 
@@ -686,12 +690,6 @@ Notes:
 5. The `content_offset` and `content_size_in_bytes` fields are used to reference a specific blob for direct access to a deletion vector. For deletion vectors, these values are required and must exactly match the `offset` and `length` stored in the Puffin footer for the deletion vector blob.
 6. The following field ids are reserved on `data_file`: 141.
 
-###### File-level column statistics
-
-Per-column metrics used for filtering and planning are stored at **file** granularity on the `data_file` struct.
-In v3, implementations use maps such as `value_counts`, `lower_bounds`, and `upper_bounds`, keyed by column id, with bounds serialized as binary (see note 1 under [Data File Fields](#data-file-fields)).
-Iceberg v4 adds the optional `content_stats` struct, which holds the same *logical* metrics (without `column_sizes` as that was deprecated) using nested structs and typed bounds (see [Content Stats](#content-stats)).
-Stats for primitive types and Geometry / Geography / Variant are supported. Stats for nested types (`struct`, `list`, `map`) are not supported.
 
 ###### Bounds for Variant, Geometry, and Geography
 
@@ -719,12 +717,9 @@ When calculating upper and lower bounds for `geometry` and `geography`, null or 
 
 ##### Content Stats
 
-In Iceberg v4 stats have been redesigned and are represented by using nested structs (`struct<struct<...>>`). The statistics for fields are tracked inside a nested struct of value counts and bounds (described in the next section). Each field-level statistics struct is a field of the `content_stats` struct, which holds all statistics for table fields.
+In Iceberg v4, column metrics for a data field are typed fields in a stats struct that corresponds to the field. These stats structs are nested within the `content_stats` struct in manifest files.
 
-###### ID assignment for stats fields
-
-ID assignment follows a deterministic mapping from the **table ID space** to the **stats ID space**, where a given field ID from the **table ID space** gets an ID assigned from the **stats ID space** for each field-level statistics struct.
-Each field-level statistic listed in the [field stats types section](#field-stats-types) has a fixed offset. Its stats field ID is the enclosing stats struct's ID plus that offset.
+A table field's stats struct uses a range of 200 IDs, starting at `10_000 + 200 * field-id`. Fields within the stats struct are each assigned IDs based on the start of the range and an offset for the field. For example, field 1 uses IDs in the range [10,200, 10,399], and its `lower_bound` field uses ID 10,201.
 
 **Data columns (normal table field ids)**
 Mapping a table field ID from the **table ID space** to the **stats ID space** is done via:
@@ -732,9 +727,6 @@ Mapping a table field ID from the **table ID space** to the **stats ID space** i
 `stats_struct_id = 10_000 + (200 * table_field_id)`
 
 The constant `10_000` is `stats_space_field_id_start_for_data_fields`. `200` represents the number of supports stats per column (`num_supported_stats_per_column = 200`).
-
-The formula is defined as:
-`stats_struct_id = stats_space_field_id_start_for_data_fields + (num_supported_stats_per_column * table_field_id)`
 
 Each field statistic listed under [Field stats types](#field-stats-types) has a fixed **offset** within that block. The field id for an individual field statistic is:
 
@@ -757,22 +749,26 @@ Valid data field ids support stats structs with ids from `10_000` through `200_0
 ###### Name assignment for `content_stats` fields
 
 Each nested stats struct is a **child field** of the root `content_stats` struct. Its **name** is the numerical string of the table column's field id (for example id `103` uses the name `"103"`).
-Its **field id** is deterministically calculated as defined in the previous section. The name is informational and readers must resolve content stats by ID.
+The name is informational and readers must resolve content stats by ID.
 
 ###### Field stats types
 
 Each stats struct holds statistics for one table column. It may contain the following metrics:
 
-| required/optional | Offset | Name                    | Type                | included for            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-|-------------------|--------|-------------------------|---------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _optional_        | 1      | value_count             | `long`              | all types               | Number of values in the column (including null and NaN values)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| _optional_        | 2      | null_value_count        | `long`              | optional columns only   | Number of null values in the column. Only included for optional columns                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| _optional_        | 3      | nan_value_count         | `long`              | float/double types      | Number of NaN values in the column. Only included for float/double types. NaN rules follow note 2 under [Data File Fields](#data-file-fields)                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| _optional_        | 4      | avg_value_size_in_bytes | `int`               | variable-length types   | Avg stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| _optional_        | 5      | max_value_size_in_bytes | `int`               | variable-length types   | Max stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| _optional_        | 6      | lower_bound             | type of table field | all types               | Lower bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography)                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| _optional_        | 7      | upper_bound             | type of table field | all types               | Upper bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography)                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| _optional_        | 8      | exact_bounds            | `boolean`           | truncated/inexact types | Whether the `lower_bound` / `upper_bound` are exact (`true`) or may be truncated or otherwise inexact (`false`). Defaults to `true`. Types such as `string` / `binary` often use `false` when bounds are truncated. For types with inherently exact bounds when written (for example boolean, integer, floating-point, date, time, timestamp, decimal, uuid, geometry, geography), writers should use `true` when bounds are present. If a deletion vector or equality delete file can match rows in the data file, implementations must treat bounds as inexact for pruning (`exact_bounds` as `false`) |
+| requirement | Offset | Name                    | Type                | included for            | Description                                                                                                                                                           |
+|-------------|--------|-------------------------|---------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _optional_  | 1      | lower_bound             | type of table field | all types               | Lower bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography) |
+| _optional_  | 2      | upper_bound             | type of table field | all types               | Upper bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography) |
+| _optional_  | 3      | tight_bounds            | `boolean`           | truncated/inexact types | Whether the `lower_bound` / `upper_bound` are tight (`true`) or may be truncated or otherwise inexact (`false`). Defaults to `true`.                                  |
+| _optional_  | 4      | value_count             | `long`              | all types               | Number of values in the column (including null and NaN values)                                                                                                        |
+| _optional_  | 5      | null_value_count        | `long`              | optional columns only   | Number of null values in the column. Only included for optional columns                                                                                               |
+| _optional_  | 6      | nan_value_count         | `long`              | float/double types      | Number of NaN values in the column. Only included for float/double types. NaN rules follow note 2 under [Data File Fields](#data-file-fields)                         |
+| _optional_  | 7      | avg_value_size_in_bytes | `int`               | variable-length types   | Avg stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                      |
+| _optional_  | 8      | max_value_size_in_bytes | `int`               | variable-length types   | Max stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                      |
+
+Notes:
+
+Types such as `string` / `binary` often use `tight_bounds=false` when bounds are truncated. For types with inherently tight bounds when written (for example boolean, integer, floating-point, date, time, timestamp, decimal, uuid, geometry, geography), writers should use `true` when bounds are present. If a deletion vector or equality delete file can match rows in the data file, implementations must treat bounds as inexact for pruning (`tight_bounds` as `false`)
 
 ###### Stats projection
 
@@ -794,7 +790,6 @@ Below are examples for some table field ID -> stats struct id calculations.
 
 | Table Field ID      | Stats ID of Stats struct  |
 |---------------------|---------------------------|
-| 0                   | 10_000                    |
 | 1                   | 10_200                    |
 | 2                   | 10_400                    |
 | 5                   | 11_000                    |
@@ -813,22 +808,22 @@ The below table shows the stats IDs of individual field statistics, which are ca
 
 | Table Field ID | Stats ID of Stats struct | Stats Type              | Stats ID of individual statistic |
 |----------------|--------------------------|-------------------------|----------------------------------|
-| 2              | 10_400                   | value_count             | 10_401                           |
-|                |                          | null_value_count        | 10_402                           |
-|                |                          | nan_value_count         | 10_403                           |
-|                |                          | avg_value_size_in_bytes | 10_404                           |
-|                |                          | max_value_size_in_bytes | 10_405                           |
-|                |                          | lower_bound             | 10_406                           |
-|                |                          | upper_bound             | 10_407                           |
-|                |                          | exact_bounds            | 10_408                           |
-| 5              | 11_000                   | value_count             | 11_001                           |
-|                |                          | null_value_count        | 11_002                           |
-|                |                          | nan_value_count         | 11_003                           |
-|                |                          | avg_value_size_in_bytes | 11_004                           |
-|                |                          | max_value_size_in_bytes | 11_005                           |
-|                |                          | lower_bound             | 11_006                           |
-|                |                          | upper_bound             | 11_007                           |
-|                |                          | exact_bounds            | 11_008                           |
+| 2              | 10_400                   | lower_bound             | 10_401                           |
+|                |                          | upper_bound             | 10_402                           |
+|                |                          | tight_bounds            | 10_403                           |
+|                |                          | value_count             | 10_404                           |
+|                |                          | null_value_count        | 10_405                           |
+|                |                          | nan_value_count         | 10_406                           |
+|                |                          | avg_value_size_in_bytes | 10_407                           |
+|                |                          | max_value_size_in_bytes | 10_408                           |
+| 5              | 11_000                   | lower_bound             | 11_001                           |
+|                |                          | upper_bound             | 11_002                           |
+|                |                          | tight_bounds            | 11_003                           |
+|                |                          | value_count             | 11_004                           |
+|                |                          | null_value_count        | 11_005                           |
+|                |                          | nan_value_count         | 11_006                           |
+|                |                          | avg_value_size_in_bytes | 11_007                           |
+|                |                          | max_value_size_in_bytes | 11_008                           |
 
 ###### Manifest schema and `content_stats` typing
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -654,6 +654,7 @@ The `data_file` struct consists of the following fields:
     | _required_ | _required_ | _required_ | **`102  partition`**              | `struct<...>`                                                               | Partition data tuple, schema based on the partition spec output using partition field ids for the struct field ids |
     | _required_ | _required_ | _required_ | **`103  record_count`**           | `long`                                                                      | Number of records in this file, or the cardinality of a deletion vector |
     | _required_ | _required_ | _required_ | **`104  file_size_in_bytes`**     | `long`                                                                      | Total file size in bytes |
+    |            |            |            | **`146  content_stats`**          | `content_stats` `struct`                                                    | Container struct for per-field metrics structs. See [Content Stats](#content-stats) |
     | _required_ |            |            | ~~**`105 block_size_in_bytes`**~~ | `long`                                                                      | **Deprecated. Always write a default in v1. Do not write in v2 or v3.** |
     | _optional_ |            |            | ~~**`106  file_ordinal`**~~       | `int`                                                                       | **Deprecated. Do not write.** |
     | _optional_ |            |            | ~~**`107  sort_columns`**~~       | `list<112: int>`                                                            | **Deprecated. Do not write.** |
@@ -675,11 +676,7 @@ The `data_file` struct consists of the following fields:
 
 The `partition` struct stores the tuple of partition values for each file. Its type is derived from the partition fields of the partition spec used to write the manifest file. In v2, the partition struct's field ids must match the ids from the partition spec.
 
-The column metrics maps are used when filtering to select both data and delete files.
-In v3, implementations use maps such as `value_counts`, `lower_bounds`, and `upper_bounds`, keyed by column id, with bounds serialized as binary (see note 1 under [Data File Fields](#data-file-fields)).
-Iceberg v4 adds the optional `content_stats` struct, which tracks the same metrics using nested structs and typed bounds (see [Content Stats](#content-stats)).
-Metrics information held in v1-v3 and v4 are both equivalent. A `null` in a v4 `lower_bound` has the same meaning as if the `lower_bounds` map is missing or if an entry is missing from that map.
-For delete files, the metrics must store bounds and counts for all deleted rows, or must be omitted. Storing metrics for deleted rows ensures that the values can be used during job planning to find delete files that must be merged during a scan.
+The v4 `content_stats` struct stores field-level metrics. Unlike the metrics maps, the type of `content_stats` is based on table metadata, like schema. Similar to the `partition` struct, the same type is used for all files tracked in a manifest.
 
 Notes:
 
@@ -690,9 +687,31 @@ Notes:
 5. The `content_offset` and `content_size_in_bytes` fields are used to reference a specific blob for direct access to a deletion vector. For deletion vectors, these values are required and must exactly match the `offset` and `length` stored in the Puffin footer for the deletion vector blob.
 6. The following field ids are reserved on `data_file`: 141.
 
-###### Bounds for Variant, Geometry, and Geography
+##### Field-level Metrics and Statistics
 
-For Variant, values in the `lower_bounds` and `upper_bounds` maps store serialized Variant objects that contain lower or upper bounds respectively. The object keys for the bound-variants are normalized JSON path expressions that uniquely identify a field. The object values are primitive Variant representations of the lower or upper bound for that field. Including bounds for any field is optional and upper and lower bounds must have the same Variant type.
+Field statistics (or, interchangeably, metrics) are used when filtering to select data and delete files.
+
+In v3 and earlier, metrics are stored in maps keyed by column id: `value_counts`, `null_value_counts`, `nan_value_counts`, `lower_bounds` and `upper_bounds`.
+
+In v4, metrics are stored as typed values in the `content_stats` struct, documented in the [Content Stats](#content-stats) section.
+
+Both representations store equivalent information. If a map or id in a map is missing in v3, it is equivalent to a `null` value or missing field struct in v4. Lower bounds must be less than or equal to all non-null and non-NaN values and upper bounds must be greater than or equal to all non-null and non-NaN values.
+
+For delete files, metrics must store bounds and counts for all deleted rows, or must be omitted. Storing metrics for deleted rows ensures that the values can be used during job planning to find delete files that must be merged during a scan.
+
+###### Bounds for Geometry and Geography
+
+For `geometry` and `geography` types, `lower_bounds` and `upper_bounds` are points with coordinates X, Y, Z (optional), and M (optional) that represent the lower and upper bounds of a bounding box that contains all objects in the file.
+
+For `geography` only, xmin (X value of `lower_bounds`) may be greater than xmax (X value of `upper_bounds`), in which case an object in this bounding box may match if it contains an X such that x >= xmin OR x <= xmax. In geographic terminology, the concepts of xmin, xmax, ymin, and ymax are also known as westernmost, easternmost, southernmost and northernmost, respectively. These points are further restricted to the canonical ranges of [-180..180] for X and [-90..90] for Y.
+
+When calculating upper and lower bounds for `geometry` and `geography`, null or NaN values in a coordinate dimension are skipped; for example, POINT (1 NaN) contributes a value to X but no values to Y, Z, or M dimension bounds. If a dimension has only null or NaN values, that dimension is omitted from the bounding box. If either the X or Y dimension is missing then the bounding box itself is not produced.
+
+In v3, lower and upper bound points are serialized as binary (see [Bound Serialization](#bound-serialization) in Appendix D). In v4, bounds are stored in `geo_lower` and `geo_upper` structs (see [Content Stats](#content-stats)).
+
+###### Bounds for Variant
+
+For Variant, lower and upper bound values store Variant objects that contain lower or upper bounds, respectively, for fields within the variant. The object keys for the bound-variants are normalized JSON path expressions that uniquely identify a field. The object values are primitive Variant representations of the lower or upper bound for that field. Including bounds for any field is optional and upper and lower bounds must have the same Variant type.
 
 Bounds for a field must be accurate for all non-null values of the field in a data file. Bounds for values within arrays must be accurate for all values in the array. Bounds must not be written to describe values with mixed Variant types (other than null). For example, a **measurement** field that contains int64 and null values may have bounds, but if the field also contained a string value such as **n/a** or **0** then the field may not have bounds.
 
@@ -708,110 +727,111 @@ Examples of valid field paths using normalized JSON path format are:
 * `$['tags']` -- the `tags` array
 * `$['addresses']['zip']` -- the `zip` field in an `addresses` array that contains objects
 
-For `geometry` and `geography` types, `lower_bounds` and `upper_bounds` are both points of the following coordinates X, Y, Z, and M (see Appendix G) which are the lower / upper bound of all objects in the file.
-
-For `geography` only, xmin (X value of `lower_bounds`) may be greater than xmax (X value of `upper_bounds`), in which case an object in this bounding box may match if it contains an X such that x >= xmin OR x <= xmax. In geographic terminology, the concepts of xmin, xmax, ymin, and ymax are also known as westernmost, easternmost, southernmost and northernmost, respectively. These points are further restricted to the canonical ranges of [-180..180] for X and [-90..90] for Y.
-
-When calculating upper and lower bounds for `geometry` and `geography`, null or NaN values in a coordinate dimension are skipped; for example, POINT (1 NaN) contributes a value to X but no values to Y, Z, or M dimension bounds. If a dimension has only null or NaN values, that dimension is omitted from the bounding box. If either the X or Y dimension is missing then the bounding box itself is not produced.
-
 ##### Content Stats
 
-In Iceberg v4, column metrics for a data field are typed fields in a stats struct that corresponds to the field. These stats structs are nested within the `content_stats` struct in manifest files.
+In Iceberg v4, statistics are stored in typed fields grouped in a struct that corresponds to the table field. These stats structs are nested within the `content_stats` struct in manifest files.
 
-A table field's stats struct uses a range of 200 IDs, starting at `10_000 + 200 * field-id`. Fields within the stats struct are each assigned IDs by adding an offset to the start of the range. For example, the stats struct for table field 1 uses IDs in the range `[10_200, 10_399]`, and its `lower_bound` field (offset 1) uses ID `10_201`.
+###### Field Statistics
 
-The stats struct ID for a data field is:
+Field-level structs in `content_stats` are based on the corresponding table field's type, requirement, and ID (`field-id`).
 
-`stats_struct_id = 10_000 + (200 * field_id)`
+Field stats structs are assigned a range of 200 IDs, starting at `10_000 + 200 * field-id`. The first ID in the range (`base-id`) is the ID of the struct field in `content_stats`. Fields within the stats struct are assigned IDs from the range by adding an offset to the `base-id`. For example, the stats struct for table field 2 uses IDs in the range `[10_400, 10_599]`, the field within `content_stats` has uses the `base-id`, ID `10_400`, and its `lower_bound` field (offset 1) uses ID `10_401`.
 
-The constant `10_000` is `stats_space_field_id_start_for_data_fields`. `200` represents the number of supports stats per column (`num_supported_stats_per_column = 200`).
+Content stats must be resovled by ID; field names used for stats structs are informational. The recommended name for each field is the full name of the field in the table schema.
 
-Each field statistic listed under [Field stats types](#field-stats-types) has a fixed **offset** within that block. The field id for an individual field statistic is:
+IDs in the range `10_000` (inclusive) to `200_000_000` (exclusive) are reserved for column stats structs in `content_stats`. Stats for table fields with IDs outside that range cannot be stored in `content_stats`.
 
-`stats_field_id = stats_struct_id + offset`
+[Reserved metadata fields](#reserved-field-ids) must use the stats ID ranges from the following table. Stats for metadata fields not in the table are not tracked.
 
-IDs in the range `10_000` (inclusive) to `200_000_000` (exclusive) are reserved for column stats structs in `content_stats`. Table fields with IDs outside that range are still valid, but their statistics cannot be stored in `content_stats`.
+| Reserved field                  | ID         | `base-id` | Range end |
+|---------------------------------|------------|-----------|-----------|
+| `_last_updated_sequence_number` | 2147483539 | 9000      | 9199 |
+| `_row_id`                       | 2147483540 | 9200      | 9399 |
 
-[Reserved metadata fields](#reserved-field-ids) use a different starting base for their stats field ids in order to not overlap with data field stats ids. Mapping a reserved table field ID to the **stats ID space** is done via:
+Each stats struct holds statistics for one table field. It may contain the following metrics:
 
-`stats_struct_id = 2_147_000_000 + (200 * (200 - (Integer.MAX_VALUE - table_field_id)))`
+| Requirement | Offset | Name                      | Type                      | Included for                                  | Description |
+|-------------|--------|---------------------------|---------------------------|-----------------------------------------------|-------------|
+| _optional_  | 1      | `lower_bound`             | Field type or `geo_lower` | all primitives or `variant`                   | Lower bound stored as the field's type, or `geo_lower` for geo types |
+| _optional_  | 2      | `upper_bound`             | Field type or `geo_upper` | all primitives or `variant`                   | Upper bound stored as the field's type, or `geo_upper` for geo types |
+| _optional_  | 3      | `tight_bounds`            | `boolean`                 | all except `geometry`, `geography`, `variant` | When true, `lower_bound` and `upper_bound` must be equal to the min and max values |
+| _optional_  | 4      | `value_count`             | `long`                    | all                                           | Number of values in the column (including null and NaN values) |
+| _optional_  | 5      | `null_value_count`        | `long`                    | optional fields                               | Number of null values in the column |
+| _optional_  | 6      | `nan_value_count`         | `long`                    | `float`, `double`                             | Number of NaN values in the column |
+| _optional_  | 7      | `avg_value_size_in_bytes` | `int`                     | `string`, `binary`, `variant`                 | Avg value size (uncompressed) in bytes to estimate memory consumption |
 
-Here `2_147_000_000` is `stats_space_field_id_start_for_metadata_fields`. This separate base is required because reserved ids are near `Integer.MAX_VALUE` and cannot use the same linear mapping as data field ids.
-The first `200` refers to `num_supported_stats_per_column = 200` and the second `200` refers to `num_reserved_field_ids = 200` from [Reserved field ids](#reserved-field-ids).
+For example, stats for a `required` `int` field named `id` with field-id `2` are stored using:
 
-The formula is defined as:
-`stats_struct_id = stats_space_field_id_start_for_metadata_fields + (num_supported_stats_per_column * (num_reserved_field_ids - (Integer.MAX_VALUE - table_field_id)))`
+```
+10_400: optional struct id (default null) {
+  10_401: optional int lower_bound; // type matches the field type (int)
+  10_402: optional int upper_bound; // type matches the field type (int)
+  10_403: optional boolean tight_bounds;
+  10_404: optional long value_count;
 
-Valid data field ids support stats structs with ids from `10_000` through `200_010_000`, so the highest supported **data** field id is `1_000_000`.
-
-###### Name assignment for `content_stats` fields
-
-Each nested stats struct is a **child field** of the root `content_stats` struct. Its **name** is the numerical string of the table column's field id (for example id `103` uses the name `"103"`).
-The name is informational and readers must resolve content stats by ID.
-
-###### Field stats types
-
-Each stats struct holds statistics for one table column. It may contain the following metrics:
-
-| requirement | Offset | Name                    | Type                | included for            | Description                                                                                                                                                         |
-|-------------|--------|-------------------------|---------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _optional_  | 1      | lower_bound             | type of table field | all types               | Lower bound serialized as the column's type. Rules follow Note 1 below                                                                                              |
-| _optional_  | 2      | upper_bound             | type of table field | all types               | Upper bound serialized as the column's type. Rules follow Note 1 below                                                                                              |
-| _optional_  | 3      | tight_bounds            | `boolean`           | truncated/inexact types | Whether the `lower_bound` / `upper_bound` are tight (`true`) or may be truncated or otherwise inexact (`false`). Defaults to `true`. See details under Note 2 below |
-| _optional_  | 4      | value_count             | `long`              | all types               | Number of values in the column (including null and NaN values)                                                                                                      |
-| _optional_  | 5      | null_value_count        | `long`              | optional columns only   | Number of null values in the column. Only included for optional columns                                                                                             |
-| _optional_  | 6      | nan_value_count         | `long`              | float/double types      | Number of NaN values in the column. Only included for float/double types. NaN rules follow Note 2 under [Data File Fields](#data-file-fields)                       |
-| _optional_  | 7      | avg_value_size_in_bytes | `int`               | variable-length types   | Avg stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                    |
-| _optional_  | 8      | max_value_size_in_bytes | `int`               | variable-length types   | Max stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                    |
-
-Notes:
-
-1. The `lower_bound` and `upper_bound` types match the table field's type for primitive types. For `geometry` and `geography`, both bounds use a `struct<x: double, y: double, z: double, m: double>` whose values are taken from the bounding box of all values in the file. For `variant`, both bounds use a `binary` containing a serialized variant object that maps normalized JSON paths to per-path bounds. See [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography) for details on producing bounds for these types.
-2. Bounds for `boolean`, `int`, `long`, `float`, `double`, `date`, `time`, `timestamp`, `decimal`, `uuid`, `geometry`, and `geography` are inherently tight. Writers should not write `tight_bounds` for these types. Bounds for `string`, `binary`, and `variant` may be truncated, in which case writers must set `tight_bounds` to `false`. When pruning, readers must treat bounds as inexact if a deletion vector or equality delete file can match rows in the data file.
-
-###### Stats projection
-
-To retrieve stats for a particular table field ID, one would always project by stats ID, where the stats ID for a given table field ID can be calculated by applying the reverse calculation.
-Below are examples for some table field ID -> stats struct ID calculations.
-
-| Table Field ID      | Stats ID of Stats struct  |
-|---------------------|---------------------------|
-| 1                   | 10_200                    |
-| 2                   | 10_400                    |
-| 5                   | 11_000                    |
-| 100                 | 30_000                    |
-| 1_000_000           | 200_010_000               |
-
-| Reserved Field ID   | Stats ID of Stats struct  |
-|---------------------|---------------------------|
-| 2_147_483_447       | 2_147_000_000             |
-| 2_147_483_448       | 2_147_000_200             |
-| 2_147_483_541       | 2_147_018_800             |
-| 2_147_483_645       | 2_147_039_600             |
-| 2_147_483_646       | 2_147_039_800             |
-
-For a table column using field ID `1` and type `int`, the stats struct is assigned ID `10_200` and the below nested struct:
-
-```text
-struct<
-  10_201: lower_bound int,
-  10_202: upper_bound int,
-  10_203: tight_bounds boolean,
-  10_204: value_count long,
-  10_205: null_value_count long,
-  10_206: nan_value_count long,
-  10_207: avg_value_size_in_bytes int,
-  10_208: max_value_size_in_bytes int
->
+  // null_value_count is only used for optional fields
+  // nan_value_count is only used for float and double
+  // avg_value_size_in_bytes is only used for variable length types
+}
 ```
 
-###### Manifest schema and `content_stats` typing
+If any field is missing from the struct, readers must assume that it is unknown.
 
-The `content_stats` type is dynamically derived from the table schema and embedded in the manifest schema for `data_file` at the reserved `content_stats` field id in v4.
+Lower and upper bounds for `geometry` and `geography` columns are XYZM points that define a bounding box, stored in `geo_lower` and `geo_upper` structs (see [Bounds for Geometry and Geography](#bounds-for-geometry-and-geography). IDs used by geo structs are assigned using offsets in the table field's stats ID range.
 
-When writing a new manifest, the `content_stats` type must be derived from the table's current schema, so the bound fields use the column's current type. If an `int` column `x` is later promoted to `long`, manifests written after the promotion must use `lower_bound long` and `upper_bound long` for `x`.
+The `geo_lower` struct is defined as:
 
-When reading a manifest, readers may use the schema embedded in that manifest. Manifests written before a type promotion still use the original bound types and Iceberg's normal type-promotion rules apply when those values are projected as the current column type.
+| Requirement | Offset | Name | Type     | Description |
+|-------------|--------|------|----------|-------------|
+| _required_  | 10     | `x`  | `double` | Bounding box westernmost/xmin; [-180..180] |
+| _required_  | 11     | `y`  | `double` | Bounding box southernmost/ymin; [-90..90] |
+| _optional_  | 12     | `z`  | `double` | Bounding box zmin |
+| _optional_  | 13     | `m`  | `double` | Bounding box mmin |
+
+The `geo_upper` struct is defined as:
+
+| Requirement | Offset | Name | Type     | Description |
+|-------------|--------|------|----------|-------------|
+| _required_  | 14     | `x`  | `double` | Bounding box eastermost/xmax; [-180..180] |
+| _required_  | 15     | `y`  | `double` | Bounding box northernmost/ymax; [-90..90] |
+| _optional_  | 16     | `z`  | `double` | Bounding box zmax |
+| _optional_  | 17     | `m`  | `double` | Bounding box mmax |
+
+For `variant`, both bounds are unshredded `variant` that store variant field bounds by normalized JSON paths as field names. See [Bounds for Variant](#bounds-for-variant) for details on producing these bounds.
+
+###### Content Stats in Manifests
+
+Manifest files are written using a specific `content_stats` struct type, determined by the writer and incorporated into the manifest schema. All field-level structs are optional fields in the `content_stats` struct.
+
+For example, stats for a table with a required int, `id`, and an optional string, `data`, are stored as:
+
+```
+146: optional struct content_stats {
+  // stats struct for table field 2: required int id
+  10_400: optional struct id (default null) {
+    10_401: optional int lower_bound;
+    10_402: optional int upper_bound;
+    10_403: optional boolean tight_bounds;
+    10_404: optional long value_count;
+  }
+
+  // stats struct for table field 3: optional string data
+  10_600: optional struct data (default null) {
+    10_601: optional string lower_bound;
+    10_602: optional string upper_bound;
+    10_603: optional boolean tight_bounds;
+    10_604: optional long value_count;
+    10_605: optional long null_value_count;
+    10_607: optional int avg_value_size_in_bytes;
+  }
+}
+```
+
+Implementations may produce stats structs for fields that are not in the table schema, if a field ID from the table's column ID space is assigned for the data values (by allocating an ID using `last-column-id`). Implementations are not required to write a stats struct for every table field.
+
+Fields with stats tracked in `content_stats` change based on updates like schema evolution or metrics configuration. Writers adapt to table changes by writing new manifest files with the implementation's current `content_stats` type. When existing file metadata is written to new manifests, writers must discard old stats, set unknown stats structs to null, and promote lower and upper bounds types to conform to the manifest schema.
+
+A simple (and recommended) way for writers to adapt existing metadata for table changes is to read manifests with the implementation's current `content_stats` type and apply schema evolution rules, such as reading `int` as `long` for promoted fields.
 
 #### Sequence Number Inheritance
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -676,7 +676,7 @@ The `data_file` struct consists of the following fields:
 
 The `partition` struct stores the tuple of partition values for each file. Its type is derived from the partition fields of the partition spec used to write the manifest file. In v2, the partition struct's field ids must match the ids from the partition spec.
 
-The v4 `content_stats` struct stores field-level metrics. Unlike the metrics maps, the type of `content_stats` is based on table metadata, like schema. Similar to the `partition` struct, the same type is used for all files tracked in a manifest.
+The v4 `content_stats` container struct stores field-level metrics. Unlike the metrics maps, the type of `content_stats` is based on table metadata, like schema. Similar to the `partition` struct, the same type is used for all files tracked in a manifest.
 
 Notes:
 
@@ -815,7 +815,7 @@ For example, stats for an optional `geometry` field named `location` with field-
   }
   10_804: optional long value_count;
   10_805: optional long null_value_count;
-  // tight_bounds / nan_value_count / avg_value_size_in_bytes are not stored for geo types
+  // tight_bounds, nan_value_count, avg_value_size_in_bytes are omitted for geo types
 }
 ```
 
@@ -823,7 +823,7 @@ For `variant`, both bounds are unshredded `variant` that store variant field bou
 
 ###### Content Stats in Manifests
 
-Manifest files are written using a specific `content_stats` struct type, determined by the writer and incorporated into the manifest schema. All field-level structs are optional fields in the `content_stats` struct.
+Manifest files are written using a specific `content_stats` container struct type, determined by the writer and incorporated into the manifest schema. All field-level structs are optional fields in the `content_stats` struct.
 
 For example, stats for a table with a required int, `id`, and an optional string, `data`, are stored as:
 
@@ -851,7 +851,7 @@ For example, stats for a table with a required int, `id`, and an optional string
 
 Implementations may produce stats structs for fields that are not in the table schema, if a field ID from the table's column ID space is assigned for the data values (by allocating an ID using `last-column-id`). Implementations are not required to write a stats struct for every table field.
 
-Fields with stats tracked in `content_stats` change based on updates like schema evolution or metrics configuration. Writers adapt to table changes by writing new manifest files with the implementation's current `content_stats` type. When existing file metadata is written to new manifests, writers must discard old stats, set unknown stats structs to null, and promote lower and upper bounds types to conform to the manifest schema.
+Fields with stats tracked in `content_stats` change based on updates like schema evolution or metrics configuration. Writers adapt to table changes by writing new manifest files with the implementation's current `content_stats` type. When existing file metadata is written to new manifests, writers must update `content_stats` by discarding old stats (for removed fields), set unknown stats structs to null (for added fields), and promote lower and upper bounds types (for type promotion) to conform to the manifest schema.
 
 A simple (and recommended) way for writers to adapt existing metadata for table changes is to read manifests with the implementation's current `content_stats` type and apply schema evolution rules, such as reading `int` as `long` for promoted fields.
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -690,8 +690,8 @@ Notes:
 
 Per-column metrics used for filtering and planning are stored at **file** granularity on the `data_file` struct.
 In v3, implementations use maps such as `value_counts`, `lower_bounds`, and `upper_bounds`, keyed by column id, with bounds serialized as binary (see note 1 under [Data File Fields](#data-file-fields)).
-Iceberg v4 adds the optional `content_stats` struct, which holds the same *logical* metrics for primitive leaf columns using nested structs and typed bounds (see [Content Stats](#content-stats)).
-The subsections below define shared bound serialization for variant, geometry, and geography, and then define v4 `content_stats`; the same bound rules apply whether values are read from v3 maps or from v4 field stats.
+Iceberg v4 adds the optional `content_stats` struct, which holds the same *logical* metrics (without `column_sizes` as that was deprecated) using nested structs and typed bounds (see [Content Stats](#content-stats)).
+Stats for primitive types and Geometry / Geography / Variant are supported. Stats for nested types (`struct`, `list`, `map`) are not supported.
 
 ###### Bounds for Variant, Geometry, and Geography
 
@@ -719,54 +719,60 @@ When calculating upper and lower bounds for `geometry` and `geography`, null or 
 
 ##### Content Stats
 
-Iceberg v4 introduces content stats which represent stats in a `struct<struct<...>>`. The statistics for fields are tracked inside a nested struct of value counts and bounds (described in the next section). Each field-level statistics struct is a field of the `content_stats` struct, which holds all statistics for table fields.
+In Iceberg v4 stats have been redesigned and are represented by using nested structs (`struct<struct<...>>`). The statistics for fields are tracked inside a nested struct of value counts and bounds (described in the next section). Each field-level statistics struct is a field of the `content_stats` struct, which holds all statistics for table fields.
 
 ###### ID assignment for stats fields
 
-ID assignment follows a deterministic transform that maps from the **table ID space** to the **metadata ID space**. For a given field ID from the **table ID space** each nested stats struct gets an ID assigned from the **metadata ID space**.
-The offset defined in the [field stats types section](#field-stats-types) is added to the stats ID of the enclosing stats struct to calculate IDs for each individual field stats type.
+ID assignment follows a deterministic mapping from the **table ID space** to the **stats ID space**, where a given field ID from the **table ID space** gets an ID assigned from the **stats ID space** for each field-level statistics struct.
+Each field-level statistic listed in the [field stats types section](#field-stats-types) has a fixed offset. Its stats field ID is the enclosing stats struct's ID plus that offset.
 
 **Data columns (normal table field ids)**
-
-Let `table_field_id` be the column's id in the table schema. Allocate a contiguous block of **200** ids per column (`num_supported_stats_per_column = 200`). The stats struct for that column starts at:
+Mapping a table field ID from the **table ID space** to the **stats ID space** is done via:
 
 `stats_struct_id = 10_000 + (200 * table_field_id)`
+
+The constant `10_000` is `stats_space_field_id_start_for_data_fields`. `200` represents the number of supports stats per column (`num_supported_stats_per_column = 200`).
+
+The formula is defined as:
+`stats_struct_id = stats_space_field_id_start_for_data_fields + (num_supported_stats_per_column * table_field_id)`
 
 Each field statistic listed under [Field stats types](#field-stats-types) has a fixed **offset** within that block. The field id for an individual field statistic is:
 
 `stats_field_id = stats_struct_id + offset`
 
-The constant `10_000` is `stats_space_field_id_start_for_data_fields`. The value **200** is both the width of each column's stats block and `num_reserved_field_ids` from [Reserved field ids](#reserved-field-ids).
+**Metadata columns (reserved table field ids)**
 
-**Reserved table field ids.**
-
-Columns whose ids fall in the [reserved field ID](#reserved-field-ids) space use a different base so their stats ids do not overlap data columns:
+[Reserved metadata fields](#reserved-field-ids) use a different starting base for their stats field ids in order to not overlap with data field stats ids. Mapping a reserved table field ID to the **stats ID space** is done via:
 
 `stats_struct_id = 2_147_000_000 + (200 * (200 - (Integer.MAX_VALUE - table_field_id)))`
 
 Here `2_147_000_000` is `stats_space_field_id_start_for_metadata_fields`. This separate base is required because reserved ids are near `Integer.MAX_VALUE` and cannot use the same linear mapping as data field ids.
+The first `200` refers to `num_supported_stats_per_column = 200` and the second `200` refers to `num_reserved_field_ids = 200` from [Reserved field ids](#reserved-field-ids).
+
+The formula is defined as:
+`stats_struct_id = stats_space_field_id_start_for_metadata_fields + (num_supported_stats_per_column * (num_reserved_field_ids - (Integer.MAX_VALUE - table_field_id)))`
 
 Valid data field ids support stats structs with ids from `10_000` through `200_010_000`, so the highest supported **data** field id is `1_000_000`.
 
 ###### Name assignment for `content_stats` fields
 
 Each nested stats struct is a **child field** of the root `content_stats` struct. Its **name** is the numerical string of the table column's field id (for example id `103` uses the name `"103"`).
-Its **field id** is deterministically calculated as defined in the previous section.
+Its **field id** is deterministically calculated as defined in the previous section. The name is informational and readers must resolve content stats by ID.
 
 ###### Field stats types
 
 Each stats struct holds statistics for one table column. It may contain the following metrics:
 
-| required/optional | Offset | Name                    | Type                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-|-------------------|--------|-------------------------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _optional_        | 1      | value_count             | `long`              | Number of values in the column (including null and NaN values)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| _optional_        | 2      | null_value_count        | `long`              | Number of null values in the column. Only included for optional columns                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| _optional_        | 3      | nan_value_count         | `long`              | Number of NaN values in the column. Only included for float/double types. NaN rules follow note 2 under [Data File Fields](#data-file-fields)                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| _optional_        | 4      | avg_value_size_in_bytes | `int`               | Avg stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| _optional_        | 5      | max_value_size_in_bytes | `int`               | Max stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| _optional_        | 6      | lower_bound             | type of table field | Lower bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography)                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| _optional_        | 7      | upper_bound             | type of table field | Upper bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography)                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| _optional_        | 8      | exact_bounds            | `boolean`           | Whether the `lower_bound` / `upper_bound` are exact (`true`) or may be truncated or otherwise inexact (`false`). Defaults to `true`. Types such as `string` / `binary` often use `false` when bounds are truncated. For types with inherently exact bounds when written (for example boolean, integer, floating-point, date, time, timestamp, decimal, uuid, `geometry`, `geography`), writers should use `true` when bounds are present. If a deletion vector or equality delete file can match rows in the data file, implementations must treat bounds as inexact for pruning (`exact_bounds` as `false`) |
+| required/optional | Offset | Name                    | Type                | included for            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|-------------------|--------|-------------------------|---------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _optional_        | 1      | value_count             | `long`              | all types               | Number of values in the column (including null and NaN values)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| _optional_        | 2      | null_value_count        | `long`              | optional columns only   | Number of null values in the column. Only included for optional columns                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| _optional_        | 3      | nan_value_count         | `long`              | float/double types      | Number of NaN values in the column. Only included for float/double types. NaN rules follow note 2 under [Data File Fields](#data-file-fields)                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| _optional_        | 4      | avg_value_size_in_bytes | `int`               | variable-length types   | Avg stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| _optional_        | 5      | max_value_size_in_bytes | `int`               | variable-length types   | Max stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| _optional_        | 6      | lower_bound             | type of table field | all types               | Lower bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography)                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| _optional_        | 7      | upper_bound             | type of table field | all types               | Upper bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography)                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| _optional_        | 8      | exact_bounds            | `boolean`           | truncated/inexact types | Whether the `lower_bound` / `upper_bound` are exact (`true`) or may be truncated or otherwise inexact (`false`). Defaults to `true`. Types such as `string` / `binary` often use `false` when bounds are truncated. For types with inherently exact bounds when written (for example boolean, integer, floating-point, date, time, timestamp, decimal, uuid, geometry, geography), writers should use `true` when bounds are present. If a deletion vector or equality delete file can match rows in the data file, implementations must treat bounds as inexact for pruning (`exact_bounds` as `false`) |
 
 ###### Stats projection
 
@@ -777,9 +783,12 @@ For data columns the reverse calculation would be:
 
 For [reserved field IDs](#reserved-field-ids), the reverse calculation would be:
 
-`table_field_id = stats_struct_id - num_reserved_field_ids + (Integer.MAX_VALUE - stats_struct_id) + (stats_struct_id - stats_space_field_id_start_for_metadata_fields) / num_supported_stats_per_column`
+`table_field_id = stats_struct_id - 200 + (Integer.MAX_VALUE - stats_struct_id) + (stats_struct_id - 2_147_000_000) / 200`
 
 using `num_reserved_field_ids = 200`, `stats_space_field_id_start_for_metadata_fields = 2_147_000_000`, and `num_supported_stats_per_column = 200` (see [ID assignment for stats fields](#id-assignment-for-stats-fields)).
+
+The formula is defined as:
+`table_field_id = stats_struct_id - num_reserved_field_ids + (Integer.MAX_VALUE - stats_struct_id) + (stats_struct_id - stats_space_field_id_start_for_metadata_fields) / num_supported_stats_per_column`
 
 Below are examples for some table field ID -> stats struct id calculations.
 
@@ -829,6 +838,9 @@ Writers and readers must use this **same** manifest schema both when writing and
 
 Using one schema for read and write is what allows **type promotion** on stats: if an `int` column `x` is promoted to `long`, the nested stats struct changes from `struct<..., lower_bound int, upper_bound int, ...>` to `struct<..., lower_bound long, upper_bound long, ...>`.
 Reading an older manifest applies normal Iceberg type promotion to those bound fields; writing after promotion then uses the promoted struct type, so round-trips stay consistent.
+
+###### Content stats aggregation
+TBD...
 
 #### Sequence Number Inheritance
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -797,6 +797,28 @@ The `geo_upper` struct is defined as:
 | _optional_  | 16     | `z`  | `double` | Bounding box zmax |
 | _optional_  | 17     | `m`  | `double` | Bounding box mmax |
 
+For example, stats for an optional `geometry` field named `location` with field-id `4` are stored as:
+
+```
+10_800: optional struct location (default null) {
+  10_801: optional struct lower_bound (default null) { // geo_lower
+    10_810: required double x;
+    10_811: required double y;
+    10_812: optional double z;
+    10_813: optional double m;
+  }
+  10_802: optional struct upper_bound (default null) { // geo_upper
+    10_814: required double x;
+    10_815: required double y;
+    10_816: optional double z;
+    10_817: optional double m;
+  }
+  10_804: optional long value_count;
+  10_805: optional long null_value_count;
+  // tight_bounds / nan_value_count / avg_value_size_in_bytes are not stored for geo types
+}
+```
+
 For `variant`, both bounds are unshredded `variant` that store variant field bounds by normalized JSON paths as field names. See [Bounds for Variant](#bounds-for-variant) for details on producing these bounds.
 
 ###### Content Stats in Manifests
@@ -823,32 +845,6 @@ For example, stats for a table with a required int, `id`, and an optional string
     10_604: optional long value_count;
     10_605: optional long null_value_count;
     10_607: optional int avg_value_size_in_bytes;
-  }
-}
-```
-
-For `geometry` and `geography` fields, `lower_bound` and `upper_bound` are nested `geo_lower` and `geo_upper` structs whose fields are assigned IDs using offsets in the table field's stats ID range. `tight_bounds`, `nan_value_count`, and `avg_value_size_in_bytes` are not used for geo types.
-
-For example, stats for a table with an optional `geometry` field, `location` with field-id `4`, are stored as:
-
-```
-146: optional struct content_stats {
-  // stats struct for table field 4: optional geometry location
-  10_800: optional struct location (default null) {
-    10_801: optional struct lower_bound (default null) { // geo_lower
-      10_810: required double x;
-      10_811: required double y;
-      10_812: optional double z;
-      10_813: optional double m;
-    }
-    10_802: optional struct upper_bound (default null) { // geo_upper
-      10_814: required double x;
-      10_815: required double y;
-      10_816: optional double z;
-      10_817: optional double m;
-    }
-    10_804: optional long value_count;
-    10_805: optional long null_value_count;
   }
 }
 ```

--- a/format/spec.md
+++ b/format/spec.md
@@ -827,6 +827,32 @@ For example, stats for a table with a required int, `id`, and an optional string
 }
 ```
 
+For `geometry` and `geography` fields, `lower_bound` and `upper_bound` are nested `geo_lower` and `geo_upper` structs whose fields are assigned IDs using offsets in the table field's stats ID range. `tight_bounds`, `nan_value_count`, and `avg_value_size_in_bytes` are not used for geo types.
+
+For example, stats for a table with an optional `geometry` field, `location` with field-id `4`, are stored as:
+
+```
+146: optional struct content_stats {
+  // stats struct for table field 4: optional geometry location
+  10_800: optional struct location (default null) {
+    10_801: optional struct lower_bound (default null) { // geo_lower
+      10_810: required double x;
+      10_811: required double y;
+      10_812: optional double z;
+      10_813: optional double m;
+    }
+    10_802: optional struct upper_bound (default null) { // geo_upper
+      10_814: required double x;
+      10_815: required double y;
+      10_816: optional double z;
+      10_817: optional double m;
+    }
+    10_804: optional long value_count;
+    10_805: optional long null_value_count;
+  }
+}
+```
+
 Implementations may produce stats structs for fields that are not in the table schema, if a field ID from the table's column ID space is assigned for the data values (by allocating an ID using `last-column-id`). Implementations are not required to write a stats struct for every table field.
 
 Fields with stats tracked in `content_stats` change based on updates like schema evolution or metrics configuration. Writers adapt to table changes by writing new manifest files with the implementation's current `content_stats` type. When existing file metadata is written to new manifests, writers must discard old stats, set unknown stats structs to null, and promote lower and upper bounds types to conform to the manifest schema.

--- a/format/spec.md
+++ b/format/spec.md
@@ -690,7 +690,6 @@ Notes:
 5. The `content_offset` and `content_size_in_bytes` fields are used to reference a specific blob for direct access to a deletion vector. For deletion vectors, these values are required and must exactly match the `offset` and `length` stored in the Puffin footer for the deletion vector blob.
 6. The following field ids are reserved on `data_file`: 141.
 
-
 ###### Bounds for Variant, Geometry, and Geography
 
 For Variant, values in the `lower_bounds` and `upper_bounds` maps store serialized Variant objects that contain lower or upper bounds respectively. The object keys for the bound-variants are normalized JSON path expressions that uniquely identify a field. The object values are primitive Variant representations of the lower or upper bound for that field. Including bounds for any field is optional and upper and lower bounds must have the same Variant type.
@@ -719,12 +718,11 @@ When calculating upper and lower bounds for `geometry` and `geography`, null or 
 
 In Iceberg v4, column metrics for a data field are typed fields in a stats struct that corresponds to the field. These stats structs are nested within the `content_stats` struct in manifest files.
 
-A table field's stats struct uses a range of 200 IDs, starting at `10_000 + 200 * field-id`. Fields within the stats struct are each assigned IDs based on the start of the range and an offset for the field. For example, field 1 uses IDs in the range [10,200, 10,399], and its `lower_bound` field uses ID 10,201.
+A table field's stats struct uses a range of 200 IDs, starting at `10_000 + 200 * field-id`. Fields within the stats struct are each assigned IDs by adding an offset to the start of the range. For example, the stats struct for table field 1 uses IDs in the range `[10_200, 10_399]`, and its `lower_bound` field (offset 1) uses ID `10_201`.
 
-**Data columns (normal table field ids)**
-Mapping a table field ID from the **table ID space** to the **stats ID space** is done via:
+The stats struct ID for a data field is:
 
-`stats_struct_id = 10_000 + (200 * table_field_id)`
+`stats_struct_id = 10_000 + (200 * field_id)`
 
 The constant `10_000` is `stats_space_field_id_start_for_data_fields`. `200` represents the number of supports stats per column (`num_supported_stats_per_column = 200`).
 
@@ -732,7 +730,7 @@ Each field statistic listed under [Field stats types](#field-stats-types) has a 
 
 `stats_field_id = stats_struct_id + offset`
 
-**Metadata columns (reserved table field ids)**
+IDs in the range `10_000` (inclusive) to `200_000_000` (exclusive) are reserved for column stats structs in `content_stats`. Table fields with IDs outside that range are still valid, but their statistics cannot be stored in `content_stats`.
 
 [Reserved metadata fields](#reserved-field-ids) use a different starting base for their stats field ids in order to not overlap with data field stats ids. Mapping a reserved table field ID to the **stats ID space** is done via:
 
@@ -755,25 +753,26 @@ The name is informational and readers must resolve content stats by ID.
 
 Each stats struct holds statistics for one table column. It may contain the following metrics:
 
-| requirement | Offset | Name                    | Type                | included for            | Description                                                                                                                                                           |
-|-------------|--------|-------------------------|---------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| _optional_  | 1      | lower_bound             | type of table field | all types               | Lower bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography) |
-| _optional_  | 2      | upper_bound             | type of table field | all types               | Upper bound serialized as the column's type. Bounds follow rules defined in [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography) |
-| _optional_  | 3      | tight_bounds            | `boolean`           | truncated/inexact types | Whether the `lower_bound` / `upper_bound` are tight (`true`) or may be truncated or otherwise inexact (`false`). Defaults to `true`.                                  |
-| _optional_  | 4      | value_count             | `long`              | all types               | Number of values in the column (including null and NaN values)                                                                                                        |
-| _optional_  | 5      | null_value_count        | `long`              | optional columns only   | Number of null values in the column. Only included for optional columns                                                                                               |
-| _optional_  | 6      | nan_value_count         | `long`              | float/double types      | Number of NaN values in the column. Only included for float/double types. NaN rules follow note 2 under [Data File Fields](#data-file-fields)                         |
-| _optional_  | 7      | avg_value_size_in_bytes | `int`               | variable-length types   | Avg stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                      |
-| _optional_  | 8      | max_value_size_in_bytes | `int`               | variable-length types   | Max stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                      |
+| requirement | Offset | Name                    | Type                | included for            | Description                                                                                                                                                         |
+|-------------|--------|-------------------------|---------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _optional_  | 1      | lower_bound             | type of table field | all types               | Lower bound serialized as the column's type. Rules follow Note 1 below                                                                                              |
+| _optional_  | 2      | upper_bound             | type of table field | all types               | Upper bound serialized as the column's type. Rules follow Note 1 below                                                                                              |
+| _optional_  | 3      | tight_bounds            | `boolean`           | truncated/inexact types | Whether the `lower_bound` / `upper_bound` are tight (`true`) or may be truncated or otherwise inexact (`false`). Defaults to `true`. See details under Note 2 below |
+| _optional_  | 4      | value_count             | `long`              | all types               | Number of values in the column (including null and NaN values)                                                                                                      |
+| _optional_  | 5      | null_value_count        | `long`              | optional columns only   | Number of null values in the column. Only included for optional columns                                                                                             |
+| _optional_  | 6      | nan_value_count         | `long`              | float/double types      | Number of NaN values in the column. Only included for float/double types. NaN rules follow Note 2 under [Data File Fields](#data-file-fields)                       |
+| _optional_  | 7      | avg_value_size_in_bytes | `int`               | variable-length types   | Avg stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                    |
+| _optional_  | 8      | max_value_size_in_bytes | `int`               | variable-length types   | Max stored (compressed, encoded) value size in bytes for variable-length types (`string` / `binary` / `variant`)                                                    |
 
 Notes:
 
-Types such as `string` / `binary` often use `tight_bounds=false` when bounds are truncated. For types with inherently tight bounds when written (for example boolean, integer, floating-point, date, time, timestamp, decimal, uuid, geometry, geography), writers should use `true` when bounds are present. If a deletion vector or equality delete file can match rows in the data file, implementations must treat bounds as inexact for pruning (`tight_bounds` as `false`)
+1. The `lower_bound` and `upper_bound` types match the table field's type for primitive types. For `geometry` and `geography`, both bounds use a `struct<x: double, y: double, z: double, m: double>` whose values are taken from the bounding box of all values in the file. For `variant`, both bounds use a `binary` containing a serialized variant object that maps normalized JSON paths to per-path bounds. See [Bounds for Variant, Geometry, and Geography](#bounds-for-variant-geometry-and-geography) for details on producing bounds for these types.
+2. Bounds for `boolean`, `int`, `long`, `float`, `double`, `date`, `time`, `timestamp`, `decimal`, `uuid`, `geometry`, and `geography` are inherently tight. Writers should not write `tight_bounds` for these types. Bounds for `string`, `binary`, and `variant` may be truncated, in which case writers must set `tight_bounds` to `false`. When pruning, readers must treat bounds as inexact if a deletion vector or equality delete file can match rows in the data file.
 
 ###### Stats projection
 
 To retrieve stats for a particular table field ID, one would always project by stats ID, where the stats ID for a given table field ID can be calculated by applying the reverse calculation.
-Below are examples for some table field ID -> stats struct id calculations.
+Below are examples for some table field ID -> stats struct ID calculations.
 
 | Table Field ID      | Stats ID of Stats struct  |
 |---------------------|---------------------------|
@@ -791,35 +790,28 @@ Below are examples for some table field ID -> stats struct id calculations.
 | 2_147_483_645       | 2_147_039_600             |
 | 2_147_483_646       | 2_147_039_800             |
 
-The below table shows the stats IDs of individual field statistics, which are calculated based on the offset that is described in the [Field stats types section](#field-stats-types)
+For a table column using field ID `1` and type `int`, the stats struct is assigned ID `10_200` and the below nested struct:
 
-| Table Field ID | Stats ID of Stats struct | Stats Type              | Stats ID of individual statistic |
-|----------------|--------------------------|-------------------------|----------------------------------|
-| 2              | 10_400                   | lower_bound             | 10_401                           |
-|                |                          | upper_bound             | 10_402                           |
-|                |                          | tight_bounds            | 10_403                           |
-|                |                          | value_count             | 10_404                           |
-|                |                          | null_value_count        | 10_405                           |
-|                |                          | nan_value_count         | 10_406                           |
-|                |                          | avg_value_size_in_bytes | 10_407                           |
-|                |                          | max_value_size_in_bytes | 10_408                           |
-| 5              | 11_000                   | lower_bound             | 11_001                           |
-|                |                          | upper_bound             | 11_002                           |
-|                |                          | tight_bounds            | 11_003                           |
-|                |                          | value_count             | 11_004                           |
-|                |                          | null_value_count        | 11_005                           |
-|                |                          | nan_value_count         | 11_006                           |
-|                |                          | avg_value_size_in_bytes | 11_007                           |
-|                |                          | max_value_size_in_bytes | 11_008                           |
+```text
+struct<
+  10_201: lower_bound int,
+  10_202: upper_bound int,
+  10_203: tight_bounds boolean,
+  10_204: value_count long,
+  10_205: null_value_count long,
+  10_206: nan_value_count long,
+  10_207: avg_value_size_in_bytes int,
+  10_208: max_value_size_in_bytes int
+>
+```
 
 ###### Manifest schema and `content_stats` typing
 
-The `content_stats` type is dynamically derived and embedded in the manifest for `data_file` at the field reserved for `content_stats` in v4.
-Using one `content_stats` schema for read and write is what allows **type promotion** on stats: if an `int` column `x` is promoted to `long`, the nested stats struct changes from `struct<..., lower_bound int, upper_bound int, ...>` to `struct<..., lower_bound long, upper_bound long, ...>`.
-Reading an older manifest applies normal Iceberg type promotion to those bound fields; writing after promotion then uses the promoted struct type, so round-trips stay consistent.
+The `content_stats` type is dynamically derived from the table schema and embedded in the manifest schema for `data_file` at the reserved `content_stats` field id in v4.
 
-###### Content stats aggregation
-TBD...
+When writing a new manifest, the `content_stats` type must be derived from the table's current schema, so the bound fields use the column's current type. If an `int` column `x` is later promoted to `long`, manifests written after the promotion must use `lower_bound long` and `upper_bound long` for `x`.
+
+When reading a manifest, readers may use the schema embedded in that manifest. Manifests written before a type promotion still use the original bound types and Iceberg's normal type-promotion rules apply when those values are projected as the current column type.
 
 #### Sequence Number Inheritance
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -712,7 +712,7 @@ When calculating upper and lower bounds for `geometry` and `geography`, null or 
 
 #### Content Stats
 
-Content stats have been introduced with v4 and hold stats in a `struct<struct<...>>` where each nested struct holds the stats for an individual field of a table. The different field stats types are defined in the next section.
+Iceberg v4 introduces content stats which represent stats in a `struct<struct<...>>` where each nested struct holds the stats for an individual field of a table. The different field stats types are defined in the next section.
 
 ##### Field Stats Types
 
@@ -727,11 +727,12 @@ The struct that holds individual stats for a particular field of a table consist
 | max_value_count  | `long`              | 5                                   | false    | The max value count for variable-length types (string/binary)                                                                                                                  |
 | lower_bound      | type of table field | 6                                   | false    | Lower bound in the column serialized as the type of the column itself. Each value must be less than or equal to all non-null, non-NaN values in the column for the file [2]    |
 | upper_bound      | type of table field | 7                                   | false    | Upper bound in the column serialized as the type of the column itself. Each value must be greater than or equal to all non-null, non-NaN values in the column for the file [2] |
-| exact_bounds     | `boolean`           | 8                                   | false    | Whether the `upper_bound` / `lower_bound` is exact or not                                                                                                                      |
+| exact_bounds     | `boolean`           | 8                                   | false    | Whether the `upper_bound` / `lower_bound` is exact or not. Defaults to true. Types such as string/binary can't have exact bounds. Additionally, if a DV or an equality delete matches a given data file, then `exact_bounds` must be treated as `false` |
 
 #### ID Assignment for Stats fields
 
 ID assignment follows a deterministic transform that maps from the **table ID space** to the **metadata ID space**. For a given field ID from the **table ID space** each nested stats struct gets an ID assigned from the **metadata ID space**.
+Offsets defined in the [field stats types section](#field-stats-types) are then applied to the stats ID of the enclosing stats struct to calculate IDs for each individual field stats type.
 The calculation is: `stats_space_field_id_start_for_data_fields + (num_supported_stats_per_column * table_field_id`)
 
 If the table field ID is a [reserved field ID](#reserved-field-ids) then a slightly adjusted calculation is used: `stats_space_field_id_start_for_metadata_fields + (num_supported_stats_per_column * (num_reserved_field_ids - (Integer.MAX_VALUE - metadata_field_id))`)

--- a/format/spec.md
+++ b/format/spec.md
@@ -691,7 +691,7 @@ Notes:
 
 Field statistics (or, interchangeably, metrics) are used when filtering to select data and delete files.
 
-In v3 and earlier, metrics are stored in maps keyed by column id: `value_counts`, `null_value_counts`, `nan_value_counts`, `lower_bounds` and `upper_bounds`.
+In v3 and earlier, metrics are stored in maps keyed by field id: `value_counts`, `null_value_counts`, `nan_value_counts`, `lower_bounds` and `upper_bounds`.
 
 In v4, metrics are stored as typed values in the `content_stats` struct, documented in the [Content Stats](#content-stats) section.
 


### PR DESCRIPTION
These spec changes are related to the [content stats proposal](https://s.apache.org/iceberg-column-stats). Note that the root `content_stats` field will use ID 146 in the manifest.