### PR TITLE
Core: Remove requiresNamespaceCreate check from TestRESTCatalog

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -904,9 +904,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
             SnapshotMode.REFS.name()));
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     // Create a table with multiple snapshots
     Table table = catalog.createTable(TABLE, SCHEMA);
@@ -978,9 +976,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
             SnapshotMode.REFS.name()));
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     Table table =
         catalog.createTable(
@@ -1088,9 +1084,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
             SnapshotMode.REFS.name()));
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     Table table =
         catalog.createTable(TABLE, SCHEMA, PartitionSpec.unpartitioned(), ImmutableMap.of());
@@ -1183,9 +1177,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             required(1, "id", Types.IntegerType.get(), "unique ID"),
             required(2, "data", Types.StringType.get()));
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TBL.namespace());
-    }
+    catalog.createNamespace(TBL.namespace());
 
     Table table = catalog.createTable(TBL, expectedSchema);
     assertThat(table.schema().asStruct())
@@ -2095,9 +2087,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Namespace namespace = Namespace.of("namespace");
     TableIdentifier identifier = TableIdentifier.of(namespace, "multipleDiffsAgainstSingleTable");
 
-    if (requiresNamespaceCreate()) {
-      catalog().createNamespace(namespace);
-    }
+    catalog().createNamespace(namespace);
 
     Table table = catalog().buildTable(identifier, SCHEMA).create();
     Transaction transaction = table.newTransaction();
@@ -2131,9 +2121,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     TableIdentifier identifier1 = TableIdentifier.of(namespace, "multiDiffTable1");
     TableIdentifier identifier2 = TableIdentifier.of(namespace, "multiDiffTable2");
 
-    if (requiresNamespaceCreate()) {
-      catalog().createNamespace(namespace);
-    }
+    catalog().createNamespace(namespace);
 
     Table table1 = catalog().buildTable(identifier1, SCHEMA).create();
     Table table2 = catalog().buildTable(identifier2, SCHEMA).create();
@@ -2177,9 +2165,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     TableIdentifier identifier1 = TableIdentifier.of(namespace, "multiDiffTable1");
     TableIdentifier identifier2 = TableIdentifier.of(namespace, "multiDiffTable2");
 
-    if (requiresNamespaceCreate()) {
-      catalog().createNamespace(namespace);
-    }
+    catalog().createNamespace(namespace);
 
     catalog().createTable(identifier1, SCHEMA);
     catalog().createTable(identifier2, SCHEMA);
@@ -2365,9 +2351,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog = catalog(adapter);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
     DataFile file =
@@ -2408,9 +2392,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog = catalog(adapter);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
     Table table = catalog.loadTable(TABLE);
@@ -2443,9 +2425,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog = catalog(adapter);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
     TableIdentifier newTable = TableIdentifier.of(TABLE.namespace(), "some_table");
@@ -2490,9 +2470,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog = catalog(adapter);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
     TableIdentifier newTable = TableIdentifier.of(TABLE.namespace(), "some_table");
@@ -2532,9 +2510,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog = catalog(adapter);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
     Mockito.doThrow(new NotAuthorizedException("not authorized"))
@@ -2575,9 +2551,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
     RESTCatalog catalog = catalog(adapter);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
     Mockito.doThrow(new ServiceFailureException("some service failure"))
@@ -2778,9 +2752,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     RESTCatalog catalog = catalogWithResponseHeaders(respHeaders);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
 
@@ -2799,9 +2771,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     RESTCatalog catalog = catalogWithResponseHeaders(respHeaders);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
 
@@ -2821,9 +2791,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     RESTCatalog catalog = catalogWithResponseHeaders(respHeaders);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     Table tbl = catalog.createTable(TABLE, SCHEMA);
 
@@ -2844,9 +2812,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     RESTCatalog catalog = catalogWithResponseHeaders(respHeaders);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     Table tbl = catalog.createTable(TABLE, SCHEMA);
 
@@ -2867,9 +2833,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     RESTCatalog catalog = catalogWithResponseHeaders(respHeaders);
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     Table tbl = catalog.createTable(TABLE, SCHEMA);
 
@@ -2912,9 +2876,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         ImmutableMap.of(
             CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
 
@@ -2972,9 +2934,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         ImmutableMap.of(
             CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
 
-    if (requiresNamespaceCreate()) {
-      catalog.createNamespace(TABLE.namespace());
-    }
+    catalog.createNamespace(TABLE.namespace());
 
     catalog.createTable(TABLE, SCHEMA);
 


### PR DESCRIPTION
TestRESTCatalog already knows its own behavior (requiresNamespaceCreate method always returns true).
This condition only makes sense for classes that don't know their behavior, such as abstract CatalogTests.