### PR TITLE
fix column prunning 1.6.x

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -87,9 +87,18 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
       Type field = fields.get(i);
       Integer fieldId = getId(originalField);
       if (fieldId != null && selectedIds.contains(fieldId)) {
-        filteredFields.add(originalField);
+        // Use pruned field if available and different from original, otherwise use original
+        if (field != null && !Objects.equal(field, originalField)) {
+          validatePrunedField(field, originalField);
+          filteredFields.add(field);
+          hasChange = true;
+        } else {
+          filteredFields.add(originalField);
+        }
       } else if (field != null) {
-        filteredFields.add(originalField);
+        // Field not directly selected but has selected children - use pruned field
+        validatePrunedField(field, originalField);
+        filteredFields.add(field);
         hasChange = true;
       }
     }
@@ -111,16 +120,19 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
     Type originalElement = ParquetSchemaUtil.determineListElementType(list);
     Integer elementId = getId(originalElement);
 
-    if (elementId != null && selectedIds.contains(elementId)) {
+    // Check if element was pruned (has fewer fields than original)
+    if (element != null && !Objects.equal(element, originalElement)) {
+      // Validate and apply the pruned element
+      validatePrunedField(element, originalElement);
+      if (originalElement.isRepetition(Type.Repetition.REPEATED)) {
+        return list.withNewFields(element);
+      } else {
+        return list.withNewFields(repeated.asGroupType().withNewFields(element));
+      }
+    } else if (elementId != null && selectedIds.contains(elementId)) {
+      // Element selected but not pruned - return as is
       return list;
     } else if (element != null) {
-      if (!Objects.equal(element, originalElement)) {
-        if (originalElement.isRepetition(Type.Repetition.REPEATED)) {
-          return list.withNewFields(element);
-        } else {
-          return list.withNewFields(repeated.asGroupType().withNewFields(element));
-        }
-      }
       return list;
     }
 
@@ -136,13 +148,16 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
     Integer keyId = getId(originalKey);
     Integer valueId = getId(originalValue);
 
-    if ((keyId != null && selectedIds.contains(keyId))
+    // Check if value was pruned (has fewer fields than original)
+    if (value != null && !Objects.equal(value, originalValue)) {
+      // Validate and apply the pruned value
+      validatePrunedField(value, originalValue);
+      return map.withNewFields(repeated.withNewFields(originalKey, value));
+    } else if ((keyId != null && selectedIds.contains(keyId))
         || (valueId != null && selectedIds.contains(valueId))) {
+      // Key or value selected but not pruned - return as is
       return map;
     } else if (value != null) {
-      if (!Objects.equal(value, originalValue)) {
-        return map.withNewFields(repeated.withNewFields(originalKey, value));
-      }
       return map;
     }
 
@@ -167,5 +182,29 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
       return !LogicalTypeAnnotation.mapType().equals(logicalTypeAnnotation)
           && !LogicalTypeAnnotation.listType().equals(logicalTypeAnnotation);
     }
+  }
+
+  /**
+   * Validates that a pruned field is compatible with the original field. The pruned field must have
+   * the same name, ID, and repetition as the original.
+   */
+  private void validatePrunedField(Type prunedField, Type originalField) {
+    Preconditions.checkState(
+        prunedField.getName().equals(originalField.getName()),
+        "Pruned field must have same name as original: '%s' vs '%s'",
+        prunedField.getName(),
+        originalField.getName());
+
+    Preconditions.checkState(
+        Objects.equal(getId(prunedField), getId(originalField)),
+        "Pruned field must have same ID as original: %s vs %s",
+        getId(prunedField),
+        getId(originalField));
+
+    Preconditions.checkState(
+        prunedField.getRepetition() == originalField.getRepetition(),
+        "Pruned field must have same repetition as original: %s vs %s",
+        prunedField.getRepetition(),
+        originalField.getRepetition());
   }
 }


### PR DESCRIPTION
When pruning nested structures (lists, maps, structs), the PruneColumns
visitor was incorrectly returning the original unpruned field when the
container's field ID was in the selectedIds set, even when child fields
had been pruned.

This fix ensures that:
1. In struct(): When a field is selected and has been pruned (field != originalField),
   use the pruned version instead of the original.
2. In list(): Check for pruned element first before checking if elementId
   is selected, ensuring nested pruning is applied.
3. In map(): Similarly check for pruned value before checking selected keys/values.
4. Add validatePrunedField() to verify pruned fields maintain compatibility
   with original fields (same name, ID, and repetition).

This enables proper column pruning for deeply nested schemas like:
list<struct<field1, nested_list: list<struct<a, b, c, d>>>>

When projecting only field1 and nested_list[].a, b, the fix ensures
fields c and d are properly pruned from the Parquet projection schema.