### PR TITLE
Core: Add RESTCatalog tests for FileIOTracker

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -58,6 +58,7 @@ import org.apache.iceberg.io.FileIOTracker;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporters;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -672,6 +673,11 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                 ErrorHandlers.namespaceErrorHandler());
 
     return !response.updated().isEmpty();
+  }
+
+  @VisibleForTesting
+  FileIOTracker fileIOTracker() {
+    return fileIOTracker;
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/io/FileIOTrackerTestUtil.java
+++ b/core/src/test/java/org/apache/iceberg/io/FileIOTrackerTestUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import org.apache.iceberg.TableOperations;
+
+public abstract class FileIOTrackerTestUtil {
+  public static Cache<TableOperations, FileIO> trackerFrom(FileIOTracker tracker) {
+    return tracker.tracker();
+  }
+
+  public static void invalidate(FileIOTracker tracker, TableOperations ops) {
+    tracker.tracker().invalidate(ops);
+    tracker.tracker().cleanUp();
+  }
+}


### PR DESCRIPTION
FileIOTracker related functionality in RESTSessionCatalog code isn't covered with tests. The PR adds test coverage, and also some adjustments to make the FileIOTracker available in tests.