### PR TITLE
site: faster make lint

### DIFF
--- a/site/dev/common.sh
+++ b/site/dev/common.sh
@@ -195,7 +195,7 @@ pull_versioned_docs () {
 
 check_markdown_files () {
   echo " --> check markdown file styles"
-  if ! "${VENV_DIR}/bin/python3" -m pymarkdown --config markdownlint.yml scan docs/docs/nightly/docs/*.md docs/*.md README.md
+  if ! "${VENV_DIR}/bin/python3" -m pymarkdown --config markdownlint.yml scan ../docs/docs/*.md docs/*.md README.md
   then
     echo "Markdown style issues found. Please run 'make lint-fix' to fix them."
     exit 1
@@ -204,7 +204,7 @@ check_markdown_files () {
 
 fix_markdown_files () {
   echo " --> fix markdown file styles"
-  "${VENV_DIR}/bin/python3" -m pymarkdown --config markdownlint.yml fix docs/docs/nightly/docs/*.md docs/*.md README.md
+  "${VENV_DIR}/bin/python3" -m pymarkdown --config markdownlint.yml fix ../docs/docs/*.md docs/*.md README.md
 }
 
 # Cleans up artifacts and temporary files generated during documentation management.

--- a/site/dev/lint.sh
+++ b/site/dev/lint.sh
@@ -20,7 +20,9 @@ source dev/common.sh
 
 set -e
 
-./dev/setup_env.sh
+create_venv
+
+install_deps
 
 if [[ "$1" == "--fix" ]]; then
   fix_markdown_files


### PR DESCRIPTION
`make lint` (`site/dev/lint.sh`) does not require running `./dev/setup_env.sh`, which pulls versioned documentation (`pull_versioned_docs`). This step is unnecessary for linting.

`make lint` only needs the environment set up via `create_venv` and `install_deps`.

Additionally, use the `../docs/docs` folder instead of `docs/docs/nightly/docs/*.md` for linting. These paths point to the same location because they are sym links
https://github.com/apache/iceberg/blob/94d9287b7a3b7474aa0776c315ec000fc97de329/site/dev/common.sh#L77


Follow up to #14466