### PR TITLE
Flink:Backport DynamicSink support dvs to Flink 2.0 and 1.20

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
@@ -32,6 +33,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
@@ -61,7 +63,8 @@ class DynamicWriteResultAggregator
   private final int cacheMaximumSize;
   private transient Map<WriteTarget, Collection<DynamicWriteResult>> results;
   private transient Map<String, Map<Integer, PartitionSpec>> specs;
-  private transient Map<String, ManifestOutputFileFactory> outputFileFactories;
+  private transient Map<String, Tuple2<ManifestOutputFileFactory, Integer>>
+      outputFileFactoriesAndFormatVersions;
   private transient String flinkJobId;
   private transient String operatorId;
   private transient int subTaskId;
@@ -81,7 +84,7 @@ class DynamicWriteResultAggregator
     this.attemptId = getRuntimeContext().getTaskInfo().getAttemptNumber();
     this.results = Maps.newHashMap();
     this.specs = new LRUCache<>(cacheMaximumSize);
-    this.outputFileFactories = new LRUCache<>(cacheMaximumSize);
+    this.outputFileFactoriesAndFormatVersions = new LRUCache<>(cacheMaximumSize);
     this.catalog = catalogLoader.loadCatalog();
   }
 
@@ -137,12 +140,14 @@ class DynamicWriteResultAggregator
     writeResults.forEach(w -> builder.add(w.writeResult()));
     WriteResult result = builder.build();
 
+    Tuple2<ManifestOutputFileFactory, Integer> outputFileFactoryAndVersion =
+        outputFileFactoryAndFormatVersion(key.tableName());
     DeltaManifests deltaManifests =
         FlinkManifestUtil.writeCompletedFiles(
             result,
-            () -> outputFileFactory(key.tableName()).create(checkpointId),
+            () -> outputFileFactoryAndVersion.f0.create(checkpointId),
             spec(key.tableName(), key.specId()),
-            2);
+            outputFileFactoryAndVersion.f1);
 
     return SimpleVersionedSerialization.writeVersionAndSerialize(
         DeltaManifestsSerializer.INSTANCE, deltaManifests);
@@ -160,8 +165,9 @@ class DynamicWriteResultAggregator
     }
   }
 
