### PR TITLE
[Core] Reduce manifest logging on table drop

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -112,6 +112,11 @@ public class CatalogUtil {
     }
 
     LOG.info("{} Manifests to delete ", manifestsToDelete.size());
+    if (LOG.isDebugEnabled()) {
+      for (ManifestFile manifest : manifestsToDelete) {
+        LOG.debug("Deleting manifest file: {}", manifest.path());
+      }
+    }
 
     // run all of the deletes
 


### PR DESCRIPTION
When dorp large table with many manifests, the CatalogUtils log every detail about manifest to be deleted and pollute the logs. Only total count of manifests to be dropped shall be sufficient, IO level logging can be selectively enabled to see exact deletion candidates
CC @huaxingao @stevenzwu 