### PR TITLE
Spark: Faster net changelogs using identifier columns

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/ComputeNetUpdateIterator.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/ComputeNetUpdateIterator.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.Iterator;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * An iterator that computes net changes across multiple snapshots by combining the first and last
+ * change for each logical row.
+ *
+ * <p>This iterator produces a single operation per logical row:
+ *
+ * <ul>
+ *   <li>INSERT: row was inserted and not deleted
+ *   <li>DELETE: row was deleted and not reinserted
+ *   <li>UPDATE_BEFORE/UPDATE_AFTER: row was modified (tracks first DELETE and last INSERT)
+ * </ul>
+ *
+ * <p>When processing multiple changes for the same logical row:
+ *
+ * <ul>
+ *   <li>Multiple DELETEs: only the first is kept
+ *   <li>Multiple INSERTs: only the last is kept
+ *   <li>DELETE then INSERT: converted to UPDATE_BEFORE and UPDATE_AFTER
+ * </ul>
+ */
+public class ComputeNetUpdateIterator extends ComputeUpdateIterator {
+
+  private Row cachedUpdateRow = null;
+  private Row cachedRow = null;
+
+  ComputeNetUpdateIterator(
+      Iterator<Row> rowIterator, StructType rowType, String[] identifierFields) {
+    super(rowIterator, rowType, identifierFields);
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (cachedUpdateRow != null || cachedRow != null) {
+      return true;
+    }
+    return rowIterator().hasNext();
+  }
+
+  @Override
+  public Row next() {
+    if (cachedUpdateRow != null) {
+      Row row = cachedUpdateRow;
+      cachedUpdateRow = null;
+      return row;
+    }
+
+    ChangeAccumulator accumulator = processLogicalRowGroup(currentRow());
+    cachedRow = accumulator.nextRow;
+
+    return buildResultRow(accumulator);
+  }
+
+  private ChangeAccumulator processLogicalRowGroup(Row currentRow) {
+    Row firstDelete = changeType(currentRow).equals(DELETE) ? currentRow : null;
+    Row lastInsert = changeType(currentRow).equals(INSERT) ? currentRow : null;
+
+    while (rowIterator().hasNext()) {
+      Row nextRow = rowIterator().next();
+      if (!sameLogicalRow(currentRow, nextRow)) {
+        return new ChangeAccumulator(firstDelete, lastInsert, nextRow);
+      }
+
+      if (firstDelete == null && changeType(nextRow).equals(DELETE)) {
+        firstDelete = nextRow;
+      }
+      if (changeType(nextRow).equals(INSERT)) {
+        lastInsert = nextRow;
+      }
+    }
+
+    return new ChangeAccumulator(firstDelete, lastInsert);
+  }
+
+  private Row currentRow() {
+    if (cachedRow != null) {
+      Row row = cachedRow;
+      cachedRow = null;
+      return row;
+    } else {
+      return rowIterator().next();
+    }
+  }
+
+  private Row buildResultRow(ChangeAccumulator accumulator) {
+    if (accumulator.firstDelete != null && accumulator.lastInsert != null) {
+      cachedUpdateRow = modify(accumulator.lastInsert, changeTypeIndex(), UPDATE_AFTER);
+      return modify(accumulator.firstDelete, changeTypeIndex(), UPDATE_BEFORE);
+    } else if (accumulator.firstDelete != null) {
+      return accumulator.firstDelete;
+    } else {
+      return accumulator.lastInsert;
+    }
+  }
+
+  /**
+   * Container for accumulated changes and the next row from a different logical group.
+   *
+   * <p>Stores the first DELETE and last INSERT for a logical row, plus the next row that belongs to
+   * a different logical group (used for look-ahead caching).
+   */
+  private static class ChangeAccumulator {
+    private final Row firstDelete;
+    private final Row lastInsert;
+    private final Row nextRow;
+
+    ChangeAccumulator(Row firstDelete, Row lastInsert) {
+      this.firstDelete = firstDelete;
+      this.lastInsert = lastInsert;
+      this.nextRow = null;
+    }
+
+    ChangeAccumulator(Row firstDelete, Row lastInsert, Row nextRow) {
+      this.firstDelete = firstDelete;
+      this.lastInsert = lastInsert;
+      this.nextRow = nextRow;
+    }
+  }
+}

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/ComputeUpdateIterator.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/ComputeUpdateIterator.java
@@ -100,7 +100,7 @@ public class ComputeUpdateIterator extends ChangelogIterator {
     return currentRow;
   }
 