-  private ManifestOutputFileFactory outputFileFactory(String tableName) {
-    return outputFileFactories.computeIfAbsent(
+  private Tuple2<ManifestOutputFileFactory, Integer> outputFileFactoryAndFormatVersion(
+      String tableName) {
+    return outputFileFactoriesAndFormatVersions.computeIfAbsent(
         tableName,
         unused -> {
           Table table = catalog.loadTable(TableIdentifier.parse(tableName));
@@ -169,14 +175,16 @@ class DynamicWriteResultAggregator
           // Make sure to append an identifier to avoid file clashes in case the factory was to get
           // re-created during a checkpoint, i.e. due to cache eviction.
           String fileSuffix = UUID.randomUUID().toString();
-          return FlinkManifestUtil.createOutputFileFactory(
-              () -> table,
-              table.properties(),
-              flinkJobId,
-              operatorId,
-              subTaskId,
-              attemptId,
-              fileSuffix);
+          ManifestOutputFileFactory outputFileFactory =
+              FlinkManifestUtil.createOutputFileFactory(
+                  () -> table,
+                  table.properties(),
+                  flinkJobId,
+                  operatorId,
+                  subTaskId,
+                  attemptId,
+                  fileSuffix);
+          return Tuple2.of(outputFileFactory, TableUtil.formatVersion(table));
         });
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -117,10 +116,6 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
                           Preconditions.checkState(
                               !equalityFieldIds.isEmpty(),
                               "Equality field columns shouldn't be empty when configuring to use UPSERT data.");
-
-                          Preconditions.checkArgument(
-                              !(TableUtil.formatVersion(table) > 2),
-                              "Dynamic Sink writer does not support upsert mode in tables (V3+)");
 
                           if (!table.spec().isUnpartitioned()) {
                             for (PartitionField partitionField : table.spec().fields()) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -44,6 +44,9 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableUtil;
+import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
@@ -316,6 +319,140 @@ class TestDynamicCommitter {
 
     // Old commits requests shouldn't affect the result
     dynamicCommitter.commit(Sets.newHashSet(oldCommitRequest));
+
+    table1.refresh();
+    assertThat(table1.snapshots()).hasSize(1);
+    Snapshot first = Iterables.getFirst(table1.snapshots(), null);
+    assertThat(first.summary())
+        .containsAllEntriesOf(
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "42")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId)
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "42")
+                .build());
+  }
+
+  @Test
+  void testCommitDeleteInDifferentFormatVersion() throws Exception {
+    Table table1 = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table1.snapshots()).isEmpty();
+
+    boolean overwriteMode = false;
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+    DynamicCommitter dynamicCommitter =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    WriteTarget writeTarget =
+        new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    final String jobId = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int checkpointId = 10;
+
+    byte[] deltaManifest =
+        aggregator.writeToManifest(
+            writeTarget,
+            Sets.newHashSet(
+                new DynamicWriteResult(
+                    writeTarget,
+                    WriteResult.builder()
+                        .addDataFiles(DATA_FILE)
+                        .addDeleteFiles(DELETE_FILE)
+                        .build())),
+            checkpointId);
+
+    CommitRequest<DynamicCommittable> commitRequest =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget, deltaManifest, jobId, operatorId, checkpointId));
+
+    // Upgrade the table version
+    UpdateProperties updateApi = table1.updateProperties();
+    updateApi.set(
+        TableProperties.FORMAT_VERSION, String.valueOf(TableUtil.formatVersion(table1) + 1));
+    updateApi.commit();
+
+    assertThatThrownBy(() -> dynamicCommitter.commit(Sets.newHashSet(commitRequest)))
+        .hasMessage(
+            "Can't add position delete file to the %s table. Concurrent table upgrade to V3 is not supported.",
+            table1.name())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testCommitOnlyDataInDifferentFormatVersion() throws Exception {
+    Table table1 = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table1.snapshots()).isEmpty();
+
+    boolean overwriteMode = false;
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+    DynamicCommitter dynamicCommitter =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    WriteTarget writeTarget =
+        new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    final String jobId = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int checkpointId = 10;
+
+    byte[] deltaManifest =
+        aggregator.writeToManifest(
+            writeTarget,
+            Sets.newHashSet(
+                new DynamicWriteResult(
+                    writeTarget, WriteResult.builder().addDataFiles(DATA_FILE).build())),
+            checkpointId);
+
+    CommitRequest<DynamicCommittable> commitRequest =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget, deltaManifest, jobId, operatorId, checkpointId));
+
+    dynamicCommitter.commit(Sets.newHashSet(commitRequest));
+
+    // Upgrade the table version
+    UpdateProperties updateApi = table1.updateProperties();
+    updateApi.set(
+        TableProperties.FORMAT_VERSION, String.valueOf(TableUtil.formatVersion(table1) + 1));
+    updateApi.commit();
 
     table1.refresh();
     assertThat(table1.snapshots()).hasSize(1);

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -31,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RowDelta;
@@ -38,6 +40,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.sink.CommitSummary;
@@ -50,6 +53,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
@@ -211,9 +215,23 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
           DeltaManifests deltaManifests =
               SimpleVersionedSerialization.readVersionAndDeSerialize(
                   DeltaManifestsSerializer.INSTANCE, committable.getCommittable().manifest());
+
+          WriteResult writeResult =
+              FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs());
+          if (TableUtil.formatVersion(table) > 2) {
+            for (DeleteFile deleteFile : writeResult.deleteFiles()) {
+              if (deleteFile.content() == FileContent.POSITION_DELETES) {
+                Preconditions.checkArgument(
+                    ContentFileUtil.isDV(deleteFile),
+                    "Can't add position delete file to the %s table. Concurrent table upgrade to V3 is not supported.",
+                    table.name());
+              }
+            }
+          }
+
           pendingResults
               .computeIfAbsent(e.getKey(), unused -> Lists.newArrayList())
-              .add(FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs()));
+              .add(writeResult);
           manifests.addAll(deltaManifests.manifests());
         }
       }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultAggregator.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
