### PR TITLE
Flink 2.1: Enhance ZkLockFactory: add maxSleepTimeMs and retryPolicyName to support multiple retry policies.

### DIFF
--- a/.baseline/checkstyle/checkstyle-suppressions.xml
+++ b/.baseline/checkstyle/checkstyle-suppressions.xml
@@ -51,6 +51,7 @@
 
     <!-- Allow using Flink's shaded Curator dependency -->
     <suppress files="org.apache.iceberg.flink.maintenance.api.ZkLockFactory" id="BanShadedClasses"/>
+    <suppress files="org.apache.iceberg.flink.maintenance.api.TestZkLockFactory" id="BanShadedClasses"/>
 
     <!-- Suppress checks for CometColumnReader -->
     <suppress files="org.apache.iceberg.spark.data.vectorized.CometColumnReader" checks="IllegalImport"/>

--- a/docs/docs/flink-maintenance.md
+++ b/docs/docs/flink-maintenance.md
@@ -378,6 +378,8 @@ These keys are used in SQL (SET or table WITH options) and are applicable when w
 | `flink-maintenance.lock.zookeeper.connection-timeout-ms` | Connection timeout (ms) | `15000` |
 | `flink-maintenance.lock.zookeeper.max-retries` | Max retries | `3` |
 | `flink-maintenance.lock.zookeeper.base-sleep-ms` | Base sleep between retries (ms) | `3000` |
+| `flink-maintenance.lock.zookeeper.max-sleep-ms`          | Maximum sleep time (ms) between retries. Caps the exponential backoff delay.  | `10000` |
+| `flink-maintenance.lock.zookeeper.retry-policy`          | Retry policy name for ZooKeeper client. Supported values include: ONE_TIME, N_TIME, BOUNDED_EXPONENTIAL_BACKOFF, UNTIL_ELAPSED, EXPONENTIAL_BACKOFF.  | `EXPONENTIAL_BACKOFF` |
 
 ### Best Practices
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/LockConfig.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/LockConfig.java
@@ -94,6 +94,28 @@ public class LockConfig {
             .intType()
             .defaultValue(3)
             .withDescription("The maximum number of retries for the Zookeeper client.");
+
+    /**
+     * The maximum sleep time (in milliseconds) between retries for the Zookeeper client. Default:
+     * 10000 ms
+     */
+    public static final ConfigOption<Integer> ZK_MAX_SLEEP_MS_OPTION =
+        ConfigOptions.key(PREFIX + ZK + ".max-sleep-ms")
+            .intType()
+            .defaultValue(10000)
+            .withDescription(
+                "The maximum sleep time (in milliseconds) between retries for the Zookeeper client. (Default: 10000)");
+
+    /**
+     * The retry policy name for the Zookeeper client. Supported values might include:
+     * "exponential-backoff", "fixed", etc. Default: "exponential-backoff"
+     */
+    public static final ConfigOption<ZKRetryPolicies> ZK_RETRY_POLICY_OPTION =
+        ConfigOptions.key(PREFIX + ZK + ".retry-policy")
+            .enumType(ZKRetryPolicies.class)
+            .defaultValue(ZKRetryPolicies.EXPONENTIAL_BACKOFF)
+            .withDescription(
+                "The retry policy for the Zookeeper client. (Default: EXPONENTIAL_BACKOFF)");
   }
 
   private final FlinkConfParser confParser;
