### PR TITLE
Uses content length to determine when to abort the stream.

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
@@ -30,6 +30,7 @@ import java.net.SocketTimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLException;
+import org.apache.http.ConnectionClosedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -52,6 +53,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 public class TestFlakyS3InputStream extends TestS3InputStream {
 
   private AtomicInteger resetForRetryCounter;
+  private static final long CONTENT_LENGTH = 1024 * 1024; // An arbitrary content length.
 
   @BeforeEach
   public void setupTest() {
@@ -60,7 +62,7 @@ public class TestFlakyS3InputStream extends TestS3InputStream {
 
   @Override
   S3InputStream newInputStream(S3Client s3Client, S3URI uri) {
-    return new S3InputStream(s3Client, uri) {
+    return new S3InputStream(s3Client, uri, CONTENT_LENGTH) {
       @Override
       void resetForRetry() throws IOException {
         resetForRetryCounter.incrementAndGet();
@@ -122,6 +124,7 @@ public class TestFlakyS3InputStream extends TestS3InputStream {
   private static Stream<Arguments> retryableExceptions() {
     return Stream.of(
         Arguments.of(
+            new ConnectionClosedException("connection closed exception"),
             new SocketTimeoutException("socket timeout exception"),
             new SSLException("some ssl exception")));
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -46,6 +46,8 @@ public class TestS3InputStream {
   private final S3Client s3 = MinioUtil.createS3Client(MINIO);
   private final Random random = new Random(1);
 
+  private static final int CONTENT_LENGTH = 1024 * 1024 * 10; // 10MB
+
   @BeforeEach
   public void before() {
     createBucket("bucket");
@@ -57,13 +59,13 @@ public class TestS3InputStream {
   }
 
   S3InputStream newInputStream(S3Client s3Client, S3URI uri) {
-    return new S3InputStream(s3Client, uri);
+    return new S3InputStream(s3Client, uri, CONTENT_LENGTH);
   }
 
   protected void testRead(S3Client s3Client) throws Exception {
     S3URI uri = new S3URI("s3://bucket/path/to/read.dat");
-    int dataSize = 1024 * 1024 * 10;
-    byte[] data = randomData(dataSize);
+
+    byte[] data = randomData(CONTENT_LENGTH);
 
     writeS3Data(uri, data);
 
@@ -121,9 +123,9 @@ public class TestS3InputStream {
 
   protected void testRangeRead(S3Client s3Client) throws Exception {
     S3URI uri = new S3URI("s3://bucket/path/to/range-read.dat");
-    int dataSize = 1024 * 1024 * 10;
-    byte[] expected = randomData(dataSize);
-    byte[] actual = new byte[dataSize];
+
+    byte[] expected = randomData(CONTENT_LENGTH);
+    byte[] actual = new byte[CONTENT_LENGTH];
 
     long position;
     int offset;
@@ -139,13 +141,13 @@ public class TestS3InputStream {
       readAndCheckRanges(in, expected, position, actual, offset, length);
 
       // last 1k
-      position = dataSize - 1024;
-      offset = dataSize - 1024;
+      position = CONTENT_LENGTH - 1024;
+      offset = CONTENT_LENGTH - 1024;
       readAndCheckRanges(in, expected, position, actual, offset, length);
 
       // middle 2k
-      position = dataSize / 2 - 1024;
-      offset = dataSize / 2 - 1024;
+      position = CONTENT_LENGTH / 2 - 1024;
+      offset = CONTENT_LENGTH / 2 - 1024;
       length = 1024 * 2;
       readAndCheckRanges(in, expected, position, actual, offset, length);
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -76,7 +76,7 @@ public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryp
     if (s3FileIOProperties().isS3AnalyticsAcceleratorEnabled()) {
       return AnalyticsAcceleratorUtil.newStream(this);
     }
-    return new S3InputStream(client(), uri(), s3FileIOProperties(), metrics());
+    return new S3InputStream(client(), uri(), s3FileIOProperties(), metrics(), getLength());
   }
 
   @Override


### PR DESCRIPTION
This PR:

* Adds ConnectionClosedException to the retry list. These surface fairly often, and currently lead to task failures.

* Removes the read() on the abort.

When the abort() is called on stream close, it will do a `read()`.

When the abort is a result of a reset after an exception, in the `resetForRetry()`, the `read()` throws an exception:

```
software.amazon.awssdk.core.exception.RetryableException: Data read has a different checksum than expected. 
Was 0x06625dea76e80c661d03ca53f74a3f11, but expected 0x00000000000000000000000000000000
```

This seems to be because after a failure the underlying stream will return a -1, and this triggers SDK's checksum validation. Since the read was not completed, the checksums are not updated, and the validation and the abort() fails.

While this does not appear to have any impact as such, it does add a lot of noise to the logs. And instead of doing a `read()` to check EoF, this can be determined from the current pos in the stream vs content length. This is what S3A does as well, here: https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java#L732