### PR TITLE
Core: Override the equals method for TableMetadata

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.BiMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableBiMap;
@@ -512,6 +513,25 @@ public class Schema implements Serializable {
   public boolean sameSchema(Schema anotherSchema) {
     return asStruct().equals(anotherSchema.asStruct())
         && identifierFieldIds().equals(anotherSchema.identifierFieldIds());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o instanceof Schema) {
+      Schema other = (Schema) o;
+      return sameSchema(other);
+    }
+
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(asStruct(), identifierFieldIds());
   }
 
   private Schema internalSelect(Collection<String> names, boolean caseSensitive) {

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -107,7 +107,7 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
   @Override
   public void commit(TableMetadata base, TableMetadata metadata) {
     // if the metadata is already out of date, reject it
-    if (base != current()) {
+    if (!Objects.equal(base, current())) {
       if (base != null) {
         throw new CommitFailedException("Cannot commit: stale table metadata");
       } else {
@@ -117,7 +117,7 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
       }
     }
     // if the metadata is not changed, return early
-    if (base == metadata) {
+    if (Objects.equal(base, metadata)) {
       LOG.info("Nothing to commit.");
       return;
     }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.metrics.LoggingMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -325,7 +326,7 @@ public class BaseTransaction implements Transaction {
 
                 // because this is a replace table, it will always completely replace the table
                 // metadata. even if it was just updated.
-                if (base != underlyingOps.current()) {
+                if (!Objects.equal(base, underlyingOps.current())) {
                   this.base = underlyingOps.current(); // just refreshed
                 }
 
@@ -353,7 +354,7 @@ public class BaseTransaction implements Transaction {
 
   private void commitSimpleTransaction() {
     // if there were no changes, don't try to commit
-    if (base == current) {
+    if (Objects.equal(base, current)) {
       return;
     }
 
@@ -459,7 +460,7 @@ public class BaseTransaction implements Transaction {
   }
 
   private void applyUpdates(TableOperations underlyingOps) {
-    if (base != underlyingOps.refresh()) {
+    if (!Objects.equal(base, underlyingOps.refresh())) {
       // use refreshed the metadata
       this.base = underlyingOps.current();
       this.current = underlyingOps.current();
@@ -514,7 +515,7 @@ public class BaseTransaction implements Transaction {
     @Override
     @SuppressWarnings("ConsistentOverrides")
     public void commit(TableMetadata underlyingBase, TableMetadata metadata) {
-      if (underlyingBase != current) {
+      if (!Objects.equal(underlyingBase, current)) {
         // trigger a refresh and retry
         throw new CommitFailedException("Table metadata refresh is required");
       }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -219,7 +219,7 @@ public class TableMetadata implements Serializable {
         return false;
       }
       MetadataLogEntry that = (MetadataLogEntry) other;
-      return timestampMillis == that.timestampMillis && java.util.Objects.equals(file, that.file);
+      return timestampMillis == that.timestampMillis && Objects.equal(file, that.file);
     }
 
     @Override
@@ -886,6 +886,70 @@ public class TableMetadata implements Serializable {
 
   public static Builder buildFromEmpty(int formatVersion) {
     return new Builder(formatVersion);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof TableMetadata) {
+      TableMetadata other = (TableMetadata) o;
+      return primitiveFieldsEqual(other) && objectFieldsEqual(other);
+    }
+    return false;
+  }
+
+  private boolean primitiveFieldsEqual(TableMetadata other) {
+    return formatVersion == other.formatVersion
+        && lastSequenceNumber == other.lastSequenceNumber
+        && lastUpdatedMillis == other.lastUpdatedMillis
+        && lastColumnId == other.lastColumnId
+        && currentSchemaId == other.currentSchemaId
+        && defaultSpecId == other.defaultSpecId
+        && lastAssignedPartitionId == other.lastAssignedPartitionId
+        && defaultSortOrderId == other.defaultSortOrderId
+        && currentSnapshotId == other.currentSnapshotId
+        && nextRowId == other.nextRowId;
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  private boolean objectFieldsEqual(TableMetadata other) {
+    return Objects.equal(uuid, other.uuid)
+        && Objects.equal(location, other.location)
+        && Objects.equal(schemas, other.schemas)
+        && Objects.equal(specs, other.specs)
+        && Objects.equal(sortOrders, other.sortOrders)
+        && Objects.equal(properties, other.properties)
+        && Objects.equal(snapshots(), other.snapshots())
+        && Objects.equal(snapshotLog, other.snapshotLog)
+        && Objects.equal(previousFiles, other.previousFiles)
+        && Objects.equal(refs(), other.refs())
+        && Objects.equal(statisticsFiles, other.statisticsFiles)
+        && Objects.equal(partitionStatisticsFiles, other.partitionStatisticsFiles)
+        && Objects.equal(encryptionKeys, other.encryptionKeys);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        formatVersion,
+        uuid,
+        location,
+        lastSequenceNumber,
+        lastUpdatedMillis,
+        lastColumnId,
+        currentSchemaId,
+        schemas,
+        defaultSpecId,
+        specs,
+        lastAssignedPartitionId,
+        defaultSortOrderId,
+        sortOrders,
+        properties,
+        currentSnapshotId,
+        nextRowId,
+        encryptionKeys);
   }
 
   public static class Builder {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
@@ -130,11 +131,11 @@ public class HadoopTableOperations implements TableOperations {
   @Override
   public void commit(TableMetadata base, TableMetadata metadata) {
     Pair<Integer, TableMetadata> current = versionAndMetadata();
-    if (base != current.second()) {
+    if (!Objects.equal(base, current.second())) {
       throw new CommitFailedException("Cannot commit changes based on stale table metadata");
     }
 
-    if (base == metadata) {
+    if (Objects.equal(base, metadata)) {
       LOG.info("Nothing to commit.");
       return;
     }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -481,7 +481,10 @@ public class TestHadoopCommits extends HadoopTableTestBase {
             new Path(table.location()), new HadoopFileIO(conf), conf, lockManager);
     tableOperations.refresh();
     BaseTable baseTable = (BaseTable) table;
-    TableMetadata meta2 = baseTable.operations().current();
+    TableMetadata meta2 =
+        TableMetadata.buildFrom(baseTable.operations().current())
+            .assignUUID(UUID.randomUUID().toString())
+            .build();
     assertThatThrownBy(() -> tableOperations.commit(tableOperations.current(), meta2))
         .isInstanceOf(CommitFailedException.class)
         .hasMessageStartingWith("Failed to acquire lock on file");


### PR DESCRIPTION
### **Summary**

- This PR fixes TableMetadata equality checks by implementing proper equals() and hashCode() methods instead of relying on reference equality.
- Since normal equality check `==` checks only the references but not the actual contents comparision, this results in committing the same changes again.
- Refactored all the TableMetadata equality checks with proper `Objects.equal()` which handles the null values as well.
- Fixes the issue https://github.com/apache/iceberg/issues/14409
###  **Tests:**
  - Added comprehensive equality and hashCode tests in TestTableMetadata.java:
    - Same object equality
    - Structural equality with copied metadata
    - Inequality with modified metadata (properties, schema)
    - Equality with serialized metadata from the metadata file.
