### PR TITLE
Metrics: Allow callers to configure metrics reporter on ScanBuilder

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.MetricsReporter;
 
 public class IcebergGenerics {
   private IcebergGenerics() {}
@@ -93,6 +94,11 @@ public class IcebergGenerics {
 
     public ScanBuilder appendsAfter(long fromSnapshotId) {
       this.tableScan = tableScan.appendsAfter(fromSnapshotId);
+      return this;
+    }
+
+    public ScanBuilder metricsReporter(MetricsReporter reporter) {
+      this.tableScan = tableScan.metricsReporter(reporter);
       return this;
     }
 


### PR DESCRIPTION
The `ScanBuilder` class encapsulates the underlying `TableScan` created from the `Table`, preventing callers from configuring how metrics are reported. Here is a simple way I envision this new method being used:
```
        MetricsReporter metricsReporter = new InMemoryMetricsReporter();
        ScanBuilder scanBuilder = IcebergGenerics.read(table);
        scanBuilder.metricsReporter(metricsReporter);
        // finish building scan and read data

        ScanReport scanReport = metricsReporter.scanReport();
        // use scan report to wire telemetry and log details