### PR TITLE
Core: Remove usage of deprecated TableProperties.MANIFEST_LISTS_ENABLED

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -282,12 +282,12 @@ public class TableProperties {
   public static final int WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT = 0;
 
   /**
-   * @deprecated will be removed in 2.0.0, writing manifest lists is always enabled
+   * @deprecated will be removed in 1.12.0, writing manifest lists is always enabled
    */
   @Deprecated public static final String MANIFEST_LISTS_ENABLED = "write.manifest-lists.enabled";
 
   /**
-   * @deprecated will be removed in 2.0.0, writing manifest lists is always enabled
+   * @deprecated will be removed in 1.12.0, writing manifest lists is always enabled
    */
   @Deprecated public static final boolean MANIFEST_LISTS_ENABLED_DEFAULT = true;
 

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -382,50 +382,6 @@ public class TestFastAppend extends TestBase {
   }
 
   @TestTemplate
-  public void testRecoveryWithManifestList() {
-    table.updateProperties().set(TableProperties.MANIFEST_LISTS_ENABLED, "true").commit();
-
-    // inject 3 failures, the last try will succeed
-    TestTables.TestTableOperations ops = table.ops();
-    ops.failCommits(3);
-
-    AppendFiles append = table.newFastAppend().appendFile(FILE_B);
-    Snapshot pending = append.apply();
-    ManifestFile newManifest = pending.allManifests(FILE_IO).get(0);
-    assertThat(new File(newManifest.path())).exists();
-
-    append.commit();
-
-    TableMetadata metadata = readMetadata();
-
-    validateSnapshot(null, metadata.currentSnapshot(), FILE_B);
-    assertThat(new File(newManifest.path())).exists();
-    assertThat(metadata.currentSnapshot().allManifests(FILE_IO)).contains(newManifest);
-  }
-
-  @TestTemplate
-  public void testRecoveryWithoutManifestList() {
-    table.updateProperties().set(TableProperties.MANIFEST_LISTS_ENABLED, "false").commit();
-
-    // inject 3 failures, the last try will succeed
-    TestTables.TestTableOperations ops = table.ops();
-    ops.failCommits(3);
-
-    AppendFiles append = table.newFastAppend().appendFile(FILE_B);
-    Snapshot pending = append.apply();
-    ManifestFile newManifest = pending.allManifests(FILE_IO).get(0);
-    assertThat(new File(newManifest.path())).exists();
-
-    append.commit();
-
-    TableMetadata metadata = readMetadata();
-
-    validateSnapshot(null, metadata.currentSnapshot(), FILE_B);
-    assertThat(new File(newManifest.path())).exists();
-    assertThat(metadata.currentSnapshot().allManifests(FILE_IO)).contains(newManifest);
-  }
-
-  @TestTemplate
   public void testWriteNewManifestsIdempotency() {
     // inject 3 failures, the last try will succeed
     TestTables.TestTableOperations ops = table.ops();


### PR DESCRIPTION
There are 2 tests using this deprecated property, however, they pass regardless how the value of this field is changed. This PR removes both tests because the same test coverage is given by
testWriteNewManifestsIdempotency.