### PR TITLE
Parquet: Fix UnnecessaryParentheses warning

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -25,7 +25,6 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -178,9 +177,8 @@ class ParquetIO {
     @Override
     public void readVectored(List<ParquetFileRange> ranges, ByteBufferAllocator allocate)
         throws IOException {
-      IntFunction<ByteBuffer> delegateAllocate = (allocate::allocate);
       List<FileRange> delegateRange = convertRanges(ranges);
-      delegate.readVectored(delegateRange, delegateAllocate);
+      delegate.readVectored(delegateRange, allocate::allocate);
     }
 
     private static List<FileRange> convertRanges(List<ParquetFileRange> ranges) {


### PR DESCRIPTION
Fix UnnecessaryParentheses warning:
```
iceberg/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java:181: warning: [UnnecessaryParentheses] These grouping parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
      IntFunction<ByteBuffer> delegateAllocate = (allocate::allocate);
                                                 ^
    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
  Did you mean 'IntFunction<ByteBuffer> delegateAllocate =  allocate::allocate;'?
```