### PR TITLE
Kafka Connect: Rename kafka-connect's project name to avoid re-publishing artifact 'iceberrg-kafka-connect'.

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-project(':iceberg-kafka-connect:iceberg-kafka-connect-events') {
+project(':iceberg-kafka-connect-parent:iceberg-kafka-connect-events') {
   dependencies {
     api project(':iceberg-api')
     implementation project(':iceberg-core')
@@ -31,14 +31,14 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-events') {
   }
 }
 
-project(':iceberg-kafka-connect:iceberg-kafka-connect') {
+project(':iceberg-kafka-connect-parent:iceberg-kafka-connect') {
   dependencies {
     api project(':iceberg-api')
     implementation project(':iceberg-core')
     implementation project(':iceberg-common')
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     implementation project(':iceberg-data')
-    implementation project(':iceberg-kafka-connect:iceberg-kafka-connect-events')
+    implementation project(':iceberg-kafka-connect-parent:iceberg-kafka-connect-events')
     implementation platform(libs.jackson.bom)
     implementation libs.jackson.core
     implementation libs.jackson.databind
@@ -58,7 +58,7 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect') {
   }
 }
 
-project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
+project(':iceberg-kafka-connect-parent:iceberg-kafka-connect-runtime') {
   apply plugin: 'distribution'
 
   configurations {
@@ -93,8 +93,8 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
   }
 
   dependencies {
-    implementation project(':iceberg-kafka-connect:iceberg-kafka-connect')
-    implementation project(':iceberg-kafka-connect:iceberg-kafka-connect-transforms')
+    implementation project(':iceberg-kafka-connect-parent:iceberg-kafka-connect')
+    implementation project(':iceberg-kafka-connect-parent:iceberg-kafka-connect-transforms')
     implementation(libs.hadoop3.common) {
       exclude group: 'log4j'
       exclude group: 'org.slf4j'
@@ -250,7 +250,7 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
   assemble.dependsOn distZip, hiveDistZip
 }
 
-project(':iceberg-kafka-connect:iceberg-kafka-connect-transforms') {
+project(':iceberg-kafka-connect-parent:iceberg-kafka-connect-transforms') {
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     implementation libs.bson

--- a/settings.gradle
+++ b/settings.gradle
@@ -177,21 +177,21 @@ if (sparkVersions.contains("4.0")) {
 
 if (kafkaVersions.contains("3")) {
   include 'kafka-connect'
-  project(':kafka-connect').name = 'iceberg-kafka-connect'
+  project(':kafka-connect').name = 'iceberg-kafka-connect-parent'
 
-  include ":iceberg-kafka-connect:kafka-connect-events"
-  project(":iceberg-kafka-connect:kafka-connect-events").projectDir = file('kafka-connect/kafka-connect-events')
-  project(":iceberg-kafka-connect:kafka-connect-events").name = "iceberg-kafka-connect-events"
+  include ":iceberg-kafka-connect-parent:kafka-connect-events"
+  project(":iceberg-kafka-connect-parent:kafka-connect-events").projectDir = file('kafka-connect/kafka-connect-events')
+  project(":iceberg-kafka-connect-parent:kafka-connect-events").name = "iceberg-kafka-connect-events"
 
-  include ":iceberg-kafka-connect:kafka-connect"
-  project(":iceberg-kafka-connect:kafka-connect").projectDir = file('kafka-connect/kafka-connect')
-  project(":iceberg-kafka-connect:kafka-connect").name = "iceberg-kafka-connect"
+  include ":iceberg-kafka-connect-parent:kafka-connect"
+  project(":iceberg-kafka-connect-parent:kafka-connect").projectDir = file('kafka-connect/kafka-connect')
+  project(":iceberg-kafka-connect-parent:kafka-connect").name = "iceberg-kafka-connect"
 
-  include ":iceberg-kafka-connect:kafka-connect-runtime"
-  project(":iceberg-kafka-connect:kafka-connect-runtime").projectDir = file('kafka-connect/kafka-connect-runtime')
-  project(":iceberg-kafka-connect:kafka-connect-runtime").name = "iceberg-kafka-connect-runtime"
+  include ":iceberg-kafka-connect-parent:kafka-connect-runtime"
+  project(":iceberg-kafka-connect-parent:kafka-connect-runtime").projectDir = file('kafka-connect/kafka-connect-runtime')
+  project(":iceberg-kafka-connect-parent:kafka-connect-runtime").name = "iceberg-kafka-connect-runtime"
 
-  include ":iceberg-kafka-connect:kafka-connect-transforms"
-  project(":iceberg-kafka-connect:kafka-connect-transforms").projectDir = file('kafka-connect/kafka-connect-transforms')
-  project(":iceberg-kafka-connect:kafka-connect-transforms").name = "iceberg-kafka-connect-transforms"
+  include ":iceberg-kafka-connect-parent:kafka-connect-transforms"
+  project(":iceberg-kafka-connect-parent:kafka-connect-transforms").projectDir = file('kafka-connect/kafka-connect-transforms')
+  project(":iceberg-kafka-connect-parent:kafka-connect-transforms").name = "iceberg-kafka-connect-transforms"
 }


### PR DESCRIPTION
This PR rename kafka-connect's parent name from 'iceberg-kafka-connect' to 'iceberg-kafka-connect-parent' to avoid re-publishing artifact 'iceberg-kafka-connect'. This should resolve https://github.com/apache/iceberg/issues/14549.