### PR TITLE
[Bigquery]: Handle multiple error messages for bigquery precondition failure

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
@@ -186,7 +186,7 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
           || msg.contains("did not meet condition if_match")
           || msg.contains("precondition check failed")) {
         throw new CommitFailedException(
-                e, "Cannot commit %s because BigQuery detected concurrent update", tableName());
+            e, "Cannot commit %s because BigQuery detected concurrent update", tableName());
       }
 
       throw e;

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryTableOperations.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryTableOperations.java
@@ -181,8 +181,7 @@ public class TestBigQueryTableOperations {
     assertThatThrownBy(
             () -> loadedTable.updateSchema().addColumn("n", Types.IntegerType.get()).commit())
         .isInstanceOf(CommitFailedException.class)
-        .hasMessageContaining(
-            "BigQuery detected concurrent update");
+        .hasMessageContaining("BigQuery detected concurrent update");
   }
 
   @Test
@@ -200,8 +199,7 @@ public class TestBigQueryTableOperations {
     assertThatThrownBy(
             () -> loadedTable.updateSchema().addColumn("n", Types.IntegerType.get()).commit())
         .isInstanceOf(CommitFailedException.class)
-        .hasMessageContaining(
-            "BigQuery detected concurrent update");
+        .hasMessageContaining("BigQuery detected concurrent update");
   }
 
   @Test


### PR DESCRIPTION
### Description

BigQuery runs its own optimistic concurrency control, and the BigQuery catalog does retry these conflict cases. However the conflict case detection seems to leave out certain message patterns when matching. I've seen errors such as the following:

```bash
BigQueryTableOperations.java:96: Exception thrown on commit: 
org.apache.iceberg.exceptions.ValidationException: Precondition Failed
{
  "code": 412,
  "errors": [
    {
      "domain": "global",
      "location": "If-Match",
      "locationType": "header",
      "message": "Resource <table_name> did not meet condition IF_MATCH",
      "reason": "conditionNotMet"
    }
  ],
  "message": "Resource <table_name>  did not meet condition IF_MATCH",
  "status": "FAILED_PRECONDITION"
}
```


and 


```bash
Caused by: org.apache.iceberg.exceptions.ValidationException: Precondition Failed
{
  "code": 412,
  "errors": [
    {
      "domain": "global",
      "message": "Precondition check failed.",
      "reason": "failedPrecondition"
    }
  ],
  "message": "Precondition check failed.",
  "status": "FAILED_PRECONDITION"
}
```

So this PR updates the conflict handling to match more message patterns that come from an etag mismatch. 