### PR TITLE
Core: Enable metadata tables support for REST scan planning

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -483,11 +483,13 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     trackFileIO(ops);
 
-    RESTTable restTable = restTableForScanPlanning(ops, finalIdentifier, tableClient);
-    // RestTable should be only be returned for non-metadata tables, because client would
+    // RestTable should only be returned for non-metadata tables, because client would
     // not have access to metadata files for example manifests, since all it needs is catalog.
-    if (restTable != null) {
-      return restTable;
+    if (metadataType == null) {
+      RESTTable restTable = restTableForScanPlanning(ops, finalIdentifier, tableClient);
+      if (restTable != null) {
+        return restTable;
+      }
     }
 
     BaseTable table =

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoteScanPlanning.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoteScanPlanning.java
@@ -55,10 +55,4 @@ public class TestRemoteScanPlanning extends TestSelect {
   public void testBinaryInFilter() {
     super.testBinaryInFilter();
   }
-
-  @TestTemplate
-  @Disabled("Metadata tables are currently not supported")
-  public void testMetadataTables() {
-    super.testMetadataTables();
-  }
 }


### PR DESCRIPTION
### About the change 

This PR enables the metadata to be read by spark, check this commit https://github.com/apache/iceberg/commit/f67e4b1a2fe04e45769a82f857db4d53f018cd98 for exact fix

caught via https://github.com/apache/iceberg/pull/14822