### PR TITLE
Docs: Mention Hive 4.1

### DIFF
--- a/docs/docs/hive.md
+++ b/docs/docs/hive.md
@@ -72,6 +72,10 @@ Starting from 1.8.0 Iceberg doesn't release Hive runtime connector. For Hive que
 with Hive 2.x and 3.x) use Hive runtime connector coming with Iceberg 1.6.1, or use Hive 4.0.0 or later
 which is released with embedded Iceberg integration.
 
+### Hive 4.1.x
+
+Hive 4.1.x comes with Iceberg 1.9.1 included.
+
 ### Hive 4.0.x
 
 Hive 4.0.x comes with Iceberg 1.4.3 included.


### PR DESCRIPTION
We have released Apache Hive 4.1.0, with Iceberg 1.9.1.
https://github.com/apache/hive/blob/rel/release-4.1.0/iceberg/pom.xml#L29