### PR TITLE
Support retaining original partition spec in rewrite data files

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1254,6 +1254,11 @@ acceptedBreaks:
       new: "method void org.apache.iceberg.data.parquet.BaseParquetWriter<T>::<init>()"
       justification: "Changing deprecated code"
   "1.9.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.method.addedToInterface"
+      new: "method int org.apache.iceberg.actions.RewriteDataFiles.FileGroupInfo::partitionSpecId()"
+      justification: "This is an immutables interface - adding a field does not break\
+        \ clients"
     org.apache.iceberg:iceberg-common:
     - code: "java.method.visibilityReduced"
       old: "method <R> R org.apache.iceberg.common.DynConstructors.Ctor<C>::invokeChecked(java.lang.Object,\

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -148,6 +148,17 @@ public interface RewriteDataFiles
   String OUTPUT_SPEC_ID = "output-spec-id";
 
   /**
+   * Should we retain the original partition spec of each file when rewriting
+   *
+   * <p>By default, the rewrite data files action will repartition data to the latest partition spec
+   * of the table. Setting retain-original-spec-id to true will force the rewrite to use the
+   * partition spec of the original data.
+   */
+  String RETAIN_ORIGINAL_PARTITION_SPEC = "retain-original-spec-id";
+
+  boolean RETAIN_ORIGINAL_PARTITION_SPEC_DEFAULT = false;
+
+  /**
    * Choose BINPACK as a strategy for this rewrite operation
    *
    * @return this for method chaining
@@ -274,6 +285,9 @@ public interface RewriteDataFiles
 
     /** returns which file group this is out of the set of file groups for this partition */
     int partitionIndex();
+
+    /** returns which partition spec this file group was written to */
+    int partitionSpecId();
 
     /** returns which partition this file group contains files from */
     StructLike partition();

--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewritePlanner.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewritePlanner.java
@@ -116,7 +116,8 @@ public abstract class SizeBasedFileRewritePlanner<
   private int minInputFiles;
   private boolean rewriteAll;
   private long maxGroupSize;
-  private int outputSpecId;
+  private int defaultOutputSpecId;
+  private boolean retainOriginalSpecId;
 
   protected SizeBasedFileRewritePlanner(Table table) {
     this.table = table;
@@ -151,7 +152,8 @@ public abstract class SizeBasedFileRewritePlanner<
     this.minInputFiles = minInputFiles(options);
     this.rewriteAll = rewriteAll(options);
     this.maxGroupSize = maxGroupSize(options);
-    this.outputSpecId = outputSpecId(options);
+    this.defaultOutputSpecId = outputSpecId(options);
+    this.retainOriginalSpecId = retainOriginalSpecId(options);
 
     if (rewriteAll) {
       LOG.info("Configured to rewrite all provided files in table {}", table.name());
@@ -267,7 +269,11 @@ public abstract class SizeBasedFileRewritePlanner<
   }
 
   protected int outputSpecId() {
-    return outputSpecId;
+    return defaultOutputSpecId;
+  }
+
+  protected boolean retainOriginalSpecId() {
+    return retainOriginalSpecId;
   }
 
   private int outputSpecId(Map<String, String> options) {
@@ -278,6 +284,13 @@ public abstract class SizeBasedFileRewritePlanner<
         "Cannot use output spec id %s because the table does not contain a reference to this spec-id.",
         specId);
     return specId;
+  }
+
+  private boolean retainOriginalSpecId(Map<String, String> options) {
+    return PropertyUtil.propertyAsBoolean(
+        options,
+        RewriteDataFiles.RETAIN_ORIGINAL_PARTITION_SPEC,
+        RewriteDataFiles.RETAIN_ORIGINAL_PARTITION_SPEC_DEFAULT);
   }
 
   private Map<String, Long> sizeThresholds(Map<String, String> options) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -80,6 +80,7 @@ public class RewriteDataFilesSparkAction
           USE_STARTING_SEQUENCE_NUMBER,
           REWRITE_JOB_ORDER,
           OUTPUT_SPEC_ID,
+          RETAIN_ORIGINAL_PARTITION_SPEC,
           REMOVE_DANGLING_DELETES,
           BinPackRewriteFilePlanner.MAX_FILES_TO_REWRITE);
 


### PR DESCRIPTION
Description:
This PR adds support for retaining original partition spec in rewrite data files

Problem:
Some tables may have multiple partition schemes defined through partition evolution, and it may be desirable to rewrite data files on existing partitions, and also to retain their partition structures. Currently, the rewrite data files operation always chooses either the current table partition spec, or a partition spec the user can pass in on their own

Solution:
This change adds a configuration parameter in the rewrite data files action that will force the action to always use the spec-id associated with the current file. This will allow us to run rewrite data files without changing the partition structure of the original data.

Testing
Added unit tests:

- TestRewriteDataFilesAction
  - testZOrderRewriteRetainingOriginalPartitionSpecs
  - testBinpackRewriteRetainingOriginalPartitionSpecs

