### PR TITLE
rewrite_position_delete_files failure on tables with non-primitive partition fields

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -740,7 +740,12 @@ public class ExpressionUtil {
     PartitionSpec.Builder specBuilder = PartitionSpec.builderFor(schema);
 
     for (int id : ids) {
-      specBuilder.identity(schema.findColumnName(id));
+      Type fieldType = schema.findType(id);
+      // Only add identity partitions for primitive types to avoid validation errors
+      // Non-primitive types (list, map, struct) cannot be used as partition fields
+      if (fieldType != null && fieldType.isPrimitiveType()) {
+        specBuilder.identity(schema.findColumnName(id));
+      }
     }
 
     return specBuilder.build();


### PR DESCRIPTION
rewrite_position_delete_files failure on tables with partition evolution containing non-primitive types. The fix filters out list/map/struct types in ExpressionUtil.identitySpec() to prevent ValidationException during partition spec validation.


fixes https://github.com/apache/iceberg/issues/14619