### PR TITLE
Update docs to refer to table format-version in spec definition

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -115,7 +115,7 @@ The value of these properties are not persisted as a part of the table metadata.
 
 | Property       | Default  | Description                                                                                                                          |
 | -------------- | -------- |--------------------------------------------------------------------------------------------------------------------------------------|
-| format-version | 2        | Table's format version (can be 1, 2 or 3) as defined in the [Spec](../../spec.md#format-versioning). Defaults to 2 since version 1.4.0. |
+| format-version | 2        | Table's format version as defined in the [Spec](../../spec.md#format-versioning). Defaults to 2 since version 1.4.0. |
 
 ### Compatibility flags
 


### PR DESCRIPTION
I noticed we didn't include v3 in [the docs here](https://iceberg.apache.org/docs/nightly/configuration/#reserved-table-properties) but we should!