### PR TITLE
rewrite_data_files with rewrite-all=true producting duplicate rows

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewritePlanner.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewritePlanner.java
@@ -170,7 +170,7 @@ public abstract class SizeBasedFileRewritePlanner<
     Iterable<T> filteredTasks = rewriteAll ? tasks : filterFiles(tasks);
     BinPacking.ListPacker<T> packer = new BinPacking.ListPacker<>(maxGroupSize, 1, false);
     List<List<T>> groups = packer.pack(filteredTasks, ContentScanTask::length);
-    
+
     // When rewrite-all is true, we still need to apply filterFileGroups to ensure
     // that we only rewrite file groups that meet the minimum criteria (e.g., enough files,
     // enough content). This is especially important when using a where clause filter,

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -984,6 +984,73 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteDataFilesWithRewriteAllAndWhereClause() {
+    createTable();
+    // Create a single file with 4 rows
+    sql("INSERT INTO %s VALUES (1, 'a', null), (2, 'b', null), (3, 'c', null), (4, 'd', null)", tableName);
+    
+    List<Object[]> expectedRecords = currentData();
+    assertEquals("Should have 4 rows initially", 4, expectedRecords.size());
+    
+    // Use rewrite-all=true with a where clause
+    // This should NOT create duplicates - it should only rewrite files that match the filter
+    // and only if they meet the minimum criteria (e.g., enough files in the group)
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_data_files("
+                + "table => '%s', "
+                + "strategy => 'sort', "
+                + "sort_order => 'c1 ASC NULLS FIRST', "
+                + "where => 'c1 IN (1,2)', "
+                + "options => map('rewrite-all', 'true'))",
+            catalogName, tableIdent);
+    
+    // With only 1 file, it should not be rewritten (doesn't meet min-input-files criteria)
+    assertEquals(
+        "Should not rewrite single file even with rewrite-all=true",
+        row(0, 0),
+        Arrays.copyOf(output.get(0), 2));
+    
+    List<Object[]> actualRecords = currentData();
+    assertEquals("Data should not change and should not have duplicates", expectedRecords, actualRecords);
+    assertEquals("Should still have exactly 4 rows (no duplicates)", 4, actualRecords.size());
+  }
+
+  @TestTemplate
+  public void testRewriteDataFilesWithRewriteAllAndWhereClauseMultipleFiles() {
+    createTable();
+    // Create multiple small files
+    for (int i = 1; i <= 4; i++) {
+      sql("INSERT INTO %s VALUES (%d, '%s', null)", tableName, i, String.valueOf((char)('a' + i - 1)));
+    }
+    
+    List<Object[]> expectedRecords = currentData();
+    assertEquals("Should have 4 rows initially", 4, expectedRecords.size());
+    
+    // Use rewrite-all=true with a where clause that matches only some rows
+    // With multiple files matching the filter, they should be rewritten
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_data_files("
+                + "table => '%s', "
+                + "strategy => 'sort', "
+                + "sort_order => 'c1 ASC NULLS FIRST', "
+                + "where => 'c1 IN (1,2)', "
+                + "options => map('rewrite-all', 'true', 'min-input-files', '2'))",
+            catalogName, tableIdent);
+    
+    // Should rewrite 2 files (those containing rows with c1 IN (1,2))
+    assertEquals(
+        "Should rewrite 2 files that match the filter",
+        row(2, 1),
+        Arrays.copyOf(output.get(0), 2));
+    
+    List<Object[]> actualRecords = currentData();
+    assertEquals("Data should not change and should not have duplicates", expectedRecords, actualRecords);
+    assertEquals("Should still have exactly 4 rows (no duplicates)", 4, actualRecords.size());
+  }
+
+  @TestTemplate
   public void testRewriteDataFilesPreservesLineage() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (c1 int, c2 string, c3 string) USING iceberg TBLPROPERTIES('format-version' = '3')",

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -987,11 +987,13 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
   public void testRewriteDataFilesWithRewriteAllAndWhereClause() {
     createTable();
     // Create a single file with 4 rows
-    sql("INSERT INTO %s VALUES (1, 'a', null), (2, 'b', null), (3, 'c', null), (4, 'd', null)", tableName);
-    
+    sql(
+        "INSERT INTO %s VALUES (1, 'a', null), (2, 'b', null), (3, 'c', null), (4, 'd', null)",
+        tableName);
+
     List<Object[]> expectedRecords = currentData();
-    assertEquals("Should have 4 rows initially", 4, expectedRecords.size());
-    
+    assertThat(expectedRecords).as("Should have 4 rows initially").hasSize(4);
+
     // Use rewrite-all=true with a where clause
     // This should NOT create duplicates - it should only rewrite files that match the filter
     // and only if they meet the minimum criteria (e.g., enough files in the group)
@@ -1004,16 +1006,17 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
                 + "where => 'c1 IN (1,2)', "
                 + "options => map('rewrite-all', 'true'))",
             catalogName, tableIdent);
-    
+
     // With only 1 file, it should not be rewritten (doesn't meet min-input-files criteria)
     assertEquals(
         "Should not rewrite single file even with rewrite-all=true",
         row(0, 0),
         Arrays.copyOf(output.get(0), 2));
-    
+
     List<Object[]> actualRecords = currentData();
-    assertEquals("Data should not change and should not have duplicates", expectedRecords, actualRecords);
-    assertEquals("Should still have exactly 4 rows (no duplicates)", 4, actualRecords.size());
+    assertEquals(
+        "Data should not change and should not have duplicates", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Should still have exactly 4 rows (no duplicates)").hasSize(4);
   }
 
   @TestTemplate
