### PR TITLE
Core: disable flaky test for batchScan RemoteScanPlanning

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -348,6 +348,7 @@ public class TestRESTScanPlanning {
     }
   }
 
+  @Disabled("Temporarily disabled: Fix tracked via issue-14823")
   @ParameterizedTest
   @EnumSource(PlanningMode.class)
   void scanPlanningWithBatchScan(


### PR DESCRIPTION
### About the change 

Since this is blocking CI for other user, and the bug doesn't seem obviously in the feature that enabled i will propose to disable the this test for now. 

would love to know what other have to think