### PR TITLE
Spark 4.0: Optional switch to log expire data files during ExpireSnapshots action

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -64,6 +64,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       optionalInParameter("snapshot_ids", DataTypes.createArrayType(DataTypes.LongType));
   private static final ProcedureParameter CLEAN_EXPIRED_METADATA_PARAM =
       optionalInParameter("clean_expired_metadata", DataTypes.BooleanType);
+  private static final ProcedureParameter LOG_EXPIRE_FILES =
+      optionalInParameter("log_expire_files", DataTypes.BooleanType);
 
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
@@ -73,7 +75,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         MAX_CONCURRENT_DELETES_PARAM,
         STREAM_RESULTS_PARAM,
         SNAPSHOT_IDS_PARAM,
-        CLEAN_EXPIRED_METADATA_PARAM
+        CLEAN_EXPIRED_METADATA_PARAM,
+        LOG_EXPIRE_FILES
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -126,7 +129,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Boolean streamResult = input.asBoolean(STREAM_RESULTS_PARAM, null);
     long[] snapshotIds = input.asLongArray(SNAPSHOT_IDS_PARAM, null);
     Boolean cleanExpiredMetadata = input.asBoolean(CLEAN_EXPIRED_METADATA_PARAM, null);
-
+    Boolean logExpireFiles = input.asBoolean(LOG_EXPIRE_FILES, null);
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0, value: %s",
@@ -172,6 +175,11 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
           if (cleanExpiredMetadata != null) {
             action.cleanExpiredMetadata(cleanExpiredMetadata);
+          }
+
+          if (logExpireFiles != null && logExpireFiles) {
+            action.option(
+                ExpireSnapshotsSparkAction.LOG_EXPIRE_FILES, Boolean.toString(logExpireFiles));
           }
 
           ExpireSnapshots.Result result = action.execute();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.actions;
 
+import static org.apache.iceberg.spark.actions.ExpireSnapshotsSparkAction.LOG_EXPIRE_FILES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1332,6 +1333,7 @@ public class TestExpireSnapshotsAction extends TestBase {
         .expireSnapshots(table)
         .expireOlderThan(after)
         .deleteWith(deletedFiles::add)
+        .option(LOG_EXPIRE_FILES, "true")
         .execute();
 
     // C, D should be retained (live)


### PR DESCRIPTION
### Description:
We need to add comprehensive logging and metrics instrumentation to the Iceberg expire snapshots functionality to help diagnose and prevent production issues where the expire snapshot job deletes more files than expected.

### Background:
We encountered a production issue where an expire snapshot job deleted significantly more files than expected, making the table unreadable and causing queries to fail with java.io.FileNotFoundException: File does not exist.

### Requirements:
Log the list of files being deleted during snapshot expiration
Log the reason for each data file why it was marked for deletion
Provide sufficient instrumentation to trace the root cause of unexpected file deletions

### Metrics:
Track the number of files being deleted
Monitor snapshot expiration operations
Alert on anomalies in deletion patterns