### PR TITLE
Fix ClassLoader leak in Spark caused by AuthSessionCache and ensure resource cleanup

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -23,6 +23,8 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Ticker;
+import java.io.Closeable;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
@@ -43,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * <p>See {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for more details regarding special
  * values for {@code expirationIntervalMillis}.
  */
-public class CachingCatalog implements Catalog {
+public class CachingCatalog implements Catalog, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(CachingCatalog.class);
   private static final MetadataTableType[] METADATA_TABLE_TYPE_VALUES = MetadataTableType.values();
 
@@ -212,6 +214,13 @@ public class CachingCatalog implements Catalog {
   @Override
   public TableBuilder buildTable(TableIdentifier identifier, Schema schema) {
     return new CachingTableBuilder(identifier, schema);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (catalog instanceof Closeable) {
+      ((Closeable) catalog).close();
+    }
   }
 
   private class CachingTableBuilder implements TableBuilder {

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthSessionCache.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthSessionCache.java
@@ -54,7 +54,7 @@ public class AuthSessionCache implements AutoCloseable {
   public AuthSessionCache(String name, Duration sessionTimeout) {
     this(
         sessionTimeout,
-        ThreadPools.newExitingWorkerPool(name + "-auth-session-evict", 1),
+        ThreadPools.newScheduledPool(name + "-auth-session-evict", 1),
         Ticker.systemTicker());
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -120,7 +122,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *
  * <p>
  */
-public class SparkCatalog extends BaseCatalog {
+public class SparkCatalog extends BaseCatalog implements Closeable {
   private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
   private static final Splitter COMMA = Splitter.on(",");
   private static final Joiner COMMA_JOINER = Joiner.on(",");
@@ -170,6 +172,13 @@ public class SparkCatalog extends BaseCatalog {
       return load(ident);
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(ident);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
     }
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -120,7 +122,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *
  * <p>
  */
-public class SparkCatalog extends BaseCatalog {
+public class SparkCatalog extends BaseCatalog implements Closeable {
   private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
   private static final Splitter COMMA = Splitter.on(",");
   private static final Joiner COMMA_JOINER = Joiner.on(",");
@@ -162,6 +164,13 @@ public class SparkCatalog extends BaseCatalog {
    */
   protected TableIdentifier buildIdentifier(Identifier identifier) {
     return Spark3Util.identifierToTableIdentifier(identifier);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
+    }
   }
 
   @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -121,7 +123,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *
  * <p>
  */
-public class SparkCatalog extends BaseCatalog {
+public class SparkCatalog extends BaseCatalog implements Closeable {
   private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
   private static final Splitter COMMA = Splitter.on(",");
   private static final Joiner COMMA_JOINER = Joiner.on(",");
@@ -163,6 +165,13 @@ public class SparkCatalog extends BaseCatalog {
    */
   protected TableIdentifier buildIdentifier(Identifier identifier) {
     return Spark3Util.identifierToTableIdentifier(identifier);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
+    }
   }
 
   @Override


### PR DESCRIPTION
# Summary
Fix memory leak in Spark from `AuthSessionCache` when using Iceberg and ensure resources get cleanup. 

# Background
I am using Spark Connect where end-users will be submitting their spark jobs/queries from their end into the remote Spark Connect server. These queries runtime can ranges from seconds to minutes and query per users can varies as well. Also, in this case, the end-users are the ones who are creating spark session and defined the connection info to Iceberg REST catalog. By default, Spark Connect server will cleanup idle sessions after one hour.

What I found out interesting is the memory usage of Spark Connect is not able to get garbage collected after Spark Connect server killed the idle sessions after reached default TTL. After some debugging, this point me to `ClassLoader` from Apache Spark leak in `AuthSessionCache.java` from Apache Iceberg.

# Changes
1. Fixing the `ClassLaoder` leak in Apache Spark in `AuthSessionCache.java`
The existed `ThreadPools.newExitingWorkerPool` created a `ScheduledExecutorService` and registers a JVM-level shutdown hook. This hook can inadvertently hold a strong reference to session specific `ClassLoader` in Spark connect via the tasks it manages, which preventing them from being released. This change replaces `newExitingWorkerPool` with `newScheduledPool` which creates a thread pool with daemon threads. Based on my understanding, daemon threads do not block JVM from existing thus prevent the issue mentioned above.

2. Ensure proper resources cleanup in catalogs
`CachingCatalog` and `SparkCatalog` now implements `java.io.Closeable` which allows them to propagate the `close` call to the underlying wrapped catalog. This will ensure that any resource referenced by catalogs are properly released.

# Reference
JIRA for Apache Spark: https://issues.apache.org/jira/browse/SPARK-54367
