### PR TITLE
Core: Fix validation of PlanTableScanRequest

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequest.java
@@ -88,9 +88,17 @@ public class PlanTableScanRequest implements RESTRequest {
 
   @Override
   public void validate() {
-    Preconditions.checkArgument(
-        snapshotId != null ^ (startSnapshotId != null && endSnapshotId != null),
-        "Either snapshotId must be provided or both startSnapshotId and endSnapshotId must be provided");
+    if (null != snapshotId) {
+      Preconditions.checkArgument(
+          null == startSnapshotId && null == endSnapshotId,
+          "Invalid scan: cannot provide both snapshotId and startSnapshotId/endSnapshotId");
+    }
+
+    if (null != startSnapshotId || null != endSnapshotId) {
+      Preconditions.checkArgument(
+          null != startSnapshotId && null != endSnapshotId,
+          "Invalid incremental scan: startSnapshotId and endSnapshotId is required");
+    }
   }
 
   @Override
@@ -107,6 +115,10 @@ public class PlanTableScanRequest implements RESTRequest {
         .toString();
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static class Builder {
     private Long snapshotId;
     private List<String> select;
@@ -117,6 +129,11 @@ public class PlanTableScanRequest implements RESTRequest {
     private Long endSnapshotId;
     private List<String> statsFields;
 
+    /**
+     * @deprecated since 1.11.0, visibility will be reduced in 1.12.0; use {@link
+     *     PlanTableScanRequest#builder()} instead.
+     */
+    @Deprecated
     public Builder() {}
 
     public Builder withSnapshotId(Long withSnapshotId) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequestParser.java
@@ -121,7 +121,7 @@ public class PlanTableScanRequestParser {
 
     List<String> statsFields = JsonUtil.getStringListOrNull(STATS_FIELDS, json);
 
-    return new PlanTableScanRequest.Builder()
+    return PlanTableScanRequest.builder()
         .withSnapshotId(snapshotId)
         .withSelect(select)
         .withFilter(filter)

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
@@ -91,6 +91,13 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
     private PlanStatus planStatus;
     private String planId;
 
+    /**
+     * @deprecated since 1.11.0, visibility will be reduced in 1.12.0; use {@link
+     *     PlanTableScanResponse#builder()} instead.
+     */
+    @Deprecated
+    public Builder() {}
+
     public Builder withPlanStatus(PlanStatus status) {
       this.planStatus = status;
       return this;


### PR DESCRIPTION
The OpenAPI spec says in https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L618-L624 that if no snapshotId is provided, the server can select the latest snapshot in the table's main branch. However, currently the request always requires to set either the `snapshotId` or the `startSnapshotId`/`endSnapshotId`