### PR TITLE
Core: Add Delete File Support and Partition Pruning for Incremental Changelog Scans

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -20,23 +20,46 @@ package org.apache.iceberg;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Deque;
+import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestGroup.CreateTasksFunction;
 import org.apache.iceberg.ManifestGroup.TaskContext;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.PartitionSet;
 import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.iceberg.util.SortedMerge;
 import org.apache.iceberg.util.TableScanUtil;
+import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class BaseIncrementalChangelogScan
     extends BaseIncrementalScan<
         IncrementalChangelogScan, ChangelogScanTask, ScanTaskGroup<ChangelogScanTask>>
     implements IncrementalChangelogScan {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseIncrementalChangelogScan.class);
 
   BaseIncrementalChangelogScan(Table table) {
     this(table, table.schema(), TableScanContext.empty());
@@ -51,6 +74,12 @@ class BaseIncrementalChangelogScan
       Table newTable, Schema newSchema, TableScanContext newContext) {
     return new BaseIncrementalChangelogScan(newTable, newSchema, newContext);
   }
+
+  // Private fields to track build call count and cache (accessed via package-private methods for
+  // testing)
+  private int existingDeleteIndexBuildCallCount = 0;
+  // Cache for the built index (null if not built yet)
+  private DeleteFileIndex cachedExistingDeleteIndex = null;
 
   @Override
   protected CloseableIterable<ChangelogScanTask> doPlanFiles(
@@ -71,6 +100,20 @@ class BaseIncrementalChangelogScan
             .filter(manifest -> changelogSnapshotIds.contains(manifest.snapshotId()))
             .toSet();
 
+    // Build per-snapshot delete file indexes for added deletes
+    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = buildAddedDeleteIndexes(changelogSnapshots);
+
+    // Check if existing delete index is needed for equality deletes
+    boolean hasEqualityDeletes =
+        addedDeletesBySnapshot.values().stream()
+            .anyMatch(index -> !index.isEmpty() && index.hasEqualityDeletes());
+
+    // Build existing index early if needed for equality deletes, otherwise use lazy initialization
+    DeleteFileIndex existingDeleteIndex =
+        hasEqualityDeletes
+            ? buildExistingDeleteIndexTracked(fromSnapshotIdExclusive)
+            : DeleteFileIndex.emptyIndex();
+
     ManifestGroup manifestGroup =
         new ManifestGroup(table().io(), newDataManifests, ImmutableList.of())
             .specsById(table().specs())
@@ -89,7 +132,41 @@ class BaseIncrementalChangelogScan
       manifestGroup = manifestGroup.planWith(planExecutor());
     }
 
-    return manifestGroup.plan(new CreateDataFileChangeTasks(changelogSnapshots));
+    // Create a supplier that reuses already-built index or builds lazily when first DELETED entry
+    // is encountered
+    Supplier<DeleteFileIndex> existingDeleteIndexSupplier =
+        () -> {
+          if (cachedExistingDeleteIndex != null) {
+            return cachedExistingDeleteIndex;
+          }
+          return buildExistingDeleteIndexTracked(fromSnapshotIdExclusive);
+        };
+
+    // Plan data file tasks (ADDED and DELETED)
+    Map<Long, List<DeleteFile>> cumulativeDeletesMap =
+        buildCumulativeDeletesBySnapshot(changelogSnapshots, addedDeletesBySnapshot);
+
+    CloseableIterable<ChangelogScanTask> dataFileTasks =
+        manifestGroup.plan(
+            new CreateDataFileChangeTasks(
+                changelogSnapshots,
+                existingDeleteIndexSupplier,
+                addedDeletesBySnapshot,
+                cumulativeDeletesMap,
+                table().specs(),
+                isCaseSensitive()));
+
+    // Find EXISTING data files affected by newly added delete files and create tasks for them
+    CloseableIterable<ChangelogScanTask> deletedRowsTasks =
+        planDeletedRowsTasks(
+            changelogSnapshots, existingDeleteIndex, addedDeletesBySnapshot, changelogSnapshotIds);
+
+    // Merge tasks from both iterables in order by changeOrdinal
+    Comparator<ChangelogScanTask> byOrdinal =
+        Comparator.comparing(ChangelogScanTask::changeOrdinal)
+            .thenComparing(ChangelogScanTask::commitSnapshotId);
+
+    return new SortedMerge<>(byOrdinal, ImmutableList.of(dataFileTasks, deletedRowsTasks));
   }
 
   @Override
@@ -105,11 +182,6 @@ class BaseIncrementalChangelogScan
 
     for (Snapshot snapshot : SnapshotUtil.ancestorsBetween(table(), toIdIncl, fromIdExcl)) {
       if (!snapshot.operation().equals(DataOperations.REPLACE)) {
-        if (!snapshot.deleteManifests(table().io()).isEmpty()) {
-          throw new UnsupportedOperationException(
-              "Delete files are currently not supported in changelog scans");
-        }
-
         changelogSnapshots.addFirst(snapshot);
       }
     }
@@ -133,13 +205,701 @@ class BaseIncrementalChangelogScan
     return snapshotOrdinals;
   }
 
+  /**
+   * Builds a delete file index for existing deletes that were present before the start snapshot.
+   * These deletes should be applied to data files but should not generate DELETE changelog rows.
+   * Uses manifest pruning and caching to optimize performance.
+   */
+  private DeleteFileIndex buildExistingDeleteIndex(Long fromSnapshotIdExclusive) {
+    if (fromSnapshotIdExclusive == null) {
+      return DeleteFileIndex.emptyIndex();
+    }
+    Snapshot fromSnapshot = table().snapshot(fromSnapshotIdExclusive);
+    Preconditions.checkState(
+        fromSnapshot != null, "Cannot find starting snapshot: %s", fromSnapshotIdExclusive);
+
+    List<ManifestFile> existingDeleteManifests = fromSnapshot.deleteManifests(table().io());
+    if (existingDeleteManifests.isEmpty()) {
+      return DeleteFileIndex.emptyIndex();
+    }
+
+    // Prune manifests based on partition filter to avoid processing irrelevant manifests
+    List<ManifestFile> prunedManifests = pruneManifestsByPartition(existingDeleteManifests);
+    if (prunedManifests.isEmpty()) {
+      return DeleteFileIndex.emptyIndex();
+    }
+
+    // Load delete files from manifests
+    Iterable<DeleteFile> deleteFiles = loadDeleteFiles(prunedManifests, null);
+
+    return DeleteFileIndex.builderFor(deleteFiles)
+        .specsById(table().specs())
+        .caseSensitive(isCaseSensitive())
+        .build();
+  }
+
+  /**
+   * Wrapper method that tracks build calls and caches the result for reuse. This ensures we only
+   * build the index once even if called from multiple places.
+   */
+  private DeleteFileIndex buildExistingDeleteIndexTracked(Long fromSnapshotIdExclusive) {
+    if (cachedExistingDeleteIndex != null) {
+      return cachedExistingDeleteIndex;
+    }
+    existingDeleteIndexBuildCallCount++;
+    cachedExistingDeleteIndex = buildExistingDeleteIndex(fromSnapshotIdExclusive);
+    return cachedExistingDeleteIndex;
+  }
+
+  // Visible for testing
+  int getExistingDeleteIndexBuildCallCount() {
+    return existingDeleteIndexBuildCallCount;
+  }
+
+  // Visible for testing
+  boolean wasExistingDeleteIndexBuilt() {
+    return existingDeleteIndexBuildCallCount > 0;
+  }
+
+  /**
+   * Builds per-snapshot delete file indexes for newly added delete files in each changelog
+   * snapshot. These deletes should generate DELETE changelog rows. Uses caching to avoid re-parsing
+   * manifests.
+   */
+  private Map<Long, DeleteFileIndex> buildAddedDeleteIndexes(Deque<Snapshot> changelogSnapshots) {
+    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = Maps.newConcurrentMap();
+    Tasks.foreach(changelogSnapshots)
+        .retry(3)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(planExecutor())
+        .onFailure(
+            (snapshot, exc) ->
+                LOG.warn(
+                    "Failed to build delete index for snapshot {}", snapshot.snapshotId(), exc))
+        .run(
+            snapshot -> {
+              List<ManifestFile> snapshotDeleteManifests = snapshot.deleteManifests(table().io());
+              if (snapshotDeleteManifests.isEmpty()) {
+                addedDeletesBySnapshot.put(snapshot.snapshotId(), DeleteFileIndex.emptyIndex());
+                return;
+              }
+
+              // Filter to only include delete files added in this snapshot
+              List<ManifestFile> addedDeleteManifests =
+                  snapshotDeleteManifests.stream()
+                      .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
+                      .collect(Collectors.toUnmodifiableList());
+
+              if (addedDeleteManifests.isEmpty()) {
+                addedDeletesBySnapshot.put(snapshot.snapshotId(), DeleteFileIndex.emptyIndex());
+              } else {
+                // Load delete files from manifests
+                Iterable<DeleteFile> deleteFiles =
+                    loadDeleteFiles(addedDeleteManifests, snapshot.snapshotId());
+
+                DeleteFileIndex index =
+                    DeleteFileIndex.builderFor(deleteFiles)
+                        .specsById(table().specs())
+                        .caseSensitive(isCaseSensitive())
+                        .build();
+                addedDeletesBySnapshot.put(snapshot.snapshotId(), index);
+              }
+            });
+    return addedDeletesBySnapshot;
+  }
+
+  /**
+   * Plans tasks for EXISTING data files that are affected by newly added delete files. These files
+   * were not added or deleted in the changelog snapshot range, but have new delete files applied to
+   * them.
+   */
+  private CloseableIterable<ChangelogScanTask> planDeletedRowsTasks(
+      Deque<Snapshot> changelogSnapshots,
+      DeleteFileIndex existingDeleteIndex,
+      Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
+      Set<Long> changelogSnapshotIds) {
+
+    Map<Long, Integer> snapshotOrdinals = computeSnapshotOrdinals(changelogSnapshots);
+    List<ChangelogScanTask> tasks = Lists.newArrayList();
+
+    // Build a map of file statuses and collect affected partitions for each snapshot
+    Pair<Map<Long, Map<String, ManifestEntry.Status>>, PartitionSet> fileStatusAndPartitions =
+        buildFileStatusBySnapshot(changelogSnapshots, changelogSnapshotIds);
+    Map<Long, Map<String, ManifestEntry.Status>> fileStatusBySnapshot =
+        fileStatusAndPartitions.first();
+    PartitionSet affectedPartitions = fileStatusAndPartitions.second();
+
+    // Accumulate actual DeleteFile entries chronologically
+    List<DeleteFile> accumulatedDeletes = Lists.newArrayList();
+
+    // Start with deletes from before the changelog range
+    if (!existingDeleteIndex.isEmpty()) {
+      for (DeleteFile df : existingDeleteIndex.referencedDeleteFiles()) {
+        accumulatedDeletes.add(df);
+      }
+    }
+
+    for (Snapshot snapshot : changelogSnapshots) {
+      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
+      if (addedDeleteIndex.isEmpty()) {
+        continue;
+      }
+
+      // Collect partitions of newly added delete files for pruning (important for the current
+      // snapshot)
+      for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
+        affectedPartitions.add(df.specId(), df.partition());
+      }
+
+      DeleteFileIndex cumulativeDeleteIndex =
+          buildDeleteIndex(accumulatedDeletes, affectedPartitions);
+
+      // Process data files for this snapshot
+      // Use a local set per snapshot to track processed files
+      Set<String> alreadyProcessedPaths = Sets.newHashSet();
+      processSnapshotForDeletedRowsTasks(
+          snapshot,
+          addedDeleteIndex,
+          cumulativeDeleteIndex,
+          fileStatusBySnapshot.get(snapshot.snapshotId()),
+          alreadyProcessedPaths,
+          snapshotOrdinals,
+          affectedPartitions,
+          tasks);
+
+      // Accumulate this snapshot's added deletes for subsequent snapshots
+      for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
+        accumulatedDeletes.add(df);
+      }
+    }
+
+    return CloseableIterable.withNoopClose(tasks);
+  }
+
+  /**
+   * Builds a map of file statuses for each snapshot, tracking which files were added or deleted in
+   * each snapshot.
+   */
+  private Pair<Map<Long, Map<String, ManifestEntry.Status>>, PartitionSet>
+      buildFileStatusBySnapshot(
+          Deque<Snapshot> changelogSnapshots, Set<Long> changelogSnapshotIds) {
+
+    Map<Long, Map<String, ManifestEntry.Status>> fileStatusBySnapshot = Maps.newConcurrentMap();
+    java.util.Queue<PartitionSet> localPartitionsQueue =
+        new java.util.concurrent.ConcurrentLinkedQueue<>();
+
+    Tasks.foreach(changelogSnapshots)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(planExecutor())
+        .run(
+            snapshot -> {
+              Map<String, ManifestEntry.Status> fileStatuses = Maps.newHashMap();
+              PartitionSet localAffected = PartitionSet.create(table().specs());
+
+              List<ManifestFile> changedDataManifests =
+                  FluentIterable.from(snapshot.dataManifests(table().io()))
+                      .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
+                      .toList();
+
+              if (!changedDataManifests.isEmpty()) {
+                ManifestGroup changedGroup =
+                    new ManifestGroup(table().io(), changedDataManifests, ImmutableList.of())
+                        .specsById(table().specs())
+                        .caseSensitive(isCaseSensitive())
+                        .select(scanColumns())
+                        .filterData(filter())
+                        .ignoreExisting()
+                        .columnsToKeepStats(columnsToKeepStats());
+
+                try (CloseableIterable<ManifestEntry<DataFile>> entries = changedGroup.entries()) {
+                  for (ManifestEntry<DataFile> entry : entries) {
+                    if (changelogSnapshotIds.contains(entry.snapshotId())) {
+                      fileStatuses.put(entry.file().location(), entry.status());
+                      localAffected.add(entry.file().specId(), entry.file().partition());
+                    }
+                  }
+                } catch (Exception e) {
+                  throw new RuntimeException(
+                      "Failed to collect file statuses for snapshot " + snapshot.snapshotId(), e);
+                }
+              }
+
+              fileStatusBySnapshot.put(snapshot.snapshotId(), fileStatuses);
+              localPartitionsQueue.add(localAffected);
+            });
+
+    PartitionSet globalAffected = PartitionSet.create(table().specs());
+    for (PartitionSet local : localPartitionsQueue) {
+      globalAffected.addAll(local);
+    }
+
+    return Pair.of(fileStatusBySnapshot, globalAffected);
+  }
+
+  private List<ManifestFile> pruneManifestsByAffectedPartitions(
+      List<ManifestFile> manifests, PartitionSet affectedPartitions) {
+    if (affectedPartitions.isEmpty()) {
+      return manifests;
+    }
+
+    Expression affectedExpr = buildAffectedPartitionExpression(affectedPartitions);
+    if (affectedExpr == Expressions.alwaysFalse()) {
+      return manifests;
+    }
+
+    List<ManifestFile> pruned = Lists.newArrayList();
+    for (ManifestFile manifest : manifests) {
+      PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
+      if (spec == null || spec.isUnpartitioned()) {
+        pruned.add(manifest);
+      } else if (manifestOverlapsFilter(manifest, spec, affectedExpr)) {
+        pruned.add(manifest);
+      }
+    }
+    return pruned;
+  }
+
+  private Expression buildAffectedPartitionExpression(PartitionSet affectedPartitions) {
+    Expression combined = null;
+
+    for (Pair<Integer, StructLike> pair : affectedPartitions) {
+      int specId = pair.first();
+      StructLike partition = pair.second();
+      PartitionSpec spec = table().specs().get(specId);
+      if (spec == null) {
+        continue;
+      } else if (spec.isUnpartitioned()) {
+        return Expressions.alwaysTrue(); // FALLBACK: Global delete exists, include ALL manifests!
+      }
+
+      Expression specExpr = null;
+      for (int i = 0; i < spec.fields().size(); i++) {
+        org.apache.iceberg.PartitionField field = spec.fields().get(i);
+        Object value = partition.get(i, Object.class);
+        if (value != null) {
+          String columnName = table().schema().findColumnName(field.sourceId());
+          if (columnName != null) {
+            Expression equalExpr = Expressions.equal(columnName, value);
+            specExpr = (specExpr == null) ? equalExpr : Expressions.and(specExpr, equalExpr);
+          }
+        }
+      }
+
+      if (specExpr != null) {
+        combined = (combined == null) ? specExpr : Expressions.or(combined, specExpr);
+      }
+    }
+
+    return combined != null ? combined : Expressions.alwaysFalse();
+  }
+
+  /**
+   * Builds a map of snapshot ID -> all delete files that were added in the scan range up to that
+   * snapshot, PRUNING files that were removed in the middle.
+   */
+  private Map<Long, List<DeleteFile>> buildCumulativeDeletesBySnapshot(
+      Deque<Snapshot> snapshots, Map<Long, DeleteFileIndex> addedDeletesBySnapshot) {
+    Map<Long, List<DeleteFile>> result = Maps.newHashMap();
+    List<DeleteFile> accumulatedDeletes = Lists.newArrayList();
+
+    for (Snapshot snapshot : snapshots) {
+      // Save state first, so that this snapshot's tasks can use any deletes active up to this point
+      result.put(snapshot.snapshotId(), Lists.newArrayList(accumulatedDeletes));
+
+      // Check for removed deletes and prune from accumulatedDeletes for FUTURE snapshots
+      List<ManifestFile> changedDeletes =
+          FluentIterable.from(snapshot.deleteManifests(table().io()))
+              .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
+              .toList();
+
+      if (!changedDeletes.isEmpty()) {
+        Iterable<DeleteFile> removedDeletes =
+            loadRemovedDeleteFiles(changedDeletes, snapshot.snapshotId());
+        Set<String> removedPaths = Sets.newHashSet();
+        for (DeleteFile rdf : removedDeletes) {
+          removedPaths.add(rdf.location());
+        }
+        accumulatedDeletes.removeIf(df -> removedPaths.contains(df.location()));
+      }
+
+      // Add new deletes for FUTURE snapshots
+      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
+      if (addedDeleteIndex != null && !addedDeleteIndex.isEmpty()) {
+        for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
+          accumulatedDeletes.add(df);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Builds a delete index from the accumulated list of delete files, pruning by affected
+   * partitions.
+   */
+  private DeleteFileIndex buildDeleteIndex(
+      List<DeleteFile> accumulatedDeletes, PartitionSet affectedPartitions) {
+    if (accumulatedDeletes.isEmpty()) {
+      return DeleteFileIndex.emptyIndex();
+    }
+
+    List<DeleteFile> filteredDeletes = accumulatedDeletes;
+    if (!affectedPartitions.isEmpty()) {
+      filteredDeletes = Lists.newArrayList();
+      for (DeleteFile df : accumulatedDeletes) {
+        PartitionSpec spec = table().specs().get(df.specId());
+        if (spec == null || spec.isUnpartitioned()) {
+          filteredDeletes.add(df); // Always include unpartitioned deletes
+        } else if (affectedPartitions.contains(df.specId(), df.partition())) {
+          filteredDeletes.add(df);
+        }
+      }
+    }
+
+    return DeleteFileIndex.builderFor(filteredDeletes)
+        .specsById(table().specs())
+        .caseSensitive(isCaseSensitive())
+        .build();
+  }
+
+  /**
+   * Processes data files for a snapshot to create DeletedRowsScanTask for existing files affected
+   * by new delete files.
+   */
+  private void processSnapshotForDeletedRowsTasks(
+      Snapshot snapshot,
+      DeleteFileIndex addedDeleteIndex,
+      DeleteFileIndex cumulativeDeleteIndex,
+      Map<String, ManifestEntry.Status> currentSnapshotFiles,
+      Set<String> alreadyProcessedPaths,
+      Map<Long, Integer> snapshotOrdinals,
+      PartitionSet affectedPartitions,
+      List<ChangelogScanTask> tasks) {
+
+    // Get all data files that exist in this snapshot, pruned by affected partitions
+    List<ManifestFile> allDataManifests = snapshot.dataManifests(table().io());
+    List<ManifestFile> prunedManifests =
+        pruneManifestsByAffectedPartitions(allDataManifests, affectedPartitions);
+
+    ManifestGroup allDataGroup =
+        new ManifestGroup(table().io(), prunedManifests, ImmutableList.of())
+            .specsById(table().specs())
+            .caseSensitive(isCaseSensitive())
+            .select(scanColumns())
+            .filterData(filter())
+            .ignoreDeleted()
+            .columnsToKeepStats(columnsToKeepStats());
+
+    if (shouldIgnoreResiduals()) {
+      allDataGroup = allDataGroup.ignoreResiduals();
+    }
+
+    String schemaString = SchemaParser.toJson(schema());
+
+    // Cache per specId - same for all files with same specId
+    Map<Integer, String> specStringCache = Maps.newHashMap();
+    Map<Integer, ResidualEvaluator> residualCache = Maps.newHashMap();
+    Expression residualFilter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
+
+    try (CloseableIterable<ManifestEntry<DataFile>> entries = allDataGroup.entries()) {
+      for (ManifestEntry<DataFile> entry : entries) {
+        DataFile dataFile = entry.file();
+        String filePath = dataFile.location();
+
+        // Skip if this file was ADDED or DELETED in this snapshot
+        // (those are handled by CreateDataFileChangeTasks)
+        if (currentSnapshotFiles.containsKey(filePath)) {
+          continue;
+        }
+
+        // Skip if we already created a task for this file in this snapshot
+        // Note: alreadyProcessedPaths is local to this snapshot's processing
+        if (alreadyProcessedPaths.contains(filePath)) {
+          continue;
+        }
+
+        // Check if this data file is affected by newly added delete files
+        DeleteFile[] addedDeletes = addedDeleteIndex.forEntry(entry);
+        if (addedDeletes.length == 0) {
+          continue;
+        }
+
+        // This data file was EXISTING but has new delete files applied
+        // Get existing deletes from before this snapshot (cumulative)
+        DeleteFile[] existingDeletes =
+            cumulativeDeleteIndex.isEmpty()
+                ? new DeleteFile[0]
+                : cumulativeDeleteIndex.forEntry(entry);
+
+        // Create a DeletedRowsScanTask
+        int changeOrdinal = snapshotOrdinals.get(snapshot.snapshotId());
+
+        // Use cached values (calculate once per specId)
+        int specId = dataFile.specId();
+        String specString =
+            specStringCache.computeIfAbsent(
+                specId, id -> PartitionSpecParser.toJson(table().specs().get(id)));
+        ResidualEvaluator residuals =
+            residualCache.computeIfAbsent(
+                specId,
+                id -> {
+                  PartitionSpec spec = table().specs().get(id);
+                  return ResidualEvaluator.of(spec, residualFilter, isCaseSensitive());
+                });
+
+        tasks.add(
+            new BaseDeletedRowsScanTask(
+                changeOrdinal,
+                snapshot.snapshotId(),
+                dataFile.copy(shouldKeepStats()),
+                addedDeletes,
+                existingDeletes,
+                schemaString,
+                specString,
+                residuals));
+
+        // Mark this file as processed for this snapshot
+        alreadyProcessedPaths.add(filePath);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to plan deleted rows tasks", e);
+    }
+  }
+
+  private boolean shouldKeepStats() {
+    Set<Integer> columns = columnsToKeepStats();
+    return columns != null && !columns.isEmpty();
+  }
+
+  /**
+   * Loads delete files from manifests by parsing each manifest.
+   *
+   * @param manifests the delete manifests to load
+   * @return list of delete files
+   */
+  private Iterable<DeleteFile> loadDeleteFiles(
+      List<ManifestFile> manifests, Long targetSnapshotId) {
+    Queue<DeleteFile> allDeleteFiles = new ConcurrentLinkedQueue<>();
+
+    Tasks.foreach(manifests)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(planExecutor())
+        .run(
+            manifest -> {
+              List<DeleteFile> deleteFiles =
+                  loadDeleteFilesFromManifest(manifest, targetSnapshotId);
+              allDeleteFiles.addAll(deleteFiles);
+            });
+
+    return allDeleteFiles;
+  }
+
+  private Iterable<DeleteFile> loadRemovedDeleteFiles(
+      List<ManifestFile> manifests, Long targetSnapshotId) {
+    Queue<DeleteFile> allDeleteFiles = new ConcurrentLinkedQueue<>();
+
+    Tasks.foreach(manifests)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(planExecutor())
+        .run(
+            manifest -> {
+              List<DeleteFile> deleteFiles =
+                  loadRemovedDeleteFilesFromManifest(manifest, targetSnapshotId);
+              allDeleteFiles.addAll(deleteFiles);
+            });
+
+    return allDeleteFiles;
+  }
+
+  private List<DeleteFile> loadRemovedDeleteFilesFromManifest(
+      ManifestFile manifest, Long targetSnapshotId) {
+    List<DeleteFile> deleteFiles = Lists.newArrayList();
+
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
+      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+        if (entry.status() == ManifestEntry.Status.DELETED
+            && entry.snapshotId().equals(targetSnapshotId)) {
+          DeleteFile file = entry.file();
+
+          if (!partitionMatchesFilter(file)) {
+            continue;
+          }
+
+          Set<Integer> columns =
+              file.content() == FileContent.POSITION_DELETES
+                  ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
+                  : Set.copyOf(file.equalityFieldIds());
+          deleteFiles.add(ContentFileUtil.copy(file, true, columns));
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to read delete manifest: " + manifest.path(), e);
+    }
+
+    return deleteFiles;
+  }
+
+  /**
+   * Prunes delete manifests based on partition filter to avoid processing irrelevant manifests.
+   * This significantly improves performance when only a subset of partitions are relevant to the
+   * scan.
+   *
+   * @param manifests all delete manifests to consider
+   * @return list of manifests that might contain relevant delete files
+   */
+  private List<ManifestFile> pruneManifestsByPartition(List<ManifestFile> manifests) {
+    Expression currentFilter = filter();
+
+    // If there's no filter, return all manifests
+    if (currentFilter == null || currentFilter.equals(Expressions.alwaysTrue())) {
+      return manifests;
+    }
+
+    List<ManifestFile> prunedManifests = Lists.newArrayList();
+
+    for (ManifestFile manifest : manifests) {
+      PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
+      if (spec == null || spec.isUnpartitioned()) {
+        // Include unpartitioned manifests
+        prunedManifests.add(manifest);
+      } else if (manifestOverlapsFilter(manifest, spec, currentFilter)) {
+        // Check if manifest partition range overlaps with filter
+        prunedManifests.add(manifest);
+      }
+    }
+
+    return prunedManifests;
+  }
+
+  /**
+   * Checks if a manifest's partition range overlaps with the given filter.
+   *
+   * @param manifest the manifest to check
+   * @param spec the partition spec for the manifest
+   * @param filter the scan filter
+   * @return true if the manifest might contain matching partitions, false otherwise
+   */
+  private boolean manifestOverlapsFilter(
+      ManifestFile manifest, PartitionSpec spec, Expression filter) {
+    try {
+      // Use inclusive projection to transform row filter to partition filter
+      Expression partitionFilter = Projections.inclusive(spec, isCaseSensitive()).project(filter);
+
+      // Create evaluator for the partition filter
+      ManifestEvaluator evaluator =
+          ManifestEvaluator.forPartitionFilter(partitionFilter, spec, isCaseSensitive());
+
+      // Check if manifest could contain matching partitions
+      return evaluator.eval(manifest);
+    } catch (Exception e) {
+      // If evaluation fails, be conservative and include the manifest
+      return true;
+    }
+  }
+
+  /**
+   * Checks if a delete file's partition overlaps with the current scan filter. This enables
+   * partition pruning to reduce memory footprint and planning overhead by skipping delete files
+   * that cannot possibly match any rows in the scan.
+   *
+   * @param file the delete file to check
+   * @return true if the delete file's partition might contain matching rows, false otherwise
+   */
+  private boolean partitionMatchesFilter(DeleteFile file) {
+    // If there's no filter, all partitions match
+    Expression currentFilter = filter();
+    if (currentFilter == null || currentFilter.equals(Expressions.alwaysTrue())) {
+      return true;
+    }
+
+    // Get the partition spec for this delete file
+    PartitionSpec spec = table().specs().get(file.specId());
+    if (spec == null || spec.isUnpartitioned()) {
+      // If spec not found or table is unpartitioned, be conservative and include the file
+      return true;
+    }
+
+    try {
+      // Project the row filter to partition space using inclusive projection
+      // This transforms expressions on source columns to expressions on partition columns
+      Expression partitionFilter =
+          Projections.inclusive(spec, isCaseSensitive()).project(currentFilter);
+
+      // Evaluate the projected filter against the delete file's partition
+      Evaluator evaluator = new Evaluator(spec.partitionType(), partitionFilter, isCaseSensitive());
+      return evaluator.eval(file.partition());
+    } catch (Exception e) {
+      // If evaluation fails, be conservative and include the file
+      return true;
+    }
+  }
+
+  /**
+   * Loads delete files from a single manifest, parsing the manifest entries.
+   *
+   * @param manifest the delete manifest to load
+   * @return list of delete files from this manifest
+   */
+  private List<DeleteFile> loadDeleteFilesFromManifest(
+      ManifestFile manifest, Long targetSnapshotId) {
+    List<DeleteFile> deleteFiles = Lists.newArrayList();
+
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
+      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+        if (entry.status() != ManifestEntry.Status.DELETED
+            && (targetSnapshotId == null || entry.snapshotId().equals(targetSnapshotId))) {
+          // Only include live delete files, copy with minimal stats to save memory
+          DeleteFile file = entry.file();
+
+          // Apply partition pruning - skip delete files that cannot match the scan filter
+          if (!partitionMatchesFilter(file)) {
+            continue;
+          }
+
+          Set<Integer> columns =
+              file.content() == FileContent.POSITION_DELETES
+                  ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
+                  : Set.copyOf(file.equalityFieldIds());
+          deleteFiles.add(ContentFileUtil.copy(file, true, columns));
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to read delete manifest: " + manifest.path(), e);
+    }
+
+    return deleteFiles;
+  }
+
   private static class CreateDataFileChangeTasks implements CreateTasksFunction<ChangelogScanTask> {
     private static final DeleteFile[] NO_DELETES = new DeleteFile[0];
 
     private final Map<Long, Integer> snapshotOrdinals;
+    private final Supplier<DeleteFileIndex> existingDeleteIndexSupplier;
+    private final Map<Long, DeleteFileIndex> addedDeletesBySnapshot;
+    private final Map<Long, List<DeleteFile>> cumulativeDeletesMap;
+    private final Map<Integer, PartitionSpec> specsById;
+    private final boolean caseSensitive;
 
-    CreateDataFileChangeTasks(Deque<Snapshot> snapshots) {
+    CreateDataFileChangeTasks(
+        Deque<Snapshot> snapshots,
+        Supplier<DeleteFileIndex> existingDeleteIndexSupplier,
+        Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
+        Map<Long, List<DeleteFile>> cumulativeDeletesMap,
+        Map<Integer, PartitionSpec> specsById,
+        boolean caseSensitive) {
       this.snapshotOrdinals = computeSnapshotOrdinals(snapshots);
+      this.existingDeleteIndexSupplier = existingDeleteIndexSupplier;
+      this.addedDeletesBySnapshot = addedDeletesBySnapshot;
+      this.cumulativeDeletesMap = cumulativeDeletesMap;
+      this.specsById = specsById;
+      this.caseSensitive = caseSensitive;
     }
 
     @Override
@@ -155,21 +915,26 @@ class BaseIncrementalChangelogScan
 
             switch (entry.status()) {
               case ADDED:
+                // For ADDED data files, attach delete files added in this snapshot
+                DeleteFile[] addedFileDeletes = getDeletesForAddedFile(entry, commitSnapshotId);
                 return new BaseAddedRowsScanTask(
                     changeOrdinal,
                     commitSnapshotId,
                     dataFile,
-                    NO_DELETES,
+                    addedFileDeletes,
                     context.schemaAsString(),
                     context.specAsString(),
                     context.residuals());
 
               case DELETED:
+                // For DELETED data files, attach ALL deletes that were present up to deletion
+                // This includes existing deletes AND deletes added in the scan range
+                DeleteFile[] deletedFileDeletes = getDeletesForDeletedFile(entry, commitSnapshotId);
                 return new BaseDeletedDataFileScanTask(
                     changeOrdinal,
                     commitSnapshotId,
                     dataFile,
-                    NO_DELETES,
+                    deletedFileDeletes,
                     context.schemaAsString(),
                     context.specAsString(),
                     context.residuals());
@@ -178,6 +943,53 @@ class BaseIncrementalChangelogScan
                 throw new IllegalArgumentException("Unexpected entry status: " + entry.status());
             }
           });
+    }
+
+    /**
+     * Gets delete files that apply to an ADDED data file. Only includes deletes added in the same
+     * snapshot as the file.
+     */
+    private DeleteFile[] getDeletesForAddedFile(
+        ManifestEntry<DataFile> entry, long commitSnapshotId) {
+      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(commitSnapshotId);
+      return addedDeleteIndex == null || addedDeleteIndex.isEmpty()
+          ? NO_DELETES
+          : addedDeleteIndex.forEntry(entry);
+    }
+
+    /**
+     * Gets all delete files that were applied to a DELETED data file up to the point it was
+     * deleted. This includes existing deletes and all deletes added in the scan range up to (but
+     * not including) the deletion snapshot.
+     */
+    private DeleteFile[] getDeletesForDeletedFile(
+        ManifestEntry<DataFile> entry, long deletionSnapshotId) {
+
+      List<DeleteFile> allDeletes = Lists.newArrayList();
+
+      // Build existing delete index lazily when first DELETED entry is encountered
+      DeleteFileIndex existingDeleteIndex = existingDeleteIndexSupplier.get();
+      DeleteFile[] existingDeletes =
+          existingDeleteIndex.isEmpty() ? NO_DELETES : existingDeleteIndex.forEntry(entry);
+      for (DeleteFile df : existingDeletes) {
+        allDeletes.add(df);
+      }
+
+      // Add all deletes from snapshots in the scan range BEFORE the deletion
+      List<DeleteFile> cumulativeDeletes = cumulativeDeletesMap.get(deletionSnapshotId);
+      if (cumulativeDeletes != null && !cumulativeDeletes.isEmpty()) {
+        DeleteFileIndex tempIndex =
+            DeleteFileIndex.builderFor(cumulativeDeletes)
+                .specsById(specsById)
+                .caseSensitive(caseSensitive)
+                .build();
+        DeleteFile[] applicable = tempIndex.forEntry(entry);
+        for (DeleteFile deleteFile : applicable) {
+          allDeletes.add(deleteFile);
+        }
+      }
+
+      return allDeletes.isEmpty() ? NO_DELETES : allDeletes.toArray(new DeleteFile[0]);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -18,17 +18,17 @@
  */
 package org.apache.iceberg;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestGroup.CreateTasksFunction;
 import org.apache.iceberg.ManifestGroup.TaskContext;
 import org.apache.iceberg.expressions.Evaluator;
@@ -39,7 +39,6 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -47,8 +46,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PartitionSet;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
-import org.apache.iceberg.util.SortedMerge;
 import org.apache.iceberg.util.TableScanUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -75,11 +74,9 @@ class BaseIncrementalChangelogScan
     return new BaseIncrementalChangelogScan(newTable, newSchema, newContext);
   }
 
-  // Private fields to track build call count and cache (accessed via package-private methods for
-  // testing)
-  private int existingDeleteIndexBuildCallCount = 0;
-  // Cache for the built index (null if not built yet)
-  private DeleteFileIndex cachedExistingDeleteIndex = null;
+  // Counts how many times the existing (pre-range) delete index was actually built across all
+  // planFiles() calls on this scan (accessed via package-private methods for testing)
+  private final AtomicInteger existingDeleteIndexBuildCallCount = new AtomicInteger(0);
 
   @Override
   protected CloseableIterable<ChangelogScanTask> doPlanFiles(
@@ -92,27 +89,93 @@ class BaseIncrementalChangelogScan
       return CloseableIterable.empty();
     }
 
-    Set<Long> changelogSnapshotIds = toSnapshotIds(changelogSnapshots);
+    // Read each snapshot's new delete manifests once, collecting added and removed delete files
+    DeleteFileChanges deleteFileChanges = collectDeleteFileChanges(changelogSnapshots);
+    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = deleteFileChanges.addedBySnapshot;
 
-    Set<ManifestFile> newDataManifests =
-        FluentIterable.from(changelogSnapshots)
-            .transformAndConcat(snapshot -> snapshot.dataManifests(table().io()))
-            .filter(manifest -> changelogSnapshotIds.contains(manifest.snapshotId()))
-            .toSet();
+    boolean rangeHasDeleteFiles =
+        hasDeleteFileChanges(deleteFileChanges) || hasExistingDeletes(fromSnapshotIdExclusive);
 
-    // Build per-snapshot delete file indexes for added deletes
-    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = buildAddedDeleteIndexes(changelogSnapshots);
+    if (rangeHasDeleteFiles && !includeDeleteFiles()) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Changelog scans cannot be planned when delete files apply to the scan range "
+                  + "(e.g. they produce %s, which not all engines can execute). Set table "
+                  + "property or scan option '%s' to true to enable delete file support in "
+                  + "changelog scans",
+              DeletedRowsScanTask.class.getSimpleName(),
+              TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES));
+    }
 
