### PR TITLE
SPEC: Add AccessDelegation header to planAPI calls which vend creds

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -615,6 +615,7 @@ paths:
       - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
+      - $ref: '#/components/parameters/data-access'
     post:
       tags:
         - Catalog API
@@ -702,6 +703,7 @@ paths:
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
       - $ref: '#/components/parameters/plan-id'
+      - $ref: '#/components/parameters/data-access'
 
     get:
       tags:


### PR DESCRIPTION
### About the change 

Post this spec change https://github.com/apache/iceberg/pull/14563 server can now send back vended creds to the client but like other routes `LoadTable` and `CreateTable` there is no way for a client to specify that it needs vended creds ? 
since creds are optional return server has option to not return creds if it thinks is not feasible for example if storage doesn't support sts.

But IMHO its would be nice to still expect this header from client for the following reasons : 
1. what if client wants to use its own storage creds (for lets say audit for s3 access logs), server sends back vended creds, client can choose not to use it.
2. Consistency with other endpoints which supports cred vending.

Server can still choose not to return any thing because of this language in spec : 
https://github.com/apache/iceberg/blob/fc434997fbc63a3f1f47481c0878073b1ccf6359/open-api/rest-catalog-open-api.yaml#L1886-L1887


~Pending~ ML list discussion : https://lists.apache.org/thread/w45r0rrlzyn8v1gzkkqzry8tkbfd0w86