### PR TITLE
Core: Add a builder method to override lastUpdateTimestamp in TableMetadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1521,7 +1521,7 @@ public class TableMetadata implements Serializable {
       return this;
     }
 
-    public Builder setLastUpdatedMillisIfNull(long lastUpdatedAt) {
+    public Builder setLastUpdatedMillis(long lastUpdatedAt) {
       Preconditions.checkArgument(
           this.lastUpdatedMillis == null,
           "Cannot set lastUpdatedMillis: field has already been initialized with value %s",

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1965,7 +1965,7 @@ public class TestTableMetadata {
     TableMetadata schemaUpdate =
         TableMetadata.buildFrom(metadata)
             .setCurrentSchema(newSchema, newSchema.highestFieldId())
-            .setLastUpdatedMillisIfNull(originalTimestamp)
+            .setLastUpdatedMillis(originalTimestamp)
             .build();
 
     assertThat(schemaUpdate.lastUpdatedMillis())
@@ -1977,7 +1977,7 @@ public class TestTableMetadata {
     TableMetadata propertyUpdate =
         TableMetadata.buildFrom(schemaUpdate)
             .setProperties(Map.of("foo", "bar"))
-            .setLastUpdatedMillisIfNull(anotherTimestamp)
+            .setLastUpdatedMillis(anotherTimestamp)
             .build();
 
     assertThat(propertyUpdate.lastUpdatedMillis())
@@ -2022,10 +2022,11 @@ public class TestTableMetadata {
                 TableMetadata.buildFrom(base)
                     .addSnapshot(snapshotToAdd)
                     .setBranchSnapshot(snapshotToAdd.snapshotId(), "main")
-                    .setLastUpdatedMillisIfNull(anotherTimestamp)
+                    .setLastUpdatedMillis(anotherTimestamp)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Cannot set lastUpdatedMillis: field has already been initialized with value");
+        .hasMessageStartingWith(
+            "Cannot set lastUpdatedMillis: field has already been initialized with value");
   }
 
   @Test


### PR DESCRIPTION
Today the lastUpdatedMillis in TableMetadata is used to sequence the metadata log entry on build https://github.com/apache/iceberg/blob/f65558ec30a27fb26ed85ba0e3dc4e498f2c046b/core/src/main/java/org/apache/iceberg/TableMetadata.java#L392

This PR allow customization of lastUpdateTimestampMilli when building the TableMetadata, as currently the table metadata last updated timestamp is derived from different sources for data change and metadata change

For data change when there's snapshot involved: 
- addSnapshot: https://github.com/apache/iceberg/blob/f65558ec30a27fb26ed85ba0e3dc4e498f2c046b/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1258
- set(snapshot)Ref: https://github.com/apache/iceberg/blob/f65558ec30a27fb26ed85ba0e3dc4e498f2c046b/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1317

For metadata change such as schema/partition spec/sort order/properties update, without produce the snapshot:
- if timestamp is unset, it will use the system clock on build https://github.com/apache/iceberg/blob/f65558ec30a27fb26ed85ba0e3dc4e498f2c046b/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1543
- or special case here when update metadataLocation in https://github.com/apache/iceberg/blob/f65558ec30a27fb26ed85ba0e3dc4e498f2c046b/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1017 (more context in #11151 )

This can be potentially problematic for REST based catalog, where snapshot is produced by the process engine and table metadata is updated on the catalog, where 2 system might have different clock. Today, there's ability to tolerate the clock screw within one minute, but this might not be enough for more complex scenario when add back-dated snapshot. Provides a dedicated builder method will give more flexibility to the needs.