### PR TITLE
Encrypting IO as a `DelegateFileIO`

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -29,6 +29,8 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestListFile;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.DelegateFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
@@ -48,7 +50,9 @@ public class EncryptingFileIO implements FileIO, Serializable {
       return combine(encryptingIO.io, em);
     }
 
-    if (io instanceof SupportsPrefixOperations) {
+    if (io instanceof DelegateFileIO) {
+      return new WithDelegateFileIO((DelegateFileIO) io, em);
+    } else if (io instanceof SupportsPrefixOperations) {
       return new WithSupportsPrefixOperations((SupportsPrefixOperations) io, em);
     } else {
       return new EncryptingFileIO(io, em);
@@ -236,6 +240,30 @@ public class EncryptingFileIO implements FileIO, Serializable {
     @Override
     public void deletePrefix(String prefix) {
       prefixIo.deletePrefix(prefix);
+    }
+  }
+
+  static class WithDelegateFileIO extends EncryptingFileIO implements DelegateFileIO {
+    private final DelegateFileIO delegateFileIO;
+
+    WithDelegateFileIO(DelegateFileIO io, EncryptionManager em) {
+      super(io, em);
+      this.delegateFileIO = io;
+    }
+
+    @Override
+    public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
+      delegateFileIO.deleteFiles(pathsToDelete);
+    }
+
+    @Override
+    public Iterable<FileInfo> listPrefix(String prefix) {
+      return delegateFileIO.listPrefix(prefix);
+    }
+
+    @Override
+    public void deletePrefix(String prefix) {
+      delegateFileIO.deletePrefix(prefix);
     }
   }
 }

--- a/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
+++ b/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
@@ -24,9 +24,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.io.DelegateFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.junit.jupiter.api.Test;
 
@@ -39,13 +42,23 @@ public class TestEncryptingFileIO {
     FileIO fileIONoMixins = mock(FileIO.class);
     assertThat(EncryptingFileIO.combine(fileIONoMixins, em))
         .isInstanceOf(EncryptingFileIO.class)
+        .isNotInstanceOf(EncryptingFileIO.WithSupportsPrefixOperations.class)
+        .isNotInstanceOf(EncryptingFileIO.WithDelegateFileIO.class)
         .extracting(EncryptingFileIO::encryptionManager)
         .isEqualTo(em);
 
-    FileIO fileIOWithMixins =
+    FileIO fileIOWithPrefixOps =
         mock(FileIO.class, withSettings().extraInterfaces(SupportsPrefixOperations.class));
-    assertThat(EncryptingFileIO.combine(fileIOWithMixins, em))
+    assertThat(EncryptingFileIO.combine(fileIOWithPrefixOps, em))
         .isInstanceOf(EncryptingFileIO.WithSupportsPrefixOperations.class)
+        .extracting(EncryptingFileIO::encryptionManager)
+        .isEqualTo(em);
+
+    DelegateFileIO delegateFileIO = mock(DelegateFileIO.class);
+    assertThat(EncryptingFileIO.combine(delegateFileIO, em))
+        .isInstanceOf(EncryptingFileIO.WithDelegateFileIO.class)
+        .isInstanceOf(DelegateFileIO.class)
+        .isInstanceOf(SupportsBulkOperations.class)
         .extracting(EncryptingFileIO::encryptionManager)
         .isEqualTo(em);
   }
@@ -65,6 +78,41 @@ public class TestEncryptingFileIO {
 
     fileIO.deletePrefix(prefix);
     verify(delegate).deletePrefix(prefix);
+  }
+
+  @Test
+  public void reWrappingDelegateFileIOPreservesType() {
+    EncryptionManager em1 = mock(EncryptionManager.class);
+    EncryptionManager em2 = mock(EncryptionManager.class);
+    DelegateFileIO delegate = mock(DelegateFileIO.class);
+
+    EncryptingFileIO first = EncryptingFileIO.combine(delegate, em1);
+    EncryptingFileIO second = EncryptingFileIO.combine(first, em2);
+    assertThat(second)
+        .isInstanceOf(EncryptingFileIO.WithDelegateFileIO.class)
+        .extracting(EncryptingFileIO::encryptionManager)
+        .isEqualTo(em2);
+  }
+
+  @Test
+  public void delegateFileIODelegation() {
+    EncryptionManager em = mock(EncryptionManager.class);
+    DelegateFileIO delegate = mock(DelegateFileIO.class);
+
+    EncryptingFileIO.WithDelegateFileIO fileIO =
+        (EncryptingFileIO.WithDelegateFileIO) EncryptingFileIO.combine(delegate, em);
+
+    String prefix = "prefix";
+    Iterable<FileInfo> fileInfos = mock(Iterable.class);
+    when(delegate.listPrefix(prefix)).thenReturn(fileInfos);
+    assertThat(fileIO.listPrefix(prefix)).isEqualTo(fileInfos);
+
+    fileIO.deletePrefix(prefix);
+    verify(delegate).deletePrefix(prefix);
+
+    List<String> pathsToDelete = List.of("path1", "path2");
+    fileIO.deleteFiles(pathsToDelete);
+    verify(delegate).deleteFiles(pathsToDelete);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
+++ b/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.io.DelegateFileIO;
@@ -113,6 +114,41 @@ public class TestEncryptingFileIO {
     List<String> pathsToDelete = List.of("path1", "path2");
     fileIO.deleteFiles(pathsToDelete);
     verify(delegate).deleteFiles(pathsToDelete);
+  }
+
+  @Test
+  public void closeClosesUnderlyingFileIO() {
+    EncryptionManager em = mock(EncryptionManager.class);
+
+    FileIO fileIONoMixins = mock(FileIO.class);
+    EncryptingFileIO.combine(fileIONoMixins, em).close();
+    verify(fileIONoMixins).close();
+
+    SupportsPrefixOperations prefixIO = mock(SupportsPrefixOperations.class);
+    EncryptingFileIO prefixEncryptingIO = EncryptingFileIO.combine(prefixIO, em);
+    assertThat(prefixEncryptingIO)
+        .isInstanceOf(EncryptingFileIO.WithSupportsPrefixOperations.class);
+    prefixEncryptingIO.close();
+    verify(prefixIO).close();
+
+    DelegateFileIO delegate = mock(DelegateFileIO.class);
+    EncryptingFileIO delegateEncryptingIO = EncryptingFileIO.combine(delegate, em);
+    assertThat(delegateEncryptingIO).isInstanceOf(EncryptingFileIO.WithDelegateFileIO.class);
+    delegateEncryptingIO.close();
+    verify(delegate).close();
+  }
+
+  @Test
+  public void closeClosesEncryptionManagerWhenCloseable() throws Exception {
+    EncryptionManager em =
+        mock(EncryptionManager.class, withSettings().extraInterfaces(Closeable.class));
+    DelegateFileIO delegate = mock(DelegateFileIO.class);
+
+    EncryptingFileIO fileIO = EncryptingFileIO.combine(delegate, em);
+    fileIO.close();
+
+    verify(delegate).close();
+    verify((Closeable) em).close();
   }
 
   @Test


### PR DESCRIPTION
A table having encryption should not discount it from it supporting bulk operations (e.g. https://github.com/apache/iceberg/blob/9ca8029b4f7932ca2c22b034a0abc0edf8972975/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java#L316-L344) if the underlying IO supports it. But currently `EncryptingFileIO#combine` will never result in a `FIleIO` that `SupportsBulkOperations`.