### PR TITLE
Document v3 types

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -188,7 +188,6 @@ MapType map = MapType.ofOptional(
 ListType list = ListType.ofRequired(1, IntegerType.get());
 ```
 
-
 ## Expressions
 
 Iceberg's expressions are used to configure table scans. To create expressions, use the factory methods in [`Expressions`](../../javadoc/{{ icebergVersion }}/org/apache/iceberg/expressions/Expressions.html).


### PR DESCRIPTION
### Summary

This PR addresses Issues #14874 adds documentation for new types including timestamp(with and without timezone support), UUID, Variant, Geometry and Unknown. It is not clear to me that all the types mentioned here where added v3, so please let me know if I have missed anything.

### Testing

tested with `cd site && make serve ` verified http://127.0.0.1:8000/docs/nightly/api/#using-version-3-types and  http://127.0.0.1:8000/docs/nightly/schemas/
<img width="1281" height="912" alt="image" src="https://github.com/user-attachments/assets/6ba01256-449d-4061-9f2b-e405283a40d6" />

