### PR TITLE
SPEC : Allow table level override for scan planning

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1468,6 +1468,9 @@ class LoadTableResult(BaseModel):
     ## General Configurations
 
     - `token`: Authorization bearer token to use for table requests if OAuth2 security is enabled
+    - `scan-planning-mode`: Communicates to clients the supported planning mode. Clients should use this value to fail fast if the supported scanning mode is not available on the client. Valid values:
+      - `client`: Clients MUST use client-side scan planning
+      - `server`: Clients MUST use server-side scan planning via the `planTableScan` endpoint
 
     ## AWS Configurations
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3468,6 +3468,9 @@ components:
         ## General Configurations
 
         - `token`: Authorization bearer token to use for table requests if OAuth2 security is enabled
+        - `scan-planning-mode`: Communicates to clients the supported planning mode. Clients should use this value to fail fast if the supported scanning mode is not available on the client. Valid values:
+          - `client`: Clients MUST use client-side scan planning
+          - `server`: Clients MUST use server-side scan planning via the `planTableScan` endpoint
 
         ## AWS Configurations
 


### PR DESCRIPTION
### About the change 

  Scan Planning Modes

  Single enum ScanPlanningMode with 2 values:
  - `client` - MUST use client-side planning
  - `server` - MUST use server-side planning

ML : https://lists.apache.org/thread/z1g4y8b4ogdrn0jjtjlgg7yjgxdbzpvg
