### PR TITLE
Add Fast Mode for Documentation Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ site/site/
 site/docs/docs/
 site/docs/.asf.yaml
 site/docs/javadoc/
+site/nav.yml.backup
 
 # benchmark output
 spark/v3.4/spark/benchmark/*

--- a/site/README.md
+++ b/site/README.md
@@ -75,6 +75,7 @@ The docs are built, run, and released using [make](https://www.gnu.org/software/
 > [deploy](dev/deploy.sh): Clean, build, and deploy the Iceberg docs site.
 > help: Show help for each of the Makefile recipes.
 > [serve](dev/serve.sh): Clean, build, and run the site locally.
+> [serve-dev](dev/serve-dev.sh): Fast iterative development mode - only builds nightly and latest.
 
 To scaffold the versioned docs and build the project, run the `build` recipe. 
 
@@ -112,6 +113,25 @@ To clear all build files, run `clean`.
 ```sh
 make clean
 ```
+
+#### Fast iterative development mode
+
+When working on the documentation, building all historical versions (1.4.0 through 1.9.2) significantly slows down the build process. For faster iteration during development, use the `serve-dev` recipe:
+
+```sh
+make serve-dev
+```
+
+This development mode:
+- **Only builds `nightly` and `latest` versions** - Skips all historical versions (1.4.0 through 1.9.2)
+- **Significantly reduces build time** - Typically 5-10x faster than building all versions
+- **Uses the `--dirty` flag** - Only rebuilds changed files for even faster iteration
+- **Perfect for iterative development** - Great for working on documentation content
+
+The development mode sets the `ICEBERG_DEV_MODE=true` environment variable and uses a simplified navigation configuration (`nav-dev.yml`) that only includes the two most recent versions.
+
+> [!NOTE]
+> Development mode is only for local iteration. Always use `make serve` or `make build` before creating a pull request to ensure all versioned docs build correctly.
 
 #### Testing local changes on versioned docs
 

--- a/site/dev/clean.sh
+++ b/site/dev/clean.sh
@@ -20,3 +20,9 @@ source dev/common.sh
 set -e
 
 clean
+
+# Restore the original nav.yml if a backup exists (from dev mode)
+if [ -f nav.yml.backup ]; then
+  echo " --> Restoring original nav.yml"
+  mv nav.yml.backup nav.yml
+fi

--- a/site/dev/common.sh
+++ b/site/dev/common.sh
@@ -211,6 +211,12 @@ for f in filter(lambda x: x.endswith('.md'), os.listdir()): lines = open(f).read
 pull_versioned_docs () {
   echo " --> pull versioned docs"
   
+  # Check if running in dev mode (only build nightly and latest for faster iteration)
+  if [ "${ICEBERG_DEV_MODE:-false}" = "true" ]; then
+    echo " --> running in DEV MODE - only building nightly and latest"
+    echo " --> This significantly reduces build time by skipping historical versions"
+  fi
+  
   # Ensure the remote repository for documentation exists and is up-to-date
   create_or_update_docs_remote  
 
@@ -231,7 +237,12 @@ pull_versioned_docs () {
   create_latest "${latest_version}"
 
   # Create the 'nightly' version of documentation
-  create_nightly  
+  create_nightly
+  
+  if [ "${ICEBERG_DEV_MODE:-false}" = "true" ]; then
+    echo " --> DEV MODE setup complete"
+    echo " --> nav-dev.yml will be used to only build nightly and latest"
+  fi
 }
 
 # Cleans up artifacts and temporary files generated during documentation management.

--- a/site/dev/serve-dev.sh
+++ b/site/dev/serve-dev.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -12,27 +14,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-.PHONY: help
-help: # Show help for each of the Makefile recipes.
-	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+# Development mode serve script - only builds nightly and latest for fast iteration
 
-.PHONY: serve
-serve: # Clean, build, and run the docs site locally.
-	dev/serve.sh
+set -e
 
-.PHONY: serve-dev
-serve-dev:
-	dev/serve-dev.sh
+export ICEBERG_DEV_MODE=true
 
-.PHONY: build
-build: # Clean and build the docs site locally.
-	dev/build.sh
+echo "=========================================="
+echo "RUNNING IN DEVELOPMENT MODE"
+echo "Only building nightly and latest versions"
+echo "=========================================="
+echo ""
 
-.PHONY: deploy
-deploy: # Clean, build, and deploy the Iceberg docs site.
-	dev/deploy.sh $(remote_name)
+./dev/setup_env.sh
 
-.PHONY: clean
-clean: # Clean the local docs site.
-	dev/clean.sh
+# Using mkdocs serve with --dirty flag for even faster rebuilds
+# The --dirty flag means only changed files are rebuilt
+mkdocs serve --dirty --watch .
+

--- a/site/dev/setup_env.sh
+++ b/site/dev/setup_env.sh
@@ -27,3 +27,14 @@ install_deps
 pull_versioned_docs
 
 git show "${REMOTE}/main:../.asf.yaml" > docs/.asf.yaml
+
+# If running in dev mode, temporarily use the dev navigation file
+if [ "${ICEBERG_DEV_MODE:-false}" = "true" ]; then
+  echo " --> Using dev navigation (nav-dev.yml) for faster builds"
+  # Create a backup of the original nav.yml
+  if [ ! -f nav.yml.backup ]; then
+    cp nav.yml nav.yml.backup
+  fi
+  # Use the dev nav file
+  cp nav-dev.yml nav.yml
+fi

--- a/site/nav-dev.yml
+++ b/site/nav-dev.yml
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This is a development navigation configuration that only includes
+# nightly and latest documentation for faster build times during
+# iterative development. Use this with ICEBERG_DEV_MODE=true.
+
+nav:
+  - Home: index.md
+  - Quickstart:
+    - Spark: spark-quickstart.md
+    - Hive: hive-quickstart.md
+  - Docs:
+    - Java:
+      - Nightly: '!include docs/docs/nightly/mkdocs.yml'
+      - Latest (1.10.0): '!include docs/docs/latest/mkdocs.yml'
+    - Other Implementations:
+      - Python: https://py.iceberg.apache.org/
+      - Rust: https://rust.iceberg.apache.org/
+      - Go: https://go.iceberg.apache.org/
+      - C++: https://github.com/apache/iceberg-cpp/
+    - Third-party:
+      - Catalogs:
+        - Apache Gravitino: https://gravitino.apache.org/
+        - Apache Polaris: https://polaris.apache.org/
+        - Boring Catalog: https://github.com/boringdata/boring-catalog
+        - DataHub: https://docs.datahub.com/docs/iceberg-catalog
+        - Google BigLake metastore: https://cloud.google.com/bigquery/docs/blms-manage-resources
+        - Lakekeeper: https://github.com/lakekeeper/lakekeeper
+      - Integrations:
+        - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
+        - Amazon Data Firehose: https://docs.aws.amazon.com/firehose/latest/dev/apache-iceberg-destination.html
+        - Amazon EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
+        - Amazon Redshift: https://docs.aws.amazon.com/redshift/latest/dg/querying-iceberg.html
+        - Apache Amoro: integrations/amoro.md
+        - Apache Doris: https://doris.apache.org/docs/dev/lakehouse/catalogs/iceberg-catalog
+        - Apache Druid: https://druid.apache.org/docs/latest/development/extensions-contrib/iceberg/
+        - BladePipe: https://www.bladepipe.com/docs/dataMigrationAndSync/datasource_func/Iceberg/props_for_iceberg_ds
+        - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
+        - Daft: integrations/daft.md
+        - Databend: https://docs.databend.com/guides/access-data-lake/iceberg
+        - Dremio: https://docs.dremio.com/data-formats/apache-iceberg/
+        - DuckDB: https://duckdb.org/docs/preview/core_extensions/iceberg/overview
+        - Estuary: https://docs.estuary.dev/reference/Connectors/materialization-connectors/apache-iceberg/
+        - Firebolt: https://docs.firebolt.io/reference-sql/functions-reference/table-valued/read_iceberg
+        - Google BigQuery: https://cloud.google.com/bigquery/docs/iceberg-tables
+        - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
+        - Memiiso Debezium: https://memiiso.github.io/debezium-server-iceberg/
+        - Nimtable: https://github.com/nimtable/nimtable
+        - OLake: https://olake.io/docs
+        - Presto: https://prestodb.io/docs/current/connector/iceberg.html
+        - Redpanda: https://docs.redpanda.com/current/manage/iceberg/about-iceberg-topics
+        - RisingWave: integrations/risingwave.md
+        - Snowflake: https://docs.snowflake.com/en/user-guide/tables-iceberg
+        - Starburst: https://docs.starburst.io/latest/connector/iceberg.html
+        - Starrocks: https://docs.starrocks.io/en-us/latest/data_source/catalog/iceberg_catalog
+        - Tinybird: https://www.tinybird.co/docs/forward/get-data-in/table-functions/iceberg
+        - Trino: https://trino.io/docs/current/connector/iceberg.html
+  - Releases: releases.md
+  - Project:
+    - Contributing: contribute.md
+    - Multi-engine support: multi-engine-support.md
+    - How to release: how-to-release.md
+    - ASF:
+      - Sponsorship: https://www.apache.org/foundation/sponsorship.html
+      - Events: https://www.apache.org/events/current-event.html
+      - Privacy: https://privacy.apache.org/policies/privacy-policy-public.html
+      - License: https://www.apache.org/licenses/
+      - Security: https://www.apache.org/security/
+      - Sponsors: https://www.apache.org/foundation/sponsors.html
+  - Community:
+    - Community: community.md
+    - Talks: talks.md
+    - Vendors: vendors.md
+  - Specification:
+    - Terms: terms.md
+    - REST Catalog Spec: rest-catalog-spec.md
+    - Table Spec: spec.md
+    - View spec: view-spec.md
+    - Puffin spec: puffin-spec.md
+    - AES GCM Stream spec: gcm-stream-spec.md
+    - Implementation status: status.md
+


### PR DESCRIPTION
Every time we build the docs, the `mkdocs-monorepo-plugin` rebuilds all 14+ versioned documentation of projects even though these old versions never change. This makes iterative development very slow.

I created A development mode that only builds nightly and latest versions to make builds are fast. The production mode still builds all versions which means slow :) 

Based on my machine performance it makes 5x more faster. `--dirty` flag makes even faster iterative rebuilds

#### How to use 
***Dev Mod***
```shell
cd site
make serve-dev  # Only builds nightly + latest
```
***Full production mode***
```shell
cd site
make serve      # Builds all 14 versions (use before PRs)
```

Closes #14124 

cc @kevinjqliu @RussellSpitzer 