### PR TITLE
API, Spark, Core, Hive: Remove redundant String.format from tests

### DIFF
--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -189,9 +189,7 @@ public class TestHelpers {
               .as("Should have matching schema id")
               .isEqualTo(schema1.schemaId());
           assertThat(schema1.sameSchema(schema2))
-              .as(
-                  String.format(
-                      "Should be the same schema. Schema 1: %s, schema 2: %s", schema1, schema2))
+              .as("Should be the same schema. Schema 1: %s, schema 2: %s", schema1, schema2)
               .isTrue();
         });
   }

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalAppendScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalAppendScan.java
@@ -92,11 +92,11 @@ public class TestBaseIncrementalAppendScan
     table.manageSnapshots().createBranch(branchName, snapshotAId).commit();
     assertThatThrownBy(() -> newScan().fromSnapshotInclusive(branchName))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(String.format("Ref %s is not a tag", branchName));
+        .hasMessage("Ref %s is not a tag", branchName);
 
     assertThatThrownBy(() -> newScan().fromSnapshotInclusive(snapshotAId).toSnapshot(branchName))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(String.format("Ref %s is not a tag", branchName));
+        .hasMessage("Ref %s is not a tag", branchName);
   }
 
   @TestTemplate
@@ -166,7 +166,7 @@ public class TestBaseIncrementalAppendScan
     assertThatThrownBy(
             () -> newScan().fromSnapshotInclusive(snapshotAId).useBranch(tagSnapshotAName))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(String.format("Ref %s is not a branch", tagSnapshotAName));
+        .hasMessage("Ref %s is not a branch", tagSnapshotAName);
   }
 
   @TestTemplate
@@ -201,9 +201,8 @@ public class TestBaseIncrementalAppendScan
                 newScan().fromSnapshotInclusive(snapshotMainBId).useBranch(branchName).planFiles())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            String.format(
-                "Starting snapshot (inclusive) %s is not an ancestor of end snapshot %s",
-                snapshotMainBId, snapshotBranchBId));
+            "Starting snapshot (inclusive) %s is not an ancestor of end snapshot %s",
+            snapshotMainBId, snapshotBranchBId);
   }
 
   @TestTemplate
@@ -290,7 +289,7 @@ public class TestBaseIncrementalAppendScan
     table.manageSnapshots().createBranch(branchName, snapshotAId).commit();
     assertThatThrownBy(() -> newScan().fromSnapshotExclusive(branchName))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(String.format("Ref %s is not a tag", branchName));
+        .hasMessage("Ref %s is not a tag", branchName);
   }
 
   @TestTemplate
@@ -356,7 +355,7 @@ public class TestBaseIncrementalAppendScan
 
     assertThatThrownBy(() -> newScan().toSnapshot(branchName))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(String.format("Ref %s is not a tag", branchName));
+        .hasMessage("Ref %s is not a tag", branchName);
   }
 
   @TestTemplate
@@ -387,9 +386,8 @@ public class TestBaseIncrementalAppendScan
     assertThatThrownBy(() -> Iterables.size(scanShouldFail.planFiles()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Starting snapshot (exclusive) %d is not a parent ancestor of end snapshot %d",
-                snapshotBId, snapshotDId));
+            "Starting snapshot (exclusive) %d is not a parent ancestor of end snapshot %d",
+            snapshotBId, snapshotDId);
 
     // scan should fail because snapshot B is not an ancestor of snapshot D
     IncrementalAppendScan scanShouldFailInclusive =
@@ -397,8 +395,7 @@ public class TestBaseIncrementalAppendScan
     assertThatThrownBy(() -> Iterables.size(scanShouldFailInclusive.planFiles()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Starting snapshot (inclusive) %d is not an ancestor of end snapshot %d",
-                snapshotBId, snapshotDId));
+            "Starting snapshot (inclusive) %d is not an ancestor of end snapshot %d",
+            snapshotBId, snapshotDId);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
@@ -88,8 +88,7 @@ public class TestFormatVersions extends TestBase {
 
     assertThatThrownBy(() -> ops.current().upgradeToFormatVersion(formatVersion))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
-            String.format("Cannot downgrade v%d table to v%d", newFormatVersion, formatVersion));
+        .hasMessage("Cannot downgrade v%d table to v%d", newFormatVersion, formatVersion);
 
     assertThat(ops.current().formatVersion()).isEqualTo(newFormatVersion);
   }
