### PR TITLE
Implement Snapshot validation API for commits

### DIFF
--- a/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
@@ -102,17 +102,6 @@ public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
   OverwriteFiles validateAddedFilesMatchOverwriteFilter();
 
   /**
-   * Set the snapshot ID used in any reads for this operation.
-   *
-   * <p>Validations will check changes after this snapshot ID. If the from snapshot is not set, all
-   * ancestor snapshots through the table's initial snapshot are validated.
-   *
-   * @param snapshotId a snapshot ID
-   * @return this for method chaining
-   */
-  OverwriteFiles validateFromSnapshot(long snapshotId);
-
-  /**
    * Enables or disables case sensitive expression binding for validations that accept expressions.
    *
    * @param caseSensitive whether expression binding should be case sensitive

--- a/api/src/main/java/org/apache/iceberg/ReplacePartitions.java
+++ b/api/src/main/java/org/apache/iceberg/ReplacePartitions.java
@@ -56,22 +56,6 @@ public interface ReplacePartitions extends SnapshotUpdate<ReplacePartitions> {
   ReplacePartitions validateAppendOnly();
 
   /**
-   * Set the snapshot ID used in validations for this operation.
-   *
-   * <p>All validations will check changes after this snapshot ID. If this is not called, validation
-   * will occur from the beginning of the table's history.
-   *
-   * <p>This method should be called before this operation is committed. If a concurrent operation
-   * committed a data or delta file or removed a data file after the given snapshot ID that might
-   * contain rows matching a partition marked for deletion, validation will detect this and fail.
-   *
-   * @param snapshotId a snapshot ID, it should be set to when this operation started to read the
-   *     table.
-   * @return this for method chaining
-   */
-  ReplacePartitions validateFromSnapshot(long snapshotId);
-
-  /**
    * Enables validation that deletes that happened concurrently do not conflict with this commit's
    * operation.
    *

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -173,15 +173,4 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
       Set<DeleteFile> deleteFilesToReplace,
       Set<DataFile> dataFilesToAdd,
       Set<DeleteFile> deleteFilesToAdd);
-
-  /**
-   * Set the snapshot ID used in any reads for this operation.
-   *
-   * <p>Validations will check changes after this snapshot ID. If this is not called, all ancestor
-   * snapshots through the table's initial snapshot are validated.
-   *
-   * @param snapshotId a snapshot ID
-   * @return this for method chaining
-   */
-  RewriteFiles validateFromSnapshot(long snapshotId);
 }

