### PR TITLE
Core, Spark: RewriteTablePath support for multiple source and destination prefixes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -98,7 +98,7 @@ public class RewriteTablePathUtil {
   }
 
   /**
-   * Create a new table metadata object, replacing path references
+   * Create a new table metadata object, replacing path references.
    *
    * @param metadata source table metadata
    * @param sourcePrefix source prefix that will be replaced
@@ -107,14 +107,30 @@ public class RewriteTablePathUtil {
    */
   public static TableMetadata replacePaths(
       TableMetadata metadata, String sourcePrefix, String targetPrefix) {
-    String newLocation = metadata.location().replaceFirst(sourcePrefix, targetPrefix);
-    List<Snapshot> newSnapshots = updatePathInSnapshots(metadata, sourcePrefix, targetPrefix);
+    return replacePaths(metadata, ImmutableMap.of(sourcePrefix, targetPrefix));
+  }
+
+  /**
+   * Create a new table metadata object, replacing path references
+   *
+   * @param metadata source table metadata
+   * @param prefixMappings source prefix amd target prefix mappings
+   * @return copy of table metadata with paths replaced
+   */
+  public static TableMetadata replacePaths(
+      TableMetadata metadata, Map<String, String> prefixMappings) {
+    Map.Entry<String, String> prefixMap = lookupPrefixMappings(metadata.location(), prefixMappings);
+    if (prefixMap == null) {
+      throw new IllegalArgumentException(
+          "unable to find prefix mapping for path: " + metadata.location());
+    }
+    String newLocation = newPath(metadata.location(), prefixMappings);
+    List<Snapshot> newSnapshots = updatePathInSnapshots(metadata, prefixMappings);
     List<TableMetadata.MetadataLogEntry> metadataLogEntries =
-        updatePathInMetadataLogs(metadata, sourcePrefix, targetPrefix);
+        updatePathInMetadataLogs(metadata, prefixMappings);
     long snapshotId =
         metadata.currentSnapshot() == null ? -1 : metadata.currentSnapshot().snapshotId();
-    Map<String, String> properties =
-        updateProperties(metadata.properties(), sourcePrefix, targetPrefix);
+    Map<String, String> properties = updateProperties(metadata.properties(), prefixMappings);
 
     return new TableMetadata(
         null,
@@ -138,25 +154,29 @@ public class RewriteTablePathUtil {
         metadata.snapshotLog(),
         metadataLogEntries,
         metadata.refs(),
-        updatePathInStatisticsFiles(metadata.statisticsFiles(), sourcePrefix, targetPrefix),
-        updatePathInPartitionStatisticsFiles(
-            metadata.partitionStatisticsFiles(), sourcePrefix, targetPrefix),
+        updatePathInStatisticsFiles(metadata.statisticsFiles(), prefixMappings),
+        updatePathInPartitionStatisticsFiles(metadata.partitionStatisticsFiles(), prefixMappings),
         metadata.nextRowId(),
         metadata.encryptionKeys(),
         metadata.changes());
   }
 
   private static Map<String, String> updateProperties(
-      Map<String, String> tableProperties, String sourcePrefix, String targetPrefix) {
+      Map<String, String> tableProperties, Map<String, String> prefixMappings) {
     Map<String, String> properties = Maps.newHashMap(tableProperties);
-    updatePathInProperty(properties, sourcePrefix, targetPrefix, TableProperties.OBJECT_STORE_PATH);
-    updatePathInProperty(
-        properties, sourcePrefix, targetPrefix, TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
-    updatePathInProperty(
-        properties, sourcePrefix, targetPrefix, TableProperties.WRITE_DATA_LOCATION);
-    updatePathInProperty(
-        properties, sourcePrefix, targetPrefix, TableProperties.WRITE_METADATA_LOCATION);
-
+    for (Map.Entry<String, String> entry : prefixMappings.entrySet()) {
+      updatePathInProperty(
+          properties, entry.getKey(), entry.getValue(), TableProperties.OBJECT_STORE_PATH);
+      updatePathInProperty(
+          properties,
+          entry.getKey(),
+          entry.getValue(),
+          TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
+      updatePathInProperty(
+          properties, entry.getKey(), entry.getValue(), TableProperties.WRITE_DATA_LOCATION);
+      updatePathInProperty(
+          properties, entry.getKey(), entry.getValue(), TableProperties.WRITE_METADATA_LOCATION);
+    }
     return properties;
   }
 
@@ -172,13 +192,13 @@ public class RewriteTablePathUtil {
   }
 
   private static List<StatisticsFile> updatePathInStatisticsFiles(
-      List<StatisticsFile> statisticsFiles, String sourcePrefix, String targetPrefix) {
+      List<StatisticsFile> statisticsFiles, Map<String, String> prefixMappings) {
     return statisticsFiles.stream()
         .map(
             existing ->
                 new GenericStatisticsFile(
                     existing.snapshotId(),
-                    newPath(existing.path(), sourcePrefix, targetPrefix),
+                    newPath(existing.path(), prefixMappings),
                     existing.fileSizeInBytes(),
                     existing.fileFooterSizeInBytes(),
                     existing.blobMetadata()))
@@ -190,46 +210,41 @@ public class RewriteTablePathUtil {
    * sourcePrefix in the file paths with the targetPrefix.
    *
    * @param partitionStatisticsFiles The list of PartitionStatisticsFile to update.
-   * @param sourcePrefix The prefix to be replaced in the file paths.
-   * @param targetPrefix The new prefix to replace the sourcePrefix in the file paths.
+   * @param prefixMappings The mappings between source prefix and destination prefix.
    * @return A new list of PartitionStatisticsFile with updated file paths.
    */
   private static List<PartitionStatisticsFile> updatePathInPartitionStatisticsFiles(
-      List<PartitionStatisticsFile> partitionStatisticsFiles,
-      String sourcePrefix,
-      String targetPrefix) {
+      List<PartitionStatisticsFile> partitionStatisticsFiles, Map<String, String> prefixMappings) {
 
     return partitionStatisticsFiles.stream()
         .map(
             existing ->
                 ImmutableGenericPartitionStatisticsFile.builder()
                     .snapshotId(existing.snapshotId())
-                    .path(newPath(existing.path(), sourcePrefix, targetPrefix))
+                    .path(newPath(existing.path(), prefixMappings))
                     .fileSizeInBytes(existing.fileSizeInBytes())
                     .build())
         .collect(Collectors.toList());
   }
 
   private static List<TableMetadata.MetadataLogEntry> updatePathInMetadataLogs(
-      TableMetadata metadata, String sourcePrefix, String targetPrefix) {
+      TableMetadata metadata, Map<String, String> prefixMappings) {
     List<TableMetadata.MetadataLogEntry> metadataLogEntries =
         Lists.newArrayListWithCapacity(metadata.previousFiles().size());
     for (TableMetadata.MetadataLogEntry metadataLog : metadata.previousFiles()) {
       TableMetadata.MetadataLogEntry newMetadataLog =
           new TableMetadata.MetadataLogEntry(
-              metadataLog.timestampMillis(),
-              newPath(metadataLog.file(), sourcePrefix, targetPrefix));
+              metadataLog.timestampMillis(), newPath(metadataLog.file(), prefixMappings));
       metadataLogEntries.add(newMetadataLog);
     }
     return metadataLogEntries;
   }
 
   private static List<Snapshot> updatePathInSnapshots(
-      TableMetadata metadata, String sourcePrefix, String targetPrefix) {
+      TableMetadata metadata, Map<String, String> prefixMappings) {
     List<Snapshot> newSnapshots = Lists.newArrayListWithCapacity(metadata.snapshots().size());
     for (Snapshot snapshot : metadata.snapshots()) {
-      String newManifestListLocation =
-          newPath(snapshot.manifestListLocation(), sourcePrefix, targetPrefix);
+      String newManifestListLocation = newPath(snapshot.manifestListLocation(), prefixMappings);
       Snapshot newSnapshot =
           new BaseSnapshot(
               snapshot.sequenceNumber(),
@@ -271,17 +286,50 @@ public class RewriteTablePathUtil {
       String targetPrefix,
       String stagingDir,
       String outputPath) {
+    return rewriteManifestList(
+        snapshot,
+        io,
+        tableMetadata,
+        manifestsToRewrite,
+        ImmutableMap.of(sourcePrefix, targetPrefix),
+        stagingDir,
+        outputPath);
+  }
+
+  /**
+   * Rewrite a manifest list representing a snapshot, replacing path references.
+   *
+   * @param snapshot snapshot represented by the manifest list
+   * @param io file io
+   * @param tableMetadata metadata of table
+   * @param manifestsToRewrite a list of manifest files to filter for rewrite
+   * @param prefixMappings map of source prefix to target prefix mappings
+   * @param stagingDir staging directory
+   * @param outputPath location to write the manifest list
+   * @return a copy plan for manifest files whose metadata were contained in the rewritten manifest
+   *     list
+   */
+  public static RewriteResult<ManifestFile> rewriteManifestList(
+      Snapshot snapshot,
+      FileIO io,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      Map<String, String> prefixMappings,
+      String stagingDir,
+      String outputPath) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
     OutputFile outputFile = io.newOutputFile(outputPath);
 
     List<ManifestFile> manifestFiles = manifestFilesInSnapshot(io, snapshot);
+    // Validate that all manifest files can be matched by at least one prefix
     manifestFiles.forEach(
-        mf ->
-            Preconditions.checkArgument(
-                mf.path().startsWith(sourcePrefix),
-                "Encountered manifest file %s not under the source prefix %s",
-                mf.path(),
-                sourcePrefix));
+        mf -> {
+          Preconditions.checkArgument(
+              lookupPrefixMappings(mf.path(), prefixMappings) != null,
+              "Encountered manifest file %s not matching any source prefix in %s",
+              mf.path(),
+              prefixMappings.keySet());
+        });
 
     EncryptionManager encryptionManager =
         (io instanceof EncryptingFileIO)
@@ -300,14 +348,16 @@ public class RewriteTablePathUtil {
 
       for (ManifestFile file : manifestFiles) {
         ManifestFile newFile = file.copy();
-        ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
+        String newPath = newPath(newFile.path(), prefixMappings);
+        ((StructLike) newFile).set(0, newPath);
         writer.add(newFile);
 
         if (manifestsToRewrite.contains(file.path())) {
           result.toRewrite().add(file);
+          String stagingFilePath = stagingPath(file.path(), prefixMappings, stagingDir);
           result
               .copyPlan()
-              .add(Pair.of(stagingPath(file.path(), sourcePrefix, stagingDir), newFile.path()));
+              .add(Pair.of(stagingFilePath != null ? stagingFilePath : file.path(), newPath));
         }
       }
       return result;
@@ -834,7 +884,42 @@ public class RewriteTablePathUtil {
   }
 
   /**
-   * Rewrite a path by replacing its source prefix with a target prefix.
+   * Lookup the longest matching prefix mapping for a given path.
+   *
+   * @param path the path to find a prefix mapping for
+   * @param prefixMappings map of source prefix to target prefix mappings
+   * @return the Map.Entry with the longest matching source prefix, or null if no match found
+   */
+  public static Map.Entry<String, String> lookupPrefixMappings(
+      String path, Map<String, String> prefixMappings) {
+    if (prefixMappings == null || prefixMappings.isEmpty() || path == null) {
+      return null;
+    }
+
+    String normalizedPath = maybeAppendFileSeparator(path);
+    return prefixMappings.entrySet().stream()
+        .filter(entry -> normalizedPath.startsWith(maybeAppendFileSeparator(entry.getKey())))
+        .max(java.util.Comparator.comparing(entry -> entry.getKey().length()))
+        .orElse(null);
+  }
+
+  public static String newPath(String path, Map<String, String> prefixMappings) {
+    if (prefixMappings == null || prefixMappings.isEmpty()) {
+      return path;
+    }
+
+    Map.Entry<String, String> entry = lookupPrefixMappings(path, prefixMappings);
+    if (entry != null) {
+      String sourcePrefix = entry.getKey();
+      String targetPrefix = entry.getValue();
+      return combinePaths(targetPrefix, relativize(path, sourcePrefix));
+    }
+
+    return path;
+  }
+
+  /**
+   * Replace path reference
    *
    * <p>If the path equals the source prefix (representing a directory location), the result will be
    * the target prefix with a trailing separator.
@@ -918,6 +1003,25 @@ public class RewriteTablePathUtil {
    */
   public static String stagingPath(String originalPath, String sourcePrefix, String stagingDir) {
     String relativePath = relativize(originalPath, sourcePrefix);
+    return combinePaths(stagingDir, relativePath);
+  }
+
+  /**
+   * Construct a staging path under a given staging directory, preserving relative directory
+   * structure to avoid conflicts when multiple files have the same name but different paths.
+   *
+   * @param originalPath source path
+   * @param prefixMappings source prefix and target prefix mappings
+   * @param stagingDir staging directory
+   * @return a staging path under the staging directory that preserves the relative path structure
+   */
+  public static String stagingPath(
+      String originalPath, Map<String, String> prefixMappings, String stagingDir) {
+    Map.Entry<String, String> entry = lookupPrefixMappings(originalPath, prefixMappings);
+    if (entry == null) {
+      throw new IllegalArgumentException("unable to find prefix mapping for path: " + originalPath);
+    }
+    String relativePath = relativize(originalPath, entry.getKey());
     return combinePaths(stagingDir, relativePath);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -102,8 +102,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private static final String RESULT_LOCATION = "file-list";
   static final String NOT_APPLICABLE = "N/A";
 
-  private String sourcePrefix;
-  private String targetPrefix;
+  private Map<String, String> prefixMappings = Maps.newConcurrentMap();
+
   private String startVersionName;
   private String endVersionName;
   private String stagingDir;
@@ -127,8 +127,12 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   public RewriteTablePath rewriteLocationPrefix(String sPrefix, String tPrefix) {
     Preconditions.checkArgument(
         sPrefix != null && !sPrefix.isEmpty(), "Source prefix('%s') cannot be empty.", sPrefix);
-    this.sourcePrefix = sPrefix;
-    this.targetPrefix = tPrefix;
+    Preconditions.checkArgument(tPrefix != null, "Target prefix cannot be null.");
+    Preconditions.checkArgument(
+        !sPrefix.equals(tPrefix),
+        "Source prefix cannot be the same as target prefix (%s)",
+        sPrefix);
+    this.prefixMappings.put(sPrefix, tPrefix);
     return this;
   }
 
@@ -187,17 +191,21 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   private void validateInputs() {
     Preconditions.checkArgument(
-        sourcePrefix != null && !sourcePrefix.isEmpty(),
-        "Source prefix('%s') cannot be empty.",
-        sourcePrefix);
-    Preconditions.checkArgument(
-        targetPrefix != null && !targetPrefix.isEmpty(),
-        "Target prefix('%s') cannot be empty.",
-        targetPrefix);
-    Preconditions.checkArgument(
-        !sourcePrefix.equals(targetPrefix),
-        "Source prefix cannot be the same as target prefix (%s)",
-        sourcePrefix);
+        !prefixMappings.isEmpty(), "At least one source-target prefix pair must be specified.");
+
+    for (Map.Entry<String, String> entry : prefixMappings.entrySet()) {
+      String sourcePrefix = entry.getKey();
+      String targetPrefix = entry.getValue();
+      Preconditions.checkArgument(
+          sourcePrefix != null && !sourcePrefix.isEmpty(),
+          "Source prefix('%s') cannot be empty.",
+          sourcePrefix);
+      Preconditions.checkArgument(targetPrefix != null, "Target prefix cannot be null.");
+      Preconditions.checkArgument(
+          !sourcePrefix.equals(targetPrefix),
+          "Source prefix cannot be the same as target prefix (%s)",
+          sourcePrefix);
+    }
 
     validateAndSetEndVersion();
     validateAndSetStartVersion();
@@ -260,17 +268,32 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   private String jobDesc() {
-    if (startVersionName == null) {
-      return String.format(
-          "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
-              + "up to version '%s'.",
-          sourcePrefix, targetPrefix, table.name(), endVersionName);
-    } else {
-      return String.format(
-          "Replacing path prefixes '%s' with '%s' in the metadata files of table %s,"
-              + "from version '%s' to '%s'.",
-          sourcePrefix, targetPrefix, table.name(), startVersionName, endVersionName);
+    StringBuilder desc = new StringBuilder();
+    desc.append("Replacing path prefixes ");
+    boolean first = true;
+    for (Map.Entry<String, String> entry : prefixMappings.entrySet()) {
+      if (!first) {
+        desc.append(", ");
+      }
+      desc.append("'")
+          .append(entry.getKey())
+          .append("' with '")
+          .append(entry.getValue())
+          .append("'");
+      first = false;
     }
+    desc.append(" in the metadata files of table ").append(table.name());
+
+    if (startVersionName == null) {
+      desc.append(", up to version '").append(endVersionName).append("'.");
+    } else {
+      desc.append(", from version '")
+          .append(startVersionName)
+          .append("' to '")
+          .append(endVersionName)
+          .append("'.");
+    }
+    return desc.toString();
   }
 
   /**
@@ -429,14 +452,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       TableMetadata metadata, String versionFilePath) {
     Set<Pair<String, String>> result = Sets.newHashSet();
     String stagingPath =
-        RewriteTablePathUtil.stagingPath(versionFilePath, sourcePrefix, stagingDir);
-    TableMetadata newTableMetadata =
-        RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
+        RewriteTablePathUtil.stagingPath(versionFilePath, prefixMappings, stagingDir);
+    TableMetadata newTableMetadata = RewriteTablePathUtil.replacePaths(metadata, prefixMappings);
     TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
-    result.add(
-        Pair.of(
-            stagingPath,
-            RewriteTablePathUtil.newPath(versionFilePath, sourcePrefix, targetPrefix)));
+    result.add(Pair.of(stagingPath, RewriteTablePathUtil.newPath(versionFilePath, prefixMappings)));
 
     // include statistics files in copy plan
     result.addAll(
@@ -503,23 +522,20 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
-    String outputPath = RewriteTablePathUtil.stagingPath(path, sourcePrefix, stagingDir);
+    String outputPath = RewriteTablePathUtil.stagingPath(path, prefixMappings, stagingDir);
     RewriteResult<ManifestFile> rewriteResult =
         RewriteTablePathUtil.rewriteManifestList(
             snapshot,
             table.io(),
             tableMetadata,
             manifestsToRewrite,
-            sourcePrefix,
-            targetPrefix,
+            prefixMappings,
             stagingDir,
             outputPath);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
-    result
-        .copyPlan()
-        .add(Pair.of(outputPath, RewriteTablePathUtil.newPath(path, sourcePrefix, targetPrefix)));
+    result.copyPlan().add(Pair.of(outputPath, RewriteTablePathUtil.newPath(path, prefixMappings)));
     return result;
   }
 
@@ -596,8 +612,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sparkContext().broadcast(deltaSnapshotIds),
                 stagingDir,
                 tableMetadata.formatVersion(),
-                sourcePrefix,
-                targetPrefix,
+                prefixMappings,
                 rewrittenDeleteFileSizes),
             Encoders.bean(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
@@ -610,8 +625,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Broadcast<Set<Long>> deltaSnapshotIds,
       String stagingLocation,
       int format,
-      String sourcePrefix,
-      String targetPrefix,
+      Map<String, String> prefixMappings,
       Broadcast<Map<String, Long>> rewrittenDeleteFileSizes) {
 
     return manifestFile -> {
@@ -620,13 +634,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         case DATA:
           result.appendDataFile(
               writeDataManifest(
-                  manifestFile,
-                  table,
-                  deltaSnapshotIds,
-                  stagingLocation,
-                  format,
-                  sourcePrefix,
-                  targetPrefix));
+                  manifestFile, table, deltaSnapshotIds, stagingLocation, format, prefixMappings));
           break;
         case DELETES:
           result.appendDeleteFile(
@@ -636,8 +644,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                   deltaSnapshotIds,
                   stagingLocation,
                   format,
-                  sourcePrefix,
-                  targetPrefix,
+                  prefixMappings,
                   rewrittenDeleteFileSizes));
           break;
         default:
@@ -654,11 +661,14 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Broadcast<Set<Long>> snapshotIds,
       String stagingLocation,
       int format,
-      String sourcePrefix,
-      String targetPrefix) {
+      Map<String, String> prefixMappings) {
     try {
+      Map.Entry<String, String> matchingPrefix =
+          RewriteTablePathUtil.lookupPrefixMappings(manifestFile.path(), prefixMappings);
+
       String stagingPath =
-          RewriteTablePathUtil.stagingPath(manifestFile.path(), sourcePrefix, stagingLocation);
+          RewriteTablePathUtil.stagingPath(
+              manifestFile.path(), matchingPrefix.getKey(), stagingLocation);
       FileIO io = table.getValue().io();
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
@@ -670,8 +680,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
           io,
           format,
           specsById,
-          sourcePrefix,
-          targetPrefix);
+          matchingPrefix.getKey(),
+          matchingPrefix.getValue());
     } catch (IOException e) {
       throw new RuntimeIOException(e);
     }
@@ -683,12 +693,19 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Broadcast<Set<Long>> snapshotIds,
       String stagingLocation,
       int format,
-      String sourcePrefix,
-      String targetPrefix,
+      Map<String, String> prefixMappings,
       Broadcast<Map<String, Long>> rewrittenDeleteFileSizes) {
     try {
+      Map.Entry<String, String> matchingPrefix =
+          RewriteTablePathUtil.lookupPrefixMappings(manifestFile.path(), prefixMappings);
+
+      if (matchingPrefix == null) {
+        throw new IllegalArgumentException(
+            "unable to find prefix mapping for path: " + manifestFile.path());
+      }
+
       String stagingPath =
-          RewriteTablePathUtil.stagingPath(manifestFile.path(), sourcePrefix, stagingLocation);
+          RewriteTablePathUtil.stagingPath(manifestFile.path(), prefixMappings, stagingLocation);
       FileIO io = table.getValue().io();
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
@@ -700,8 +717,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
           io,
           format,
           specsById,
-          sourcePrefix,
-          targetPrefix,
+          matchingPrefix.getKey(),
+          matchingPrefix.getValue(),
           stagingLocation,
           rewrittenDeleteFileSizes.value());
     } catch (IOException e) {
@@ -777,11 +794,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             .repartition(physicalFiles.size())
             .map(
                 rewritePositionDelete(
-                    tableBroadcast(),
-                    sourcePrefix,
-                    targetPrefix,
-                    stagingDir,
-                    posDeleteReaderWriter),
+                    tableBroadcast(), prefixMappings, stagingDir, posDeleteReaderWriter),
                 Encoders.tuple(Encoders.STRING(), Encoders.LONG()))
             .collectAsList();
 
@@ -794,15 +807,20 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   private static MapFunction<DeleteFile, Tuple2<String, Long>> rewritePositionDelete(
       Broadcast<Table> tableArg,
-      String sourcePrefixArg,
-      String targetPrefixArg,
+      Map<String, String> prefixMappings,
       String stagingLocationArg,
       PositionDeleteReaderWriter posDeleteReaderWriter) {
     return deleteFile -> {
       FileIO io = tableArg.getValue().io();
+      Map.Entry<String, String> matchingPrefix =
+          RewriteTablePathUtil.lookupPrefixMappings(deleteFile.location(), prefixMappings);
+      if (matchingPrefix == null) {
+        throw new IllegalArgumentException(
+            "unable to find prefix mapping for path: " + deleteFile.location());
+      }
       String newPath =
           RewriteTablePathUtil.stagingPath(
-              deleteFile.location(), sourcePrefixArg, stagingLocationArg);
+              deleteFile.location(), prefixMappings, stagingLocationArg);
       OutputFile outputFile = io.newOutputFile(newPath);
       PartitionSpec spec = tableArg.getValue().specs().get(deleteFile.specId());
       long rewrittenLength =
@@ -811,8 +829,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
               outputFile,
               io,
               spec,
-              sourcePrefixArg,
-              targetPrefixArg,
+              matchingPrefix.getKey(),
+              matchingPrefix.getValue(),
               posDeleteReaderWriter);
       return new Tuple2<>(deleteFile.location(), rewrittenLength);
     };


### PR DESCRIPTION
  ### What changed

  `RewriteTablePath` today accepts a **single** `source → target` location prefix.
  This PR generalizes it to support **multiple prefix mappings** in one run, so a table whose files live under more than one prefix (e.g. data under one bucket/path and metadata under another) can be relocated in a single action.

  ### API
  
  `rewriteLocationPrefix(sourcePrefix, targetPrefix)` can now be **called multiple times** — each call registers one mapping:

  ```java
  SparkActions.get()
      .rewriteTablePath(table)
      .rewriteLocationPrefix("s3://old-data/",  "s3://new-data/")
      .rewriteLocationPrefix("s3://old-meta/",  "s3://new-meta/")
      .endVersion("v3.metadata.json")
      .execute();
   ```

  For every path, the longest matching source prefix wins (RewriteTablePathUtil.lookupPrefixMappings), so overlapping prefixes resolve deterministically. A path that matches no mapping fails fast with a clear error.

  ###  Implementation
  
  - Core (RewriteTablePathUtil) — path rewriting is now driven by a
  Map<String,String> prefixMappings. The previous single-prefix public methods
  (replacePaths, rewriteManifestList, stagingPath, newPath, …) are retained as backward-compatible overloads that delegate to the map-based versions, so existing callers keep working.
  - Partition statistics — the map-based replacePaths previously rejected tables that had partition-statistics files; that guard was spurious (the code already rewrites those paths), so it is removed and partition-statistics file paths are now rewritten correctly.
  - Spark 4.1 — RewriteTablePathSparkAction switched to the prefixMappings map API, resolving the matching prefix per manifest / delete file. This is combined with the rewritten delete-file size tracking already on main.

  ### Scope
  
  Multi-prefix support is exposed in Spark 4.1 only for now. Spark 3.5 and 4.0
  are unchanged and continue to compile/behave exactly as before (they use the
  retained single-prefix overloads). Porting the action to 3.5/4.0 can follow up.

  ###  Testing

  - [ ] Existing TestRewriteTablePath* suites pass (single-prefix path unchanged).
  - [ ] New test: multiple prefix mappings relocate data + metadata + delete files.
  - [ ] New test: overlapping prefixes resolve to the longest match.
  - [ ] New test: a path matching no mapping fails with a clear error.
  - [ ] New test: table with partition-statistics files is rewritten (no longer rejected).