### PR TITLE
Spark: Disable testTimestampAsOf/testVersionAsOf due to flakiness

### DIFF
--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoteScanPlanning.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoteScanPlanning.java
@@ -61,4 +61,10 @@ public class TestRemoteScanPlanning extends TestSelect {
   public void testTimestampAsOf() {
     super.testTimestampAsOf();
   }
+
+  @TestTemplate
+  @Disabled("Currently flaky and will be fixed by https://github.com/apache/iceberg/issues/14892")
+  public void testVersionAsOf() {
+    super.testVersionAsOf();
+  }
 }


### PR DESCRIPTION
I'm attempting to fix the flakiness https://github.com/apache/iceberg/pull/14894, so this PR is just in case we want to unblock others and the attempt doesn't work immediately