@@ -104,9 +103,8 @@ public class TestFormatVersions extends TestBase {
             () -> ops.commit(base, base.upgradeToFormatVersion(unsupportedFormatVersion)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Cannot upgrade table to unsupported format version: v%d (supported: v%d)",
-                unsupportedFormatVersion, TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION));
+            "Cannot upgrade table to unsupported format version: v%d (supported: v%d)",
+            unsupportedFormatVersion, TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION);
 
     assertThat(ops.current().formatVersion()).isEqualTo(formatVersion);
   }

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -183,9 +183,8 @@ public class TestLocationProvider extends TestBase {
     assertThatThrownBy(() -> table.locationProvider())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Provided implementation for dynamic instantiation should implement %s.",
-                LocationProvider.class));
+            "Provided implementation for dynamic instantiation should implement %s.",
+            LocationProvider.class);
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -82,8 +82,7 @@ public class TestRewriteFiles extends TestBase {
                             ImmutableSet.of(fileBDeletes())),
                     branch))
         .isInstanceOf(ValidationException.class)
-        .hasMessage(
-            String.format("Missing required files to delete: %s", fileADeletes().location()));
+        .hasMessage("Missing required files to delete: %s", fileADeletes().location());
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestSortOrder.java
+++ b/core/src/test/java/org/apache/iceberg/TestSortOrder.java
@@ -394,7 +394,7 @@ public class TestSortOrder {
                     .asc(fieldName)
                     .build())
         .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(String.format("Cannot find field '%s' in struct", fieldName));
+        .hasMessageContaining("Cannot find field '%s' in struct", fieldName);
 
     SortOrder ext1 =
         SortOrder.builderFor(SCHEMA).caseSensitive(false).withOrderId(10).asc("ext1").build();

--- a/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateRequirements.java
@@ -149,9 +149,8 @@ public class TestUpdateRequirements {
     assertThatThrownBy(() -> requirements.forEach(req -> req.validate(updated)))
         .isInstanceOf(CommitFailedException.class)
         .hasMessage(
-            String.format(
-                "Requirement failed: UUID does not match: expected %s != %s",
-                updated.uuid(), metadata.uuid()));
+            "Requirement failed: UUID does not match: expected %s != %s",
+            updated.uuid(), metadata.uuid());
   }
 
   @Test
@@ -182,9 +181,8 @@ public class TestUpdateRequirements {
     assertThatThrownBy(() -> requirements.forEach(req -> req.validate(updatedViewMetadata)))
         .isInstanceOf(CommitFailedException.class)
         .hasMessage(
-            String.format(
-                "Requirement failed: view UUID does not match: expected %s != %s",
-                updatedViewMetadata.uuid(), viewMetadata.uuid()));
+            "Requirement failed: view UUID does not match: expected %s != %s",
+            updatedViewMetadata.uuid(), viewMetadata.uuid());
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/TestWapWorkflow.java
+++ b/core/src/test/java/org/apache/iceberg/TestWapWorkflow.java
@@ -591,7 +591,6 @@ public class TestWapWorkflow extends TestBase {
             // double cherrypicking of second snapshot
             () -> table.manageSnapshots().cherrypick(firstSnapshotId).commit())
         .isInstanceOf(CherrypickAncestorCommitException.class)
-        .hasMessage(
-            String.format("Cannot cherrypick snapshot %s: already an ancestor", firstSnapshotId));
+        .hasMessage("Cannot cherrypick snapshot %s: already an ancestor", firstSnapshotId);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -78,7 +78,7 @@ public class TestStaticTable extends HadoopTableTestBase {
       } else {
         assertThatThrownBy(() -> staticTable.newScan().appendsAfter(1))
             .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessage(String.format("Cannot incrementally scan table of type %s", type));
+            .hasMessage("Cannot incrementally scan table of type %s", type);
       }
     }
   }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -197,7 +197,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
     assertThatThrownBy(() -> jdbcCatalog.listNamespaces())
         .isInstanceOf(UncheckedSQLException.class)
