### PR TITLE
Adding config option for worker poll duration to avoid consumer join issues (#14818)

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -82,6 +82,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
 | iceberg.control.commit.threads             | Number of threads to use for commits, default is (`cores * 2`)                                                     |
 | iceberg.coordinator.transactional.prefix   | Prefix for the transactional id to use for the coordinator producer, default is to use no/empty prefix           |
+| iceberg.worker.poll.duration-ms            | Worker poll duration, in millis, default is 0                                                                    |
 | iceberg.catalog                            | Name of the catalog, default is `iceberg`                                                                        |
 | iceberg.catalog.*                          | Properties passed through to Iceberg catalog initialization                                                      |
 | iceberg.hadoop-conf-dir                    | If specified, Hadoop config files in this directory will be loaded                                               |

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -89,6 +89,8 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String CONNECT_GROUP_ID_PROP = "iceberg.connect.group-id";
   private static final String TRANSACTIONAL_PREFIX_PROP =
       "iceberg.coordinator.transactional.prefix";
+  private static final String WORKER_POLL_DURATION_MS_PROP = "iceberg.worker.poll.duration-ms";
+  private static final int WORKER_POLL_DURATION_MS_DEFAULT = 0;
   private static final String HADOOP_CONF_DIR_PROP = "iceberg.hadoop-conf-dir";
 
   private static final String NAME_PROP = "name";
@@ -235,6 +237,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         120000L,
         Importance.LOW,
         "config to control coordinator executor keep alive time");
+    configDef.define(
+        WORKER_POLL_DURATION_MS_PROP,
+        ConfigDef.Type.INT,
+        WORKER_POLL_DURATION_MS_DEFAULT,
+        Importance.MEDIUM,
+        "Worker poll duration, in millis");
     return configDef;
   }
 
@@ -394,6 +402,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public String controlGroupIdPrefix() {
     return getString(CONTROL_GROUP_ID_PREFIX_PROP);
+  }
+
+  public int workerPollDurationMs() {
+    return getInt(WORKER_POLL_DURATION_MS_PROP);
   }
 
   public String connectGroupId() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -42,6 +42,7 @@ class Worker extends Channel {
   private final IcebergSinkConfig config;
   private final SinkTaskContext context;
   private final SinkWriter sinkWriter;
+  private final Duration pollDuration;
 
   Worker(
       IcebergSinkConfig config,
@@ -59,10 +60,11 @@ class Worker extends Channel {
     this.config = config;
     this.context = context;
     this.sinkWriter = sinkWriter;
+    this.pollDuration = Duration.ofMillis(config.workerPollDurationMs());
   }
 
   void process() {
-    consumeAvailable(Duration.ZERO);
+    consumeAvailable(pollDuration);
   }
 
   @Override


### PR DESCRIPTION
Added a new config option:

```
  private static final String WORKER_POLL_DURATION_MS_PROP = "iceberg.worker.poll.duration-ms";
  private static final int WORKER_POLL_DURATION_MS_DEFAULT = 0;
```

I kept the duration at 0 so that there in effect no change to the existing behavior in Worker.java:

```
   void process() {
-    consumeAvailable(Duration.ZERO);
+    consumeAvailable(pollDuration);
   }
```