### PR TITLE
Build: bump testcontainers from 1.21.3 to 2.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,7 +87,7 @@ spark34 = "3.4.4"
 spark35 = "3.5.7"
 spark40 = "4.0.1"
 sqlite-jdbc = "3.50.3.0"
-testcontainers = "1.21.3"
+testcontainers = "2.0.1"
 tez08 = { strictly = "0.8.4"}  # see rich version usage explanation above
 
 [libraries]
@@ -218,7 +218,7 @@ nessie-versioned-storage-testextension = { module = "org.projectnessie.nessie:ne
 orc-tools = { module = "org.apache.orc:orc-tools", version.ref = "orc" }
 sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite-jdbc" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
-testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
-testcontainers-minio = { module = "org.testcontainers:minio", version.ref = "testcontainers" }
+testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers" }
+testcontainers-minio = { module = "org.testcontainers:testcontainers-minio", version.ref = "testcontainers" }
 tez08-dag = { module = "org.apache.tez:tez-dag", version.ref = "tez08" }
 tez08-mapreduce = { module = "org.apache.tez:tez-mapreduce", version.ref = "tez08" }


### PR DESCRIPTION
Testcontainers v2 was released on October 14 2025

Release notes:

https://github.com/testcontainers/testcontainers-java/releases


# Related work

Apache Polaris has already upgraded to Testcontainers v2

https://github.com/apache/polaris/blob/main/gradle/libs.versions.toml
