### PR TITLE
API, Core: Fix byte buffer conversion for Variant in bounds

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -32,6 +32,9 @@ import java.util.UUID;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
 
 public class Conversions {
 
@@ -117,6 +120,17 @@ public class Conversions {
         return (ByteBuffer) value;
       case DECIMAL:
         return ByteBuffer.wrap(((BigDecimal) value).unscaledValue().toByteArray());
+      case VARIANT:
+        // Produce a concatenated buffer of metadata and value
+        Variant variant = (Variant) value;
+        VariantMetadata variantMetadata = variant.metadata();
+        VariantValue variantValue = variant.value();
+        ByteBuffer variantBuffer =
+            ByteBuffer.allocate(variantMetadata.sizeInBytes() + variantValue.sizeInBytes())
+                .order(ByteOrder.LITTLE_ENDIAN);
+        variantMetadata.writeTo(variantBuffer, 0);
+        variantValue.writeTo(variantBuffer, variantMetadata.sizeInBytes());
+        return variantBuffer;
       default:
         throw new UnsupportedOperationException("Cannot serialize type: " + typeId);
     }
@@ -177,6 +191,8 @@ public class Conversions {
         byte[] unscaledBytes = new byte[buffer.remaining()];
         tmp.get(unscaledBytes);
         return new BigDecimal(new BigInteger(unscaledBytes), decimal.scale());
+      case VARIANT:
+        return Variant.from(tmp);
       default:
         throw new UnsupportedOperationException("Cannot deserialize type: " + type);
     }

--- a/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
@@ -24,6 +24,8 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
@@ -83,5 +85,17 @@ public class TestPrimitiveWrapper {
     assertThat(actual.type()).isEqualTo(primitive.type());
     assertThat(actual).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.asPrimitive().get()).isEqualTo(primitive.get());
+  }
+
+  @ParameterizedTest
+  @FieldSource("PRIMITIVES")
+  public void testByteBufferConversion(VariantPrimitive<?> primitive) {
+    VariantMetadata primitiveMetadata = Variants.metadata("$['primitive']");
+    Variant expectedVariant = Variant.of(primitiveMetadata, primitive);
+    ByteBuffer convertedValue = Conversions.toByteBuffer(Types.VariantType.get(), expectedVariant);
+    Variant readValue = Conversions.fromByteBuffer(Types.VariantType.get(), convertedValue);
+
+    VariantTestUtil.assertEqual(expectedVariant.metadata(), readValue.metadata());
+    VariantTestUtil.assertEqual(expectedVariant.value(), readValue.value());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/variants/TestValueArray.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestValueArray.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Random;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,6 +87,18 @@ public class TestValueArray {
     VariantTestUtil.assertVariantString(actual.get(1), "iceberg");
     assertThat(actual.get(2)).isInstanceOf(VariantPrimitive.class);
     assertThat(actual.get(2).asPrimitive().get()).isEqualTo(new BigDecimal("12.21"));
+  }
+
+  @Test
+  public void testByteBufferConversion() {
+    ValueArray arr = createArray(ELEMENTS);
+    VariantMetadata metadata = Variants.metadata("$['arr']");
+    Variant expectedVariant = Variant.of(metadata, arr);
+    ByteBuffer convertedValue = Conversions.toByteBuffer(Types.VariantType.get(), expectedVariant);
+    Variant readValue = Conversions.fromByteBuffer(Types.VariantType.get(), convertedValue);
+
+    VariantTestUtil.assertEqual(expectedVariant.metadata(), readValue.metadata());
+    VariantTestUtil.assertEqual(expectedVariant.value(), readValue.value());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Currently Conversions to/fromByteBuffer will fail when trying to handle variant type. 
This issue primarily manifests in fromByteBuffer when querying metadata tables like the files table and there are stats on shredded fields; specifically, the failure surfaces when trying to [project the lower bounds/upper bounds in the results ](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/MetricsUtil.java#L190) .

This PR contains the following changes:

1. Support toByteBuffer, which will interpret the object as a Variant and produce a concatenated ByteBuffer of metadata and variant. This isn't quite exercised since we have a package private util in Parquet which is actually doing this for  stats on shredded fields, but I do feel like it's reasonable to have this behavior in Conversions as well.

2. Support from byte buffer which will interpret the byte buffer into the in-memory Variant structure.

This change does have the assumption that the bytebuffer is always a concatenated  of metadata + value arrays but I think that this is reasonable as well because the primary use case of the Conversions API is around lower/upper bounds handling which does have this structure.  Additionally, I don't think there's really any reasonable alternative interpretations because every other interpretation is really an incomplete variant (e.g. could just interpret it as a value without metadata or vice versa).