### PR TITLE
Core, Parquet: Fix Parquet to work OutputFiles generated by StandardEncryptionManager.ecrypt().encryptingOutputFile()

### DIFF
--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -289,6 +290,35 @@ public class StandardEncryptionManager implements EncryptionManager {
 
     @Override
     public OutputFile encryptingOutputFile() {
+      return this;
+    }
+
+    @Override
+    public OutputFile plainOutputFile() {
+      return plainOutputFile;
+    }
+
+    @Override
+    public PositionOutputStream create() {
+      return lazyEncryptingOutputFile().create();
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite() {
+      return lazyEncryptingOutputFile().createOrOverwrite();
+    }
+
+    @Override
+    public String location() {
+      return lazyEncryptingOutputFile().location();
+    }
+
+    @Override
+    public InputFile toInputFile() {
+      return lazyEncryptingOutputFile().toInputFile();
+    }
+
+    private OutputFile lazyEncryptingOutputFile() {
       if (null == lazyEncryptingOutputFile) {
         this.lazyEncryptingOutputFile =
             new AesGcmOutputFile(
@@ -298,11 +328,6 @@ public class StandardEncryptionManager implements EncryptionManager {
       }
 
       return lazyEncryptingOutputFile;
-    }
-
-    @Override
-    public OutputFile plainOutputFile() {
-      return plainOutputFile;
     }
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetEncryption.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetEncryption.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.Files.localInput;
 import static org.apache.iceberg.Files.localOutput;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.createTempFile;
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.parquet.hadoop.ParquetFileWriter.EF_MAGIC_STR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -29,14 +30,26 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptionTestHelpers;
+import org.apache.iceberg.encryption.NativeEncryptionKeyMetadata;
+import org.apache.iceberg.encryption.NativeEncryptionOutputFile;
+import org.apache.iceberg.hadoop.HadoopInputFile;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
@@ -124,5 +137,58 @@ public class TestParquetEncryption {
         assertThat(readRecord.get(COLUMN_NAME)).isEqualTo(i);
       }
     }
+  }
+
+  @Test
+  public void testReadAndWriteHadoopFile() throws IOException {
+    List<GenericRecord> records = Lists.newArrayListWithCapacity(RECORD_COUNT);
+    for (int i = 1; i <= RECORD_COUNT; i++) {
+      GenericRecord record = GenericRecord.create(SCHEMA.asStruct());
+      record.set(0, i);
+      records.add(record);
+    }
+
+    org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(createTempFile(temp).toURI());
+
+    EncryptedOutputFile encryptedOutputFile =
+        EncryptionTestHelpers.createEncryptionManager()
+            .encrypt(HadoopOutputFile.fromPath(path, new Configuration()));
+    NativeEncryptionKeyMetadata keyMetadata =
+        ((NativeEncryptionOutputFile) encryptedOutputFile).keyMetadata();
+    FileAppender<GenericRecord> writer =
+        Parquet.write(encryptedOutputFile.encryptingOutputFile())
+            .withFileEncryptionKey(keyMetadata.encryptionKey())
+            .withAADPrefix(keyMetadata.aadPrefix())
+            .schema(SCHEMA)
+            .createWriterFunc(fileSchema -> GenericParquetWriter.create(SCHEMA, fileSchema))
+            .build();
+
+    try (writer) {
+      writer.addAll(Lists.newArrayList(records.toArray(new GenericRecord[] {})));
+    }
+
+    InputFile inputFile = HadoopInputFile.fromPath(path, new Configuration());
+    checkFileEncryption(inputFile);
+    try (CloseableIterator readRecords =
+        Parquet.read(inputFile)
+            .withFileEncryptionKey(keyMetadata.encryptionKey())
+            .withAADPrefix(keyMetadata.aadPrefix())
+            .project(SCHEMA)
+            .callInit()
+            .build()
+            .iterator()) {
+      for (int i = 1; i <= RECORD_COUNT; i++) {
+        GenericData.Record readRecord = (GenericData.Record) readRecords.next();
+        assertThat(readRecord.get(COLUMN_NAME)).isEqualTo(i);
+      }
+    }
+  }
+
+  private void checkFileEncryption(InputFile inputFile) throws IOException {
+    SeekableInputStream stream = inputFile.newStream();
+    byte[] magic = new byte[4];
+    stream.read(magic);
+    stream.close();
+    assertThat(magic).isEqualTo(EF_MAGIC_STR.getBytes(StandardCharsets.UTF_8));
   }
 }


### PR DESCRIPTION
The `EncryptedOutputFile` objects generated by the `StandardEncryptionManager.encrypt` method hide the underlying `OutputFile`. 

Unfortunately, there are some hidden requirements in the Parquet implementation for encryption to work properly.
Parquet encryption was only functioning when the target was a `HadoopOutputFile`. Using `StandardEncryptedOutputFile.encryptingOutputFile()` produced an `AesGcmOutputFile`, which resulted in corrupt files.

Updated `StandardEncryptedOutputFile` to return itself as the `encryptingOutputFile`, instead of exposing the underlying `AesGcmOutputFile`. The methods coming from the `OutputFile` are now wrapped and return the values directly from the wrapped output file.

Added a test to highlight the issue.

The test currently fails without the patch, but successful if we change:
```
        Parquet.write(encryptedOutputFile.encryptingOutputFile())
```
to 
```
        Parquet.write(encryptedOutputFile)
```

After the patch both `OutputFile` objects could be used.