### PR TITLE
Flink: Backport clear globalStatisticsState in init to avoid duplication to Flink 2.0 and 1.20

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
@@ -119,6 +119,9 @@ public class DataStatisticsOperator extends AbstractStreamOperator<StatisticsOrR
         this.globalStatistics = restoredStatistics;
       }
 
+      // Perform a cleanup first to ensure that the state is empty.
+      globalStatisticsState.clear();
+
       // Always request for new statistics from coordinator upon task initialization.
       // There are a few scenarios this is needed
       // 1. downstream writer parallelism changed due to rescale.
@@ -262,5 +265,10 @@ public class DataStatisticsOperator extends AbstractStreamOperator<StatisticsOrR
   @VisibleForTesting
   GlobalStatistics globalStatistics() {
     return globalStatistics;
+  }
+
+  @VisibleForTesting
+  ListState<GlobalStatistics> globalStatisticsState() {
+    return globalStatisticsState;
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsOperator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsOperator.java
@@ -250,6 +250,12 @@ public class TestDataStatisticsOperator {
       testHarness2.setup();
       testHarness2.initializeState(snapshot);
 
+      // When we restore from the savepoint, we should ensure that `globalStatisticsState` has been
+      // completely cleaned up
+      Iterable<GlobalStatistics> globalStatisticsIterable =
+          restoredOperator.globalStatisticsState().get();
+      assertThat(globalStatisticsIterable).isEmpty();
+
       GlobalStatistics globalStatistics = restoredOperator.globalStatistics();
       // global statistics is always restored and used initially even if
       // downstream parallelism changed.

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
@@ -122,6 +122,9 @@ public class DataStatisticsOperator extends AbstractStreamOperator<StatisticsOrR
         this.globalStatistics = restoredStatistics;
       }
 
+      // Perform a cleanup first to ensure that the state is empty.
+      globalStatisticsState.clear();
+
       // Always request for new statistics from coordinator upon task initialization.
       // There are a few scenarios this is needed
       // 1. downstream writer parallelism changed due to rescale.
@@ -265,5 +268,10 @@ public class DataStatisticsOperator extends AbstractStreamOperator<StatisticsOrR
   @VisibleForTesting
   GlobalStatistics globalStatistics() {
     return globalStatistics;
+  }
+
+  @VisibleForTesting
+  ListState<GlobalStatistics> globalStatisticsState() {
+    return globalStatisticsState;
   }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsOperator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/shuffle/TestDataStatisticsOperator.java
@@ -242,6 +242,12 @@ public class TestDataStatisticsOperator {
       testHarness2.setup();
       testHarness2.initializeState(snapshot);
 
+      // When we restore from the savepoint, we should ensure that `globalStatisticsState` has been
+      // completely cleaned up
+      Iterable<GlobalStatistics> globalStatisticsIterable =
+          restoredOperator.globalStatisticsState().get();
+      assertThat(globalStatisticsIterable).isEmpty();
+
       GlobalStatistics globalStatistics = restoredOperator.globalStatistics();
       // global statistics is always restored and used initially even if
       // downstream parallelism changed.


### PR DESCRIPTION
It is a clearn backport for https://github.com/apache/iceberg/pull/14294