-        .hasMessage(String.format("Failed to execute query: %s", JdbcUtil.LIST_ALL_NAMESPACES_SQL));
+        .hasMessage("Failed to execute query: %s", JdbcUtil.LIST_ALL_NAMESPACES_SQL);
   }
 
   @Test
@@ -239,7 +239,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     expectedRetryableExceptions.forEach(
         exception -> {
           assertThat(jdbcClientPool.isConnectionException(exception))
-              .as(String.format("%s status should be retryable", exception.getSQLState()))
+              .as("%s status should be retryable", exception.getSQLState())
               .isTrue();
         });
 
@@ -250,7 +250,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     expectedRetryableExceptions.forEach(
         exception -> {
           assertThat(updatedClientPool.isConnectionException(exception))
-              .as(String.format("%s status should be retryable", exception.getSQLState()))
+              .as("%s status should be retryable", exception.getSQLState())
               .isTrue();
         });
   }

--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -54,7 +54,7 @@ public class TestExponentialHttpRequestRetryStrategy {
   public void invalidRetries(int retries) {
     assertThatThrownBy(() -> new ExponentialHttpRequestRetryStrategy(retries))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(String.format("Cannot set retries to %s, the value must be positive", retries));
+        .hasMessage("Cannot set retries to %s, the value must be positive", retries);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -300,9 +300,8 @@ public class TestHTTPClient {
               () -> clientWithProxy.get("v1/config", Item.class, ImmutableMap.of(), onError))
           .isInstanceOf(RuntimeException.class)
           .hasMessage(
-              String.format(
-                  "%s - %s",
-                  "Proxy Authentication Required", HttpStatus.SC_PROXY_AUTHENTICATION_REQUIRED));
+              "%s - %s",
+              "Proxy Authentication Required", HttpStatus.SC_PROXY_AUTHENTICATION_REQUIRED);
     }
   }
 
@@ -435,7 +434,7 @@ public class TestHTTPClient {
                     .uri(URI)
                     .build())
         .isInstanceOf(NumberFormatException.class)
-        .hasMessage(String.format("For input string: \"%s\"", invalidTimeoutMs));
+        .hasMessage("For input string: \"%s\"", invalidTimeoutMs);
 
     String invalidNegativeTimeoutMs = "-1";
     assertThatThrownBy(
@@ -444,7 +443,7 @@ public class TestHTTPClient {
                     .uri(URI)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(String.format("duration must not be negative: %s", invalidNegativeTimeoutMs));
+        .hasMessage("duration must not be negative: %s", invalidNegativeTimeoutMs);
   }
 
   @Test
@@ -520,8 +519,7 @@ public class TestHTTPClient {
     assertThatThrownBy(() -> doExecuteRequest(method, path, body, onError, h -> {}))
         .isInstanceOf(RuntimeException.class)
         .hasMessage(
-            String.format(
-                "Called error handler for method %s due to status code: %d", method, statusCode));
+            "Called error handler for method %s due to status code: %d", method, statusCode);
 
     verify(onError).accept(any());
   }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -2238,9 +2238,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                 catalog.initialize("test", ImmutableMap.of(RESTCatalogProperties.PAGE_SIZE, "-1")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Invalid value for %s, must be a positive integer",
-                RESTCatalogProperties.PAGE_SIZE));
+            "Invalid value for %s, must be a positive integer", RESTCatalogProperties.PAGE_SIZE);
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
@@ -189,14 +189,8 @@ public class TestZOrderByteUtil {
 
       assertThat(byteCompare)
           .as(
-              String.format(
-                  "Ordering of ints should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
-                  aInt,
-                  bInt,
-                  intCompare,
-                  Arrays.toString(aBytes),
-                  Arrays.toString(bBytes),
-                  byteCompare))
+              "Ordering of ints should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
+              aInt, bInt, intCompare, Arrays.toString(aBytes), Arrays.toString(bBytes), byteCompare)
           .isEqualTo(intCompare);
     }
   }
