### PR TITLE
Docs: Fix package of iceberg.catalog.io-impl

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -218,7 +218,7 @@ be found in the [Google Cloud documentation](https://cloud.google.com/docs/authe
 "iceberg.catalog.type": "rest",
 "iceberg.catalog.uri": "https://catalog:8181",
 "iceberg.catalog.warehouse": "gs://bucket-name/warehouse",
-"iceberg.catalog.io-impl": "org.apache.iceberg.google.gcs.GCSFileIO"
+"iceberg.catalog.io-impl": "org.apache.iceberg.gcp.gcs.GCSFileIO"
 ```
 
 ### Hadoop configuration


### PR DESCRIPTION
`org.apache.iceberg.gcp.gcs` is the right package for GCSFileIO class:

https://github.com/apache/iceberg/blob/d2d4135724b844107b6a0cc117c1776abbcf69d9/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java#L19

Fixes #14670