### PR TITLE
SPEC: Mark plan-id as required for submitted status

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -981,8 +981,8 @@ class FailedPlanningResult(IcebergErrorResponse):
 
 class AsyncPlanningResult(BaseModel):
     status: Literal['submitted'] = Field(..., const=True)
-    plan_id: Optional[str] = Field(
-        None, alias='plan-id', description='ID used to track a planning request'
+    plan_id: str = Field(
+        ..., alias='plan-id', description='ID used to track a planning request'
     )
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3400,6 +3400,7 @@ components:
       type: object
       required:
         - status
+        - plan-id
       properties:
         status:
           $ref: '#/components/schemas/PlanStatus'


### PR DESCRIPTION
### About the change 

Spec clearly calls out that when async planning is happening and its a submitted status the /plan should respond with a plan-id so plan-id in this case is not optional hence marking the same in spec 

https://github.com/apache/iceberg/blob/4ee507d5788e31c74d5ef77204ef126ae0105981/open-api/rest-catalog-open-api.yaml#L633-L634


Not sure if we require vote for this it seems like a miss IMHO 