@@ -216,14 +210,13 @@ public class TestZOrderByteUtil {
 
       assertThat(byteCompare)
           .as(
-              String.format(
-                  "Ordering of longs should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
-                  aLong,
-                  bLong,
-                  longCompare,
-                  Arrays.toString(aBytes),
-                  Arrays.toString(bBytes),
-                  byteCompare))
+              "Ordering of longs should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
+              aLong,
+              bLong,
+              longCompare,
+              Arrays.toString(aBytes),
+              Arrays.toString(bBytes),
+              byteCompare)
           .isEqualTo(longCompare);
     }
   }
@@ -243,14 +236,13 @@ public class TestZOrderByteUtil {
 
       assertThat(byteCompare)
           .as(
-              String.format(
-                  "Ordering of longs should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
-                  aShort,
-                  bShort,
-                  longCompare,
-                  Arrays.toString(aBytes),
-                  Arrays.toString(bBytes),
-                  byteCompare))
+              "Ordering of longs should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
+              aShort,
+              bShort,
+              longCompare,
+              Arrays.toString(aBytes),
+              Arrays.toString(bBytes),
+              byteCompare)
           .isEqualTo(longCompare);
     }
   }
@@ -270,14 +262,13 @@ public class TestZOrderByteUtil {
 
       assertThat(byteCompare)
           .as(
-              String.format(
-                  "Ordering of longs should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
-                  aByte,
-                  bByte,
-                  longCompare,
-                  Arrays.toString(aBytes),
-                  Arrays.toString(bBytes),
-                  byteCompare))
+              "Ordering of longs should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
+              aByte,
+              bByte,
+              longCompare,
+              Arrays.toString(aBytes),
+              Arrays.toString(bBytes),
+              byteCompare)
           .isEqualTo(longCompare);
     }
   }
@@ -297,14 +288,13 @@ public class TestZOrderByteUtil {
 
       assertThat(byteCompare)
           .as(
-              String.format(
-                  "Ordering of floats should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
-                  aFloat,
-                  bFloat,
-                  floatCompare,
-                  Arrays.toString(aBytes),
-                  Arrays.toString(bBytes),
-                  byteCompare))
+              "Ordering of floats should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
+              aFloat,
+              bFloat,
+              floatCompare,
+              Arrays.toString(aBytes),
+              Arrays.toString(bBytes),
+              byteCompare)
           .isEqualTo(floatCompare);
     }
   }
@@ -324,14 +314,13 @@ public class TestZOrderByteUtil {
 
       assertThat(byteCompare)
           .as(
-              String.format(
-                  "Ordering of doubles should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
-                  aDouble,
-                  bDouble,
-                  doubleCompare,
-                  Arrays.toString(aBytes),
-                  Arrays.toString(bBytes),
-                  byteCompare))
+              "Ordering of doubles should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
+              aDouble,
+              bDouble,
+              doubleCompare,
+              Arrays.toString(aBytes),
+              Arrays.toString(bBytes),
+              byteCompare)
           .isEqualTo(doubleCompare);
     }
   }
@@ -352,14 +341,13 @@ public class TestZOrderByteUtil {
 
       assertThat(byteCompare)
           .as(
-              String.format(
-                  "Ordering of strings should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
-                  aString,
-                  bString,
-                  stringCompare,
-                  Arrays.toString(aBytes),
-                  Arrays.toString(bBytes),
-                  byteCompare))
+              "Ordering of strings should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
+              aString,
+              bString,
+              stringCompare,
+              Arrays.toString(aBytes),
+              Arrays.toString(bBytes),
+              byteCompare)
           .isEqualTo(stringCompare);
     }
   }
@@ -380,14 +368,13 @@ public class TestZOrderByteUtil {
 
       assertThat(byteCompare)
           .as(
-              String.format(
-                  "Ordering of strings should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
-                  aBytesRaw,
-                  bBytesRaw,
-                  stringCompare,
-                  Arrays.toString(aBytes),
-                  Arrays.toString(bBytes),
-                  byteCompare))
+              "Ordering of strings should match ordering of bytes, %s ~ %s -> %s != %s ~ %s -> %s ",
+              aBytesRaw,
+              bBytesRaw,
+              stringCompare,
+              Arrays.toString(aBytes),
+              Arrays.toString(bBytes),
+              byteCompare)
           .isEqualTo(stringCompare);
     }
   }

