### PR TITLE
Spark: Fix typo in private method name in RewriteViewCommands

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
@@ -61,7 +61,7 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
           allowExisting,
           replace) =>
       val q = CTESubstitution.apply(query)
-      verifyTemporaryObjectsDontExist(resolved, q)
+      verifyTemporaryObjectsDoNotExist(resolved, q)
       CreateIcebergView(
         child = resolved,
         queryText = queryText,
@@ -126,7 +126,7 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
   /**
    * Permanent views are not allowed to reference temp objects
    */
-  private def verifyTemporaryObjectsDontExist(
+  private def verifyTemporaryObjectsDoNotExist(
       identifier: ResolvedIdentifier,
       child: LogicalPlan): Unit = {
     val tempViews = collectTemporaryViews(child)

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
@@ -61,7 +61,7 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
           allowExisting,
           replace) =>
       val q = CTESubstitution.apply(query)
-      verifyTemporaryObjectsDontExist(resolved, q)
+      verifyTemporaryObjectsDoNotExist(resolved, q)
       CreateIcebergView(
         child = resolved,
         queryText = queryText,
@@ -126,7 +126,7 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
   /**
    * Permanent views are not allowed to reference temp objects
    */
-  private def verifyTemporaryObjectsDontExist(
+  private def verifyTemporaryObjectsDoNotExist(
       identifier: ResolvedIdentifier,
       child: LogicalPlan): Unit = {
     val tempViews = collectTemporaryViews(child)

--- a/spark/v4.0/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
+++ b/spark/v4.0/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteViewCommands.scala
@@ -62,7 +62,7 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
           replace,
           _) =>
       val q = CTESubstitution.apply(query)
-      verifyTemporaryObjectsDontExist(resolved, q)
+      verifyTemporaryObjectsDoNotExist(resolved, q)
       CreateIcebergView(
         child = resolved,
         queryText = queryText,
@@ -127,7 +127,7 @@ case class RewriteViewCommands(spark: SparkSession) extends Rule[LogicalPlan] wi
   /**
    * Permanent views are not allowed to reference temp objects
    */
-  private def verifyTemporaryObjectsDontExist(
+  private def verifyTemporaryObjectsDoNotExist(
       identifier: ResolvedIdentifier,
       child: LogicalPlan): Unit = {
     val tempViews = collectTemporaryViews(child)


### PR DESCRIPTION
This PR fixes a typo in a private method name in RewriteViewCommands.

The method verifyTemporaryObjectsDontExist has been renamed to verifyTemporaryObjectsDoNotExist. The change is cosmetic only and does not affect behavior or public APIs.

This PR addresses a small typo found during Spark related code review.