### PR TITLE
[Doc Update] Iceberg type to Spark type table

### DIFF
--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -190,7 +190,7 @@ This type conversion table describes how Iceberg types are converted to the Spar
 | map                        | map                     |               |
 | nanosecond timestamp       |                         | Not supported |
 | nanosecond timestamp with timezone |                 | Not supported |
-| unknown                    |                         | Not supported |
+| unknown                    | null                    | Spark 4.0+    |
 | variant                    | variant                 | Spark 4.0+    | 
 | geometry                   |                         | Not supported |
 | geography                  |                         | Not supported |


### PR DESCRIPTION
Added as part of this PR - https://github.com/apache/iceberg/pull/13445/files#diff-5020f749a706f5eb2fd1ae3607d0578f0a06496db0363bf71a7e65af85af9a1a

Will send out an Iceberg PR after this one to add support for parquet in Spark 3.5, then will drop the Spark 4.0+ note in this table.