### PR TITLE
Spark: Add comet reader test

### DIFF
--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetCometVectorizedScan.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetCometVectorizedScan.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import org.junit.jupiter.api.BeforeAll;
+
+public class TestParquetCometVectorizedScan extends TestParquetScan {
+  @BeforeAll
+  public static void setComet() {
+    ScanTestBase.spark.conf().set("spark.sql.iceberg.parquet.reader-type", "COMET");
+  }
+
+  @Override
+  protected boolean vectorized() {
+    return true;
+  }
+}


### PR DESCRIPTION
It would be nice to have a test which continuously exercises the Comet reader path.