### PR TITLE
REST: Add spatial expressions to REST Catalog OpenAPI Spec

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -133,6 +133,8 @@ class ExpressionType(BaseModel):
             'not-null',
             'is-nan',
             'not-nan',
+            'st-intersects',
+            'st-disjoint',
         ],
     )
 
@@ -143,6 +145,11 @@ class TrueExpression(BaseModel):
 
 class FalseExpression(BaseModel):
     type: str = Field('false', const=True)
+
+
+class CoordinateRange(BaseModel):
+    min: float
+    max: float
 
 
 class Reference(BaseModel):
@@ -997,6 +1004,13 @@ class RenameTableRequest(BaseModel):
     destination: TableIdentifier
 
 
+class BoundingBox(BaseModel):
+    x: CoordinateRange
+    y: CoordinateRange
+    z: Optional[CoordinateRange] = None
+    m: Optional[CoordinateRange] = None
+
+
 class TransformTerm(BaseModel):
     type: str = Field('transform', const=True)
     transform: Transform
@@ -1123,6 +1137,12 @@ class SetExpression(BaseModel):
     values: List[PrimitiveTypeValue]
 
 
+class SpatialExpression(BaseModel):
+    type: Literal['st-intersects', 'st-disjoint']
+    term: Term
+    value: BoundingBox
+
+
 class ResidualFilter6(SetExpression, ResidualFilter1):
     """
     An optional filter to be applied to rows in this file scan task.
@@ -1138,6 +1158,13 @@ class ResidualFilter7(LiteralExpression, ResidualFilter1):
 
 
 class ResidualFilter8(UnaryExpression, ResidualFilter1):
+    """
+    An optional filter to be applied to rows in this file scan task.
+    If the residual is not present, the client must produce the residual or use the original filter.
+    """
+
+
+class ResidualFilter9(SpatialExpression, ResidualFilter1):
     """
     An optional filter to be applied to rows in this file scan task.
     If the residual is not present, the client must produce the residual or use the original filter.
@@ -1188,6 +1215,7 @@ class Expression(BaseModel):
         SetExpression,
         LiteralExpression,
         UnaryExpression,
+        SpatialExpression,
     ]
 
 
@@ -1544,6 +1572,7 @@ class ResidualFilter(BaseModel):
         ResidualFilter6,
         ResidualFilter7,
         ResidualFilter8,
+        ResidualFilter9,
     ] = Field(
         ...,
         description='An optional filter to be applied to rows in this file scan task.\nIf the residual is not present, the client must produce the residual or use the original filter.',

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2252,6 +2252,7 @@ components:
         - $ref: '#/components/schemas/SetExpression'
         - $ref: '#/components/schemas/LiteralExpression'
         - $ref: '#/components/schemas/UnaryExpression'
+        - $ref: '#/components/schemas/SpatialExpression'
 
     ExpressionType:
       type: string
@@ -2275,6 +2276,8 @@ components:
         - "not-null"
         - "is-nan"
         - "not-nan"
+        - "st-intersects"
+        - "st-disjoint"
 
     TrueExpression:
       type: object
@@ -2364,6 +2367,49 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PrimitiveTypeValue'
+
+    SpatialExpression:
+      type: object
+      required:
+        - type
+        - term
+        - value
+      properties:
+        type:
+          $ref: '#/components/schemas/ExpressionType'
+          enum: ["st-intersects", "st-disjoint"]
+        term:
+          $ref: '#/components/schemas/Term'
+        value:
+          $ref: '#/components/schemas/BoundingBox'
+
+    BoundingBox:
+      type: object
+      required:
+        - x
+        - y
+      properties:
+        x:
+          $ref: '#/components/schemas/CoordinateRange'
+        y:
+          $ref: '#/components/schemas/CoordinateRange'
+        z:
+          $ref: '#/components/schemas/CoordinateRange'
+        m:
+          $ref: '#/components/schemas/CoordinateRange'
+
+    CoordinateRange:
+      type: object
+      required:
+        - min
+        - max
+      properties:
+        min:
+          type: number
+          format: double
+        max:
+          type: number
+          format: double
 
     Term:
       oneOf:


### PR DESCRIPTION
This PR updates the REST Catalog OpenAPI specification to support spatial predicate operators and bounding box literals. This change aligns the REST spec with the core Iceberg expression updates proposed in https://github.com/apache/iceberg/pull/14101.

**Changes**:

* Added `st-intersects` and `st-disjoint` to the allowed `ExpressionType` enum.
* Added new schemas for bounding box literal.

Here is an example of proposed JSON representation of spatial filter:

```json
{
  "type": "st-intersects",
  "term": "column-name",
  "value": {
    "x": {
      "min": 1.0,
      "max": 3.0
    },
    "y": {
      "min": 2.0,
      "max": 4.0
    },
    "z": {
      "min": 3.0,
      "max": 5.0
    },
    "m": {
      "min": 4.0,
      "max": 6.0
    }
  }
}
```