@@ -1021,12 +1024,14 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
     createTable();
     // Create multiple small files
     for (int i = 1; i <= 4; i++) {
-      sql("INSERT INTO %s VALUES (%d, '%s', null)", tableName, i, String.valueOf((char)('a' + i - 1)));
+      sql(
+          "INSERT INTO %s VALUES (%d, '%s', null)",
+          tableName, i, String.valueOf((char) ('a' + i - 1)));
     }
-    
+
     List<Object[]> expectedRecords = currentData();
-    assertEquals("Should have 4 rows initially", 4, expectedRecords.size());
-    
+    assertThat(expectedRecords).as("Should have 4 rows initially").hasSize(4);
+
     // Use rewrite-all=true with a where clause that matches only some rows
     // With multiple files matching the filter, they should be rewritten
     List<Object[]> output =
@@ -1038,16 +1043,15 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
                 + "where => 'c1 IN (1,2)', "
                 + "options => map('rewrite-all', 'true', 'min-input-files', '2'))",
             catalogName, tableIdent);
-    
+
     // Should rewrite 2 files (those containing rows with c1 IN (1,2))
     assertEquals(
-        "Should rewrite 2 files that match the filter",
-        row(2, 1),
-        Arrays.copyOf(output.get(0), 2));
-    
+        "Should rewrite 2 files that match the filter", row(2, 1), Arrays.copyOf(output.get(0), 2));
+
     List<Object[]> actualRecords = currentData();
-    assertEquals("Data should not change and should not have duplicates", expectedRecords, actualRecords);
-    assertEquals("Should still have exactly 4 rows (no duplicates)", 4, actualRecords.size());
+    assertEquals(
+        "Data should not change and should not have duplicates", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Should still have exactly 4 rows (no duplicates)").hasSize(4);
   }
 
   @TestTemplate

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -982,6 +982,77 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteDataFilesWithRewriteAllAndWhereClause() {
+    createTable();
+    // Create a single file with 4 rows
+    sql(
+        "INSERT INTO %s VALUES (1, 'a', null), (2, 'b', null), (3, 'c', null), (4, 'd', null)",
+        tableName);
+
+    List<Object[]> expectedRecords = currentData();
+    assertThat(expectedRecords).as("Should have 4 rows initially").hasSize(4);
+
+    // Use rewrite-all=true with a where clause
+    // This should NOT create duplicates - it should only rewrite files that match the filter
+    // and only if they meet the minimum criteria (e.g., enough files in the group)
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_data_files("
+                + "table => '%s', "
+                + "strategy => 'sort', "
+                + "sort_order => 'c1 ASC NULLS FIRST', "
+                + "where => 'c1 IN (1,2)', "
+                + "options => map('rewrite-all', 'true'))",
+            catalogName, tableIdent);
+
+    // With only 1 file, it should not be rewritten (doesn't meet min-input-files criteria)
+    assertEquals(
+        "Should not rewrite single file even with rewrite-all=true",
+        row(0, 0),
+        Arrays.copyOf(output.get(0), 2));
+
+    List<Object[]> actualRecords = currentData();
+    assertEquals(
+        "Data should not change and should not have duplicates", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Should still have exactly 4 rows (no duplicates)").hasSize(4);
+  }
+
+  @TestTemplate
+  public void testRewriteDataFilesWithRewriteAllAndWhereClauseMultipleFiles() {
+    createTable();
+    // Create multiple small files
+    for (int i = 1; i <= 4; i++) {
+      sql(
+          "INSERT INTO %s VALUES (%d, '%s', null)",
+          tableName, i, String.valueOf((char) ('a' + i - 1)));
+    }
+
+    List<Object[]> expectedRecords = currentData();
+    assertThat(expectedRecords).as("Should have 4 rows initially").hasSize(4);
+
+    // Use rewrite-all=true with a where clause that matches only some rows
+    // With multiple files matching the filter, they should be rewritten
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_data_files("
+                + "table => '%s', "
+                + "strategy => 'sort', "
+                + "sort_order => 'c1 ASC NULLS FIRST', "
+                + "where => 'c1 IN (1,2)', "
+                + "options => map('rewrite-all', 'true', 'min-input-files', '2'))",
+            catalogName, tableIdent);
+
+    // Should rewrite 2 files (those containing rows with c1 IN (1,2))
+    assertEquals(
+        "Should rewrite 2 files that match the filter", row(2, 1), Arrays.copyOf(output.get(0), 2));
+
+    List<Object[]> actualRecords = currentData();
+    assertEquals(
+        "Data should not change and should not have duplicates", expectedRecords, actualRecords);
+    assertThat(actualRecords).as("Should still have exactly 4 rows (no duplicates)").hasSize(4);
+  }
+
+  @TestTemplate
   public void testRewriteDataFilesPreservesLineage() throws NoSuchTableException {
     sql(
         "CREATE TABLE %s (c1 int, c2 string, c3 string) USING iceberg TBLPROPERTIES('format-version' = '3')",


### PR DESCRIPTION
The rewrite-all=true option incorrectly bypassed file group validation (filterFileGroups()), allowing single-file groups to be rewritten. This caused the commit phase to incorrectly handle file replacement, resulting in both old and new files being retained in the table metadata, leading to duplicate rows

Fixes https://github.com/apache/iceberg/issues/14667