### PR TITLE
docs: remove hidden spark-runtime-jar link

### DIFF
--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -328,9 +328,6 @@ If you already have a Spark environment, you can add Iceberg, using the `--packa
     If you want to include Iceberg in your Spark installation, add the Iceberg Spark runtime to Spark's `jars` folder.
     You can download the runtime by visiting to the [Releases](releases.md) page.
 
-<!-- markdown-link-check-disable-next-line -->
-[spark-runtime-jar]: https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-{{ sparkVersionMajor }}/{{ icebergVersion }}/iceberg-spark-runtime-{{ sparkVersionMajor }}-{{ icebergVersion }}.jar
-
 #### Learn More
 
 Now that you're up an running with Iceberg and Spark, check out the [Iceberg-Spark docs](docs/latest/spark-ddl.md) to learn more!


### PR DESCRIPTION
Follow up to #14357
Context: https://github.com/apache/iceberg/pull/14357#discussion_r2508549817

`spark-runtime-jar` is not rendered since its not referenced anywhere.
Furthermore, the Note section above points to the Release section where all the jars are references. 
We dont need this link to reference the iceberg-spark-runtime jar again

<img width="1561" height="687" alt="Screenshot 2025-11-10 at 10 15 08 AM" src="https://github.com/user-attachments/assets/7f97158d-2a5c-448c-9135-3286f22af72e" />