-    // Check if existing delete index is needed for equality deletes
-    boolean hasEqualityDeletes =
-        addedDeletesBySnapshot.values().stream()
-            .anyMatch(index -> !index.isEmpty() && index.hasEqualityDeletes());
+    // Collect data file changes in the range and derive the scope of existing deletes that can
+    // apply to tasks, so that building the existing delete index only reads relevant delete files.
+    // Both outputs only feed the delete file machinery, so when no delete file exists before the
+    // range and none is added or removed within it, this extra manifest pass is skipped: every
+    // cumulative index can only be empty and no DeletedRowsScanTask can be planned
+    ChangedDataFiles changedDataFiles = ChangedDataFiles.empty(table().specs());
+    ExistingDeleteScope existingDeleteScope = null;
+    if (rangeHasDeleteFiles) {
+      changedDataFiles = collectChangedDataFiles(changelogSnapshots);
+      existingDeleteScope = buildExistingDeleteScope(changedDataFiles, addedDeletesBySnapshot);
+    }
 
-    // Build existing index early if needed for equality deletes, otherwise use lazy initialization
-    DeleteFileIndex existingDeleteIndex =
-        hasEqualityDeletes
-            ? buildExistingDeleteIndexTracked(fromSnapshotIdExclusive)
-            : DeleteFileIndex.emptyIndex();
+    // Tracks all deletes that applied before each snapshot in the range; the existing (pre-range)
+    // delete index is built lazily on first use and memoized for this invocation only, as a later
+    // plan of the same scan may resolve a different range
+    ExistingDeleteIndexHolder existingDeleteIndexHolder =
+        new ExistingDeleteIndexHolder(fromSnapshotIdExclusive, existingDeleteScope);
+    CumulativeDeleteIndexes cumulativeDeleteIndexes =
+        new CumulativeDeleteIndexes(
+            changelogSnapshots,
+            addedDeletesBySnapshot,
+            deleteFileChanges.removedBySnapshot,
+            existingDeleteIndexHolder::get);
+
+    Map<Long, Integer> snapshotOrdinals = computeSnapshotOrdinals(changelogSnapshots);
+
+    // The task factory derives everything it needs from the manifest entry, so a single instance
+    // is shared by every snapshot in the range
+    CreateDataFileChangeTasks createDataFileChangeTasks =
+        new CreateDataFileChangeTasks(
+            snapshotOrdinals, addedDeletesBySnapshot, cumulativeDeleteIndexes);
+
+    // Plan progressively: walk snapshots oldest to newest, emitting each snapshot's data file
+    // tasks and then its deleted-rows tasks before moving on. Tasks come out ordered by change
+    // ordinal by construction, and consumers stream them without materializing the whole range
+    List<CloseableIterable<ChangelogScanTask>> perSnapshotTasks = Lists.newArrayList();
+    for (Snapshot snapshot : changelogSnapshots) {
+      perSnapshotTasks.add(planDataFileTasks(snapshot, createDataFileChangeTasks));
+      perSnapshotTasks.add(
+          planDeletedRowsTasksForSnapshot(
+              snapshot,
+              addedDeletesBySnapshot,
+              cumulativeDeleteIndexes,
+              changedDataFiles,
+              snapshotOrdinals));
+    }
+
+    return CloseableIterable.concat(perSnapshotTasks);
+  }
+
+  /**
+   * Plans ADDED and DELETED data file tasks for one snapshot from the data manifests that snapshot
+   * wrote. ADDED entries in a manifest carry the snapshot ID that committed them (or inherit the
+   * manifest's), and DELETED entries carry the deleting snapshot's ID, so filtering both manifests
+   * and entries by this snapshot's ID partitions the range's changes exactly.
+   */
+  private CloseableIterable<ChangelogScanTask> planDataFileTasks(
+      Snapshot snapshot, CreateDataFileChangeTasks createTasks) {
+    long snapshotId = snapshot.snapshotId();
+
+    List<ManifestFile> newDataManifests =
+        snapshot.dataManifests(table().io()).stream()
+            .filter(
+                manifest -> manifest.snapshotId() != null && manifest.snapshotId() == snapshotId)
+            .toList();
+
+    if (newDataManifests.isEmpty()) {
+      return CloseableIterable.empty();
+    }
 
     ManifestGroup manifestGroup =
         new ManifestGroup(table().io(), newDataManifests, ImmutableList.of())
@@ -120,7 +183,8 @@ class BaseIncrementalChangelogScan
             .caseSensitive(isCaseSensitive())
             .select(scanColumns())
             .filterData(filter())
-            .filterManifestEntries(entry -> changelogSnapshotIds.contains(entry.snapshotId()))
+            .filterManifestEntries(
+                entry -> entry.snapshotId() != null && entry.snapshotId() == snapshotId)
             .ignoreExisting()
             .columnsToKeepStats(columnsToKeepStats());
 
@@ -132,41 +196,46 @@ class BaseIncrementalChangelogScan
       manifestGroup = manifestGroup.planWith(planExecutor());
     }
 
