### PR TITLE
Fix: Arrow vectorized reads for TIMESTAMP_MILLIS and shaded JAR initialization

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/ArrowAllocation.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/ArrowAllocation.java
@@ -21,13 +21,28 @@ package org.apache.iceberg.arrow;
 import org.apache.arrow.memory.RootAllocator;
 
 public class ArrowAllocation {
+  private static final String ALLOCATION_MANAGER_TYPE_PROPERTY =
+      "arrow.memory.allocation.manager.type";
+
   static {
-    ROOT_ALLOCATOR = new RootAllocator(Long.MAX_VALUE);
+    if (System.getProperty(ALLOCATION_MANAGER_TYPE_PROPERTY) == null) {
+      System.setProperty(ALLOCATION_MANAGER_TYPE_PROPERTY, "Netty");
+    }
+
+    ROOT_ALLOCATOR = createRootAllocator();
   }
 
   private static final RootAllocator ROOT_ALLOCATOR;
 
   private ArrowAllocation() {}
+
+  private static RootAllocator createRootAllocator() {
+    try {
+      return new RootAllocator(Long.MAX_VALUE);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to initialize Arrow RootAllocator", e);
+    }
+  }
 
   public static RootAllocator rootAllocator() {
     return ROOT_ALLOCATOR;


### PR DESCRIPTION
Fixes: #14430 & #14046

#### Description

This PR fixed two critical issues preventing vectorized Arrow Reads in iceberg when:

1. Reading Parquet files with `TIMESTAMP_MILLIS` encoding.
2. Using shaded Arrow classes in runtime JARs (e.g., `iceberg-spark-runtime`)

Error:

```bash
java.lang.ClassCastException: class org.apache.iceberg.shaded.org.apache.arrow.vector.TimeStampMicroTZVector cannot be cast to class org.apache.iceberg.shaded.org.apache.arrow.vector.BigIntVector (org.apache.iceberg.shaded.org.apache.arrow.vector.TimeStampMicroTZVector and org.apache.iceberg.shaded.org.apache.arrow.vector.BigIntVector are in unnamed module of loader 'app')
```

Cause: when reading parquet files with `TIMESTAMP_MILLIS` logical type annotation, the **VectorizedArrowReader** incorrectly allocated a *TimeStampMicroTZVector* based on iceberg schema (which expects microsecond precision), but the actual reader (*TimeStampMicroTZVector*) writes raw long values that require a BigIntVector.

Fix:

* Explicitly create a **`Field`** with **`ArrowType.Int(Long.SIZE, true)`** type
* Allocate a **`BigIntVector`** that matches what *TimestampMillisReader* expects and return **`ReadType.TIMESTAMP_MILLIS`** to trigger millisecond-to-microsecond conversion

Also, setting **`arrow.memory.allocation.manager.type=Netty`**, if already not set.

### Testing

1. Creating a Parquet file with **`spark.sql.parquet.outputTimestampType=TIMESTAMP_MILLIS`**
2. Sending the parquet file path to the Iceberg Table to consider it as a data file (an `AddFile()` API)
3. Querying with **`spark.sql.iceberg.vectorization.enabled=true`**
4. Confirming successful vectorized reads with correct timestamp values