-  private Row modify(Row row, int valueIndex, Object value) {
+  protected Row modify(Row row, int valueIndex, Object value) {
     if (row instanceof GenericRow) {
       GenericRow genericRow = (GenericRow) row;
       genericRow.values()[valueIndex] = value;
@@ -115,6 +115,15 @@ public class ComputeUpdateIterator extends ChangelogIterator {
     }
   }
 
+  protected boolean sameLogicalRow(Row currentRow, Row nextRow) {
+    for (int idx : identifierFieldIdx) {
+      if (isDifferentValue(currentRow, nextRow, idx)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private boolean cachedUpdateRecord() {
     return cachedRow != null && changeType(cachedRow).equals(UPDATE_AFTER);
   }
@@ -127,14 +136,5 @@ public class ComputeUpdateIterator extends ChangelogIterator {
     } else {
       return rowIterator().next();
     }
-  }
-
-  private boolean sameLogicalRow(Row currentRow, Row nextRow) {
-    for (int idx : identifierFieldIdx) {
-      if (isDifferentValue(currentRow, nextRow, idx)) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/RemoveNoopPairIterator.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/RemoveNoopPairIterator.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * This class computes the net changes across multiple snapshots. It is different from {@link
+ * RemoveNetCarryoverIterator}, which only nets changes across the "same" row. Here we net changes
+ * based on the identifier columns when an INSERT is immediately followed by a DELETE (even if it's
+ * across different snapshots). It takes a row iterator, and assumes the following:
+ *
+ * <ul>
+ *   <li>The row iterator is partitioned by identifier fields.
+ *   <li>The row iterator is sorted by identifier fields, change order, and change type. The change
+ *       order is 1-to-1 mapping to snapshot id.
+ * </ul>
+ */
+public class RemoveNoopPairIterator extends ChangelogIterator {
+
+  private final List<Integer> identifierFieldIdx;
+
+  private Row cachedRow;
+
+  public RemoveNoopPairIterator(
+      Iterator<Row> rowIterator, StructType rowType, String[] identifierFields) {
+    super(rowIterator, rowType);
+    this.identifierFieldIdx =
+        Arrays.stream(identifierFields).map(rowType::fieldIndex).collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean hasNext() {
+    return cachedRow != null || rowIterator().hasNext();
+  }
+
+  @Override
+  public Row next() {
+    if (cachedRow == null) {
+      cachedRow = rowIterator().next();
+    }
+
+    // Early return in case of DELETE change type.
+    if (changeType(cachedRow).equals(DELETE) || !rowIterator().hasNext()) {
+      Row prevCachedRow = cachedRow;
+      cachedRow = null;
+      return prevCachedRow;
+    }
+
+    Row nextRow = rowIterator().next();
+    if (!sameLogicalRow(cachedRow, nextRow) || changeType(nextRow).equals(INSERT)) {
+      Row prevCachedRow = cachedRow;
+      cachedRow = nextRow;
+      return prevCachedRow;
+    }
+
+    cachedRow = null;
+    return null;
+  }
+
+  private boolean sameLogicalRow(Row currentRow, Row nextRow) {
+    for (int idx : identifierFieldIdx) {
+      if (isDifferentValue(currentRow, nextRow, idx)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/ChangelogRowBuilder.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/ChangelogRowBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.iceberg.ChangelogOperation;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public class ChangelogRowBuilder {
+  private static final StructType SCHEMA =
+      new StructType(
+          new StructField[] {
+            new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField("name", DataTypes.StringType, true, Metadata.empty()),
+            new StructField("data", DataTypes.StringType, true, Metadata.empty()),
+            new StructField(
+                MetadataColumns.CHANGE_TYPE.name(), DataTypes.StringType, false, Metadata.empty()),
+            new StructField(
+                MetadataColumns.CHANGE_ORDINAL.name(),
+                DataTypes.IntegerType,
+                false,
+                Metadata.empty()),
+            new StructField(
+                MetadataColumns.COMMIT_SNAPSHOT_ID.name(),
+                DataTypes.LongType,
+                false,
+                Metadata.empty())
+          });
+
+  private final List<Object[]> rows = Lists.newArrayList();
+
+  public ChangelogRowBuilder insert(int id, String name, String data, int ordinal, long snapshot) {
+    return add(id, name, data, ChangelogOperation.INSERT, ordinal, snapshot);
+  }
+
+  public ChangelogRowBuilder delete(int id, String name, String data, int ordinal, long snapshot) {
+    return add(id, name, data, ChangelogOperation.DELETE, ordinal, snapshot);
+  }
+
+  public ChangelogRowBuilder updateBefore(
+      int id, String name, String data, int ordinal, long snapshot) {
+    return add(id, name, data, ChangelogOperation.UPDATE_BEFORE, ordinal, snapshot);
+  }
+
+  public ChangelogRowBuilder updateAfter(
+      int id, String name, String data, int ordinal, long snapshot) {
+    return add(id, name, data, ChangelogOperation.UPDATE_AFTER, ordinal, snapshot);
+  }
+
+  private ChangelogRowBuilder add(
+      int id, String name, String data, ChangelogOperation op, int ordinal, long snapshot) {
+    rows.add(new Object[] {id, name, data, op.name(), ordinal, snapshot});
+    return this;
+  }
+
+  public List<Row> buildRows() {
+    return rows.stream()
+        .map(row -> new GenericRowWithSchema(row, SCHEMA))
+        .collect(Collectors.toList());
+  }
+
+  public List<Object[]> build() {
+    return rows;
+  }
+
+  public static StructType schema() {
+    return SCHEMA;
+  }
+}

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestComputeNetUpdateIterator.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestComputeNetUpdateIterator.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.Iterator;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+public class TestComputeNetUpdateIterator extends SparkTestHelperBase {
+  private static final String[] IDENTIFIER_FIELDS = new String[] {"id", "name"};
+
+  @Test
+  public void testMultipleInsertsTakesLast() {
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .insert(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .buildRows();
+
+    List<Object[]> expected = new ChangelogRowBuilder().insert(1, "a", "data2", 2, 2L).build();
+
+    validateNetUpdates(rows, expected, ChangelogRowBuilder.schema());
+  }
+
+  @Test
+  public void testMultipleDeletesTakesFirst() {
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data", 1, 1L)
+            .delete(1, "a", "data", 2, 2L)
+            .buildRows();
+
+    List<Object[]> expected = new ChangelogRowBuilder().delete(1, "a", "data", 1, 1L).build();
+
+    validateNetUpdates(rows, expected, ChangelogRowBuilder.schema());
+  }
+
+  @Test
+  public void testDeleteThenInsertBecomesUpdate() {
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .buildRows();
+
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data2", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected, ChangelogRowBuilder.schema());
+  }
+
+  @Test
+  public void testInsertThenDeleteIsNoOp() {
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data", 1, 1L)
+            .insert(1, "a", "data1", 1, 1L)
+            .delete(1, "a", "data2", 3, 3L)
+            .insert(1, "a", "data3", 3, 3L)
+            .buildRows();
+
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data", 1, 1L)
+            .updateAfter(1, "a", "data3", 3, 3L)
+            .build();
+
+    validateNetUpdates(rows, expected, ChangelogRowBuilder.schema());
+  }
+
+  @Test
+  public void testMultipleChangesWithFirstDeleteLastInsert() {
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 1, 1L)
+            .delete(1, "a", "data2", 2, 2L)
+            .insert(1, "a", "data3", 2, 2L)
+            .buildRows();
+
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data3", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected, ChangelogRowBuilder.schema());
+  }
+
+  @Test
+  public void testMultipleKeys() {
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .insert(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .delete(2, "b", "data", 1, 1L)
+            .delete(2, "b", "data", 2, 2L)
+            .delete(3, "c", "data1", 1, 1L)
+            .insert(3, "c", "data2", 2, 2L)
+            .insert(4, "d", "data", 1, 1L)
+            .delete(4, "d", "data", 2, 2L)
+            .buildRows();
+
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .insert(1, "a", "data2", 2, 2L)
+            .delete(2, "b", "data", 1, 1L)
+            .updateBefore(3, "c", "data1", 1, 1L)
+            .updateAfter(3, "c", "data2", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected, ChangelogRowBuilder.schema());
+  }
+
+  @Test
+  public void testWithNullIdentifiers() {
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .delete(2, null, "data1", 1, 1L)
+            .insert(2, null, "data2", 2, 2L)
+            .delete(3, null, "data1", 1, 1L)
+            .insert(3, "c", "data2", 2, 2L)
+            .buildRows();
+
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data2", 2, 2L)
+            .updateBefore(2, null, "data1", 1, 1L)
+            .updateAfter(2, null, "data2", 2, 2L)
+            .delete(3, null, "data1", 1, 1L)
+            .insert(3, "c", "data2", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected, ChangelogRowBuilder.schema());
+  }
+
+  private void validateNetUpdates(
+      List<Row> rows, List<Object[]> expected, org.apache.spark.sql.types.StructType schema) {
+    Iterator<Row> iterator =
+        ChangelogIterator.computeNetUpdates(rows.iterator(), schema, IDENTIFIER_FIELDS);
+    List<Row> result = Lists.newArrayList(iterator);
+
+    assertEquals("Rows should match", expected, rowsToJava(result));
+  }
+}

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestNetUpdateChangelogIterator.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestNetUpdateChangelogIterator.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.Iterator;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the net update computation across multiple snapshots. This tests the logic used by
+ * computeNetUpdateImage method which filters rows to first and last changes per identifier group,
+ * then computes net updates.
+ */
+public class TestNetUpdateChangelogIterator extends SparkTestHelperBase {
+  private static final String[] IDENTIFIER_FIELDS = new String[] {"id", "name"};
+
+  @Test
+  public void testSimpleInsert() {
+    // Single insert operation across snapshots
+    List<Row> rows = new ChangelogRowBuilder().insert(1, "a", "data1", 1, 1L).buildRows();
+    List<Object[]> expected = new ChangelogRowBuilder().insert(1, "a", "data1", 1, 1L).build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testSimpleDelete() {
+    // Single delete operation across snapshots
+    List<Row> rows = new ChangelogRowBuilder().delete(1, "a", "data1", 1, 1L).buildRows();
+    List<Object[]> expected = new ChangelogRowBuilder().delete(1, "a", "data1", 1, 1L).build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testInsertThenDelete() {
+    // Insert in one snapshot, delete in another => no-op (row never existed long-term)
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .insert(1, "a", "data1", 1, 1L)
+            .delete(1, "a", "data1", 2, 2L)
+            .buildRows();
+    List<Object[]> expected = Lists.newArrayList();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testDeleteThenInsert() {
+    // Delete in one snapshot, insert in another => UPDATE (row changed)
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data2", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testMultipleInsertsAcrossSnapshots() {
+    // Multiple inserts across snapshots, only last one matters
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .insert(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .insert(1, "a", "data3", 3, 3L)
+            .buildRows();
+    List<Object[]> expected = new ChangelogRowBuilder().insert(1, "a", "data3", 3, 3L).build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testMultipleDeletesAcrossSnapshots() {
+    // Multiple deletes across snapshots, only first one matters
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .delete(1, "a", "data1", 2, 2L)
+            .delete(1, "a", "data1", 3, 3L)
+            .buildRows();
+    List<Object[]> expected = new ChangelogRowBuilder().delete(1, "a", "data1", 1, 1L).build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testDeleteInsertDeleteAcrossSnapshots() {
+    // Delete -> Insert -> Delete => net result is DELETE (first one)
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .delete(1, "a", "data2", 3, 3L)
+            .buildRows();
+    List<Object[]> expected = new ChangelogRowBuilder().delete(1, "a", "data1", 1, 1L).build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testInsertDeleteInsertAcrossSnapshots() {
+    // Insert -> Delete -> Insert => net result is last INSERT
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .insert(1, "a", "data1", 1, 1L)
+            .delete(1, "a", "data1", 2, 2L)
+            .insert(1, "a", "data2", 3, 3L)
+            .buildRows();
+    List<Object[]> expected = new ChangelogRowBuilder().insert(1, "a", "data2", 3, 3L).build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testComplexUpdateSequence() {
+    // Delete -> Insert -> Delete -> Insert => UPDATE (first DELETE to last INSERT)
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .delete(1, "a", "data2", 3, 3L)
+            .insert(1, "a", "data3", 4, 4L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data3", 4, 4L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testMultipleRowsDifferentIdentifiers() {
+    // Multiple rows with different identifiers processed independently
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            // Row 1: Insert -> Delete => no-op
+            .insert(1, "a", "data1", 1, 1L)
+            .delete(1, "a", "data1", 2, 2L)
+            // Row 2: Delete -> Insert => UPDATE
+            .delete(2, "b", "data1", 1, 1L)
+            .insert(2, "b", "data2", 2, 2L)
+            // Row 3: Just INSERT
+            .insert(3, "c", "data1", 1, 1L)
+            // Row 4: Just DELETE
+            .delete(4, "d", "data1", 1, 1L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            // Row 1: no-op (not included)
+            // Row 2: UPDATE
+            .updateBefore(2, "b", "data1", 1, 1L)
+            .updateAfter(2, "b", "data2", 2, 2L)
+            // Row 3: INSERT
+            .insert(3, "c", "data1", 1, 1L)
+            // Row 4: DELETE
+            .delete(4, "d", "data1", 1, 1L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testSameIdentifierDifferentData() {
+    // Row with same identifier but data changes across snapshots
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 1, 1L)
+            .delete(1, "a", "data2", 2, 2L)
+            .insert(1, "a", "data3", 2, 2L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data3", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testMultipleOperationsSameOrdinal() {
+    // Multiple operations at the same ordinal (same snapshot, different files)
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 1, 1L)
+            .delete(1, "a", "data2", 1, 1L)
+            .insert(1, "a", "data3", 1, 1L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data3", 1, 1L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testNullValuesInData() {
+    // Test with null values in non-identifier columns
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", null, 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", null, 1, 1L)
+            .updateAfter(1, "a", "data2", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testNullValuesInIdentifierColumns() {
+    // Test with null values in identifier columns
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            // Row 1: null name identifier
+            .delete(1, null, "data1", 1, 1L)
+            .insert(1, null, "data2", 2, 2L)
+            // Row 2: different null identifier (different id)
+            .insert(2, null, "data3", 1, 1L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            // Row 1: UPDATE (same identifier including null)
+            .updateBefore(1, null, "data1", 1, 1L)
+            .updateAfter(1, null, "data2", 2, 2L)
+            // Row 2: INSERT
+            .insert(2, null, "data3", 1, 1L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testCarryoverRowsRemoved() {
+    // Carryover rows (DELETE + INSERT with same data at same ordinal) should be removed first
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            // Carryover at ordinal 1 (should be filtered out before net update computation)
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data1", 1, 1L)
+            // Real change at ordinal 2
+            .delete(1, "a", "data1", 2, 2L)
+            .insert(1, "a", "data2", 2, 2L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data2", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testLongSequenceOfChanges() {
+    // Long sequence of changes: only first and last matter
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "v1", 1, 1L)
+            .insert(1, "a", "v2", 2, 2L)
+            .delete(1, "a", "v2", 3, 3L)
+            .insert(1, "a", "v3", 4, 4L)
+            .delete(1, "a", "v3", 5, 5L)
+            .insert(1, "a", "v4", 6, 6L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "v1", 1, 1L)
+            .updateAfter(1, "a", "v4", 6, 6L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testMixedIdentifierTypes() {
+    // Test with different identifier values to ensure proper grouping
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            // Group 1: (id=1, name="a")
+            .delete(1, "a", "data1", 1, 1L)
+            .insert(1, "a", "data2", 2, 2L)
+            // Group 2: (id=1, name="b") - different name, different group
+            .insert(1, "b", "data3", 1, 1L)
+            .delete(1, "b", "data3", 2, 2L)
+            // Group 3: (id=2, name="a") - different id, different group
+            .insert(2, "a", "data4", 1, 1L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            // Group 1: UPDATE
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data2", 2, 2L)
+            // Group 2: no-op (not included)
+            // Group 3: INSERT
+            .insert(2, "a", "data4", 1, 1L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testMultipleUpdatesInSequence() {
+    // Multiple deletes followed by multiple inserts
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            .delete(1, "a", "data1", 1, 1L)
+            .delete(1, "a", "data1", 2, 2L)
+            .insert(1, "a", "data2", 3, 3L)
+            .insert(1, "a", "data3", 4, 4L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .updateBefore(1, "a", "data1", 1, 1L)
+            .updateAfter(1, "a", "data3", 4, 4L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  @Test
+  public void testAllOperationTypes() {
+    // Comprehensive test with all operation types across multiple rows
+    List<Row> rows =
+        new ChangelogRowBuilder()
+            // Row 1: Pure insert
+            .insert(1, "pure_insert", "data", 1, 1L)
+            // Row 2: Pure delete
+            .delete(2, "pure_delete", "data", 1, 1L)
+            // Row 3: Insert then delete (no-op)
+            .insert(3, "temp_insert", "data", 1, 1L)
+            .delete(3, "temp_insert", "data", 2, 2L)
+            // Row 4: Update
+            .delete(4, "updated", "old", 1, 1L)
+            .insert(4, "updated", "new", 2, 2L)
+            .buildRows();
+    List<Object[]> expected =
+        new ChangelogRowBuilder()
+            .insert(1, "pure_insert", "data", 1, 1L)
+            .delete(2, "pure_delete", "data", 1, 1L)
+            // Row 3 is no-op (not included)
+            .updateBefore(4, "updated", "old", 1, 1L)
+            .updateAfter(4, "updated", "new", 2, 2L)
+            .build();
+
+    validateNetUpdates(rows, expected);
+  }
+
+  private void validateNetUpdates(List<Row> rows, List<Object[]> expected) {
+    ChangelogRowBuilder schemaBuilder = new ChangelogRowBuilder();
+    Iterator<Row> iterator =
+        ChangelogIterator.computeNetUpdates(
+            rows.iterator(), schemaBuilder.schema(), IDENTIFIER_FIELDS);
+    List<Row> result = Lists.newArrayList(iterator);
+
+    assertEquals("Rows should match", expected, rowsToJava(result));
+  }
+}

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestRemoveNoopPairIterator.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestRemoveNoopPairIterator.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.Iterator;
+import java.util.List;
+import org.apache.iceberg.ChangelogOperation;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+public class TestRemoveNoopPairIterator extends SparkTestHelperBase {
+  private static final String DELETE = ChangelogOperation.DELETE.name();
+  private static final String INSERT = ChangelogOperation.INSERT.name();
+
+  private static final StructType SCHEMA =
+      new StructType(
+          new StructField[] {
+            new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField("name", DataTypes.StringType, false, Metadata.empty()),
+            new StructField(
+                MetadataColumns.CHANGE_TYPE.name(), DataTypes.StringType, false, Metadata.empty()),
+            new StructField(
+                MetadataColumns.CHANGE_ORDINAL.name(),
+                DataTypes.IntegerType,
+                false,
+                Metadata.empty()),
+            new StructField(
+                MetadataColumns.COMMIT_SNAPSHOT_ID.name(),
+                DataTypes.LongType,
+                false,
+                Metadata.empty())
+          });
+  private static final String[] IDENTIFIER_FIELDS = new String[] {"id", "name"};
+
+  @Test
+  public void testSingleInsertDelete() {
+    // i -> d => removed (net no-op)
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 1, 1L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testSingleDeleteInsert() {
+    // d -> i => both kept (not a carry-over pattern)
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "b", INSERT, 1, 1L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {1, "a", DELETE, 0, 0L}, new Object[] {1, "b", INSERT, 1, 1L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testMultipleInsertDeletePairs() {
+    // i -> d -> i -> d => removed (all net no-ops)
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 1, 1L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 2, 2L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 3, 3L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testInsertDeleteWithExtraInsert() {
+    // i -> d -> i => last insert kept (net insert after cancellation)
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 1, 1L}, null),
+            new GenericRowWithSchema(new Object[] {1, "b", INSERT, 2, 2L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {1, "b", INSERT, 2, 2L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testDeleteOnly() {
+    // d => kept (no cancellation)
+    List<Row> rows =
+        Lists.newArrayList(new GenericRowWithSchema(new Object[] {1, "a", DELETE, 0, 0L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {1, "a", DELETE, 0, 0L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testInsertOnly() {
+    // i => kept (no cancellation)
+    List<Row> rows =
+        Lists.newArrayList(new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {1, "a", INSERT, 0, 0L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testMultipleKeys() {
+    List<Row> rows =
+        Lists.newArrayList(
+            // Key 1: i -> d => removed
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 1, 1L}, null),
+
+            // Key 2: d => kept
+            new GenericRowWithSchema(new Object[] {2, "b", DELETE, 0, 0L}, null),
+
+            // Key 3: i => kept
+            new GenericRowWithSchema(new Object[] {3, "c", INSERT, 0, 0L}, null),
+
+            // Key 4: d -> i => kept (both)
+            new GenericRowWithSchema(new Object[] {4, "d", DELETE, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {4, "e", INSERT, 1, 1L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {2, "b", DELETE, 0, 0L},
+            new Object[] {3, "c", INSERT, 0, 0L},
+            new Object[] {4, "d", DELETE, 0, 0L},
+            new Object[] {4, "e", INSERT, 1, 1L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testConsecutiveInserts() {
+    // i -> i => both kept (second INSERT doesn't cancel first)
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "b", INSERT, 1, 1L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {1, "a", INSERT, 0, 0L}, new Object[] {1, "b", INSERT, 1, 1L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testConsecutiveDeletes() {
+    // d -> d => both kept (second DELETE doesn't cancel first)
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 1, 1L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {1, "a", DELETE, 0, 0L}, new Object[] {1, "a", DELETE, 1, 1L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testInsertDeleteInsert() {
+    // i -> d -> i => last insert kept (first i-d pair cancelled)
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 1, 1L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 2, 2L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {1, "a", INSERT, 2, 2L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testDeleteInsertDelete() {
+    // d -> i -> d => first delete kept, i-d cancelled
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "b", INSERT, 1, 1L}, null),
+            new GenericRowWithSchema(new Object[] {1, "b", DELETE, 2, 2L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {1, "a", DELETE, 0, 0L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testWithNullIdentifiers() {
+    List<Row> rows =
+        Lists.newArrayList(
+            // Key with null name: i -> d => removed
+            new GenericRowWithSchema(new Object[] {1, null, INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, null, DELETE, 1, 1L}, null),
+
+            // Different null keys: kept separately
+            new GenericRowWithSchema(new Object[] {2, null, DELETE, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {3, null, INSERT, 0, 0L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {2, null, DELETE, 0, 0L}, new Object[] {3, null, INSERT, 0, 0L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testComplexSequence() {
+    // Complex pattern: d -> i -> d -> i -> d -> i
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "b", INSERT, 1, 1L}, null),
+            new GenericRowWithSchema(new Object[] {1, "b", DELETE, 2, 2L}, null),
+            new GenericRowWithSchema(new Object[] {1, "c", INSERT, 3, 3L}, null),
+            new GenericRowWithSchema(new Object[] {1, "c", DELETE, 4, 4L}, null),
+            new GenericRowWithSchema(new Object[] {1, "d", INSERT, 5, 5L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {1, "a", DELETE, 0, 0L}, new Object[] {1, "d", INSERT, 5, 5L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testSameOrdinalDifferentSnapshots() {
+    // INSERT and DELETE at same ordinal but different snapshot IDs
+    // (This tests the ordinal-based sorting, not snapshot-based)
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 1, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 1, 1L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testDifferentIdentifierValues() {
+    // INSERT with one identifier value, DELETE with different value => both kept
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {1, "b", DELETE, 1, 1L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {1, "a", INSERT, 0, 0L}, new Object[] {1, "b", DELETE, 1, 1L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testEmptyInput() {
+    List<Row> rows = Lists.newArrayList();
+    List<Object[]> expected = Lists.newArrayList();
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testSingleInsert() {
+    List<Row> rows =
+        Lists.newArrayList(new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {1, "a", INSERT, 0, 0L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testSingleDelete() {
+    List<Row> rows =
+        Lists.newArrayList(new GenericRowWithSchema(new Object[] {1, "a", DELETE, 0, 0L}, null));
+
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {1, "a", DELETE, 0, 0L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testAllDeletes() {
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", DELETE, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {2, "b", DELETE, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {3, "c", DELETE, 0, 0L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {1, "a", DELETE, 0, 0L},
+            new Object[] {2, "b", DELETE, 0, 0L},
+            new Object[] {3, "c", DELETE, 0, 0L});
+
+    validate(rows, expected);
+  }
+
+  @Test
+  public void testAllInserts() {
+    List<Row> rows =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {1, "a", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {2, "b", INSERT, 0, 0L}, null),
+            new GenericRowWithSchema(new Object[] {3, "c", INSERT, 0, 0L}, null));
+
+    List<Object[]> expected =
+        Lists.newArrayList(
+            new Object[] {1, "a", INSERT, 0, 0L},
+            new Object[] {2, "b", INSERT, 0, 0L},
+            new Object[] {3, "c", INSERT, 0, 0L});
+
+    validate(rows, expected);
+  }
+
+  private void validate(List<Row> rows, List<Object[]> expected) {
+    Iterator<Row> iterator =
+        ChangelogIterator.removeLogicalNoopPairs(rows.iterator(), SCHEMA, IDENTIFIER_FIELDS);
+    List<Row> result = Lists.newArrayList(iterator);
+
+    assertEquals("Rows should match", expected, rowsToJava(result));
+  }
+}


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/14249

## Implementation

The implementation is similar to what was initially proposed:

1. Repartition by `identifier_columns` and sort within partition by `identifier_columns + change_ordinal`
2. Apply `RemoveCarryoverIterator`.

Note: Above is the same as `net_changes` without identifier columns but with a simpler repartition spec.

3. Use window functions to identify first and last changes for each logical row
4. Filter to keep only first and last changes (as per `change_ordinal`) for each logical row

Note: Above performs the _netting_ of the changes, we get rid of all change except for the first and last change ordinal, this is cheaper than iterating through them all. Existing `net_changes` cannot leverage this as we do not have a consistent set of identifier columns across the entire snapshot range so we need to iterate through them all to build the lineage.

5. Remove INSERT-DELETE (no-op) pairs using an iterator. 
6. Calculate pre/post images using first DELETE - last INSERT pairs. 

Note: Above is similar to existing [ComputeUpdateIterator](https://github.com/apache/iceberg/blob/e92696998e1338fac05aedb315050d39e82b6b66/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/ComputeUpdateIterator.java#L50)). Here we need to handle multiple INSERTS/DELETEs entries(as the intermediate changes aren't present).

## Testing

- Added iterator tests for [ComputeNetUpdateIterator](https://github.com/1raghavmahajan/iceberg/blob/158177f565055884e3703af49a4155b1b5a60707/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestComputeNetUpdateIterator.java) and [RemoveNoopPairIterator](https://github.com/1raghavmahajan/iceberg/blob/158177f565055884e3703af49a4155b1b5a60707/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestRemoveNoopPairIterator.java)
- Updated integration tests for [CreateChangelogViewProcedure](https://github.com/1raghavmahajan/iceberg/blob/158177f565055884e3703af49a4155b1b5a60707/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java) 