### PR TITLE
docs: replace minio with rustfs in quick start

### DIFF
--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -52,8 +52,8 @@ services:
       - ./notebooks:/home/iceberg/notebooks/notebooks
       - ./spark-defaults.conf:/opt/spark/conf/spark-defaults.conf
     environment:
-      - AWS_ACCESS_KEY_ID=rustfsadmin
-      - AWS_SECRET_ACCESS_KEY=rustfsadmin
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
       - AWS_REGION=us-east-1
     ports:
       - 8888:8888
@@ -68,8 +68,8 @@ services:
     ports:
       - 8181:8181
     environment:
-      - AWS_ACCESS_KEY_ID=rustfsadmin
-      - AWS_SECRET_ACCESS_KEY=rustfsadmin
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
       - AWS_REGION=us-east-1
       - CATALOG_WAREHOUSE=s3://warehouse/
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
@@ -98,12 +98,12 @@ services:
     networks:
       iceberg_net:
     environment:
-      - AWS_ACCESS_KEY_ID=rustfsadmin
-      - AWS_SECRET_ACCESS_KEY=rustfsadmin
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
       - AWS_REGION=us-east-1
     entrypoint: |
       /bin/sh -c "
-      until (/usr/bin/mc alias set rustfs http://rustfs:9000 rustfsadmin rustfsadmin) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set rustfs http://rustfs:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force rustfs/warehouse;
       /usr/bin/mc mb rustfs/warehouse;
       /usr/bin/mc policy set public rustfs/warehouse;

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -79,8 +79,8 @@ services:
     image: rustfs/rustfs:latest
     container_name: rustfs
     environment:
-      - RUSTFS_ACCESS_KEY=rustfsadmin
-      - RUSTFS_SECRET_KEY=rustfsadmin
+      - RUSTFS_ACCESS_KEY=admin
+      - RUSTFS_SECRET_KEY=password
       - RUSTFS_VOLUMES=/data
       - RUSTFS_ADDRESS=0.0.0.0:9000
       - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -46,13 +46,14 @@ services:
       iceberg_net:
     depends_on:
       - rest
-      - minio
+      - rustfs
     volumes:
       - ./warehouse:/home/iceberg/warehouse
       - ./notebooks:/home/iceberg/notebooks/notebooks
+      - ./spark-defaults.conf:/opt/spark/conf/spark-defaults.conf
     environment:
-      - AWS_ACCESS_KEY_ID=admin
-      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_ACCESS_KEY_ID=rustfsadmin
+      - AWS_SECRET_ACCESS_KEY=rustfsadmin
       - AWS_REGION=us-east-1
     ports:
       - 8888:8888
@@ -67,44 +68,45 @@ services:
     ports:
       - 8181:8181
     environment:
-      - AWS_ACCESS_KEY_ID=admin
-      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_ACCESS_KEY_ID=rustfsadmin
+      - AWS_SECRET_ACCESS_KEY=rustfsadmin
       - AWS_REGION=us-east-1
       - CATALOG_WAREHOUSE=s3://warehouse/
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
-      - CATALOG_S3_ENDPOINT=http://minio:9000
-  minio:
-    image: minio/minio
-    container_name: minio
+      - CATALOG_S3_ENDPOINT=http://rustfs:9000
+      - CATALOG_S3_PATH__STYLE__ACCESS=true
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: rustfs
     environment:
-      - MINIO_ROOT_USER=admin
-      - MINIO_ROOT_PASSWORD=password
-      - MINIO_DOMAIN=minio
+      - RUSTFS_ACCESS_KEY=rustfsadmin
+      - RUSTFS_SECRET_KEY=rustfsadmin
+      - RUSTFS_VOLUMES=/data
+      - RUSTFS_ADDRESS=0.0.0.0:9000
+      - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001
+      - RUSTFS_CONSOLE_ENABLE=true
     networks:
       iceberg_net:
-        aliases:
-          - warehouse.minio
     ports:
       - 9001:9001
       - 9000:9000
-    command: ["server", "/data", "--console-address", ":9001"]
   mc:
     depends_on:
-      - minio
+      - rustfs
     image: minio/mc
     container_name: mc
     networks:
       iceberg_net:
     environment:
-      - AWS_ACCESS_KEY_ID=admin
-      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_ACCESS_KEY_ID=rustfsadmin
+      - AWS_SECRET_ACCESS_KEY=rustfsadmin
       - AWS_REGION=us-east-1
     entrypoint: |
       /bin/sh -c "
-      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc rm -r --force minio/warehouse;
-      /usr/bin/mc mb minio/warehouse;
-      /usr/bin/mc policy set public minio/warehouse;
+      until (/usr/bin/mc alias set rustfs http://rustfs:9000 rustfsadmin rustfsadmin) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force rustfs/warehouse;
+      /usr/bin/mc mb rustfs/warehouse;
+      /usr/bin/mc policy set public rustfs/warehouse;
       tail -f /dev/null
       "
 networks:
@@ -112,9 +114,23 @@ networks:
 
 ```
 
+!!! note
+
+    Since the [default Spark config](https://github.com/databricks/docker-spark-iceberg/blob/main/spark/spark-defaults.conf) hardcodes the value for `spark.sql.catalog.demo.s3.endpoint`, you **must** change it from `http://minio:9000` to `http://rustfs:9000`. Additionally, add the configuration `spark.sql.catalog.demo.s3.path-style-access true` to disable virtual host mode for RustFS. Keep all other configurations as they are, and mount the spark-defaults.conf file to the container.
+
+    ```conf
+
+    # replace minio address with rustfs address
+    spark.sql.catalog.demo.s3.endpoint     http://rustfs:9000
+
+    # add new configuration to disable virtual host mode for rustfs
+    spark.sql.catalog.demo.s3.path-style-access true
+
+    ```
+
 Next, start up the docker containers with this command:
 ```sh
-docker-compose up
+docker-compose up -d
 ```
 
 You can then run any of the following commands to start a Spark session.
@@ -149,6 +165,7 @@ using `demo.nyc.taxis` where `demo` is the catalog name, `nyc` is the database n
 === "SparkSQL"
 
     ```sql
+    CREATE NAMESPACE demo.nyc;
     CREATE TABLE demo.nyc.taxis
     (
       vendor_id bigint,

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -74,7 +74,6 @@ services:
       - CATALOG_WAREHOUSE=s3://warehouse/
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
       - CATALOG_S3_ENDPOINT=http://rustfs:9000
-      - CATALOG_S3_PATH__STYLE__ACCESS=true
   rustfs:
     image: rustfs/rustfs:latest
     container_name: rustfs
@@ -85,8 +84,11 @@ services:
       - RUSTFS_ADDRESS=0.0.0.0:9000
       - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001
       - RUSTFS_CONSOLE_ENABLE=true
+      - RUSTFS_SERVER_DOMAINS=rustfs:9001
     networks:
       iceberg_net:
+        aliases:
+          - warehouse.rustfs
     ports:
       - 9001:9001
       - 9000:9000
@@ -111,7 +113,6 @@ services:
       "
 networks:
   iceberg_net:
-
 ```
 
 !!! note
@@ -122,9 +123,6 @@ networks:
 
     # replace minio address with rustfs address
     spark.sql.catalog.demo.s3.endpoint     http://rustfs:9000
-
-    # add new configuration to disable virtual host mode for rustfs
-    spark.sql.catalog.demo.s3.path-style-access true
 
     ```
 


### PR DESCRIPTION
As discussed in https://github.com/apache/iceberg/issues/14638, minio is under maintenance mode, so replacing the minio with RustFS. Testing works fine locally.

Testing steps:

- Generating spark default conf

   ```
    spark.sql.extensions                   org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
    spark.sql.catalog.demo                 org.apache.iceberg.spark.SparkCatalog
    spark.sql.catalog.demo.type            rest
    spark.sql.catalog.demo.uri             http://rest:8181
    spark.sql.catalog.demo.io-impl         org.apache.iceberg.aws.s3.S3FileIO
    spark.sql.catalog.demo.warehouse       s3://warehouse/wh
    spark.sql.catalog.demo.s3.endpoint     http://rustfs:9000
    spark.sql.defaultCatalog               demo
    spark.eventLog.enabled                 true
    spark.eventLog.dir                     /home/iceberg/spark-events
    spark.history.fs.logDirectory          /home/iceberg/spark-events
    spark.sql.catalogImplementation        in-memory
    spark.sql.catalog.demo.s3.path-style-access true
    ```

- Running container 

   Running docker command to run all containers

   ```
    docker compose up -d
   ```

- Insert data

   ```
    docker exec -it spark-iceberg spark-sql
    Setting default log level to "WARN".
    To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
    25/12/25 01:41:54 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
    25/12/25 01:42:05 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.
    Spark Web UI available at http://4dbf6384ac7a:4041
    Spark master: local[*], Application Id: local-1766626926764
    spark-sql ()> 
                > CREATE NAMESPACE demo.nyc;
    Time taken: 4.89 seconds
    spark-sql ()> CREATE TABLE demo.nyc.taxis
                > (
                >   vendor_id bigint,
                >   trip_id bigint,
                >   trip_distance float,
                >   fare_amount double,
                >   store_and_fwd_flag string
                > )
                > PARTITIONED BY (vendor_id);
    Time taken: 6.362 seconds
    spark-sql ()> INSERT INTO demo.nyc.taxis
                > VALUES (1, 1000371, 1.8, 15.32, 'N'), (2, 1000372, 2.5, 22.15, 'N'), (2, 1000373, 0.9, 9.01, 'N'), (1, 1000374, 8.4, 42.13, 'Y');
    Time taken: 17.706 seconds
    spark-sql ()> 
    ```

- Data verification

   Checking inserted data on RustFS instance

    <img width="1912" height="355" alt="截屏2025-12-25 09 44 13" src="https://github.com/user-attachments/assets/3856d7e2-cf55-45d7-824e-4842307fd4c0" />

    