-    // Create a supplier that reuses already-built index or builds lazily when first DELETED entry
-    // is encountered
-    Supplier<DeleteFileIndex> existingDeleteIndexSupplier =
+    return manifestGroup.plan(createTasks);
+  }
+
+  /**
+   * Plans DeletedRowsScanTask instances for EXISTING data files affected by this snapshot's added
+   * delete files. The scan of the snapshot's live data manifests is deferred until the returned
+   * iterable is consumed.
+   */
+  private CloseableIterable<ChangelogScanTask> planDeletedRowsTasksForSnapshot(
+      Snapshot snapshot,
+      Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
+      CumulativeDeleteIndexes cumulativeDeleteIndexes,
+      ChangedDataFiles changedDataFiles,
+      Map<Long, Integer> snapshotOrdinals) {
+    DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
+    if (addedDeleteIndex == null || addedDeleteIndex.isEmpty()) {
+      return CloseableIterable.empty();
+    }
+
+    // re-iterating the returned iterable replans this snapshot's tasks (same as ManifestGroup.plan)
+    return CloseableIterable.withNoopClose(
         () -> {
-          if (cachedExistingDeleteIndex != null) {
-            return cachedExistingDeleteIndex;
-          }
-          return buildExistingDeleteIndexTracked(fromSnapshotIdExclusive);
-        };
+          // A task for an EXISTING file requires one of this snapshot's added deletes to apply,
+          // so data manifests are pruned to the partitions of this snapshot's added delete files
+          // and, when every added delete is file-scoped, entries to the referenced files
+          PartitionSet snapshotDeletePartitions = addedDeletePartitions(addedDeleteIndex);
+          Set<String> candidateLocations = fileScopedTargets(addedDeleteIndex);
 
-    // Plan data file tasks (ADDED and DELETED)
-    Map<Long, List<DeleteFile>> cumulativeDeletesMap =
-        buildCumulativeDeletesBySnapshot(changelogSnapshots, addedDeletesBySnapshot);
-
-    CloseableIterable<ChangelogScanTask> dataFileTasks =
-        manifestGroup.plan(
-            new CreateDataFileChangeTasks(
-                changelogSnapshots,
-                existingDeleteIndexSupplier,
-                addedDeletesBySnapshot,
-                cumulativeDeletesMap,
-                table().specs(),
-                isCaseSensitive()));
-
-    // Find EXISTING data files affected by newly added delete files and create tasks for them
-    CloseableIterable<ChangelogScanTask> deletedRowsTasks =
-        planDeletedRowsTasks(
-            changelogSnapshots, existingDeleteIndex, addedDeletesBySnapshot, changelogSnapshotIds);
-
-    // Merge tasks from both iterables in order by changeOrdinal
-    Comparator<ChangelogScanTask> byOrdinal =
-        Comparator.comparing(ChangelogScanTask::changeOrdinal)
-            .thenComparing(ChangelogScanTask::commitSnapshotId);
-
-    return new SortedMerge<>(byOrdinal, ImmutableList.of(dataFileTasks, deletedRowsTasks));
+          List<ChangelogScanTask> tasks = Lists.newArrayList();
+          processSnapshotForDeletedRowsTasks(
+              snapshot,
+              addedDeleteIndex,
+              cumulativeDeleteIndexes,
+              changedDataFiles.statusBySnapshot.getOrDefault(snapshot.snapshotId(), Map.of()),
+              snapshotOrdinals,
+              snapshotDeletePartitions,
+              candidateLocations,
+              tasks);
+          return tasks.iterator();
+        });
   }
 
   @Override
@@ -189,10 +258,6 @@ class BaseIncrementalChangelogScan
     return changelogSnapshots;
   }
 
