### PR TITLE
feat: adding s3fileio vector reader

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileRange.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileRange.java
@@ -18,19 +18,25 @@
  */
 package org.apache.iceberg.io;
 
-import java.io.EOFException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-public class FileRange {
-  private final CompletableFuture<ByteBuffer> byteBuffer;
+public class FileRange implements Comparable<FileRange> {
+  private CompletableFuture<ByteBuffer> byteBuffer;
   private final long offset;
   private final int length;
 
-  public FileRange(CompletableFuture<ByteBuffer> byteBuffer, long offset, int length)
-      throws EOFException {
-    Preconditions.checkNotNull(byteBuffer, "byteBuffer can't be null");
+  public FileRange(long offset, int length) {
+    Preconditions.checkArgument(
+        length() >= 0, "Invalid length: %s in range (must be >= 0)", length);
+    Preconditions.checkArgument(
+        offset() >= 0, "Invalid offset: %s in range (must be >= 0)", offset);
+    this.offset = offset;
+    this.length = length;
+  }
+
+  public FileRange(CompletableFuture<ByteBuffer> byteBuffer, long offset, int length) {
     Preconditions.checkArgument(
         length() >= 0, "Invalid length: %s in range (must be >= 0)", length);
     Preconditions.checkArgument(
@@ -51,5 +57,10 @@ public class FileRange {
 
   public int length() {
     return length;
+  }
+
+  @Override
+  public int compareTo(FileRange other) {
+    return Long.compare(this.offset, other.offset);
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -41,6 +41,8 @@ import java.util.Random;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -66,9 +68,11 @@ import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileIOParser;
 import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.FileRange;
 import org.apache.iceberg.io.IOUtil;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.RangeReadable;
 import org.apache.iceberg.io.ResolvingFileIO;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.jdbc.JdbcCatalog;
@@ -964,6 +968,148 @@ public class TestS3FileIO {
     assertThatThrownBy(() -> actualConfiguration.credentialsProvider().resolveIdentity())
         .isInstanceOf(SdkClientException.class)
         .hasMessageContaining("Unable to load credentials from any of the providers");
+  }
+
+  @Test
+  public void testVectoredRead() throws Exception {
+    String location = "s3://bucket/path/to/vectored-read.dat";
+    int dataSize = 1024 * 1024 * 8;
+
+    byte[] expected = new byte[dataSize];
+    random.nextBytes(expected);
+
+    InputFile inputFile = s3FileIO.newInputFile(location);
+    assertThat(inputFile.exists()).isFalse();
+
+    OutputFile out = s3FileIO.newOutputFile(location);
+    try (OutputStream os = out.createOrOverwrite()) {
+      IOUtil.writeFully(os, ByteBuffer.wrap(expected));
+    }
+
+    try (InputStream inputStream = inputFile.newStream()) {
+      assertThat(inputStream instanceof RangeReadable);
+      RangeReadable in = (RangeReadable) inputStream;
+
+      IntFunction<ByteBuffer> allocate = ByteBuffer::allocate;
+
+      List<FileRange> ranges = Lists.newArrayList();
+      CompletableFuture<ByteBuffer> future1 = new CompletableFuture<>();
+      CompletableFuture<ByteBuffer> future2 = new CompletableFuture<>();
+      CompletableFuture<ByteBuffer> future3 = new CompletableFuture<>();
+
+      // First range: first 1024 bytes
+      int range1Offset = 0;
+      int range1Length = 1024;
+      ranges.add(new FileRange(future1, range1Offset, range1Length));
+
+      // Second range: middle 2048 bytes
+      int range2Offset = dataSize / 2;
+      int range2Length = 2048;
+      ranges.add(new FileRange(future2, range2Offset, range2Length));
+
+      // Third range: last 1024 bytes
+      int range3Offset = range2Offset + range2Length;
+      int range3Length = 1024;
+      ranges.add(new FileRange(future3, range3Offset, range3Length));
+
+      in.readVectored(ranges, allocate);
+
+      ByteBuffer buffer1 = future1.get();
+      ByteBuffer buffer2 = future2.get();
+      ByteBuffer buffer3 = future3.get();
+
+      assertThat(future1.isDone()).isTrue();
+      assertThat(future2.isDone()).isTrue();
+      assertThat(future3.isDone()).isTrue();
+
+      assertThat(buffer1.limit()).isEqualTo(range1Length);
+      assertThat(buffer2.limit()).isEqualTo(range2Length);
+      assertThat(buffer3.limit()).isEqualTo(range3Length);
+
+      byte[] range1Data = new byte[range1Length];
+      byte[] range2Data = new byte[range2Length];
+      byte[] range3Data = new byte[range3Length];
+
+      buffer1.get(range1Data);
+      buffer2.get(range2Data);
+      buffer3.get(range3Data);
+    }
+  }
+
+  @Test
+  public void testVectoredReadWithNonContinuousRanges() throws Exception {
+
+    String location = "s3://bucket/path/to/vectored-read-overlapping.dat";
+    int dataSize = 8 * 1024 * 1024;
+
+    byte[] expected = new byte[dataSize];
+    random.nextBytes(expected);
+
+    InputFile inputFile = s3FileIO.newInputFile(location);
+    assertThat(inputFile.exists()).isFalse();
+
+    OutputFile out = s3FileIO.newOutputFile(location);
+    try (OutputStream os = out.createOrOverwrite()) {
+      IOUtil.writeFully(os, ByteBuffer.wrap(expected));
+    }
+
+    try (InputStream inputStream = inputFile.newStream()) {
+      assertThat(inputStream instanceof RangeReadable);
+      RangeReadable in = (RangeReadable) inputStream;
+      List<FileRange> ranges = Lists.newArrayList();
+      CompletableFuture<ByteBuffer> future1 = new CompletableFuture<>();
+      CompletableFuture<ByteBuffer> future2 = new CompletableFuture<>();
+      CompletableFuture<ByteBuffer> future3 = new CompletableFuture<>();
+
+      // First range: first 1024 bytes
+      int range1Offset = 0;
+      int range1Length = 1024;
+      ranges.add(new FileRange(future1, range1Offset, range1Length));
+
+      // Second range: middle 2048 bytes
+      int range2Offset = range1Offset + range1Length;
+      int range2Length = 2048;
+      ranges.add(new FileRange(future2, range2Offset, range2Length));
+
+      // Third range: last 1024 bytes
+      int range3Offset = dataSize - 1024;
+      int range3Length = 1024;
+      ranges.add(new FileRange(future3, range3Offset, range3Length));
+
+      // Call readVectored
+      IntFunction<ByteBuffer> allocate = ByteBuffer::allocate;
+      in.readVectored(ranges, allocate);
+
+      // Verify the buffers have the expected content
+      ByteBuffer buffer1 = future1.get();
+      ByteBuffer buffer2 = future2.get();
+      ByteBuffer buffer3 = future3.get();
+
+      // Verify the futures were completed
+      assertThat(future1.isDone()).isTrue();
+      assertThat(future2.isDone()).isTrue();
+      assertThat(future3.isDone()).isTrue();
+
+      assertThat(buffer1.limit()).isEqualTo(range1Length);
+      assertThat(buffer2.limit()).isEqualTo(range2Length);
+      assertThat(buffer3.limit()).isEqualTo(range3Length);
+
+      // Verify the buffer content matches the original data
+      byte[] range1Data = new byte[range1Length];
+      byte[] range2Data = new byte[range2Length];
+      byte[] range3Data = new byte[range3Length];
+
+      buffer1.get(range1Data);
+      buffer2.get(range2Data);
+      buffer3.get(range3Data);
+
+      assertThat(range1Data)
+          .isEqualTo(Arrays.copyOfRange(expected, range1Offset, range1Offset + range1Length));
+      assertThat(range2Data)
+          .isEqualTo(Arrays.copyOfRange(expected, range2Offset, range2Offset + range2Length));
+      assertThat(range3Data)
+          .isEqualTo(Arrays.copyOfRange(expected, range3Offset, range3Offset + range3Length));
+    }
   }
 
   private void createRandomObjects(String prefix, int count) {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -142,12 +142,13 @@ public class S3FileIO
 
   @Override
   public InputFile newInputFile(String path) {
-    return S3InputFile.fromLocation(path, clientForStoragePath(path), metrics);
+    return S3InputFile.fromLocation(path, clientForStoragePath(path), metrics, executorService());
   }
 
   @Override
   public InputFile newInputFile(String path, long length) {
-    return S3InputFile.fromLocation(path, length, clientForStoragePath(path), metrics);
+    return S3InputFile.fromLocation(
+        path, length, clientForStoragePath(path), metrics, executorService());
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -186,6 +186,12 @@ public class S3FileIOProperties implements Serializable {
   public static final String MULTIPART_UPLOAD_THREADS = "s3.multipart.num-threads";
 
   /**
+   * Number of threads to use for reading from S3 (shared pool across all input streams), default to
+   * {@link Runtime#availableProcessors()}
+   */
+  public static final String READ_THREADS = "s3.read.num-threads";
+
+  /**
    * The size of a single part for multipart upload requests in bytes (default: 32MB). based on S3
    * requirement, the part size must be at least 5MB. To ensure performance of the reader and
    * writer, the part size must be less than 2GB.
@@ -503,6 +509,7 @@ public class S3FileIOProperties implements Serializable {
   private boolean isS3AccessGrantsEnabled;
   private boolean isS3AccessGrantsFallbackToIamEnabled;
   private int multipartUploadThreads;
+  private int readThreads;
   private int multiPartSize;
   private int deleteBatchSize;
   private double multipartThresholdFactor;
@@ -546,6 +553,7 @@ public class S3FileIOProperties implements Serializable {
     this.acl = null;
     this.endpoint = null;
     this.multipartUploadThreads = Runtime.getRuntime().availableProcessors();
+    this.readThreads = Runtime.getRuntime().availableProcessors();
     this.multiPartSize = MULTIPART_SIZE_DEFAULT;
     this.multipartThresholdFactor = MULTIPART_THRESHOLD_FACTOR_DEFAULT;
     this.deleteBatchSize = DELETE_BATCH_SIZE_DEFAULT;
@@ -601,6 +609,9 @@ public class S3FileIOProperties implements Serializable {
     this.multipartUploadThreads =
         PropertyUtil.propertyAsInt(
             properties, MULTIPART_UPLOAD_THREADS, Runtime.getRuntime().availableProcessors());
+    this.readThreads =
+        PropertyUtil.propertyAsInt(
+            properties, READ_THREADS, Runtime.getRuntime().availableProcessors());
     this.isPathStyleAccess =
         PropertyUtil.propertyAsBoolean(properties, PATH_STYLE_ACCESS, PATH_STYLE_ACCESS_DEFAULT);
     this.isUseArnRegionEnabled =
@@ -742,6 +753,14 @@ public class S3FileIOProperties implements Serializable {
 
   public void setMultipartUploadThreads(int threads) {
     this.multipartUploadThreads = threads;
+  }
+
+  public int readThreads() {
+    return readThreads;
+  }
+
+  public void setReadThreads(int threads) {
+    this.readThreads = threads;
   }
 
   public int multiPartSize() {


### PR DESCRIPTION
### What am I doing
Implementing vectored reading capabilities for S3FileIO, enabling efficient batch reading of multiple file ranges with automatic coalescing to minimize S3 requests.

### How am I doing it
Using the Iceberg task manager and a executor thread pool to send requests to s3 concurrently.
Range coalescing works by using a hashmap to link ranges that, it then sends one request and uses one stream to populate the buffers for the linked ranges.

### Testing:
• Added some integration tests, will try add a few more, or will try read some more data.
• Ran a benchmark and was happy with the result, will see what I can share later.
