### PR TITLE
Docs: recommendation for packaging uberjars

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Iceberg table support is organized in library modules:
 
 Iceberg also has modules for adding Iceberg support to processing engines:
 
-* `iceberg-spark` is an implementation of Spark's Datasource V2 API for Iceberg with submodules for each spark versions (use runtime jars for a shaded version to avoid dependency conflicts, see [the documentation](https://iceberg.apache.org/multi-engine-support/#runtime-jar))
-* `iceberg-flink` contains classes for integrating with Apache Flink (use iceberg-flink-runtime for a shaded version, see [the documentation](https://iceberg.apache.org/multi-engine-support/#runtime-jar))
+* `iceberg-spark` is an implementation of Spark's Datasource V2 API for Iceberg with submodules for each spark versions (use [runtime jars](https://iceberg.apache.org/multi-engine-support/#runtime-jar) for a shaded version to avoid dependency conflicts)
+* `iceberg-flink` contains classes for integrating with Apache Flink (use [iceberg-flink-runtime](https://iceberg.apache.org/multi-engine-support/#runtime-jar) for a shaded version)
 * `iceberg-mr` contains an InputFormat and other classes for integrating with Apache Hive
 
 ---

--- a/site/docs/multi-engine-support.md
+++ b/site/docs/multi-engine-support.md
@@ -44,7 +44,7 @@ For example, to use Iceberg with Spark 3.5 and AWS integrations, `iceberg-spark-
 
 > ℹ️ It's important to make sure that only the runtime jars (plus storage specific bundles if needed, eg. `iceberg-aws-bundle` or `iceberg-gcp-bundle`) are included in the runtime classpath.
 > All other modules should be excluded as they may introduce dependency version conflicts with engine runtimes.
-> For example, when packaging uberjar for a Spark application, we should include `iceberg-spark-runtime` and exclude modules such as `iceberg-core` or `iceberg-parquet`.
+> For example, when packaging an uberjar for a Spark application, only include `iceberg-spark-runtime` and exclude modules such as `iceberg-core` or `iceberg-parquet`.
 
 Spark and Flink provide different runtime jars for each supported engine version.
 Hive 2 and Hive 3 currently share the same runtime jar.


### PR DESCRIPTION
Sometimes iceberg may use verisons of parquet, avro, or other libs that are incompatible with what's deployed in engine runtime. Users should package only iceberg-spark-runtime (it provides shaded transitive deps) into the uberjar to avoid such issue.
Highlight this in the site docs.
Close #14232