### PR TITLE
Core: Fix failure when finding a column during time travel

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -95,7 +95,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
     ImmutableMap.Builder<Integer, PartitionSpec> newSpecs =
         ImmutableMap.builderWithExpectedSize(specs.size());
     for (Map.Entry<Integer, PartitionSpec> entry : specs.entrySet()) {
-      newSpecs.put(entry.getKey(), entry.getValue().toUnbound().bind(snapshotSchema));
+      newSpecs.put(entry.getKey(), entry.getValue().toUnbound().bind(snapshotSchema, true));
     }
 
     return newSpecs.build();


### PR DESCRIPTION
#13301 broke an existing test about time-travel with new partition columns in Trino Iceberg connector. 

We should fix the regression before releasing 1.11.0. 