### PR TITLE
Core: Group binpack fileGroup by output partitionSpec

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -220,4 +220,30 @@ enum Dates implements Transform<Integer, Integer> {
   public String dedupName() {
     return "time";
   }
+
+  @Override
+  public Integer toSourceTypeValue(Type sourceType, Integer transformedValue) {
+    if (transformedValue == null) {
+      return null;
+    }
+
+    // Convert the transformed value back to days (start of the period)
+    switch (granularity) {
+      case YEARS:
+        // Convert years since epoch to days since epoch (start of the year)
+        return (int)
+            ChronoUnit.DAYS.between(
+                DateTimeUtil.EPOCH_DAY, DateTimeUtil.EPOCH_DAY.plusYears(transformedValue));
+      case MONTHS:
+        // Convert months since epoch to days since epoch (start of the month)
+        return (int)
+            ChronoUnit.DAYS.between(
+                DateTimeUtil.EPOCH_DAY, DateTimeUtil.EPOCH_DAY.plusMonths(transformedValue));
+      case DAYS:
+        // Already in days
+        return transformedValue;
+      default:
+        throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
+    }
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/Days.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Days.java
@@ -57,6 +57,24 @@ public class Days<T> extends TimeTransform<T> {
     return "day";
   }
 
+  @Override
+  @SuppressWarnings("unchecked")
+  public T toSourceTypeValue(Type sourceType, Integer days) {
+    if (days == null) {
+      return null;
+    }
+    // For DATE type, return the days value as-is
+    if (sourceType.typeId() == Type.TypeID.DATE) {
+      return (T) days;
+    }
+    // Convert days since epoch to micros/nanos since epoch (start of the day)
+    long micros = days * 24L * 3600L * 1_000_000L;
+    if (sourceType.typeId() == Type.TypeID.TIMESTAMP_NANO) {
+      return (T) (Long) (micros * 1000L);
+    }
+    return (T) (Long) micros;
+  }
+
   Object writeReplace() throws ObjectStreamException {
     return SerializationProxies.DaysTransformProxy.get();
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Hours.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Hours.java
@@ -63,6 +63,20 @@ public class Hours<T> extends TimeTransform<T> {
     return "hour";
   }
 
+  @Override
+  @SuppressWarnings("unchecked")
+  public T toSourceTypeValue(Type sourceType, Integer hours) {
+    if (hours == null) {
+      return null;
+    }
+    // Convert hours since epoch to micros/nanos since epoch (start of the hour)
+    long micros = hours * 3600L * 1_000_000L;
+    if (sourceType.typeId() == Type.TypeID.TIMESTAMP_NANO) {
+      return (T) (Long) (micros * 1000L);
+    }
+    return (T) (Long) micros;
+  }
+
   Object writeReplace() throws ObjectStreamException {
     return SerializationProxies.HoursTransformProxy.get();
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -183,6 +183,12 @@ class Identity<T> implements Transform<T, T> {
     return "identity";
   }
 
+  @Override
+  public T toSourceTypeValue(Type sourceType, T transformedValue) {
+    // Identity transform preserves the value as-is
+    return transformedValue;
+  }
+
   Object writeReplace() throws ObjectStreamException {
     return SerializationProxies.IdentityTransformProxy.get();
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Months.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Months.java
@@ -57,6 +57,32 @@ public class Months<T> extends TimeTransform<T> {
     return "month";
   }
 
+  @Override
+  @SuppressWarnings("unchecked")
+  public T toSourceTypeValue(Type sourceType, Integer months) {
+    if (months == null) {
+      return null;
+    }
+    // For DATE type, convert to days
+    if (sourceType.typeId() == Type.TypeID.DATE) {
+      return (T)
+          (Integer)
+              (int)
+                  ChronoUnit.DAYS.between(
+                      org.apache.iceberg.util.DateTimeUtil.EPOCH_DAY,
+                      org.apache.iceberg.util.DateTimeUtil.EPOCH_DAY.plusMonths(months));
+    }
+    // Convert months since epoch to micros/nanos since epoch (start of the month)
+    long micros =
+        ChronoUnit.MICROS.between(
+            org.apache.iceberg.util.DateTimeUtil.EPOCH,
+            org.apache.iceberg.util.DateTimeUtil.EPOCH.plusMonths(months));
+    if (sourceType.typeId() == Type.TypeID.TIMESTAMP_NANO) {
+      return (T) (Long) (micros * 1000L);
+    }
+    return (T) (Long) micros;
+  }
+
   Object writeReplace() throws ObjectStreamException {
     return SerializationProxies.MonthsTransformProxy.get();
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Transform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transform.java
@@ -102,6 +102,29 @@ public interface Transform<S, T> extends Serializable {
   }
 
   /**
+   * Converts a transformed partition value back to a representative source type value.
+   *
+   * <p>This method returns a source value that would produce the given transformed value when this
+   * transform is applied. For temporal transforms, this returns the start of the period (e.g.,
+   * start of hour, day, month, or year). For truncate transforms, this returns the truncated value
+   * as-is since it preserves the source type.
+   *
+   * <p>This is useful for chaining transforms when {@link #satisfiesOrderOf(Transform)} is true,
+   * allowing conversion from a finer granularity to a coarser one by converting back to source type
+   * and reapplying the coarser transform.
+   *
+   * @param sourceType the source type for this transform
+   * @param transformedValue the transformed partition value
+   * @return a source value that would produce this transformed value, or null if the input is null
+   * @throws UnsupportedOperationException if this transform does not support conversion back to
+   *     source type
+   */
+  default S toSourceTypeValue(Type sourceType, T transformedValue) {
+    throw new UnsupportedOperationException(
+        "toSourceTypeValue is not supported for " + this.getClass().getSimpleName());
+  }
+
+  /**
    * Transforms a {@link BoundPredicate predicate} to an inclusive predicate on the partition values
    * produced by the transform.
    *

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -161,6 +161,12 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
     return "truncate[" + width + "]";
   }
 
+  @Override
+  public T toSourceTypeValue(Type sourceType, T transformedValue) {
+    // Truncate preserves the source type, so just return the value
+    return transformedValue;
+  }
+
   private static class TruncateInteger extends Truncate<Integer>
       implements SerializableFunction<Integer, Integer> {
 

--- a/api/src/main/java/org/apache/iceberg/transforms/Years.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Years.java
@@ -57,6 +57,32 @@ class Years<T> extends TimeTransform<T> {
     return "year";
   }
 
+  @Override
+  @SuppressWarnings("unchecked")
+  public T toSourceTypeValue(Type sourceType, Integer years) {
+    if (years == null) {
+      return null;
+    }
+    // For DATE type, convert to days
+    if (sourceType.typeId() == Type.TypeID.DATE) {
+      return (T)
+          (Integer)
+              (int)
+                  ChronoUnit.DAYS.between(
+                      org.apache.iceberg.util.DateTimeUtil.EPOCH_DAY,
+                      org.apache.iceberg.util.DateTimeUtil.EPOCH_DAY.plusYears(years));
+    }
+    // Convert years since epoch to micros/nanos since epoch (start of the year)
+    long micros =
+        ChronoUnit.MICROS.between(
+            org.apache.iceberg.util.DateTimeUtil.EPOCH,
+            org.apache.iceberg.util.DateTimeUtil.EPOCH.plusYears(years));
+    if (sourceType.typeId() == Type.TypeID.TIMESTAMP_NANO) {
+      return (T) (Long) (micros * 1000L);
+    }
+    return (T) (Long) micros;
+  }
+
   Object writeReplace() throws ObjectStreamException {
     return SerializationProxies.YearsTransformProxy.get();
   }

--- a/core/src/test/java/org/apache/iceberg/util/TestPartitionUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPartitionUtil.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.UnaryOperator;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestPartitionUtil {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.IntegerType.get()),
+          required(2, "data", Types.StringType.get()),
+          required(3, "ts", Types.TimestampType.withoutZone()),
+          required(4, "category", Types.StringType.get()));
+
+  @Test
+  void testConvertPartitionFuncIdentity() {
+    // Test when source and output specs are the same
+    PartitionSpec spec =
+        PartitionSpec.builderFor(SCHEMA).identity("category").withSpecId(1).build();
+
+    UnaryOperator<StructLike> converter = PartitionUtil.convertPartitionFunc(spec, spec);
+    StructLike partition = Row.of("test");
+
+    StructLike result = converter.apply(partition);
+    assertThat(result).isSameAs(partition);
+  }
+
+  @Test
+  void testConvertPartitionFuncIdentityToIdentity() {
+    // Test converting between specs with same identity transform
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("category").withSpecId(1).build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("category").withSpecId(2).build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    StructLike sourcePartition = Row.of("test_value");
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, String.class)).isEqualTo("test_value");
+  }
+
+  @Test
+  void testConvertPartitionFuncHoursToDays() {
+    // Test converting hours to days
+    PartitionSpec sourceSpec = PartitionSpec.builderFor(SCHEMA).hour("ts").withSpecId(1).build();
+    PartitionSpec outputSpec = PartitionSpec.builderFor(SCHEMA).day("ts").withSpecId(2).build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    // 489100 hours since epoch = 2025-10-18-04
+    StructLike sourcePartition = Row.of(489100);
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, Integer.class)).isEqualTo(20379);
+  }
+
+  @Test
+  void testConvertPartitionFuncDaysToMonths() {
+    // Test converting days to months
+    PartitionSpec sourceSpec = PartitionSpec.builderFor(SCHEMA).day("ts").withSpecId(1).build();
+    PartitionSpec outputSpec = PartitionSpec.builderFor(SCHEMA).month("ts").withSpecId(2).build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    // 20379 days since epoch = 2025-10-18
+    StructLike sourcePartition = Row.of(20379);
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, Integer.class)).isEqualTo(669);
+  }
+
+  @Test
+  void testConvertPartitionFuncDaysToYears() {
+    // Test converting days to years
+    PartitionSpec sourceSpec = PartitionSpec.builderFor(SCHEMA).day("ts").withSpecId(1).build();
+    PartitionSpec outputSpec = PartitionSpec.builderFor(SCHEMA).year("ts").withSpecId(2).build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    // 20379 days since epoch = 2025-10-18
+    StructLike sourcePartition = Row.of(20379);
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, Integer.class)).isEqualTo(55);
+  }
+
+  @Test
+  void testConvertPartitionFuncTruncateString() {
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA).truncate("category", 10).withSpecId(1).build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA).truncate("category", 5).withSpecId(2).build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    StructLike sourcePartition = Row.of("1234567890");
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, String.class)).isEqualTo("12345");
+  }
+
+  @Test
+  void testConvertPartitionFuncTruncateInteger() {
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA).truncate("id", 10).withSpecId(1).build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA).truncate("id", 100).withSpecId(2).build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    StructLike sourcePartition = Row.of(123450);
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, Integer.class)).isEqualTo(123400);
+  }
+
+  @Test
+  void testConvertPartitionFuncWithNullValue() {
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("category").withSpecId(1).build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("category").withSpecId(2).build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    StructLike sourcePartition = Row.of((Object) null);
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, Object.class)).isNull();
+  }
+
+  @Test
+  void testConvertPartitionFuncMultipleFields() {
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA)
+            .identity("data")
+            .bucket("category", 16)
+            .withSpecId(1)
+            .build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA)
+            .identity("data")
+            .bucket("category", 16)
+            .withSpecId(2)
+            .build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    StructLike sourcePartition = Row.of("test", 5);
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, String.class)).isEqualTo("test");
+    assertThat(result.get(1, Integer.class)).isEqualTo(5);
+  }
+
+  @Test
+  void testConvertPartitionFuncSubsetOfFields() {
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("category").hour("ts").withSpecId(1).build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("category").withSpecId(2).build();
+
+    UnaryOperator<StructLike> converter =
+        PartitionUtil.convertPartitionFunc(sourceSpec, outputSpec);
+    StructLike sourcePartition = Row.of("test", 5);
+
+    StructLike result = converter.apply(sourcePartition);
+    assertThat(result.get(0, String.class)).isEqualTo("test");
+  }
+
+  @Test
+  void testNoRepartitionNeededIdentity() {
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("data").withSpecId(1).build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("data").withSpecId(2).build();
+
+    assertThat(PartitionUtil.needRepartition(sourceSpec, outputSpec)).isFalse();
+  }
+
+  @Test
+  void testNoRepartitionNeededTimeTransforms() {
+    PartitionSpec sourceSpec = PartitionSpec.builderFor(SCHEMA).hour("ts").withSpecId(1).build();
+    PartitionSpec outputSpec = PartitionSpec.builderFor(SCHEMA).day("ts").withSpecId(2).build();
+
+    assertThat(PartitionUtil.needRepartition(sourceSpec, outputSpec)).isFalse();
+  }
+
+  @Test
+  void testNoRepartitionNeededTruncateString() {
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA).truncate("category", 10).withSpecId(1).build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA).truncate("category", 5).withSpecId(2).build();
+
+    assertThat(PartitionUtil.needRepartition(sourceSpec, outputSpec)).isFalse();
+  }
+
+  @Test
+  void testNeedRepartitionMissingSourceField() {
+    PartitionSpec sourceSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("data").withSpecId(1).build();
+    PartitionSpec outputSpec =
+        PartitionSpec.builderFor(SCHEMA).identity("category").withSpecId(2).build();
+
+    assertThat(PartitionUtil.needRepartition(sourceSpec, outputSpec)).isTrue();
+  }
+
+  @Test
+  void testNeedRepartitionIncompatibleTransforms() {
+    PartitionSpec sourceSpec = PartitionSpec.builderFor(SCHEMA).day("ts").withSpecId(1).build();
+    PartitionSpec outputSpec = PartitionSpec.builderFor(SCHEMA).hour("ts").withSpecId(2).build();
+
+    // Can't convert from coarser (day) to finer (hour) granularity
+    assertThat(PartitionUtil.needRepartition(sourceSpec, outputSpec)).isTrue();
+  }
+}

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackFileRewriteRunner.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackFileRewriteRunner.java
@@ -23,6 +23,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.util.PartitionUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -65,7 +66,8 @@ class SparkBinPackFileRewriteRunner extends SparkDataFileRewriteRunner {
   // invoke a shuffle if the original spec does not match the output spec
   private DistributionMode distributionMode(RewriteFileGroup group) {
     boolean requiresRepartition =
-        !group.fileScanTasks().get(0).spec().equals(spec(group.outputSpecId()));
+        PartitionUtil.needRepartition(
+            group.fileScanTasks().get(0).spec(), spec(group.outputSpecId()));
     return requiresRepartition ? DistributionMode.RANGE : DistributionMode.NONE;
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackFileRewriteRunner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackFileRewriteRunner.java
@@ -23,6 +23,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.util.PartitionUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -65,7 +66,8 @@ class SparkBinPackFileRewriteRunner extends SparkDataFileRewriteRunner {
   // invoke a shuffle if the original spec does not match the output spec
   private DistributionMode distributionMode(RewriteFileGroup group) {
     boolean requiresRepartition =
-        !group.fileScanTasks().get(0).spec().equals(spec(group.outputSpecId()));
+        PartitionUtil.needRepartition(
+            group.fileScanTasks().get(0).spec(), spec(group.outputSpecId()));
     return requiresRepartition ? DistributionMode.RANGE : DistributionMode.NONE;
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackFileRewriteRunner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackFileRewriteRunner.java
@@ -23,6 +23,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.util.PartitionUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -65,7 +66,9 @@ class SparkBinPackFileRewriteRunner extends SparkDataFileRewriteRunner {
   // invoke a shuffle if the original spec does not match the output spec
   private DistributionMode distributionMode(RewriteFileGroup group) {
     boolean requiresRepartition =
-        !group.fileScanTasks().get(0).spec().equals(spec(group.outputSpecId()));
+        PartitionUtil.needRepartition(
+            group.fileScanTasks().get(0).spec(), spec(group.outputSpecId()));
+
     return requiresRepartition ? DistributionMode.RANGE : DistributionMode.NONE;
   }
 }


### PR DESCRIPTION
Iceberg 1.8+ introduces support in `rewrite_data_files` for writing to an output spec that differs from the table’s current partition spec.

In our use case, the current table is partitioned by event/date/hour/batchId, where `batchId` serves as a work unit identifier. To address the small files problem, we want to roll up mature data to a coarser partition layout (event/date). This feature enables an efficient in-table rollup.

We observed two issues:

1. Files are grouped by the current table’s partition spec, which places each small file into its own group — effectively preventing any bin-packing.
2. When running `rewrite_data_files` again, because the files no longer conform to the table’s current output partition spec, Spark places all files into a single group, causing a large and unnecessary shuffle.

This patch resolves the issue by grouping files according to the *output* partition spec instead. As an additional benefit, when the output spec is only partially compatible with the current one, the grouping logic will still align on shared partitions — for example, when rolling up from event/date/hour to event/server/date, it will group data primarily by event/date.