### PR TITLE
[1.10.x] Core: Fix overflow due to default value on timestamp nanos (#14359)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -197,7 +197,14 @@ public class SchemaParser {
 
   private static Literal<?> defaultFromJson(String defaultField, Type type, JsonNode json) {
     if (json.has(defaultField)) {
-      return Expressions.lit(SingleValueParser.fromJson(type, json.get(defaultField)));
+      Object value = SingleValueParser.fromJson(type, json.get(defaultField));
+      if (type instanceof Types.TimestampNanoType) {
+        // Call Expressions.nanos instead of Expressions.lit to prevent overflow
+        // https://github.com/apache/iceberg/issues/13160
+        return Expressions.nanos((long) value);
+      }
+
+      return Expressions.lit(value);
     }
 
     return null;

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.iceberg.data.DataTestBase;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -117,8 +118,15 @@ public class TestSchemaParser extends DataTestBase {
             Types.TimestampType.withZone(),
             Literal.of(DateTimeUtil.isoTimestamptzToMicros("2024-12-17T23:59:59.999999+00:00"))),
         Arguments.of(
+            Types.TimestampNanoType.withZone(),
+            Expressions.nanos(
+                DateTimeUtil.isoTimestamptzToNanos("2024-12-17T23:59:59.123456789+00:00"))),
+        Arguments.of(
             Types.TimestampType.withoutZone(),
             Literal.of(DateTimeUtil.isoTimestampToMicros("2024-12-17T23:59:59.999999"))),
+        Arguments.of(
+            Types.TimestampNanoType.withoutZone(),
+            Expressions.nanos(DateTimeUtil.isoTimestampToNanos("2024-12-17T23:59:59.123456789"))),
         Arguments.of(Types.StringType.get(), Literal.of("iceberg")),
         Arguments.of(Types.UUIDType.get(), Literal.of(UUID.randomUUID())),
         Arguments.of(


### PR DESCRIPTION
Clean cherry-pick of https://github.com/apache/iceberg/pull/14359

(cherry picked from commit e268df62feaf52a72b9ed52ce24593d59eb41ea0)