### PR TITLE
Parquet: Fix nested field pruning in PruneColumns

### DIFF
--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
@@ -202,6 +202,310 @@ public class TestPruneColumns {
   }
 
   @Test
+  public void testNestedListWithStructPruning() {
+    // Test case: list of structs where each struct contains another list of structs
+    // Similar to: pv_requests: list<struct<available, servedItems: list<struct<boosts, clicked,
+    // ...other fields>>>>
+    MessageType fileSchema =
+        Types.buildMessage()
+            .addField(
+                Types.buildGroup(Type.Repetition.OPTIONAL)
+                    .addField(
+                        Types.buildGroup(Type.Repetition.REPEATED)
+                            .addField(
+                                Types.buildGroup(Type.Repetition.OPTIONAL)
+                                    .addField(
+                                        Types.primitive(
+                                                PrimitiveTypeName.BOOLEAN, Type.Repetition.OPTIONAL)
+                                            .id(4)
+                                            .named("available"))
+                                    .addField(
+                                        Types.buildGroup(Type.Repetition.OPTIONAL)
+                                            .addField(
+                                                Types.buildGroup(Type.Repetition.REPEATED)
+                                                    .addField(
+                                                        Types.buildGroup(Type.Repetition.OPTIONAL)
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.DOUBLE,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(8)
+                                                                    .named("boosts"))
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.BOOLEAN,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(9)
+                                                                    .named("clicked"))
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.DOUBLE,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(10)
+                                                                    .named("other_field_1"))
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.DOUBLE,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(11)
+                                                                    .named("other_field_2"))
+                                                            .id(7)
+                                                            .named("element"))
+                                                    .named("list"))
+                                            .as(LogicalTypeAnnotation.listType())
+                                            .id(5)
+                                            .named("servedItems"))
+                                    .id(3)
+                                    .named("element"))
+                            .named("list"))
+                    .as(LogicalTypeAnnotation.listType())
+                    .id(1)
+                    .named("pv_requests"))
+            .named("table");
+
+    // Project only: pv_requests[].available and pv_requests[].servedItems[].boosts, clicked
+    Schema projection =
+        new Schema(
+            NestedField.optional(
+                1,
+                "pv_requests",
+                ListType.ofOptional(
+                    3,
+                    StructType.of(
+                        NestedField.optional(
+                            4, "available", org.apache.iceberg.types.Types.BooleanType.get()),
+                        NestedField.optional(
+                            5,
+                            "servedItems",
+                            ListType.ofOptional(
+                                7,
+                                StructType.of(
+                                    NestedField.optional(8, "boosts", DoubleType.get()),
+                                    NestedField.optional(
+                                        9,
+                                        "clicked",
+                                        org.apache.iceberg.types.Types.BooleanType.get()))))))));
+
+    // Expected: only available, servedItems with boosts and clicked (no other_field_1,
+    // other_field_2)
+    MessageType expected =
+        Types.buildMessage()
+            .addField(
+                Types.buildGroup(Type.Repetition.OPTIONAL)
+                    .addField(
+                        Types.buildGroup(Type.Repetition.REPEATED)
+                            .addField(
+                                Types.buildGroup(Type.Repetition.OPTIONAL)
+                                    .addField(
+                                        Types.primitive(
+                                                PrimitiveTypeName.BOOLEAN, Type.Repetition.OPTIONAL)
+                                            .id(4)
+                                            .named("available"))
+                                    .addField(
+                                        Types.buildGroup(Type.Repetition.OPTIONAL)
+                                            .addField(
+                                                Types.buildGroup(Type.Repetition.REPEATED)
+                                                    .addField(
+                                                        Types.buildGroup(Type.Repetition.OPTIONAL)
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.DOUBLE,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(8)
+                                                                    .named("boosts"))
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.BOOLEAN,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(9)
+                                                                    .named("clicked"))
+                                                            .id(7)
+                                                            .named("element"))
+                                                    .named("list"))
+                                            .as(LogicalTypeAnnotation.listType())
+                                            .id(5)
+                                            .named("servedItems"))
+                                    .id(3)
+                                    .named("element"))
+                            .named("list"))
+                    .as(LogicalTypeAnnotation.listType())
+                    .id(1)
+                    .named("pv_requests"))
+            .named("table");
+
+    MessageType actual = ParquetSchemaUtil.pruneColumns(fileSchema, projection);
+    assertThat(actual)
+        .as("Pruned schema should remove other_field_1 and other_field_2 from nested list")
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testExplicitStructSelectionPreservesAllFields() {
+    // Test case: SELECT struct_field, struct_field.sub_field FROM ...
+    // When a struct is explicitly selected, all its fields should be preserved
+    // even if a sub-field is also independently selected
+    MessageType fileSchema =
+        Types.buildMessage()
+            .addField(
+                Types.primitive(PrimitiveTypeName.INT32, Type.Repetition.REQUIRED)
+                    .id(1)
+                    .named("id"))
+            .addField(
+                Types.buildGroup(Type.Repetition.OPTIONAL)
+                    .addField(
+                        Types.primitive(PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED)
+                            .id(3)
+                            .named("x"))
+                    .addField(
+                        Types.primitive(PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED)
+                            .id(4)
+                            .named("y"))
+                    .addField(
+                        Types.primitive(PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED)
+                            .id(5)
+                            .named("z"))
+                    .id(2)
+                    .named("point"))
+            .named("table");
+
+    // Project the whole struct (all fields) - simulates SELECT point, point.x FROM ...
+    // The struct is explicitly selected with all its fields
+    Schema projection =
+        new Schema(
+            NestedField.optional(
+                2,
+                "point",
+                StructType.of(
+                    NestedField.required(3, "x", DoubleType.get()),
+                    NestedField.required(4, "y", DoubleType.get()),
+                    NestedField.required(5, "z", DoubleType.get()))));
+
+    // Expected: full struct with all fields preserved
+    MessageType expected =
+        Types.buildMessage()
+            .addField(
+                Types.buildGroup(Type.Repetition.OPTIONAL)
+                    .addField(
+                        Types.primitive(PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED)
+                            .id(3)
+                            .named("x"))
+                    .addField(
+                        Types.primitive(PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED)
+                            .id(4)
+                            .named("y"))
+                    .addField(
+                        Types.primitive(PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED)
+                            .id(5)
+                            .named("z"))
+                    .id(2)
+                    .named("point"))
+            .named("table");
+
+    MessageType actual = ParquetSchemaUtil.pruneColumns(fileSchema, projection);
+    assertThat(actual)
+        .as("Full struct should be preserved when explicitly selected")
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testNestedListExplicitStructSelectionPreservesAllFields() {
+    // Test case: Using the same nested schema as testNestedListWithStructPruning,
+    // but selecting the full inner struct element with ALL its fields.
+    // This simulates: SELECT pv_requests[].servedItems[] FROM ...
+    // When the inner struct is explicitly selected with all fields, they should all be preserved.
+    MessageType fileSchema =
+        Types.buildMessage()
+            .addField(
+                Types.buildGroup(Type.Repetition.OPTIONAL)
+                    .addField(
+                        Types.buildGroup(Type.Repetition.REPEATED)
+                            .addField(
+                                Types.buildGroup(Type.Repetition.OPTIONAL)
+                                    .addField(
+                                        Types.primitive(
+                                                PrimitiveTypeName.BOOLEAN, Type.Repetition.OPTIONAL)
+                                            .id(4)
+                                            .named("available"))
+                                    .addField(
+                                        Types.buildGroup(Type.Repetition.OPTIONAL)
+                                            .addField(
+                                                Types.buildGroup(Type.Repetition.REPEATED)
+                                                    .addField(
+                                                        Types.buildGroup(Type.Repetition.OPTIONAL)
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.DOUBLE,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(8)
+                                                                    .named("boosts"))
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.BOOLEAN,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(9)
+                                                                    .named("clicked"))
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.DOUBLE,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(10)
+                                                                    .named("other_field_1"))
+                                                            .addField(
+                                                                Types.primitive(
+                                                                        PrimitiveTypeName.DOUBLE,
+                                                                        Type.Repetition.OPTIONAL)
+                                                                    .id(11)
+                                                                    .named("other_field_2"))
+                                                            .id(7)
+                                                            .named("element"))
+                                                    .named("list"))
+                                            .as(LogicalTypeAnnotation.listType())
+                                            .id(5)
+                                            .named("servedItems"))
+                                    .id(3)
+                                    .named("element"))
+                            .named("list"))
+                    .as(LogicalTypeAnnotation.listType())
+                    .id(1)
+                    .named("pv_requests"))
+            .named("table");
+
+    // Project ALL fields of the inner struct - simulates selecting the full struct
+    Schema projection =
+        new Schema(
+            NestedField.optional(
+                1,
+                "pv_requests",
+                ListType.ofOptional(
+                    3,
+                    StructType.of(
+                        NestedField.optional(
+                            4, "available", org.apache.iceberg.types.Types.BooleanType.get()),
+                        NestedField.optional(
+                            5,
+                            "servedItems",
+                            ListType.ofOptional(
+                                7,
+                                StructType.of(
+                                    NestedField.optional(8, "boosts", DoubleType.get()),
+                                    NestedField.optional(
+                                        9,
+                                        "clicked",
+                                        org.apache.iceberg.types.Types.BooleanType.get()),
+                                    NestedField.optional(10, "other_field_1", DoubleType.get()),
+                                    NestedField.optional(
+                                        11, "other_field_2", DoubleType.get()))))))));
+
+    // Expected: ALL fields preserved since the full struct was explicitly selected
+    MessageType expected = fileSchema;
+
+    MessageType actual = ParquetSchemaUtil.pruneColumns(fileSchema, projection);
+    assertThat(actual)
+        .as("All fields should be preserved when full nested struct is explicitly selected")
+        .isEqualTo(expected);
+  }
+
+  @Test
   public void testStructElementName() {
     MessageType fileSchema =
         Types.buildMessage()


### PR DESCRIPTION
When pruning nested structures (lists, maps, structs), the PruneColumns visitor was incorrectly returning the original unpruned field when the container's field ID was in the selectedIds set, even when child fields had been pruned.

This fix ensures that:
1. In struct(): When a field is selected and has been pruned (field != originalField), use the pruned version instead of the original.
2. In list(): Check for pruned element first before checking if elementId is selected, ensuring nested pruning is applied.
3. In map(): Similarly check for pruned value before checking selected keys/values.
4. Add validatePrunedField() to verify pruned fields maintain compatibility with original fields (same name, ID, and repetition).

This enables proper column pruning for deeply nested schemas like:
list<struct<field1, nested_list: list<struct<a, b, c, d>>>>

When projecting only field1 and nested_list[].a, b, the fix ensures fields c and d are properly pruned from the Parquet projection schema.