### PR TITLE
Hive: Assume the minimum Hive version = 2

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -380,7 +380,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
     if (hiveLockEnabled(metadata, conf)) {
       return new MetastoreLock(conf, metaClients, catalogName, database, tableName);
     } else {
-      return new NoLock();
+      return NoLock.get();
     }
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveVersion.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveVersion.java
@@ -26,7 +26,6 @@ public enum HiveVersion {
   HIVE_4(4),
   HIVE_3(3),
   HIVE_2(2),
-  HIVE_1_2(1),
   NOT_SUPPORTED(0);
 
   private final int order;
@@ -54,12 +53,6 @@ public enum HiveVersion {
         return HIVE_3;
       case "2":
         return HIVE_2;
-      case "1":
-        if (versions.get(1).equals("2")) {
-          return HIVE_1_2;
-        } else {
-          return NOT_SUPPORTED;
-        }
       default:
         return NOT_SUPPORTED;
     }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -325,7 +325,7 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
     if (hiveLockEnabled(conf)) {
       return new MetastoreLock(conf, metaClients, catalogName, database, viewName);
     } else {
-      return new NoLock();
+      return NoLock.get();
     }
   }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/NoLock.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/NoLock.java
@@ -18,22 +18,22 @@
  */
 package org.apache.iceberg.hive;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
 public class NoLock implements HiveLock {
-  public NoLock() {
-    Preconditions.checkArgument(
-        HiveVersion.min(HiveVersion.HIVE_2),
-        "Minimally Hive 2 HMS client is needed to use HIVE-26882 based locking");
+  private static final NoLock INSTANCE = new NoLock();
+
+  public static NoLock get() {
+    return INSTANCE;
   }
 
+  private NoLock() {}
+
   @Override
-  public void lock() throws LockException {
+  public void lock() {
     // no-op
   }
 
   @Override
-  public void ensureActive() throws LockException {
+  public void ensureActive() {
     // no-op
   }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -336,7 +336,7 @@ public class TestHiveCommits extends HiveTableTestBase {
     HiveTableOperations spyOps = spy(ops);
 
     // Sets NoLock
-    doReturn(new NoLock()).when(spyOps).lockObject(any());
+    doReturn(NoLock.get()).when(spyOps).lockObject(any());
 
     // Simulate a concurrent table modification error
     doThrow(

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -375,7 +375,7 @@ public class TestHiveViewCommits {
     HiveViewOperations spyOps = spy(ops);
 
     // Sets NoLock
-    doReturn(new NoLock()).when(spyOps).lockObject();
+    doReturn(NoLock.get()).when(spyOps).lockObject();
 
     // Simulate a concurrent view modification error
     doThrow(


### PR DESCRIPTION
I assume the Iceberg community dropped Hive 1.2 support([the Hive community also EOLed 1.2 in April 2024](https://lists.apache.org/thread/z9hgsp01rcb7q94o4yv7vbccwo5vf924)).
- https://iceberg.apache.org/docs/latest/hive/
- https://iceberg.apache.org/multi-engine-support/

The current implementation has some conditions or assertions that verify the Hive version is 2 or newer for locking features. I presume we can safely remove them and simplify the codebase.