### PR TITLE
Flink: Add TableCreator interface to set table properties/location on DynamicIcebergSink table creation

### DIFF
--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -536,6 +536,7 @@ The Dynamic Iceberg Flink Sink is configured using the Builder pattern. Here are
 | `immediateTableUpdate(boolean enabled)`              | Controls whether table metadata (schema/partition spec) updates immediately (default: false)                                                                                                                                                                   |
 | `set(String property, String value)`                 | Set any Iceberg write property (e.g., `"write.format"`, `"write.upsert.enabled"`).Check out all the options here: [write-options](flink-configuration.md#write-options) |
 | `setAll(Map<String, String> properties)`             | Set multiple properties at once                                                                                                                                         |
+| `tableCreator(TableCreator creator)` | When DynamicIcebergSink creates new Iceberg tables, allows overriding how tables are created - setting custom table properties and location based on the table name. |
 
 ### Notes
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -185,6 +185,7 @@ public class DynamicIcebergSink
     private final Map<String, String> writeOptions = Maps.newHashMap();
     private final Map<String, String> snapshotSummary = Maps.newHashMap();
     private ReadableConfig readableConfig = new Configuration();
+    private TableCreator tableCreator = TableCreator.DEFAULT;
     private boolean immediateUpdate = false;
     private int cacheMaximumSize = 100;
     private long cacheRefreshMs = 1_000;
@@ -240,6 +241,15 @@ public class DynamicIcebergSink
 
     public Builder<T> flinkConf(ReadableConfig config) {
       this.readableConfig = config;
+      return this;
+    }
+
+    /**
+     * Logic to create a table. Allows setting custom table properties/location on a per-table
+     * basis.
+     */
+    public Builder<T> tableCreator(TableCreator tableCreationFunction) {
+      this.tableCreator = tableCreationFunction;
       return this;
     }
 
@@ -374,7 +384,8 @@ public class DynamicIcebergSink
                       immediateUpdate,
                       cacheMaximumSize,
                       cacheRefreshMs,
-                      inputSchemasPerTableCacheMaximumSize))
+                      inputSchemasPerTableCacheMaximumSize,
+                      tableCreator))
               .uid(prefixIfNotNull(uidPrefix, "-generator"))
               .name(operatorName("generator"))
               .returns(type);
@@ -391,7 +402,8 @@ public class DynamicIcebergSink
                       catalogLoader,
                       cacheMaximumSize,
                       cacheRefreshMs,
-                      inputSchemasPerTableCacheMaximumSize))
+                      inputSchemasPerTableCacheMaximumSize,
+                      tableCreator))
               .uid(prefixIfNotNull(uidPrefix, "-updater"))
               .name(operatorName("Updater"))
               .returns(type)

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -43,6 +43,7 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
   private final int cacheMaximumSize;
   private final long cacheRefreshMs;
   private final int inputSchemasPerTableCacheMaximumSize;
+  private final TableCreator tableCreator;
 
   private transient TableMetadataCache tableCache;
   private transient HashKeyGenerator hashKeyGenerator;
@@ -57,13 +58,15 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
       boolean immediateUpdate,
       int cacheMaximumSize,
       long cacheRefreshMs,
-      int inputSchemasPerTableCacheMaximumSize) {
+      int inputSchemasPerTableCacheMaximumSize,
+      TableCreator tableCreator) {
     this.generator = generator;
     this.catalogLoader = catalogLoader;
     this.immediateUpdate = immediateUpdate;
     this.cacheMaximumSize = cacheMaximumSize;
     this.cacheRefreshMs = cacheRefreshMs;
     this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
+    this.tableCreator = tableCreator;
   }
 
   @Override
