### PR TITLE
REST spec: Metadata integrity for encrypted tables

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1259,7 +1259,7 @@ class LoadTableResult(BaseModel):
     In encrypted Iceberg tables, malicious modifications of the table metadata fields can break the data encryption
     or alter the table content via replay and other attacks. The REST catalog implementations, working with encrypted
     Iceberg tables, must protect integrity of the table metadata, by either storing it in a trusted tamper-proof storage
-    or database, or by cryptographically signing the metadata content in an untrusted storage.
+    or database, or by checking the metadata content in an untrusted storage.
 
     The `config` map returns table-specific configuration for the table's resources, including its HTTP client and FileIO. For example, config may contain a specific FileIO implementation class for the table depending on its underlying storage.
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3286,7 +3286,7 @@ components:
         In encrypted Iceberg tables, malicious modifications of the table metadata fields can break the data encryption
         or alter the table content via replay and other attacks. The REST catalog implementations, working with encrypted
         Iceberg tables, must protect integrity of the table metadata, by either storing it in a trusted tamper-proof storage
-        or database, or by cryptographically signing the metadata content in an untrusted storage.
+        or database, or by checking the metadata content in an untrusted storage.
 
         The `config` map returns table-specific configuration for the table's resources, including its HTTP client and FileIO. For example, config may contain a specific FileIO implementation class for the table depending on its underlying storage.
       


### PR DESCRIPTION
Follow up on the discussion thread starting at https://github.com/apache/iceberg/pull/13225#discussion_r2465759567.

tl;dr: The REST implementations that keep the table metadata in a json file in an untrusted storage, are not safe for table encryption. The data confidentiality and integrity can be broken by malicious modifications of the metadata.json.
This patch proposes a short addition to the REST spec that requires protection of the metadata integrity in catalog implementations that will be used for encrypted tables.