### PR TITLE
GCP: Add gcp.auth.credentials-key property

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -180,6 +180,7 @@ Required and optional properties to include while using `google` authentication
 | Property                   | Default                                          | Description                                      |
 |----------------------------|--------------------------------------------------|--------------------------------------------------|
 | `gcp.auth.credentials-path`| Application Default Credentials (ADC)            | Path to a service account JSON key file.         |
+| `gcp.auth.credentials-key` | Application Default Credentials (ADC)            | Base64-encoded string of a service account JSON file. |
 | `gcp.auth.scopes`          | `https://www.googleapis.com/auth/cloud-platform` | Comma-separated list of OAuth scopes to request. |
 
 ### Lock catalog properties


### PR DESCRIPTION
Trino supports both `gcs.json-key-file-path` (credentials file) and `gcs.json-key` (credentials key) in the GCS file system module. https://trino.io/docs/current/object-storage/file-system-gcs.html#authentication

The new property simplifies deployment because it removes the need for a separate file.