### PR TITLE
Core, API, Spark: Add option to restore schema during rollback

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -659,4 +659,15 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   default UpdateSchema caseSensitive(boolean caseSensitive) {
     throw new UnsupportedOperationException();
   }
+
+  /**
+   * Rollback table's schema to a specific {@link Schema} identified by id.
+   *
+   * @param schemaId schema id to roll back table to.
+   * @return this for method chaining
+   * @throws IllegalArgumentException If the table has no schema with the given id
+   */
+  default UpdateSchema rollbackTo(int schemaId) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -59,10 +59,11 @@ To roll back to a specific time, use [`rollback_to_timestamp`](#rollback_to_time
 
 #### Usage
 
-| Argument Name | Required? | Type | Description |
-|---------------|-----------|------|-------------|
-| `table`       | ✔️  | string | Name of the table to update |
-| `snapshot_id` | ✔️  | long   | Snapshot ID to rollback to |
+| Argument Name     | Required? | Type    | Description                               |
+|-------------------|-----------|---------|-------------------------------------------|
+| `table`           | ✔️        | string  | Name of the table to update               |
+| `snapshot_id`     | ✔️        | long    | Snapshot ID to rollback to                |
+| `rollback_schema` | ️         | boolean | When true, roll back the table definition |
 
 #### Output
 
@@ -88,10 +89,11 @@ Roll back a table to the snapshot that was current at some time.
 
 #### Usage
 
-| Argument Name | Required? | Type | Description |
-|---------------|-----------|------|-------------|
-| `table`       | ✔️  | string | Name of the table to update |
-| `timestamp`   | ✔️  | timestamp | A timestamp to rollback to |
+| Argument Name     | Required? | Type      | Description                               |
+|-------------------|-----------|-----------|-------------------------------------------|
+| `table`           | ✔️        | string    | Name of the table to update               |
+| `timestamp`       | ✔️        | timestamp | A timestamp to rollback to                |
+| `rollback_schema` | ️         | boolean   | When true, roll back the table definition |
 
 #### Output
 


### PR DESCRIPTION
Relates to #14488 and #5591

Add `rollbackTo(int schemaId)` method to `UpdateSchema`, and use it from Spark `rollback_to_snapshot` and `rollback_to_timestamp` procedures  when a new parameter `rollback_schema` is enabled. 