### PR TITLE
Spark: Improve the table, view, and function existence verification logic

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -561,6 +561,11 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  public boolean viewExists(Identifier ident) {
+    return asViewCatalog != null && asViewCatalog.viewExists(buildIdentifier(ident));
+  }
+
+  @Override
   public View loadView(Identifier ident) throws NoSuchViewException {
     if (null != asViewCatalog) {
       try {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -408,6 +408,11 @@ public class SparkSessionCatalog<
   }
 
   @Override
+  public boolean functionExists(Identifier ident) {
+    return super.functionExists(ident) || getSessionCatalog().functionExists(ident);
+  }
+
+  @Override
   public UnboundFunction loadFunction(Identifier ident) throws NoSuchFunctionException {
     try {
       return super.loadFunction(ident);
@@ -429,6 +434,12 @@ public class SparkSessionCatalog<
     }
 
     return new Identifier[0];
+  }
+
+  @Override
+  public boolean viewExists(Identifier ident) {
+    return (asViewCatalog != null && asViewCatalog.viewExists(ident))
+        || (isViewCatalog() && getSessionCatalog().viewExists(ident));
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -561,6 +561,11 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  public boolean viewExists(Identifier ident) {
+    return asViewCatalog != null && asViewCatalog.viewExists(buildIdentifier(ident));
+  }
+
+  @Override
   public View loadView(Identifier ident) throws NoSuchViewException {
     if (null != asViewCatalog) {
       try {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -410,6 +410,11 @@ public class SparkSessionCatalog<
   }
 
   @Override
+  public boolean functionExists(Identifier ident) {
+    return super.functionExists(ident) || getSessionCatalog().functionExists(ident);
+  }
+
+  @Override
   public UnboundFunction loadFunction(Identifier ident) throws NoSuchFunctionException {
     try {
       return super.loadFunction(ident);
@@ -431,6 +436,12 @@ public class SparkSessionCatalog<
     }
 
     return new Identifier[0];
+  }
+
+  @Override
+  public boolean viewExists(Identifier ident) {
+    return (asViewCatalog != null && asViewCatalog.viewExists(ident))
+        || (isViewCatalog() && getSessionCatalog().viewExists(ident));
   }
 
   @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -562,6 +562,11 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  public boolean viewExists(Identifier ident) {
+    return asViewCatalog != null && asViewCatalog.viewExists(buildIdentifier(ident));
+  }
+
+  @Override
   public View loadView(Identifier ident) throws NoSuchViewException {
     if (null != asViewCatalog) {
       try {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -411,6 +411,11 @@ public class SparkSessionCatalog<
   }
 
   @Override
+  public boolean functionExists(Identifier ident) {
+    return super.functionExists(ident) || getSessionCatalog().functionExists(ident);
+  }
+
+  @Override
   public UnboundFunction loadFunction(Identifier ident) throws NoSuchFunctionException {
     try {
       return super.loadFunction(ident);
@@ -432,6 +437,12 @@ public class SparkSessionCatalog<
     }
 
     return new Identifier[0];
+  }
+
+  @Override
+  public boolean viewExists(Identifier ident) {
+    return (asViewCatalog != null && asViewCatalog.viewExists(ident))
+        || (isViewCatalog() && getSessionCatalog().viewExists(ident));
   }
 
   @Override


### PR DESCRIPTION
Default implementation used the load the table to judge the table exists. It' better to use the method `tableExists` in the class `SparkCatalog` and `SessionCatalog` directly . Because these classes may have more effective implementation like `RESTCatalog`. Applied the same optimization to views and functions.