### PR TITLE
site: use jinja comment in  header.html override

### DIFF
--- a/site/overrides/partials/header.html
+++ b/site/overrides/partials/header.html
@@ -1,4 +1,4 @@
-<!--
+{#-
   Copyright (c) 2016-2023 Martin Donath <martin.donath@squidfunk.com>
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -18,7 +18,7 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
   IN THE SOFTWARE.
--->
+-#}
 
 <!-- Determine classes -->
 {% set class = "md-header" %} {% if "navigation.tabs.sticky" in features %} {%


### PR DESCRIPTION
Closes #14275

This PR uses jinja comment instead of html comment so that the copyright notice is hidden when rendered by the iceberg website. 
Otherwise, this copyright notice appears on every page of [iceberg.apache.org](iceberg.apache.org) since it is part of the `header.html` override 

New:
<img width="1474" height="488" alt="Screenshot 2025-10-31 at 10 32 42 AM" src="https://github.com/user-attachments/assets/5e62ac2a-e49b-4665-ba49-9b81b1f5604b" />

Old:
<img width="1474" height="488" alt="Screenshot 2025-10-31 at 10 32 53 AM" src="https://github.com/user-attachments/assets/2bbc6d43-61e4-45ef-9fb6-81c5f76f8218" />
