### PR TITLE
[1.10.x] Backport #14358: Flink: Prevent recreation of ManifestOutputFileFactory during flushing

### DIFF
--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -68,9 +68,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     implementation libs.datasketches
 
-    // for caching in DynamicSink
-    implementation libs.caffeine
-
     testImplementation libs.flink119.connector.test.utils
     testImplementation libs.flink119.core
     testImplementation libs.flink119.runtime

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -74,7 +74,19 @@ public class FlinkManifestUtil {
       int subTaskId,
       long attemptNumber) {
     return new ManifestOutputFileFactory(
-        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber);
+        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, null);
+  }
+
+  public static ManifestOutputFileFactory createOutputFileFactory(
+      Supplier<Table> tableSupplier,
+      Map<String, String> tableProps,
+      String flinkJobId,
+      String operatorUniqueId,
+      int subTaskId,
+      long attemptNumber,
+      String suffix) {
+    return new ManifestOutputFileFactory(
+        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, suffix);
   }
 
   /**

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
@@ -43,6 +44,7 @@ public class ManifestOutputFileFactory {
   private final int subTaskId;
   private final long attemptNumber;
   private final AtomicInteger fileCount = new AtomicInteger(0);
+  @Nullable private final String suffix;
 
   ManifestOutputFileFactory(
       Supplier<Table> tableSupplier,
@@ -50,26 +52,29 @@ public class ManifestOutputFileFactory {
       String flinkJobId,
       String operatorUniqueId,
       int subTaskId,
-      long attemptNumber) {
+      long attemptNumber,
+      @Nullable String suffix) {
     this.tableSupplier = tableSupplier;
     this.props = props;
     this.flinkJobId = flinkJobId;
     this.operatorUniqueId = operatorUniqueId;
     this.subTaskId = subTaskId;
     this.attemptNumber = attemptNumber;
+    this.suffix = suffix;
   }
 
   private String generatePath(long checkpointId) {
     return FileFormat.AVRO.addExtension(
         String.format(
             Locale.ROOT,
-            "%s-%s-%05d-%d-%d-%05d",
+            "%s-%s-%05d-%d-%d-%05d%s",
             flinkJobId,
             operatorUniqueId,
             subTaskId,
             attemptNumber,
             checkpointId,
-            fileCount.incrementAndGet()));
+            fileCount.incrementAndGet(),
+            suffix != null ? "-" + suffix : ""));
   }
 
   public OutputFile create(long checkpointId) {

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -168,7 +168,7 @@ public class DynamicIcebergSink
         .transform(
             prefixIfNotNull(uidPrefix, sinkId + " Pre Commit"),
             typeInformation,
-            new DynamicWriteResultAggregator(catalogLoader))
+            new DynamicWriteResultAggregator(catalogLoader, cacheMaximumSize))
         .uid(prefixIfNotNull(uidPrefix, sinkId + "-pre-commit-topology"));
   }
 

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
@@ -18,12 +18,10 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
@@ -58,20 +56,21 @@ class DynamicWriteResultAggregator
         CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>> {
   private static final Logger LOG = LoggerFactory.getLogger(DynamicWriteResultAggregator.class);
   private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
-  private static final Duration CACHE_EXPIRATION_DURATION = Duration.ofMinutes(1);
 
   private final CatalogLoader catalogLoader;
+  private final int cacheMaximumSize;
   private transient Map<WriteTarget, Collection<DynamicWriteResult>> results;
-  private transient Cache<String, Map<Integer, PartitionSpec>> specs;
-  private transient Cache<String, ManifestOutputFileFactory> outputFileFactories;
+  private transient Map<String, Map<Integer, PartitionSpec>> specs;
+  private transient Map<String, ManifestOutputFileFactory> outputFileFactories;
   private transient String flinkJobId;
   private transient String operatorId;
   private transient int subTaskId;
   private transient int attemptId;
   private transient Catalog catalog;
 
-  DynamicWriteResultAggregator(CatalogLoader catalogLoader) {
+  DynamicWriteResultAggregator(CatalogLoader catalogLoader, int cacheMaximumSize) {
     this.catalogLoader = catalogLoader;
+    this.cacheMaximumSize = cacheMaximumSize;
   }
 
   @Override
@@ -81,10 +80,8 @@ class DynamicWriteResultAggregator
     this.subTaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
     this.attemptId = getRuntimeContext().getTaskInfo().getAttemptNumber();
     this.results = Maps.newHashMap();
-    this.specs =
-        Caffeine.newBuilder().expireAfterWrite(CACHE_EXPIRATION_DURATION).softValues().build();
-    this.outputFileFactories =
-        Caffeine.newBuilder().expireAfterWrite(CACHE_EXPIRATION_DURATION).softValues().build();
+    this.specs = new LRUCache<>(cacheMaximumSize);
+    this.outputFileFactories = new LRUCache<>(cacheMaximumSize);
     this.catalog = catalogLoader.loadCatalog();
   }
 
@@ -163,18 +160,27 @@ class DynamicWriteResultAggregator
   }
 
   private ManifestOutputFileFactory outputFileFactory(String tableName) {
-    return outputFileFactories.get(
+    return outputFileFactories.computeIfAbsent(
         tableName,
         unused -> {
           Table table = catalog.loadTable(TableIdentifier.parse(tableName));
           specs.put(tableName, table.specs());
+          // Make sure to append an identifier to avoid file clashes in case the factory was to get
+          // re-created during a checkpoint, i.e. due to cache eviction.
+          String fileSuffix = UUID.randomUUID().toString();
           return FlinkManifestUtil.createOutputFileFactory(
-              () -> table, table.properties(), flinkJobId, operatorId, subTaskId, attemptId);
+              () -> table,
+              table.properties(),
+              flinkJobId,
+              operatorId,
+              subTaskId,
+              attemptId,
+              fileSuffix);
         });
   }
 
   private PartitionSpec spec(String tableName, int specId) {
-    Map<Integer, PartitionSpec> knownSpecs = specs.getIfPresent(tableName);
+    Map<Integer, PartitionSpec> knownSpecs = specs.get(tableName);
     if (knownSpecs != null) {
       PartitionSpec spec = knownSpecs.get(specId);
       if (spec != null) {

--- a/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v1.19/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -210,4 +210,9 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
   DynamicWriterMetrics getMetrics() {
     return metrics;
   }
+
+  @VisibleForTesting
+  Map<WriteTarget, RowDataTaskWriterFactory> getTaskWriterFactories() {
+    return taskWriterFactories;
+  }
 }

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
@@ -137,7 +137,7 @@ public class TestFlinkManifest {
             ManifestOutputFileFactory.FLINK_MANIFEST_LOCATION,
             userProvidedFolder.getAbsolutePath() + "///");
     ManifestOutputFileFactory factory =
-        new ManifestOutputFileFactory(() -> table, props, flinkJobId, operatorId, 1, 1);
+        new ManifestOutputFileFactory(() -> table, props, flinkJobId, operatorId, 1, 1, null);
 
     List<DataFile> dataFiles = generateDataFiles(5);
     DeltaManifests deltaManifests =

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestManifestOutputFileFactory.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/TestManifestOutputFileFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class TestManifestOutputFileFactory {
+
+  @RegisterExtension
+  static final HadoopCatalogExtension CATALOG_EXTENSION = new HadoopCatalogExtension("db", "table");
+
+  private Table table;
+
+  @BeforeEach
+  void before() throws IOException {
+    table = CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
+  }
+
+  @Test
+  public void testFileNameFormat() {
+    String flinkJobId = "job123";
+    String operatorUniqueId = "operator456";
+    int subTaskId = 7;
+    long attemptNumber = 2;
+    long checkpointId = 100;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, null);
+
+    String file1 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("job123-operator456-00007-2-100-00001.avro");
+
+    String file2 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("job123-operator456-00007-2-100-00002.avro");
+
+    String file3 = new File(factory.create(checkpointId + 1).location()).getName();
+    assertThat(file3).isEqualTo("job123-operator456-00007-2-101-00003.avro");
+  }
+
+  @Test
+  public void testFileNameFormatWithSuffix() {
+    String flinkJobId = "job123";
+    String operatorUniqueId = "operator456";
+    int subTaskId = 7;
+    long attemptNumber = 2;
+    long checkpointId = 100;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix");
+
+    String file1 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("job123-operator456-00007-2-100-00001-suffix.avro");
+
+    String file2 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("job123-operator456-00007-2-100-00002-suffix.avro");
+  }
+
+  @Test
+  public void testSuffixedFileNamesWithRecreatedFactory() {
+    String flinkJobId = "test-job";
+    String operatorUniqueId = "test-operator";
+    int subTaskId = 0;
+    long attemptNumber = 1;
+    long checkpointId = 1;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory1 =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix1");
+    String file1 = new File(factory1.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("test-job-test-operator-00000-1-1-00001-suffix1.avro");
+
+    ManifestOutputFileFactory factory2 =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix2");
+    String file2 = new File(factory2.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("test-job-test-operator-00000-1-1-00001-suffix2.avro");
+
+    assertThat(file1).isNotEqualTo(file2);
+  }
+}

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -68,6 +68,8 @@ class TestDynamicCommitter {
 
   Catalog catalog;
 
+  final int cacheMaximumSize = 10;
+
   private static final DataFile DATA_FILE =
       DataFiles.builder(PartitionSpec.unpartitioned())
           .withPath("/path/to/data-1.parquet")
@@ -155,7 +157,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE2, "branch2", 43, 0, true, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -281,7 +283,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -339,7 +341,7 @@ class TestDynamicCommitter {
     assertThat(table.snapshots()).isEmpty();
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -454,7 +456,7 @@ class TestDynamicCommitter {
     assertThat(table.snapshots()).isEmpty();
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -613,7 +615,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();

--- a/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultAggregator.java
+++ b/flink/v1.19/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultAggregator.java
@@ -20,15 +20,26 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.hadoop.util.Sets;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.flink.sink.DeltaManifests;
+import org.apache.iceberg.flink.sink.DeltaManifestsSerializer;
 import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -37,13 +48,22 @@ class TestDynamicWriteResultAggregator {
   @RegisterExtension
   static final HadoopCatalogExtension CATALOG_EXTENSION = new HadoopCatalogExtension("db", "table");
 
+  final int cacheMaximumSize = 1;
+
+  private static final DataFile DATA_FILE =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-1.parquet")
+          .withFileSizeInBytes(100)
+          .withRecordCount(1)
+          .build();
+
   @Test
   void testAggregator() throws Exception {
     CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
     CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table2"), new Schema());
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     try (OneInputStreamOperatorTestHarness<
             CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>>
         testHarness = new OneInputStreamOperatorTestHarness<>(aggregator)) {
@@ -78,5 +98,75 @@ class TestDynamicWriteResultAggregator {
       // Only contains a CommittableSummary
       assertThat(testHarness.getRecordOutput()).hasSize(4);
     }
+  }
+
+  @Test
+  void testPreventOutputFileFactoryCacheEvictionDuringFlush() throws Exception {
+    CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
+
+    // Disable caching of ManifestOutputFileFactory.
+    final int zeroCacheSize = 0;
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), zeroCacheSize);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>>
+        testHarness = new OneInputStreamOperatorTestHarness<>(aggregator)) {
+      testHarness.open();
+
+      WriteTarget writeTarget1 =
+          new WriteTarget("table", "branch", 42, 0, false, Sets.newHashSet());
+      DynamicWriteResult dynamicWriteResult1 =
+          new DynamicWriteResult(
+              writeTarget1, WriteResult.builder().addDataFiles(DATA_FILE).build());
+
+      // Different WriteTarget
+      WriteTarget writeTarget2 =
+          new WriteTarget("table", "branch2", 23, 0, true, Sets.newHashSet());
+      DynamicWriteResult dynamicWriteResult2 =
+          new DynamicWriteResult(
+              writeTarget2, WriteResult.builder().addDataFiles(DATA_FILE).build());
+
+      CommittableWithLineage<DynamicWriteResult> committable1 =
+          new CommittableWithLineage<>(dynamicWriteResult1, 0, 0);
+      testHarness.processElement(new StreamRecord<>(committable1));
+
+      CommittableWithLineage<DynamicWriteResult> committable2 =
+          new CommittableWithLineage<>(dynamicWriteResult2, 0, 0);
+      testHarness.processElement(new StreamRecord<>(committable2));
+
+      assertThat(testHarness.getOutput()).isEmpty();
+
+      testHarness.prepareSnapshotPreBarrier(1L);
+      List<StreamRecord<CommittableMessage<DynamicCommittable>>> output =
+          Lists.newArrayList(testHarness.getRecordOutput().iterator());
+
+      assertThat(testHarness.getOutput()).hasSize(3);
+      assertThat(output.get(0).getValue()).isInstanceOf(CommittableSummary.class);
+      assertThat(output.get(1).getValue()).isInstanceOf(CommittableWithLineage.class);
+      assertThat(output.get(2).getValue()).isInstanceOf(CommittableWithLineage.class);
+
+      // There should be two unique file paths, despite the cache being disabled.
+      Set<String> manifestPaths = getManifestPaths(output);
+      assertThat(manifestPaths).hasSize(2);
+    }
+  }
+
+  private static Set<String> getManifestPaths(
+      List<StreamRecord<CommittableMessage<DynamicCommittable>>> messages) throws IOException {
+    Set<String> manifestPaths = Sets.newHashSet();
+
+    for (StreamRecord<CommittableMessage<DynamicCommittable>> record : messages) {
+      CommittableMessage<DynamicCommittable> message = record.getValue();
+      if (message instanceof CommittableWithLineage) {
+        DeltaManifests deltaManifests =
+            SimpleVersionedSerialization.readVersionAndDeSerialize(
+                DeltaManifestsSerializer.INSTANCE,
+                (((CommittableWithLineage<DynamicCommittable>) message).getCommittable())
+                    .manifest());
+        deltaManifests.manifests().forEach(manifest -> manifestPaths.add(manifest.path()));
+      }
+    }
+
+    return manifestPaths;
   }
 }

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -68,9 +68,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     implementation libs.datasketches
 
-    // for caching in DynamicSink
-    implementation libs.caffeine
-
     testImplementation libs.flink120.connector.test.utils
     testImplementation libs.flink120.core
     testImplementation libs.flink120.runtime

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -74,7 +74,19 @@ public class FlinkManifestUtil {
       int subTaskId,
       long attemptNumber) {
     return new ManifestOutputFileFactory(
-        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber);
+        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, null);
+  }
+
+  public static ManifestOutputFileFactory createOutputFileFactory(
+      Supplier<Table> tableSupplier,
+      Map<String, String> tableProps,
+      String flinkJobId,
+      String operatorUniqueId,
+      int subTaskId,
+      long attemptNumber,
+      String suffix) {
+    return new ManifestOutputFileFactory(
+        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, suffix);
   }
 
   /**

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
@@ -43,6 +44,7 @@ public class ManifestOutputFileFactory {
   private final int subTaskId;
   private final long attemptNumber;
   private final AtomicInteger fileCount = new AtomicInteger(0);
+  @Nullable private final String suffix;
 
   ManifestOutputFileFactory(
       Supplier<Table> tableSupplier,
@@ -50,26 +52,29 @@ public class ManifestOutputFileFactory {
       String flinkJobId,
       String operatorUniqueId,
       int subTaskId,
-      long attemptNumber) {
+      long attemptNumber,
+      @Nullable String suffix) {
     this.tableSupplier = tableSupplier;
     this.props = props;
     this.flinkJobId = flinkJobId;
     this.operatorUniqueId = operatorUniqueId;
     this.subTaskId = subTaskId;
     this.attemptNumber = attemptNumber;
+    this.suffix = suffix;
   }
 
   private String generatePath(long checkpointId) {
     return FileFormat.AVRO.addExtension(
         String.format(
             Locale.ROOT,
-            "%s-%s-%05d-%d-%d-%05d",
+            "%s-%s-%05d-%d-%d-%05d%s",
             flinkJobId,
             operatorUniqueId,
             subTaskId,
             attemptNumber,
             checkpointId,
-            fileCount.incrementAndGet()));
+            fileCount.incrementAndGet(),
+            suffix != null ? "-" + suffix : ""));
   }
 
   public OutputFile create(long checkpointId) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -168,7 +168,7 @@ public class DynamicIcebergSink
         .transform(
             prefixIfNotNull(uidPrefix, sinkId + " Pre Commit"),
             typeInformation,
-            new DynamicWriteResultAggregator(catalogLoader))
+            new DynamicWriteResultAggregator(catalogLoader, cacheMaximumSize))
         .uid(prefixIfNotNull(uidPrefix, sinkId + "-pre-commit-topology"));
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
@@ -18,12 +18,10 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
@@ -58,20 +56,21 @@ class DynamicWriteResultAggregator
         CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>> {
   private static final Logger LOG = LoggerFactory.getLogger(DynamicWriteResultAggregator.class);
   private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
-  private static final Duration CACHE_EXPIRATION_DURATION = Duration.ofMinutes(1);
 
   private final CatalogLoader catalogLoader;
+  private final int cacheMaximumSize;
   private transient Map<WriteTarget, Collection<DynamicWriteResult>> results;
-  private transient Cache<String, Map<Integer, PartitionSpec>> specs;
-  private transient Cache<String, ManifestOutputFileFactory> outputFileFactories;
+  private transient Map<String, Map<Integer, PartitionSpec>> specs;
+  private transient Map<String, ManifestOutputFileFactory> outputFileFactories;
   private transient String flinkJobId;
   private transient String operatorId;
   private transient int subTaskId;
   private transient int attemptId;
   private transient Catalog catalog;
 
-  DynamicWriteResultAggregator(CatalogLoader catalogLoader) {
+  DynamicWriteResultAggregator(CatalogLoader catalogLoader, int cacheMaximumSize) {
     this.catalogLoader = catalogLoader;
+    this.cacheMaximumSize = cacheMaximumSize;
   }
 
   @Override
@@ -81,10 +80,8 @@ class DynamicWriteResultAggregator
     this.subTaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
     this.attemptId = getRuntimeContext().getTaskInfo().getAttemptNumber();
     this.results = Maps.newHashMap();
-    this.specs =
-        Caffeine.newBuilder().expireAfterWrite(CACHE_EXPIRATION_DURATION).softValues().build();
-    this.outputFileFactories =
-        Caffeine.newBuilder().expireAfterWrite(CACHE_EXPIRATION_DURATION).softValues().build();
+    this.specs = new LRUCache<>(cacheMaximumSize);
+    this.outputFileFactories = new LRUCache<>(cacheMaximumSize);
     this.catalog = catalogLoader.loadCatalog();
   }
 
@@ -163,18 +160,27 @@ class DynamicWriteResultAggregator
   }
 
   private ManifestOutputFileFactory outputFileFactory(String tableName) {
-    return outputFileFactories.get(
+    return outputFileFactories.computeIfAbsent(
         tableName,
         unused -> {
           Table table = catalog.loadTable(TableIdentifier.parse(tableName));
           specs.put(tableName, table.specs());
+          // Make sure to append an identifier to avoid file clashes in case the factory was to get
+          // re-created during a checkpoint, i.e. due to cache eviction.
+          String fileSuffix = UUID.randomUUID().toString();
           return FlinkManifestUtil.createOutputFileFactory(
-              () -> table, table.properties(), flinkJobId, operatorId, subTaskId, attemptId);
+              () -> table,
+              table.properties(),
+              flinkJobId,
+              operatorId,
+              subTaskId,
+              attemptId,
+              fileSuffix);
         });
   }
 
   private PartitionSpec spec(String tableName, int specId) {
-    Map<Integer, PartitionSpec> knownSpecs = specs.getIfPresent(tableName);
+    Map<Integer, PartitionSpec> knownSpecs = specs.get(tableName);
     if (knownSpecs != null) {
       PartitionSpec spec = knownSpecs.get(specId);
       if (spec != null) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -210,4 +210,9 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
   DynamicWriterMetrics getMetrics() {
     return metrics;
   }
+
+  @VisibleForTesting
+  Map<WriteTarget, RowDataTaskWriterFactory> getTaskWriterFactories() {
+    return taskWriterFactories;
+  }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
@@ -137,7 +137,7 @@ public class TestFlinkManifest {
             ManifestOutputFileFactory.FLINK_MANIFEST_LOCATION,
             userProvidedFolder.getAbsolutePath() + "///");
     ManifestOutputFileFactory factory =
-        new ManifestOutputFileFactory(() -> table, props, flinkJobId, operatorId, 1, 1);
+        new ManifestOutputFileFactory(() -> table, props, flinkJobId, operatorId, 1, 1, null);
 
     List<DataFile> dataFiles = generateDataFiles(5);
     DeltaManifests deltaManifests =

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestManifestOutputFileFactory.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestManifestOutputFileFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class TestManifestOutputFileFactory {
+
+  @RegisterExtension
+  static final HadoopCatalogExtension CATALOG_EXTENSION = new HadoopCatalogExtension("db", "table");
+
+  private Table table;
+
+  @BeforeEach
+  void before() throws IOException {
+    table = CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
+  }
+
+  @Test
+  public void testFileNameFormat() {
+    String flinkJobId = "job123";
+    String operatorUniqueId = "operator456";
+    int subTaskId = 7;
+    long attemptNumber = 2;
+    long checkpointId = 100;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, null);
+
+    String file1 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("job123-operator456-00007-2-100-00001.avro");
+
+    String file2 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("job123-operator456-00007-2-100-00002.avro");
+
+    String file3 = new File(factory.create(checkpointId + 1).location()).getName();
+    assertThat(file3).isEqualTo("job123-operator456-00007-2-101-00003.avro");
+  }
+
+  @Test
+  public void testFileNameFormatWithSuffix() {
+    String flinkJobId = "job123";
+    String operatorUniqueId = "operator456";
+    int subTaskId = 7;
+    long attemptNumber = 2;
+    long checkpointId = 100;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix");
+
+    String file1 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("job123-operator456-00007-2-100-00001-suffix.avro");
+
+    String file2 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("job123-operator456-00007-2-100-00002-suffix.avro");
+  }
+
+  @Test
+  public void testSuffixedFileNamesWithRecreatedFactory() {
+    String flinkJobId = "test-job";
+    String operatorUniqueId = "test-operator";
+    int subTaskId = 0;
+    long attemptNumber = 1;
+    long checkpointId = 1;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory1 =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix1");
+    String file1 = new File(factory1.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("test-job-test-operator-00000-1-1-00001-suffix1.avro");
+
+    ManifestOutputFileFactory factory2 =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix2");
+    String file2 = new File(factory2.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("test-job-test-operator-00000-1-1-00001-suffix2.avro");
+
+    assertThat(file1).isNotEqualTo(file2);
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -68,6 +68,8 @@ class TestDynamicCommitter {
 
   Catalog catalog;
 
+  final int cacheMaximumSize = 10;
+
   private static final DataFile DATA_FILE =
       DataFiles.builder(PartitionSpec.unpartitioned())
           .withPath("/path/to/data-1.parquet")
@@ -155,7 +157,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE2, "branch2", 43, 0, true, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -281,7 +283,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -339,7 +341,7 @@ class TestDynamicCommitter {
     assertThat(table.snapshots()).isEmpty();
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -454,7 +456,7 @@ class TestDynamicCommitter {
     assertThat(table.snapshots()).isEmpty();
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -613,7 +615,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultAggregator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultAggregator.java
@@ -20,15 +20,26 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.hadoop.util.Sets;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.flink.sink.DeltaManifests;
+import org.apache.iceberg.flink.sink.DeltaManifestsSerializer;
 import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -37,13 +48,22 @@ class TestDynamicWriteResultAggregator {
   @RegisterExtension
   static final HadoopCatalogExtension CATALOG_EXTENSION = new HadoopCatalogExtension("db", "table");
 
+  final int cacheMaximumSize = 1;
+
+  private static final DataFile DATA_FILE =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-1.parquet")
+          .withFileSizeInBytes(100)
+          .withRecordCount(1)
+          .build();
+
   @Test
   void testAggregator() throws Exception {
     CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
     CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table2"), new Schema());
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     try (OneInputStreamOperatorTestHarness<
             CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>>
         testHarness = new OneInputStreamOperatorTestHarness<>(aggregator)) {
@@ -78,5 +98,75 @@ class TestDynamicWriteResultAggregator {
       // Only contains a CommittableSummary
       assertThat(testHarness.getRecordOutput()).hasSize(4);
     }
+  }
+
+  @Test
+  void testPreventOutputFileFactoryCacheEvictionDuringFlush() throws Exception {
+    CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
+
+    // Disable caching of ManifestOutputFileFactory.
+    final int zeroCacheSize = 0;
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), zeroCacheSize);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>>
+        testHarness = new OneInputStreamOperatorTestHarness<>(aggregator)) {
+      testHarness.open();
+
+      WriteTarget writeTarget1 =
+          new WriteTarget("table", "branch", 42, 0, false, Sets.newHashSet());
+      DynamicWriteResult dynamicWriteResult1 =
+          new DynamicWriteResult(
+              writeTarget1, WriteResult.builder().addDataFiles(DATA_FILE).build());
+
+      // Different WriteTarget
+      WriteTarget writeTarget2 =
+          new WriteTarget("table", "branch2", 23, 0, true, Sets.newHashSet());
+      DynamicWriteResult dynamicWriteResult2 =
+          new DynamicWriteResult(
+              writeTarget2, WriteResult.builder().addDataFiles(DATA_FILE).build());
+
+      CommittableWithLineage<DynamicWriteResult> committable1 =
+          new CommittableWithLineage<>(dynamicWriteResult1, 0, 0);
+      testHarness.processElement(new StreamRecord<>(committable1));
+
+      CommittableWithLineage<DynamicWriteResult> committable2 =
+          new CommittableWithLineage<>(dynamicWriteResult2, 0, 0);
+      testHarness.processElement(new StreamRecord<>(committable2));
+
+      assertThat(testHarness.getOutput()).isEmpty();
+
+      testHarness.prepareSnapshotPreBarrier(1L);
+      List<StreamRecord<CommittableMessage<DynamicCommittable>>> output =
+          Lists.newArrayList(testHarness.getRecordOutput().iterator());
+
+      assertThat(testHarness.getOutput()).hasSize(3);
+      assertThat(output.get(0).getValue()).isInstanceOf(CommittableSummary.class);
+      assertThat(output.get(1).getValue()).isInstanceOf(CommittableWithLineage.class);
+      assertThat(output.get(2).getValue()).isInstanceOf(CommittableWithLineage.class);
+
+      // There should be two unique file paths, despite the cache being disabled.
+      Set<String> manifestPaths = getManifestPaths(output);
+      assertThat(manifestPaths).hasSize(2);
+    }
+  }
+
+  private static Set<String> getManifestPaths(
+      List<StreamRecord<CommittableMessage<DynamicCommittable>>> messages) throws IOException {
+    Set<String> manifestPaths = Sets.newHashSet();
+
+    for (StreamRecord<CommittableMessage<DynamicCommittable>> record : messages) {
+      CommittableMessage<DynamicCommittable> message = record.getValue();
+      if (message instanceof CommittableWithLineage) {
+        DeltaManifests deltaManifests =
+            SimpleVersionedSerialization.readVersionAndDeSerialize(
+                DeltaManifestsSerializer.INSTANCE,
+                (((CommittableWithLineage<DynamicCommittable>) message).getCommittable())
+                    .manifest());
+        deltaManifests.manifests().forEach(manifest -> manifestPaths.add(manifest.path()));
+      }
+    }
+
+    return manifestPaths;
   }
 }

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -68,9 +68,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     implementation libs.datasketches
 
-    // for caching in DynamicSink
-    implementation libs.caffeine
-
     testImplementation libs.flink20.connector.test.utils
     testImplementation libs.flink20.core
     testImplementation libs.flink20.runtime

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -74,7 +74,19 @@ public class FlinkManifestUtil {
       int subTaskId,
       long attemptNumber) {
     return new ManifestOutputFileFactory(
-        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber);
+        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, null);
+  }
+
+  public static ManifestOutputFileFactory createOutputFileFactory(
+      Supplier<Table> tableSupplier,
+      Map<String, String> tableProps,
+      String flinkJobId,
+      String operatorUniqueId,
+      int subTaskId,
+      long attemptNumber,
+      String suffix) {
+    return new ManifestOutputFileFactory(
+        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, suffix);
   }
 
   /**

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
@@ -43,6 +44,7 @@ public class ManifestOutputFileFactory {
   private final int subTaskId;
   private final long attemptNumber;
   private final AtomicInteger fileCount = new AtomicInteger(0);
+  @Nullable private final String suffix;
 
   ManifestOutputFileFactory(
       Supplier<Table> tableSupplier,
@@ -50,26 +52,29 @@ public class ManifestOutputFileFactory {
       String flinkJobId,
       String operatorUniqueId,
       int subTaskId,
-      long attemptNumber) {
+      long attemptNumber,
+      @Nullable String suffix) {
     this.tableSupplier = tableSupplier;
     this.props = props;
     this.flinkJobId = flinkJobId;
     this.operatorUniqueId = operatorUniqueId;
     this.subTaskId = subTaskId;
     this.attemptNumber = attemptNumber;
+    this.suffix = suffix;
   }
 
   private String generatePath(long checkpointId) {
     return FileFormat.AVRO.addExtension(
         String.format(
             Locale.ROOT,
-            "%s-%s-%05d-%d-%d-%05d",
+            "%s-%s-%05d-%d-%d-%05d%s",
             flinkJobId,
             operatorUniqueId,
             subTaskId,
             attemptNumber,
             checkpointId,
-            fileCount.incrementAndGet()));
+            fileCount.incrementAndGet(),
+            suffix != null ? "-" + suffix : ""));
   }
 
   public OutputFile create(long checkpointId) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -168,7 +168,7 @@ public class DynamicIcebergSink
         .transform(
             prefixIfNotNull(uidPrefix, sinkId + " Pre Commit"),
             typeInformation,
-            new DynamicWriteResultAggregator(catalogLoader))
+            new DynamicWriteResultAggregator(catalogLoader, cacheMaximumSize))
         .uid(prefixIfNotNull(uidPrefix, sinkId + "-pre-commit-topology"));
   }
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
@@ -18,12 +18,10 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
@@ -58,20 +56,21 @@ class DynamicWriteResultAggregator
         CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>> {
   private static final Logger LOG = LoggerFactory.getLogger(DynamicWriteResultAggregator.class);
   private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
-  private static final Duration CACHE_EXPIRATION_DURATION = Duration.ofMinutes(1);
 
   private final CatalogLoader catalogLoader;
+  private final int cacheMaximumSize;
   private transient Map<WriteTarget, Collection<DynamicWriteResult>> results;
-  private transient Cache<String, Map<Integer, PartitionSpec>> specs;
-  private transient Cache<String, ManifestOutputFileFactory> outputFileFactories;
+  private transient Map<String, Map<Integer, PartitionSpec>> specs;
+  private transient Map<String, ManifestOutputFileFactory> outputFileFactories;
   private transient String flinkJobId;
   private transient String operatorId;
   private transient int subTaskId;
   private transient int attemptId;
   private transient Catalog catalog;
 
-  DynamicWriteResultAggregator(CatalogLoader catalogLoader) {
+  DynamicWriteResultAggregator(CatalogLoader catalogLoader, int cacheMaximumSize) {
     this.catalogLoader = catalogLoader;
+    this.cacheMaximumSize = cacheMaximumSize;
   }
 
   @Override
@@ -81,10 +80,8 @@ class DynamicWriteResultAggregator
     this.subTaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
     this.attemptId = getRuntimeContext().getTaskInfo().getAttemptNumber();
     this.results = Maps.newHashMap();
-    this.specs =
-        Caffeine.newBuilder().expireAfterWrite(CACHE_EXPIRATION_DURATION).softValues().build();
-    this.outputFileFactories =
-        Caffeine.newBuilder().expireAfterWrite(CACHE_EXPIRATION_DURATION).softValues().build();
+    this.specs = new LRUCache<>(cacheMaximumSize);
+    this.outputFileFactories = new LRUCache<>(cacheMaximumSize);
     this.catalog = catalogLoader.loadCatalog();
   }
 
@@ -163,18 +160,27 @@ class DynamicWriteResultAggregator
   }
 
   private ManifestOutputFileFactory outputFileFactory(String tableName) {
-    return outputFileFactories.get(
+    return outputFileFactories.computeIfAbsent(
         tableName,
         unused -> {
           Table table = catalog.loadTable(TableIdentifier.parse(tableName));
           specs.put(tableName, table.specs());
+          // Make sure to append an identifier to avoid file clashes in case the factory was to get
+          // re-created during a checkpoint, i.e. due to cache eviction.
+          String fileSuffix = UUID.randomUUID().toString();
           return FlinkManifestUtil.createOutputFileFactory(
-              () -> table, table.properties(), flinkJobId, operatorId, subTaskId, attemptId);
+              () -> table,
+              table.properties(),
+              flinkJobId,
+              operatorId,
+              subTaskId,
+              attemptId,
+              fileSuffix);
         });
   }
 
   private PartitionSpec spec(String tableName, int specId) {
-    Map<Integer, PartitionSpec> knownSpecs = specs.getIfPresent(tableName);
+    Map<Integer, PartitionSpec> knownSpecs = specs.get(tableName);
     if (knownSpecs != null) {
       PartitionSpec spec = knownSpecs.get(specId);
       if (spec != null) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -210,4 +210,9 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
   DynamicWriterMetrics getMetrics() {
     return metrics;
   }
+
+  @VisibleForTesting
+  Map<WriteTarget, RowDataTaskWriterFactory> getTaskWriterFactories() {
+    return taskWriterFactories;
+  }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
@@ -137,7 +137,7 @@ public class TestFlinkManifest {
             ManifestOutputFileFactory.FLINK_MANIFEST_LOCATION,
             userProvidedFolder.getAbsolutePath() + "///");
     ManifestOutputFileFactory factory =
-        new ManifestOutputFileFactory(() -> table, props, flinkJobId, operatorId, 1, 1);
+        new ManifestOutputFileFactory(() -> table, props, flinkJobId, operatorId, 1, 1, null);
 
     List<DataFile> dataFiles = generateDataFiles(5);
     DeltaManifests deltaManifests =

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestManifestOutputFileFactory.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestManifestOutputFileFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class TestManifestOutputFileFactory {
+
+  @RegisterExtension
+  static final HadoopCatalogExtension CATALOG_EXTENSION = new HadoopCatalogExtension("db", "table");
+
+  private Table table;
+
+  @BeforeEach
+  void before() throws IOException {
+    table = CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
+  }
+
+  @Test
+  public void testFileNameFormat() {
+    String flinkJobId = "job123";
+    String operatorUniqueId = "operator456";
+    int subTaskId = 7;
+    long attemptNumber = 2;
+    long checkpointId = 100;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, null);
+
+    String file1 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("job123-operator456-00007-2-100-00001.avro");
+
+    String file2 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("job123-operator456-00007-2-100-00002.avro");
+
+    String file3 = new File(factory.create(checkpointId + 1).location()).getName();
+    assertThat(file3).isEqualTo("job123-operator456-00007-2-101-00003.avro");
+  }
+
+  @Test
+  public void testFileNameFormatWithSuffix() {
+    String flinkJobId = "job123";
+    String operatorUniqueId = "operator456";
+    int subTaskId = 7;
+    long attemptNumber = 2;
+    long checkpointId = 100;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix");
+
+    String file1 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("job123-operator456-00007-2-100-00001-suffix.avro");
+
+    String file2 = new File(factory.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("job123-operator456-00007-2-100-00002-suffix.avro");
+  }
+
+  @Test
+  public void testSuffixedFileNamesWithRecreatedFactory() {
+    String flinkJobId = "test-job";
+    String operatorUniqueId = "test-operator";
+    int subTaskId = 0;
+    long attemptNumber = 1;
+    long checkpointId = 1;
+    Map<String, String> props = table.properties();
+
+    ManifestOutputFileFactory factory1 =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix1");
+    String file1 = new File(factory1.create(checkpointId).location()).getName();
+    assertThat(file1).isEqualTo("test-job-test-operator-00000-1-1-00001-suffix1.avro");
+
+    ManifestOutputFileFactory factory2 =
+        new ManifestOutputFileFactory(
+            () -> table, props, flinkJobId, operatorUniqueId, subTaskId, attemptNumber, "suffix2");
+    String file2 = new File(factory2.create(checkpointId).location()).getName();
+    assertThat(file2).isEqualTo("test-job-test-operator-00000-1-1-00001-suffix2.avro");
+
+    assertThat(file1).isNotEqualTo(file2);
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -68,6 +68,8 @@ class TestDynamicCommitter {
 
   Catalog catalog;
 
+  final int cacheMaximumSize = 10;
+
   private static final DataFile DATA_FILE =
       DataFiles.builder(PartitionSpec.unpartitioned())
           .withPath("/path/to/data-1.parquet")
@@ -155,7 +157,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE2, "branch2", 43, 0, true, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -281,7 +283,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -339,7 +341,7 @@ class TestDynamicCommitter {
     assertThat(table.snapshots()).isEmpty();
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -454,7 +456,7 @@ class TestDynamicCommitter {
     assertThat(table.snapshots()).isEmpty();
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();
@@ -613,7 +615,7 @@ class TestDynamicCommitter {
         new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     OneInputStreamOperatorTestHarness aggregatorHarness =
         new OneInputStreamOperatorTestHarness(aggregator);
     aggregatorHarness.open();

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultAggregator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultAggregator.java
@@ -20,15 +20,26 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.hadoop.util.Sets;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.flink.sink.DeltaManifests;
+import org.apache.iceberg.flink.sink.DeltaManifestsSerializer;
 import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -37,13 +48,22 @@ class TestDynamicWriteResultAggregator {
   @RegisterExtension
   static final HadoopCatalogExtension CATALOG_EXTENSION = new HadoopCatalogExtension("db", "table");
 
+  final int cacheMaximumSize = 1;
+
+  private static final DataFile DATA_FILE =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-1.parquet")
+          .withFileSizeInBytes(100)
+          .withRecordCount(1)
+          .build();
+
   @Test
   void testAggregator() throws Exception {
     CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
     CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table2"), new Schema());
 
     DynamicWriteResultAggregator aggregator =
-        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader());
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
     try (OneInputStreamOperatorTestHarness<
             CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>>
         testHarness = new OneInputStreamOperatorTestHarness<>(aggregator)) {
@@ -78,5 +98,75 @@ class TestDynamicWriteResultAggregator {
       // Only contains a CommittableSummary
       assertThat(testHarness.getRecordOutput()).hasSize(4);
     }
+  }
+
+  @Test
+  void testPreventOutputFileFactoryCacheEvictionDuringFlush() throws Exception {
+    CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), new Schema());
+
+    // Disable caching of ManifestOutputFileFactory.
+    final int zeroCacheSize = 0;
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), zeroCacheSize);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<DynamicWriteResult>, CommittableMessage<DynamicCommittable>>
+        testHarness = new OneInputStreamOperatorTestHarness<>(aggregator)) {
+      testHarness.open();
+
+      WriteTarget writeTarget1 =
+          new WriteTarget("table", "branch", 42, 0, false, Sets.newHashSet());
+      DynamicWriteResult dynamicWriteResult1 =
+          new DynamicWriteResult(
+              writeTarget1, WriteResult.builder().addDataFiles(DATA_FILE).build());
+
+      // Different WriteTarget
+      WriteTarget writeTarget2 =
+          new WriteTarget("table", "branch2", 23, 0, true, Sets.newHashSet());
+      DynamicWriteResult dynamicWriteResult2 =
+          new DynamicWriteResult(
+              writeTarget2, WriteResult.builder().addDataFiles(DATA_FILE).build());
+
+      CommittableWithLineage<DynamicWriteResult> committable1 =
+          new CommittableWithLineage<>(dynamicWriteResult1, 0, 0);
+      testHarness.processElement(new StreamRecord<>(committable1));
+
+      CommittableWithLineage<DynamicWriteResult> committable2 =
+          new CommittableWithLineage<>(dynamicWriteResult2, 0, 0);
+      testHarness.processElement(new StreamRecord<>(committable2));
+
+      assertThat(testHarness.getOutput()).isEmpty();
+
+      testHarness.prepareSnapshotPreBarrier(1L);
+      List<StreamRecord<CommittableMessage<DynamicCommittable>>> output =
+          Lists.newArrayList(testHarness.getRecordOutput().iterator());
+
+      assertThat(testHarness.getOutput()).hasSize(3);
+      assertThat(output.get(0).getValue()).isInstanceOf(CommittableSummary.class);
+      assertThat(output.get(1).getValue()).isInstanceOf(CommittableWithLineage.class);
+      assertThat(output.get(2).getValue()).isInstanceOf(CommittableWithLineage.class);
+
+      // There should be two unique file paths, despite the cache being disabled.
+      Set<String> manifestPaths = getManifestPaths(output);
+      assertThat(manifestPaths).hasSize(2);
+    }
+  }
+
+  private static Set<String> getManifestPaths(
+      List<StreamRecord<CommittableMessage<DynamicCommittable>>> messages) throws IOException {
+    Set<String> manifestPaths = Sets.newHashSet();
+
+    for (StreamRecord<CommittableMessage<DynamicCommittable>> record : messages) {
+      CommittableMessage<DynamicCommittable> message = record.getValue();
+      if (message instanceof CommittableWithLineage) {
+        DeltaManifests deltaManifests =
+            SimpleVersionedSerialization.readVersionAndDeSerialize(
+                DeltaManifestsSerializer.INSTANCE,
+                (((CommittableWithLineage<DynamicCommittable>) message).getCommittable())
+                    .manifest());
+        deltaManifests.manifests().forEach(manifest -> manifestPaths.add(manifest.path()));
+      }
+    }
+
+    return manifestPaths;
   }
 }


### PR DESCRIPTION
This is a backport of #14358 for the 1.10.x release branch. 

Note that there is no support for Flink 2.1 in the 1.10.x branch. The backport is for Flink 1.19, 1.20, and 2.0 only.