### PR TITLE
Core: Wrong reported length of encrypted Puffin files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinWriter.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinWriter.java
@@ -143,6 +143,8 @@ public class PuffinWriter implements FileAppender<Blob> {
     writeFooter();
     this.footerSize = Optional.of(Math.toIntExact(outputStream.getPos() - footerOffset));
     outputStream.close();
+    // some streams (e.g. AesGcmOutputStream) may only write the last bytes upon
+    // having close() invoked
     this.fileSize = Optional.of(outputStream.storedLength());
     this.finished = true;
   }

--- a/core/src/test/java/org/apache/iceberg/puffin/TestPuffinWriter.java
+++ b/core/src/test/java/org/apache/iceberg/puffin/TestPuffinWriter.java
@@ -39,7 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestPuffinWriter {
 
@@ -99,8 +99,8 @@ public class TestPuffinWriter {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testFileSizeCalculation(boolean isEncrypted) throws Exception {
+  @CsvSource({"true, 158", "false, 122"})
+  public void testFileSizeCalculation(boolean isEncrypted, long expectedSize) throws Exception {
     final OutputFile outputFile;
 
     if (isEncrypted) {
@@ -126,7 +126,7 @@ public class TestPuffinWriter {
             null,
             ImmutableMap.of()));
     writer.close();
-    assertThat(writer.length()).isEqualTo(isEncrypted ? 158L : 122L);
+    assertThat(writer.length()).isEqualTo(expectedSize);
   }
 
   private void testWriteMetric(PuffinCompressionCodec compression, String expectedResource)


### PR DESCRIPTION
Manifest files made for puffin files track the size
of new files as `PuffinWriter#length()`.
The underlying PositionOutputStream provides this
as `getPos()`, but for encrypted files this is not the
true file length, rather the unencrypted content length.

Calling `storedLength()` reveals the true file size, but
the OutputStream must be closed first before such
an invocation. Since a PuffinWriter provides a `finish()`
method, I refactored calling `close()` into there.

Tested locally and with UT.