--- a/api/src/main/java/org/apache/iceberg/RowDelta.java
+++ b/api/src/main/java/org/apache/iceberg/RowDelta.java
@@ -69,17 +69,6 @@ public interface RowDelta extends SnapshotUpdate<RowDelta> {
   }
 
   /**
-   * Set the snapshot ID used in any reads for this operation.
-   *
-   * <p>Validations will check changes after this snapshot ID. If the from snapshot is not set, all
-   * ancestor snapshots through the table's initial snapshot are validated.
-   *
-   * @param snapshotId a snapshot ID
-   * @return this for method chaining
-   */
-  RowDelta validateFromSnapshot(long snapshotId);
-
-  /**
    * Enables or disables case sensitive expression binding for validations that accept expressions.
    *
    * @param caseSensitive whether expression binding should be case sensitive

--- a/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -71,4 +71,32 @@ public interface SnapshotUpdate<ThisT> extends PendingUpdate<Snapshot> {
             "Cannot commit to branch %s: %s does not support branch commits",
             branch, this.getClass().getName()));
   }
+
+  /**
+   * Enables snapshot validation with a user-provided function, which must throw a {@link
+   * org.apache.iceberg.exceptions.ValidationException} on validation failures.
+   *
+   * <p>Clients can use this method to validate summary and other metadata of parent snapshots.
+   *
+   * @param snapshotValidator a user function to validate parent snapshots
+   * @return this for method chaining
+   */
+  default ThisT validateWith(Consumer<Snapshot> snapshotValidator) {
+    throw new UnsupportedOperationException(
+        getClass().getName() + " does not implement validateWith");
+  }
+
+  /**
+   * Set the snapshot ID used in any reads for this operation.
+   *
+   * <p>Validations will check changes after this snapshot ID. If the from snapshot is not set, all
+   * ancestor snapshots through the table's initial snapshot are validated.
+   *
+   * @param snapshotId a snapshot ID
+   * @return this for method chaining
+   */
+  default ThisT validateFromSnapshot(long snapshotId) {
+    throw new UnsupportedOperationException(
+        getClass().getName() + " does not implement validateFromSnapshot");
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
@@ -27,7 +27,6 @@ public class BaseReplacePartitions extends MergingSnapshotProducer<ReplacePartit
     implements ReplacePartitions {
 
   private final PartitionSet replacedPartitions;
-  private Long startingSnapshotId;
   private boolean validateConflictingData = false;
   private boolean validateConflictingDeletes = false;
 
@@ -62,12 +61,6 @@ public class BaseReplacePartitions extends MergingSnapshotProducer<ReplacePartit
   }
 
   @Override
-  public ReplacePartitions validateFromSnapshot(long newStartingSnapshotId) {
-    this.startingSnapshotId = newStartingSnapshotId;
-    return this;
-  }
-
-  @Override
   public ReplacePartitions validateNoConflictingDeletes() {
     this.validateConflictingDeletes = true;
     return this;
@@ -87,24 +80,26 @@ public class BaseReplacePartitions extends MergingSnapshotProducer<ReplacePartit
 
   @Override
   public void validate(TableMetadata currentMetadata, Snapshot parent) {
+    super.validate(currentMetadata, parent);
+
     if (validateConflictingData) {
       if (dataSpec().isUnpartitioned()) {
         validateAddedDataFiles(
-            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), parent);
+            currentMetadata, startingSnapshotId(), Expressions.alwaysTrue(), parent);
       } else {
-        validateAddedDataFiles(currentMetadata, startingSnapshotId, replacedPartitions, parent);
+        validateAddedDataFiles(currentMetadata, startingSnapshotId(), replacedPartitions, parent);
       }
     }
 
     if (validateConflictingDeletes) {
       if (dataSpec().isUnpartitioned()) {
         validateDeletedDataFiles(
-            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), parent);
+            currentMetadata, startingSnapshotId(), Expressions.alwaysTrue(), parent);
         validateNoNewDeleteFiles(
-            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), parent);
+            currentMetadata, startingSnapshotId(), Expressions.alwaysTrue(), parent);
       } else {
-        validateDeletedDataFiles(currentMetadata, startingSnapshotId, replacedPartitions, parent);
-        validateNoNewDeleteFiles(currentMetadata, startingSnapshotId, replacedPartitions, parent);
+        validateDeletedDataFiles(currentMetadata, startingSnapshotId(), replacedPartitions, parent);
+        validateNoNewDeleteFiles(currentMetadata, startingSnapshotId(), replacedPartitions, parent);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -25,7 +25,6 @@ import org.apache.iceberg.util.DataFileSet;
 
 class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
   private final DataFileSet replacedDataFiles = DataFileSet.create();
-  private Long startingSnapshotId = null;
 
   BaseRewriteFiles(String tableName, TableOperations ops) {
     super(tableName, ops);
@@ -120,12 +119,6 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
-  public RewriteFiles validateFromSnapshot(long snapshotId) {
-    this.startingSnapshotId = snapshotId;
-    return this;
-  }
-
-  @Override
   public BaseRewriteFiles toBranch(String branch) {
     targetBranch(branch);
     return this;
@@ -133,11 +126,13 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
 
   @Override
   protected void validate(TableMetadata base, Snapshot parent) {
+    super.validate(base, parent);
+
     validateReplacedAndAddedFiles();
     if (!replacedDataFiles.isEmpty()) {
       // if there are replaced data files, there cannot be any new row-level deletes for those data
       // files
-      validateNoNewDeletesForDataFiles(base, startingSnapshotId, replacedDataFiles, parent);
+      validateNoNewDeletesForDataFiles(base, startingSnapshotId(), replacedDataFiles, parent);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
+++ b/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
@@ -156,6 +156,8 @@ class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
 
   @Override
   protected void validate(TableMetadata base, Snapshot snapshot) {
+    super.validate(base, snapshot);
+
     // this is only called after apply() passes off to super, but check fast-forward status just in
     // case
     if (!isFastForward(base)) {

--- a/core/src/main/java/org/apache/iceberg/StreamingDelete.java
+++ b/core/src/main/java/org/apache/iceberg/StreamingDelete.java
@@ -70,6 +70,8 @@ public class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implem
 
   @Override
   protected void validate(TableMetadata base, Snapshot parent) {
+    super.validate(base, parent);
+
     if (validateFilesToDeleteExist) {
       failMissingDeletePaths();
     }


### PR DESCRIPTION
This change implements the ability to add custom `Snapshot` validations to the existing `SnapshotUpdate` API.

It focuses on reusing existing validation APIs in `SnapshotProducer` and removing code duplication, while providing enough flexibility for clients, such as Kafka Connect and Flink.

It is an alternative solution to https://github.com/apache/iceberg/pull/14509.

**Why?**

Custom `Snapshot` validation is necessary for non-idempotent table update operations, which rely on the existing state for correctness and exactly-once delivery. Applications like Flink and Kafka Connect use snapshot properties to store their idempotence keys, which identify the base state during recovery. Due to the nature of concurrent commits in Iceberg, these applications need the ability to check information of the new base snapshots to identify idempotence violations. This change addresses this problem and allows clients to implement custom idempotence validations.

**How?**

This change achieves the following:
1. Add the new `validateWith(Consumer<Snapshot> snapshotValidator)` method to the `SnapshotUpdate` to allow custom `Snapshot` validations.
2. Move the existing duplicate definitions of `validateFromSnapshot(long snapshotId)` from child interfaces (`OverwriteFiles`, `ReplacePartitions`, and `RowDelta`, etc.) to the parent `SnapshotUpdate` and remove duplicate definitions.
  - This method allows configuring the starting `Snapshot` for validation, which is used by the Kafka Connect PR (https://github.com/apache/iceberg/pull/14517) and other validations.
3. Implement snapshot validation in the base class `SnapshotProducer::validate(TableMetadata currentMetadata, Snapshot snapshot)`, allowing child classes to inherit the validation functionality.

This approach results in maximised code reuse and aligns with the existing validation functionality.

**Impact?**

This change is used as a parent in the following PRs:
1. Implement commit validations for Kafka connect: https://github.com/apache/iceberg/pull/14515
2. Fix commit duplication issue in Flink: https://github.com/apache/iceberg/pull/14517