### PR TITLE
GCS: bump up gcs-analytics-core version from 1.2.1 -> 1.2.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ flink120 = { strictly = "1.20.1"}
 flink20 = { strictly = "2.0.0"}
 flink21 = { strictly = "2.1.0"}
 google-libraries-bom = "26.72.0"
-gcs-analytics-core = "1.2.1"
+gcs-analytics-core = "1.2.3"
 guava = "33.5.0-jre"
 hadoop3 = "3.4.2"
 httpcomponents-httpclient5 = "5.5.1"


### PR DESCRIPTION
[Changelog](https://github.com/GoogleCloudPlatform/gcs-analytics-core/blob/main/CHANGELOG.md) of gcs-analytics-core:

- Fix issue with vectored IO where read requests were not bounded, resulting in poor performance with larger data files.
- Disable small object prefetch optimization by default, does not contribute to performance gain for larger data set, regresses few querie's scan time.


Consecutive Benchmark Results with updated version for 1 TB schema size: 
**benchmark**|**scan\_time (analytics core disabled)**|**scan\_time (analytics core enabled)**|**% Scan time improvement**
:-----:|:-----:|:-----:|:-----:
tpcds\_sf1000|29,946,605|19,370,576|35.32
tpcds\_sf1000|29,626,952|18,743,899|36.73
tpcds\_sf1000|30,714,037|19,084,079|37.87
tpcds\_sf1000|29,281,478|18,700,487|36.14



**benchmark**|**scan\_time (analytics core disabled)**|**scan\_time (analytics core enabled)**|**% Scan time improvement**
:-----:|:-----:|:-----:|:-----:
tpch\_sf1000|16,753,626|13,833,931|17.43
tpch\_sf1000|17,615,900|14,144,223|19.71
tpch\_sf1000|17,780,989|13,958,524|21.50
tpch\_sf1000|17,025,561|13,746,540|19.26

*scan_time is total of custom scan time metric added in BatchScan nodes for all queries. This was achieved by adding the metric in [BatchDataReader](https://github.com/ajayky-os/iceberg/pull/5/changes#diff-0485c2443c033338ff0b2d516831269b0432d1929e6699c352140e5006b2af30) in Iceberg spark runtime and captured the metrics by registering SparkListener in spark job running queries. 
