### PR TITLE
Outdated: Fix commit duplication in DynamicIcebergSink

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ReplacePartitions.java
+++ b/api/src/main/java/org/apache/iceberg/ReplacePartitions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import java.util.function.Consumer;
+
 /**
  * API for overwriting files in a table by partition.
  *
@@ -70,6 +72,20 @@ public interface ReplacePartitions extends SnapshotUpdate<ReplacePartitions> {
    * @return this for method chaining
    */
   ReplacePartitions validateFromSnapshot(long snapshotId);
+
+  /**
+   * Enables snapshot validation with a user-provided function, which must throw an exception on
+   * validation failures.
+   *
+   * <p>Clients can use this method to validate summary and other metadata of parent snapshots.
+   *
+   * @param snapshotValidator a user function to validate parent snapshots
+   * @return this for method chaining
+   */
+  default ReplacePartitions validateSnapshot(Consumer<Snapshot> snapshotValidator) {
+    throw new UnsupportedOperationException(
+        getClass().getName() + " does not implement validateSnapshot");
+  }
 
   /**
    * Enables validation that deletes that happened concurrently do not conflict with this commit's

--- a/api/src/main/java/org/apache/iceberg/RowDelta.java
+++ b/api/src/main/java/org/apache/iceberg/RowDelta.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.util.function.Consumer;
 import org.apache.iceberg.expressions.Expression;
 
 /**
@@ -78,6 +79,20 @@ public interface RowDelta extends SnapshotUpdate<RowDelta> {
    * @return this for method chaining
    */
   RowDelta validateFromSnapshot(long snapshotId);
+
+  /**
+   * Enables snapshot validation with a user-provided function, which must throw an exception on
+   * validation failures.
+   *
+   * <p>Clients can use this method to validate summary and other metadata of parent snapshots.
+   *
+   * @param snapshotValidator a user function to validate parent snapshots
+   * @return this for method chaining
+   */
+  default RowDelta validateSnapshot(Consumer<Snapshot> snapshotValidator) {
+    throw new UnsupportedOperationException(
+        getClass().getName() + " does not implement validateSnapshot");
+  }
 
   /**
    * Enables or disables case sensitive expression binding for validations that accept expressions.


### PR DESCRIPTION
Fix the race condition in https://github.com/apache/iceberg/issues/14425 by validating that all new parent snapshots, fetched by the table refresh in `SnapshotProducer.apply()`, have a committed checkpoint id strictly lower than the checkpoint id of the currently staged committable. Abort the commit to prevent duplication otherwise.