### PR TITLE
Expose failed commit count and exceptions in BaseCommitService

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
@@ -52,17 +52,19 @@ abstract class BaseCommitService<T> implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(BaseCommitService.class);
 
   public static final long TIMEOUT_IN_MS_DEFAULT = TimeUnit.MINUTES.toMillis(120);
+  private static final int MAX_RECORDED_FAILURES = 100;
 
   private final Table table;
   private final ExecutorService committerService;
   private final ConcurrentLinkedQueue<T> completedRewrites;
   private final ConcurrentLinkedQueue<String> inProgressCommits;
   private final ConcurrentLinkedQueue<T> committedRewrites;
-  private final List<Exception> exceptionsOfFailedCommits;
+  private final List<Exception> recentCommitFailures;
   private final int rewritesPerCommit;
   private final AtomicBoolean running = new AtomicBoolean(false);
   private final long timeoutInMS;
   private int succeededCommits = 0;
+  private int failedCommits = 0;
 
   /**
    * Constructs a {@link BaseCommitService}
@@ -96,7 +98,7 @@ abstract class BaseCommitService<T> implements Closeable {
     completedRewrites = Queues.newConcurrentLinkedQueue();
     committedRewrites = Queues.newConcurrentLinkedQueue();
     inProgressCommits = Queues.newConcurrentLinkedQueue();
-    exceptionsOfFailedCommits = Collections.synchronizedList(Lists.newArrayList());
+    recentCommitFailures = Collections.synchronizedList(Lists.newArrayList());
   }
 
   /**
@@ -234,7 +236,10 @@ abstract class BaseCommitService<T> implements Closeable {
         succeededCommits++;
       } catch (Exception e) {
         LOG.error("Failure during rewrite commit process, partial progress enabled. Ignoring", e);
-        exceptionsOfFailedCommits.add(e);
+        failedCommits++;
+        if (recentCommitFailures.size() < MAX_RECORDED_FAILURES) {
+          recentCommitFailures.add(e);
+        }
       }
       inProgressCommits.remove(inProgressCommitToken);
     }
@@ -245,11 +250,11 @@ abstract class BaseCommitService<T> implements Closeable {
   }
 
   public int failedCommits() {
-    return exceptionsOfFailedCommits.size();
+    return failedCommits;
   }
 
-  public List<Exception> exceptionsOfFailedCommits() {
-    return Lists.newArrayList(exceptionsOfFailedCommits);
+  public List<Exception> recentCommitFailures() {
+    return Lists.newArrayList(recentCommitFailures);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### What does this change do?

This PR adds lightweight tracking for failed commit attempts in BaseCommitService.

Specifically, it:

- Counts the number of failed commit attempts during rewrite actions
- Captures the exceptions thrown by failed commits for diagnostic purposes
- Exposes this information via accessor methods for use by callers and tests

###  Why is this change needed?

BaseCommitService explicitly supports partial progress, but today failed commits are only logged.
This makes it difficult to:

- Programmatically detect partial failures
- Surface useful diagnostics to callers
- Write tests that assert failure behavior without relying on log inspection

This change improves observability without altering commit behavior or public APIs.

###  Scope and compatibility

The change is limited to BaseCommitService, which is package-private and internal
No behavioral changes to commit execution or error handling
No impact on existing public APIs