### PR TITLE
Flink: Refactor WriteResult aggregation in DynamicIcebergSink

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/WriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/WriteResult.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.CharSequenceSet;
@@ -133,5 +134,15 @@ public class WriteResult implements Serializable {
     public WriteResult build() {
       return new WriteResult(dataFiles, deleteFiles, referencedDataFiles, rewrittenDeleteFiles);
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("dataFiles", dataFiles)
+        .add("deleteFiles", deleteFiles)
+        .add("referencedDataFiles", referencedDataFiles)
+        .add("rewrittenDeleteFiles", rewrittenDeleteFiles)
+        .toString();
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/CommitSummary.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/CommitSummary.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.flink.sink;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.NavigableMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.flink.annotation.Internal;
@@ -37,17 +36,11 @@ public class CommitSummary {
   private final AtomicLong deleteFilesRecordCount = new AtomicLong();
   private final AtomicLong deleteFilesByteCount = new AtomicLong();
 
-  public CommitSummary() {}
-
   public CommitSummary(NavigableMap<Long, WriteResult> pendingResults) {
     pendingResults.values().forEach(this::addWriteResult);
   }
 
-  public void addAll(NavigableMap<Long, List<WriteResult>> pendingResults) {
-    pendingResults.values().forEach(writeResults -> writeResults.forEach(this::addWriteResult));
-  }
-
-  private void addWriteResult(WriteResult writeResult) {
+  public void addWriteResult(WriteResult writeResult) {
     dataFilesCount.addAndGet(writeResult.dataFiles().length);
     Arrays.stream(writeResult.dataFiles())
         .forEach(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommittable.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommittable.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
 /**
  * The aggregated results of a single checkpoint which should be committed. Containing the
- * serialized {@link DeltaManifests} file - which contains the commit data, and the jobId,
+ * serialized {@link DeltaManifests} files - which contains the commit data, and the jobId,
  * operatorId, checkpointId triplet to identify the specific commit.
  *
  * <p>{@link DynamicCommittableSerializer} is used to serialize {@link DynamicCommittable} between
@@ -34,27 +34,27 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
  */
 class DynamicCommittable implements Serializable {
 
-  private final WriteTarget key;
-  private final byte[] manifest;
+  private final TableKey key;
+  private final byte[][] manifests;
   private final String jobId;
   private final String operatorId;
   private final long checkpointId;
 
   DynamicCommittable(
-      WriteTarget key, byte[] manifest, String jobId, String operatorId, long checkpointId) {
+      TableKey key, byte[][] manifests, String jobId, String operatorId, long checkpointId) {
     this.key = key;
-    this.manifest = manifest;
+    this.manifests = manifests;
     this.jobId = jobId;
     this.operatorId = operatorId;
     this.checkpointId = checkpointId;
   }
 
-  WriteTarget key() {
+  TableKey key() {
     return key;
   }
 
-  byte[] manifest() {
-    return manifest;
+  byte[][] manifests() {
+    return manifests;
   }
 
   String jobId() {
@@ -78,14 +78,14 @@ class DynamicCommittable implements Serializable {
     DynamicCommittable that = (DynamicCommittable) o;
     return checkpointId == that.checkpointId
         && Objects.equals(key, that.key)
-        && Objects.deepEquals(manifest, that.manifest)
+        && Arrays.deepEquals(manifests, that.manifests)
         && Objects.equals(jobId, that.jobId)
         && Objects.equals(operatorId, that.operatorId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(key, Arrays.hashCode(manifest), jobId, operatorId, checkpointId);
+    return Objects.hash(key, Arrays.deepHashCode(manifests), jobId, operatorId, checkpointId);
   }
 
   @Override
@@ -96,9 +96,5 @@ class DynamicCommittable implements Serializable {
         .add("checkpointId", checkpointId)
         .add("operatorId", operatorId)
         .toString();
-  }
-
-  public WriteTarget writeTarget() {
-    return key;
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResult.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResult.java
@@ -19,22 +19,30 @@
 package org.apache.iceberg.flink.sink.dynamic;
 
 import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
 class DynamicWriteResult {
-
-  private final WriteTarget key;
+  private final TableKey key;
   private final WriteResult writeResult;
 
-  DynamicWriteResult(WriteTarget key, WriteResult writeResult) {
+  DynamicWriteResult(TableKey key, WriteResult writeResult) {
     this.key = key;
     this.writeResult = writeResult;
   }
 
-  WriteTarget key() {
+  TableKey key() {
     return key;
   }
 
   WriteResult writeResult() {
     return writeResult;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("key", key)
+        .add("writeResult", writeResult)
+        .toString();
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -50,7 +50,7 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
   public DynamicWriteResult deserialize(int version, byte[] serialized) throws IOException {
     if (version == 1) {
       DataInputDeserializer view = new DataInputDeserializer(serialized);
-      WriteTarget key = WriteTarget.deserializeFrom(view);
+      TableKey key = TableKey.deserializeFrom(view);
       byte[] resultBuf = new byte[view.available()];
       view.read(resultBuf);
       WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(version, resultBuf);

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -193,7 +193,8 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
           writeResult.dataFiles().length,
           writeResult.deleteFiles().length);
 
-      result.add(new DynamicWriteResult(writeTarget, writeResult));
+      TableKey tableKey = new TableKey(writeTarget.tableName(), writeTarget.branch());
+      result.add(new DynamicWriteResult(tableKey, writeResult));
     }
 
     writers.clear();

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableKey.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableKey.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+
+class TableKey implements Serializable {
+  private final String tableName;
+  private final String branch;
+
+  TableKey(String tableName, String branch) {
+    this.tableName = tableName;
+    this.branch = branch;
+  }
+
+  TableKey(DynamicCommittable committable) {
+    this.tableName = committable.key().tableName();
+    this.branch = committable.key().branch();
+  }
+
+  String tableName() {
+    return tableName;
+  }
+
+  String branch() {
+    return branch;
+  }
+
+  void serializeTo(DataOutputView view) throws IOException {
+    view.writeUTF(tableName);
+    view.writeUTF(branch);
+  }
+
+  static TableKey deserializeFrom(DataInputView view) throws IOException {
+    return new TableKey(view.readUTF(), view.readUTF());
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    TableKey that = (TableKey) other;
+    return tableName.equals(that.tableName) && branch.equals(that.branch);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tableName, branch);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("tableName", tableName)
+        .add("branch", branch)
+        .toString();
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommittableSerializer.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommittableSerializer.java
@@ -24,38 +24,28 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
 class TestDynamicCommittableSerializer {
+  private static final DynamicCommittable COMMITTABLE =
+      new DynamicCommittable(
+          new TableKey("table", "branch"),
+          new byte[][] {{3, 4}},
+          JobID.generate().toHexString(),
+          new OperatorID().toHexString(),
+          5);
 
   @Test
   void testRoundtrip() throws IOException {
-    DynamicCommittable committable =
-        new DynamicCommittable(
-            new WriteTarget("table", "branch", 42, 23, false, Sets.newHashSet(1, 2)),
-            new byte[] {3, 4},
-            JobID.generate().toHexString(),
-            new OperatorID().toHexString(),
-            5);
-
     DynamicCommittableSerializer serializer = new DynamicCommittableSerializer();
-    assertThat(serializer.deserialize(serializer.getVersion(), serializer.serialize(committable)))
-        .isEqualTo(committable);
+    assertThat(serializer.deserialize(serializer.getVersion(), serializer.serialize(COMMITTABLE)))
+        .isEqualTo(COMMITTABLE);
   }
 
   @Test
-  void testUnsupportedVersion() throws IOException {
-    DynamicCommittable committable =
-        new DynamicCommittable(
-            new WriteTarget("table", "branch", 42, 23, false, Sets.newHashSet(1, 2)),
-            new byte[] {3, 4},
-            JobID.generate().toHexString(),
-            new OperatorID().toHexString(),
-            5);
-
+  void testUnsupportedVersion() {
     DynamicCommittableSerializer serializer = new DynamicCommittableSerializer();
-    assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(committable)))
+    assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(COMMITTABLE)))
         .hasMessage("Unrecognized version or corrupt state: -1")
         .isInstanceOf(IOException.class);
   }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -55,6 +55,8 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -73,6 +75,7 @@ import org.apache.iceberg.flink.sink.dynamic.TestDynamicCommitter.FailBeforeAndA
 import org.apache.iceberg.inmemory.InMemoryInputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -423,6 +426,26 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
             new DynamicIcebergDataImpl(SimpleDataUtil.SCHEMA, "t1", "main", spec2));
 
     runTest(rows);
+
+    // Validate the table has expected partition specs
+    Table table = CATALOG_EXTENSION.catalog().loadTable(TableIdentifier.of(DATABASE, "t1"));
+
+    Map<Integer, PartitionSpec> tableSpecs = table.specs();
+    List<PartitionSpec> expectedSpecs = List.of(spec1, spec2, PartitionSpec.unpartitioned());
+
+    assertThat(tableSpecs).hasSize(expectedSpecs.size());
+    expectedSpecs.forEach(
+        expectedSpec ->
+            assertThat(
+                    tableSpecs.values().stream()
+                        // TODO: Fix PartitionSpecEvolution#evolve to re-use PartitionField names of
+                        // the target spec,
+                        //       which would allow us to compare specs with
+                        // PartitionSpec#compatibleWith here.
+                        .anyMatch(
+                            spec -> PartitionSpecEvolution.checkCompatibility(spec, expectedSpec)))
+                .withFailMessage("Table spec not found: %s.", expectedSpec)
+                .isTrue());
   }
 
   @Test
@@ -568,6 +591,71 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     final CommitHook commitHook = new AppendRightBeforeCommit(tableIdentifier.toString());
 
     executeDynamicSink(rows, env, true, 1, commitHook);
+  }
+
+  @Test
+  void testProducesSingleSnapshotPerTableBranchAndCheckpoint() throws Exception {
+    String tableName = "t1";
+    String branch = SnapshotRef.MAIN_BRANCH;
+    PartitionSpec spec1 = PartitionSpec.unpartitioned();
+    PartitionSpec spec2 = PartitionSpec.builderFor(SimpleDataUtil.SCHEMA).bucket("id", 10).build();
+    Set<String> equalityFields = Sets.newHashSet("id");
+
+    List<DynamicIcebergDataImpl> inputRecords =
+        Lists.newArrayList(
+            // Two schemas
+            new DynamicIcebergDataImpl(SimpleDataUtil.SCHEMA, tableName, branch, spec1),
+            new DynamicIcebergDataImpl(SimpleDataUtil.SCHEMA2, tableName, branch, spec1),
+            // Two specs
+            new DynamicIcebergDataImpl(SimpleDataUtil.SCHEMA, tableName, branch, spec1),
+            new DynamicIcebergDataImpl(SimpleDataUtil.SCHEMA, tableName, branch, spec2),
+            // Some upserts
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA, tableName, branch, spec1, true, equalityFields, false),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA, tableName, branch, spec1, true, equalityFields, true));
+
+    executeDynamicSink(inputRecords, env, true, 1, null);
+
+    List<Record> actualRecords;
+    try (CloseableIterable<Record> iterable =
+        IcebergGenerics.read(
+                CATALOG_EXTENSION.catalog().loadTable(TableIdentifier.of("default", "t1")))
+            .build()) {
+      actualRecords = Lists.newArrayList(iterable);
+    }
+
+    int expectedRecords = inputRecords.size() - 1; // 1 duplicate
+    assertThat(actualRecords).hasSize(expectedRecords);
+
+    for (int i = 0; i < expectedRecords; i++) {
+      Record actual = actualRecords.get(0);
+      assertThat(inputRecords)
+          .anySatisfy(
+              inputRecord -> {
+                assertThat(actual.get(0)).isEqualTo(inputRecord.rowProvided.getField(0));
+                assertThat(actual.get(1)).isEqualTo(inputRecord.rowProvided.getField(1));
+                if (inputRecord.schemaProvided.equals(SimpleDataUtil.SCHEMA2)) {
+                  assertThat(actual.get(2)).isEqualTo(inputRecord.rowProvided.getField(2));
+                }
+                // There is an additional _pos field which gets added
+              });
+    }
+
+    TableIdentifier tableIdentifier = TableIdentifier.of("default", tableName);
+    Table table = CATALOG_EXTENSION.catalog().loadTable(tableIdentifier);
+    List<Snapshot> snapshots = Lists.newArrayList(table.snapshots().iterator());
+
+    assertThat(snapshots).hasSize(2); // Table creation + data changes
+    assertThat(snapshots.get(1).summary())
+        .containsAllEntriesOf(
+            ImmutableMap.<String, String>builder()
+                .put("added-records", "6")
+                .put("changed-partition-count", "2")
+                .put("total-equality-deletes", "1")
+                .put("total-position-deletes", "1")
+                .put("total-records", "6")
+                .build());
   }
 
   private static class AppendRightBeforeCommit implements CommitHook {

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import org.apache.hadoop.util.Sets;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Metrics;
@@ -48,13 +47,12 @@ class TestDynamicWriteResultSerializer {
                   ImmutableMap.of(1, ByteBuffer.allocate(1)),
                   ImmutableMap.of(1, ByteBuffer.allocate(1))))
           .build();
+  private static final TableKey TABLE_KEY = new TableKey("table", "branch");
 
   @Test
   void testRoundtrip() throws IOException {
     DynamicWriteResult dynamicWriteResult =
-        new DynamicWriteResult(
-            new WriteTarget("table", "branch", 42, 23, false, Sets.newHashSet(1, 2)),
-            WriteResult.builder().addDataFiles(DATA_FILE).build());
+        new DynamicWriteResult(TABLE_KEY, WriteResult.builder().addDataFiles(DATA_FILE).build());
 
     DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
     DynamicWriteResult copy =
@@ -68,11 +66,9 @@ class TestDynamicWriteResultSerializer {
   }
 
   @Test
-  void testUnsupportedVersion() throws IOException {
+  void testUnsupportedVersion() {
     DynamicWriteResult dynamicWriteResult =
-        new DynamicWriteResult(
-            new WriteTarget("table", "branch", 42, 23, false, Sets.newHashSet(1, 2)),
-            WriteResult.builder().addDataFiles(DATA_FILE).build());
+        new DynamicWriteResult(TABLE_KEY, WriteResult.builder().addDataFiles(DATA_FILE).build());
 
     DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
     assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(dynamicWriteResult)))


### PR DESCRIPTION
This PR moves the `WriteResult` aggregation logic from `DynamicCommitter` to `DynamicWriteResultAggregator`, as described in this comment: https://github.com/apache/iceberg/pull/14182#issuecomment-3336891582.

`DynamicWriteResultAggregator` currently produces multiple `DynamicCommittables` per (table, branch, checkpoint) triplet. This initially broke the commit recovery of the dynamic Iceberg sink (see https://github.com/apache/iceberg/issues/14090), and was later addressed by a hot fix to aggregate `WriteResults` in the `DynamicCommitter`. 

Refactor the `DynamicWriteResultAggregator` to output only one committable per triplet. Clean up `DynamicCommitter` to remove assumptions of multiple commit requests per table, branch, and checkpoint. This requires serializing the aggregated WriteResult using multiple temporary manifests for each unique partition spec because the Iceberg manifest writer requires a single partition spec per file. We can improve this later by changing how we serialize `DataFiles` and `DeleteFiles` for Flink checkpoints in the `DynamicSink`.