### PR TITLE
Build: Bump org.apache.hadoop.thirdparty:hadoop-shaded-guava

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -67,12 +67,13 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
     }
     all {
       exclude group: 'javax.activation', module: 'activation'
+      exclude group: 'org.jspecify', module: 'jspecify'
       // force upgrades for dependencies with known vulnerabilities...
       resolutionStrategy {
         force 'org.codehaus.jettison:jettison:1.5.4'
         force 'org.xerial.snappy:snappy-java:1.1.10.8'
         force 'org.apache.commons:commons-compress:1.28.0'
-        force 'org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.4.0'
+        force 'org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.5.0'
         force 'com.fasterxml.woodstox:woodstox-core:6.7.0'
         force 'commons-beanutils:commons-beanutils:1.11.0'
       }


### PR DESCRIPTION
Bumps org.apache.hadoop.thirdparty:hadoop-shaded-guava from 1.4.0 to 1.5.0.

Closes #14537