### PR TITLE
OpenAPI: Add SetPartitionStatisticsUpdate/RemovePartitionStatisticsUpdate to TableUpdate

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1259,6 +1259,8 @@ class TableUpdate(BaseModel):
         | RemovePropertiesUpdate
         | SetStatisticsUpdate
         | RemoveStatisticsUpdate
+        | SetPartitionStatisticsUpdate
+        | RemovePartitionStatisticsUpdate
         | RemovePartitionSpecsUpdate
         | RemoveSchemasUpdate
         | AddEncryptionKeyUpdate

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3219,6 +3219,8 @@ components:
         - $ref: '#/components/schemas/RemovePropertiesUpdate'
         - $ref: '#/components/schemas/SetStatisticsUpdate'
         - $ref: '#/components/schemas/RemoveStatisticsUpdate'
+        - $ref: '#/components/schemas/SetPartitionStatisticsUpdate'
+        - $ref: '#/components/schemas/RemovePartitionStatisticsUpdate'
         - $ref: '#/components/schemas/RemovePartitionSpecsUpdate'
         - $ref: '#/components/schemas/RemoveSchemasUpdate'
         - $ref: '#/components/schemas/AddEncryptionKeyUpdate'


### PR DESCRIPTION
I think this should be a follow-up to #9690 (`set-partition-statistics` and `remove-partition-statistics` were added to `BaseUpdate`'s `discriminator:` YAML sequence but not `TableUpdate`'s `anyOf:` YAML sequence) and #9240 (original refactor from `enum:` to `discriminator:`).

Without this, the JSON Schema I'm generating for my validator is incorrectly rejecting `CommitTableRequest` payloads with [TableUpdate schema objects](https://github.com/apache/iceberg/blob/00046005889c66ffc860bae012d7fc560e8f040a/open-api/rest-catalog-open-api.yaml#L3571-L3574C22) such as `set-partition-statistics`.

---

Ran my changes through:

```
make install
make generate
make lint
```

and everything passes.