--- a/delta-lake/src/test/java/org/apache/iceberg/delta/TestDeltaLakeTypeToType.java
+++ b/delta-lake/src/test/java/org/apache/iceberg/delta/TestDeltaLakeTypeToType.java
@@ -170,13 +170,13 @@ public class TestDeltaLakeTypeToType {
                 DeltaLakeDataTypeVisitor.visit(
                     deltaNullTypeSchema, new DeltaLakeTypeToType(deltaNullTypeSchema)))
         .isInstanceOf(ValidationException.class)
-        .hasMessage(String.format("Not a supported type: %s", new NullType().getCatalogString()));
+        .hasMessage("Not a supported type: %s", new NullType().getCatalogString());
     assertThatThrownBy(
             () ->
                 DeltaLakeDataTypeVisitor.visit(
                     deltaShallowNullTypeSchema,
                     new DeltaLakeTypeToType(deltaShallowNullTypeSchema)))
         .isInstanceOf(ValidationException.class)
-        .hasMessage(String.format("Not a supported type: %s", new NullType().getCatalogString()));
+        .hasMessage("Not a supported type: %s", new NullType().getCatalogString());
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -460,7 +460,7 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
 
     assertThatThrownBy(() -> catalog.createNamespace(namespace1))
         .isInstanceOf(AlreadyExistsException.class)
-        .hasMessage(String.format("Namespace already exists: %s", namespace1));
+        .hasMessage("Namespace already exists: %s", namespace1);
     String hiveLocalDir = temp.toFile().toURI().toString();
     // remove the trailing slash of the URI
     hiveLocalDir = hiveLocalDir.substring(0, hiveLocalDir.length() - 1);
@@ -530,9 +530,8 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
                     null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Create namespace setting %s without setting %s is not allowed",