@@ -114,7 +117,8 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
         || foundSchema.compareResult() == CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED) {
       if (immediateUpdate) {
         Tuple2<TableMetadataCache.ResolvedSchemaInfo, PartitionSpec> newData =
-            updater.update(data.tableIdentifier(), data.branch(), data.schema(), data.spec());
+            updater.update(
+                data.tableIdentifier(), data.branch(), data.schema(), data.spec(), tableCreator);
         emit(
             collector,
             data,

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
@@ -41,6 +41,7 @@ class DynamicTableUpdateOperator
   private final int cacheMaximumSize;
   private final long cacheRefreshMs;
   private final int inputSchemasPerTableCacheMaximumSize;
+  private final TableCreator tableCreator;
 
   private transient TableUpdater updater;
 
@@ -48,11 +49,13 @@ class DynamicTableUpdateOperator
       CatalogLoader catalogLoader,
       int cacheMaximumSize,
       long cacheRefreshMs,
-      int inputSchemasPerTableCacheMaximumSize) {
+      int inputSchemasPerTableCacheMaximumSize,
+      TableCreator tableCreator) {
     this.catalogLoader = catalogLoader;
     this.cacheMaximumSize = cacheMaximumSize;
     this.cacheRefreshMs = cacheRefreshMs;
     this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
+    this.tableCreator = tableCreator;
   }
 
   @Override
@@ -70,7 +73,11 @@ class DynamicTableUpdateOperator
   public DynamicRecordInternal map(DynamicRecordInternal data) throws Exception {
     Tuple2<TableMetadataCache.ResolvedSchemaInfo, PartitionSpec> newData =
         updater.update(
-            TableIdentifier.parse(data.tableName()), data.branch(), data.schema(), data.spec());
+            TableIdentifier.parse(data.tableName()),
+            data.branch(),
+            data.schema(),
+            data.spec(),
+            tableCreator);
     TableMetadataCache.ResolvedSchemaInfo compareInfo = newData.f0;
 
     data.setSchema(compareInfo.resolvedTableSchema());

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableCreator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableCreator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.io.Serializable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+@FunctionalInterface
+public interface TableCreator extends Serializable {
+
+  TableCreator DEFAULT = Catalog::createTable;
+
+  Table createTable(Catalog catalog, TableIdentifier identifier, Schema schema, PartitionSpec spec);
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
@@ -61,7 +61,8 @@ class TestDynamicTableUpdateOperator {
             CATALOG_EXTENSION.catalogLoader(),
             cacheMaximumSize,
             cacheRefreshMs,
-            inputSchemaCacheMaximumSize);
+            inputSchemaCacheMaximumSize,
+            TableCreator.DEFAULT);
     operator.open(null);
 
     DynamicRecordInternal input =
@@ -93,7 +94,8 @@ class TestDynamicTableUpdateOperator {
             CATALOG_EXTENSION.catalogLoader(),
             cacheMaximumSize,
             cacheRefreshMs,
-            inputSchemaCacheMaximumSize);
+            inputSchemaCacheMaximumSize,
+            TableCreator.DEFAULT);
     operator.open(null);
 
     catalog.createTable(table, SCHEMA1);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
@@ -76,7 +76,8 @@ public class TestTableMetadataCache extends TestFlinkIcebergSinkBase {
 
     catalog.dropTable(tableIdentifier);
     catalog.createTable(tableIdentifier, SCHEMA2);
-    tableUpdater.update(tableIdentifier, "main", SCHEMA2, PartitionSpec.unpartitioned());
+    tableUpdater.update(
+        tableIdentifier, "main", SCHEMA2, PartitionSpec.unpartitioned(), TableCreator.DEFAULT);
 
     Schema schema2 = cache.schema(tableIdentifier, SCHEMA2).resolvedTableSchema();
     assertThat(schema2.sameSchema(SCHEMA2)).isTrue();


### PR DESCRIPTION
The DynamicIcebergSink does not currently allow providing a set of reasonable default table properties at table creation. This change will apply these properties when a table is created (not updated). This helps for specifying things like iceberg version, merge-on-read vs. copy-on-write, table location, and others.