### PR TITLE
implement cache policy

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
@@ -47,17 +48,58 @@ public class CachingCatalog implements Catalog {
   private static final Logger LOG = LoggerFactory.getLogger(CachingCatalog.class);
   private static final MetadataTableType[] METADATA_TABLE_TYPE_VALUES = MetadataTableType.values();
 
+  /**
+   * @deprecated since 1.11.1, will be removed in 1.12.0; use {@link CachingCatalog#wrap(Catalog,
+   *     boolean, long, long)} instead
+   */
+  @Deprecated
   public static Catalog wrap(Catalog catalog) {
     return wrap(catalog, CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF);
   }
 
+  /**
+   * @deprecated since 1.11.1, will be removed in 1.12.0; use {@link CachingCatalog#wrap(Catalog,
+   *     boolean, long, long)} instead
+   */
+  @Deprecated
   public static Catalog wrap(Catalog catalog, long expirationIntervalMillis) {
-    return wrap(catalog, true, expirationIntervalMillis);
+    return wrap(
+        catalog,
+        expirationIntervalMillis,
+        CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT);
+  }
+
+  /**
+   * @deprecated since 1.11.1, will be removed in 1.12.0; use {@link CachingCatalog#wrap(Catalog,
+   *     boolean, long, long)} instead
+   */
+  @Deprecated
+  public static Catalog wrap(
+      Catalog catalog, long expirationIntervalMillis, long expireAfterWriteIntervalMillis) {
+    return wrap(catalog, true, expirationIntervalMillis, expireAfterWriteIntervalMillis);
+  }
+
+  /**
+   * @deprecated since 1.11.1, will be removed in 1.12.0; use {@link CachingCatalog#wrap(Catalog,
+   *     boolean, long, long)} instead
+   */
+  @Deprecated
+  public static Catalog wrap(
+      Catalog catalog, boolean caseSensitive, long expirationIntervalMillis) {
+    return wrap(
+        catalog,
+        caseSensitive,
+        expirationIntervalMillis,
+        CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT);
   }
 
   public static Catalog wrap(
-      Catalog catalog, boolean caseSensitive, long expirationIntervalMillis) {
-    return new CachingCatalog(catalog, caseSensitive, expirationIntervalMillis);
+      Catalog catalog,
+      boolean caseSensitive,
+      long expirationIntervalMillis,
+      long expireAfterWriteIntervalMillis) {
+    return new CachingCatalog(
+        catalog, caseSensitive, expirationIntervalMillis, expireAfterWriteIntervalMillis);
   }
 
   private final Catalog catalog;
@@ -67,22 +109,60 @@ public class CachingCatalog implements Catalog {
   protected final long expirationIntervalMillis;
 
   @SuppressWarnings("checkstyle:VisibilityModifier")
+  protected long expireAfterWriteIntervalMillis;
+
+  @SuppressWarnings("checkstyle:VisibilityModifier")
   protected final Cache<TableIdentifier, Table> tableCache;
 
-  private CachingCatalog(Catalog catalog, boolean caseSensitive, long expirationIntervalMillis) {
-    this(catalog, caseSensitive, expirationIntervalMillis, Ticker.systemTicker());
+  private CachingCatalog(
+      Catalog catalog,
+      boolean caseSensitive,
+      long expirationIntervalMillis,
+      long expireAfterWriteIntervalMillis) {
+    this(
+        catalog,
+        caseSensitive,
+        expirationIntervalMillis,
+        expireAfterWriteIntervalMillis,
+        Ticker.systemTicker());
   }
 
+  /**
+   * Caching Catalog
+   *
+   * @deprecated since 1.11.1, will be removed in 1.12.0; use {@link #CachingCatalog(Catalog,
+   *     boolean, long, long, Ticker)} instead.
+   */
+  @Deprecated
+  @VisibleForTesting
   @SuppressWarnings("checkstyle:VisibilityModifier")
   protected CachingCatalog(
       Catalog catalog, boolean caseSensitive, long expirationIntervalMillis, Ticker ticker) {
+    this(
+        catalog,
+        caseSensitive,
+        expirationIntervalMillis,
+        CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT,
+        ticker);
+  }
+
+  @VisibleForTesting
+  CachingCatalog(
+      Catalog catalog,
+      boolean caseSensitive,
+      long expirationIntervalMillis,
+      long expireAfterWriteIntervalMillis,
+      Ticker ticker) {
     Preconditions.checkArgument(
-        expirationIntervalMillis != 0,
-        "When %s is set to 0, the catalog cache should be disabled. This indicates a bug.",
-        CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
+        expirationIntervalMillis != 0 && expireAfterWriteIntervalMillis != 0,
+        "When either %s and %s are set to 0, the catalog cache should be disabled. This indicates a bug.",
+        CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
+        CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS);
+
     this.catalog = catalog;
     this.caseSensitive = caseSensitive;
     this.expirationIntervalMillis = expirationIntervalMillis;
+    this.expireAfterWriteIntervalMillis = expireAfterWriteIntervalMillis;
     this.tableCache = createTableCache(ticker);
   }
 
@@ -104,15 +184,20 @@ public class CachingCatalog implements Catalog {
   }
 
   private Cache<TableIdentifier, Table> createTableCache(Ticker ticker) {
-    Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder().softValues();
+    Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder().softValues().ticker(ticker);
 
-    if (expirationIntervalMillis > 0) {
-      return cacheBuilder
+    if (expirationIntervalMillis > 0 || expireAfterWriteIntervalMillis > 0) {
+      cacheBuilder
           .removalListener(new MetadataTableInvalidatingRemovalListener())
-          .executor(Runnable::run) // Makes the callbacks to removal listener synchronous
-          .expireAfterAccess(Duration.ofMillis(expirationIntervalMillis))
-          .ticker(ticker)
-          .build();
+          .executor(Runnable::run);
+
+      if (expirationIntervalMillis > 0) {
+        cacheBuilder.expireAfterAccess(Duration.ofMillis(expirationIntervalMillis));
+      }
+
+      if (expireAfterWriteIntervalMillis > 0) {
+        cacheBuilder.expireAfterWrite(Duration.ofMillis(expireAfterWriteIntervalMillis));
+      }
     }
 
     return cacheBuilder.build();

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -49,21 +49,26 @@ public class CatalogProperties {
   public static final boolean CACHE_CASE_SENSITIVE_DEFAULT = true;
 
   /**
-   * Controls the duration for which entries in the catalog are cached.
+   * Controls Iceberg cache behavior
    *
-   * <p>Behavior of specific values of cache.expiration-interval-ms:
+   * <p>Cache expiration is controlled by two configurable policies that can work independently or
+   * together:
    *
    * <ul>
-   *   <li>Zero - Caching and cache expiration are both disabled
-   *   <li>Negative Values - Cache expiration is turned off and entries expire only on refresh etc
-   *   <li>Positive Values - Cache entries expire if not accessed via the cache after this many
-   *       milliseconds
+   *   <li>{@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} - Controls expire-after-access
+   *       expiration policy
+   *   <li>{@link CatalogProperties#CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS} - Controls
+   *       expire-after-write expiration policy
    * </ul>
    */
   public static final String CACHE_EXPIRATION_INTERVAL_MS = "cache.expiration-interval-ms";
 
   public static final long CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.SECONDS.toMillis(30);
   public static final long CACHE_EXPIRATION_INTERVAL_MS_OFF = -1;
+
+  public static final String CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS =
+      "cache.expiration-after-write-interval-ms";
+  public static final long CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT = -1;
 
   /**
    * Controls whether to use caching during manifest reads or not.

--- a/core/src/test/java/org/apache/iceberg/TestableCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/TestableCachingCatalog.java
@@ -34,15 +34,39 @@ public class TestableCachingCatalog extends CachingCatalog {
   public static TestableCachingCatalog wrap(
       Catalog catalog, Duration expirationInterval, Ticker ticker) {
     return new TestableCachingCatalog(
-        catalog, true /* caseSensitive */, expirationInterval, ticker);
+        catalog,
+        true /* caseSensitive */,
+        expirationInterval,
+        Duration.ofMillis(CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT),
+        ticker);
+  }
+
+  public static TestableCachingCatalog wrap(
+      Catalog catalog,
+      Duration expirationInterval,
+      Duration expireAfterWriteInterval,
+      Ticker ticker) {
+    return new TestableCachingCatalog(
+        catalog, true /* caseSensitive */, expirationInterval, expireAfterWriteInterval, ticker);
   }
 
   private final Duration cacheExpirationInterval;
+  private final Duration expireAfterWriteInterval;
 
   TestableCachingCatalog(
-      Catalog catalog, boolean caseSensitive, Duration expirationInterval, Ticker ticker) {
-    super(catalog, caseSensitive, expirationInterval.toMillis(), ticker);
+      Catalog catalog,
+      boolean caseSensitive,
+      Duration expirationInterval,
+      Duration expireAfterWriteInterval,
+      Ticker ticker) {
+    super(
+        catalog,
+        caseSensitive,
+        expirationInterval.toMillis(),
+        expireAfterWriteInterval.toMillis(),
+        ticker);
     this.cacheExpirationInterval = expirationInterval;
+    this.expireAfterWriteInterval = expireAfterWriteInterval;
   }
 
   public Cache<TableIdentifier, Table> cache() {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -69,7 +69,12 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
   @Test
   public void testInvalidateMetadataTablesIfBaseTableIsModified() throws Exception {
-    Catalog catalog = CachingCatalog.wrap(hadoopCatalog());
+    Catalog catalog =
+        CachingCatalog.wrap(
+            hadoopCatalog(),
+            true,
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF,
+            CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT);
     TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
     Table table = catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key2", "value2"));
 
@@ -103,7 +108,12 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
   @Test
   public void testInvalidateMetadataTablesIfBaseTableIsDropped() throws IOException {
-    Catalog catalog = CachingCatalog.wrap(hadoopCatalog());
+    Catalog catalog =
+        CachingCatalog.wrap(
+            hadoopCatalog(),
+            true,
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF,
+            CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT);
 
     // create the original table
     TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
@@ -153,7 +163,12 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
   @Test
   public void testTableName() throws Exception {
-    Catalog catalog = CachingCatalog.wrap(hadoopCatalog());
+    Catalog catalog =
+        CachingCatalog.wrap(
+            hadoopCatalog(),
+            true,
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF,
+            CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT);
     TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
     catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key2", "value2"));
 
@@ -170,7 +185,12 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
   @Test
   public void testNonExistingTable() throws Exception {
-    Catalog catalog = CachingCatalog.wrap(hadoopCatalog());
+    Catalog catalog =
+        CachingCatalog.wrap(
+            hadoopCatalog(),
+            true,
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF,
+            CatalogProperties.CACHE_EXPIRATION_AFTER_WRITE_INTERVAL_MS_DEFAULT);
 
     TableIdentifier tableIdent = TableIdentifier.of("otherDB", "otherTbl");
 
@@ -373,10 +393,18 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
   @Test
   public void testCachingCatalogRejectsExpirationIntervalOfZero() {
+    String message =
+        "When either cache.expiration-interval-ms and cache.expiration-after-write-interval-ms are set to 0, the catalog cache should be disabled. This indicates a bug.";
     assertThatThrownBy(() -> TestableCachingCatalog.wrap(hadoopCatalog(), Duration.ZERO, ticker))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
-            "When cache.expiration-interval-ms is set to 0, the catalog cache should be disabled. This indicates a bug.");
+        .hasMessage(message);
+
+    assertThatThrownBy(
+            () ->
+                TestableCachingCatalog.wrap(
+                    hadoopCatalog(), Duration.ofMillis(-1), Duration.ZERO, ticker))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(message);
   }
 
   @Test
@@ -434,6 +462,49 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
     // cache should have been invalidated by registerTable
     assertThat(catalog.cache().asMap()).doesNotContainKey(targetIdent);
+  }
+
+  @Test
+  public void testCachePolicyExpireAfterWrite() throws Exception {
+    Duration expireAfterWriteInterval = Duration.ofMinutes(3);
+    TestableCachingCatalog catalog =
+        TestableCachingCatalog.wrap(
+            hadoopCatalog(), EXPIRATION_TTL, expireAfterWriteInterval, ticker);
+
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+    catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key", "value"));
+
+    // Ensure table is cached with full ttl remaining upon creation
+    assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    assertThat(catalog.remainingAgeFor(tableIdent)).isPresent().get().isEqualTo(EXPIRATION_TTL);
+    assertThat(catalog.cache().policy().expireAfterWrite().flatMap(t -> t.ageOf(tableIdent)))
+        .isPresent()
+        .get()
+        .isEqualTo(Duration.ZERO);
+
+    ticker.advance(HALF_OF_EXPIRATION);
+    assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION);
+    assertThat(catalog.cache().policy().expireAfterWrite().flatMap(t -> t.ageOf(tableIdent)))
+        .isPresent()
+        .get()
+        .isEqualTo(HALF_OF_EXPIRATION);
+
+    // Access the cache to check policy behaviour
+    catalog.loadTable(tableIdent);
+
+    //  Object age does not change after access
+    assertThat(catalog.cache().policy().expireAfterWrite().get().ageOf(tableIdent))
+        .isPresent()
+        .get()
+        .isEqualTo(HALF_OF_EXPIRATION);
+
+    ticker.advance(HALF_OF_EXPIRATION.plus(Duration.ofMinutes(1)));
+    assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+    assertThat(catalog.loadTable(tableIdent))
+        .as("CachingCatalog should return a new instance after expiration")
+        .isNotSameAs(table);
   }
 
   public static TableIdentifier[] metadataTables(TableIdentifier tableIdent) {

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -33,6 +33,7 @@ Iceberg catalogs support using catalog properties to configure catalog behaviors
 | clients                           | 2                  | client pool size                                       |
 | cache-enabled                     | true               | Whether to cache catalog entries |
 | cache.expiration-interval-ms      | 30000              | How long catalog entries are locally cached, in milliseconds; 0 disables caching, negative values disable expiration |
+| cache.expiration-after-write-interval-ms       | -1                 | Removes a table from the cache after the specified duration since it was created or last updated. |
 | metrics-reporter-impl | org.apache.iceberg.metrics.LoggingMetricsReporter | Custom `MetricsReporter` implementation to use in a catalog. See the [Metrics reporting](metrics-reporting.md) section for additional details |
 | unique-table-location             | false              | Whether to use a unique location for new tables |
 | encryption.kms-impl               | null               | a custom `KeyManagementClient` implementation to use in a catalog for interactions with KMS (key management service). See the [Encryption](encryption.md) document for additional details |


### PR DESCRIPTION
### Allow dual catalog cache expiration policies (expire-after-access and expire-after-write)
---
This change enhances Iceberg’s catalog-level cache by allowing `expire-after-access` and `expire-after-write` policies to be used concurrently. This provides more flexible and powerful cache-tuning strategies by enabling both time-since-last-access and time-since-creation eviction policies on the same cache.

This is achieved by introducing a new property, `cache.expiration.expire-after-write-interval-ms`, which works in conjunction with the existing `cache.expiration-interval-ms` (which controls `expire-after-access`).

This addresses the pain point described in Issue #14417, where long-running streaming jobs could prevent cache entries from ever expiring under a pure access-based policy. By combining both policies, users can ensure periodic data refreshes while still efficiently caching frequently accessed tables.

 ---
#### Background

In many scenarios, especially with long-running services, you want to balance performance with data freshness. For example:

- Performance: Caching is essential to avoid the high cost of reloading table metadata for every query.
- Freshness: Cached entries must be periodically refreshed to pick up new snapshots or to prevent issues with expired credentials.

Using `expire-after-access` alone is not sufficient for continuous workloads, as frequently accessed entries may never be evicted. Using` expire-after-write` alone can be inefficient if it evicts "hot" entries that are still in active use.

By using both, you can configure a "best-of-both-worlds" strategy:
- A shorter expire-after-access duration to quickly evict inactive tables.
- A longer expire-after-write duration to act as a safety net, ensuring that even "hot" tables are refreshed periodically (e.g., before underlying credentials expire).
 
 ---
#### What changed in this PR
##### ✅ New catalog property for dual-policy expiration
Two distinct properties now control cache expiration. An entry is evicted if either condition is met. If both are set to a non-positive value, caching is disabled.


| Property                          | Default            | Description                                            |
| --------------------------------- | ------------------ | ------------------------------------------------------ |
| cache.expire-after-write-ms       | 0                  | Duration in milliseconds to expire a table from the cache after being created.tables will not refresh on write. 0 disables this policy. its disabled by default |

##### ✅ CachingCatalog supports dual policies
`CachingCatalog.wrap(...)` has been updated to configure the underlying Caffeine cache with both expiration policies when both properties are provided.
##### ✅ Tests cover dual-policy scenarios
Tests have been added to validate that when both policies are active, an entry is evicted based on whichever condition is met first, and that each policy works correctly on its own.