-                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
+            "Create namespace setting %s without setting %s is not allowed",
+            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER);
 
     assertThatThrownBy(
             () ->
@@ -655,9 +654,8 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
                     null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Setting %s and %s has to be performed together or not at all",
-                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
+            "Setting %s and %s has to be performed together or not at all",
+            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER);
 
     assertThatThrownBy(
             () ->
@@ -671,9 +669,8 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
                     null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Setting %s and %s has to be performed together or not at all",
-                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
+            "Setting %s and %s has to be performed together or not at all",
+            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER);
 
     assertThatThrownBy(
             () ->
@@ -846,9 +843,8 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
                     null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Removing %s and %s has to be performed together or not at all",
-                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
+            "Removing %s and %s has to be performed together or not at all",
+            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER);
 
     assertThatThrownBy(
             () ->
@@ -866,9 +862,8 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
                     null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            String.format(
-                "Removing %s and %s has to be performed together or not at all",
-                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
+            "Removing %s and %s has to be performed together or not at all",
+            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER);
   }
 
   private void removeNamespaceOwnershipAndVerify(

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -310,7 +310,7 @@ public class TestHiveCommits extends HiveTableTestBase {
     TableIdentifier badTi = TableIdentifier.of(DB_NAME, "`tbl`");
     assertThatThrownBy(() -> catalog.createTable(badTi, SCHEMA, PartitionSpec.unpartitioned()))
         .isInstanceOf(ValidationException.class)
-        .hasMessage(String.format("Invalid Hive object for %s.%s", DB_NAME, "`tbl`"));
+        .hasMessage("Invalid Hive object for %s.%s", DB_NAME, "`tbl`");
   }
 
   @Test
@@ -318,7 +318,7 @@ public class TestHiveCommits extends HiveTableTestBase {
     assertThatThrownBy(
             () -> catalog.createTable(TABLE_IDENTIFIER, SCHEMA, PartitionSpec.unpartitioned()))
         .isInstanceOf(AlreadyExistsException.class)
-        .hasMessage(String.format("Table already exists: %s.%s", DB_NAME, TABLE_NAME));
+        .hasMessage("Table already exists: %s.%s", DB_NAME, TABLE_NAME);
   }
 
   /** Uses NoLock and pretends we throw an error because of a concurrent commit */

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveTable.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveTable.java
@@ -441,7 +441,7 @@ public class TestHiveTable extends HiveTableTestBase {
     // create an iceberg table with the same name
     assertThatThrownBy(() -> catalog.createTable(identifier, SCHEMA, PartitionSpec.unpartitioned()))
         .isInstanceOf(NoSuchIcebergTableException.class)
-        .hasMessageStartingWith(String.format("Not an iceberg table: hive.%s", identifier));
+        .hasMessageStartingWith("Not an iceberg table: hive.%s", identifier);
 
     assertThat(catalog.tableExists(identifier)).isFalse();
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1068,7 +1068,7 @@ public class TestViews extends ExtensionsTestBase {
             String.format(
                 "Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewReferencingTempView))
         .hasMessageContaining("that references temporary view:")
-        .hasMessageContaining(String.format("%s.%s", "global_temp", globalTempView));
+        .hasMessageContaining("%s.%s", "global_temp", globalTempView);
   }
 
   @TestTemplate
@@ -1118,7 +1118,7 @@ public class TestViews extends ExtensionsTestBase {
                     viewName, NAMESPACE, functionName, tableName))
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining("Cannot resolve function")
-        .hasMessageContaining(String.format("`%s`.`%s`", NAMESPACE, functionName));
+        .hasMessageContaining("`%s`.`%s`", NAMESPACE, functionName);
   }
 
   @TestTemplate
@@ -1340,7 +1340,7 @@ public class TestViews extends ExtensionsTestBase {
         .hasMessageContaining(
             String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
         .hasMessageContaining("that references temporary view:")
-        .hasMessageContaining(String.format("%s.%s", "global_temp", globalTempView));
+        .hasMessageContaining("%s.%s", "global_temp", globalTempView);
   }
 
   @TestTemplate
@@ -1382,7 +1382,7 @@ public class TestViews extends ExtensionsTestBase {
 
       assertThatThrownBy(() -> sql(sql))
           .isInstanceOf(AnalysisException.class)
-          .hasMessageContaining(String.format("The table or view `%s` cannot be found", tableName));
+          .hasMessageContaining("The table or view `%s` cannot be found", tableName);
     }
 
     // the underlying SQL in the View should be rewritten to have catalog & namespace
@@ -1409,7 +1409,7 @@ public class TestViews extends ExtensionsTestBase {
 
       assertThatThrownBy(() -> sql(sql))
           .isInstanceOf(AnalysisException.class)
-          .hasMessageContaining(String.format("The table or view `%s` cannot be found", tableName));
+          .hasMessageContaining("The table or view `%s` cannot be found", tableName);
     }
 
     // the underlying SQL in the View should be rewritten to have catalog & namespace

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -731,9 +731,8 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
                       catalogName, tableName, fileTableDir.getAbsolutePath()))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining(
-              String.format(
-                  "Cannot find a partition spec in Iceberg table %s that matches the partition columns ([id]) in input table",
-                  tableName));
+              "Cannot find a partition spec in Iceberg table %s that matches the partition columns ([id]) in input table",
+              tableName);
       return;
     }
 
@@ -780,9 +779,8 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
                     catalogName, tableName, fileTableDir.getAbsolutePath()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            String.format(
-                "Cannot find a partition spec in Iceberg table %s that matches the partition columns (%s) in input table",
-                fullTableName, "[id]"));
+            "Cannot find a partition spec in Iceberg table %s that matches the partition columns (%s) in input table",
+            fullTableName, "[id]");
   }
 
   @TestTemplate

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -215,9 +215,7 @@ public class TestViews extends ExtensionsTestBase {
     assertThatThrownBy(() -> sql("SELECT * FROM %s", viewName))
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining(
-            String.format(
-                "The table or view `%s`.`%s`.`non_existing` cannot be found",
-                catalogName, NAMESPACE));
+            "The table or view `%s`.`%s`.`non_existing` cannot be found", catalogName, NAMESPACE);
   }
 
   @TestTemplate
