### PR TITLE
Remove version of dependencies, and cleanup LICENSE/NOTICE to remove the version upgrades pain

### DIFF
--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -203,326 +203,59 @@
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains code from the following projects:
+This binary artifact bundles from the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: commons-codec  Name: commons-codec  Version: 1.17.1
-Project URL: https://commons.apache.org/proper/commons-codec/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Netty Project
 
---------------------------------------------------------------------------------
-
-Group: commons-logging  Name: commons-logging  Version: 1.2
-Project URL: http://commons.apache.org/proper/commons-logging/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-buffer  Version: 4.1.124.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-http  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-http2  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-common  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-handler  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.124.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.13
-Project URL: http://hc.apache.org/httpcomponents-client
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
-Project URL: http://hc.apache.org/httpcomponents-core-ga
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
 Group: org.reactivestreams  Name: reactive-streams  Version: 1.0.4
 Project URL: http://reactive-streams.org
-License: CC0 - http://creativecommons.org/publicdomain/zero/1.0/
+License: MIT-0 - https://spdx.org/licenses/MIT-0.html
+| MIT No Attribution
+| 
+| Copyright 2014 Reactive Streams
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: annotations  Version: 2.33.0
+AWS Java SDK
+
+Project URL: https://aws.amazon.com/fr/sdk-for-java/
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.33.0
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+AWS CRT Java
 
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: arns  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: auth  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: aws-core  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: checksums  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: crt-core  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.33.0
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: glue  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.33.0
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: iam  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: identity-spi  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: json-utils  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: kms  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.33.0
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.33.0
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: profiles  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: protocol-core  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: regions  Version: 2.33.0
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: s3  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: sdk-core  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: sso  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: sts  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk  Name: utils  Version: 2.33.0
-Project URL: https://aws.amazon.com/sdkforjava
-License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
-
---------------------------------------------------------------------------------
-
-Group: software.amazon.awssdk.crt  Name: aws-crt  Version: 0.38.9
 Project URL: https://github.com/awslabs/aws-crt-java
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.eventstream  Name: eventstream  Version: 1.0.1
+AWS EventStream for Java
+
 Project URL: https://github.com/awslabs/aws-eventstream-java
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.s3.accessgrants  Name: aws-s3-accessgrants-java-plugin  Version: 2.3.0
+AMAZON S3 ACCESS GRANTS PLUGIN FOR AWS JAVA SDK 2.0
+
 Project URL: https://github.com/aws/aws-s3-accessgrants-plugin-java-v2
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
-Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.3.0
+
+Analytics Accelerator Library for Amazon S3
+
 Project URL: https://github.com/awslabs/analytics-accelerator-s3
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -7,100 +7,50 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: software.amazon.awssdk  Name: annotations  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: apache-client  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: arns  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: auth  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: aws-core  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: checksums  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: crt-core  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: dynamodb  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: glue  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: http-auth  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws-crt  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: iam  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: identity-spi  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: json-utils  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: kms  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: lakeformation  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: profiles  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: protocol-core  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: regions  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: retries  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: retries-spi  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: s3  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: sdk-core  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: sso  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: sts  Version: 2.33.0
-NOTICE for Group: software.amazon.awssdk  Name: utils  Version: 2.33.0
-NOTICE for Group: software.amazon.s3.accessgrants  Name: aws-s3-accessgrants-java-plugin  Version: 2.3.0
-NOTICE for Group: software.amazon.s3.analyticsaccelerator  Name: analyticsaccelerator-s3  Version: 1.3.0
-
-AWS SDK for Java 2.0
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-This product includes software developed by
-Amazon Technologies, Inc (http://www.amazon.com/).
-
-**********************
-THIRD PARTY COMPONENTS
-**********************
-This software includes third party software subject to the following copyrights:
-- XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
-- PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
-- Apache Commons Lang - https://github.com/apache/commons-lang
-- Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
-- Jackson-core - https://github.com/FasterXML/jackson-core
-- Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
-
-The licenses for these third party components are included in LICENSE.txt
+NOTICE for AWS SDK for Java
+| AWS SDK for Java 2.0
+| Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+| 
+| This product includes software developed by
+| Amazon Technologies, Inc (http://www.amazon.com/).
+| 
+| **********************
+| THIRD PARTY COMPONENTS
+| **********************
+| This software includes third party software subject to the following copyrights:
+| - XML parsing and utility functions from JetS3t - Copyright 2006-2009 James Murty.
+| - PKCS#1 PEM encoded private key parsing and utility functions from oauth.googlecode.com - Copyright 1998-2010 AOL Inc.
+| - Apache Commons Lang - https://github.com/apache/commons-lang
+| - Netty Reactive Streams - https://github.com/playframework/netty-reactive-streams
+| - Jackson-core - https://github.com/FasterXML/jackson-core
+| - Jackson-dataformat-cbor - https://github.com/FasterXML/jackson-dataformats-binary
+| 
+| The licenses for these third party components are included in LICENSE.txt
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.33.0
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
+NOTICE for Jackson
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: io.netty  Name: netty-buffer                          Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-codec                           Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-codec-http                      Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-codec-http2                     Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-common                          Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-handler                         Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-resolver                        Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-transport                       Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-transport-classes-epoll         Version: 4.1.124.Final
-NOTICE for Group: io.netty  Name: netty-transport-native-unix-common    Version: 4.1.124.Final
-
+NOTICE for The Netty Project
 |                             The Netty Project
 |                             =================
 | 

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -203,293 +203,185 @@
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains code from the following projects:
+This binary artifact bundles the following projects:
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-core-http-netty  Version: 1.15.13
+Azure SDK for Java
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: The MIT License (MIT) - http://opensource.org/licenses/MIT
+| The MIT License (MIT)
+| 
+| Copyright (c) 2015 Microsoft
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-identity  Version: 1.16.2
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
+Jackson, JSON for Jqvq
 
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-json  Version: 1.5.0
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-blob  Version: 12.31.1
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-common  Version: 12.30.1
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-file-datalake  Version: 12.24.1
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-internal-avro  Version: 12.16.1
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.18.4
 Project URL: http://github.com/FasterXML/jackson
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.4
-Project URL: https://github.com/FasterXML/jackson-core
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+JCIP Annotations
 
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.18.4
-Project URL: http://github.com/FasterXML/jackson
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.18.4
-Project URL: https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.github.stephenc.jcip  Name: jcip-annotations  Version: 1.0-1
-Project URL: http://stephenc.github.com/jcip-annotations
+Project URL: https://github.com/stephenc/jcip-annotations
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.microsoft.azure  Name: msal4j  Version: 1.21.0
+Microsoft Authentication Library for Java
+
 Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
 License: MIT License
+|     MIT License
+| 
+|     Copyright (c) Microsoft Corporation. All rights reserved.
+| 
+|     Permission is hereby granted, free of charge, to any person obtaining a copy
+|     of this software and associated documentation files (the "Software"), to deal
+|     in the Software without restriction, including without limitation the rights
+|     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+|     copies of the Software, and to permit persons to whom the Software is
+|     furnished to do so, subject to the following conditions:
+| 
+|     The above copyright notice and this permission notice shall be included in all
+|     copies or substantial portions of the Software.
+| 
+|     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+|     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+|     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+|     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+|     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+|     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+|     SOFTWARE
 
 --------------------------------------------------------------------------------
 
-Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.3.0
+Microsoft Authentication Extensions for Java
+
 Project URL: https://github.com/AzureAD/microsoft-authentication-extensions-for-java
 License: MIT License
+|     MIT License
+| 
+|     Copyright (c) Microsoft Corporation. All rights reserved.
+| 
+|     Permission is hereby granted, free of charge, to any person obtaining a copy
+|     of this software and associated documentation files (the "Software"), to deal
+|     in the Software without restriction, including without limitation the rights
+|     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+|     copies of the Software, and to permit persons to whom the Software is
+|     furnished to do so, subject to the following conditions:
+| 
+|     The above copyright notice and this permission notice shall be included in all
+|     copies or substantial portions of the Software.
+| 
+|     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+|     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+|     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+|     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+|     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+|     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+|     SOFTWARE
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: content-type  Version: 2.3
+Connect2Id Nimbus Jose JWT & OIDC SDK
+
 Project URL: https://bitbucket.org/connect2id/nimbus-content-type
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: lang-tag  Version: 1.7
 Project URL: https://bitbucket.org/connect2id/nimbus-language-tags
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 10.0.1
 Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
+Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 11.23
-Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
-License: Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
+Project Netty
 
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-buffer  Version: 4.1.118.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+Project Reactor
 
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-dns  Version: 4.1.112.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-http  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-http2  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-socks  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-common  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-handler  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-handler-proxy  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns  Version: 4.1.112.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.112.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.112.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.70.Final
-Project URL: https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.70.Final
-Project URL: https://netty.io/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.projectreactor  Name: reactor-core  Version: 3.4.41
 Project URL: https://github.com/reactor/reactor-core
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.48
-Project URL: https://github.com/reactor/reactor-netty
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Java Native Access
 
---------------------------------------------------------------------------------
-
-Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.48
-Project URL: https://github.com/reactor/reactor-netty
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: net.java.dev.jna  Name: jna  Version: 5.13.0
 Project URL: https://github.com/java-native-access/jna
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: net.java.dev.jna  Name: jna-platform  Version: 5.13.0
-Project URL: https://github.com/java-native-access/jna
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+JSON Smart & Accessors Smart 
 
---------------------------------------------------------------------------------
-
-Group: net.minidev  Name: accessors-smart  Version: 2.5.2
 Project URL: https://urielch.github.io/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: net.minidev  Name: json-smart  Version: 2.5.2
-Project URL: https://urielch.github.io/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.ow2.asm  Name: asm  Version: 9.7.1
+ASM
 Project URL: http://asm.ow2.io/
 License: BSD-3-Clause - https://asm.ow2.io/license.html
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+| ASM: a very small and fast Java bytecode manipulation framework
+| Copyright (c) 2000-2011 INRIA, France Telecom
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions
+| are met:
+| 1. Redistributions of source code must retain the above copyright
+|   notice, this list of conditions and the following disclaimer.
+| 2. Redistributions in binary form must reproduce the above copyright
+|   notice, this list of conditions and the following disclaimer in the
+|   documentation and/or other materials provided with the distribution.
+| 3. Neither the name of the copyright holders nor the names of its
+|   contributors may be used to endorse or promote products derived from
+|   this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+| THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: org.reactivestreams  Name: reactive-streams  Version: 1.0.4
+Reactive Streams
 Project URL: http://www.reactive-streams.org/
 License: MIT-0 - https://spdx.org/licenses/MIT-0.html
+| MIT No Attribution
+| 
+| Copyright 2014 Reactive Streams
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/azure-bundle/NOTICE
+++ b/azure-bundle/NOTICE
@@ -6,9 +6,7 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.4
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.18.4
+NOTICE for Jackson
 
 | # Jackson JSON processor
 | 
@@ -29,28 +27,7 @@ NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2
 | from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
-
-NOTICE for Group: io.netty  Name: netty-buffer  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-codec  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-codec-dns  Version: 4.1.112.Final
-NOTICE for Group: io.netty  Name: netty-codec-http  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-codec-http2  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-codec-socks  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-common  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-handler  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-handler-proxy  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-resolver  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-resolver-dns  Version: 4.1.112.Final
-NOTICE for Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.112.Final
-NOTICE for Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.112.Final
-NOTICE for Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.69.Final
-NOTICE for Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.69.Final
-NOTICE for Group: io.netty  Name: netty-transport  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.118.Final
+NOTICE for Netty Project
 
 |                             The Netty Project
 |                             =================

--- a/gcp-bundle/LICENSE
+++ b/gcp-bundle/LICENSE
@@ -203,1077 +203,509 @@
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains:
+This binary artifact bundles:
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.2
-Project URL: https://github.com/FasterXML/jackson-core
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Jackson JSON
 
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.18.2
-Project URL: https://github.com/FasterXML/jackson
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.18.2
 Project URL: https://github.com/FasterXML/jackson
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.18.2
-Project URL: https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310 
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Android Annotations
 
---------------------------------------------------------------------------------
-
-Group: com.google.android  Name: annotations  Version: 4.1.1.4
 Project URL: http://source.android.com/
 License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: api-common  Version: 2.52.0
+Google API Common
+
 License: BSD-3-Clause
-Copyright 2016, Google Inc.
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+| Copyright 2016, Google Inc.
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|    * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: gax  Version: 2.69.0
+Google GAX
 Project URL: https://github.com/googleapis/gax-java
 License: BSD-3-Clause
-Copyright 2016, Google Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-
-Group: com.google.api  Name: gax-grpc  Version: 2.69.0
-Project URL: https://github.com/googleapis/gax-java
-License: BSD-3-Clause
-Copyright 2016, Google Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+| Copyright 2016, Google Inc. All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: gax-httpjson  Version: 2.69.0
-Project URL: https://github.com/googleapis/gax-java
-License: BSD-3-Clause
-Copyright 2016, Google Inc. All rights reserved.
+Google API Client
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-
-Group: com.google.api-client  Name: google-api-client  Version: 2.7.2
 Project URL: https://developers.google.com/api-client-library/java/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: gapic-google-cloud-storage-v2  Version: 2.55.0
+Google API gRPC
+
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: grpc-google-cloud-storage-v2  Version: 2.55.0
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Google API Services
 
---------------------------------------------------------------------------------
+License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
-Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.55.0
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-common-protos  Version: 2.60.0
-Project URL: https://github.com/googleapis/sdk-platform-java
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-iam-v1  Version: 1.55.0
-Project URL: https://github.com/googleapis/sdk-platform-java
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: grpc-google-cloud-bigquerystorage-v1  Version: 3.16.2
-Project URL: https://github.com/googleapis/java-bigquerystorage/
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: grpc-google-cloud-bigquerystorage-v1beta1  Version: 0.188.2
-Project URL: https://github.com/googleapis/java-bigquerystorage/
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: grpc-google-cloud-bigquerystorage-v1beta2  Version: 0.188.2
-Project URL: https://github.com/googleapis/java-bigquerystorage/
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-bigquerystorage-v1  Version: 3.16.2
-Project URL: https://github.com/googleapis/java-bigquerystorage/
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-bigquerystorage-v1alpha  Version: 3.16.2
-Project URL: https://github.com/googleapis/java-bigquerystorage/
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-bigquerystorage-v1beta  Version: 3.16.2
-Project URL: https://github.com/googleapis/java-bigquerystorage/
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-bigquerystorage-v1beta1  Version: 0.188.2
-Project URL: https://github.com/googleapis/java-bigquerystorage/
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-bigquerystorage-v1beta2  Version: 0.188.2
-Project URL: https://github.com/googleapis/java-bigquerystorage/
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-monitoring-v3  Version: 3.73.0
-Project URL: https://github.com/googleapis/google-cloud-java
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.55.0
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt 
-
---------------------------------------------------------------------------------
-
-Group: com.google.apis  Name: google-api-services-storage  Version: v1-rev20250718-2.0.0
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.apis  Name: google-api-services-bigquery  Version: v2-rev20250706-2.0.0
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Google Auth Library
 
---------------------------------------------------------------------------------
-
-Group: com.google.auth  Name: google-auth-library-credentials  Version: 1.37.1
 License: BSD New license
-Copyright 2014, Google Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-
-Group: com.google.auth  Name: google-auth-library-oauth2-http  Version: 1.37.1
-License: BSD New license
-Copyright 2014, Google Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+| Copyright 2014, Google Inc. All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+| 
+|    * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.auto.value  Name: auto-value-annotations  Version: 1.11.0
+Google Auto Value
+
 Project URL: https://github.com/google/auto/tree/master/value
 License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.auto.value  Name: auto-value  Version: 1.11.0
-Project URL: https://github.com/google/auto/tree/main/value
-License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Google EscapeVelocity
 
---------------------------------------------------------------------------------
-
-Group: com.google.escapevelocity Name: escapevelocity Version: 0.9
 Project URL: https://github.com/google/escapevelocity
 License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.squareup Name: javapoet Version: 1.13.0
+JavaPoet
 Project URL: https://github.com/square/javapoet
 License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.ow2.asm Name: asm Version: 9.2
+ASM
 Project URL: https://asm.ow2.io/
 License: BSD-3-Clause
-
-Copyright (c) 2000-2011 INRIA, France Telecom
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-Neither the name of the copyright holders nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-THE POSSIBILITY OF SUCH DAMAGE.
+| ASM: a very small and fast Java bytecode manipulation framework
+| Copyright (c) 2000-2011 INRIA, France Telecom
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions
+| are met:
+| 1. Redistributions of source code must retain the above copyright
+|   notice, this list of conditions and the following disclaimer.
+| 2. Redistributions in binary form must reproduce the above copyright
+|   notice, this list of conditions and the following disclaimer in the
+|   documentation and/or other materials provided with the distribution.
+| 3. Neither the name of the copyright holders nor the names of its
+|   contributors may be used to endorse or promote products derived from
+|   this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+| THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud  Name: google-cloud-core  Version: 2.59.0
+Google Cloud APIs
+
 Project URL: https://github.com/googleapis/java-core
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud  Name: google-cloud-core-grpc  Version: 2.59.0
-Project URL: https://github.com/googleapis/java-core
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+Google Cloud OpenTelemetry
 
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core-http  Version: 2.59.0
-Project URL: https://github.com/googleapis/java-core
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-storage  Version: 2.55.0
-Project URL: https://github.com/googleapis/java-storage
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-bigquery  Version: 2.54.1
-Project URL: https://github.com/googleapis/java-bigquery
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-bigquerystorage  Version: 3.16.2
-Project URL: https://github.com/googleapis/java-bigquerystorage
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-monitoring  Version: 3.73.0
-Project URL: https://github.com/googleapis/google-cloud-java
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud.opentelemetry  Name: detector-resources-support  Version: 0.33.0
 Project URL: https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
 License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.cloud.opentelemetry  Name: exporter-metrics  Version: 0.33.0
-Project URL: https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Google GSON
 
---------------------------------------------------------------------------------
-
-Group: com.google.cloud.opentelemetry  Name: shared-resourcemapping  Version: 0.33.0
-Project URL: https://github.com/GoogleCloudPlatform/opentelemetry-operations-java
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt 
-
---------------------------------------------------------------------------------
-
-Group: com.google.code.gson  Name: gson  Version: 2.12.1
 Project URL: https://github.com/google/gson/
 License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.code.findbugs  Name: jsr305  Version: 3.0.2
+Google findbugs JSR305
+
 Project URL: http://findbugs.sourceforge.net/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.errorprone  Name: error_prone_annotations  Version: 2.38.0
+Google ErrorProne
+
 Project URL: https://github.com/google/error-prone
 License: Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.flatbuffers  Name: flatbuffers-java  Version: 24.3.25
+Google FlatBuffers
 Project URL: https://github.com/google/flatbuffers
 License: Apache License V2.0 - https://raw.githubusercontent.com/google/flatbuffers/master/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: com.google.guava  Name: failureaccess  Version: 1.0.2
+Guava
+
 Project URL: https://github.com/google/guava/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.guava  Name: guava  Version: 33.4.0-jre
-Project URL: https://github.com/google/guava/
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Google Http Client
 
---------------------------------------------------------------------------------
-
-Group: com.google.guava  Name: listenablefuture  Version: 9999.0-empty-to-avoid-conflict-with-guava
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client  Version: 1.47.1
 Project URL: https://www.google.com/
 License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.http-client  Name: google-http-client-apache-v2  Version: 1.47.1
-Project URL: https://www.google.com/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Google j2objc
 
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-appengine  Version: 1.47.1
-Project URL: https://github.com/googleapis/google-http-java-client
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-gson  Version: 1.47.1
-Project URL: https://github.com/googleapis/google-http-java-client
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.http-client  Name: google-http-client-jackson2  Version: 1.47.1
-Project URL: https://github.com/googleapis/google-http-java-client
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.j2objc  Name: j2objc-annotations  Version: 3.0.0
 Project URL: https://github.com/google/j2objc/
 License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.oauth-client  Name: google-oauth-client  Version: 1.39.0
+Google OAuth Client
+
 Project URL: https://www.google.com/
 License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.protobuf  Name: protobuf-java  Version: 4.29.4
+Protobuf Java
+
 Project URL: https://developers.google.com/protocol-buffers/
 License: BSD-3-Clause
-Copyright 2008 Google Inc.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Code generated by the Protocol Buffer compiler is owned by the owner
-of the input file used when generating it.  This code is not
-standalone and requires a support library to be linked with it.  This
-support library is itself covered by the above license.
+| Copyright 2008 Google Inc.  All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+| 
+| Code generated by the Protocol Buffer compiler is owned by the owner
+| of the input file used when generating it.  This code is not
+| standalone and requires a support library to be linked with it.  This
+| support library is itself covered by the above license.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.protobuf  Name: protobuf-java-util  Version: 4.29.4
-Project URL: https://developers.google.com/protocol-buffers/
-License: BSD-3-Clause
-Copyright 2008 Google Inc.  All rights reserved.
+Google re2j
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Code generated by the Protocol Buffer compiler is owned by the owner
-of the input file used when generating it.  This code is not
-standalone and requires a support library to be linked with it.  This
-support library is itself covered by the above license.
-
---------------------------------------------------------------------------------
-
-Group: com.google.re2j  Name: re2j  Version: 1.8
 Project URL: http://github.com/google/re2j
 License: Go License
-This is a work derived from Russ Cox's RE2 in Go, whose license
-http://golang.org/LICENSE is as follows:
-
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-     notice, this list of conditions and the following disclaimer.
-
-   * Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in
-     the documentation and/or other materials provided with the
-     distribution.
-
-   * Neither the name of Google Inc. nor the names of its contributors
-     may be used to endorse or promote products derived from this
-     software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-
-Group: commons-codec  Name: commons-codec  Version: 1.18.0
-Project URL: https://commons.apache.org/proper/commons-codec/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+| This is a work derived from Russ Cox's RE2 in Go, whose license
+| http://golang.org/LICENSE is as follows:
+| 
+| Copyright (c) 2009 The Go Authors. All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+|      notice, this list of conditions and the following disclaimer.
+| 
+|    * Redistributions in binary form must reproduce the above copyright
+|      notice, this list of conditions and the following disclaimer in
+|      the documentation and/or other materials provided with the
+|      distribution.
+| 
+|    * Neither the name of Google Inc. nor the names of its contributors
+|      may be used to endorse or promote products derived from this
+|      software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-alts  Version: 1.71.0
+gRPC
+
 Project URL: https://github.com/grpc/grpc-java
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.grpc  Name: grpc-api  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
+The Netty Project
 
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-auth  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-context  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-core  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-googleapis  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-grpclb  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-netty-shaded  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-protobuf  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-rls  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-services  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-stub  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-xds  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-inprocess  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java 
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-opentelemetry  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.grpc  Name: grpc-util  Version: 1.71.0
-Project URL: https://github.com/grpc/grpc-java
-License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-buffer  Version: 4.1.110.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-common  Version: 4.1.110.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0 
+OpenCensus
 
---------------------------------------------------------------------------------
-
-Group: io.opencensus  Name: opencensus-api  Version: 0.31.1
 Project URL: https://github.com/census-instrumentation/opencensus-java
 License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.opencensus  Name: opencensus-contrib-http-util  Version: 0.31.1
-Project URL: https://github.com/census-instrumentation/opencensus-java
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+Perfmark
 
---------------------------------------------------------------------------------
-
-Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
 Project URL: https://github.com/perfmark/perfmark
 License: Apache 2.0 - https://opensource.org/licenses/Apache-2.0
 
 --------------------------------------------------------------------------------
 
-Group: javax.annotation  Name: javax.annotation-api  Version: 1.3.2
+Javax Annotation
+
 Project URL: https://javaee.github.io/glassfish
-Project URL: http://jcp.org/en/jsr/detail?id=250
-License: CDDL + GPLv2 with classpath exception - https://github.com/javaee/javax.annotation/blob/master/LICENSE
+License: CDDL
 
 --------------------------------------------------------------------------------
 
-Group: org.checkerframework  Name: checker-qual  Version: 3.33.0
+Checker Qual
+
 Project URL: https://checkerframework.org/
 License: The MIT License - http://opensource.org/licenses/MIT
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: org.codehaus.mojo  Name: animal-sniffer-annotations  Version: 1.24
+Animal Sniffer Annotations
+
 License: MIT license
-The MIT License
-
-Copyright (c) 2009 codehaus.org.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+| The MIT License
+| 
+| Copyright (c) 2009 codehaus.org.
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: org.conscrypt  Name: conscrypt-openjdk-uber  Version: 2.5.2
+Conscrypt OpenJDK Uber
+
 Project URL: https://conscrypt.org/
 License: Apache 2 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: org.threeten  Name: threetenbp  Version: 1.7.0
+Threeten
+
 Project URL: https://www.threeten.org/threetenbp
 License: BSD-3-Clause
-Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos.
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of JSR-310 nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+| Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos.
+| 
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+| 
+| * Redistributions of source code must retain the above copyright notice,
+|   this list of conditions and the following disclaimer.
+| 
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+| 
+| * Neither the name of JSR-310 nor the names of its contributors
+|   may be used to endorse or promote products derived from this software
+|   without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: io.opentelemetry Name: opentelemetry-api   Version: 1.47.0
+OpenTelemetry
+
 Project URL: https://opentelemetry.io/
 License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: io.opentelemetry Name: opentelemetry-context   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+JSON Java
 
---------------------------------------------------------------------------------
-
-Group: io.opentelemetry Name: opentelemetry-sdk   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opentelemetry Name: opentelemetry-sdk-common   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opentelemetry Name: opentelemetry-sdk-logs   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opentelemetry Name: opentelemetry-sdk-metrics Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opentelemetry Name: opentelemetry-sdk-trace   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opentelemetry Name: opentelemetry-sdk-extension-autoconfigure-spi   Version: 1.47.0
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opentelemetry.contrib Name: opentelemetry-gcp-resources Version: 1.37.0-alpha
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.opentelemetry.semconv Name: opentelemetry-semconv Version: 1.27.0-alpha
-Project URL: https://opentelemetry.io/
-License: The Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.arrow  Name: arrow-format  Version: 17.0.0
-Project URL: https://github.com/apache/arrow
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.arrow  Name: arrow-memory-core  Version: 17.0.0
-Project URL: https://github.com/apache/arrow
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt 
-
---------------------------------------------------------------------------------
-
-Group: org.apache.arrow  Name: arrow-memory-netty  Version: 17.0.0
-Project URL: https://github.com/apache/arrow
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.arrow  Name: arrow-vector  Version: 17.0.0
-Project URL: https://github.com/apache/arrow
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents  Name: httpclient  Version: 4.5.14
-Project URL: http://hc.apache.org/httpcomponents-client-ga
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.apache.httpcomponents  Name: httpcore  Version: 4.4.16
-Project URL: http://hc.apache.org/httpcomponents-core-ga
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.checkerframework  Name: checker-compat-qual  Version: 2.5.6
-Project URL: https://checkerframework.org
-License: The MIT License
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
-Group: org.checkerframework  Name: checker-qual  Version: 3.49.0
-Project URL: https://checkerframework.org/
-License: The MIT License
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
-Group: org.json  Name: json  Version: 20250107
 Project URL: https://github.com/douglascrockford/JSON-java
 License: Public Domain - https://github.com/stleary/JSON-java/blob/master/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: org.slf4j  Name: slf4j-api  Version: 2.0.17
+SLF4J
+
 Project URL: http://www.slf4j.org
 License: MIT
-Copyright (c) 2004-2025 QOS.ch
- All rights reserved.
-
- Permission is hereby granted, free  of charge, to any person obtaining
- a  copy  of this  software  and  associated  documentation files  (the
- "Software"), to  deal in  the Software without  restriction, including
- without limitation  the rights to  use, copy, modify,  merge, publish,
- distribute,  sublicense, and/or sell  copies of  the Software,  and to
- permit persons to whom the Software  is furnished to do so, subject to
- the following conditions:
-
- The  above  copyright  notice  and  this permission  notice  shall  be
- included in all copies or substantial portions of the Software.
-
- THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
- EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
- MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
- NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
- WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
---------------------------------------------------------------------------------
-
-Group: org.threeten  Name: threeten-extra  Version: 1.8.0
-Project URL: https://www.threeten.org/threeten-extra 
-License: BSD 3-clause
-Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos.
-
-All rights reserved.
-
-* Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of JSR-310 nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+| Copyright (c) 2004-2025 QOS.ch
+|  All rights reserved.
+| 
+|  Permission is hereby granted, free  of charge, to any person obtaining
+|  a  copy  of this  software  and  associated  documentation files  (the
+|  "Software"), to  deal in  the Software without  restriction, including
+|  without limitation  the rights to  use, copy, modify,  merge, publish,
+|  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+|  permit persons to whom the Software  is furnished to do so, subject to
+|  the following conditions:
+| 
+|  The  above  copyright  notice  and  this permission  notice  shall  be
+|  included in all copies or substantial portions of the Software.
+| 
+|  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+|  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+|  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+|  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+|  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+|  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+|  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/gcp-bundle/NOTICE
+++ b/gcp-bundle/NOTICE
@@ -7,30 +7,28 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.2
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
+NOTICE for Jackson
+| # Jackson JSON processor
+| 
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+| 
+| ## Licensing
+| 
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+| 
+| ## Credits
+| 
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: io.grpc  Name: grpc-netty-shaded  Version: 1.71.0
-
+NOTICE for The Netty Project
 |                           The Netty Project
 |                           =================
 | 
@@ -85,20 +83,7 @@ NOTICE for Group: io.grpc  Name: grpc-netty-shaded  Version: 1.71.0
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: io.grpc  Name: grpc-alts  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-api  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-auth  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-context  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-core  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-googleapis  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-grpclb  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-protobuf  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-protobuf-lite  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-rls  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-services  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-stub  Version: 1.71.0
-NOTICE for Group: io.grpc  Name: grpc-xds  Version: 1.71.0
-
+NOTICE for gRPC
 | Copyright 2014 The gRPC Authors
 | 
 | Licensed under the Apache License, Version 2.0 (the "License");
@@ -164,8 +149,7 @@ NOTICE for Group: io.grpc  Name: grpc-xds  Version: 1.71.0
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
-
+NOTICE for Perfmark
 | Copyright 2019 Google LLC
 | 
 | Licensed under the Apache License, Version 2.0 (the "License");
@@ -209,8 +193,7 @@ NOTICE for Group: io.perfmark  Name: perfmark-api  Version: 0.27.0
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: org.conscrypt  Name: conscrypt-openjdk-uber  Version: 2.5.2
-
+NOTICE for Conscrypt OpenJDK Uber
 | Copyright 2016 The Android Open Source Project
 | 
 | Licensed under the Apache License, Version 2.0 (the "License");
@@ -241,57 +224,10 @@ NOTICE for Group: org.conscrypt  Name: conscrypt-openjdk-uber  Version: 2.5.2
 |     * licenses/LICENSE.harmony.txt (Apache License 2.0)
 |   * HOMEPAGE:
 |     * https://harmony.apache.org/
---------------------------------------------------------------------------------
-
-NOTICE for Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.18.2
-
-| # Jackson JSON processor
-|
-| Jackson is a high-performance, Free/Open Source JSON processing library.
-| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-| been in development since 2007.
-| It is currently developed by a community of developers.
-| ## Licensing
-|
-| Jackson components are licensed under Apache (Software) License, version 2.0,
-| as per accompanying LICENSE file.
-| ## Credits
-|
-| A list of contributors may be found from CREDITS file, which is included
-| in some artifacts (usually source distributions);
-| but is always available
-| from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.18.2
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.18.2
-
-| # Jackson JSON processor
-|
-| Jackson is a high-performance, Free/Open Source JSON processing library.
-| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-| been in development since 2007.
-| It is currently developed by a community of developers.
-| ## Copyright
-|
-| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-|
-| ## Licensing
-|
-| Jackson 2.x core and extension components are licensed under Apache License 2.0
-| To find the details that apply to this artifact see the accompanying LICENSE file.
-| ## Credits
-|
-| A list of contributors may be found from CREDITS(-2.x) file, which is included
-| in some artifacts (usually source distributions);
-| but is always available
-| from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
-
-NOTICE for Group: com.google.escapevelocity Name: escapevelocity Version: 0.9
-
+NOTICE for Google EscapeVelocity
 | Apache Velocity
 |
 | Copyright (C) 2000-2007 The Apache Software Foundation


### PR DESCRIPTION
I'm proposing a new format for binary `LICENSE` and `NOTICE`, removing the specific versions and grouping the dependencies.
It removes the pain of version updates.