### PR TITLE
Core: Make plan status consistent with the SPEC

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponseParser.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.rest.TableScanResponseParser;
 import org.apache.iceberg.util.JsonUtil;
 
 public class FetchPlanningResultResponseParser {
-  private static final String PLAN_STATUS = "plan-status";
+  private static final String STATUS = "status";
   private static final String PLAN_TASKS = "plan-tasks";
 
   private FetchPlanningResultResponseParser() {}
@@ -54,7 +54,7 @@ public class FetchPlanningResultResponseParser {
             || (response.fileScanTasks() == null || response.fileScanTasks().isEmpty()),
         "Cannot serialize fileScanTasks in fetchingPlanningResultResponse without specsById");
     gen.writeStartObject();
-    gen.writeStringField(PLAN_STATUS, response.planStatus().status());
+    gen.writeStringField(STATUS, response.planStatus().status());
     if (response.planTasks() != null) {
       JsonUtil.writeStringArray(PLAN_TASKS, response.planTasks(), gen);
     }
@@ -77,7 +77,7 @@ public class FetchPlanningResultResponseParser {
     Preconditions.checkArgument(
         json != null && !json.isEmpty(), "Invalid fetchPlanningResult response: null or empty");
 
-    PlanStatus planStatus = PlanStatus.fromName(JsonUtil.getString(PLAN_STATUS, json));
+    PlanStatus planStatus = PlanStatus.fromName(JsonUtil.getString(STATUS, json));
     List<String> planTasks = JsonUtil.getStringListOrNull(PLAN_TASKS, json);
     List<DeleteFile> deleteFiles = TableScanResponseParser.parseDeleteFiles(json, specsById);
     List<FileScanTask> fileScanTasks =

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponseParser.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.rest.TableScanResponseParser;
 import org.apache.iceberg.util.JsonUtil;
 
 public class PlanTableScanResponseParser {
-  private static final String PLAN_STATUS = "plan-status";
+  private static final String STATUS = "status";
   private static final String PLAN_ID = "plan-id";
   private static final String PLAN_TASKS = "plan-tasks";
 
@@ -55,7 +55,7 @@ public class PlanTableScanResponseParser {
         response.specsById() != null, "Cannot serialize planTableScanResponse without specsById");
 
     gen.writeStartObject();
-    gen.writeStringField(PLAN_STATUS, response.planStatus().status());
+    gen.writeStringField(STATUS, response.planStatus().status());
 
     if (response.planId() != null) {
       gen.writeStringField(PLAN_ID, response.planId());
@@ -85,7 +85,7 @@ public class PlanTableScanResponseParser {
         json != null && !json.isEmpty(),
         "Cannot parse planTableScan response from empty or null object");
 
-    PlanStatus planStatus = PlanStatus.fromName(JsonUtil.getString(PLAN_STATUS, json));
+    PlanStatus planStatus = PlanStatus.fromName(JsonUtil.getString(STATUS, json));
     String planId = JsonUtil.getStringOrNull(PLAN_ID, json);
     List<String> planTasks = JsonUtil.getStringListOrNull(PLAN_TASKS, json);
     List<DeleteFile> deleteFiles = TableScanResponseParser.parseDeleteFiles(json, specsById);

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
@@ -92,7 +92,7 @@ public class TestFetchPlanningResultResponseParser {
 
   @Test
   public void roundTripSerdeWithInvalidPlanStatus() {
-    String invalidStatusJson = "{\"plan-status\": \"someStatus\"}";
+    String invalidStatusJson = "{\"status\": \"someStatus\"}";
     assertThatThrownBy(
             () ->
                 FetchPlanningResultResponseParser.fromJson(
@@ -107,7 +107,7 @@ public class TestFetchPlanningResultResponseParser {
     FetchPlanningResultResponse response =
         FetchPlanningResultResponse.builder().withPlanStatus(planStatus).build();
 
-    String expectedJson = "{\"plan-status\":\"submitted\"}";
+    String expectedJson = "{\"status\":\"submitted\"}";
     String json = FetchPlanningResultResponseParser.toJson(response);
     assertThat(json).isEqualTo(expectedJson);
 
@@ -128,8 +128,7 @@ public class TestFetchPlanningResultResponseParser {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid response: tasks can only be returned in a 'completed' status");
 
-    String invalidJson =
-        "{\"plan-status\":\"submitted\"," + "\"plan-tasks\":[\"task1\",\"task2\"]}";
+    String invalidJson = "{\"status\":\"submitted\"," + "\"plan-tasks\":[\"task1\",\"task2\"]}";
 
     assertThatThrownBy(
             () ->
@@ -155,7 +154,7 @@ public class TestFetchPlanningResultResponseParser {
             "Invalid response: deleteFiles should only be returned with fileScanTasks that reference them");
 
     String invalidJson =
-        "{\"plan-status\":\"submitted\","
+        "{\"status\":\"submitted\","
             + "\"delete-files\":[{\"spec-id\":0,\"content\":\"POSITION_DELETES\","
             + "\"file-path\":\"/path/to/data-a-deletes.parquet\",\"file-format\":\"PARQUET\","
             + "\"partition\":{\"1000\":0},\"file-size-in-bytes\":10,\"record-count\":1}]"
@@ -193,7 +192,7 @@ public class TestFetchPlanningResultResponseParser {
             .build();
 
     String expectedToJson =
-        "{\"plan-status\":\"completed\","
+        "{\"status\":\"completed\","
             + "\"delete-files\":[{\"spec-id\":0,\"content\":\"POSITION_DELETES\","
             + "\"file-path\":\"/path/to/data-a-deletes.parquet\",\"file-format\":\"PARQUET\","
             + "\"partition\":{\"1000\":0},\"file-size-in-bytes\":10,\"record-count\":1}],"

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -78,7 +78,7 @@ public class TestPlanTableScanResponseParser {
     assertThat(response.planStatus()).isEqualTo(PlanStatus.COMPLETED);
     assertThat(response.planId()).isNull();
     assertThat(PlanTableScanResponseParser.toJson(response))
-        .isEqualTo("{\"plan-status\":\"completed\"}");
+        .isEqualTo("{\"status\":\"completed\"}");
 
     response =
         PlanTableScanResponse.builder()
@@ -90,7 +90,7 @@ public class TestPlanTableScanResponseParser {
     assertThat(response.planId()).isEqualTo("somePlanId");
 
     assertThat(PlanTableScanResponseParser.toJson(response))
-        .isEqualTo("{\"plan-status\":\"completed\",\"plan-id\":\"somePlanId\"}");
+        .isEqualTo("{\"status\":\"completed\",\"plan-id\":\"somePlanId\"}");
   }
 
   @Test
@@ -104,12 +104,12 @@ public class TestPlanTableScanResponseParser {
     assertThat(response.planStatus()).isEqualTo(PlanStatus.SUBMITTED);
     assertThat(response.planId()).isEqualTo("somePlanId");
     assertThat(PlanTableScanResponseParser.toJson(response))
-        .isEqualTo("{\"plan-status\":\"submitted\",\"plan-id\":\"somePlanId\"}");
+        .isEqualTo("{\"status\":\"submitted\",\"plan-id\":\"somePlanId\"}");
   }
 
   @Test
   public void roundTripSerdeWithInvalidPlanStatus() {
-    String invalidStatusJson = "{\"plan-status\": \"someStatus\"}";
+    String invalidStatusJson = "{\"status\": \"someStatus\"}";
     assertThatThrownBy(
             () ->
                 PlanTableScanResponseParser.fromJson(
@@ -125,7 +125,7 @@ public class TestPlanTableScanResponseParser {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid response: plan id should be defined when status is 'submitted'");
 
-    String invalidJson = "{\"plan-status\":\"submitted\"}";
+    String invalidJson = "{\"status\":\"submitted\"}";
     assertThatThrownBy(
             () -> PlanTableScanResponseParser.fromJson(invalidJson, PARTITION_SPECS_BY_ID, false))
         .isInstanceOf(IllegalArgumentException.class)
@@ -139,7 +139,7 @@ public class TestPlanTableScanResponseParser {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid response: 'cancelled' is not a valid status for planTableScan");
 
-    String invalidJson = "{\"plan-status\":\"cancelled\"}";
+    String invalidJson = "{\"status\":\"cancelled\"}";
     assertThatThrownBy(
             () -> PlanTableScanResponseParser.fromJson(invalidJson, PARTITION_SPECS_BY_ID, false))
         .isInstanceOf(IllegalArgumentException.class)
@@ -159,7 +159,7 @@ public class TestPlanTableScanResponseParser {
         .hasMessage("Invalid response: tasks can only be defined when status is 'completed'");
 
     String invalidJson =
-        "{\"plan-status\":\"submitted\","
+        "{\"status\":\"submitted\","
             + "\"plan-id\":\"somePlanId\","
             + "\"plan-tasks\":[\"task1\",\"task2\"]}";
 
@@ -181,7 +181,7 @@ public class TestPlanTableScanResponseParser {
         .hasMessage(
             "Invalid response: plan id can only be defined when status is 'submitted' or 'completed'");
 
-    String invalidJson = "{\"plan-status\":\"failed\"," + "\"plan-id\":\"somePlanId\"}";
+    String invalidJson = "{\"status\":\"failed\"," + "\"plan-id\":\"somePlanId\"}";
 
     assertThatThrownBy(
             () -> PlanTableScanResponseParser.fromJson(invalidJson, PARTITION_SPECS_BY_ID, false))
@@ -204,7 +204,7 @@ public class TestPlanTableScanResponseParser {
             "Invalid response: deleteFiles should only be returned with fileScanTasks that reference them");
 
     String invalidJson =
-        "{\"plan-status\":\"submitted\","
+        "{\"status\":\"submitted\","
             + "\"plan-id\":\"somePlanId\","
             + "\"delete-files\":[{\"spec-id\":0,\"content\":\"POSITION_DELETES\","
             + "\"file-path\":\"/path/to/data-a-deletes.parquet\",\"file-format\":\"PARQUET\","
@@ -239,7 +239,7 @@ public class TestPlanTableScanResponseParser {
             .build();
 
     String expectedToJson =
-        "{\"plan-status\":\"completed\","
+        "{\"status\":\"completed\","
             + "\"delete-files\":[{\"spec-id\":0,\"content\":\"POSITION_DELETES\","
             + "\"file-path\":\"/path/to/data-a-deletes.parquet\",\"file-format\":\"PARQUET\","
             + "\"partition\":{\"1000\":0},\"file-size-in-bytes\":10,\"record-count\":1}],"
@@ -309,7 +309,7 @@ public class TestPlanTableScanResponseParser {
 
     String expectedJson =
         "{\n"
-            + "  \"plan-status\" : \"completed\",\n"
+            + "  \"status\" : \"completed\",\n"
             + "  \"delete-files\" : [ {\n"
             + "    \"spec-id\" : 0,\n"
             + "    \"content\" : \"POSITION_DELETES\",\n"
@@ -415,7 +415,7 @@ public class TestPlanTableScanResponseParser {
             .build();
 
     String expectedJson =
-        "{\"plan-status\":\"completed\","
+        "{\"status\":\"completed\","
             + "\"file-scan-tasks\":["
             + "{\"data-file\":{\"spec-id\":0,\"content\":\"DATA\",\"file-path\":\"/path/to/data-a.parquet\","
             + "\"file-format\":\"PARQUET\",\"partition\":{\"1000\":0},"


### PR DESCRIPTION
### About the change 

Fixes https://github.com/apache/iceberg/issues/14632

considering we have plan-id and plan-task, plan-status seems reasonable but there are clients like duck-db out there 
https://github.com/duckdb/duckdb-iceberg/blob/main/src/rest_catalog/objects/completed_planning_result.cpp#L31 which will break if we do this so fixing java impl is only choice here.

I will put a code for 1.10.1 cherry pick too. 

### Test 

updated existing test