### PR TITLE
Core: Increase visibility of builder of ParserContext

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ParserContext.java
@@ -40,11 +40,11 @@ public class ParserContext {
     return new InjectableValues.Std(data);
   }
 
-  static Builder builder() {
+  public static Builder builder() {
     return new Builder();
   }
 
-  static class Builder {
+  public static class Builder {
     private final Map<String, Object> data = Maps.newHashMap();
 
     private Builder() {}


### PR DESCRIPTION
### About the change 

Parser context is a public class, with private constructor the builder should least be public


part of extracting changes from : https://github.com/apache/iceberg/pull/13400