### PR TITLE
infra: use new `del_branch_on_merge` in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,14 +33,16 @@ github:
     squash: true
     rebase: true
 
+  pull_requests:
+    # auto-delete head branches after being merged
+    del_branch_on_merge: true
+
   protected_branches:
     main:
       required_pull_request_reviews:
         required_approving_review_count: 1
 
       required_linear_history: true
-
-  del_branch_on_merge: true
   
   features:
     wiki: true


### PR DESCRIPTION
Previous use of `del_branch_on_merge` 
```
github:
  del_branch_on_merge: true
```
is deprecated, https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#delete-branch-on-merge

New way is to 
```
github:
  pull_requests:
    del_branch_on_merge: true
```
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#pull_requests