@@ -32,6 +33,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
@@ -61,7 +63,8 @@ class DynamicWriteResultAggregator
   private final int cacheMaximumSize;
   private transient Map<WriteTarget, Collection<DynamicWriteResult>> results;
   private transient Map<String, Map<Integer, PartitionSpec>> specs;
-  private transient Map<String, ManifestOutputFileFactory> outputFileFactories;
+  private transient Map<String, Tuple2<ManifestOutputFileFactory, Integer>>
+      outputFileFactoriesAndFormatVersions;
   private transient String flinkJobId;
   private transient String operatorId;
   private transient int subTaskId;
@@ -81,7 +84,7 @@ class DynamicWriteResultAggregator
     this.attemptId = getRuntimeContext().getTaskInfo().getAttemptNumber();
     this.results = Maps.newHashMap();
     this.specs = new LRUCache<>(cacheMaximumSize);
-    this.outputFileFactories = new LRUCache<>(cacheMaximumSize);
+    this.outputFileFactoriesAndFormatVersions = new LRUCache<>(cacheMaximumSize);
     this.catalog = catalogLoader.loadCatalog();
   }
 
@@ -137,12 +140,14 @@ class DynamicWriteResultAggregator
     writeResults.forEach(w -> builder.add(w.writeResult()));
     WriteResult result = builder.build();
 
+    Tuple2<ManifestOutputFileFactory, Integer> outputFileFactoryAndVersion =
+        outputFileFactoryAndFormatVersion(key.tableName());
     DeltaManifests deltaManifests =
         FlinkManifestUtil.writeCompletedFiles(
             result,
-            () -> outputFileFactory(key.tableName()).create(checkpointId),
+            () -> outputFileFactoryAndVersion.f0.create(checkpointId),
             spec(key.tableName(), key.specId()),
-            2);
+            outputFileFactoryAndVersion.f1);
 
     return SimpleVersionedSerialization.writeVersionAndSerialize(
         DeltaManifestsSerializer.INSTANCE, deltaManifests);
@@ -160,8 +165,9 @@ class DynamicWriteResultAggregator
     }
   }
 
