### PR TITLE
OpenAPI: Add idempotency key for the mutating plan endpoints

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -768,6 +768,8 @@ paths:
         - Catalog API
       summary: Cancels scan planning for a plan-id
       operationId: cancelPlanning
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description: >
         Cancels scan planning for a plan-id.
 


### PR DESCRIPTION
### About the change 

Add idempotency key for the mutating endpoint for plan api for example lets say same client keeps resubmitting the plan request, it will help the server to know its the same client and send / fetch the same plan-id in progress in the response ? 


