### PR TITLE
Allow removing unused deletes when planning

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Scan.java
+++ b/api/src/main/java/org/apache/iceberg/Scan.java
@@ -120,6 +120,11 @@ public interface Scan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>> {
    */
   ThisT filter(Expression expr);
 
+  default ThisT removeUnusedDeletesWhenPlanning() {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement planByPartition");
+  }
+
   /**
    * Returns this scan's filter {@link Expression}.
    *

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -134,6 +134,10 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     return context().ignoreResiduals();
   }
 
+  protected boolean shouldRemoveUnusedDeletesWhenPlanning() {
+    return context().removeUnusedDeletesWhenPlanning();
+  }
+
   protected Expression residualFilter() {
     return shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
   }
@@ -148,6 +152,12 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
 
   protected abstract ThisT newRefinedScan(
       Table newTable, Schema newSchema, TableScanContext newContext);
+
+  @Override
+  public ThisT removeUnusedDeletesWhenPlanning() {
+    return newRefinedScan(
+        table, tableSchema(), context.shouldRemoveUnusedDeletesWhenPlanning(true));
+  }
 
   @Override
   public ThisT option(String property, String value) {

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -79,6 +79,10 @@ public class DataTableScan extends BaseTableScan {
             .ignoreDeleted()
             .columnsToKeepStats(columnsToKeepStats());
 
+    if (shouldRemoveUnusedDeletesWhenPlanning()) {
+      manifestGroup = manifestGroup.planByPartition();
+    }
+
     if (shouldIgnoreResiduals()) {
       manifestGroup = manifestGroup.ignoreResiduals();
     }

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -60,6 +60,11 @@ abstract class TableScanContext {
     return false;
   }
 
+  @Value.Default
+  public boolean removeUnusedDeletesWhenPlanning() {
+    return false;
+  }
+
   @Nullable
   public abstract Set<Integer> columnsToKeepStats();
 
@@ -126,6 +131,13 @@ abstract class TableScanContext {
     return ImmutableTableScanContext.builder()
         .from(this)
         .returnColumnStats(returnColumnStats)
+        .build();
+  }
+
+  TableScanContext shouldRemoveUnusedDeletesWhenPlanning(boolean removeUnusedDeletesWhenPlanning) {
+    return ImmutableTableScanContext.builder()
+        .from(this)
+        .removeUnusedDeletesWhenPlanning(removeUnusedDeletesWhenPlanning)
         .build();
   }
 


### PR DESCRIPTION
## Motivation

When planning queries on large tables with a high volume of delete files, the planner currently keeps all delete file metadata in memory for the entire planning phase. This significantly increases memory pressure and can lead to OOM failures, especially for tables with many partitions and delete-heavy workloads.

## Proposed Change

This PR makes ManifestGroup closeable so that it can proactively release memory during planning, rather than retaining all delete-related state until planning completes.

The memory release mechanism is based on partition reference counting:
* At the beginning of planning, we track the reference count of partitions across all data manifests.
* As each manifest finishes planning, the reference count for its associated partitions is decremented.
* Once a partition is no longer referenced by any remaining data files, its corresponding delete file information is no longer needed.
* At that point, we use the partition value to remove and release the related entries from DeleteFileIndex.

## Benefits
* Reduces peak memory usage during planning for large, delete-heavy tables.
* Avoids retaining unnecessary delete file metadata beyond its useful lifetime.
* Mitigates OOM risks without changing query semantics.