### PR TITLE
Docs: Update community meetup guidelines

### DIFF
--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -90,7 +90,7 @@ Hosts are required to ensure that:
 
 Meetups *must* be small events under the [ASF branding guidelines](https://www.apache.org/foundation/marks/events.html#dates) and are typically small, informal gatherings. If you're unsure whether an event is a meetup, meetups usually:
 
-* Rely on a curated selection of talks, where organizers work with the community to include a diverse representation of speakers, topics, and companies. They don't have selection committees or use a formal, paid call for papers like a conference.
+* Rely on a curated selection of talks, where organizers work with the community to include a diverse representation of speakers, topics, and companies. Due to the small number of submissions, meetups might use, but don't require, a CfP.
 * Are single-tracked and accommodate only a handful of sessions.
 * Have at most 2-3 hours of content, plus networking time.
 * Are sponsored by 1-3 companies providing food, drinks, or meeting space; not by selling booth space or marketing opportunities. They don't require substantial financial support.


### PR DESCRIPTION
Hi all! Based on discussions that were happening across the community, I've drafted a few additions to the meetup guidelines to help meetup organizers know what makes a meetup a meetup and give them better guidance as they plan community events. Specifically, it's important that meetups are small events under the ASF event guidelines and that they don't stray too far into conference territory with all-day, multi-track agendas.

Here's what it looks like:
<img width="793" height="689" alt="Screenshot 2025-12-04 at 10 04 53 AM" src="https://github.com/user-attachments/assets/8be564d1-480a-4546-b279-ec7d073bdb0e" />

Will also send out to the original meetup guideline [thread](https://lists.apache.org/thread/ls2rg4xcwk9hnhtotor5f9xsrbdknw1s).