### PR TITLE
SPEC: Make plan status consistent

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -982,11 +982,11 @@ class FailedPlanningResult(IcebergErrorResponse):
     Failed server-side planning result
     """
 
-    status: Literal['failed'] = Field(..., const=True)
+    plan_status: Literal['failed'] = Field(..., alias='plan-status', const=True)
 
 
 class AsyncPlanningResult(BaseModel):
-    status: Literal['submitted'] = Field(..., const=True)
+    plan_status: Literal['submitted'] = Field(..., alias='plan-status', const=True)
     plan_id: Optional[str] = Field(
         None, alias='plan-id', description='ID used to track a planning request'
     )
@@ -997,7 +997,7 @@ class EmptyPlanningResult(BaseModel):
     Empty server-side planning result
     """
 
-    status: Literal['cancelled']
+    plan_status: Literal['cancelled'] = Field(..., alias='plan-status')
 
 
 class ReportMetricsRequest2(CommitReport):
@@ -1330,7 +1330,7 @@ class FetchPlanningResult(BaseModel):
     ] = Field(
         ...,
         description='Result of server-side scan planning for fetchPlanningResult',
-        discriminator='status',
+        discriminator='plan_status',
     )
 
 
@@ -1343,7 +1343,7 @@ class PlanTableScanResult(BaseModel):
     ] = Field(
         ...,
         description='Result of server-side scan planning for planTableScan',
-        discriminator='status',
+        discriminator='plan_status',
     )
 
 
@@ -1498,7 +1498,7 @@ class CompletedPlanningResult(ScanTasks):
     Completed server-side planning result
     """
 
-    status: Literal['completed'] = Field(..., const=True)
+    plan_status: Literal['completed'] = Field(..., alias='plan-status', const=True)
 
 
 class FetchScanTasksResult(ScanTasks):
@@ -1515,7 +1515,7 @@ class CompletedPlanningWithIDResult(CompletedPlanningResult):
     plan_id: Optional[str] = Field(
         None, alias='plan-id', description='ID used to track a planning request'
     )
-    status: Literal['completed']
+    plan_status: Literal['completed'] = Field(..., alias='plan-status')
 
 
 StructField.update_forward_refs()

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3439,9 +3439,9 @@ components:
         - $ref: '#/components/schemas/ScanTasks'
         - type: object
           required:
-            - status
+            - plan-status
           properties:
-            status:
+            plan-status:
               $ref: '#/components/schemas/PlanStatus'
               const: "completed"
 
@@ -3462,18 +3462,18 @@ components:
         - $ref: '#/components/schemas/IcebergErrorResponse'
         - type: object
           required:
-            - status
+            - plan-status
           properties:
-            status:
+            plan-status:
               $ref: '#/components/schemas/PlanStatus'
               const: "failed"
 
     AsyncPlanningResult:
       type: object
       required:
-        - status
+        - plan-status
       properties:
-        status:
+        plan-status:
           $ref: '#/components/schemas/PlanStatus'
           const: "submitted"
         plan-id:
@@ -3484,9 +3484,9 @@ components:
       type: object
       description: Empty server-side planning result
       required:
-        - status
+        - plan-status
       properties:
-        status:
+        plan-status:
           $ref: '#/components/schemas/PlanStatus'
           enum: ["submitted", "cancelled"]
 
@@ -3499,7 +3499,7 @@ components:
       type: object
       description: Result of server-side scan planning for fetchPlanningResult
       discriminator:
-        propertyName: status
+        propertyName: plan-status
         mapping:
           completed: '#/components/schemas/CompletedPlanningResult'
           submitted: '#/components/schemas/EmptyPlanningResult'
@@ -3514,7 +3514,7 @@ components:
       type: object
       description: Result of server-side scan planning for planTableScan
       discriminator:
-        propertyName: status
+        propertyName: plan-status
         mapping:
           completed: '#/components/schemas/CompletedPlanningWithIDResult'
           submitted: '#/components/schemas/AsyncPlanningResult'


### PR DESCRIPTION
### About the change

Fixes https://github.com/apache/iceberg/issues/14632

considering we have plan-id and plan-task, plan-status seems reasonable, I can now think how this confusion arised when i was implementing

I am open to updating the implementation too considering 1.10.1 window is open 

