### PR TITLE
[doc] Add highlight note for Hadoop S3A FileSystem

### DIFF
--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -416,10 +416,8 @@ There is no redundant consistency wait and check which might negatively impact p
 
 ### Hadoop S3A FileSystem
 
-> ⚠️ **Important**
->
-> **S3FileIO is recommended** for S3 use cases rather than the `S3A FileSystem` (`HadoopFileIO`).
->
+!!! important
+    **S3FileIO is recommended** for S3 use cases rather than the `S3A FileSystem` (`HadoopFileIO`).
 
 Before `S3FileIO` was introduced, many Iceberg users choose to use `HadoopFileIO` to write data to S3 through the [S3A FileSystem](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java).
 As introduced in the previous sections, `S3FileIO` adopts the latest AWS clients and S3 features for optimized security and performance.


### PR DESCRIPTION
## Why:
* Docs of Iceberg mentioned using S3FileIO instead of HadoopFileIO, but it is not highlighted. I would like to add a highlight note for the Hadoop S3A FileSystem.

## Preview
* It looks like:

<img width="1509" height="844" alt="image" src="https://github.com/user-attachments/assets/f4b3af37-2d04-49f8-ba16-0880f9847c98" />

