### PR TITLE
OpenAPI, Test: RCK is not aware of some test namespaces

### DIFF
--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RCKUtils.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RCKUtils.java
@@ -37,7 +37,24 @@ class RCKUtils {
   static final String RCK_LOCAL = "rck.local";
   static final String RCK_PURGE_TEST_NAMESPACES = "rck.purge-test-namespaces";
 
-  static final List<Namespace> TEST_NAMESPACES = List.of(Namespace.of("ns"), Namespace.of("newdb"));
+  static final List<Namespace> TEST_NAMESPACES =
+      List.of(
+          Namespace.empty(),
+          Namespace.of("a"),
+          Namespace.of("ns"),
+          Namespace.of("ns1"),
+          Namespace.of("ns2"),
+          Namespace.of("ns_1"),
+          Namespace.of("ns_2"),
+          Namespace.of("newdb"),
+          Namespace.of("newdb_1"),
+          Namespace.of("newdb_2"),
+          Namespace.of("other_ns"),
+          Namespace.of("parent"),
+          Namespace.of("parent", "child1"),
+          Namespace.of("parent", "child2"),
+          Namespace.of("new/db"),
+          Namespace.of("new.db"));
 
   private RCKUtils() {}
 


### PR DESCRIPTION
RCKUtils lists all namespaces used in the integration test suite. The list is used for two purposes: (1) [the reference integration tests](https://github.com/apache/iceberg/blob/8b55ac834015ce664f879ecfe1e80a941a994420/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java#L43-L45) assert those namespaces don't exist at the beginning and (2) [RCKUtils.purgeCatalogTestEntries](https://github.com/apache/iceberg/blob/8b55ac834015ce664f879ecfe1e80a941a994420/open-api/src/testFixtures/java/org/apache/iceberg/rest/RCKUtils.java#L126-L139) removes them.

Since the current list is not comprehensive, `RCKUtils.purgeCatalogTestEntries` is also incomplete. For example, when we run [CatalogTests#testRegisterExistingTable](https://github.com/apache/iceberg/blob/8b55ac834015ce664f879ecfe1e80a941a994420/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java#L3151-L3168) twice against a REST catalog process, the test case fails unless we additionally clean up namespaces or fully recreate the REST server resource.

I have some options here.
- (1) Maintain the list of tested namespaces
- (2) Let RCKUtils.purgeCatalogTestEntries purge all namespaces
- (3) Or else?

I drafted this PR with the first option, which is likely the most consistent with the existing implementation. The biggest drawback is that it's too easy to make the list obsolete again.