### PR TITLE
Docs: Add schema selection example for time travel queries

### DIFF
--- a/docs/docs/spark-queries.md
+++ b/docs/docs/spark-queries.md
@@ -116,7 +116,7 @@ SELECT * FROM prod.db.table VERSION AS OF 'historical-snapshot';
 SELECT * FROM prod.db.table.`tag_historical-snapshot`;
 ```
 
-For example, consider a table that evolves its schema over time:
+For example, consider a table that evolves its schema over time, and see how each type of time travel query selects its schema:
 
 ```sql
 -- snapshot S1: initial schema (id, status)


### PR DESCRIPTION
This PR adds a concrete example to the "Schema selection in time travel queries"
section in the Spark queries documentation.

The example demonstrates how schema selection behaves when:

- time traveling by `TIMESTAMP AS OF` and `VERSION AS OF <snapshot_id>` (uses the snapshot's schema)
- time traveling by `VERSION AS OF 'branch-name'` and `table.\`branch_<branch-name>\`` (uses the table's current schema)
- time traveling by `VERSION AS OF 'tag-name'` and `table.\`tag_<tag-name>\`` (uses the referenced snapshot's schema)

The scenario uses a simple `orders` table that evolves its schema (adding a new
column) and shows which columns are visible in each kind of time travel query.

Closes #13065.
