### PR TITLE
Core: Allow retries on socket timeouts to REST

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestExponentialHttpRequestRetryStrategy.java
@@ -92,11 +92,18 @@ public class TestExponentialHttpRequestRetryStrategy {
   }
 
   @Test
-  public void noRetryOnConnectTimeout() {
+  public void noRetryOnInterruptedIO() {
     HttpGet request = new HttpGet("/");
 
-    assertThat(retryStrategy.retryRequest(request, new SocketTimeoutException(), 1, null))
+    assertThat(retryStrategy.retryRequest(request, new InterruptedIOException(), 1, null))
         .isFalse();
+  }
+
+  @Test
+  public void retryOnSocketTimeout() {
+    HttpGet request = new HttpGet("/");
+
+    assertThat(retryStrategy.retryRequest(request, new SocketTimeoutException(), 1, null)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Add `retriableExceptions` with SocketTimeoutException, so that it isn't one of the `nonRetriableExceptions`.

We've observed infrequent, transient SocketTimeoutExceptions that cause the Iceberg Kakfa Connector sink task to fail and require a manual intervention to restart. Increasing the socket timeout doesn't solve the problem, but retrying the connection works immediately.

It looks like there's some subtle implications to changing retriability (see https://github.com/apache/iceberg/pull/13619 and the discussions linked there).  I'd appreciate any insight about whether this seems like it would be safe to retry!

Closes: #14704 