### PR TITLE
Core, REST: Avoid logging on every error

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogServlet.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogServlet.java
@@ -127,6 +127,9 @@ public class RESTCatalogServlet extends HttpServlet {
         }
       }
     } catch (RESTException e) {
+      if (response.isCommitted()) {
+        return;
+      }
       LOG.error("Error processing REST request", e);
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     } catch (Exception e) {


### PR DESCRIPTION
I see a long stack trace every time a REST server returns an error response, e.g., 404. This is the minimal reproduction.

```bash
$ gradle :iceberg-core:test --tests "org.apache.iceberg.rest.TestRESTCatalog.testSetNamespacePropertiesNamespaceDoesNotExist"
...
[qtp236002428-39] ERROR org.apache.iceberg.rest.RESTCatalogServlet - Error processing REST request
org.apache.iceberg.exceptions.RESTException: Unhandled error: ErrorResponse(code=404, type=NoSuchNamespaceException, message=Namespace does not exist: newdb)
org.apache.iceberg.exceptions.NoSuchNamespaceException: Namespace does not exist: newdb
	at org.apache.iceberg.inmemory.InMemoryCatalog.loadNamespaceMetadata(InMemoryCatalog.java:275)
	at org.apache.iceberg.rest.CatalogHandlers.updateNamespaceProperties(CatalogHandlers.java:218)
	at org.apache.iceberg.rest.RESTCatalogAdapter.handleRequest(RESTCatalogAdapter.java:242)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732)
	at org.apache.iceberg.rest.RESTCatalogAdapter.handleRequest(RESTCatalogAdapter.java:165)
	at org.apache.iceberg.rest.RESTCatalogAdapter.execute(RESTCatalogAdapter.java:569)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:732)
```

Or we can reproduce it by sending a request, e.g., `curl http://localhost:8181/v1/namespaces/default/tables/test`, against `iceberg-rest-fixture`.

```
% docker run --rm -p 8181:8181 apache/iceberg-rest-fixture:1.10.0
...
[qtp254749889-22] ERROR org.apache.iceberg.rest.RESTCatalogServlet - Error processing REST request
org.apache.iceberg.exceptions.RESTException: Unhandled error: ErrorResponse(code=404, type=NoSuchTableException, message=Table does not exist: default.test)
org.apache.iceberg.exceptions.NoSuchTableException: Table does not exist: default.test
	at org.apache.iceberg.BaseMetastoreCatalog.loadTable(BaseMetastoreCatalog.java:55)
	at org.apache.iceberg.rest.CatalogHandlers.loadTable(CatalogHandlers.java:329)
	at org.apache.iceberg.rest.RESTCatalogAdapter.handleRequest(RESTCatalogAdapter.java:420)
	at org.apache.iceberg.rest.RESTServerCatalogAdapter.handleRequest(RESTServerCatalogAdapter.java:42)
	at org.apache.iceberg.rest.RESTCatalogAdapter.execute(RESTCatalogAdapter.java:628)
	at org.apache.iceberg.rest.RESTCatalogAdapter.execute(RESTCatalogAdapter.java:609)
	at org.apache.iceberg.rest.RESTCatalogServlet.execute(RESTCatalogServlet.java:108)
```

1. When an error happens, [errorHandler is triggered](https://github.com/apache/iceberg/blob/d6d44a7803b218e7da6d514e96ad98282f22a2b6/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java#L584)
2. [The error handler constructs the error response, without throwing an exception](https://github.com/apache/iceberg/blob/d6d44a7803b218e7da6d514e96ad98282f22a2b6/core/src/test/java/org/apache/iceberg/rest/RESTCatalogServlet.java#L152-L161)
3. [The adapter throws a RESTException](https://github.com/apache/iceberg/blob/d6d44a7803b218e7da6d514e96ad98282f22a2b6/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java#L587)
4. [The servlet implementation attempts a non-local exit and logs the exception](https://github.com/apache/iceberg/blob/d6d44a7803b218e7da6d514e96ad98282f22a2b6/core/src/test/java/org/apache/iceberg/rest/RESTCatalogServlet.java#L109-L131)

Logging a stack trace for a 404 Not Found response is verbose in most use cases.

The first implementation of this pull request does not change the overall flow control. Ideally, `RESTCatalogAdapter#execute` should probably not throw a RESTException; however, it may require modifying `BaseHTTPClient`, so I opened this PR with a minimal change.