### PR TITLE
Spark: Improve namespace existence verification logic

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -456,6 +456,12 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  public boolean namespaceExists(String[] namespace) {
+    return asNamespaceCatalog != null
+        && asNamespaceCatalog.namespaceExists(Namespace.of(namespace));
+  }
+
+  @Override
   public Map<String, String> loadNamespaceMetadata(String[] namespace)
       throws NoSuchNamespaceException {
     if (asNamespaceCatalog != null) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -456,6 +456,12 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  public boolean namespaceExists(String[] namespace) {
+    return asNamespaceCatalog != null
+        && asNamespaceCatalog.namespaceExists(Namespace.of(namespace));
+  }
+
+  @Override
   public Map<String, String> loadNamespaceMetadata(String[] namespace)
       throws NoSuchNamespaceException {
     if (asNamespaceCatalog != null) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -457,6 +457,12 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  public boolean namespaceExists(String[] namespace) {
+    return asNamespaceCatalog != null
+        && asNamespaceCatalog.namespaceExists(Namespace.of(namespace));
+  }
+
+  @Override
   public Map<String, String> loadNamespaceMetadata(String[] namespace)
       throws NoSuchNamespaceException {
     if (asNamespaceCatalog != null) {


### PR DESCRIPTION
Improve namespace existence verification logic.  Similar to #14457
It seems that `SparkSessionCatalog` class handles v1 DDL commands. `SparkCatalog` class handles v2 DDL commands.
So it's ok that we only modify the `SparkCatalog` class.