### PR TITLE
Docs: add Delta Lake Migration to nav (fix #14309)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -58,6 +58,10 @@ nav:
       - flink-configuration.md
     - Kafka Connect: kafka-connect.md
     - Apache Hive: hive.md
+  - Migration:
+      - Overview: table-migration.md
+      - Hive Migration: hive-migration.md
+      - Delta Lake Migration: delta-lake-migration.md
   - Catalogs:
     - AWS Glue: aws/#glue-catalog
     - AWS DynamoDB: aws/#dynamodb-catalog


### PR DESCRIPTION
Restored the missing Delta Lake Migration page in the documentation navigation.

Changes:
- Updated docs/mkdocs.yml to include a Migration section:
  - table-migration.md
  - hive-migration.md
  - delta-lake-migration.md

Verified locally using: `mkdocs serve -f docs/docs/mkdocs.yml`

![Migration menu and Delta Lake Migration page](https://github.com/user-attachments/assets/da87c994-3f29-4e37-9f45-142c6098c1ff)

Related Issues:
Fixes #14309
See also #13761 (original missing migration issue)