### PR TITLE
OpenAPI: Make namespace separator configurable by server

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -264,8 +264,9 @@ paths:
             If not provided, all top-level namespaces should be listed.
             For backward compatibility, empty string is treated as absent for now.
             If parent is a multipart namespace, the parts must be separated by the namespace separator as
-            indicated via the /config override `namespace-separator`, which defaults to the unit separator (`0x1F`) byte.
+            indicated via the /config override `namespace-separator`, which defaults to the unit separator `0x1F` byte (url encoded `%1F`).
             To be compatible with older clients, servers must use both the advertised separator and `0x1F` as valid separators when decoding namespaces.
+            The `namespace-separator` should be provided in a url encoded form.
           required: false
           schema:
             type: string
@@ -1840,8 +1841,9 @@ components:
       description:
         A namespace identifier as a single string.
         Multipart namespace parts must be separated by the namespace separator as
-        indicated via the /config override `namespace-separator`, which defaults to the unit separator (`0x1F`) byte.
+        indicated via the /config override `namespace-separator`, which defaults to the unit separator `0x1F` byte (url encoded `%1F`).
         To be compatible with older clients, servers must use both the advertised separator and `0x1F` as valid separators when decoding namespaces.
+        The `namespace-separator` should be provided in a url encoded form.
       schema:
         type: string
       examples:


### PR DESCRIPTION
The [REST spec](https://github.com/apache/iceberg/blob/6319712b612b724fedbc5bed41942ac3426ffe48/open-api/rest-catalog-open-api.yaml#L225) currently uses `%1F` as the UTF-8 encoded namespace separator for multi-part namespaces.
This causes [issues](https://github.com/apache/iceberg/issues/10338), since it's a [control character](https://www.compart.com/en/unicode/category/Cc) and the [Servlet spec](https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0.html#uri-path-canonicalization) can reject such characters.

This PR makes the hard-coded namespace separator configurable by giving servers an option to send an **optional** namespace separator instead of `%1F`. The configuration part is entirely optional for REST server implementers and there's no behavioral change for existing installations.

The actual implementation for this can be seen at https://github.com/apache/iceberg/pull/10877