### PR TITLE
[1.10.x] cherry pick Parquet: Handle NPE for VariantLogicalType in TypeWithSchemaVisitor (#14261)

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -64,7 +64,7 @@ public class TypeWithSchemaVisitor<T> {
       } else if (annotation instanceof LogicalTypeAnnotation.VariantLogicalTypeAnnotation
           || (iType != null && iType.isVariantType())) {
         // when Parquet has a VARIANT logical type, use it here
-        return visitVariant(iType.asVariantType(), group, visitor);
+        return visitVariant(iType != null ? iType.asVariantType() : null, group, visitor);
       }
 
       Types.StructType struct = iType != null ? iType.asStructType() : null;


### PR DESCRIPTION


(cherry picked from commit 9be7c1820c5e27cc029590af1dfca470dbbeb8b7)