### PR TITLE
Spec: Clarify restrictions for geometry types in V3

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -241,6 +241,8 @@ For details on how to serialize a schema to JSON, see Appendix C.
 
 For `geometry` and `geography` types, the parameter C refers to the CRS (coordinate reference system), a mapping of how coordinates refer to locations on Earth.
 
+For `geometry` type, the CRS does not affect geometric calculations, which are always Cartesian.
+
 The default CRS value `OGC:CRS84` means that the objects must be stored in longitude, latitude based on the WGS84 datum.
 
 Custom CRS values can be specified by a string of the format `type:identifier`, where `type` is one of the following values:
@@ -713,7 +715,9 @@ Examples of valid field paths using normalized JSON path format are:
 * `$['tags']` -- the `tags` array 
 * `$['addresses']['zip']` -- the `zip` field in an `addresses` array that contains objects
 
-For `geometry` and `geography` types, `lower_bounds` and `upper_bounds` are both points of the following coordinates X, Y, Z, and M (see [Appendix G](#appendix-g-geospatial-notes)) which are the lower / upper bound of all objects in the file. For the X values only, xmin may be greater than xmax, in which case an object in this bounding box may match if it contains an X such that `x >= xmin` OR`x <= xmax`. In geographic terminology, the concepts of `xmin`, `xmax`, `ymin`, and `ymax` are also known as `westernmost`, `easternmost`, `southernmost` and `northernmost`, respectively. For `geography` types, these points are further restricted to the canonical ranges of [-180 180] for X and [-90 90] for Y.
+For geometry and geography types, lower_bounds and upper_bounds are both points of the following coordinates X, Y, Z, and M (see Appendix G) which are the lower / upper bound of all objects in the file.
+
+For geography, for the X values only, xmin may be greater than xmax, in which case an object in this bounding box may match if it contains an X such that x >= xmin OR x <= xmax. In geographic terminology, the concepts of xmin, xmax, ymin, and ymax are also known as westernmost, easternmost, southernmost and northernmost, respectively. These points are further restricted to the canonical ranges of [-180..180] for X and [-90..90] for Y.
 
 When calculating upper and lower bounds for `geometry` and `geography`, null or NaN values in a coordinate dimension are skipped; for example, POINT (1 NaN) contributes a value to X but no values to Y, Z, or M dimension bounds. If a dimension has only null or NaN values, that dimension is omitted from the bounding box. If either the X or Y dimension is missing then the bounding box itself is not produced.
 


### PR DESCRIPTION
See for context:  https://lists.apache.org/thread/x9ll3rhg26mngm10cjn74w66ov23grmm  and closed pr: https://github.com/apache/iceberg/pull/13227

The latest consensus is that we can wait for V4 or later to support the case of Geometry_with_wraparound.  So add restrictions to the spec for 'geometry' type to ease implementation for V3.

- Clarify that the wraparound (xmin > xmax) is only for 'geography'
- Follow up implication that geometry CRS does not affect calcuations which are Cartesian.  The potential wraparound CRS  was the only blocker here.  This will make the engine life a lot simpler.