### PR TITLE
Avoid always adding columns as optional on schema evolution

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -183,7 +183,7 @@ class RecordConverter {
               if (type != null) {
                 String parentFieldName =
                     structFieldId < 0 ? null : tableSchema.findColumnName(structFieldId);
-                schemaUpdateConsumer.addColumn(parentFieldName, recordFieldName, type);
+                schemaUpdateConsumer.addColumn(parentFieldName, recordFieldName, type, true);
               }
             }
           } else {
@@ -218,7 +218,11 @@ class RecordConverter {
                   String parentFieldName =
                       structFieldId < 0 ? null : tableSchema.findColumnName(structFieldId);
                   Type type = SchemaUtils.toIcebergType(recordField.schema(), config);
-                  schemaUpdateConsumer.addColumn(parentFieldName, recordField.name(), type);
+                  schemaUpdateConsumer.addColumn(
+                      parentFieldName,
+                      recordField.name(),
+                      type,
+                      config.schemaForceOptional() || recordField.schema().isOptional());
                 }
               } else {
                 boolean hasSchemaUpdates = false;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUpdate.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUpdate.java
@@ -47,8 +47,8 @@ class SchemaUpdate {
       return addColumns.isEmpty() && updateTypes.isEmpty() && makeOptionals.isEmpty();
     }
 
-    void addColumn(String parentName, String name, Type type) {
-      AddColumn addCol = new AddColumn(parentName, name, type);
+    void addColumn(String parentName, String name, Type type, boolean isOptional) {
+      AddColumn addCol = new AddColumn(parentName, name, type, isOptional);
       addColumns.put(addCol.key(), addCol);
     }
 
@@ -65,11 +65,13 @@ class SchemaUpdate {
     private final String parentName;
     private final String name;
     private final Type type;
+    private final boolean isOptional;
 
-    AddColumn(String parentName, String name, Type type) {
+    AddColumn(String parentName, String name, Type type, boolean isOptional) {
       this.parentName = parentName;
       this.name = name;
       this.type = type;
+      this.isOptional = isOptional;
     }
 
     String parentName() {
@@ -86,6 +88,10 @@ class SchemaUpdate {
 
     Type type() {
       return type;
+    }
+
+    boolean isOptional() {
+      return isOptional;
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
@@ -123,7 +123,13 @@ class SchemaUtils {
     // apply the updates
     UpdateSchema updateSchema = table.updateSchema();
     addColumns.forEach(
-        update -> updateSchema.addColumn(update.parentName(), update.name(), update.type()));
+        update -> {
+          if (update.isOptional()) {
+            updateSchema.addColumn(update.parentName(), update.name(), update.type());
+          } else {
+            updateSchema.addRequiredColumn(update.parentName(), update.name(), update.type());
+          }
+        });
     updateTypes.forEach(update -> updateSchema.updateColumn(update.name(), update.type()));
     makeOptionals.forEach(update -> updateSchema.makeColumnOptional(update.name()));
     updateSchema.commit();

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUpdate.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUpdate.java
@@ -28,7 +28,7 @@ public class TestSchemaUpdate {
   @Test
   public void testAddColumn() {
     SchemaUpdate.Consumer updateConsumer = new SchemaUpdate.Consumer();
-    updateConsumer.addColumn("parent", "name", Types.StringType.get());
+    updateConsumer.addColumn("parent", "name", Types.StringType.get(), true);
     assertThat(updateConsumer.addColumns()).hasSize(1);
     assertThat(updateConsumer.updateTypes()).isEmpty();
     assertThat(updateConsumer.makeOptionals()).isEmpty();
@@ -37,6 +37,22 @@ public class TestSchemaUpdate {
     assertThat(addColumn.parentName()).isEqualTo("parent");
     assertThat(addColumn.name()).isEqualTo("name");
     assertThat(addColumn.type()).isEqualTo(Types.StringType.get());
+    assertThat(addColumn.isOptional()).isTrue();
+  }
+
+  @Test
+  public void testAddColumnRequired() {
+    SchemaUpdate.Consumer updateConsumer = new SchemaUpdate.Consumer();
+    updateConsumer.addColumn("parent", "name", Types.StringType.get(), false);
+    assertThat(updateConsumer.addColumns()).hasSize(1);
+    assertThat(updateConsumer.updateTypes()).isEmpty();
+    assertThat(updateConsumer.makeOptionals()).isEmpty();
+
+    SchemaUpdate.AddColumn addColumn = updateConsumer.addColumns().iterator().next();
+    assertThat(addColumn.parentName()).isEqualTo("parent");
+    assertThat(addColumn.name()).isEqualTo("name");
+    assertThat(addColumn.type()).isEqualTo(Types.StringType.get());
+    assertThat(addColumn.isOptional()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
### Problem
When performing schema evolution (adding a new field), the code currently calls `addColumn()` → `addInternalColumn()`, which **always** marks the new column as `OPTIONAL` (i.e. nullable = true), regardless of what the Connect schema says.

This behaviour is **inconsistent** with table creation:

- On **initial table creation** we correctly respect `schema.isOptional()` (and the related configuration) to decide whether a column should be `REQUIRED` or `OPTIONAL`.
- On **schema evolution** we ignore that and force the new column to be `OPTIONAL`.

As a result:
- If you create the table directly with schema **v2** (which already contains the new field), the column is created with the correct nullability.
- If you create the table with **v1** and later evolve to **v2**, the same column is added as `OPTIONAL` → different physical schema.

### Solution
This PR aligns schema-evolution nullability handling with the logic used during initial table creation.

Now the same code path (respecting `ConnectSchema.isOptional()` and the configured default for required fields) is used in **both** cases, eliminating the dual behaviour and guaranteeing that the resulting Parquet files have identical column nullability no matter whether the field was present at creation time or added later via schema evolution.

### Result
- Consistent Parquet schema across creation and evolution paths
- New columns respect the nullability declared in the Connect schema
- No more surprise `OPTIONAL` columns when the source schema says the field is required