-  private Set<Long> toSnapshotIds(Collection<Snapshot> snapshots) {
-    return snapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
-  }
-
   private static Map<Long, Integer> computeSnapshotOrdinals(Deque<Snapshot> snapshots) {
     Map<Long, Integer> snapshotOrdinals = Maps.newHashMap();
 
@@ -208,9 +273,11 @@ class BaseIncrementalChangelogScan
   /**
    * Builds a delete file index for existing deletes that were present before the start snapshot.
    * These deletes should be applied to data files but should not generate DELETE changelog rows.
-   * Uses manifest pruning and caching to optimize performance.
+   * Manifests that cannot hold a delete relevant to the range are pruned before the index builder
+   * reads the rest, and files outside the affected scope are skipped as entries are read.
    */
-  private DeleteFileIndex buildExistingDeleteIndex(Long fromSnapshotIdExclusive) {
+  private DeleteFileIndex buildExistingDeleteIndex(
+      Long fromSnapshotIdExclusive, ExistingDeleteScope scope) {
     if (fromSnapshotIdExclusive == null) {
       return DeleteFileIndex.emptyIndex();
     }
@@ -218,56 +285,104 @@ class BaseIncrementalChangelogScan
     Preconditions.checkState(
         fromSnapshot != null, "Cannot find starting snapshot: %s", fromSnapshotIdExclusive);
 
-    List<ManifestFile> existingDeleteManifests = fromSnapshot.deleteManifests(table().io());
-    if (existingDeleteManifests.isEmpty()) {
+    List<ManifestFile> deleteManifests = fromSnapshot.deleteManifests(table().io());
+    if (deleteManifests.isEmpty()) {
       return DeleteFileIndex.emptyIndex();
     }
 
-    // Prune manifests based on partition filter to avoid processing irrelevant manifests
-    List<ManifestFile> prunedManifests = pruneManifestsByPartition(existingDeleteManifests);
-    if (prunedManifests.isEmpty()) {
+    // Prune manifests that cannot contain deletes for any partition affected by the scan range
+    if (scope != null) {
+      deleteManifests =
+          pruneManifestsByAffectedPartitions(deleteManifests, scope.allAffectedPartitions);
+    }
+
+    if (deleteManifests.isEmpty()) {
       return DeleteFileIndex.emptyIndex();
     }
 
-    // Load delete files from manifests
-    Iterable<DeleteFile> deleteFiles = loadDeleteFiles(prunedManifests, null);
+    // filterData prunes manifests and entries against the scan filter with per-spec cached
+    // evaluators and keeps minimal stats. Entry pruning also runs the filter against each delete
+    // file's own stats, which may drop a delete file whose bounds cannot match the filter; that is
+    // only safe because the task residual re-applies the filter to the rows a task emits, so
+    // ignoreResiduals must be forwarded (as ManifestGroup does) to disable it when the residual is
+    // dropped. Deliberately no planWith: this may run lazily under the cumulative-index monitor on
+    // shared worker-pool threads, and nested submission to the same pool can starve it
+    DeleteFileIndex.Builder builder =
+        DeleteFileIndex.builderFor(table().io(), deleteManifests)
+            .specsById(table().specs())
+            .caseSensitive(isCaseSensitive())
+            .filterData(filter());
 
-    return DeleteFileIndex.builderFor(deleteFiles)
-        .specsById(table().specs())
-        .caseSensitive(isCaseSensitive())
-        .build();
+    if (shouldIgnoreResiduals()) {
+      builder.ignoreResiduals();
+    }
+
+    if (scope != null) {
+      // skip delete files that cannot apply to any task in the scan range
+      builder.deleteFilePredicate(scope::keeps);
+    }
+
+    return builder.build();
   }
 
   /**
-   * Wrapper method that tracks build calls and caches the result for reuse. This ensures we only
-   * build the index once even if called from multiple places.
+   * Builds the existing (pre-range) delete index at most once per planFiles() invocation, so that
+   * concurrent planning threads share one index while a later plan of the same scan, which may
+   * resolve a different range and scope, builds its own.
    */
-  private DeleteFileIndex buildExistingDeleteIndexTracked(Long fromSnapshotIdExclusive) {
-    if (cachedExistingDeleteIndex != null) {
-      return cachedExistingDeleteIndex;
+  private class ExistingDeleteIndexHolder {
+    private final Long fromSnapshotIdExclusive;
+    private final ExistingDeleteScope scope;
+    private DeleteFileIndex index = null;
+
+    ExistingDeleteIndexHolder(Long fromSnapshotIdExclusive, ExistingDeleteScope scope) {
+      this.fromSnapshotIdExclusive = fromSnapshotIdExclusive;
+      this.scope = scope;
     }
-    existingDeleteIndexBuildCallCount++;
-    cachedExistingDeleteIndex = buildExistingDeleteIndex(fromSnapshotIdExclusive);
-    return cachedExistingDeleteIndex;
+
+    synchronized DeleteFileIndex get() {
+      if (index == null) {
+        this.index = buildExistingDeleteIndex(fromSnapshotIdExclusive, scope);
+        existingDeleteIndexBuildCallCount.incrementAndGet();
+      }
+
+      return index;
+    }
   }
 
   // Visible for testing
-  int getExistingDeleteIndexBuildCallCount() {
-    return existingDeleteIndexBuildCallCount;
+  int existingDeleteIndexBuildCount() {
+    return existingDeleteIndexBuildCallCount.get();
   }
 
   // Visible for testing
   boolean wasExistingDeleteIndexBuilt() {
-    return existingDeleteIndexBuildCallCount > 0;
+    return existingDeleteIndexBuildCallCount.get() > 0;
+  }
+
+  /** Added delete indexes and removed delete files, per snapshot, read in one manifest pass. */
+  private static class DeleteFileChanges {
+    private final Map<Long, DeleteFileIndex> addedBySnapshot;
+    private final Map<Long, List<DeleteFile>> removedBySnapshot;
+
+    DeleteFileChanges(
+        Map<Long, DeleteFileIndex> addedBySnapshot, Map<Long, List<DeleteFile>> removedBySnapshot) {
+      this.addedBySnapshot = addedBySnapshot;
+      this.removedBySnapshot = removedBySnapshot;
+    }
   }
 
   /**
-   * Builds per-snapshot delete file indexes for newly added delete files in each changelog
-   * snapshot. These deletes should generate DELETE changelog rows. Uses caching to avoid re-parsing
-   * manifests.
+   * Reads the delete manifests written by each changelog snapshot exactly once, splitting live
+   * entries into the snapshot's added delete files (indexed) and removed delete files.
    */
-  private Map<Long, DeleteFileIndex> buildAddedDeleteIndexes(Deque<Snapshot> changelogSnapshots) {
-    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = Maps.newConcurrentMap();
+  private DeleteFileChanges collectDeleteFileChanges(Deque<Snapshot> changelogSnapshots) {
+    Map<Long, DeleteFileIndex> addedBySnapshot = Maps.newConcurrentMap();
+    Map<Long, List<DeleteFile>> removedBySnapshot = Maps.newConcurrentMap();
+
+    // one evaluator of the scan filter per partition spec, shared by all manifests and snapshots
+    Map<Integer, Evaluator> partitionEvaluators = Maps.newConcurrentMap();
+
     Tasks.foreach(changelogSnapshots)
         .retry(3)
         .stopOnFailure()
@@ -276,118 +391,219 @@ class BaseIncrementalChangelogScan
         .onFailure(
             (snapshot, exc) ->
                 LOG.warn(
-                    "Failed to build delete index for snapshot {}", snapshot.snapshotId(), exc))
+                    "Failed to read delete manifests for snapshot {}", snapshot.snapshotId(), exc))
         .run(
             snapshot -> {
-              List<ManifestFile> snapshotDeleteManifests = snapshot.deleteManifests(table().io());
-              if (snapshotDeleteManifests.isEmpty()) {
-                addedDeletesBySnapshot.put(snapshot.snapshotId(), DeleteFileIndex.emptyIndex());
-                return;
+              long snapshotId = snapshot.snapshotId();
+              List<ManifestFile> newDeleteManifests =
+                  snapshot.deleteManifests(table().io()).stream()
+                      .filter(
+                          manifest ->
+                              manifest.snapshotId() != null && manifest.snapshotId() == snapshotId)
+                      .toList();
+
+              List<DeleteFile> added = Lists.newArrayList();
+              List<DeleteFile> removed = Lists.newArrayList();
+              for (ManifestFile manifest : newDeleteManifests) {
+                readDeleteManifest(manifest, snapshotId, partitionEvaluators, added, removed);
               }
 
-              // Filter to only include delete files added in this snapshot
-              List<ManifestFile> addedDeleteManifests =
-                  snapshotDeleteManifests.stream()
-                      .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
-                      .collect(Collectors.toUnmodifiableList());
-
-              if (addedDeleteManifests.isEmpty()) {
-                addedDeletesBySnapshot.put(snapshot.snapshotId(), DeleteFileIndex.emptyIndex());
-              } else {
-                // Load delete files from manifests
-                Iterable<DeleteFile> deleteFiles =
-                    loadDeleteFiles(addedDeleteManifests, snapshot.snapshotId());
-
-                DeleteFileIndex index =
-                    DeleteFileIndex.builderFor(deleteFiles)
-                        .specsById(table().specs())
-                        .caseSensitive(isCaseSensitive())
-                        .build();
-                addedDeletesBySnapshot.put(snapshot.snapshotId(), index);
-              }
+              addedBySnapshot.put(
+                  snapshotId,
+                  added.isEmpty()
+                      ? DeleteFileIndex.emptyIndex()
+                      : DeleteFileIndex.builderFor(added)
+                          .specsById(table().specs())
+                          .caseSensitive(isCaseSensitive())
+                          .build());
+              removedBySnapshot.put(snapshotId, removed);
             });
-    return addedDeletesBySnapshot;
+
+    return new DeleteFileChanges(addedBySnapshot, removedBySnapshot);
   }
 
   /**
-   * Plans tasks for EXISTING data files that are affected by newly added delete files. These files
-   * were not added or deleted in the changelog snapshot range, but have new delete files applied to
-   * them.
+   * Reads one delete manifest, collecting the delete files this snapshot added and removed. Only
+   * entries committed by the given snapshot are considered; EXISTING entries carried over from
+   * earlier snapshots keep their original snapshot ID and are skipped.
    */
-  private CloseableIterable<ChangelogScanTask> planDeletedRowsTasks(
-      Deque<Snapshot> changelogSnapshots,
-      DeleteFileIndex existingDeleteIndex,
-      Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
-      Set<Long> changelogSnapshotIds) {
+  private void readDeleteManifest(
+      ManifestFile manifest,
+      long snapshotId,
+      Map<Integer, Evaluator> partitionEvaluators,
+      List<DeleteFile> added,
+      List<DeleteFile> removed) {
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
+      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+        if (entry.snapshotId() == null || entry.snapshotId() != snapshotId) {
+          continue;
+        }
 
-    Map<Long, Integer> snapshotOrdinals = computeSnapshotOrdinals(changelogSnapshots);
-    List<ChangelogScanTask> tasks = Lists.newArrayList();
+        DeleteFile file = entry.file();
 
-    // Build a map of file statuses and collect affected partitions for each snapshot
-    Pair<Map<Long, Map<String, ManifestEntry.Status>>, PartitionSet> fileStatusAndPartitions =
-        buildFileStatusBySnapshot(changelogSnapshots, changelogSnapshotIds);
-    Map<Long, Map<String, ManifestEntry.Status>> fileStatusBySnapshot =
-        fileStatusAndPartitions.first();
-    PartitionSet affectedPartitions = fileStatusAndPartitions.second();
+        // Apply partition pruning - skip delete files that cannot match the scan filter
+        if (!partitionMatchesFilter(file, partitionEvaluators)) {
+          continue;
+        }
 
-    // Accumulate actual DeleteFile entries chronologically
-    List<DeleteFile> accumulatedDeletes = Lists.newArrayList();
+        Set<Integer> columns =
+            file.content() == FileContent.POSITION_DELETES
+                ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
+                : Set.copyOf(file.equalityFieldIds());
+        DeleteFile copied = ContentFileUtil.copy(file, true, columns);
 
-    // Start with deletes from before the changelog range
-    if (!existingDeleteIndex.isEmpty()) {
-      for (DeleteFile df : existingDeleteIndex.referencedDeleteFiles()) {
-        accumulatedDeletes.add(df);
+        if (entry.status() == ManifestEntry.Status.DELETED) {
+          removed.add(copied);
+        } else {
+          added.add(copied);
+        }
       }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read delete manifest: " + manifest.path(), e);
     }
-
-    for (Snapshot snapshot : changelogSnapshots) {
-      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
-      if (addedDeleteIndex.isEmpty()) {
-        continue;
-      }
-
-      // Collect partitions of newly added delete files for pruning (important for the current
-      // snapshot)
-      for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
-        affectedPartitions.add(df.specId(), df.partition());
-      }
-
-      DeleteFileIndex cumulativeDeleteIndex =
-          buildDeleteIndex(accumulatedDeletes, affectedPartitions);
-
-      // Process data files for this snapshot
-      // Use a local set per snapshot to track processed files
-      Set<String> alreadyProcessedPaths = Sets.newHashSet();
-      processSnapshotForDeletedRowsTasks(
-          snapshot,
-          addedDeleteIndex,
-          cumulativeDeleteIndex,
-          fileStatusBySnapshot.get(snapshot.snapshotId()),
-          alreadyProcessedPaths,
-          snapshotOrdinals,
-          affectedPartitions,
-          tasks);
-
-      // Accumulate this snapshot's added deletes for subsequent snapshots
-      for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
-        accumulatedDeletes.add(df);
-      }
-    }
-
-    return CloseableIterable.withNoopClose(tasks);
   }
 
   /**
-   * Builds a map of file statuses for each snapshot, tracking which files were added or deleted in
-   * each snapshot.
+   * Returns true if the delete file's partition may contain rows matching the scan filter, so that
+   * delete files that cannot apply to any scanned row are skipped. The scan filter is projected
+   * into each spec's partition space once and the resulting evaluator is cached in the given map,
+   * which may be shared by concurrent readers.
    */
-  private Pair<Map<Long, Map<String, ManifestEntry.Status>>, PartitionSet>
-      buildFileStatusBySnapshot(
-          Deque<Snapshot> changelogSnapshots, Set<Long> changelogSnapshotIds) {
+  private boolean partitionMatchesFilter(DeleteFile file, Map<Integer, Evaluator> evaluatorCache) {
+    Expression currentFilter = filter();
+    if (currentFilter.equals(Expressions.alwaysTrue())) {
+      return true;
+    }
 
-    Map<Long, Map<String, ManifestEntry.Status>> fileStatusBySnapshot = Maps.newConcurrentMap();
-    java.util.Queue<PartitionSet> localPartitionsQueue =
-        new java.util.concurrent.ConcurrentLinkedQueue<>();
+    PartitionSpec spec = table().specs().get(file.specId());
+    if (spec == null || spec.isUnpartitioned()) {
+      // if the spec is unknown or the table is unpartitioned, be conservative and keep the file
+      return true;
+    }
+
+    try {
+      Evaluator evaluator =
+          evaluatorCache.computeIfAbsent(
+              file.specId(),
+              ignored -> {
+                // an inclusive projection turns predicates on source columns into predicates on
+                // partition values, so non-identity transforms are handled correctly
+                Expression partitionFilter =
+                    Projections.inclusive(spec, isCaseSensitive()).project(currentFilter);
+                return new Evaluator(spec.partitionType(), partitionFilter, isCaseSensitive());
+              });
+      return evaluator.eval(file.partition());
+    } catch (Exception e) {
+      // if the filter cannot be projected or evaluated, be conservative and keep the file
+      return true;
+    }
+  }
+
+  /**
+   * Returns the partitions of the added delete files, or an empty set when some delete has global
+   * reach (an unpartitioned spec) and data manifests cannot be pruned by partition.
+   */
+  private PartitionSet addedDeletePartitions(DeleteFileIndex addedDeleteIndex) {
+    PartitionSet partitions = PartitionSet.create(table().specs());
+    for (DeleteFile file : addedDeleteIndex.referencedDeleteFiles()) {
+      PartitionSpec spec = table().specs().get(file.specId());
+      if (spec == null || spec.isUnpartitioned()) {
+        // an empty set disables partition pruning
+        return PartitionSet.create(table().specs());
+      }
+
+      partitions.add(file.specId(), file.partition());
+    }
+
+    return partitions;
+  }
+
+  /**
+   * Returns the data file locations referenced by the added delete files when every added delete is
+   * file-scoped (a DV or a single-file position delete), or null when some added delete may apply
+   * to files other than the ones it references.
+   */
+  private static Set<String> fileScopedTargets(DeleteFileIndex addedDeleteIndex) {
+    Set<String> locations = Sets.newHashSet();
+    for (DeleteFile file : addedDeleteIndex.referencedDeleteFiles()) {
+      String referencedLocation = ContentFileUtil.referencedDataFileLocation(file);
+      if (referencedLocation == null) {
+        return null;
+      }
+
+      locations.add(referencedLocation);
+    }
+
+    return locations;
+  }
+
+  /** Data file changes observed across the changelog snapshots. */
+  private static class ChangedDataFiles {
+    private final Map<Long, Map<String, ManifestEntry.Status>> statusBySnapshot;
+    private final Set<String> deletedFileLocations;
+    private final PartitionSet deletedFilePartitions;
+
+    ChangedDataFiles(
+        Map<Long, Map<String, ManifestEntry.Status>> statusBySnapshot,
+        Set<String> deletedFileLocations,
+        PartitionSet deletedFilePartitions) {
+      this.statusBySnapshot = statusBySnapshot;
+      this.deletedFileLocations = deletedFileLocations;
+      this.deletedFilePartitions = deletedFilePartitions;
+    }
+
+    static ChangedDataFiles empty(Map<Integer, PartitionSpec> specsById) {
+      return new ChangedDataFiles(Map.of(), Set.of(), PartitionSet.create(specsById));
+    }
+  }
+
+  /** Returns true if any snapshot in the range added or removed a delete file. */
+  private static boolean hasDeleteFileChanges(DeleteFileChanges deleteFileChanges) {
+    for (DeleteFileIndex addedDeletes : deleteFileChanges.addedBySnapshot.values()) {
+      if (!addedDeletes.isEmpty()) {
+        return true;
+      }
+    }
+
+    for (List<DeleteFile> removedDeletes : deleteFileChanges.removedBySnapshot.values()) {
+      if (!removedDeletes.isEmpty()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /** Returns true if the snapshot the range starts from has any delete files. */
+  private boolean hasExistingDeletes(Long fromSnapshotIdExclusive) {
+    if (fromSnapshotIdExclusive == null) {
+      return false;
+    }
+
+    Snapshot fromSnapshot = table().snapshot(fromSnapshotIdExclusive);
+    return fromSnapshot != null && !fromSnapshot.deleteManifests(table().io()).isEmpty();
+  }
+
+  private boolean includeDeleteFiles() {
+    boolean tableValue =
+        PropertyUtil.propertyAsBoolean(
+            table().properties(),
+            TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES,
+            TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES_DEFAULT);
+    return PropertyUtil.propertyAsBoolean(
+        options(), TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES, tableValue);
+  }
+
+  /**
+   * Collects, for each snapshot, the statuses of data files changed in it, along with the locations
+   * and partitions of data files removed anywhere in the scan range.
+   */
+  private ChangedDataFiles collectChangedDataFiles(Deque<Snapshot> changelogSnapshots) {
+
+    Map<Long, Map<String, ManifestEntry.Status>> statusBySnapshot = Maps.newConcurrentMap();
+    Queue<Set<String>> localDeletedLocations = new ConcurrentLinkedQueue<>();
+    Queue<PartitionSet> localDeletedPartitions = new ConcurrentLinkedQueue<>();
 
     Tasks.foreach(changelogSnapshots)
         .stopOnFailure()
@@ -395,12 +611,16 @@ class BaseIncrementalChangelogScan
         .executeWith(planExecutor())
         .run(
             snapshot -> {
+              long snapshotId = snapshot.snapshotId();
               Map<String, ManifestEntry.Status> fileStatuses = Maps.newHashMap();
-              PartitionSet localAffected = PartitionSet.create(table().specs());
+              Set<String> deletedLocations = Sets.newHashSet();
+              PartitionSet deletedPartitions = PartitionSet.create(table().specs());
 
               List<ManifestFile> changedDataManifests =
-                  FluentIterable.from(snapshot.dataManifests(table().io()))
-                      .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
+                  snapshot.dataManifests(table().io()).stream()
+                      .filter(
+                          manifest ->
+                              manifest.snapshotId() != null && manifest.snapshotId() == snapshotId)
                       .toList();
 
               if (!changedDataManifests.isEmpty()) {
@@ -415,9 +635,15 @@ class BaseIncrementalChangelogScan
 
                 try (CloseableIterable<ManifestEntry<DataFile>> entries = changedGroup.entries()) {
                   for (ManifestEntry<DataFile> entry : entries) {
-                    if (changelogSnapshotIds.contains(entry.snapshotId())) {
+                    if (entry.snapshotId() != null && entry.snapshotId() == snapshotId) {
                       fileStatuses.put(entry.file().location(), entry.status());
-                      localAffected.add(entry.file().specId(), entry.file().partition());
+                      if (entry.status() == ManifestEntry.Status.DELETED) {
+                        // copy the file: the reader reuses the entry, so the partition struct
+                        // must not be stored as a live reference
+                        DataFile deletedFile = entry.file().copyWithoutStats();
+                        deletedLocations.add(deletedFile.location());
+                        deletedPartitions.add(deletedFile.specId(), deletedFile.partition());
+                      }
                     }
                   }
                 } catch (Exception e) {
@@ -426,143 +652,339 @@ class BaseIncrementalChangelogScan
                 }
               }
 
-              fileStatusBySnapshot.put(snapshot.snapshotId(), fileStatuses);
-              localPartitionsQueue.add(localAffected);
+              statusBySnapshot.put(snapshot.snapshotId(), fileStatuses);
+              localDeletedLocations.add(deletedLocations);
+              localDeletedPartitions.add(deletedPartitions);
             });
 
-    PartitionSet globalAffected = PartitionSet.create(table().specs());
-    for (PartitionSet local : localPartitionsQueue) {
-      globalAffected.addAll(local);
-    }
+    Set<String> deletedFileLocations = Sets.newHashSet();
+    localDeletedLocations.forEach(deletedFileLocations::addAll);
 
-    return Pair.of(fileStatusBySnapshot, globalAffected);
+    PartitionSet deletedFilePartitions = PartitionSet.create(table().specs());
+    localDeletedPartitions.forEach(deletedFilePartitions::addAll);
+
+    return new ChangedDataFiles(statusBySnapshot, deletedFileLocations, deletedFilePartitions);
   }
 
+  /**
+   * Scope of existing (pre-range) delete files that can apply to changelog tasks in the scan range.
+   * Existing deletes are only attached to data files that were removed in the range or hit by newly
+   * added deletes, so delete files outside this scope can be skipped while building the existing
+   * delete index:
+   *
+   * <ul>
+   *   <li>file-scoped position deletes and DVs are kept only if they reference an affected data
+   *       file location, or lie in a partition where a partition-scoped delete was added
+   *   <li>equality deletes and partition-scoped position deletes are kept only if they have global
+   *       reach or lie in an affected partition
+   * </ul>
+   */
+  private static class ExistingDeleteScope {
+    private final Map<Integer, PartitionSpec> specsById;
+    private final PartitionSet allAffectedPartitions;
+    private final PartitionSet broadDeletePartitions;
+    private final Set<String> affectedDataFileLocations;
+
+    ExistingDeleteScope(
+        Map<Integer, PartitionSpec> specsById,
+        PartitionSet allAffectedPartitions,
+        PartitionSet broadDeletePartitions,
+        Set<String> affectedDataFileLocations) {
+      this.specsById = specsById;
+      this.allAffectedPartitions = allAffectedPartitions;
+      this.broadDeletePartitions = broadDeletePartitions;
+      this.affectedDataFileLocations = affectedDataFileLocations;
+    }
+
+    boolean keeps(DeleteFile file) {
+      String referencedLocation = ContentFileUtil.referencedDataFileLocation(file);
+      if (referencedLocation != null) {
+        // file-scoped position delete or DV
+        return affectedDataFileLocations.contains(referencedLocation)
+            || broadDeletePartitions.contains(file.specId(), file.partition());
+      }
+
+      // equality delete or partition-scoped position delete
+      PartitionSpec spec = specsById.get(file.specId());
+      return spec == null
+          || spec.isUnpartitioned()
+          || allAffectedPartitions.contains(file.specId(), file.partition());
+    }
+  }
+
+  /**
+   * Derives the scope of existing deletes that can apply to tasks in the scan range from the
+   * removed data files and the added delete files. Returns null when scoping is not possible
+   * because some added delete has global reach and can affect any data file.
+   */
+  private ExistingDeleteScope buildExistingDeleteScope(
+      ChangedDataFiles changedDataFiles, Map<Long, DeleteFileIndex> addedDeletesBySnapshot) {
+    PartitionSet allAffected = PartitionSet.create(table().specs());
+    PartitionSet broadDeletePartitions = PartitionSet.create(table().specs());
+    Set<String> affectedLocations = Sets.newHashSet(changedDataFiles.deletedFileLocations);
+
+    allAffected.addAll(changedDataFiles.deletedFilePartitions);
+
+    for (DeleteFileIndex index : addedDeletesBySnapshot.values()) {
+      for (DeleteFile file : index.referencedDeleteFiles()) {
+        PartitionSpec spec = table().specs().get(file.specId());
+        String referencedLocation = ContentFileUtil.referencedDataFileLocation(file);
+        if (referencedLocation != null) {
+          affectedLocations.add(referencedLocation);
+        } else if (spec == null || spec.isUnpartitioned()) {
+          // an equality delete or a partition-scoped position delete with global reach can
+          // affect any data file, so existing deletes cannot be scoped
+          return null;
+        } else {
+          broadDeletePartitions.add(file.specId(), file.partition());
+        }
+
+        allAffected.add(file.specId(), file.partition());
+      }
+    }
+
+    return new ExistingDeleteScope(
+        table().specs(), allAffected, broadDeletePartitions, affectedLocations);
+  }
+
+  /**
+   * Prunes manifests that cannot contain files in any affected partition. A partitioned manifest
+   * whose spec has no affected partitions is pruned: every delete-to-data match requires equal spec
+   * IDs (file-scoped deletes share their target data file's spec and partition, and
+   * partition-scoped lookups are keyed by the data file's spec), so neither an affected delete file
+   * nor a data file matched by this range's deletes can live in a manifest of an unaffected spec.
+   * Deletes with global reach disable this pruning upstream (null scope for existing deletes; an
+   * empty partition set for per-snapshot data manifest pruning).
+   */
   private List<ManifestFile> pruneManifestsByAffectedPartitions(
       List<ManifestFile> manifests, PartitionSet affectedPartitions) {
     if (affectedPartitions.isEmpty()) {
       return manifests;
     }
 
-    Expression affectedExpr = buildAffectedPartitionExpression(affectedPartitions);
-    if (affectedExpr == Expressions.alwaysFalse()) {
+    Map<Integer, Expression> partitionExprsBySpec =
+        buildAffectedPartitionExpressions(affectedPartitions);
+    if (partitionExprsBySpec == null) {
+      // some affected partition cannot be expressed; skip pruning
       return manifests;
     }
 
-    List<ManifestFile> pruned = Lists.newArrayList();
-    for (ManifestFile manifest : manifests) {
-      PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
-      if (spec == null || spec.isUnpartitioned()) {
-        pruned.add(manifest);
-      } else if (manifestOverlapsFilter(manifest, spec, affectedExpr)) {
-        pruned.add(manifest);
+    try {
+      Map<Integer, ManifestEvaluator> evaluatorsBySpec = Maps.newHashMap();
+      List<ManifestFile> pruned = Lists.newArrayList();
+      for (ManifestFile manifest : manifests) {
+        PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
+        if (spec == null || spec.isUnpartitioned()) {
+          pruned.add(manifest);
+          continue;
+        }
+
+        Expression expr = partitionExprsBySpec.get(manifest.partitionSpecId());
+        if (expr == null) {
+          // no affected partitions in this manifest's spec: see method javadoc
+          continue;
+        }
+
+        ManifestEvaluator evaluator = evaluatorsBySpec.get(manifest.partitionSpecId());
+        if (evaluator == null) {
+          evaluator = ManifestEvaluator.forPartitionFilter(expr, spec, isCaseSensitive());
+          evaluatorsBySpec.put(manifest.partitionSpecId(), evaluator);
+        }
+
+        if (evaluator.eval(manifest)) {
+          pruned.add(manifest);
+        }
       }
+
+      return pruned;
+    } catch (Exception e) {
+      // if the partition expressions cannot be evaluated, be conservative and keep all manifests
+      LOG.warn("Failed to prune manifests by affected partitions, skipping pruning", e);
+      return manifests;
     }
-    return pruned;
   }
 
-  private Expression buildAffectedPartitionExpression(PartitionSet affectedPartitions) {
-    Expression combined = null;
+  /**
+   * Builds partition-space expressions (one per spec) matching the affected partition tuples. The
+   * expressions reference partition field names and compare transformed partition values directly,
+   * so they are correct for non-identity transforms such as bucket or truncate. Returns null if
+   * some affected partition cannot be translated to an expression and pruning must be skipped.
+   */
+  private Map<Integer, Expression> buildAffectedPartitionExpressions(
+      PartitionSet affectedPartitions) {
+    Map<Integer, Expression> exprsBySpec = Maps.newHashMap();
 
     for (Pair<Integer, StructLike> pair : affectedPartitions) {
       int specId = pair.first();
-      StructLike partition = pair.second();
       PartitionSpec spec = table().specs().get(specId);
-      if (spec == null) {
-        continue;
-      } else if (spec.isUnpartitioned()) {
-        return Expressions.alwaysTrue(); // FALLBACK: Global delete exists, include ALL manifests!
+      if (spec == null || spec.isUnpartitioned()) {
+        // a partition tuple without a known partitioned spec may affect any manifest
+        return null;
       }
 
-      Expression specExpr = null;
-      for (int i = 0; i < spec.fields().size(); i++) {
-        org.apache.iceberg.PartitionField field = spec.fields().get(i);
-        Object value = partition.get(i, Object.class);
-        if (value != null) {
-          String columnName = table().schema().findColumnName(field.sourceId());
-          if (columnName != null) {
-            Expression equalExpr = Expressions.equal(columnName, value);
-            specExpr = (specExpr == null) ? equalExpr : Expressions.and(specExpr, equalExpr);
-          }
+      StructLike partition = pair.second();
+      Expression tupleExpr = Expressions.alwaysTrue();
+      for (int pos = 0; pos < spec.fields().size(); pos++) {
+        String name = spec.partitionType().fields().get(pos).name();
+        Object value = partition.get(pos, Object.class);
+        if (value == null) {
+          tupleExpr = Expressions.and(tupleExpr, Expressions.isNull(name));
+        } else if (isNaN(value)) {
+          // NaN cannot be expressed as an equality predicate
+          return null;
+        } else {
+          tupleExpr = Expressions.and(tupleExpr, Expressions.equal(name, value));
         }
       }
 
-      if (specExpr != null) {
-        combined = (combined == null) ? specExpr : Expressions.or(combined, specExpr);
-      }
+      exprsBySpec.merge(specId, tupleExpr, Expressions::or);
     }
 
-    return combined != null ? combined : Expressions.alwaysFalse();
+    return exprsBySpec;
+  }
+
+  private static boolean isNaN(Object value) {
+    return (value instanceof Double && ((Double) value).isNaN())
+        || (value instanceof Float && ((Float) value).isNaN());
   }
 
   /**
-   * Builds a map of snapshot ID -> all delete files that were added in the scan range up to that
-   * snapshot, PRUNING files that were removed in the middle.
+   * Tracks the delete files that applied before each snapshot in the scan range and lazily builds a
+   * per-snapshot index of them.
+   *
+   * <p>The index for a snapshot combines deletes that existed before the scan range with deletes
+   * added by earlier snapshots in the range. Delete files that were removed by earlier snapshots in
+   * the range are excluded, so removed delete files are never assigned to tasks.
+   *
+   * <p>Snapshots are consumed oldest to newest, so this class keeps a single advancing cursor over
+   * the range instead of materializing per-snapshot state: one running list of accumulated added
+   * deletes, one running set of removed delete paths, and only the most recently built index.
+   * Within one snapshot, planning worker threads may request the same index concurrently; those
+   * calls are serialized by this object's monitor.
    */
-  private Map<Long, List<DeleteFile>> buildCumulativeDeletesBySnapshot(
-      Deque<Snapshot> snapshots, Map<Long, DeleteFileIndex> addedDeletesBySnapshot) {
-    Map<Long, List<DeleteFile>> result = Maps.newHashMap();
-    List<DeleteFile> accumulatedDeletes = Lists.newArrayList();
+  private class CumulativeDeleteIndexes {
+    private final Supplier<DeleteFileIndex> existingDeleteIndexSupplier;
+    private final List<Long> orderedSnapshotIds;
+    private final Map<Long, DeleteFileIndex> addedDeletesBySnapshot;
+    private final Map<Long, List<DeleteFile>> removedDeletesBySnapshot;
 
-    for (Snapshot snapshot : snapshots) {
-      // Save state first, so that this snapshot's tasks can use any deletes active up to this point
-      result.put(snapshot.snapshotId(), Lists.newArrayList(accumulatedDeletes));
+    // cursor state: position in orderedSnapshotIds of the next snapshot whose effects to apply,
+    // together with the state produced by all snapshots before that position
+    private int cursor = 0;
+    private final List<DeleteFile> accumulatedAddedDeletes = Lists.newArrayList();
+    private final Set<String> removedPaths = Sets.newHashSet();
+    private Long latestIndexSnapshotId = null;
+    private DeleteFileIndex latestIndex = null;
 
-      // Check for removed deletes and prune from accumulatedDeletes for FUTURE snapshots
-      List<ManifestFile> changedDeletes =
-          FluentIterable.from(snapshot.deleteManifests(table().io()))
-              .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
-              .toList();
+    CumulativeDeleteIndexes(
+        Deque<Snapshot> snapshots,
+        Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
+        Map<Long, List<DeleteFile>> removedDeletesBySnapshot,
+        Supplier<DeleteFileIndex> existingDeleteIndexSupplier) {
+      this.existingDeleteIndexSupplier = existingDeleteIndexSupplier;
+      this.orderedSnapshotIds = snapshots.stream().map(Snapshot::snapshotId).toList();
+      this.addedDeletesBySnapshot = addedDeletesBySnapshot;
+      this.removedDeletesBySnapshot = removedDeletesBySnapshot;
+    }
 
-      if (!changedDeletes.isEmpty()) {
-        Iterable<DeleteFile> removedDeletes =
-            loadRemovedDeleteFiles(changedDeletes, snapshot.snapshotId());
-        Set<String> removedPaths = Sets.newHashSet();
-        for (DeleteFile rdf : removedDeletes) {
-          removedPaths.add(rdf.location());
-        }
-        accumulatedDeletes.removeIf(df -> removedPaths.contains(df.location()));
+    /** Returns an index of all delete files that applied before the given snapshot. */
+    synchronized DeleteFileIndex deletesBefore(long snapshotId) {
+      if (latestIndexSnapshotId != null && latestIndexSnapshotId == snapshotId) {
+        return latestIndex;
       }
 
-      // Add new deletes for FUTURE snapshots
-      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
+      int position = orderedSnapshotIds.indexOf(snapshotId);
+      Preconditions.checkArgument(
+          position >= 0, "Cannot find snapshot %s in the changelog range", snapshotId);
+
+      // a consumer that re-iterates the plan may ask for a snapshot the cursor already passed;
+      // restarting from the beginning is correct, just slower
+      if (position < cursor) {
+        resetCursor();
+      }
+
+      // apply the effects of every snapshot strictly before the requested one
+      while (cursor < position) {
+        advanceCursor(orderedSnapshotIds.get(cursor));
+        cursor += 1;
+      }
+
+      this.latestIndex = buildIndex();
+      this.latestIndexSnapshotId = snapshotId;
+      return latestIndex;
+    }
+
+    private void resetCursor() {
+      this.cursor = 0;
+      accumulatedAddedDeletes.clear();
+      removedPaths.clear();
+    }
+
+    /** Applies one snapshot's delete file removals and additions to the running state. */
+    private void advanceCursor(long snapshotId) {
+      List<DeleteFile> removedDeletes =
+          removedDeletesBySnapshot.getOrDefault(snapshotId, List.of());
+      if (!removedDeletes.isEmpty()) {
+        Set<String> currentRemovedPaths = Sets.newHashSet();
+        for (DeleteFile removed : removedDeletes) {
+          currentRemovedPaths.add(removed.location());
+        }
+
+        // the cumulative set is still needed to filter pre-range existing delete files, but only
+        // this snapshot's removals may evict accumulated in-range deletes: a path removed earlier
+        // and re-added later in the range is live again
+        removedPaths.addAll(currentRemovedPaths);
+        accumulatedAddedDeletes.removeIf(file -> currentRemovedPaths.contains(file.location()));
+      }
+
+      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshotId);
       if (addedDeleteIndex != null && !addedDeleteIndex.isEmpty()) {
-        for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
-          accumulatedDeletes.add(df);
+        for (DeleteFile file : addedDeleteIndex.referencedDeleteFiles()) {
+          accumulatedAddedDeletes.add(file);
         }
       }
     }
 
-    return result;
-  }
-
-  /**
-   * Builds a delete index from the accumulated list of delete files, pruning by affected
-   * partitions.
-   */
-  private DeleteFileIndex buildDeleteIndex(
-      List<DeleteFile> accumulatedDeletes, PartitionSet affectedPartitions) {
-    if (accumulatedDeletes.isEmpty()) {
-      return DeleteFileIndex.emptyIndex();
-    }
-
-    List<DeleteFile> filteredDeletes = accumulatedDeletes;
-    if (!affectedPartitions.isEmpty()) {
-      filteredDeletes = Lists.newArrayList();
-      for (DeleteFile df : accumulatedDeletes) {
-        PartitionSpec spec = table().specs().get(df.specId());
-        if (spec == null || spec.isUnpartitioned()) {
-          filteredDeletes.add(df); // Always include unpartitioned deletes
-        } else if (affectedPartitions.contains(df.specId(), df.partition())) {
-          filteredDeletes.add(df);
+    private DeleteFileIndex buildIndex() {
+      List<DeleteFile> candidates = Lists.newArrayList();
+      for (DeleteFile file : existingDeleteIndexSupplier.get().referencedDeleteFiles()) {
+        if (!removedPaths.contains(file.location())) {
+          candidates.add(file);
         }
       }
-    }
 
-    return DeleteFileIndex.builderFor(filteredDeletes)
-        .specsById(table().specs())
-        .caseSensitive(isCaseSensitive())
-        .build();
+      candidates.addAll(accumulatedAddedDeletes);
+
+      if (candidates.isEmpty()) {
+        return DeleteFileIndex.emptyIndex();
+      }
+
+      // A data file has at most one live DV, but when a DV was replaced by a snapshot this scan
+      // does not track (e.g. a mid-range REPLACE rewrote it), both versions may be accumulated.
+      // Keep only the newest DV per referenced data file: DVs are cumulative, so the newest one
+      // carries all previously deleted positions. Candidates are ordered oldest to newest.
+      //
+      // When a skipped REPLACE snapshot rewrote a delete file, the DV retained here is the
+      // pre-range one, which is content-equivalent to the rewritten one but may already have been
+      // physically removed by expire_snapshots; execution then fails on a missing file. This is an
+      // accepted limitation, discussed on the PR.
+      List<DeleteFile> deleteFiles = Lists.newArrayList();
+      Map<String, DeleteFile> dvByReferencedFile = Maps.newHashMap();
+      for (DeleteFile file : candidates) {
+        if (ContentFileUtil.isDV(file)) {
+          dvByReferencedFile.put(file.referencedDataFile(), file);
+        } else {
+          deleteFiles.add(file);
+        }
+      }
+
+      deleteFiles.addAll(dvByReferencedFile.values());
+
+      return DeleteFileIndex.builderFor(deleteFiles)
+          .specsById(table().specs())
+          .caseSensitive(isCaseSensitive())
+          .build();
+    }
   }
 
   /**
@@ -572,17 +994,18 @@ class BaseIncrementalChangelogScan
   private void processSnapshotForDeletedRowsTasks(
       Snapshot snapshot,
       DeleteFileIndex addedDeleteIndex,
-      DeleteFileIndex cumulativeDeleteIndex,
+      CumulativeDeleteIndexes cumulativeDeleteIndexes,
       Map<String, ManifestEntry.Status> currentSnapshotFiles,
-      Set<String> alreadyProcessedPaths,
       Map<Long, Integer> snapshotOrdinals,
-      PartitionSet affectedPartitions,
+      PartitionSet snapshotDeletePartitions,
+      Set<String> candidateLocations,
       List<ChangelogScanTask> tasks) {
 
-    // Get all data files that exist in this snapshot, pruned by affected partitions
+    // Get all data files that exist in this snapshot, pruned to the partitions of this
+    // snapshot's added delete files
     List<ManifestFile> allDataManifests = snapshot.dataManifests(table().io());
     List<ManifestFile> prunedManifests =
-        pruneManifestsByAffectedPartitions(allDataManifests, affectedPartitions);
+        pruneManifestsByAffectedPartitions(allDataManifests, snapshotDeletePartitions);
 
     ManifestGroup allDataGroup =
         new ManifestGroup(table().io(), prunedManifests, ImmutableList.of())
@@ -604,10 +1027,18 @@ class BaseIncrementalChangelogScan
     Map<Integer, ResidualEvaluator> residualCache = Maps.newHashMap();
     Expression residualFilter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
 
+    // Track files already processed within this snapshot
+    Set<String> alreadyProcessedPaths = Sets.newHashSet();
+
     try (CloseableIterable<ManifestEntry<DataFile>> entries = allDataGroup.entries()) {
       for (ManifestEntry<DataFile> entry : entries) {
         DataFile dataFile = entry.file();
         String filePath = dataFile.location();
+
+        // When every added delete is file-scoped, only the referenced files can produce tasks
+        if (candidateLocations != null && !candidateLocations.contains(filePath)) {
+          continue;
+        }
 
         // Skip if this file was ADDED or DELETED in this snapshot
         // (those are handled by CreateDataFileChangeTasks)
@@ -627,12 +1058,13 @@ class BaseIncrementalChangelogScan
           continue;
         }
 
-        // This data file was EXISTING but has new delete files applied
-        // Get existing deletes from before this snapshot (cumulative)
+        // This data file was EXISTING but has new delete files applied.
+        // Attach all deletes that applied before this snapshot so that rows deleted earlier are
+        // not emitted again; the underlying index is built lazily on first use
+        DeleteFileIndex deletesBefore =
+            cumulativeDeleteIndexes.deletesBefore(snapshot.snapshotId());
         DeleteFile[] existingDeletes =
-            cumulativeDeleteIndex.isEmpty()
-                ? new DeleteFile[0]
-                : cumulativeDeleteIndex.forEntry(entry);
+            deletesBefore.isEmpty() ? new DeleteFile[0] : deletesBefore.forEntry(entry);
 
         // Create a DeletedRowsScanTask
         int changeOrdinal = snapshotOrdinals.get(snapshot.snapshotId());
@@ -654,7 +1086,7 @@ class BaseIncrementalChangelogScan
             new BaseDeletedRowsScanTask(
                 changeOrdinal,
                 snapshot.snapshotId(),
-                dataFile.copy(shouldKeepStats()),
+                ContentFileUtil.copy(dataFile, shouldReturnColumnStats(), columnsToKeepStats()),
                 addedDeletes,
                 existingDeletes,
                 schemaString,
@@ -669,237 +1101,20 @@ class BaseIncrementalChangelogScan
     }
   }
 
-  private boolean shouldKeepStats() {
-    Set<Integer> columns = columnsToKeepStats();
-    return columns != null && !columns.isEmpty();
-  }
-
-  /**
-   * Loads delete files from manifests by parsing each manifest.
-   *
-   * @param manifests the delete manifests to load
-   * @return list of delete files
-   */
-  private Iterable<DeleteFile> loadDeleteFiles(
-      List<ManifestFile> manifests, Long targetSnapshotId) {
-    Queue<DeleteFile> allDeleteFiles = new ConcurrentLinkedQueue<>();
-
-    Tasks.foreach(manifests)
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .executeWith(planExecutor())
-        .run(
-            manifest -> {
-              List<DeleteFile> deleteFiles =
-                  loadDeleteFilesFromManifest(manifest, targetSnapshotId);
-              allDeleteFiles.addAll(deleteFiles);
-            });
-
-    return allDeleteFiles;
-  }
-
-  private Iterable<DeleteFile> loadRemovedDeleteFiles(
-      List<ManifestFile> manifests, Long targetSnapshotId) {
-    Queue<DeleteFile> allDeleteFiles = new ConcurrentLinkedQueue<>();
-
-    Tasks.foreach(manifests)
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .executeWith(planExecutor())
-        .run(
-            manifest -> {
-              List<DeleteFile> deleteFiles =
-                  loadRemovedDeleteFilesFromManifest(manifest, targetSnapshotId);
-              allDeleteFiles.addAll(deleteFiles);
-            });
-
-    return allDeleteFiles;
-  }
-
-  private List<DeleteFile> loadRemovedDeleteFilesFromManifest(
-      ManifestFile manifest, Long targetSnapshotId) {
-    List<DeleteFile> deleteFiles = Lists.newArrayList();
-
-    try (ManifestReader<DeleteFile> reader =
-        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
-      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
-        if (entry.status() == ManifestEntry.Status.DELETED
-            && entry.snapshotId().equals(targetSnapshotId)) {
-          DeleteFile file = entry.file();
-
-          if (!partitionMatchesFilter(file)) {
-            continue;
-          }
-
-          Set<Integer> columns =
-              file.content() == FileContent.POSITION_DELETES
-                  ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
-                  : Set.copyOf(file.equalityFieldIds());
-          deleteFiles.add(ContentFileUtil.copy(file, true, columns));
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to read delete manifest: " + manifest.path(), e);
-    }
-
-    return deleteFiles;
-  }
-
-  /**
-   * Prunes delete manifests based on partition filter to avoid processing irrelevant manifests.
-   * This significantly improves performance when only a subset of partitions are relevant to the
-   * scan.
-   *
-   * @param manifests all delete manifests to consider
-   * @return list of manifests that might contain relevant delete files
-   */
-  private List<ManifestFile> pruneManifestsByPartition(List<ManifestFile> manifests) {
-    Expression currentFilter = filter();
-
-    // If there's no filter, return all manifests
-    if (currentFilter == null || currentFilter.equals(Expressions.alwaysTrue())) {
-      return manifests;
-    }
-
-    List<ManifestFile> prunedManifests = Lists.newArrayList();
-
-    for (ManifestFile manifest : manifests) {
-      PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
-      if (spec == null || spec.isUnpartitioned()) {
-        // Include unpartitioned manifests
-        prunedManifests.add(manifest);
-      } else if (manifestOverlapsFilter(manifest, spec, currentFilter)) {
-        // Check if manifest partition range overlaps with filter
-        prunedManifests.add(manifest);
-      }
-    }
-
-    return prunedManifests;
-  }
-
-  /**
-   * Checks if a manifest's partition range overlaps with the given filter.
-   *
-   * @param manifest the manifest to check
-   * @param spec the partition spec for the manifest
-   * @param filter the scan filter
-   * @return true if the manifest might contain matching partitions, false otherwise
-   */
-  private boolean manifestOverlapsFilter(
-      ManifestFile manifest, PartitionSpec spec, Expression filter) {
-    try {
-      // Use inclusive projection to transform row filter to partition filter
-      Expression partitionFilter = Projections.inclusive(spec, isCaseSensitive()).project(filter);
-
-      // Create evaluator for the partition filter
-      ManifestEvaluator evaluator =
-          ManifestEvaluator.forPartitionFilter(partitionFilter, spec, isCaseSensitive());
-
-      // Check if manifest could contain matching partitions
-      return evaluator.eval(manifest);
-    } catch (Exception e) {
-      // If evaluation fails, be conservative and include the manifest
-      return true;
-    }
-  }
-
-  /**
-   * Checks if a delete file's partition overlaps with the current scan filter. This enables
-   * partition pruning to reduce memory footprint and planning overhead by skipping delete files
-   * that cannot possibly match any rows in the scan.
-   *
-   * @param file the delete file to check
-   * @return true if the delete file's partition might contain matching rows, false otherwise
-   */
-  private boolean partitionMatchesFilter(DeleteFile file) {
-    // If there's no filter, all partitions match
-    Expression currentFilter = filter();
-    if (currentFilter == null || currentFilter.equals(Expressions.alwaysTrue())) {
-      return true;
-    }
-
-    // Get the partition spec for this delete file
-    PartitionSpec spec = table().specs().get(file.specId());
-    if (spec == null || spec.isUnpartitioned()) {
-      // If spec not found or table is unpartitioned, be conservative and include the file
-      return true;
-    }
-
-    try {
-      // Project the row filter to partition space using inclusive projection
-      // This transforms expressions on source columns to expressions on partition columns
-      Expression partitionFilter =
-          Projections.inclusive(spec, isCaseSensitive()).project(currentFilter);
-
-      // Evaluate the projected filter against the delete file's partition
-      Evaluator evaluator = new Evaluator(spec.partitionType(), partitionFilter, isCaseSensitive());
-      return evaluator.eval(file.partition());
-    } catch (Exception e) {
-      // If evaluation fails, be conservative and include the file
-      return true;
-    }
-  }
-
-  /**
-   * Loads delete files from a single manifest, parsing the manifest entries.
-   *
-   * @param manifest the delete manifest to load
-   * @return list of delete files from this manifest
-   */
-  private List<DeleteFile> loadDeleteFilesFromManifest(
-      ManifestFile manifest, Long targetSnapshotId) {
-    List<DeleteFile> deleteFiles = Lists.newArrayList();
-
-    try (ManifestReader<DeleteFile> reader =
-        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
-      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
-        if (entry.status() != ManifestEntry.Status.DELETED
-            && (targetSnapshotId == null || entry.snapshotId().equals(targetSnapshotId))) {
-          // Only include live delete files, copy with minimal stats to save memory
-          DeleteFile file = entry.file();
-
-          // Apply partition pruning - skip delete files that cannot match the scan filter
-          if (!partitionMatchesFilter(file)) {
-            continue;
-          }
-
-          Set<Integer> columns =
-              file.content() == FileContent.POSITION_DELETES
-                  ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
-                  : Set.copyOf(file.equalityFieldIds());
-          deleteFiles.add(ContentFileUtil.copy(file, true, columns));
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to read delete manifest: " + manifest.path(), e);
-    }
-
-    return deleteFiles;
-  }
-
   private static class CreateDataFileChangeTasks implements CreateTasksFunction<ChangelogScanTask> {
     private static final DeleteFile[] NO_DELETES = new DeleteFile[0];
 
     private final Map<Long, Integer> snapshotOrdinals;
-    private final Supplier<DeleteFileIndex> existingDeleteIndexSupplier;
     private final Map<Long, DeleteFileIndex> addedDeletesBySnapshot;
-    private final Map<Long, List<DeleteFile>> cumulativeDeletesMap;
-    private final Map<Integer, PartitionSpec> specsById;
-    private final boolean caseSensitive;
+    private final CumulativeDeleteIndexes cumulativeDeleteIndexes;
 
     CreateDataFileChangeTasks(
-        Deque<Snapshot> snapshots,
-        Supplier<DeleteFileIndex> existingDeleteIndexSupplier,
+        Map<Long, Integer> snapshotOrdinals,
         Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
-        Map<Long, List<DeleteFile>> cumulativeDeletesMap,
-        Map<Integer, PartitionSpec> specsById,
-        boolean caseSensitive) {
-      this.snapshotOrdinals = computeSnapshotOrdinals(snapshots);
-      this.existingDeleteIndexSupplier = existingDeleteIndexSupplier;
+        CumulativeDeleteIndexes cumulativeDeleteIndexes) {
+      this.snapshotOrdinals = snapshotOrdinals;
       this.addedDeletesBySnapshot = addedDeletesBySnapshot;
-      this.cumulativeDeletesMap = cumulativeDeletesMap;
-      this.specsById = specsById;
-      this.caseSensitive = caseSensitive;
+      this.cumulativeDeleteIndexes = cumulativeDeleteIndexes;
     }
 
     @Override
@@ -911,12 +1126,14 @@ class BaseIncrementalChangelogScan
           entry -> {
             long commitSnapshotId = entry.snapshotId();
             int changeOrdinal = snapshotOrdinals.get(commitSnapshotId);
-            DataFile dataFile = entry.file().copy(context.shouldKeepStats());
+            DataFile dataFile =
+                ContentFileUtil.copy(
+                    entry.file(), context.shouldKeepStats(), context.columnsToKeepStats());
 
             switch (entry.status()) {
               case ADDED:
                 // For ADDED data files, attach delete files added in this snapshot
-                DeleteFile[] addedFileDeletes = getDeletesForAddedFile(entry, commitSnapshotId);
+                DeleteFile[] addedFileDeletes = deletesForAddedFile(entry, commitSnapshotId);
                 return new BaseAddedRowsScanTask(
                     changeOrdinal,
                     commitSnapshotId,
@@ -929,7 +1146,7 @@ class BaseIncrementalChangelogScan
               case DELETED:
                 // For DELETED data files, attach ALL deletes that were present up to deletion
                 // This includes existing deletes AND deletes added in the scan range
-                DeleteFile[] deletedFileDeletes = getDeletesForDeletedFile(entry, commitSnapshotId);
+                DeleteFile[] deletedFileDeletes = deletesForDeletedFile(entry, commitSnapshotId);
                 return new BaseDeletedDataFileScanTask(
                     changeOrdinal,
                     commitSnapshotId,
@@ -949,8 +1166,7 @@ class BaseIncrementalChangelogScan
      * Gets delete files that apply to an ADDED data file. Only includes deletes added in the same
      * snapshot as the file.
      */
-    private DeleteFile[] getDeletesForAddedFile(
-        ManifestEntry<DataFile> entry, long commitSnapshotId) {
+    private DeleteFile[] deletesForAddedFile(ManifestEntry<DataFile> entry, long commitSnapshotId) {
       DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(commitSnapshotId);
       return addedDeleteIndex == null || addedDeleteIndex.isEmpty()
           ? NO_DELETES
@@ -960,36 +1176,13 @@ class BaseIncrementalChangelogScan
     /**
      * Gets all delete files that were applied to a DELETED data file up to the point it was
      * deleted. This includes existing deletes and all deletes added in the scan range up to (but
-     * not including) the deletion snapshot.
+     * not including) the deletion snapshot. The underlying per-snapshot index is built once and
+     * reused for all entries deleted in the same snapshot.
      */
-    private DeleteFile[] getDeletesForDeletedFile(
+    private DeleteFile[] deletesForDeletedFile(
         ManifestEntry<DataFile> entry, long deletionSnapshotId) {
-
-      List<DeleteFile> allDeletes = Lists.newArrayList();
-
-      // Build existing delete index lazily when first DELETED entry is encountered
-      DeleteFileIndex existingDeleteIndex = existingDeleteIndexSupplier.get();
-      DeleteFile[] existingDeletes =
-          existingDeleteIndex.isEmpty() ? NO_DELETES : existingDeleteIndex.forEntry(entry);
-      for (DeleteFile df : existingDeletes) {
-        allDeletes.add(df);
-      }
-
-      // Add all deletes from snapshots in the scan range BEFORE the deletion
-      List<DeleteFile> cumulativeDeletes = cumulativeDeletesMap.get(deletionSnapshotId);
-      if (cumulativeDeletes != null && !cumulativeDeletes.isEmpty()) {
-        DeleteFileIndex tempIndex =
-            DeleteFileIndex.builderFor(cumulativeDeletes)
-                .specsById(specsById)
-                .caseSensitive(caseSensitive)
-                .build();
-        DeleteFile[] applicable = tempIndex.forEntry(entry);
-        for (DeleteFile deleteFile : applicable) {
-          allDeletes.add(deleteFile);
-        }
-      }
-
-      return allDeletes.isEmpty() ? NO_DELETES : allDeletes.toArray(new DeleteFile[0]);
+      DeleteFileIndex deletesBefore = cumulativeDeleteIndexes.deletesBefore(deletionSnapshotId);
+      return deletesBefore.isEmpty() ? NO_DELETES : deletesBefore.forEntry(entry);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.util.Tasks;
  */
 class DeleteFileIndex {
   private static final DeleteFile[] EMPTY_DELETES = new DeleteFile[0];
+  private static final DeleteFileIndex EMPTY = new DeleteFileIndex(null, null, null, null, null);
 
   private final EqualityDeletes globalDeletes;
   private final PartitionMap<EqualityDeletes> eqDeletesByPartition;
@@ -361,6 +362,10 @@ class DeleteFileIndex {
 
   static Builder builderFor(Iterable<DeleteFile> deleteFiles) {
     return new Builder(deleteFiles);
+  }
+
+  static DeleteFileIndex emptyIndex() {
+    return EMPTY;
   }
 
   static class Builder {

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.util.Tasks;
  */
 class DeleteFileIndex {
   private static final DeleteFile[] EMPTY_DELETES = new DeleteFile[0];
+  private static final DeleteFileIndex EMPTY = new DeleteFileIndex(null, null, null, null, null);
 
   private final EqualityDeletes globalDeletes;
   private final PartitionMap<EqualityDeletes> eqDeletesByPartition;
@@ -400,6 +401,10 @@ class DeleteFileIndex {
 
   static Builder builderFor(Iterable<DeleteFile> deleteFiles) {
     return new Builder(deleteFiles);
+  }
+
+  static DeleteFileIndex emptyIndex() {
+    return EMPTY;
   }
 
   static class Builder {

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -69,7 +70,8 @@ import org.apache.iceberg.util.Tasks;
  */
 class DeleteFileIndex {
   private static final DeleteFile[] EMPTY_DELETES = new DeleteFile[0];
-  private static final DeleteFileIndex EMPTY = new DeleteFileIndex(null, null, null, null, null);
+  private static final DeleteFileIndex EMPTY =
+      new DeleteFileIndex(null, null, null, null, null, null);
 
   private final EqualityDeletes globalDeletes;
   private final PartitionMap<EqualityDeletes> eqDeletesByPartition;
@@ -421,6 +423,7 @@ class DeleteFileIndex {
     private ExecutorService executorService = null;
     private ScanMetrics scanMetrics = ScanMetrics.noop();
     private boolean ignoreResiduals = false;
+    private Predicate<DeleteFile> deleteFilePredicate = null;
 
     Builder(FileIO io, Set<ManifestFile> deleteManifests) {
       this.io = io;
@@ -490,6 +493,20 @@ class DeleteFileIndex {
       return this;
     }
 
+    /**
+     * Keeps only the delete files accepted by the given predicate, evaluated on raw manifest
+     * entries before stats are trimmed, so that excluded files cost neither a copy nor index space.
+     *
+     * <p>The predicate must be thread-safe: when {@link #planWith(ExecutorService)} is set, delete
+     * manifests are loaded in parallel and the predicate is called from every loader thread.
+     */
+    Builder deleteFilePredicate(Predicate<DeleteFile> newDeleteFilePredicate) {
+      Preconditions.checkArgument(
+          deleteFiles == null, "Index constructed from files does not support file predicates");
+      this.deleteFilePredicate = newDeleteFilePredicate;
+      return this;
+    }
+
     private Iterable<DeleteFile> filterDeleteFiles() {
       return Iterables.filter(deleteFiles, file -> file.dataSequenceNumber() > minSequenceNumber);
     }
@@ -508,6 +525,9 @@ class DeleteFileIndex {
                   for (ManifestEntry<DeleteFile> entry : reader) {
                     if (entry.dataSequenceNumber() > minSequenceNumber) {
                       DeleteFile file = entry.file();
+                      if (deleteFilePredicate != null && !deleteFilePredicate.test(file)) {
+                        continue;
+                      }
                       // keep minimum stats to avoid memory pressure
                       Set<Integer> columns =
                           file.content() == FileContent.POSITION_DELETES

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -261,6 +261,10 @@ public class TableProperties {
   public static final String ADAPTIVE_SPLIT_SIZE_ENABLED = "read.split.adaptive-size.enabled";
   public static final boolean ADAPTIVE_SPLIT_SIZE_ENABLED_DEFAULT = true;
 
+  public static final String CHANGELOG_SCAN_INCLUDE_DELETE_FILES =
+      "changelog.scan.include-delete-files";
+  public static final boolean CHANGELOG_SCAN_INCLUDE_DELETE_FILES_DEFAULT = false;
+
   public static final String PARQUET_VECTORIZATION_ENABLED = "read.parquet.vectorization.enabled";
   public static final boolean PARQUET_VECTORIZATION_ENABLED_DEFAULT = true;
 

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
@@ -248,16 +247,701 @@ public class TestBaseIncrementalChangelogScan
   }
 
   @TestTemplate
-  public void testDeleteFilesAreNotSupported() {
+  public void testPositionDeletesOnExistingFile() {
     assumeThat(formatVersion).isEqualTo(2);
 
+    // Add initial data files
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Add position deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one DeletedRowsScanTask for FILE_A
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.addedDeletes())
+        .as("Must have added deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+    assertThat(task.existingDeletes()).as("Must have no existing deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testEqualityDeletesOnExistingFile() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Add initial data files
     table.newFastAppend().appendFile(FILE_A2).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
 
+    // Add equality deletes for FILE_A2
     table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
 
-    assertThatThrownBy(() -> plan(newScan()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Delete files are currently not supported in changelog scans");
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one DeletedRowsScanTask for FILE_A2
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task.addedDeletes())
+        .as("Must have added deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    assertThat(task.existingDeletes()).as("Must have no existing deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testAddedFileWithExistingDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Add FILE_A with deletes
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Add FILE_B in the changelog range
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one AddedRowsScanTask for FILE_B (no deletes apply to FILE_B)
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    AddedRowsScanTask task = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
+    assertThat(task.deletes()).as("Must have no deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testDeletedFileWithExistingDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    // Add deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Delete FILE_A in the changelog range
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one DeletedDataFileScanTask for FILE_A with existing deletes
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.existingDeletes())
+        .as("Must have existing deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testMultipleSnapshotsWithDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A and FILE_B
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add FILE_C
+    table.newFastAppend().appendFile(FILE_C).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Snapshot 4: Add deletes for FILE_B
+    DeleteFile fileBDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-b-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(fileBDeletes).commit();
+    Snapshot snap4 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have:
+    // 1. DeletedRowsScanTask for FILE_A (snap2)
+    // 2. AddedRowsScanTask for FILE_C (snap3)
+    // 3. DeletedRowsScanTask for FILE_B (snap4)
+    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task1.addedDeletes()).as("Must have added deletes").hasSize(1);
+
+    AddedRowsScanTask task2 = (AddedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_C.location());
+
+    DeletedRowsScanTask task3 = (DeletedRowsScanTask) tasks.get(2);
+    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
+    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
+    assertThat(task3.addedDeletes()).as("Must have added deletes").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testInsertDeleteReinsert() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Insert FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality delete for FILE_A
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Re-insert FILE_A (same file, new snapshot)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have:
+    // 1. DeletedRowsScanTask for FILE_A affected by delete (snap2)
+    // 2. AddedRowsScanTask for FILE_A re-insert (snap3)
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task1.addedDeletes()).as("Must have added deletes").hasSize(1);
+
+    AddedRowsScanTask task2 = (AddedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    // The re-inserted file is a fresh insert, so the deletes from snap2 were already
+    // accounted for in the DeletedRowsScanTask above
+    assertThat(task2.deletes()).as("Re-insert should not carry previous deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testInsertAndDeleteInSameCommit() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: baseline
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add FILE_A and delete it in the same commit (using row delta)
+    table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should emit an AddedRowsScanTask with deletes attached
+    // The net result depends on whether all rows are deleted
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    AddedRowsScanTask task = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    // The delete should be attached to the added file task
+    assertThat(task.deletes())
+        .as("Must have deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testOverlappingEqualityAndPositionDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add position deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality deletes that also affect FILE_A
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have 2 DeletedRowsScanTask for FILE_A (one per snapshot with deletes)
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task1.addedDeletes())
+        .as("Must have 1 added delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have 1 added delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    // The position delete from snap2 should be an existing delete for snap3
+    assertThat(task2.existingDeletes())
+        .as("Must be 1 position delete from previous snapshot")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testEqualityDeleteOverlapsEqualityDelete() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A2 (has equality delete support)
+    table.newFastAppend().appendFile(FILE_A2).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality delete on field 'id'
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality delete on different field 'data' that matches the same logical rows
+    // This tests behavior when two equality deletes on different columns target overlapping
+    // rows
+    DeleteFile eqDeleteOnData =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-data.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDeleteOnData).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have 2 DeletedRowsScanTask for FILE_A2 (one per snapshot with deletes)
+    // This documents current behavior - whether duplicate DELETE rows are emitted or deduplicated
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task1.addedDeletes())
+        .as("Must have first equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have second equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(eqDeleteOnData.location());
+    // First equality delete should be an existing delete for the second task
+    assertThat(task2.existingDeletes())
+        .as("Must have first equality delete as existing")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testDeletedFileWithBothDeleteTypes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add position deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality deletes for FILE_A (potentially overlapping)
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Snapshot 4: Delete FILE_A entirely
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap4 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have:
+    // 1. DeletedRowsScanTask for FILE_A with position deletes (snap2)
+    // 2. DeletedRowsScanTask for FILE_A with equality deletes (snap3)
+    // 3. DeletedDataFileScanTask for FILE_A deletion (snap4) with both types of existing deletes
+    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task1.addedDeletes())
+        .as("Must have position deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have equality deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    // Position delete from snap2 should be an existing delete for snap3
+    assertThat(task2.existingDeletes())
+        .as("Must have position delete as existing")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+
+    DeletedDataFileScanTask task3 = (DeletedDataFileScanTask) tasks.get(2);
+    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
+    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    // When file is deleted, all existing deletes should be included to omit previously deleted rows
+    assertThat(task3.existingDeletes())
+        .as("Must have both position and equality deletes as existing")
+        .hasSize(2)
+        .extracting(DeleteFile::location)
+        .containsExactlyInAnyOrder(FILE_A_DELETES.location(), FILE_A2_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testMultipleEqualityDeletesSameFile() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A2
+    table.newFastAppend().appendFile(FILE_A2).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality delete #1 on field 'id'
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality delete #2 on field 'id' (different values, no overlap)
+    DeleteFile eqDelete2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDelete2).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Snapshot 4: Add equality delete #3 on field 'data' (potentially overlaps with delete #1 or
+    // #2)
+    DeleteFile eqDelete3 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-3.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDelete3).commit();
+    Snapshot snap4 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have 3 DeletedRowsScanTask for FILE_A2 (one per snapshot with deletes)
+    // This documents cumulative equality delete tracking across multiple snapshots
+    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task1.addedDeletes())
+        .as("Must have first equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have second equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(eqDelete2.location());
+    // First equality delete should be an existing delete for the second task
+    assertThat(task2.existingDeletes())
+        .as("Must have first equality delete as existing")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+
+    DeletedRowsScanTask task3 = (DeletedRowsScanTask) tasks.get(2);
+    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
+    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task3.addedDeletes())
+        .as("Must have third equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(eqDelete3.location());
+    // Both previous equality deletes should be existing deletes for the third task
+    assertThat(task3.existingDeletes())
+        .as("Must have both previous equality deletes as existing")
+        .hasSize(2)
+        .extracting(DeleteFile::location)
+        .containsExactlyInAnyOrder(FILE_A2_DELETES.location(), eqDelete2.location());
+  }
+
+  @TestTemplate
+  public void testExistingAndNewDeletesBothApplied() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A with position deletes
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add FILE_B
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality deletes affecting FILE_A
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have:
+    // 1. AddedRowsScanTask for FILE_B (snap2)
+    // 2. DeletedRowsScanTask for FILE_A with new equality delete (snap3)
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    AddedRowsScanTask task1 = (AddedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have newly added delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    assertThat(task2.existingDeletes())
+        .as("Must have existing delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testOverwriteSnapshotWithExistingDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A and FILE_B with deletes on FILE_A
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Overwrite - replace FILE_A with FILE_A2, keep FILE_B
+    table.newOverwrite().addFile(FILE_A2).deleteFile(FILE_A).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    // Should not throw NPE and should handle the overwrite correctly
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // The overwrite creates ADDED and DELETED tasks
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    AddedRowsScanTask addedTask = (AddedRowsScanTask) tasks.get(0);
+    assertThat(addedTask.file().location())
+        .as("Added file must match")
+        .isEqualTo(FILE_A2.location());
+
+    DeletedDataFileScanTask deletedTask = (DeletedDataFileScanTask) tasks.get(1);
+    assertThat(deletedTask.file().location())
+        .as("Deleted file must match")
+        .isEqualTo(FILE_A.location());
+    // FILE_A had existing deletes which should be included
+    assertThat(deletedTask.existingDeletes())
+        .as("Must have existing deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testDeletedFileWithPreScanRangeDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    // Snapshot 2: Add deletes for FILE_A (before scan range)
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Delete FILE_A entirely (within scan range)
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Scan from snap2 (exclusive) to snap3
+    // This means the delete of FILE_A happens within the range,
+    // but the delete file (FILE_A_DELETES) was added before the range
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one DeletedDataFileScanTask for FILE_A
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+
+    // The key assertion: existingDeletes should include FILE_A_DELETES
+    // so consumers know to omit those previously deleted rows
+    assertThat(task.existingDeletes())
+        .as("Must include pre-existing deletes to omit previously deleted rows")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testLargeDeleteSetWithPruning() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A in partition 0
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add large equality delete set, but only affecting partition 0
+    // Create multiple equality delete files for different partitions
+    DeleteFile eqDelete1 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-1.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(100)
+            .build();
+
+    DeleteFile eqDelete2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(100)
+            .build();
+
+    DeleteFile eqDelete3 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-3.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=2")
+            .withRecordCount(100)
+            .build();
+
+    table.newRowDelta().addDeletes(eqDelete1).addDeletes(eqDelete2).addDeletes(eqDelete3).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have 1 DeletedRowsScanTask for FILE_A
+    // Only eqDelete1 should be included (partition 0), not eqDelete2 or eqDelete3
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    // Should only have 1 delete file (the one in partition 0)
+    // The DeleteFileIndex should prune out the other partition's delete files
+    assertThat(task.addedDeletes())
+        .as("Must have only 1 delete (partition pruning should eliminate others)")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(eqDelete1.location());
   }
 
   // plans tasks and reorders them to have deterministic order
@@ -272,6 +956,45 @@ public class TestBaseIncrementalChangelogScan
     }
   }
 
+  @TestTemplate
+  public void testDeleteFilePartitionPruning() throws IOException {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A (partition 0)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add delete files for FILE_A (partition 0) and FILE_C (partition 2)
+    // FILE_C is not present as a data file, only its delete file
+    table.newRowDelta().addDeletes(FILE_A_DELETES).addDeletes(FILE_C2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Scan without filter
+    // Partition pruning will automatically exclude FILE_C2_DELETES because:
+    // 1. There's no data file in partition 2 (FILE_C doesn't exist)
+    // 2. The delete file's partition doesn't overlap with any existing data files
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have a DeletedRowsScanTask for FILE_A only
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+
+    // Verify that only FILE_A_DELETES is included (partition 0)
+    // FILE_C2_DELETES should have been pruned because:
+    // - Its partition (data_bucket=2) doesn't contain any data files
+    // - The partition pruning optimization skips it during accumulation
+    assertThat(task.addedDeletes())
+        .as("Must have added deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
   private Comparator<? super ChangelogScanTask> taskComparator() {
     return (t1, t2) ->
         ComparisonChain.start()
@@ -283,5 +1006,363 @@ public class TestBaseIncrementalChangelogScan
 
   private String path(ChangelogScanTask task) {
     return ((ContentScanTask<?>) task).file().location().toString();
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexAppendOnly() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Scenario 1: Append-only with position deletes (no equality deletes, no DELETED files)
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add position deletes for FILE_A
+    // This creates a DeletedRowsScanTask for EXISTING file FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan1 =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks1 = plan(scan1);
+
+    // Verify no errors and correct results
+    assertThat(tasks1).isNotEmpty();
+
+    // Verify existingDeleteIndex was NOT built (position deletes don't require it)
+    BaseIncrementalChangelogScan baseScan1 = (BaseIncrementalChangelogScan) scan1;
+    assertThat(baseScan1.getExistingDeleteIndexBuildCallCount())
+        .as(
+            "Should not call buildExistingDeleteIndex for position deletes without equality deletes/DELETED files")
+        .isEqualTo(0);
+    assertThat(baseScan1.wasExistingDeleteIndexBuilt())
+        .as(
+            "Should not build existingDeleteIndex for position deletes without equality deletes/DELETED files")
+        .isFalse();
+
+    // Scenario 2: Pure append-only (no deletes at all, no DELETED files)
+    // Snapshot 3: Add FILE_B (pure append, no deletes)
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan2 =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks2 = plan(scan2);
+
+    // Verify correct results
+    assertThat(tasks2).hasSize(1);
+    AddedRowsScanTask task = (AddedRowsScanTask) tasks2.get(0);
+    assertThat(task.file().location()).isEqualTo(FILE_B.location());
+
+    // Verify existingDeleteIndex was NOT built (pure append, no deletes, no DELETED files)
+    BaseIncrementalChangelogScan baseScan2 = (BaseIncrementalChangelogScan) scan2;
+    assertThat(baseScan2.getExistingDeleteIndexBuildCallCount())
+        .as("Should not call buildExistingDeleteIndex for pure append-only workload")
+        .isEqualTo(0);
+    assertThat(baseScan2.wasExistingDeleteIndexBuilt())
+        .as("Should not build existingDeleteIndex for pure append-only workload")
+        .isFalse();
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexWithEqualityDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality deletes for FILE_A (triggers early building)
+    DeleteFile eqDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartition(FILE_A.partition())
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDeletes).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Verify correct results
+    assertThat(tasks).isNotEmpty();
+    DeletedRowsScanTask task = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task.file().location()).isEqualTo(FILE_A.location());
+
+    // Verify existingDeleteIndex was built EARLY (for equality deletes, not lazily)
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+        .as("Should call buildExistingDeleteIndex exactly once for equality deletes")
+        .isEqualTo(1);
+    assertThat(baseScan.wasExistingDeleteIndexBuilt())
+        .as("Should build existingDeleteIndex early when equality deletes exist")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexWithDeletedFiles() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    // Snapshot 2: Add deletes for FILE_A (before scan range)
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Delete FILE_A entirely (within scan range, no equality deletes)
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Verify correct results
+    assertThat(tasks).hasSize(1);
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) tasks.get(0);
+    assertThat(task.file().location()).isEqualTo(FILE_A.location());
+    assertThat(task.existingDeletes())
+        .as("Must include pre-existing deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+
+    // Verify existingDeleteIndex was built LAZILY (on-demand for DELETED file)
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+        .as("Should call buildExistingDeleteIndex exactly once (lazily) for DELETED file")
+        .isEqualTo(1);
+    assertThat(baseScan.wasExistingDeleteIndexBuilt())
+        .as("Should build existingDeleteIndex lazily when DELETED file is encountered")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexWithBothEqualityDeletesAndDeletedFiles() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A and FILE_B
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality deletes for FILE_A (triggers early building)
+    DeleteFile eqDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartition(FILE_A.partition())
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDeletes).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Delete FILE_B (different file) - this will trigger Supplier.get()
+    table.newDelete().deleteFile(FILE_B).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Verify correct results
+    assertThat(tasks).isNotEmpty();
+
+    // This proves that the cached index was reused when DELETED file was encountered
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+        .as(
+            "Should call buildExistingDeleteIndex exactly once (early), then reuse cached index for DELETED file")
+        .isEqualTo(1);
+    assertThat(baseScan.wasExistingDeleteIndexBuilt())
+        .as(
+            "Should build existingDeleteIndex early when equality deletes exist, even with DELETED files")
+        .isTrue();
+
+    // ensure DELETED file task has correct deletes
+    DeletedDataFileScanTask deletedTask =
+        tasks.stream()
+            .filter(t -> t instanceof DeletedDataFileScanTask)
+            .map(t -> (DeletedDataFileScanTask) t)
+            .findFirst()
+            .orElse(null);
+    if (deletedTask != null) {
+      assertThat(deletedTask.file().location()).isEqualTo(FILE_B.location());
+    }
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexNoExistingDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A (before scan range)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Delete FILE_A (within scan range, no existing deletes, no equality deletes)
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Verify correct results
+    assertThat(tasks).hasSize(1);
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) tasks.get(0);
+    assertThat(task.file().location()).isEqualTo(FILE_A.location());
+    assertThat(task.existingDeletes()).isEmpty();
+
+    // Verify existingDeleteIndex was built (lazily for DELETED file, even though no existing
+    // deletes)
+    // Note: It will be built but will be empty
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+        .as("Should call buildExistingDeleteIndex exactly once (lazily) even if result is empty")
+        .isEqualTo(1);
+    assertThat(baseScan.wasExistingDeleteIndexBuilt())
+        .as(
+            "Should build existingDeleteIndex when DELETED file is encountered, even with no existing deletes")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testMixedDeleteManifestEntries() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    table
+        .updateProperties()
+        .set(MANIFEST_MIN_MERGE_COUNT, "1")
+        .set(MANIFEST_MERGE_ENABLED, "true")
+        .commit();
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add Delete 1 for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add Delete 2 for FILE_A
+    DeleteFile fileADeletes2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartition(FILE_A.partition())
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(fileADeletes2).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // We scan from snap2 to snap3 (meaning we only care about snap3's changes).
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).isNotEmpty();
+
+    // Find the task for snap3
+    DeletedRowsScanTask snap3Task =
+        tasks.stream()
+            .filter(
+                t -> t instanceof DeletedRowsScanTask && t.commitSnapshotId() == snap3.snapshotId())
+            .map(t -> (DeletedRowsScanTask) t)
+            .findFirst()
+            .orElse(null);
+
+    assertThat(snap3Task).isNotNull();
+    assertThat(snap3Task.addedDeletes())
+        .as("Must only contain the new delete from snap3")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(fileADeletes2.location());
+  }
+
+  @TestTemplate
+  public void testUnpartitionedEqualityDeletePruning() throws Exception {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Create a new table specifically for this test, starting unpartitioned (Spec ID 0)
+    String tableName =
+        "test_unpartitioned_pruning_" + java.util.UUID.randomUUID().toString().replace("-", "");
+    TestTables.TestTable localTable =
+        TestTables.create(
+            tableDir, tableName, SCHEMA, PartitionSpec.unpartitioned(), formatVersion);
+
+    // Snapshot 1: Add fileA (unpartitioned, Spec ID 0)
+    DataFile fileA =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath(localTable.location() + "/data-unpartitioned-a.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    localTable.newFastAppend().appendFile(fileA).commit();
+    Snapshot snap1 = localTable.currentSnapshot();
+
+    // Evolve spec to bucketed (Spec ID 1)
+    localTable
+        .updateSpec()
+        .addField(org.apache.iceberg.expressions.Expressions.bucket("data", 16))
+        .commit();
+    PartitionSpec bucketedSpec = localTable.spec();
+
+    // Snapshot 2: Add fileB (bucketed, Spec ID 1)
+    String bucketFieldName = bucketedSpec.fields().get(0).name();
+    DataFile fileB =
+        DataFiles.builder(bucketedSpec)
+            .withPath(localTable.location() + "/data-bucketed-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath(bucketFieldName + "=1")
+            .withRecordCount(1)
+            .build();
+    localTable.newFastAppend().appendFile(fileB).commit();
+    Snapshot snap2 = localTable.currentSnapshot();
+
+    // Snapshot 3: Create an unpartitioned equality delete (Spec ID 0)
+    int idFieldId = localTable.schema().findField("id").fieldId();
+    DeleteFile globalDelete =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofEqualityDeletes(idFieldId)
+            .withPath(localTable.location() + "/global-delete.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    localTable.newRowDelta().addDeletes(globalDelete).commit();
+    Snapshot snap3 = localTable.currentSnapshot();
+
+    // Scan from snap1 exclusive to snap3 using localTable
+    IncrementalChangelogScan scan =
+        localTable
+            .newIncrementalChangelogScan()
+            .fromSnapshotExclusive(snap1.snapshotId())
+            .toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Expecting 3 tasks:
+    // 1 AddedRowsScanTask for fileB (Snap 2)
+    // 2 DeletedRowsScanTask for fileA and fileB (Snap 3, since global delete disables pruning)
+    assertThat(tasks).hasSize(3);
+
+    long addedCount = tasks.stream().filter(t -> t instanceof AddedRowsScanTask).count();
+    long deletedCount = tasks.stream().filter(t -> t instanceof DeletedRowsScanTask).count();
+
+    assertThat(addedCount).isEqualTo(1);
+    assertThat(deletedCount).isEqualTo(2);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -21,11 +21,19 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ComparisonChain;
@@ -33,6 +41,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -44,6 +56,14 @@ public class TestBaseIncrementalChangelogScan
   @Override
   protected IncrementalChangelogScan newScan() {
     return table.newIncrementalChangelogScan();
+  }
+
+  @BeforeEach
+  public void enableChangelogDeleteFiles() {
+    table
+        .updateProperties()
+        .set(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES, "true")
+        .commit();
   }
 
   @TestTemplate
@@ -275,6 +295,387 @@ public class TestBaseIncrementalChangelogScan
         .extracting(DeleteFile::location)
         .containsExactly(FILE_A_DELETES.location());
     assertThat(task.existingDeletes()).as("Must have no existing deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testPositionDeletesOnFileWithPreExistingPositionDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A and FILE_B with position deletes on FILE_A (before the scan range)
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add more position deletes for FILE_A within the scan range
+    DeleteFile newFileADeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(newFileADeletes).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.addedDeletes())
+        .as("Must have the newly added position delete")
+        .extracting(DeleteFile::location)
+        .containsExactly(newFileADeletes.location());
+
+    // Pre-range position deletes must be attached as existing deletes even when there are no
+    // equality deletes in the range, so previously deleted rows are not emitted again
+    assertThat(task.existingDeletes())
+        .as("Must include position deletes from before the scan range")
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testExistingDeletesOutsideAffectedPartitions() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: FILE_A (bucket 0) and FILE_B (bucket 1), position deletes on both
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).addDeletes(FILE_B_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: a new position delete for FILE_A only
+    DeleteFile newFileADeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-3.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(newFileADeletes).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // FILE_B is untouched in the range: its pre-range deletes are outside the affected scope
+    // and must not surface, while FILE_A's pre-range deletes must still be attached
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.addedDeletes())
+        .as("Must have the new delete")
+        .extracting(DeleteFile::location)
+        .containsExactly(newFileADeletes.location());
+    assertThat(task.existingDeletes())
+        .as("Must have only FILE_A's pre-range delete")
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testExistingDVKeptForEqualityTriggeredTask() {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    // Snapshot 1: Add FILE_A with a DV (before the scan range)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    DeleteFile dv = newDV(FILE_A);
+    table.newRowDelta().addDeletes(dv).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 2: an equality delete in FILE_A's partition (no file-scoped deletes added)
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.addedDeletes())
+        .as("Must have the equality delete")
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+
+    // The pre-range DV references a file that is not in the affected location set, but it lies
+    // in a partition where a partition-scoped delete was added, so it must be kept to suppress
+    // positions already deleted before the range
+    assertThat(task.existingDeletes())
+        .as("Must include the pre-range DV")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv.location());
+  }
+
+  @TestTemplate
+  public void testDVOnExistingFile() {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    // Snapshot 1: Add FILE_A and FILE_B
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add a DV for FILE_A
+    DeleteFile dv = newDV(FILE_A);
+    table.newRowDelta().addDeletes(dv).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.addedDeletes())
+        .as("Must have the added DV")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv.location());
+    assertThat(task.existingDeletes()).as("Must have no existing deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testDVReplacementOnExistingFile() {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    // Snapshot 2: Add a DV for FILE_A (before the scan range)
+    DeleteFile dv1 = newDV(FILE_A);
+    table.newRowDelta().addDeletes(dv1).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Replace the DV — a new DV carries all previously deleted positions, so the
+    // old DV must be removed in the same commit
+    DeleteFile dv2 = newDV(FILE_A);
+    table
+        .newRowDelta()
+        .removeDeletes(dv1)
+        .addDeletes(dv2)
+        .validateFromSnapshot(snap2.snapshotId())
+        .commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.addedDeletes())
+        .as("Must have the replacement DV")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv2.location());
+
+    // The replaced DV must be attached as an existing delete: the new DV is cumulative, so
+    // positions already deleted by the old DV must not be emitted as DELETE rows again
+    assertThat(task.existingDeletes())
+        .as("Must include the replaced DV to suppress previously deleted positions")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv1.location());
+  }
+
+  @TestTemplate
+  public void testDVReplacementWithinScanRange() {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add a DV for FILE_A within the scan range
+    DeleteFile dv1 = newDV(FILE_A);
+    table.newRowDelta().addDeletes(dv1).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Replace the DV within the scan range
+    DeleteFile dv2 = newDV(FILE_A);
+    table
+        .newRowDelta()
+        .removeDeletes(dv1)
+        .addDeletes(dv2)
+        .validateFromSnapshot(snap2.snapshotId())
+        .commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task1.addedDeletes())
+        .as("Must have the first DV")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv1.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
+    assertThat(task2.addedDeletes())
+        .as("Must have the replacement DV")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv2.location());
+    assertThat(task2.existingDeletes())
+        .as("Must include the DV replaced in this snapshot")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv1.location());
+  }
+
+  @TestTemplate
+  public void testDeletedFileWithDV() {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    // Snapshot 2: Add a DV for FILE_A (before the scan range)
+    DeleteFile dv = newDV(FILE_A);
+    table.newRowDelta().addDeletes(dv).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Delete FILE_A entirely within the scan range
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.existingDeletes())
+        .as("Must include the DV so previously deleted positions are not emitted")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv.location());
+  }
+
+  @TestTemplate
+  public void testAddedFileWithDVInSameSnapshot() {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add FILE_B together with a DV on it (same-commit upsert pattern)
+    DeleteFile dvB = newDV(FILE_B);
+    table.newRowDelta().addRows(FILE_B).addDeletes(dvB).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    AddedRowsScanTask task = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
+    assertThat(task.deletes())
+        .as("Must have the DV added in the same snapshot")
+        .extracting(DeleteFile::location)
+        .containsExactly(dvB.location());
+  }
+
+  @TestTemplate
+  public void testDVRewrittenByMidRangeReplaceSnapshot() {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    // Snapshot 1: Add FILE_A with a DV (before the scan range)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    DeleteFile dv1 = newDV(FILE_A);
+    table.newRowDelta().addDeletes(dv1).commit();
+    Snapshot rangeStart = table.currentSnapshot();
+
+    // Snapshot 2: REPLACE snapshot rewrites the DV (e.g. delete compaction); changelog scans
+    // skip REPLACE snapshots, so this removal/addition is never observed by planning
+    DeleteFile dv1b = newDV(FILE_A);
+    table.newRewrite().deleteFile(dv1).addFile(dv1b, rangeStart.sequenceNumber()).commit();
+    Snapshot replaceSnap = table.currentSnapshot();
+
+    // Snapshot 3: Replace the rewritten DV within the scan range
+    DeleteFile dv2 = newDV(FILE_A);
+    table
+        .newRowDelta()
+        .removeDeletes(dv1b)
+        .addDeletes(dv2)
+        .validateFromSnapshot(replaceSnap.snapshotId())
+        .commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Snapshot 4: Replace the DV again
+    DeleteFile dv3 = newDV(FILE_A);
+    table
+        .newRowDelta()
+        .removeDeletes(dv2)
+        .addDeletes(dv3)
+        .validateFromSnapshot(snap3.snapshotId())
+        .commit();
+    Snapshot snap4 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(rangeStart.snapshotId()).toSnapshot(snap4.snapshotId());
+
+    // Planning must not fail on multiple DV versions for the same file: the pre-range dv1 is
+    // never observed as removed (its removal happened in the skipped REPLACE snapshot), so it
+    // would collide with dv2 unless the newest DV per file wins
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
+    assertThat(task1.addedDeletes())
+        .as("Must have the DV added in snapshot 3")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv2.location());
+    assertThat(task1.existingDeletes())
+        .as("Must carry the content-equivalent pre-range DV")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv1.location());
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap4.snapshotId());
+    assertThat(task2.addedDeletes())
+        .as("Must have the DV added in snapshot 4")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv3.location());
+    assertThat(task2.existingDeletes())
+        .as("Must keep only the newest DV for the file")
+        .extracting(DeleteFile::location)
+        .containsExactly(dv2.location());
   }
 
   @TestTemplate
@@ -807,6 +1208,71 @@ public class TestBaseIncrementalChangelogScan
   }
 
   @TestTemplate
+  public void testExistingDeletesWithStatsAreKeptWhenResidualsAreIgnored() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // a pre-range equality delete on "id" whose bounds (id = 100) cannot match a filter of id = 1.
+    // "id" is not a partition column, so only the delete file's own stats can prune this file
+    int idFieldId = table.schema().findField("id").fieldId();
+    ByteBuffer bound = Conversions.toByteBuffer(Types.IntegerType.get(), 100);
+    DeleteFile existingEqDeletes =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofEqualityDeletes(idFieldId)
+            .withPath("/path/to/existing-id-100-eq-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withMetrics(
+                new Metrics(
+                    1L, null, null, null, null, Map.of(idFieldId, bound), Map.of(idFieldId, bound)))
+            .build();
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(existingEqDeletes).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // an in-range delete on FILE_A, which turns FILE_A into a DeletedRowsScanTask
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    Expression filter = Expressions.equal("id", 1);
+
+    // with residuals, the task filter still suppresses rows the pruned delete would have removed
+    DeletedRowsScanTask withResiduals =
+        (DeletedRowsScanTask)
+            Iterables.getOnlyElement(
+                plan(
+                    newScan()
+                        .filter(filter)
+                        .fromSnapshotExclusive(snap1.snapshotId())
+                        .toSnapshot(snap2.snapshotId())));
+    assertThat(withResiduals.residual())
+        .as("Residual must re-apply the filter to emitted rows")
+        .isEqualTo(filter);
+
+    // without residuals, nothing re-applies the filter, so the existing delete must be retained
+    DeletedRowsScanTask ignoringResiduals =
+        (DeletedRowsScanTask)
+            Iterables.getOnlyElement(
+                plan(
+                    newScan()
+                        .filter(filter)
+                        .ignoreResiduals()
+                        .fromSnapshotExclusive(snap1.snapshotId())
+                        .toSnapshot(snap2.snapshotId())));
+    assertThat(ignoringResiduals.residual())
+        .as("Residual must be dropped")
+        .isEqualTo(Expressions.alwaysTrue());
+    assertThat(ignoringResiduals.addedDeletes())
+        .as("Must have the newly added delete")
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+    assertThat(ignoringResiduals.existingDeletes())
+        .as("Existing delete must not be pruned by its stats when residuals are ignored")
+        .extracting(DeleteFile::location)
+        .containsExactly(existingEqDeletes.location());
+  }
+
+  @TestTemplate
   public void testOverwriteSnapshotWithExistingDeletes() {
     assumeThat(formatVersion).isEqualTo(2);
 
@@ -1030,16 +1496,12 @@ public class TestBaseIncrementalChangelogScan
     // Verify no errors and correct results
     assertThat(tasks1).isNotEmpty();
 
-    // Verify existingDeleteIndex was NOT built (position deletes don't require it)
+    // Position deletes on an EXISTING file produce a DeletedRowsScanTask, which must attach
+    // deletes from before the scan range; verify the index was built lazily exactly once
     BaseIncrementalChangelogScan baseScan1 = (BaseIncrementalChangelogScan) scan1;
-    assertThat(baseScan1.getExistingDeleteIndexBuildCallCount())
-        .as(
-            "Should not call buildExistingDeleteIndex for position deletes without equality deletes/DELETED files")
-        .isEqualTo(0);
-    assertThat(baseScan1.wasExistingDeleteIndexBuilt())
-        .as(
-            "Should not build existingDeleteIndex for position deletes without equality deletes/DELETED files")
-        .isFalse();
+    assertThat(baseScan1.existingDeleteIndexBuildCount())
+        .as("Should build existingDeleteIndex lazily exactly once for DeletedRowsScanTask")
+        .isEqualTo(1);
 
     // Scenario 2: Pure append-only (no deletes at all, no DELETED files)
     // Snapshot 3: Add FILE_B (pure append, no deletes)
@@ -1058,7 +1520,7 @@ public class TestBaseIncrementalChangelogScan
 
     // Verify existingDeleteIndex was NOT built (pure append, no deletes, no DELETED files)
     BaseIncrementalChangelogScan baseScan2 = (BaseIncrementalChangelogScan) scan2;
-    assertThat(baseScan2.getExistingDeleteIndexBuildCallCount())
+    assertThat(baseScan2.existingDeleteIndexBuildCount())
         .as("Should not call buildExistingDeleteIndex for pure append-only workload")
         .isEqualTo(0);
     assertThat(baseScan2.wasExistingDeleteIndexBuilt())
@@ -1098,7 +1560,7 @@ public class TestBaseIncrementalChangelogScan
 
     // Verify existingDeleteIndex was built EARLY (for equality deletes, not lazily)
     BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
-    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+    assertThat(baseScan.existingDeleteIndexBuildCount())
         .as("Should call buildExistingDeleteIndex exactly once for equality deletes")
         .isEqualTo(1);
     assertThat(baseScan.wasExistingDeleteIndexBuilt())
@@ -1138,7 +1600,7 @@ public class TestBaseIncrementalChangelogScan
 
     // Verify existingDeleteIndex was built LAZILY (on-demand for DELETED file)
     BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
-    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+    assertThat(baseScan.existingDeleteIndexBuildCount())
         .as("Should call buildExistingDeleteIndex exactly once (lazily) for DELETED file")
         .isEqualTo(1);
     assertThat(baseScan.wasExistingDeleteIndexBuilt())
@@ -1180,7 +1642,7 @@ public class TestBaseIncrementalChangelogScan
 
     // This proves that the cached index was reused when DELETED file was encountered
     BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
-    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+    assertThat(baseScan.existingDeleteIndexBuildCount())
         .as(
             "Should call buildExistingDeleteIndex exactly once (early), then reuse cached index for DELETED file")
         .isEqualTo(1);
@@ -1228,7 +1690,7 @@ public class TestBaseIncrementalChangelogScan
     // deletes)
     // Note: It will be built but will be empty
     BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
-    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+    assertThat(baseScan.existingDeleteIndexBuildCount())
         .as("Should call buildExistingDeleteIndex exactly once (lazily) even if result is empty")
         .isEqualTo(1);
     assertThat(baseScan.wasExistingDeleteIndexBuilt())
@@ -1302,6 +1764,10 @@ public class TestBaseIncrementalChangelogScan
     TestTables.TestTable localTable =
         TestTables.create(
             tableDir, tableName, SCHEMA, PartitionSpec.unpartitioned(), formatVersion);
+    localTable
+        .updateProperties()
+        .set(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES, "true")
+        .commit();
 
     // Snapshot 1: Add fileA (unpartitioned, Spec ID 0)
     DataFile fileA =
@@ -1364,5 +1830,925 @@ public class TestBaseIncrementalChangelogScan
 
     assertThat(addedCount).isEqualTo(1);
     assertThat(deletedCount).isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void testPlanningIsProgressive() throws IOException {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: FILE_A with position deletes (before the scan range)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: a new position delete for FILE_A within the scan range
+    DeleteFile newFileADeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-progressive.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(newFileADeletes).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+
+    try (CloseableIterable<ChangelogScanTask> tasks = scan.planFiles()) {
+      // Planning must be progressive: work that is only needed for emitted tasks (here, the
+      // existing delete index behind the DeletedRowsScanTask) must not run until consumption
+      assertThat(baseScan.wasExistingDeleteIndexBuilt())
+          .as("Existing delete index must not be built before tasks are consumed")
+          .isFalse();
+
+      List<ChangelogScanTask> materialized = Lists.newArrayList(tasks);
+      assertThat(materialized).as("Must have 1 task").hasSize(1);
+      assertThat(baseScan.wasExistingDeleteIndexBuilt())
+          .as("Existing delete index must be built once tasks are consumed")
+          .isTrue();
+    }
+  }
+
+  @TestTemplate
+  public void testNoDataManifestReadsBeforeConsumption() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Pre-range: FILE_A in its own data manifest
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    String preRangeDataManifest = Iterables.getOnlyElement(snap1.dataManifests(table.io())).path();
+
+    // In range: a position delete for FILE_A, whose DeletedRowsScanTask requires scanning the
+    // live data manifests (including the pre-range one)
+    DeleteFile newFileADeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-io-defer.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(newFileADeletes).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    // Planning must not read live data manifests; only consuming the tasks may
+    withUnavailableLocations(
+        ImmutableList.of(preRangeDataManifest),
+        () -> assertThatCode(scan::planFiles).doesNotThrowAnyException());
+
+    // With the manifest available again, consuming produces the expected task
+    List<ChangelogScanTask> tasks = plan(scan);
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.addedDeletes())
+        .extracting(DeleteFile::location)
+        .containsExactly(newFileADeletes.location());
+  }
+
+  @TestTemplate
+  public void testUnaffectedExistingDeleteManifestsAreNotRead() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Two partitions with pre-range deletes committed separately, so each delete manifest
+    // covers a single partition
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    table.newRowDelta().addDeletes(FILE_B_DELETES).commit();
+    Snapshot rangeStart = table.currentSnapshot();
+    String fileBDeleteManifest =
+        rangeStart.deleteManifests(table.io()).stream()
+            .filter(m -> m.snapshotId().equals(rangeStart.snapshotId()))
+            .map(ManifestFile::path)
+            .findFirst()
+            .orElseThrow();
+
+    // The range only touches FILE_A's partition
+    DeleteFile newFileADeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-io-guard.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(newFileADeletes).commit();
+    Snapshot snap = table.currentSnapshot();
+
+    // FILE_B's delete manifest is outside the affected scope: planning must succeed without
+    // ever opening it
+    withUnavailableLocations(
+        ImmutableList.of(fileBDeleteManifest),
+        () -> {
+          IncrementalChangelogScan scan =
+              newScan()
+                  .fromSnapshotExclusive(rangeStart.snapshotId())
+                  .toSnapshot(snap.snapshotId());
+
+          List<ChangelogScanTask> tasks = plan(scan);
+
+          assertThat(tasks).as("Must have 1 task").hasSize(1);
+          DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+          assertThat(task.existingDeletes())
+              .as("Must have only FILE_A's pre-range delete")
+              .extracting(DeleteFile::location)
+              .containsExactly(FILE_A_DELETES.location());
+        });
+  }
+
+  @TestTemplate
+  public void testAffectedPartitionPruningAfterSpecEvolution() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Two partitions with pre-range deletes committed separately, so each delete manifest
+    // covers a single partition
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    table.newRowDelta().addDeletes(FILE_B_DELETES).commit();
+    Snapshot rangeStart = table.currentSnapshot();
+    String fileBDeleteManifest =
+        rangeStart.deleteManifests(table.io()).stream()
+            .filter(m -> m.snapshotId() != null && m.snapshotId() == rangeStart.snapshotId())
+            .map(ManifestFile::path)
+            .findFirst()
+            .orElseThrow();
+
+    // Evolve the spec (a metadata-only change, no new snapshot) so the range below can produce
+    // affected partitions spanning both the old and the new spec
+    table.updateSpec().addField("id").commit();
+
+    // In range: a new delete on FILE_A (old spec, bucket 0) - affected partitions now contain
+    // the old-spec bucket-0 tuple; nothing touches bucket 1
+    DeleteFile newFileADeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-evolved.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(newFileADeletes).commit();
+
+    // In a separate in-range commit: a delete under the newly evolved spec. No data file lives
+    // at this tuple, so it contributes no task, but it does add a new-spec tuple to the range's
+    // affected partitions, so affected partitions now span two specs
+    DeleteFile newSpecDeletes =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/data-evolved-spec-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0/id=1")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(newSpecDeletes).commit();
+    Snapshot snap = table.currentSnapshot();
+
+    // With per-spec pruning, the bucket-1 delete manifest must never be read even though the
+    // range's affected partitions span two specs (the old-spec bucket-0 tuple and the new-spec
+    // tuple)
+    withUnavailableLocations(
+        ImmutableList.of(fileBDeleteManifest),
+        () -> {
+          IncrementalChangelogScan scan =
+              newScan()
+                  .fromSnapshotExclusive(rangeStart.snapshotId())
+                  .toSnapshot(snap.snapshotId());
+
+          List<ChangelogScanTask> tasks = plan(scan);
+          assertThat(tasks).as("Must have 1 task").hasSize(1);
+          DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+          assertThat(task.existingDeletes())
+              .as("Must have only FILE_A's pre-range delete")
+              .extracting(DeleteFile::location)
+              .containsExactly(FILE_A_DELETES.location());
+        });
+  }
+
+  @TestTemplate
+  public void testDeleteManifestsReadOnceDuringPlanning() throws IOException {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    CountingLocalFileIO countingIO = new CountingLocalFileIO();
+    File location = java.nio.file.Files.createTempDirectory(temp, "counting-table").toFile();
+    TestTables.TestTable countingTable =
+        TestTables.create(
+            location,
+            "counting_changelog",
+            SCHEMA,
+            SPEC,
+            SortOrder.unsorted(),
+            formatVersion,
+            new TestTables.TestTableOperations("counting_changelog", location, countingIO));
+    countingTable
+        .updateProperties()
+        .set(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES, "true")
+        .commit();
+
+    // Pre-range: FILE_A with position deletes
+    countingTable.newFastAppend().appendFile(FILE_A).commit();
+    countingTable.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot rangeStart = countingTable.currentSnapshot();
+    String preRangeDeleteManifest =
+        Iterables.getOnlyElement(rangeStart.deleteManifests(countingTable.io())).path();
+
+    // In range: a new position delete for FILE_A
+    DeleteFile inRangeDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-io-count.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    countingTable.newRowDelta().addDeletes(inRangeDeletes).commit();
+    Snapshot snap = countingTable.currentSnapshot();
+    String inRangeDeleteManifest =
+        snap.deleteManifests(countingTable.io()).stream()
+            .filter(m -> m.snapshotId().equals(snap.snapshotId()))
+            .map(ManifestFile::path)
+            .findFirst()
+            .orElseThrow();
+
+    // Count only planning-time reads, not commit-time reads
+    countingIO.reset();
+
+    IncrementalChangelogScan scan =
+        countingTable
+            .newIncrementalChangelogScan()
+            .fromSnapshotExclusive(rangeStart.snapshotId())
+            .toSnapshot(snap.snapshotId());
+    List<ChangelogScanTask> tasks = plan(scan);
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    assertThat(countingIO.opens(inRangeDeleteManifest))
+        .as("Each in-range delete manifest must be read exactly once during planning")
+        .isEqualTo(1);
+    assertThat(countingIO.opens(preRangeDeleteManifest))
+        .as("Each existing delete manifest must be read exactly once during planning")
+        .isEqualTo(1);
+  }
+
+  @TestTemplate
+  public void testDeleteManifestsReadOnceDuringPlanningWithDVs() throws IOException {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    CountingLocalFileIO countingIO = new CountingLocalFileIO();
+    File location = java.nio.file.Files.createTempDirectory(temp, "counting-table-dv").toFile();
+    TestTables.TestTable countingTable =
+        TestTables.create(
+            location,
+            "counting_changelog_dv",
+            SCHEMA,
+            SPEC,
+            SortOrder.unsorted(),
+            formatVersion,
+            new TestTables.TestTableOperations("counting_changelog_dv", location, countingIO));
+    countingTable
+        .updateProperties()
+        .set(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES, "true")
+        .commit();
+
+    // Pre-range: FILE_A with a DV
+    countingTable.newFastAppend().appendFile(FILE_A).commit();
+    DeleteFile dv1 = FileGenerationUtil.generateDV(countingTable, FILE_A);
+    countingTable.newRowDelta().addDeletes(dv1).commit();
+    Snapshot rangeStart = countingTable.currentSnapshot();
+    String preRangeDeleteManifest =
+        Iterables.getOnlyElement(rangeStart.deleteManifests(countingTable.io())).path();
+
+    // In range: replace the DV — the commit writes the added DV and the removed DV entry into
+    // this snapshot's delete manifests, which planning must split in a single read
+    DeleteFile dv2 = FileGenerationUtil.generateDV(countingTable, FILE_A);
+    countingTable
+        .newRowDelta()
+        .removeDeletes(dv1)
+        .addDeletes(dv2)
+        .validateFromSnapshot(rangeStart.snapshotId())
+        .commit();
+    Snapshot snap = countingTable.currentSnapshot();
+    List<String> inRangeDeleteManifests =
+        snap.deleteManifests(countingTable.io()).stream()
+            .filter(m -> m.snapshotId() != null && m.snapshotId() == snap.snapshotId())
+            .map(ManifestFile::path)
+            .toList();
+    assertThat(inRangeDeleteManifests).isNotEmpty();
+
+    // Count only planning-time reads, not commit-time reads
+    countingIO.reset();
+
+    IncrementalChangelogScan scan =
+        countingTable
+            .newIncrementalChangelogScan()
+            .fromSnapshotExclusive(rangeStart.snapshotId())
+            .toSnapshot(snap.snapshotId());
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.addedDeletes())
+        .extracting(DeleteFile::location)
+        .containsExactly(dv2.location());
+    assertThat(task.existingDeletes())
+        .extracting(DeleteFile::location)
+        .containsExactly(dv1.location());
+
+    for (String manifest : inRangeDeleteManifests) {
+      assertThat(countingIO.opens(manifest))
+          .as("Each in-range delete manifest must be read exactly once during planning")
+          .isEqualTo(1);
+    }
+
+    assertThat(countingIO.opens(preRangeDeleteManifest))
+        .as("Each existing delete manifest must be read exactly once during planning")
+        .isEqualTo(1);
+  }
+
+  @TestTemplate
+  public void testTasksEmittedInChangeOrdinalOrderWithoutSorting() throws IOException {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: new data file + position delete on the existing FILE_A in one commit
+    DeleteFile fileADeletes2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-order-1.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addRows(FILE_B).addDeletes(fileADeletes2).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: same shape again
+    DeleteFile fileADeletes3 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-order-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addRows(FILE_C).addDeletes(fileADeletes3).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    // Deliberately NOT using the sorting plan(...) helper: the raw iteration order is the contract
+    List<ChangelogScanTask> tasks;
+    try (CloseableIterable<ChangelogScanTask> iterable = scan.planFiles()) {
+      tasks = Lists.newArrayList(iterable);
+    }
+
+    assertThat(tasks).hasSize(4);
+    assertThat(tasks.get(0)).isInstanceOf(AddedRowsScanTask.class);
+    assertThat(tasks.get(0).changeOrdinal()).isEqualTo(0);
+    assertThat(tasks.get(1)).isInstanceOf(DeletedRowsScanTask.class);
+    assertThat(tasks.get(1).changeOrdinal()).isEqualTo(0);
+    assertThat(tasks.get(2)).isInstanceOf(AddedRowsScanTask.class);
+    assertThat(tasks.get(2).changeOrdinal()).isEqualTo(1);
+    assertThat(tasks.get(3)).isInstanceOf(DeletedRowsScanTask.class);
+    assertThat(tasks.get(3).changeOrdinal()).isEqualTo(1);
+    assertThat(tasks.get(0).commitSnapshotId()).isEqualTo(snap2.snapshotId());
+    assertThat(tasks.get(2).commitSnapshotId()).isEqualTo(snap3.snapshotId());
+  }
+
+  @TestTemplate
+  public void testTasksEmittedInChangeOrdinalOrderWithoutSortingWithDVs() throws IOException {
+    assumeThat(formatVersion).isEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: new data file + DV on the existing FILE_A in one commit
+    DeleteFile dvA1 = newDV(FILE_A);
+    table.newRowDelta().addRows(FILE_B).addDeletes(dvA1).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: same shape again — the new DV is cumulative, so the old one is replaced
+    DeleteFile dvA2 = newDV(FILE_A);
+    table
+        .newRowDelta()
+        .addRows(FILE_C)
+        .removeDeletes(dvA1)
+        .addDeletes(dvA2)
+        .validateFromSnapshot(snap2.snapshotId())
+        .commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    // Deliberately NOT using the sorting plan(...) helper: the raw iteration order is the contract
+    List<ChangelogScanTask> tasks;
+    try (CloseableIterable<ChangelogScanTask> iterable = scan.planFiles()) {
+      tasks = Lists.newArrayList(iterable);
+    }
+
+    assertThat(tasks).hasSize(4);
+    assertThat(tasks.get(0)).isInstanceOf(AddedRowsScanTask.class);
+    assertThat(tasks.get(0).changeOrdinal()).isEqualTo(0);
+    assertThat(tasks.get(1)).isInstanceOf(DeletedRowsScanTask.class);
+    assertThat(tasks.get(1).changeOrdinal()).isEqualTo(0);
+    assertThat(tasks.get(2)).isInstanceOf(AddedRowsScanTask.class);
+    assertThat(tasks.get(2).changeOrdinal()).isEqualTo(1);
+    assertThat(tasks.get(3)).isInstanceOf(DeletedRowsScanTask.class);
+    assertThat(tasks.get(3).changeOrdinal()).isEqualTo(1);
+    assertThat(tasks.get(0).commitSnapshotId()).isEqualTo(snap2.snapshotId());
+    assertThat(tasks.get(2).commitSnapshotId()).isEqualTo(snap3.snapshotId());
+
+    // DV replacement semantics hold in raw order too: the snap3 task attaches the replaced DV
+    // as existing so only newly deleted positions are emitted
+    DeletedRowsScanTask replacement = (DeletedRowsScanTask) tasks.get(3);
+    assertThat(replacement.addedDeletes())
+        .extracting(DeleteFile::location)
+        .containsExactly(dvA2.location());
+    assertThat(replacement.existingDeletes())
+        .extracting(DeleteFile::location)
+        .containsExactly(dvA1.location());
+  }
+
+  @TestTemplate
+  public void testConsumingEarlySnapshotsDoesNotReadLaterSnapshotWork() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Pre-range: FILE_A in its own manifest
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    String preRangeDataManifest = Iterables.getOnlyElement(snap1.dataManifests(table.io())).path();
+
+    // Snapshot 2: pure append (its task needs no pre-range manifests)
+    table.newFastAppend().appendFile(FILE_B).commit();
+
+    // Snapshot 3: position delete on FILE_A — planning ITS tasks must read the pre-range manifest
+    DeleteFile fileADeletes2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-progressive-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(fileADeletes2).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    // With the pre-range manifest unavailable, planning and consuming ONLY snapshot 2's task
+    // must succeed: snapshot 3's work is not touched until the walk reaches it
+    withUnavailableLocations(
+        ImmutableList.of(preRangeDataManifest),
+        () -> {
+          try (CloseableIterable<ChangelogScanTask> tasks = scan.planFiles()) {
+            Iterator<ChangelogScanTask> iter = tasks.iterator();
+            ChangelogScanTask first = iter.next();
+            assertThat(first).isInstanceOf(AddedRowsScanTask.class);
+            assertThat(((AddedRowsScanTask) first).file().location()).isEqualTo(FILE_B.location());
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+
+    // Fully consumable once the manifest is back
+    List<ChangelogScanTask> all = plan(scan);
+    assertThat(all).hasSize(2);
+  }
+
+  @TestTemplate
+  public void testReplanningUnpinnedScanRebuildsExistingDeleteIndex() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Pre-range: FILE_A (bucket 0) and FILE_B (bucket 1), each with its own position delete
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    table.newRowDelta().addDeletes(FILE_B_DELETES).commit();
+    Snapshot rangeStart = table.currentSnapshot();
+
+    // First range touches only bucket 0, so the existing delete index is scoped to bucket 0
+    DeleteFile fileADeletes2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-replan.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(fileADeletes2).commit();
+
+    // the scan is not pinned to an end snapshot, so each planFiles() resolves a wider range
+    IncrementalChangelogScan scan = newScan().fromSnapshotExclusive(rangeStart.snapshotId());
+
+    List<ChangelogScanTask> firstPlan = plan(scan);
+    assertThat(firstPlan).hasSize(1);
+    assertThat(((DeletedRowsScanTask) firstPlan.get(0)).file().location())
+        .isEqualTo(FILE_A.location());
+
+    // Second range additionally touches bucket 1, whose existing delete was out of the first scope
+    DeleteFile fileBDeletes2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-b-deletes-replan.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(fileBDeletes2).commit();
+
+    List<ChangelogScanTask> secondPlan = plan(scan);
+    assertThat(secondPlan).hasSize(2);
+
+    DeletedRowsScanTask fileBTask =
+        (DeletedRowsScanTask)
+            secondPlan.stream()
+                .filter(task -> path(task).equals(FILE_B.location()))
+                .findFirst()
+                .orElseThrow();
+
+    assertThat(fileBTask.existingDeletes())
+        .as("Replanning must rebuild the existing delete index for the wider range")
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_B_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testReAddedDeleteFileSurvivesLaterUnrelatedRemoval() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot rangeStart = table.currentSnapshot();
+
+    String reusedPath = "/path/to/data-a-deletes-readded.parquet";
+    DeleteFile delete1 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath(reusedPath)
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    DeleteFile unrelatedDelete =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-b-deletes-unrelated.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(1)
+            .build();
+
+    // s1: add a delete on FILE_A and an unrelated delete on FILE_B
+    table.newRowDelta().addDeletes(delete1).addDeletes(unrelatedDelete).commit();
+
+    // s2: remove the delete on FILE_A
+    table.newRowDelta().removeDeletes(delete1).commit();
+
+    // s3: re-add a delete file at the same path
+    DeleteFile reAddedDelete1 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath(reusedPath)
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(2)
+            .build();
+    table.newRowDelta().addDeletes(reAddedDelete1).commit();
+
+    // s4: remove an unrelated delete file; the re-added one must not be evicted with it
+    table.newRowDelta().removeDeletes(unrelatedDelete).commit();
+
+    // s5: add another delete on FILE_A
+    DeleteFile delete3 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-third.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(delete3).commit();
+    Snapshot snap5 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(rangeStart.snapshotId()).toSnapshot(snap5.snapshotId());
+
+    DeletedRowsScanTask lastTask =
+        (DeletedRowsScanTask)
+            plan(scan).stream()
+                .filter(task -> task instanceof DeletedRowsScanTask)
+                .filter(task -> task.commitSnapshotId() == snap5.snapshotId())
+                .findFirst()
+                .orElseThrow();
+
+    assertThat(lastTask.addedDeletes())
+        .extracting(DeleteFile::location)
+        .containsExactly(delete3.location());
+    assertThat(lastTask.existingDeletes())
+        .as("A re-added delete file must survive a later removal of an unrelated delete file")
+        .extracting(DeleteFile::location)
+        .containsExactly(reusedPath);
+  }
+
+  @TestTemplate
+  public void testDeletedRowsScanTaskColumnStats() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    DataFile fileWithStats = FileGenerationUtil.generateDataFile(table, TestHelpers.Row.of(0));
+    table.newFastAppend().appendFile(fileWithStats).commit();
+    Snapshot rangeStart = table.currentSnapshot();
+
+    DeleteFile deletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-stats-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(deletes).commit();
+    Snapshot snap = table.currentSnapshot();
+
+    DeletedRowsScanTask withStats =
+        (DeletedRowsScanTask)
+            Iterables.getOnlyElement(
+                plan(
+                    newScan()
+                        .includeColumnStats()
+                        .fromSnapshotExclusive(rangeStart.snapshotId())
+                        .toSnapshot(snap.snapshotId())));
+
+    assertThat(withStats.file().lowerBounds())
+        .as("Column stats must be returned when requested")
+        .isNotNull()
+        .isNotEmpty();
+    assertThat(withStats.file().upperBounds()).isNotNull().isNotEmpty();
+
+    DeletedRowsScanTask withoutStats =
+        (DeletedRowsScanTask)
+            Iterables.getOnlyElement(
+                plan(
+                    newScan()
+                        .fromSnapshotExclusive(rangeStart.snapshotId())
+                        .toSnapshot(snap.snapshotId())));
+
+    assertThat(withoutStats.file().lowerBounds())
+        .as("Column stats must be dropped when not requested")
+        .isNull();
+    assertThat(withoutStats.file().upperBounds()).isNull();
+  }
+
+  @TestTemplate
+  public void testDeletedRowsScanTaskColumnStatsForSubsetOfColumns() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    DataFile fileWithStats = FileGenerationUtil.generateDataFile(table, TestHelpers.Row.of(0));
+    table.newFastAppend().appendFile(fileWithStats).commit();
+    Snapshot rangeStart = table.currentSnapshot();
+
+    DeleteFile deletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-stats-subset-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(deletes).commit();
+    Snapshot snap = table.currentSnapshot();
+
+    int idFieldId = table.schema().findField("id").fieldId();
+
+    DeletedRowsScanTask task =
+        (DeletedRowsScanTask)
+            Iterables.getOnlyElement(
+                plan(
+                    newScan()
+                        .includeColumnStats(ImmutableList.of("id"))
+                        .fromSnapshotExclusive(rangeStart.snapshotId())
+                        .toSnapshot(snap.snapshotId())));
+
+    assertThat(task.file().lowerBounds())
+        .as("Only stats for the requested columns must be returned")
+        .containsOnlyKeys(idFieldId);
+    assertThat(task.file().upperBounds()).containsOnlyKeys(idFieldId);
+  }
+
+  @TestTemplate
+  public void testAddedRowsScanTaskColumnStatsForSubsetOfColumns() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot rangeStart = table.currentSnapshot();
+
+    DataFile fileWithStats = FileGenerationUtil.generateDataFile(table, TestHelpers.Row.of(0));
+    table.newFastAppend().appendFile(fileWithStats).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    int idFieldId = table.schema().findField("id").fieldId();
+
+    AddedRowsScanTask task =
+        (AddedRowsScanTask)
+            Iterables.getOnlyElement(
+                plan(
+                    newScan()
+                        .includeColumnStats(ImmutableList.of("id"))
+                        .fromSnapshotExclusive(rangeStart.snapshotId())
+                        .toSnapshot(snap2.snapshotId())));
+
+    assertThat(task.file().lowerBounds())
+        .as("Only stats for the requested columns must be returned")
+        .containsOnlyKeys(idFieldId);
+    assertThat(task.file().upperBounds()).containsOnlyKeys(idFieldId);
+  }
+
+  @TestTemplate
+  public void testAppendOnlyRangeReadsDataManifestsOnce() throws IOException {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    CountingLocalFileIO countingIO = new CountingLocalFileIO();
+    File location = java.nio.file.Files.createTempDirectory(temp, "append-only-table").toFile();
+    TestTables.TestTable countingTable =
+        TestTables.create(
+            location,
+            "append_only_changelog",
+            SCHEMA,
+            SPEC,
+            SortOrder.unsorted(),
+            formatVersion,
+            new TestTables.TestTableOperations("append_only_changelog", location, countingIO));
+    countingTable
+        .updateProperties()
+        .set(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES, "true")
+        .commit();
+
+    countingTable.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot rangeStart = countingTable.currentSnapshot();
+
+    countingTable.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = countingTable.currentSnapshot();
+    String snap2DataManifest = newDataManifestPath(countingTable, snap2);
+
+    countingTable.newFastAppend().appendFile(FILE_C).commit();
+    Snapshot snap3 = countingTable.currentSnapshot();
+    String snap3DataManifest = newDataManifestPath(countingTable, snap3);
+
+    // Count only planning-time reads, not commit-time reads
+    countingIO.reset();
+
+    List<ChangelogScanTask> tasks =
+        plan(
+            countingTable
+                .newIncrementalChangelogScan()
+                .fromSnapshotExclusive(rangeStart.snapshotId())
+                .toSnapshot(snap3.snapshotId()));
+
+    assertThat(tasks).hasSize(2);
+    assertThat(tasks).allMatch(AddedRowsScanTask.class::isInstance);
+    assertThat(tasks).extracting(this::path).containsExactly(FILE_B.location(), FILE_C.location());
+
+    assertThat(countingIO.opens(snap2DataManifest))
+        .as("An append-only range must read each changed data manifest exactly once")
+        .isEqualTo(1);
+    assertThat(countingIO.opens(snap3DataManifest))
+        .as("An append-only range must read each changed data manifest exactly once")
+        .isEqualTo(1);
+  }
+
+  @TestTemplate
+  public void testDeleteFilesRequireOptIn() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // this test verifies default-off behavior: remove the opt-in the setup hook added
+    table.updateProperties().remove(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES).commit();
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    assertThatThrownBy(scan::planFiles)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES);
+  }
+
+  @TestTemplate
+  public void testPreRangeDeleteFilesRequireOptIn() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    table.updateProperties().remove(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES).commit();
+
+    // deletes exist only BEFORE the range; DeletedDataFileScanTask would attach them
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    assertThatThrownBy(scan::planFiles)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES);
+  }
+
+  @TestTemplate
+  public void testAppendOnlyRangeDoesNotRequireOptIn() {
+    // runs on every format version: append-only changelogs must keep working with default settings
+    table.updateProperties().remove(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES).commit();
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    assertThat(plan(scan)).hasSize(1);
+  }
+
+  @TestTemplate
+  public void testScanOptionOverridesDeleteFileOptIn() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    table.updateProperties().remove(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES).commit();
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan()
+            .option(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES, "true")
+            .fromSnapshotExclusive(snap1.snapshotId())
+            .toSnapshot(snap2.snapshotId());
+
+    assertThat(plan(scan)).hasSize(1);
+  }
+
+  @TestTemplate
+  public void testScanOptionDisablesDeleteFileOptIn() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // table property is ON via the setup hook; an explicit option=false must win
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan()
+            .option(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES, "false")
+            .fromSnapshotExclusive(snap1.snapshotId())
+            .toSnapshot(snap2.snapshotId());
+
+    assertThatThrownBy(scan::planFiles)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining(TableProperties.CHANGELOG_SCAN_INCLUDE_DELETE_FILES);
+  }
+
+  private String newDataManifestPath(Table tbl, Snapshot snapshot) {
+    return snapshot.dataManifests(tbl.io()).stream()
+        .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
+        .map(ManifestFile::path)
+        .findFirst()
+        .orElseThrow();
+  }
+
+  /** Counts how often each path is opened for reading, on top of local file IO. */
+  private static class CountingLocalFileIO extends TestTables.LocalFileIO {
+    private final Map<String, Integer> inputOpens = Maps.newConcurrentMap();
+
+    @Override
+    public org.apache.iceberg.io.InputFile newInputFile(String path) {
+      inputOpens.merge(path, 1, Integer::sum);
+      return super.newInputFile(path);
+    }
+
+    void reset() {
+      inputOpens.clear();
+    }
+
+    int opens(String path) {
+      return inputOpens.getOrDefault(path, 0);
+    }
   }
 }

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -39,6 +39,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | read.orc.vectorization.batch-size | 5000               | The batch size for orc vectorized reads                |
 | read.data-planning-mode           | auto               | Mode used to plan data manifests: auto, local, or distributed |
 | read.delete-planning-mode         | auto               | Mode used to plan delete manifests: auto, local, or distributed |
+| changelog.scan.include-delete-files | false            | Enables changelog scans over ranges containing delete files; produces DeletedRowsScanTask, which requires engine support |
 
 ### Write properties
 


### PR DESCRIPTION
This PR adds delete file support (position deletes, equality deletes, and deletion vectors) to `BaseIncrementalChangelogScan`, so changelog scans produce correct `AddedRowsScanTask`, `DeletedDataFileScanTask`, and `DeletedRowsScanTask` for MoR tables. Fresh approach after #10935, core module only.

**How it works.** Planning walks the changelog snapshots oldest to newest and streams each snapshot's tasks in order. For each snapshot, a lazily built "effective delete list" (pre-range deletes + deletes added earlier in the range − deletes removed earlier in the range) supplies `existingDeletes()`, so already-deleted rows are never re-emitted and removed delete files are never assigned to tasks. Added data files only get same-snapshot deletes. The pre-range delete index is built at most once, only when a task needs it, and is pruned to the partitions and file locations actually affected by the range (transform-safe, e.g. bucket).

#### Task semantics

1. **AddedRowsScanTask** — newly added data files. Only deletes committed in the *same snapshot* are attached (existing deletes never apply to newer data files). Produces INSERT rows.
2. **DeletedDataFileScanTask** — removed data files. All deletes that applied *before* the deletion snapshot are attached as existing deletes, so rows deleted earlier are not re-emitted. Produces DELETE rows for the remaining live rows of the file.
3. **DeletedRowsScanTask** — existing data files hit by newly added deletes. `addedDeletes()` holds this snapshot's new delete files (generate DELETE rows); `existingDeletes()` holds every delete that applied before this snapshot (suppress already-deleted rows). Produces DELETE rows only for newly deleted records.

**Known limitation.** If a mid-range REPLACE rewrote a delete file and the original was later removed by `expire_snapshots`, execution fails on the missing file.

#### Test coverage (scenarios)

Scenario | Expected behavior
-- | --
Insert → Equality Delete → Re-insert | One DELETE + one INSERT changelog event
Insert & delete in same commit | One task with attached deletes
Overlapping equality + position deletes | Earlier deletes attached as existing — no duplicate DELETE rows
Equality delete over an earlier equality delete | Same — first delete becomes `existingDeletes()` of the second task
Deleted file with prior deletes (incl. pre-range) | Previously deleted rows not re-emitted
Mixed existing/new entries in a merged delete manifest | Only files added by the snapshot are indexed
Delete file removed mid-range | Never assigned to later tasks (no phantom deletes)
DV add / replacement / deleted file with DV / mid-range DV rewrite | Correct added vs existing DV assignment (v3)
Lazy index behavior | Existing delete index built exactly once, and never for append-only ranges
Progressive planning | No data manifest reads before consumption; per-snapshot streaming; delete manifests read once
Partition pruning | Unaffected delete manifests never read; correct across spec evolution and bucket transforms