@@ -260,7 +258,7 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("SELECT * FROM %s", viewName))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(String.format("Invalid view name: %s", viewName));
+        .hasMessageContaining("Invalid view name: %s", viewName);
   }
 
   @TestTemplate
@@ -875,8 +873,7 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("ALTER VIEW %s RENAME TO %s", viewName, target))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view default.%s because it already exists", target));
+        .hasMessageContaining("Cannot create view default.%s because it already exists", target);
   }
 
   @TestTemplate
@@ -900,8 +897,7 @@ public class TestViews extends ExtensionsTestBase {
         catalogName, NAMESPACE, target, catalogName.equals(SPARK_CATALOG) ? " USING iceberg" : "");
     assertThatThrownBy(() -> sql("ALTER VIEW %s RENAME TO %s", viewName, target))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view default.%s because it already exists", target));
+        .hasMessageContaining("Cannot create view default.%s because it already exists", target);
   }
 
   @TestTemplate
@@ -995,8 +991,7 @@ public class TestViews extends ExtensionsTestBase {
     assertThatThrownBy(() -> sql("CREATE VIEW %s AS SELECT id FROM %s", viewName, tableName))
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining(
-            String.format(
-                "Cannot create view %s.%s because it already exists", NAMESPACE, viewName));
+            "Cannot create view %s.%s because it already exists", NAMESPACE, viewName);
 
     // using IF NOT EXISTS should work
     assertThatNoException()
@@ -1040,8 +1035,7 @@ public class TestViews extends ExtensionsTestBase {
             () -> sql("CREATE VIEW %s AS SELECT id FROM %s", viewReferencingTempView, tempView))
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining(
-            String.format(
-                "Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewReferencingTempView))
+            "Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewReferencingTempView)
         .hasMessageContaining("that references temporary view:")
         .hasMessageContaining(tempView);
   }
@@ -1064,10 +1058,9 @@ public class TestViews extends ExtensionsTestBase {
                     viewReferencingTempView, globalTempView))
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining(
-            String.format(
-                "Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewReferencingTempView))
+            "Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewReferencingTempView)
         .hasMessageContaining("that references temporary view:")
-        .hasMessageContaining(String.format("%s.%s", "global_temp", globalTempView));
+        .hasMessageContaining("%s.%s", "global_temp", globalTempView);
   }
 
   @TestTemplate
@@ -1083,8 +1076,7 @@ public class TestViews extends ExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CREATE VIEW %s AS SELECT %s(id) FROM %s", viewName, functionName, tableName))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
+        .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("that references temporary function:")
         .hasMessageContaining(functionName);
   }
@@ -1106,8 +1098,7 @@ public class TestViews extends ExtensionsTestBase {
                     viewName, catalogName, NAMESPACE, functionName, tableName))
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining("Cannot resolve routine")
-        .hasMessageContaining(
-            String.format("`%s`.`%s`.`%s`", catalogName, NAMESPACE, functionName));
+        .hasMessageContaining("`%s`.`%s`.`%s`", catalogName, NAMESPACE, functionName);
 
     // TEMP Function can't be referenced using schema.name
     assertThatThrownBy(
@@ -1117,7 +1108,7 @@ public class TestViews extends ExtensionsTestBase {
                     viewName, NAMESPACE, functionName, tableName))
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining("Cannot resolve routine")
-        .hasMessageContaining(String.format("`%s`.`%s`", NAMESPACE, functionName));
+        .hasMessageContaining("`%s`.`%s`", NAMESPACE, functionName);
   }
 
   @TestTemplate
@@ -1135,8 +1126,7 @@ public class TestViews extends ExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CREATE VIEW %s (id, data) AS SELECT id FROM %s", viewName, tableName))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
+        .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("not enough data columns")
         .hasMessageContaining("View columns: id, data")
         .hasMessageContaining("Data columns: id");
@@ -1144,8 +1134,7 @@ public class TestViews extends ExtensionsTestBase {
     assertThatThrownBy(
             () -> sql("CREATE VIEW %s (id) AS SELECT id, data FROM %s", viewName, tableName))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
+        .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("too many data columns")
         .hasMessageContaining("View columns: id")
         .hasMessageContaining("Data columns: id, data");
@@ -1264,8 +1253,7 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CREATE VIEW %s AS %s", viewName, sql))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
+        .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("that references temporary view:")
         .hasMessageContaining(tempViewInCTE);
   }
