### PR TITLE
Core: rewrite file if to a different output spec

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BinPackRewriteFilePlanner.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackRewriteFilePlanner.java
@@ -190,7 +190,10 @@ public class BinPackRewriteFilePlanner
     return Iterables.filter(
         tasks,
         task ->
-            outsideDesiredFileSizeRange(task) || tooManyDeletes(task) || tooHighDeleteRatio(task));
+            (task.file() != null && task.file().specId() != outputSpecId())
+                || outsideDesiredFileSizeRange(task)
+                || tooManyDeletes(task)
+                || tooHighDeleteRatio(task));
   }
 
   @Override
@@ -198,7 +201,10 @@ public class BinPackRewriteFilePlanner
     return Iterables.filter(
         groups,
         group ->
-            enoughInputFiles(group)
+            (group.size() >= 1
+                    && group.get(0).file() != null
+                    && group.get(0).file().specId() != outputSpecId())
+                || enoughInputFiles(group)
                 || enoughContent(group)
                 || tooMuchContent(group)
                 || group.stream().anyMatch(this::tooManyDeletes)


### PR DESCRIPTION
when rewrite to a different spec, if there is only one small file unless rewrite-all, this file won't be able to rewrite if it does not also it won't meet any other criteria. 
- enoughInputFiles
- enoughContent
but when write to a different spec, we do want the spec align with the storage layout. so it's better check this situation and rewrite the file.

this specifically addressed an issue when we do in-table rollup to rewrite files to a coarser partition. in this case we don't want to rewrite-all but also think it's better to make the output file path align with the spec.