### PR TITLE
Flink: Report records/bytes send metrics in DynamicWriter

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriter.java
@@ -145,6 +145,7 @@ class DynamicWriter implements CommittingSinkWriter<DynamicRecordInternal, Dynam
               return taskWriterFactory.create();
             })
         .write(element.rowData());
+    metrics.mainMetricsGroup().getNumRecordsSendCounter().inc();
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriter.java
@@ -243,7 +243,7 @@ class TestDynamicWriter extends TestFlinkIcebergSinkBase {
             1024L,
             properties,
             100,
-            new DynamicWriterMetrics(new UnregisteredMetricsGroup()),
+            new DynamicWriterMetrics(UnregisteredMetricsGroup.createSinkWriterMetricGroup()),
             0,
             0);
     return dynamicWriter;


### PR DESCRIPTION
Report standard Flink `numRecordsOut` and `numBytesOut` metrics in `DynamicWriter` operator to monitor writing performance to external systems. It will add a visibility per writer operator (subtask) with no table granularity, which we can add separately in the future. 