### PR TITLE
REST: Add 429 Too Many Requests error response to REST catalog spec

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -164,6 +164,8 @@ paths:
           $ref: '#/components/responses/ForbiddenResponse'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -288,6 +290,8 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -331,6 +335,8 @@ paths:
                   $ref: '#/components/examples/NamespaceAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -367,6 +373,8 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -399,6 +407,8 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -440,6 +450,8 @@ paths:
                   $ref: '#/components/examples/NamespaceNotEmptyError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -505,6 +517,8 @@ paths:
                   $ref: '#/components/examples/UnprocessableEntityDuplicateKey'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -544,6 +558,8 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -605,6 +621,8 @@ paths:
                   $ref: '#/components/examples/TableAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -691,6 +709,8 @@ paths:
           $ref: '#/components/responses/UnsupportedOperationResponse'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -756,6 +776,8 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -807,6 +829,8 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -858,6 +882,8 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -913,6 +939,8 @@ paths:
                   $ref: '#/components/examples/TableAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -993,6 +1021,8 @@ paths:
                   $ref: '#/components/examples/NoSuchTableError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1059,6 +1089,8 @@ paths:
                 $ref: '#/components/schemas/IcebergErrorResponse'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         500:
           description:
             An unknown server-side problem occurred; the commit state is unknown.
@@ -1154,6 +1186,8 @@ paths:
                   $ref: '#/components/examples/NoSuchTableError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1187,6 +1221,8 @@ paths:
                   $ref: '#/components/examples/NoSuchTableError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1232,6 +1268,8 @@ paths:
                   $ref: '#/components/examples/NoSuchTableError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1296,6 +1334,8 @@ paths:
                 $ref: '#/components/examples/TableAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1340,6 +1380,8 @@ paths:
                   $ref: '#/components/examples/NoSuchTableError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1403,6 +1445,8 @@ paths:
                 $ref: '#/components/schemas/IcebergErrorResponse'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         500:
           description:
             An unknown server-side problem occurred; the commit state is unknown.
@@ -1496,6 +1540,8 @@ paths:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1543,6 +1589,8 @@ paths:
                   $ref: '#/components/examples/ViewAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1595,6 +1643,8 @@ paths:
                   $ref: '#/components/examples/NoSuchViewError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1643,6 +1693,8 @@ paths:
                 $ref: '#/components/schemas/ErrorModel'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         500:
           description:
             An unknown server-side problem occurred; the commit state is unknown.
@@ -1731,6 +1783,8 @@ paths:
                   $ref: '#/components/examples/NoSuchViewError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1754,6 +1808,8 @@ paths:
           description: Not Found
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -1818,6 +1874,8 @@ paths:
                 $ref: '#/components/examples/ViewAlreadyExistsError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        429:
+          $ref: '#/components/responses/TooManyRequestsResponse'
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
         5XX:
@@ -4739,6 +4797,23 @@ components:
               "message": "Credentials have timed out",
               "type": "AuthenticationTimeoutException",
               "code": 419
+            }
+          }
+
+    TooManyRequestsResponse:
+      description:
+        The client has sent too many requests in a given amount of time. The client should
+        wait before retrying the request. The service may send a Retry-After header to
+        indicate when to retry.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/IcebergErrorResponse'
+          example: {
+            "error": {
+              "message": "Too many requests",
+              "type": "ThrottlingException",
+              "code": 429
             }
           }
 


### PR DESCRIPTION
As we are implementing rate limiting in our rest catalog, we notice 429 are not defined yet in rest spec. This PR adds the new Error Code into the Spec.