### PR TITLE
Core: Fix view version ID deduplication with schema ID assignment

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
@@ -293,11 +293,10 @@ public interface ViewMetadata extends Serializable {
         return newVersionId;
       }
 
-      if (newVersion.schemaId() == LAST_ADDED) {
+      if (version.schemaId() == LAST_ADDED) {
         ValidationException.check(
             lastAddedSchemaId != null, "Cannot set last added schema: no schema has been added");
-        version =
-            ImmutableViewVersion.builder().from(newVersion).schemaId(lastAddedSchemaId).build();
+        version = ImmutableViewVersion.builder().from(version).schemaId(lastAddedSchemaId).build();
       }
 
       Preconditions.checkArgument(

--- a/core/src/test/java/org/apache/iceberg/view/TestViewMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewMetadata.java
@@ -976,6 +976,26 @@ public class TestViewMetadata {
   }
 
   @Test
+  public void deduplicatingViewVersionByIdAndAssigningSchemaId() {
+    ViewVersion viewVersion = newViewVersion(1, 0, "select * from ns.tbl");
+    ViewVersion viewVersionTwo = newViewVersion(2, 1, "select x from ns.tbl");
+    ViewVersion viewVersionThree = newViewVersion(2, -1, "select count(*) from ns.tbl");
+    ViewMetadata metadata =
+        ViewMetadata.builder()
+            .setLocation("custom-location")
+            .addSchema(new Schema(Types.NestedField.required(1, "x", Types.LongType.get())))
+            .addSchema(new Schema(Types.NestedField.required(2, "y", Types.LongType.get())))
+            .addVersion(viewVersion)
+            .addVersion(viewVersionTwo)
+            .addVersion(viewVersionThree)
+            .setCurrentVersionId(3)
+            .build();
+    assertThat(metadata.versions()).hasSize(3);
+    assertThat(metadata.currentVersion().versionId()).isEqualTo(3);
+    assertThat(metadata.currentVersion().schemaId()).isEqualTo(1);
+  }
+
+  @Test
   public void droppingDialectFailsByDefault() {
     Schema schema = new Schema(Types.NestedField.required(1, "x", Types.LongType.get()));
     ViewRepresentation spark =


### PR DESCRIPTION
Without this fix the test would fail with
```
Cannot set current version to unknown version: 3
java.lang.IllegalArgumentException: Cannot set current version to unknown version: 3
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:190)
	at org.apache.iceberg.view.ViewMetadata$Builder.setCurrentVersionId(ViewMetadata.java:241)
	at org.apache.iceberg.view.TestViewMetadata.deduplicatingViewVersionByIdAndAssigningSchemaId(TestViewMetadata.java:991)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```
because the the `ViewVersion` was assigned a new ID and later when we tried to re-assign the schema ID, we used the wrong `ViewVersion` instance (the one where the version ID was not re-assigned).