### PR TITLE
Refactor: populate writeOptions in extraSnapshotMetadata using common util

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -262,11 +262,7 @@ public class SparkWriteConf {
 
     // Add write options, overriding session configuration if necessary
     extraSnapshotMetadata.putAll(
-            PropertyUtil.propertiesWithPrefix(
-                    writeOptions,
-                    SnapshotSummary.EXTRA_METADATA_PREFIX
-            )
-    );
+        PropertyUtil.propertiesWithPrefix(writeOptions, SnapshotSummary.EXTRA_METADATA_PREFIX));
 
     return extraSnapshotMetadata;
   }


### PR DESCRIPTION
Small refactor to use common util` PropertyUtil.propertiesWithPrefix` when populating write options in extraSnapshotMetadata.