### PR TITLE
Outdated: Fix commit duplication in DynamicIcebergSink (alternative)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
@@ -31,7 +31,7 @@ public class BaseReplacePartitions extends MergingSnapshotProducer<ReplacePartit
   private boolean validateConflictingData = false;
   private boolean validateConflictingDeletes = false;
 
-  BaseReplacePartitions(String tableName, TableOperations ops) {
+  protected BaseReplacePartitions(String tableName, TableOperations ops) {
     super(tableName, ops);
     set(SnapshotSummary.REPLACE_PARTITIONS_PROP, "true");
     replacedPartitions = PartitionSet.create(ops.current().specsById());

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkReplacePartitions.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkReplacePartitions.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import org.apache.iceberg.BaseReplacePartitions;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+
+class FlinkReplacePartitions extends BaseReplacePartitions
+    implements FlinkSnapshotValidator<FlinkReplacePartitions> {
+  private final Consumer<Snapshot> snapshotValidator;
+
+  private Long startingSnapshotId = null; // check all versions by default
+
+  FlinkReplacePartitions(
+      String tableName, TableOperations ops, Consumer<Snapshot> snapshotValidator) {
+    super(tableName, ops);
+    this.snapshotValidator = snapshotValidator;
+  }
+
+  @Override
+  public void validateSnapshot(Snapshot snapshot) {
+    snapshotValidator.accept(snapshot);
+  }
+
+  @Nullable
+  @Override
+  public Long startingSnapshotId() {
+    return startingSnapshotId;
+  }
+
+  @Override
+  public void validate(TableMetadata base, Snapshot parent) {
+    super.validate(base, parent);
+    validateSnapshots(base, parent);
+  }
+
+  FlinkReplacePartitions validateFromSnapshot(@Nullable Snapshot snapshot) {
+    if (snapshot != null) {
+      super.validateFromSnapshot(snapshot.snapshotId());
+      startingSnapshotId = snapshot.snapshotId();
+    }
+
+    return this;
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkRowDelta.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkRowDelta.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import org.apache.iceberg.BaseRowDelta;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+
+class FlinkRowDelta extends BaseRowDelta implements FlinkSnapshotValidator<FlinkRowDelta> {
+  private final Consumer<Snapshot> snapshotValidator;
+
+  private Long startingSnapshotId = null; // check all versions by default
+
+  FlinkRowDelta(String tableName, TableOperations ops, Consumer<Snapshot> snapshotValidator) {
+    super(tableName, ops);
+    this.snapshotValidator = snapshotValidator;
+  }
+
+  @Override
+  public void validateSnapshot(Snapshot snapshot) {
+    snapshotValidator.accept(snapshot);
+  }
+
+  @Nullable
+  @Override
+  public Long startingSnapshotId() {
+    return startingSnapshotId;
+  }
+
+  @Override
+  protected void validate(TableMetadata base, Snapshot parent) {
+    super.validate(base, parent);
+    validateSnapshots(base, parent);
+  }
+
+  FlinkRowDelta validateFromSnapshot(@Nullable Snapshot snapshot) {
+    if (snapshot != null) {
+      super.validateFromSnapshot(snapshot.snapshotId());
+      startingSnapshotId = snapshot.snapshotId();
+    }
+
+    return this;
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkSnapshotValidator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkSnapshotValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import javax.annotation.Nullable;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.util.SnapshotUtil;
+
+interface FlinkSnapshotValidator<T> {
+  void validateSnapshot(Snapshot snapshot);
+
+  @Nullable
+  Long startingSnapshotId();
+
+  default void validateSnapshots(TableMetadata base, @Nullable Snapshot parent) {
+    if (parent == null) {
+      return;
+    }
+
+    SnapshotUtil.ancestorsBetween(parent.snapshotId(), startingSnapshotId(), base::snapshot)
+        .forEach(this::validateSnapshot);
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/MaxCommittedCheckpointIdValidator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/MaxCommittedCheckpointIdValidator.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
+
+class MaxCommittedCheckpointIdValidator implements Consumer<Snapshot> {
+  private static final String FLINK_JOB_ID = "flink.job-id";
+  private static final String OPERATOR_ID = "flink.operator-id";
+  private static final String MAX_COMMITTED_CHECKPOINT_ID = "flink.max-committed-checkpoint-id";
+  private static final long INITIAL_CHECKPOINT_ID = -1L;
+
+  private final long stagedCheckpointId;
+  private final String flinkJobId;
+  private final String flinkOperatorId;
+
+  MaxCommittedCheckpointIdValidator(
+      long stagedCheckpointId, String flinkJobId, String flinkOperatorId) {
+    this.stagedCheckpointId = stagedCheckpointId;
+    this.flinkJobId = flinkJobId;
+    this.flinkOperatorId = flinkOperatorId;
+  }
+
+  @Override
+  public void accept(Snapshot snapshot) {
+    @Nullable
+    Long checkpointId = extractCommittedCheckpointId(snapshot, flinkJobId, flinkOperatorId);
+    if (checkpointId == null) {
+      return;
+    }
+
+    ValidationException.check(
+        checkpointId < stagedCheckpointId,
+        "The new parent snapshot '%s' has '%s': '%s' >= '%s' of the currently staged committable."
+            + "\nThis can happen, for example, when using the REST catalog: if the previous commit request failed"
+            + " in the Flink client but succeeded on the server after the Flink job decided to retry it with the new request."
+            + "\nFlink should retry this exception, and the committer should skip the duplicate request during the next retry.",
+        snapshot.snapshotId(),
+        MAX_COMMITTED_CHECKPOINT_ID,
+        checkpointId,
+        stagedCheckpointId);
+  }
+
+  /** TODO: Reuse {@link org.apache.iceberg.flink.sink.SinkUtil#getMaxCommittedCheckpointId} * */
+  static long getMaxCommittedCheckpointId(
+      Table table, String flinkJobId, String operatorId, String branch) {
+    Snapshot snapshot = table.snapshot(branch);
+
+    while (snapshot != null) {
+      @Nullable
+      Long committedCheckpointId = extractCommittedCheckpointId(snapshot, flinkJobId, operatorId);
+      if (committedCheckpointId != null) {
+        return committedCheckpointId;
+      }
+
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
+    }
+
+    return INITIAL_CHECKPOINT_ID;
+  }
+
+  @Nullable
+  static Long extractCommittedCheckpointId(
+      Snapshot snapshot, String flinkJobId, String operatorId) {
+    Map<String, String> summary = snapshot.summary();
+    String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
+    String snapshotOperatorId = summary.get(OPERATOR_ID);
+    if (flinkJobId.equals(snapshotFlinkJobId)
+        && (snapshotOperatorId == null || snapshotOperatorId.equals(operatorId))) {
+      String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
+      if (value != null) {
+        return Long.parseLong(value);
+      }
+    }
+
+    return null;
+  }
+
+  static void setFlinkProperties(
+      SnapshotUpdate<?> operation, long checkpointId, String flinkJobId, String operatorId) {
+    operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));
+    operation.set(FLINK_JOB_ID, flinkJobId);
+    operation.set(OPERATOR_ID, operatorId);
+  }
+}


### PR DESCRIPTION
This PR is an alternative solution to https://github.com/apache/iceberg/issues/14425, which uses the same idea of checking duplicate concurrent commits using snapshot validation, similar to https://github.com/apache/iceberg/pull/14445.

The current solution extends `BaseRowDelta` and `BaseReplacePartitions` operations in Flink packages instead of adding public API methods to `RowDelta` and `ReplacePartitions` interfaces in https://github.com/apache/iceberg/pull/14445.