### PR TITLE
REST: Align expression schema with ExpressionParser

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -112,8 +112,6 @@ class ExpressionType(BaseModel):
     __root__: str = Field(
         ...,
         example=[
-            'true',
-            'false',
             'eq',
             'and',
             'or',
@@ -133,14 +131,6 @@ class ExpressionType(BaseModel):
             'not-nan',
         ],
     )
-
-
-class TrueExpression(BaseModel):
-    type: Literal['true'] = Field('true', const=True)
-
-
-class FalseExpression(BaseModel):
-    type: Literal['false'] = Field('false', const=True)
 
 
 class Reference(BaseModel):
@@ -1165,8 +1155,7 @@ class Type(BaseModel):
 
 class Expression(BaseModel):
     __root__: (
-        TrueExpression
-        | FalseExpression
+        bool
         | AndOrExpression
         | NotExpression
         | SetExpression

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2305,8 +2305,7 @@ components:
 
     Expression:
       oneOf:
-        - $ref: '#/components/schemas/TrueExpression'
-        - $ref: '#/components/schemas/FalseExpression'
+        - type: boolean
         - $ref: '#/components/schemas/AndOrExpression'
         - $ref: '#/components/schemas/NotExpression'
         - $ref: '#/components/schemas/SetExpression'
@@ -2316,8 +2315,6 @@ components:
     ExpressionType:
       type: string
       example:
-        - "true"
-        - "false"
         - "eq"
         - "and"
         - "or"
@@ -2335,24 +2332,6 @@ components:
         - "not-null"
         - "is-nan"
         - "not-nan"
-
-    TrueExpression:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/ExpressionType'
-          const: "true"
-
-    FalseExpression:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/ExpressionType'
-          const: "false"
 
     AndOrExpression:
       type: object


### PR DESCRIPTION
## Summary

This PR updates the REST spec so the `AlwaysTrue()` and `AlwaysFalse()` expressions match how [`ExpressionParser`](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java#L101-L108) actually serializes them. 

While testing scan planning, I ran into an exception when sending filters that followed the current rest spec models, since the spec shows the AlwaysTrue/False expressions represented as objects with a `type` field (e.g., `{"type": "true"}`). However, the Java `ExpressionParser` actually expects literal boolean primitives `true`/`false` and successfully parses them.

Alternatively, we could modify the expression parser to follow the REST spec as it stands today. However, the `ExpressionParser` has been in the client for quite some time. Serializing expressions in a few places such as the metrics API with the scan report, and in Flink.

Curious to hear what others think about this!

## Testing 

**Serialize a true expression to json type bool:**
```
> ExpressionParser.toJson(Expressions.alwaysTrue(), true)

true

```
**Deserialize from what the models expect fails:**
```
> ExpressionParser.fromJson("\"true\"")

java.lang.IllegalArgumentException: Cannot parse expression from non-object: "true"
```

**Pass in json boolean type pass:**
```
> ExpressionParser.fromJson("true")

true
```

How this looks in filter context now:
```
{
  "filter": true  
}
```