-  private ManifestOutputFileFactory outputFileFactory(String tableName) {
-    return outputFileFactories.computeIfAbsent(
+  private Tuple2<ManifestOutputFileFactory, Integer> outputFileFactoryAndFormatVersion(
+      String tableName) {
+    return outputFileFactoriesAndFormatVersions.computeIfAbsent(
         tableName,
         unused -> {
           Table table = catalog.loadTable(TableIdentifier.parse(tableName));
@@ -169,14 +175,16 @@ class DynamicWriteResultAggregator
           // Make sure to append an identifier to avoid file clashes in case the factory was to get
           // re-created during a checkpoint, i.e. due to cache eviction.
           String fileSuffix = UUID.randomUUID().toString();
-          return FlinkManifestUtil.createOutputFileFactory(
-              () -> table,
-              table.properties(),
-              flinkJobId,
-              operatorId,
-              subTaskId,
-              attemptId,
-              fileSuffix);
+          ManifestOutputFileFactory outputFileFactory =
+              FlinkManifestUtil.createOutputFileFactory(
+                  () -> table,
+                  table.properties(),
+                  flinkJobId,
+                  operatorId,
+                  subTaskId,
+                  attemptId,
+                  fileSuffix);
+          return Tuple2.of(outputFileFactory, TableUtil.formatVersion(table));
         });
   }
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -117,10 +116,6 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
                           Preconditions.checkState(
                               !equalityFieldIds.isEmpty(),
                               "Equality field columns shouldn't be empty when configuring to use UPSERT data.");
-
-                          Preconditions.checkArgument(
-                              !(TableUtil.formatVersion(table) > 2),
-                              "Dynamic Sink writer does not support upsert mode in tables (V3+)");
 
                           if (!table.spec().isUnpartitioned()) {
                             for (PartitionField partitionField : table.spec().fields()) {

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -43,6 +43,9 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableUtil;
+import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
@@ -313,6 +316,140 @@ class TestDynamicCommitter {
 
     // Old commits requests shouldn't affect the result
     dynamicCommitter.commit(Sets.newHashSet(oldCommitRequest));
+
+    table1.refresh();
+    assertThat(table1.snapshots()).hasSize(1);
+    Snapshot first = Iterables.getFirst(table1.snapshots(), null);
+    assertThat(first.summary())
+        .containsAllEntriesOf(
+            ImmutableMap.<String, String>builder()
+                .put("added-data-files", "1")
+                .put("added-records", "42")
+                .put("changed-partition-count", "1")
+                .put("flink.job-id", jobId)
+                .put("flink.max-committed-checkpoint-id", "" + checkpointId)
+                .put("flink.operator-id", operatorId)
+                .put("total-data-files", "1")
+                .put("total-delete-files", "0")
+                .put("total-equality-deletes", "0")
+                .put("total-files-size", "0")
+                .put("total-position-deletes", "0")
+                .put("total-records", "42")
+                .build());
+  }
+
+  @Test
+  void testCommitDeleteInDifferentFormatVersion() throws Exception {
+    Table table1 = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table1.snapshots()).isEmpty();
+
+    boolean overwriteMode = false;
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+    DynamicCommitter dynamicCommitter =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    WriteTarget writeTarget =
+        new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    final String jobId = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int checkpointId = 10;
+
+    byte[] deltaManifest =
+        aggregator.writeToManifest(
+            writeTarget,
+            Sets.newHashSet(
+                new DynamicWriteResult(
+                    writeTarget,
+                    WriteResult.builder()
+                        .addDataFiles(DATA_FILE)
+                        .addDeleteFiles(DELETE_FILE)
+                        .build())),
+            checkpointId);
+
+    CommitRequest<DynamicCommittable> commitRequest =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget, deltaManifest, jobId, operatorId, checkpointId));
+
+    // Upgrade the table version
+    UpdateProperties updateApi = table1.updateProperties();
+    updateApi.set(
+        TableProperties.FORMAT_VERSION, String.valueOf(TableUtil.formatVersion(table1) + 1));
+    updateApi.commit();
+
+    assertThatThrownBy(() -> dynamicCommitter.commit(Sets.newHashSet(commitRequest)))
+        .hasMessage(
+            "Can't add position delete file to the %s table. Concurrent table upgrade to V3 is not supported.",
+            table1.name())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testCommitOnlyDataInDifferentFormatVersion() throws Exception {
+    Table table1 = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table1.snapshots()).isEmpty();
+
+    boolean overwriteMode = false;
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+    DynamicCommitter dynamicCommitter =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    WriteTarget writeTarget =
+        new WriteTarget(TABLE1, "branch", 42, 0, false, Sets.newHashSet(1, 2));
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    final String jobId = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int checkpointId = 10;
+
+    byte[] deltaManifest =
+        aggregator.writeToManifest(
+            writeTarget,
+            Sets.newHashSet(
+                new DynamicWriteResult(
+                    writeTarget, WriteResult.builder().addDataFiles(DATA_FILE).build())),
+            checkpointId);
+
+    CommitRequest<DynamicCommittable> commitRequest =
+        new MockCommitRequest<>(
+            new DynamicCommittable(writeTarget, deltaManifest, jobId, operatorId, checkpointId));
+
+    dynamicCommitter.commit(Sets.newHashSet(commitRequest));
+
+    // Upgrade the table version
+    UpdateProperties updateApi = table1.updateProperties();
+    updateApi.set(
+        TableProperties.FORMAT_VERSION, String.valueOf(TableUtil.formatVersion(table1) + 1));
+    updateApi.commit();
 
     table1.refresh();
     assertThat(table1.snapshots()).hasSize(1);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.IcebergGenerics;
@@ -73,6 +74,7 @@ import org.apache.iceberg.flink.sink.dynamic.TestDynamicCommitter.FailBeforeAndA
 import org.apache.iceberg.inmemory.InMemoryInputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -519,6 +521,209 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
       assertThat(actual.get(0)).isEqualTo(input.rowProvided.getField(0));
       assertThat(actual.get(1)).isEqualTo(input.rowProvided.getField(1));
       // There is an additional _pos field which gets added
+    }
+  }
+
+  @Test
+  void testUpsertV3() throws Exception {
+    ImmutableMap<String, String> properties = ImmutableMap.of(TableProperties.FORMAT_VERSION, "3");
+    CATALOG_EXTENSION
+        .catalog()
+        .createTable(
+            TableIdentifier.of(DATABASE, "t1"),
+            SimpleDataUtil.SCHEMA,
+            PartitionSpec.unpartitioned(),
+            null,
+            properties);
+
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            // Insert one rows
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                false),
+            // Remaining rows are duplicates
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true));
+
+    executeDynamicSink(rows, env, true, 1, null);
+
+    try (CloseableIterable<Record> iterable =
+        IcebergGenerics.read(
+                CATALOG_EXTENSION.catalog().loadTable(TableIdentifier.of("default", "t1")))
+            .build()) {
+      List<Record> records = Lists.newArrayList();
+      for (Record record : iterable) {
+        records.add(record);
+      }
+
+      assertThat(records).hasSize(1);
+      Record actual = records.get(0);
+      DynamicIcebergDataImpl input = rows.get(0);
+      assertThat(actual.get(0)).isEqualTo(input.rowProvided.getField(0));
+      assertThat(actual.get(1)).isEqualTo(input.rowProvided.getField(1));
+    }
+  }
+
+  @Test
+  void testMultiFormatVersion() throws Exception {
+    ImmutableMap<String, String> properties = ImmutableMap.of(TableProperties.FORMAT_VERSION, "3");
+    CATALOG_EXTENSION
+        .catalog()
+        .createTable(
+            TableIdentifier.of(DATABASE, "t1"),
+            SimpleDataUtil.SCHEMA,
+            PartitionSpec.unpartitioned(),
+            null,
+            properties);
+
+    ImmutableMap<String, String> properties1 = ImmutableMap.of(TableProperties.FORMAT_VERSION, "2");
+    CATALOG_EXTENSION
+        .catalog()
+        .createTable(
+            TableIdentifier.of(DATABASE, "t2"),
+            SimpleDataUtil.SCHEMA,
+            PartitionSpec.unpartitioned(),
+            null,
+            properties1);
+
+    List<DynamicIcebergDataImpl> rowsForTable1 =
+        Lists.newArrayList(
+            // Insert one rows
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                false),
+            // Remaining rows are duplicates
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true));
+
+    List<DynamicIcebergDataImpl> rowsForTable2 =
+        Lists.newArrayList(
+            // Insert one rows
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t2",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                false),
+            // Remaining rows are duplicates
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t2",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t2",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                "t2",
+                "main",
+                PartitionSpec.unpartitioned(),
+                true,
+                Sets.newHashSet("id"),
+                true));
+
+    List<DynamicIcebergDataImpl> rows = Lists.newArrayList();
+    rows.addAll(rowsForTable1);
+    rows.addAll(rowsForTable2);
+
+    executeDynamicSink(rows, env, true, 1, null);
+
+    try (CloseableIterable<Record> iterable =
+        IcebergGenerics.read(
+                CATALOG_EXTENSION.catalog().loadTable(TableIdentifier.of("default", "t1")))
+            .build()) {
+      List<Record> records = Lists.newArrayList();
+      for (Record record : iterable) {
+        records.add(record);
+      }
+
+      assertThat(records).hasSize(1);
+      Record actual = records.get(0);
+      DynamicIcebergDataImpl input = rowsForTable1.get(0);
+      assertThat(actual.get(0)).isEqualTo(input.rowProvided.getField(0));
+      assertThat(actual.get(1)).isEqualTo(input.rowProvided.getField(1));
+    }
+
+    try (CloseableIterable<Record> iterable =
+        IcebergGenerics.read(
+                CATALOG_EXTENSION.catalog().loadTable(TableIdentifier.of("default", "t2")))
+            .build()) {
+      List<Record> records = Lists.newArrayList();
+      for (Record record : iterable) {
+        records.add(record);
+      }
+
+      assertThat(records).hasSize(1);
+      Record actual = records.get(0);
+      DynamicIcebergDataImpl input = rowsForTable2.get(0);
+      assertThat(actual.get(0)).isEqualTo(input.rowProvided.getField(0));
+      assertThat(actual.get(1)).isEqualTo(input.rowProvided.getField(1));
     }
   }
 


### PR DESCRIPTION
This is a clearn backport for https://github.com/apache/iceberg/pull/14414 to Flink 1.20 and 2.0