### PR TITLE
Core: Align PlanTableScanRequest filter with OpenAPI spec

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequestParser.java
@@ -79,7 +79,8 @@ public class PlanTableScanRequestParser {
     }
 
     if (request.filter() != null) {
-      gen.writeStringField(FILTER, ExpressionParser.toJson(request.filter()));
+      gen.writeFieldName(FILTER);
+      ExpressionParser.toJson(request.filter(), gen);
     }
 
     gen.writeBooleanField(CASE_SENSITIVE, request.caseSensitive());
@@ -111,7 +112,7 @@ public class PlanTableScanRequestParser {
 
     Expression filter = null;
     if (json.has(FILTER)) {
-      filter = ExpressionParser.fromJson(json.get(FILTER).textValue());
+      filter = ExpressionParser.fromJson(json.get(FILTER));
     }
 
     boolean caseSensitive = true;

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestPlanTableScanRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestPlanTableScanRequestParser.java
@@ -132,7 +132,7 @@ public class TestPlanTableScanRequestParser {
 
     String expectedJson =
         "{\"snapshot-id\":1,"
-            + "\"filter\":\"false\","
+            + "\"filter\":false,"
             + "\"case-sensitive\":true,"
             + "\"use-snapshot-schema\":false}";
 
@@ -219,7 +219,7 @@ public class TestPlanTableScanRequestParser {
         "{\"start-snapshot-id\":1,"
             + "\"end-snapshot-id\":2,"
             + "\"select\":[\"col1\",\"col2\"],"
-            + "\"filter\":\"true\","
+            + "\"filter\":true,"
             + "\"case-sensitive\":false,"
             + "\"use-snapshot-schema\":true,"
             + "\"stats-fields\":[\"col1\",\"col2\"],"
@@ -253,5 +253,34 @@ public class TestPlanTableScanRequestParser {
         .contains("useSnapshotSchema=true")
         .contains("statsFields=[stat1]")
         .contains("minRowsRequested=23");
+  }
+
+  @Test
+  public void roundTripSerdeWithFilterExpression() {
+    PlanTableScanRequest request =
+        PlanTableScanRequest.builder()
+            .withSnapshotId(1L)
+            .withFilter(Expressions.equal("id", 1))
+            .build();
+
+    String expectedJson =
+        "{\"snapshot-id\":1,"
+            + "\"filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1},"
+            + "\"case-sensitive\":true,"
+            + "\"use-snapshot-schema\":false}";
+
+    String json = PlanTableScanRequestParser.toJson(request, false);
+    assertThat(json).isEqualTo(expectedJson);
+    assertThat(PlanTableScanRequestParser.toJson(PlanTableScanRequestParser.fromJson(json), false))
+        .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void testFilterFieldWithExplicitNullThrowsError() {
+    String json = "{\"snapshot-id\":123,\"filter\":null,\"case-sensitive\":true}";
+
+    assertThatThrownBy(() -> PlanTableScanRequestParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse expression from non-object: null");
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes the parser to accept the correct JSON object format per the [OpenAPI specification](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L4486-L4489). While working on integrating server-side scanning in PyIceberg, I noticed that the `filter` field in `PlanTableScanRequest` was expecting a string representation of the expression rather than the Expression object defined in the OpenAPI spec.

For instance, to get a scan to work today, we need to supply the filter as a string:

```
{
    "snapshot-id": 2540284336700708540,
    "filter": "{\"type\":\"lt-eq\",\"term\":\"id\",\"value\":200000}",
    "case-sensitive": true
}
```

But this throws an error:

```
{
    "snapshot-id": 2540284336700708540,
    "filter": {
        "type": "lt-eq",
        "term": "id",
        "value": 200000
    },
    "case-sensitive": true
}
```

Error:

```
java.lang.IllegalArgumentException: argument &quot;content&quot; is null
```

## Testing 

Updated existing tests and added new tests to validte filter expressions serialize/deserialize correctly as JSON objects.

cc: @singhpk234 @amogh-jahagirdar 