### PR TITLE
Revert "BigQuery: Add iceberg-bigquery dependency to spark and flink build scripts (#14221)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1037,7 +1037,6 @@ project(':iceberg-open-api') {
     testFixturesImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testFixturesImplementation project(':iceberg-aws')
     testFixturesImplementation project(':iceberg-gcp')
-    testFixturesImplementation project(':iceberg-bigquery')
     testFixturesImplementation project(':iceberg-azure')
     testFixturesImplementation(libs.hadoop3.common) {
       exclude group: 'org.slf4j'

--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -164,7 +164,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation project(':iceberg-gcp')
-    implementation project(':iceberg-bigquery')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -164,7 +164,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation project(':iceberg-gcp')
-    implementation project(':iceberg-bigquery')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -164,7 +164,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation project(':iceberg-gcp')
-    implementation project(':iceberg-bigquery')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -246,7 +246,6 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation project(':iceberg-gcp')
-    implementation project(':iceberg-bigquery')
     implementation project(':iceberg-hive-metastore')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -246,7 +246,6 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation project(':iceberg-gcp')
-    implementation project(':iceberg-bigquery')
     implementation project(':iceberg-hive-metastore')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -251,7 +251,6 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'commons-logging', module: 'commons-logging'
     }
     implementation project(':iceberg-gcp')
-    implementation project(':iceberg-bigquery')
     implementation project(':iceberg-hive-metastore')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'


### PR DESCRIPTION

This reverts commit 16f5bc6934e2a7d172936b679184edc27fc7fa29.
We want to keep 1.10.x as a bug‑fix branch and remove this new runtime dependency from 1.10.x.