### PR TITLE
REST, OAuth2: Support for authentication challenges

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPChallenge.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPChallenge.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * Represents an HTTP challenge according to RFC 7235.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7235#section-2.1">RFC 7235 Section 2.1</a>
+ */
+@Value.Style(depluralize = true)
+@Value.Immutable
+public interface HTTPChallenge {
+
+  static HTTPChallenge of(String scheme, @Nullable String value, Map<String, String> params) {
+    return ImmutableHTTPChallenge.builder().scheme(scheme).value(value).params(params).build();
+  }
+
+  /** Returns the challenge's scheme, such as "Basic" or "Bearer". */
+  String scheme();
+
+  /** Returns the challenge's token68 value, or null if none provided. */
+  @Nullable
+  String value();
+
+  /** Returns the challenge's parameters, or an empty map if none provided. */
+  Map<String, String> params();
+}

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPHeaders.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPHeaders.java
@@ -82,6 +82,17 @@ public interface HTTPHeaders {
         : ImmutableHTTPHeaders.builder().from(this).addAllEntries(newHeaders).build();
   }
 
+  /**
+   * Merges the given headers into the current group. If there are entries with the same name in
+   * both groups, the values from the given headers take precedence.
+   */
+  default HTTPHeaders merge(HTTPHeaders headers) {
+    Preconditions.checkNotNull(headers, "headers");
+    ImmutableHTTPHeaders.Builder builder = ImmutableHTTPHeaders.builder().from(headers);
+    entries().stream().filter(e -> !headers.contains(e.name())).forEach(builder::addEntry);
+    return builder.build();
+  }
+
   static HTTPHeaders of(HTTPHeader... headers) {
     return ImmutableHTTPHeaders.builder().addEntries(headers).build();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthSession.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthSession.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iceberg.rest.auth;
 
+import javax.annotation.Nullable;
+import org.apache.iceberg.rest.HTTPChallenge;
 import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.RESTClient;
 
 /**
  * An authentication session that can be used to authenticate outgoing HTTP requests.
@@ -45,6 +48,30 @@ public interface AuthSession extends AutoCloseable {
    * Authenticates the given request and returns a new request with the necessary authentication.
    */
   HTTPRequest authenticate(HTTPRequest request);
+
+  /**
+   * Called when the request was challenged (the server returned a 401 response).
+   *
+   * <p>Implementations may choose to return a new request with updated authentication data, or null
+   * if the request should not be retried. The default implementation returns null.
+   *
+   * <p>If this method returns null, the 401 response will be surfaced to the caller as a {@link
+   * org.apache.iceberg.exceptions.NotAuthorizedException}.
+   *
+   * @param restClient the REST client that sent the request
+   * @param request the original request that caused the authentication failure
+   * @param challenge the authentication challenge
+   * @param retryAttempt the retry attempt number, starting with 1
+   * @return a new request with updated authentication headers, or null if the request should not be
+   *     retried
+   * @see <a href="https://datatracker.ietf.org/doc/html/rfc7235#section-2.1">RFC 7235 Section
+   *     2.1</a>
+   */
+  @Nullable
+  default HTTPRequest processChallenge(
+      RESTClient restClient, HTTPRequest request, HTTPChallenge challenge, int retryAttempt) {
+    return null;
+  }
 
   /**
    * Closes the session and releases any resources. This method is called when the session is no

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPHeaders.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPHeaders.java
@@ -121,6 +121,34 @@ class TestHTTPHeaders {
   }
 
   @Test
+  void merge() {
+    HTTPHeaders actual = headers.merge(HTTPHeaders.of(HTTPHeader.of("Header1", "value1c")));
+    assertThat(actual)
+        .isEqualTo(
+            HTTPHeaders.of(
+                HTTPHeader.of("Header1", "value1c"), HTTPHeader.of("header2", "value2")));
+
+    actual =
+        headers.merge(
+            ImmutableHTTPHeaders.builder()
+                .addEntry(HTTPHeader.of("Header1", "value1c"))
+                .addEntry(HTTPHeader.of("HEADER1", "value1d"))
+                .addEntry(HTTPHeader.of("header3", "value3"))
+                .build());
+    assertThat(actual)
+        .isEqualTo(
+            HTTPHeaders.of(
+                HTTPHeader.of("Header1", "value1c"),
+                HTTPHeader.of("HEADER1", "value1d"),
+                HTTPHeader.of("header2", "value2"),
+                HTTPHeader.of("header3", "value3")));
+
+    assertThatThrownBy(() -> headers.merge(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("headers");
+  }
+
+  @Test
   void ofMap() {
     HTTPHeaders actual =
         HTTPHeaders.of(


### PR DESCRIPTION
As suggested [on the mailing list](https://lists.apache.org/thread/g3kbckxsjgb83ofh0n2p4rhjroff9yj0) and discussed at the last catalog sync, this PR introduces support for auth challenges in the `AuthSession` API.

Whenever an auth session provokes a 401 response, it can now decide whether it makes sense to retry the request with renewed credentials.

Existing implementations of `AuthSession` were modified to take the following decisions:

* `NoopAuthManager`: never retries.
* `BasicAuthManager`: never retries.
* `RESTSigV4AuthManager`: never retries.
* `GoogleAuthManager`: attempts to refresh the credentials, if the challenge is `Bearer`, at most once.
* `OAuth2Manager`: attempts to refresh the credentials, if the challenge is `Bearer` and the `error` parameter is `invalid_token` (see [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)), at most once.

\cc @danielcweeks @rdblue @talatuyarer 