### PR TITLE
REST: Mark plan-id as required on CompletedPlanningWithIDResult result

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1506,8 +1506,8 @@ class ReportMetricsRequest1(ScanReport):
 
 
 class CompletedPlanningWithIDResult(CompletedPlanningResult):
-    plan_id: Optional[str] = Field(
-        None, alias='plan-id', description='ID used to track a planning request'
+    plan_id: str = Field(
+        ..., alias='plan-id', description='ID used to track a planning request'
     )
     status: Literal['completed']
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3385,6 +3385,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/CompletedPlanningResult'
         - type: object
+          required:
+            - plan-id
           properties:
             plan-id:
               description: ID used to track a planning request


### PR DESCRIPTION
### About the change 

CompletedPlanningWithIDResult should have plan-id as required as it literally says its CompletedPlanningWithIDResult, this is intentionally required because this is where the server sends the client the plan-id irrespective the state is submitted / completed which can be used the client later for the cancel API call. 

This came up while coding this https://github.com/apache/iceberg/pull/14629. 

https://github.com/apache/iceberg/blob/4ee507d5788e31c74d5ef77204ef126ae0105981/open-api/rest-catalog-open-api.yaml#L3454

Not sure if we need a vote for this as this seems like a miss.