### PR TITLE
Core: Deprecate Namespace Joiner/Splitter and use separate methods

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -570,7 +570,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     Map<String, String> queryParams = Maps.newHashMap();
     if (!namespace.isEmpty()) {
-      queryParams.put("parent", RESTUtil.NAMESPACE_JOINER.join(namespace.levels()));
+      queryParams.put("parent", RESTUtil.namespaceToQueryParam(namespace));
     }
 
     ImmutableList.Builder<Namespace> namespaces = ImmutableList.builder();

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -32,12 +32,22 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class RESTUtil {
   private static final char NAMESPACE_SEPARATOR = '\u001f';
-  public static final Joiner NAMESPACE_JOINER = Joiner.on(NAMESPACE_SEPARATOR);
-  public static final Splitter NAMESPACE_SPLITTER = Splitter.on(NAMESPACE_SEPARATOR);
   private static final String NAMESPACE_ESCAPED_SEPARATOR = "%1F";
   private static final Joiner NAMESPACE_ESCAPED_JOINER = Joiner.on(NAMESPACE_ESCAPED_SEPARATOR);
   private static final Splitter NAMESPACE_ESCAPED_SPLITTER =
       Splitter.on(NAMESPACE_ESCAPED_SEPARATOR);
+
+  /**
+   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
+   *     RESTUtil#namespaceToQueryParam(Namespace)}} instead.
+   */
+  @Deprecated public static final Joiner NAMESPACE_JOINER = Joiner.on(NAMESPACE_SEPARATOR);
+
+  /**
+   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
+   *     RESTUtil#namespaceFromQueryParam(String)} instead.
+   */
+  @Deprecated public static final Splitter NAMESPACE_SPLITTER = Splitter.on(NAMESPACE_SEPARATOR);
 
   private RESTUtil() {}
 
@@ -158,6 +168,41 @@ public class RESTUtil {
   public static String decodeString(String encoded) {
     Preconditions.checkArgument(encoded != null, "Invalid string to decode: null");
     return URLDecoder.decode(encoded, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * This converts the given namespace to a string and separates each part in a multipart namespace
+   * using the unicode character '\u001f'. Note that this method is different from {@link
+   * RESTUtil#encodeNamespace(Namespace)}, which uses the UTF-8 escaped version of '\u001f', which
+   * is '0x1F'.
+   *
+   * <p>{@link #namespaceFromQueryParam(String)} should be used to convert the namespace string back
+   * to a {@link Namespace} instance.
+   *
+   * @param namespace The namespace to convert
+   * @return The namespace converted to a string where each part in a multipart namespace is
+   *     separated using the unicode character '\u001f'
+   */
+  public static String namespaceToQueryParam(Namespace namespace) {
+    Preconditions.checkArgument(null != namespace, "Invalid namespace: null");
+    return RESTUtil.NAMESPACE_JOINER.join(namespace.levels());
+  }
+
+  /**
+   * This converts a namespace where each part in a multipart namespace has been separated using
+   * '\u001f' to its original {@link Namespace} instance.
+   *
+   * <p>{@link #namespaceToQueryParam(Namespace)} should be used to convert the {@link Namespace} to
+   * a string.
+   *
+   * @param namespace The namespace to convert
+   * @return The namespace instance from the given namespace string, where each multipart separator
+   *     ('\u001f') is converted to a separate namespace level
+   */
+  public static Namespace namespaceFromQueryParam(String namespace) {
+    Preconditions.checkArgument(null != namespace, "Invalid namespace: null");
+    return Namespace.of(
+        RESTUtil.NAMESPACE_SPLITTER.splitToStream(namespace).toArray(String[]::new));
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -314,11 +314,7 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
         if (asNamespaceCatalog != null) {
           Namespace ns;
           if (vars.containsKey("parent")) {
-            ns =
-                Namespace.of(
-                    RESTUtil.NAMESPACE_SPLITTER
-                        .splitToStream(vars.get("parent"))
-                        .toArray(String[]::new));
+            ns = RESTUtil.namespaceFromQueryParam(vars.get("parent"));
           } else {
             ns = Namespace.empty();
           }


### PR DESCRIPTION
This revisits https://github.com/apache/iceberg/pull/10858 (which was reverted in https://github.com/apache/iceberg/pull/11574) and uses separate method to join/split a namespace using the unicode character \001f. We eventually want to make the namespace separator configurable and in order to do that, all namespace joining/splitting needs to go through respective methods instead of using the Joiner/Splitter directly