@@ -199,6 +221,26 @@ public class LockConfig {
         .option(ZkLockConfig.ZK_MAX_RETRIES_OPTION.key())
         .flinkConfig(ZkLockConfig.ZK_MAX_RETRIES_OPTION)
         .defaultValue(ZkLockConfig.ZK_MAX_RETRIES_OPTION.defaultValue())
+        .parse();
+  }
+
+  /** Gets the Zookeeper maximum sleep time configuration (in milliseconds). */
+  public int zkMaxSleepMs() {
+    return confParser
+        .intConf()
+        .option(ZkLockConfig.ZK_MAX_SLEEP_MS_OPTION.key())
+        .flinkConfig(ZkLockConfig.ZK_MAX_SLEEP_MS_OPTION)
+        .defaultValue(ZkLockConfig.ZK_MAX_SLEEP_MS_OPTION.defaultValue())
+        .parse();
+  }
+
+  /** Gets the Zookeeper retry policy configuration. */
+  public ZKRetryPolicies zkRetryPolicy() {
+    return confParser
+        .enumConfParser(ZKRetryPolicies.class)
+        .option(ZkLockConfig.ZK_RETRY_POLICY_OPTION.key())
+        .flinkConfig(ZkLockConfig.ZK_RETRY_POLICY_OPTION)
+        .defaultValue(ZKRetryPolicies.EXPONENTIAL_BACKOFF)
         .parse();
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZKRetryPolicies.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ZKRetryPolicies.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+public enum ZKRetryPolicies {
+  /** A retry policy that retries only once */
+  ONE_TIME,
+
+  /** A retry policy that retries a max number of times */
+  N_TIME,
+
+  /** A retry policy that retries a set number of times with increasing sleep time */
+  EXPONENTIAL_BACKOFF,
+
+  /** A retry policy that retries with exponential backoff up to a max sleep time */
+  BOUNDED_EXPONENTIAL_BACKOFF,
+
+  /** A retry policy that retries until a given amount of time elapses */
+  UNTIL_ELAPSED;
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/LockFactoryBuilder.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/LockFactoryBuilder.java
@@ -82,6 +82,8 @@ public class LockFactoryBuilder {
         lockConfig.zkSessionTimeoutMs(),
         lockConfig.zkConnectionTimeoutMs(),
         lockConfig.zkBaseSleepMs(),
-        lockConfig.zkMaxRetries());
+        lockConfig.zkMaxRetries(),
+        lockConfig.zkRetryPolicy(),
+        lockConfig.zkMaxSleepMs());
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestZkLockFactory.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestZkLockFactory.java
@@ -18,10 +18,30 @@
  */
 package org.apache.iceberg.flink.maintenance.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
 import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.curator.test.TestingServer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.shaded.curator5.org.apache.curator.RetryPolicy;
+import org.apache.flink.shaded.curator5.org.apache.curator.retry.BoundedExponentialBackoffRetry;
+import org.apache.flink.shaded.curator5.org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.flink.shaded.curator5.org.apache.curator.retry.RetryNTimes;
+import org.apache.flink.shaded.curator5.org.apache.curator.retry.RetryOneTime;
+import org.apache.flink.shaded.curator5.org.apache.curator.retry.RetryUntilElapsed;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestZkLockFactory extends TestLockFactoryBase {
 
@@ -29,7 +49,15 @@ public class TestZkLockFactory extends TestLockFactoryBase {
 
   @Override
   TriggerLockFactory lockFactory(String tableName) {
-    return new ZkLockFactory(zkTestServer.getConnectString(), tableName, 5000, 3000, 1000, 3);
+    return new ZkLockFactory(
+        zkTestServer.getConnectString(),
+        tableName,
+        5000,
+        3000,
+        1000,
+        3,
+        ZKRetryPolicies.EXPONENTIAL_BACKOFF,
+        2000);
   }
 
   @BeforeEach
@@ -50,5 +78,51 @@ public class TestZkLockFactory extends TestLockFactoryBase {
     if (zkTestServer != null) {
       zkTestServer.close();
     }
+  }
+
+  private static Stream<Arguments> retryPolicyProvider() {
+    return Stream.of(
+        Arguments.of(ZKRetryPolicies.ONE_TIME, RetryOneTime.class),
+        Arguments.of(ZKRetryPolicies.N_TIME, RetryNTimes.class),
+        Arguments.of(ZKRetryPolicies.EXPONENTIAL_BACKOFF, ExponentialBackoffRetry.class),
+        Arguments.of(
+            ZKRetryPolicies.BOUNDED_EXPONENTIAL_BACKOFF, BoundedExponentialBackoffRetry.class),
+        Arguments.of(ZKRetryPolicies.UNTIL_ELAPSED, RetryUntilElapsed.class));
+  }
+
+  @ParameterizedTest(name = "{0} should create {1}")
+  @MethodSource("retryPolicyProvider")
+  @DisplayName(
+      "Verify ZkLockFactory creates correct Curator RetryPolicy for each ZKRetryPolicies enum")
+  void testRetryPolicyCreationAndType(
+      ZKRetryPolicies policy, Class<? extends RetryPolicy> expectedClass) {
+    ZkLockFactory factory =
+        new ZkLockFactory("localhost:2181", "test", 3000, 3000, 1000, 3, policy, 2000);
+
+    RetryPolicy retryPolicy = factory.createRetryPolicy();
+
+    assertThat(retryPolicy)
+        .as("RetryPolicy should not be null for policy %s", policy)
+        .isNotNull()
+        .as("Expected %s for policy %s", expectedClass.getSimpleName(), policy)
+        .isInstanceOf(expectedClass);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "non_existing_policy"})
+  void testInvalidOrMissingRetryPolicyFallsBackToDefault(String retryPolicyConfig) {
+    Map<String, String> options = Maps.newHashMap();
+    if (retryPolicyConfig != null) {
+      options.put("iceberg.maintenance.lock.zookeeper.retry-policy", retryPolicyConfig);
+    }
+
+    LockConfig config = new LockConfig(mock(Table.class), options, new Configuration());
+
+    ZKRetryPolicies policy = config.zkRetryPolicy();
+
+    assertThat(policy)
+        .as("Invalid, empty, or missing retry-policy should fallback to EXPONENTIAL_BACKOFF")
+        .isEqualTo(ZKRetryPolicies.EXPONENTIAL_BACKOFF);
   }
 }


### PR DESCRIPTION
## Summary

This PR enhances ZkLockFactory by introducing two new configuration options:

- maxSleepTimeMs
- retryPolicyName

Previously, `ZkLockFactory` only supported the `EXPONENTIAL_BACKOFF` retry strategy. With this change, users can now configure different retry policies via retryPolicyName (e.g., `ONE_TIME`, `N_TIME`, `BOUNDED_EXPONENTIAL_BACKOFF`, `UNTIL_ELAPSED`).

## Changes

- Added `maxSleepTimeMs` parameter to allow bounded exponential backoff and until-elapsed policies.
- Added `retryPolicyName` parameter to select the retry strategy dynamically.
- Refactored retry policy creation logic into a switch/factory method for better extensibility.
- Maintained backward compatibility: if no `retryPolicyName` is provided, it defaults to `EXPONENTIAL_BACKOFF`.

## Motivation
This improves flexibility and robustness of `ZkLockFactory` by giving users fine-grained control over retry behavior, rather than being limited to a single exponential backoff policy.