### PR TITLE
Refactor SnapshotAncestryValidator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotAncestryValidator.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotAncestryValidator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg;
 
-import java.util.function.Function;
 import javax.annotation.Nonnull;
 
 /**
@@ -28,7 +27,7 @@ import javax.annotation.Nonnull;
  * table state.
  */
 @FunctionalInterface
-public interface SnapshotAncestryValidator extends Function<Iterable<Snapshot>, Boolean> {
+public interface SnapshotAncestryValidator {
 
   SnapshotAncestryValidator NON_VALIDATING = baseSnapshots -> true;
 
@@ -38,8 +37,7 @@ public interface SnapshotAncestryValidator extends Function<Iterable<Snapshot>, 
    * @param baseSnapshots ancestry of the base table metadata snapshots
    * @return boolean for whether the update is valid
    */
-  @Override
-  Boolean apply(Iterable<Snapshot> baseSnapshots);
+  boolean validate(Iterable<Snapshot> baseSnapshots);
 
   /**
    * Validation message that will be included when throwing {@link

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -354,7 +354,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             ? SnapshotUtil.ancestorsOf(parentSnapshot.snapshotId(), base::snapshot)
             : List.of();
 
-    boolean valid = snapshotAncestryValidator.apply(snapshotAncestry);
+    boolean valid = snapshotAncestryValidator.validate(snapshotAncestry);
     ValidationException.check(
         valid, "Snapshot ancestry validation failed: %s", snapshotAncestryValidator.errorMessage());
   }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
@@ -95,7 +95,7 @@ public class TestSnapshotProducer extends TestBase {
     SnapshotAncestryValidator validator =
         new SnapshotAncestryValidator() {
           @Override
-          public Boolean apply(Iterable<Snapshot> baseSnapshots) {
+          public boolean validate(Iterable<Snapshot> baseSnapshots) {
             return false;
           }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -369,7 +369,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     }
 
     @Override
-    public Boolean apply(Iterable<Snapshot> baseSnapshots) {
+    public boolean validate(Iterable<Snapshot> baseSnapshots) {
       long maxCommittedCheckpointId =
           getMaxCommittedCheckpointId(baseSnapshots, flinkJobId, flinkOperatorId);
       if (maxCommittedCheckpointId >= stagedCheckpointId) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -369,7 +369,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     }
 
     @Override
-    public Boolean apply(Iterable<Snapshot> baseSnapshots) {
+    public boolean validate(Iterable<Snapshot> baseSnapshots) {
       long maxCommittedCheckpointId =
           getMaxCommittedCheckpointId(baseSnapshots, flinkJobId, flinkOperatorId);
       if (maxCommittedCheckpointId >= stagedCheckpointId) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -369,7 +369,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     }
 
     @Override
-    public Boolean apply(Iterable<Snapshot> baseSnapshots) {
+    public boolean validate(Iterable<Snapshot> baseSnapshots) {
       long maxCommittedCheckpointId =
           getMaxCommittedCheckpointId(baseSnapshots, flinkJobId, flinkOperatorId);
       if (maxCommittedCheckpointId >= stagedCheckpointId) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -308,7 +308,7 @@ class Coordinator extends Channel {
       private Map<Integer, Long> lastCommittedOffsets;
 
       @Override
-      public Boolean apply(Iterable<Snapshot> baseSnapshots) {
+      public boolean validate(Iterable<Snapshot> baseSnapshots) {
         lastCommittedOffsets = lastCommittedOffsets(baseSnapshots);
 
         return expectedOffsets.equals(lastCommittedOffsets);


### PR DESCRIPTION
Simplify the return type to a primitive boolean by removing the `Function` interface.
Change the interface name to `validate()` instead of `apply()`.