### PR TITLE
OpenAPI: Add planId as query param to /credentials endpoint

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1192,6 +1192,13 @@ paths:
         - Catalog API
       summary: Load vended credentials for a table from the catalog
       operationId: loadCredentials
+      parameters:
+        - name: planId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: The plan ID that has been used for server-side scan planning
       description: Load vended credentials for a table from the catalog.
       responses:
         200:


### PR DESCRIPTION
Some additoinal context is needed when refreshing credentials that are used for server-side scan planning, hence this is adding the `planId` as query param.

ML Discussion: https://lists.apache.org/thread/ln9z418pkgcqrpt3y6m4qhl07bxrkoq3