### PR TITLE
Core: Remove duplicate test assertion in delete file index tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -216,10 +216,6 @@ public abstract class DeleteFileIndexTestBase<
         .isEqualTo(deleteFiles);
 
     assertThat(index.forDataFile(4, unpartitionedFile))
-        .as("All deletes should apply to seq 4")
-        .isEqualTo(Arrays.copyOfRange(deleteFiles, 1, 4));
-
-    assertThat(index.forDataFile(4, unpartitionedFile))
         .as("Last 3 deletes should apply to seq 4")
         .isEqualTo(Arrays.copyOfRange(deleteFiles, 1, 4));
 


### PR DESCRIPTION
Was going through these test cases for another PR and noticed that we're asserting the same case twice but the second one has an incorrect message. Just removing this to avoid confusion.