@@ -1286,8 +1274,7 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CREATE VIEW %s AS %s", viewName, sql))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
+        .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("that references temporary function:")
         .hasMessageContaining(functionName);
   }
@@ -1315,8 +1302,7 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CREATE VIEW %s AS %s", viewName, sql))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
+        .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("that references temporary view:")
         .hasMessageContaining(tempView);
   }
@@ -1336,10 +1322,9 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CREATE VIEW %s AS %s", viewName, sql))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
+        .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("that references temporary view:")
-        .hasMessageContaining(String.format("%s.%s", "global_temp", globalTempView));
+        .hasMessageContaining("%s.%s", "global_temp", globalTempView);
   }
 
   @TestTemplate
@@ -1357,8 +1342,7 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("CREATE VIEW %s AS %s", viewName, sql))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining(
-            String.format("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName))
+        .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("that references temporary function:")
         .hasMessageContaining(functionName);
   }
@@ -1381,7 +1365,7 @@ public class TestViews extends ExtensionsTestBase {
 
       assertThatThrownBy(() -> sql(sql))
           .isInstanceOf(AnalysisException.class)
-          .hasMessageContaining(String.format("The table or view `%s` cannot be found", tableName));
+          .hasMessageContaining("The table or view `%s` cannot be found", tableName);
     }
 
     // the underlying SQL in the View should be rewritten to have catalog & namespace
@@ -1408,7 +1392,7 @@ public class TestViews extends ExtensionsTestBase {
 
       assertThatThrownBy(() -> sql(sql))
           .isInstanceOf(AnalysisException.class)
-          .hasMessageContaining(String.format("The table or view `%s` cannot be found", tableName));
+          .hasMessageContaining("The table or view `%s` cannot be found", tableName);
     }
 
     // the underlying SQL in the View should be rewritten to have catalog & namespace
@@ -2020,8 +2004,7 @@ public class TestViews extends ExtensionsTestBase {
     String cycle = String.format("%s -> %s -> %s", view1, view2, view1);
     assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS SELECT * FROM %s", viewOne, view2))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageStartingWith(
-            String.format("Recursive cycle in view detected: %s (cycle: %s)", view1, cycle));
+        .hasMessageStartingWith("Recursive cycle in view detected: %s (cycle: %s)", view1, cycle);
   }
 
   @TestTemplate
@@ -2042,8 +2025,7 @@ public class TestViews extends ExtensionsTestBase {
     String cycle = String.format("%s -> %s -> %s", view1, view2, view1);
     assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS SELECT * FROM %s", viewOne, view2))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageStartingWith(
-            String.format("Recursive cycle in view detected: %s (cycle: %s)", view1, cycle));
+        .hasMessageStartingWith("Recursive cycle in view detected: %s (cycle: %s)", view1, cycle);
   }
 
   @TestTemplate
@@ -2067,8 +2049,7 @@ public class TestViews extends ExtensionsTestBase {
     String cycle = String.format("%s -> %s -> %s", view1, viewTwo, view1);
     assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewOne, sql))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageStartingWith(
-            String.format("Recursive cycle in view detected: %s (cycle: %s)", view1, cycle));
+        .hasMessageStartingWith("Recursive cycle in view detected: %s (cycle: %s)", view1, cycle);
   }
 
   @TestTemplate
@@ -2089,8 +2070,7 @@ public class TestViews extends ExtensionsTestBase {
     String cycle = String.format("%s -> %s -> %s", view1, viewTwo, view1);
     assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewOne, sql))
         .isInstanceOf(AnalysisException.class)
-        .hasMessageStartingWith(
-            String.format("Recursive cycle in view detected: %s (cycle: %s)", view1, cycle));
+        .hasMessageStartingWith("Recursive cycle in view detected: %s (cycle: %s)", view1, cycle);
   }
 
   @TestTemplate


### PR DESCRIPTION
I skipped TestViews in Spark 3.4 since it's deprecated. 