### PR TITLE
String `ends-with` and `not-ends-with` expressions

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
@@ -88,6 +88,10 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return String.valueOf(value).startsWith((String) literal.value());
       case NOT_STARTS_WITH:
         return !String.valueOf(value).startsWith((String) literal.value());
+      case ENDS_WITH:
+        return String.valueOf(value).endsWith((String) literal.value());
+      case NOT_ENDS_WITH:
+        return !String.valueOf(value).endsWith((String) literal.value());
       default:
         throw new IllegalStateException("Invalid operation for BoundLiteralPredicate: " + op());
     }
@@ -159,6 +163,10 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return term() + " startsWith \"" + literal + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal + "\"";
+      case ENDS_WITH:
+        return term() + " endsWith \"" + literal + "\"";
+      case NOT_ENDS_WITH:
+        return term() + " notEndsWith \"" + literal + "\"";
       case IN:
         return term() + " in { " + literal + " }";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -156,5 +156,16 @@ public class Evaluator implements Serializable {
     public <T> Boolean notStartsWith(Bound<T> valueExpr, Literal<T> lit) {
       return !startsWith(valueExpr, lit);
     }
+
+    @Override
+    public <T> Boolean endsWith(Bound<T> valueExpr, Literal<T> lit) {
+      T evalRes = valueExpr.eval(struct);
+      return evalRes != null && ((String) evalRes).endsWith((String) lit.value());
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(Bound<T> valueExpr, Literal<T> lit) {
+      return !endsWith(valueExpr, lit);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -44,6 +44,8 @@ public interface Expression extends Serializable {
     OR,
     STARTS_WITH,
     NOT_STARTS_WITH,
+    ENDS_WITH,
+    NOT_ENDS_WITH,
     COUNT,
     COUNT_NULL,
     COUNT_STAR,
@@ -91,6 +93,10 @@ public interface Expression extends Serializable {
           return Operation.NOT_STARTS_WITH;
         case NOT_STARTS_WITH:
           return Operation.STARTS_WITH;
+        case ENDS_WITH:
+          return Operation.NOT_ENDS_WITH;
+        case NOT_ENDS_WITH:
+          return Operation.ENDS_WITH;
         default:
           throw new IllegalArgumentException("No negation for operation: " + this);
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -341,6 +341,8 @@ public class ExpressionUtil {
         case NOT_EQ:
         case STARTS_WITH:
         case NOT_STARTS_WITH:
+        case ENDS_WITH:
+        case NOT_ENDS_WITH:
           return new UnboundPredicate<>(
               pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
         case IN:
@@ -441,6 +443,10 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case ENDS_WITH:
+          return term + " ENDS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_ENDS_WITH:
+          return term + " NOT ENDS WITH " + value((BoundLiteralPredicate<?>) pred);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());
@@ -493,6 +499,10 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case ENDS_WITH:
+          return term + " ENDS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_ENDS_WITH:
+          return term + " NOT ENDS WITH " + sanitize(pred.literal(), nowMicros, today);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -126,6 +126,16 @@ public class ExpressionVisitors {
           "notStartsWith expression is not supported by the visitor");
     }
 
+    public <T> R endsWith(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "endsWith expression is not supported by the visitor");
+    }
+
+    public <T> R notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "notEndsWith expression is not supported by the visitor");
+    }
+
     /**
      * Handle a non-reference value in this visitor.
      *
@@ -166,6 +176,10 @@ public class ExpressionVisitors {
             return startsWith((BoundReference<T>) pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith((BoundReference<T>) pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -266,6 +280,14 @@ public class ExpressionVisitors {
       throw new UnsupportedOperationException("Unsupported operation.");
     }
 
+    public <T> R endsWith(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R notEndsWith(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
     @Override
     public <T> R predicate(BoundPredicate<T> pred) {
       if (pred.isLiteralPredicate()) {
@@ -287,6 +309,10 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith(pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -465,6 +491,10 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case ENDS_WITH:
+            return endsWith(pred.term(), literalPred.literal());
+          case NOT_ENDS_WITH:
+            return notEndsWith(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -553,6 +583,14 @@ public class ExpressionVisitors {
     }
 
     public <T> R notStartsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R endsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R notEndsWith(BoundTerm<T> term, Literal<T> lit) {
       return null;
     }
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -202,6 +202,22 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, expr, value);
   }
 
+  public static UnboundPredicate<String> endsWith(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.ENDS_WITH, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> endsWith(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.ENDS_WITH, expr, value);
+  }
+
+  public static UnboundPredicate<String> notEndsWith(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_ENDS_WITH, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> notEndsWith(UnboundTerm<String> expr, String value) {
+    return new UnboundPredicate<>(Expression.Operation.NOT_ENDS_WITH, expr, value);
+  }
+
   public static <T> UnboundPredicate<T> in(String name, T... values) {
     return predicate(Operation.IN, name, Lists.newArrayList(values));
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -471,6 +471,22 @@ public class InclusiveMetricsEvaluator {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(Bound<T> term, Literal<T> lit) {
+      // the only transforms that produce strings are truncate and identity, which work with this
+      int id = term.ref().fieldId();
+      if (containsNullsOnly(id)) {
+        return ROWS_CANNOT_MATCH;
+      }
+
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(Bound<T> term, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
     private boolean mayContainNull(Integer id) {
       return nullCounts == null || !nullCounts.containsKey(id) || nullCounts.get(id) != 0;
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -400,6 +400,22 @@ public class ManifestEvaluator {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      int pos = Accessors.toPosition(ref.accessor());
+      PartitionFieldSummary fieldStats = stats.get(pos);
+      if (fieldStats.lowerBound() == null) {
+        return ROWS_CANNOT_MATCH; // values are all null, cannot end with the literal
+      }
+
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
     private boolean allValuesAreNull(PartitionFieldSummary summary, Type.TypeID typeId) {
       // containsNull encodes whether at least one partition value is null,
       // lowerBound is null if all partition values are null

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -223,6 +223,20 @@ public class ResidualEvaluator implements Serializable {
     }
 
     @Override
+    public <T> Expression endsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).endsWith((String) lit.value())
+          ? alwaysTrue()
+          : alwaysFalse();
+    }
+
+    @Override
+    public <T> Expression notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).endsWith((String) lit.value())
+          ? alwaysFalse()
+          : alwaysTrue();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <T> Expression predicate(BoundPredicate<T> pred) {
       // Get the strict projection and inclusive projection of this predicate in partition data,

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -472,6 +472,16 @@ public class StrictMetricsEvaluator {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
     private boolean isNestedColumn(int id) {
       return struct.field(id) == null;
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -168,10 +168,14 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
   }
 
   private Expression bindLiteralOperation(BoundTerm<T> boundTerm) {
-    if (op() == Operation.STARTS_WITH || op() == Operation.NOT_STARTS_WITH) {
+    if (op() == Operation.STARTS_WITH
+        || op() == Operation.NOT_STARTS_WITH
+        || op() == Operation.ENDS_WITH
+        || op() == Operation.NOT_ENDS_WITH) {
       ValidationException.check(
           boundTerm.type().equals(Types.StringType.get()),
-          "Term for STARTS_WITH or NOT_STARTS_WITH must produce a string: %s: %s",
+          "Term for %s must produce a string: %s: %s",
+          op().name(),
           boundTerm,
           boundTerm.type());
     }
@@ -284,6 +288,10 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
         return term() + " startsWith \"" + literal() + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal() + "\"";
+      case ENDS_WITH:
+        return term() + " endsWith \"" + literal() + "\"";
+      case NOT_ENDS_WITH:
+        return term() + " notEndsWith \"" + literal() + "\"";
       case IN:
         return term() + " in (" + COMMA.join(literals()) + ")";
       case NOT_IN:

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.expressions;
 import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -30,6 +31,7 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notEndsWith;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
@@ -345,6 +347,54 @@ public class TestEvaluator {
         .isFalse();
     assertThat(evaluator.eval(TestHelpers.Row.of("Abcde")))
         .as("Abcde notStartsWith abc should be true")
+        .isTrue();
+  }
+
+  @Test
+  public void testEndsWith() {
+    StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
+    Evaluator evaluator = new Evaluator(struct, endsWith("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
+        .as("abc endsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcx")))
+        .as("abcx endsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("Abc")))
+        .as("Abc endsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("c")))
+        .as("c endsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("xyzabc")))
+        .as("xyzabc endsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of((String) null)))
+        .as("null endsWith abc should be false")
+        .isFalse();
+  }
+
+  @Test
+  public void testNotEndsWith() {
+    StructType struct = StructType.of(required(24, "s", Types.StringType.get()));
+    Evaluator evaluator = new Evaluator(struct, notEndsWith("s", "abc"));
+    assertThat(evaluator.eval(TestHelpers.Row.of("abc")))
+        .as("abc notEndsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("abcx")))
+        .as("abcx notEndsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("Abc")))
+        .as("Abc notEndsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("c")))
+        .as("c notEndsWith abc should be true")
+        .isTrue();
+    assertThat(evaluator.eval(TestHelpers.Row.of("xyzabc")))
+        .as("xyzabc notEndsWith abc should be false")
+        .isFalse();
+    assertThat(evaluator.eval(TestHelpers.Row.of("XyzAbc")))
+        .as("XyzAbc notEndsWith abc should be true")
         .isTrue();
   }
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.expressions.Expressions.day;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -33,6 +34,7 @@ import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.month;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notEndsWith;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNull;
@@ -178,7 +180,9 @@ public class TestExpressionHelpers {
           {or(equal("a", 5), isNull("a")), not(and(notEqual("a", 5), notNull("a")))},
           {or(equal("a", 5), notNull("a")), or(equal("a", 5), not(isNull("a")))},
           {startsWith("s", "hello"), not(notStartsWith("s", "hello"))},
-          {notStartsWith("s", "world"), not(startsWith("s", "world"))}
+          {notStartsWith("s", "world"), not(startsWith("s", "world"))},
+          {endsWith("s", "hello"), not(notEndsWith("s", "hello"))},
+          {notEndsWith("s", "world"), not(endsWith("s", "world"))}
         };
 
     for (Expression[] pair : expressions) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionSerialization.java
@@ -53,6 +53,8 @@ public class TestExpressionSerialization {
           Expressions.notNaN("maybeNaN2"),
           Expressions.startsWith("col", "abc"),
           Expressions.notStartsWith("col", "abc"),
+          Expressions.endsWith("col", "abc"),
+          Expressions.notEndsWith("col", "abc"),
           Expressions.not(Expressions.greaterThan("a", 10)),
           Expressions.and(Expressions.greaterThanOrEqual("a", 0), Expressions.lessThan("a", 3)),
           Expressions.or(Expressions.lessThan("a", 0), Expressions.greaterThan("a", 10)),
@@ -61,7 +63,9 @@ public class TestExpressionSerialization {
           Expressions.notIn("s", "abc", "xyz").bind(schema.asStruct()),
           Expressions.isNull("a").bind(schema.asStruct()),
           Expressions.startsWith("s", "abc").bind(schema.asStruct()),
-          Expressions.notStartsWith("s", "xyz").bind(schema.asStruct())
+          Expressions.notStartsWith("s", "xyz").bind(schema.asStruct()),
+          Expressions.endsWith("s", "abc").bind(schema.asStruct()),
+          Expressions.notEndsWith("s", "xyz").bind(schema.asStruct())
         };
 
     for (Expression expression : expressions) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -343,6 +343,45 @@ public class TestExpressionUtil {
   }
 
   @Test
+  public void testSanitizeEndsWith() {
+    assertEquals(
+        Expressions.endsWith("test", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(Expressions.endsWith("test", "aaa")));
+
+    assertEquals(
+        Expressions.endsWith("data", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.endsWith("data", "aaa"), true));
+
+    assertThat(ExpressionUtil.toSanitizedString(Expressions.endsWith("test", "aaa")))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test ENDS WITH (hash-34d05fb7)");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.endsWith("data", "aaa"), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("data ENDS WITH (hash-34d05fb7)");
+  }
+
+  @Test
+  public void testSanitizeNotEndsWith() {
+    assertEquals(
+        Expressions.notEndsWith("test", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(Expressions.notEndsWith("test", "aaa")));
+
+    assertEquals(
+        Expressions.notEndsWith("data", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.notEndsWith("data", "aaa"), true));
+
+    assertThat(ExpressionUtil.toSanitizedString(Expressions.notEndsWith("test", "aaa")))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test NOT ENDS WITH (hash-34d05fb7)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(STRUCT, Expressions.notEndsWith("data", "aaa"), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("data NOT ENDS WITH (hash-34d05fb7)");
+  }
+
+  @Test
   public void testSanitizeTransformedTerm() {
     assertEquals(
         Expressions.equal(Expressions.truncate("test", 2), "(2-digit-int)"),
@@ -830,6 +869,8 @@ public class TestExpressionUtil {
           Expressions.notIn("id", 5, 6),
           Expressions.startsWith("data", "aaa"),
           Expressions.notStartsWith("data", "aaa"),
+          Expressions.endsWith("data", "aaa"),
+          Expressions.notEndsWith("data", "aaa"),
           Expressions.alwaysTrue(),
           Expressions.alwaysFalse(),
           Expressions.and(Expressions.lessThan("id", 5), Expressions.notNull("data")),

--- a/api/src/test/java/org/apache/iceberg/transforms/TestResiduals.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestResiduals.java
@@ -164,7 +164,9 @@ public class TestResiduals {
           Expressions.notNaN("g"),
           Expressions.isNaN("h"),
           Expressions.startsWith("data", "abcd"),
-          Expressions.notStartsWith("data", "abcd")
+          Expressions.notStartsWith("data", "abcd"),
+          Expressions.endsWith("data", "abcd"),
+          Expressions.notEndsWith("data", "abcd")
         };
 
     for (Expression expr : expressions) {

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -434,6 +434,16 @@ public class AllManifestsTable extends BaseMetadataTable {
         return ROWS_MIGHT_MATCH;
       }
 
+      @Override
+      public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       /**
        * Comparison of snapshot reference and literal, using long comparator.
        *

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -251,6 +251,16 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
         return ROWS_MIGHT_MATCH;
       }
 
+      @Override
+      public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       private <T> boolean fileContent(BoundReference<T> ref) {
         return ref.fieldId() == DataFile.CONTENT.fieldId();
       }

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -347,6 +347,8 @@ public class ExpressionParser {
       case NOT_EQ:
       case STARTS_WITH:
       case NOT_STARTS_WITH:
+      case ENDS_WITH:
+      case NOT_ENDS_WITH:
         // literal predicates
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);

--- a/core/src/test/java/org/apache/iceberg/TestFindFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFindFiles.java
@@ -182,6 +182,42 @@ public class TestFindFiles extends TestBase {
   }
 
   @TestTemplate
+  public void testWithMetadataMatchingEndsWith() {
+    table
+        .newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .appendFile(FILE_C)
+        .appendFile(FILE_D)
+        .commit();
+
+    Iterable<DataFile> files =
+        FindFiles.in(table)
+            .withMetadataMatching(Expressions.endsWith("file_path", "data-a.parquet"))
+            .collect();
+
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_A));
+  }
+
+  @TestTemplate
+  public void testWithMetadataMatchingNotEndsWith() {
+    table
+        .newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .appendFile(FILE_C)
+        .appendFile(FILE_D)
+        .commit();
+
+    Iterable<DataFile> files =
+        FindFiles.in(table)
+            .withMetadataMatching(Expressions.notEndsWith("file_path", "data-a.parquet"))
+            .collect();
+
+    assertThat(pathSet(files)).isEqualTo(pathSet(FILE_B, FILE_C, FILE_D));
+  }
+
+  @TestTemplate
   public void testIncludeColumnStats() {
     table.newAppend().appendFile(FILE_WITH_STATS).commit();
 

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -84,6 +84,8 @@ public class TestExpressionParser {
           Expressions.notNaN("f"),
           Expressions.startsWith("s", "crackle"),
           Expressions.notStartsWith("s", "tackle"),
+          Expressions.endsWith("s", "crackle"),
+          Expressions.notEndsWith("s", "tackle"),
           Expressions.equal(Expressions.day("date"), "2022-08-14"),
           Expressions.equal(Expressions.bucket("id", 100), 0),
           Expressions.and(
@@ -539,6 +541,38 @@ public class TestExpressionParser {
             + "}";
 
     Expression expression = Expressions.in("column-name", new BigDecimal("3.14E+4"));
+
+    assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testEndsWithExpression() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"ends-with\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"value\" : \"suffix\"\n"
+            + "}";
+
+    Expression expression = Expressions.endsWith("column-name", "suffix");
+
+    assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testNotEndsWithExpression() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"not-ends-with\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"value\" : \"suffix\"\n"
+            + "}";
+
+    Expression expression = Expressions.notEndsWith("column-name", "suffix");
 
     assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
     assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))

--- a/core/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluatorWithExtract.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluatorWithExtract.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.expressions;
 
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.extract;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
@@ -29,6 +30,7 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notEndsWith;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
@@ -166,6 +168,14 @@ public class TestInclusiveMetricsEvaluatorWithExtract {
 
     assertThat(shouldRead(notStartsWith(extract("all_nulls", "$.event_type", "string"), "a")))
         .as("Should read: notStartsWith on all null column")
+        .isTrue();
+
+    assertThat(shouldRead(endsWith(extract("all_nulls", "$.event_type", "string"), "a")))
+        .as("Should skip: endsWith on all null column")
+        .isFalse();
+
+    assertThat(shouldRead(notEndsWith(extract("all_nulls", "$.event_type", "string"), "a")))
+        .as("Should read: notEndsWith on all null column")
         .isTrue();
 
     assertThat(shouldRead(isNaN(extract("all_nulls", "$.measurement", "double"))))
@@ -564,6 +574,20 @@ public class TestInclusiveMetricsEvaluatorWithExtract {
 
     assertThat(shouldRead(notStartsWith(extract("variant", "$.str", "string"), "abex")))
         .as("Should read: upper is prefix of value, some values do not match")
+        .isTrue();
+  }
+
+  @Test
+  public void testStringEndsWith() {
+    assertThat(shouldRead(endsWith(extract("variant", "$.str", "string"), "c")))
+        .as("Should read: no bounds-based pruning for endsWith")
+        .isTrue();
+  }
+
+  @Test
+  public void testStringNotEndsWith() {
+    assertThat(shouldRead(notEndsWith(extract("variant", "$.str", "string"), "c")))
+        .as("Should read: no bounds-based pruning for notEndsWith")
         .isTrue();
   }
 

--- a/core/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluatorWithTransforms.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluatorWithTransforms.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.expressions;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.expressions.Expressions.day;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -29,6 +30,7 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notEndsWith;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNull;
@@ -258,6 +260,14 @@ public class TestInclusiveMetricsEvaluatorWithTransforms {
 
     assertThat(shouldRead(notStartsWith(truncate("all_nulls_str", 10), "a")))
         .as("Should read: notStartsWith on all null column")
+        .isTrue();
+
+    assertThat(shouldRead(endsWith(truncate("all_nulls_str", 10), "a")))
+        .as("Should skip: endsWith on all null column")
+        .isFalse();
+
+    assertThat(shouldRead(notEndsWith(truncate("all_nulls_str", 10), "a")))
+        .as("Should read: notEndsWith on all null column")
         .isTrue();
   }
 
@@ -577,15 +587,45 @@ public class TestInclusiveMetricsEvaluatorWithTransforms {
 
   @Test
   public void testStringNotStartsWith() {
-    assertThat(shouldRead(startsWith(truncate("str", 10), "a")))
+    assertThat(shouldRead(notStartsWith(truncate("str", 10), "a")))
         .as("Should read: not rewritten")
         .isTrue();
 
-    assertThat(shouldRead(startsWith(truncate("str", 10), "ab")))
+    assertThat(shouldRead(notStartsWith(truncate("str", 10), "ab")))
         .as("Should read: not rewritten")
         .isTrue();
 
-    assertThat(shouldRead(startsWith(truncate("str", 10), "b")))
+    assertThat(shouldRead(notStartsWith(truncate("str", 10), "b")))
+        .as("Should read: not rewritten")
+        .isTrue();
+  }
+
+  @Test
+  public void testStringEndsWith() {
+    assertThat(shouldRead(endsWith(truncate("str", 10), "a")))
+        .as("Should read: not rewritten")
+        .isTrue();
+
+    assertThat(shouldRead(endsWith(truncate("str", 10), "ab")))
+        .as("Should read: not rewritten")
+        .isTrue();
+
+    assertThat(shouldRead(endsWith(truncate("str", 10), "b")))
+        .as("Should read: not rewritten")
+        .isTrue();
+  }
+
+  @Test
+  public void testStringNotEndsWith() {
+    assertThat(shouldRead(notEndsWith(truncate("str", 10), "a")))
+        .as("Should read: not rewritten")
+        .isTrue();
+
+    assertThat(shouldRead(notEndsWith(truncate("str", 10), "ab")))
+        .as("Should read: not rewritten")
+        .isTrue();
+
+    assertThat(shouldRead(notEndsWith(truncate("str", 10), "b")))
         .as("Should read: not rewritten")
         .isTrue();
   }

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.data;
 
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -28,6 +29,7 @@ import static org.apache.iceberg.expressions.Expressions.isNull;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notEndsWith;
 import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
@@ -486,7 +488,9 @@ public class TestMetricsRowGroupFilter {
           isNull("no_stats_parquet"),
           notNull("no_stats_parquet"),
           startsWith("no_stats_parquet", "a"),
-          notStartsWith("no_stats_parquet", "a")
+          notStartsWith("no_stats_parquet", "a"),
+          endsWith("no_stats_parquet", "a"),
+          notEndsWith("no_stats_parquet", "a")
         };
 
     for (Expression expr : exprs) {
@@ -888,6 +892,20 @@ public class TestMetricsRowGroupFilter {
 
     shouldRead = shouldRead(notStartsWith("some_nulls", "som"));
     assertThat(shouldRead).as("Should read: range matches").isTrue();
+  }
+
+  @TestTemplate
+  public void testStringEndsWith() {
+    assertThat(shouldRead(endsWith("str", "1")))
+        .as("Should read: no bounds-based pruning for endsWith")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testStringNotEndsWith() {
+    assertThat(shouldRead(notEndsWith("str", "1")))
+        .as("Should read: no bounds-based pruning for notEndsWith")
+        .isTrue();
   }
 
   @TestTemplate

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
@@ -45,6 +45,7 @@ public class FlinkFilters {
   private FlinkFilters() {}
 
   private static final Pattern STARTS_WITH_PATTERN = Pattern.compile("([^%]+)%");
+  private static final Pattern ENDS_WITH_PATTERN = Pattern.compile("%([^%]+)");
 
   private static final Map<FunctionDefinition, Operation> FILTERS =
       ImmutableMap.<FunctionDefinition, Operation>builder()
@@ -178,11 +179,18 @@ public class FlinkFilters {
               lit -> {
                 if (lit instanceof String) {
                   String pattern = (String) lit;
-                  Matcher matcher = STARTS_WITH_PATTERN.matcher(pattern);
                   // exclude special char of LIKE
                   // '_' is the wildcard of the SQL LIKE
-                  if (!pattern.contains("_") && matcher.matches()) {
-                    return Optional.of(Expressions.startsWith(name, matcher.group(1)));
+                  if (!pattern.contains("_")) {
+                    Matcher startsWithMatcher = STARTS_WITH_PATTERN.matcher(pattern);
+                    if (startsWithMatcher.matches()) {
+                      return Optional.of(Expressions.startsWith(name, startsWithMatcher.group(1)));
+                    }
+
+                    Matcher endsWithMatcher = ENDS_WITH_PATTERN.matcher(pattern);
+                    if (endsWithMatcher.matches()) {
+                      return Optional.of(Expressions.endsWith(name, endsWithMatcher.group(1)));
+                    }
                   }
                 }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkFilters.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkFilters.java
@@ -337,12 +337,14 @@ public class TestFlinkFilters {
     assertThat(actual).isPresent();
     assertPredicatesMatch(expected, actual.get());
 
+    expected = org.apache.iceberg.expressions.Expressions.endsWith("field5", "abc");
     expr =
         resolve(
             ApiExpressionUtils.unresolvedCall(
                 BuiltInFunctionDefinitions.LIKE, Expressions.$("field5"), Expressions.lit("%abc")));
     actual = FlinkFilters.convert(expr);
-    assertThat(actual).isNotPresent();
+    assertThat(actual).isPresent();
+    assertPredicatesMatch(expected, actual.get());
 
     expr =
         resolve(

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableSource.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableSource.java
@@ -501,20 +501,23 @@ public class TestFlinkTableSource extends TableSourceTestBase {
         .as("Should contain the push down filter")
         .asString()
         .isEqualTo(expectedScan);
+
+    // endsWith
+    expectedFilter = "ref(name=\"data\") endsWith \"\"g\"\"";
+    sqlLike = "SELECT * FROM " + TABLE_NAME + " WHERE data LIKE '%%g' ";
+    resultLike = sql(sqlLike);
+    assertThat(resultLike).hasSize(1).first().isEqualTo(Row.of(1, "iceberg", 10.0));
+    assertThat(lastScanEvent.filter())
+        .as("Should contain the push down filter")
+        .asString()
+        .isEqualTo(expectedFilter);
   }
 
   @TestTemplate
   public void testFilterNotPushDownLike() {
     Row expectRecord = Row.of(1, "iceberg", 10.0);
-    String sqlNoPushDown = "SELECT * FROM " + TABLE_NAME + " WHERE data LIKE '%%i' ";
+    String sqlNoPushDown = "SELECT * FROM " + TABLE_NAME + " WHERE data LIKE '%%i%%' ";
     List<Row> resultLike = sql(sqlNoPushDown);
-    assertThat(resultLike).isEmpty();
-    assertThat(lastScanEvent.filter())
-        .as("Should not push down a filter")
-        .isEqualTo(Expressions.alwaysTrue());
-
-    sqlNoPushDown = "SELECT * FROM " + TABLE_NAME + " WHERE data LIKE '%%i%%' ";
-    resultLike = sql(sqlNoPushDown);
     assertThat(resultLike).hasSize(1).first().isEqualTo(expectRecord);
     assertThat(lastScanEvent.filter())
         .as("Should not push down a filter")

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -123,6 +123,8 @@ class ExpressionType(BaseModel):
             'not-eq',
             'starts-with',
             'not-starts-with',
+            'ends-with',
+            'not-ends-with',
             'is-null',
             'not-null',
             'is-nan',

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2186,6 +2186,8 @@ components:
         - "not-eq"
         - "starts-with"
         - "not-starts-with"
+        - "ends-with"
+        - "not-ends-with"
         - "is-null"
         - "not-null"
         - "is-nan"
@@ -2260,7 +2262,7 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/ExpressionType'
-          enum: ["lt", "lt-eq", "gt", "gt-eq", "eq", "not-eq", "starts-with", "not-starts-with"]
+          enum: ["lt", "lt-eq", "gt", "gt-eq", "eq", "not-eq", "starts-with", "not-starts-with", "ends-with", "not-ends-with"]
         term:
           $ref: '#/components/schemas/Term'
         value:

--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -270,6 +270,22 @@ class ExpressionToSearchArgument
   }
 
   @Override
+  public <T> Action endsWith(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down ENDS_WITH operator to ORC, so return TruthValue.YES_NO_NULL which
+    // signifies
+    // that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
+  public <T> Action notEndsWith(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down NOT_ENDS_WITH operator to ORC, so return TruthValue.YES_NO_NULL which
+    // signifies
+    // that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
   public <T> Action predicate(BoundPredicate<T> pred) {
     if (UNSUPPORTED_TYPES.contains(pred.ref().type().typeId())
         || !(pred.term() instanceof BoundReference)) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -259,6 +259,18 @@ public class ParquetBloomRowGroupFilter {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      // bloom filter is based on hash and cannot eliminate based on endsWith
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      // bloom filter is based on hash and cannot eliminate based on endsWith
+      return ROWS_MIGHT_MATCH;
+    }
+
     private BloomFilter loadBloomFilter(int id) {
       if (bloomCache.containsKey(id)) {
         return bloomCache.get(id);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -406,6 +406,44 @@ public class ParquetDictionaryRowGroupFilter {
       return ROWS_CANNOT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      Set<T> dictionary = dict(id, lit.comparator());
+      for (T item : dictionary) {
+        if (item.toString().endsWith(lit.value().toString())) {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      Set<T> dictionary = dict(id, lit.comparator());
+      for (T item : dictionary) {
+        if (!item.toString().endsWith(lit.value().toString())) {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
     @SuppressWarnings("unchecked")
     private <T> Set<T> dict(int id, Comparator<T> comparator) {
       Preconditions.checkNotNull(dictionaries, "Dictionary is required");

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -550,6 +550,30 @@ public class ParquetMetricsRowGroupFilter {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean endsWith(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Long valueCount = valueCounts.get(id);
+      if (valueCount == null) {
+        // the column is not present and is all nulls
+        return ROWS_CANNOT_MATCH;
+      }
+
+      @SuppressWarnings("unchecked")
+      Statistics<Binary> colStats = (Statistics<Binary>) stats.get(id);
+      if (colStats != null && !colStats.isEmpty() && allNulls(colStats, valueCount)) {
+        return ROWS_CANNOT_MATCH;
+      }
+
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notEndsWith(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
     @SuppressWarnings("unchecked")
     private <T> T min(Statistics<?> statistics, int id) {
       return (T) conversions.get(id).apply(statistics.genericGetMin());

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -627,11 +627,12 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
     sql(
         "CALL %s.system.rewrite_data_files(table => '%s'," + " where => 'c2 like \"%s\"')",
         catalogName, tableIdent, "car%");
-    // TODO: Enable when org.apache.iceberg.spark.SparkFilters have implementations for
-    // StringEndsWith & StringContains
     // StringEndsWith
-    // sql("CALL %s.system.rewrite_data_files(table => '%s'," +
-    //     " where => 'c2 like \"%s\"')", catalogName, tableIdent, "%car");
+    sql(
+        "CALL %s.system.rewrite_data_files(table => '%s'," + " where => 'c2 like \"%s\"')",
+        catalogName, tableIdent, "%car");
+    // TODO: Enable when org.apache.iceberg.spark.SparkFilters has an implementations for
+    // StringContains
     // StringContains
     // sql("CALL %s.system.rewrite_data_files(table => '%s'," +
     //     " where => 'c2 like \"%s\"')", catalogName, tableIdent, "%car%");

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -678,6 +678,10 @@ public class Spark3Util {
           return sqlString(pred.term()) + " LIKE '" + pred.literal().value() + "%'";
         case NOT_STARTS_WITH:
           return sqlString(pred.term()) + " NOT LIKE '" + pred.literal().value() + "%'";
+        case ENDS_WITH:
+          return sqlString(pred.term()) + " LIKE '%" + pred.literal().value() + "'";
+        case NOT_ENDS_WITH:
+          return sqlString(pred.term()) + " NOT LIKE '%" + pred.literal().value() + "'";
         case IN:
           return sqlString(pred.term()) + " IN (" + sqlString(pred.literals()) + ")";
         case NOT_IN:

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -68,6 +69,7 @@ import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
 import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.sources.StringEndsWith;
 import org.apache.spark.sql.sources.StringStartsWith;
 
 public class SparkFilters {
@@ -95,6 +97,7 @@ public class SparkFilters {
           .put(Or.class, Operation.OR)
           .put(Not.class, Operation.NOT)
           .put(StringStartsWith.class, Operation.STARTS_WITH)
+          .put(StringEndsWith.class, Operation.ENDS_WITH)
           .buildOrThrow();
 
   public static Expression convert(Filter[] filters) {
@@ -219,6 +222,12 @@ public class SparkFilters {
           {
             StringStartsWith stringStartsWith = (StringStartsWith) filter;
             return startsWith(unquote(stringStartsWith.attribute()), stringStartsWith.value());
+          }
+
+        case ENDS_WITH:
+          {
+            StringEndsWith stringEndsWith = (StringEndsWith) filter;
+            return endsWith(unquote(stringEndsWith.attribute()), stringEndsWith.value());
           }
       }
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.expressions.Expressions.day;
+import static org.apache.iceberg.expressions.Expressions.endsWith;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -88,6 +89,7 @@ public class SparkV2Filters {
   private static final String OR = "OR";
   private static final String NOT = "NOT";
   private static final String STARTS_WITH = "STARTS_WITH";
+  private static final String ENDS_WITH = "ENDS_WITH";
 
   private static final Map<String, Operation> FILTERS =
       ImmutableMap.<String, Operation>builder()
@@ -107,6 +109,7 @@ public class SparkV2Filters {
           .put(OR, Operation.OR)
           .put(NOT, Operation.NOT)
           .put(STARTS_WITH, Operation.STARTS_WITH)
+          .put(ENDS_WITH, Operation.ENDS_WITH)
           .buildOrThrow();
 
   private SparkV2Filters() {}
@@ -303,6 +306,10 @@ public class SparkV2Filters {
         case STARTS_WITH:
           String colName = SparkUtil.toColumnName(leftChild(predicate));
           return startsWith(colName, convertLiteral(rightChild(predicate)).toString());
+
+        case ENDS_WITH:
+          String colNameEndsWith = SparkUtil.toColumnName(leftChild(predicate));
+          return endsWith(colNameEndsWith, convertLiteral(rightChild(predicate)).toString());
       }
     }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -42,6 +42,8 @@ import org.apache.spark.sql.sources.IsNull;
 import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
+import org.apache.spark.sql.sources.StringEndsWith;
+import org.apache.spark.sql.sources.StringStartsWith;
 import org.junit.jupiter.api.Test;
 
 public class TestSparkFilters {
@@ -122,6 +124,22 @@ public class TestSparkFilters {
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkFilters.convert(in);
           assertThat(actualIn).asString().as("In must match").isEqualTo(expectedIn.toString());
+
+          StringStartsWith startsWith = StringStartsWith.apply(quoted, "a");
+          Expression expectedStartsWith = Expressions.startsWith(unquoted, "a");
+          Expression actualStartsWith = SparkFilters.convert(startsWith);
+          assertThat(actualStartsWith)
+              .asString()
+              .as("StringStartsWith must match")
+              .isEqualTo(expectedStartsWith.toString());
+
+          StringEndsWith endsWith = StringEndsWith.apply(quoted, "a");
+          Expression expectedEndsWith = Expressions.endsWith(unquoted, "a");
+          Expression actualEndsWith = SparkFilters.convert(endsWith);
+          assertThat(actualEndsWith)
+              .asString()
+              .as("StringEndsWith must match")
+              .isEqualTo(expectedEndsWith.toString());
         });
   }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -226,6 +226,14 @@ public class TestSparkV2Filters {
               .as("StartsWith must match")
               .isEqualTo(expectedStartsWith.toString());
 
+          Predicate endsWith = new Predicate("ENDS_WITH", attrAndStr);
+          Expression expectedEndsWith = Expressions.endsWith(unquoted, "iceberg");
+          Expression actualEndsWith = SparkV2Filters.convert(endsWith);
+          assertThat(actualEndsWith)
+              .asString()
+              .as("EndsWith must match")
+              .isEqualTo(expectedEndsWith.toString());
+
           Predicate in = new Predicate("IN", attrAndValue);
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkV2Filters.convert(in);

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
@@ -203,8 +203,8 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkFilters(
         "dep LIKE '%d5' AND id IN (1, 5)" /* query predicate */,
-        "EndsWith(dep, d5) AND id IN (1,5)" /* Spark post scan filter */,
-        "dep IS NOT NULL, id IN (1, 5)" /* Iceberg scan filters */,
+        "id IN (1,5)" /* Spark post scan filter */,
+        "dep IS NOT NULL, dep LIKE '%d5', id IN (1, 5)" /* Iceberg scan filters */,
         ImmutableList.of(row(5, 500, "d5")));
   }
 


### PR DESCRIPTION
Devlist thread: https://lists.apache.org/thread/w5jc08s5z3sbdm3hw1cwmqx86s5tsr4b

Iceberg does not currently support string-ends-with and string-not-ends-with expressions. Iceberg expressions are emerging as a standard for predicates, and are already relied on for Iceberg's file pruning during scan planning (before this PR, if you partitioned by a string column `url` and filter using, say, `F.col('url').endswith('fr')`, it won't be used for Iceberg level partition pruning).

This PR supports `ends-with` and `not-ends-with` expressions. It also includes the corresponding spec changes.

(If/when this work is completed, would like to discuss https://github.com/apache/iceberg/pull/14647 also)