### PR TITLE
site: fix live loading in `make serve-dev`

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -141,7 +141,6 @@ make serve-dev
 This development mode:
 - **Only builds `nightly` and `latest` versions** - Skips all historical versions
 - **Significantly reduces build time** - Typically 5-10x faster than building all versions
-- **Uses the `--dirty` flag** - Only rebuilds changed files for even faster iteration
 - **Perfect for iterative development** - Great for working on documentation content
 
 The development mode sets the `ICEBERG_DEV_MODE=true` environment variable and uses a simplified mkdocs configuration (`mkdocs-dev.yml`) that only includes the most recent versions.

--- a/site/dev/serve-dev.sh
+++ b/site/dev/serve-dev.sh
@@ -32,6 +32,4 @@ echo ""
 
 ./dev/setup_env.sh
 
-# Using mkdocs serve with --dirty flag for even faster rebuilds
-# The --dirty flag means only changed files are rebuilt
-"${VENV_DIR}/bin/python3" -m mkdocs serve --dirty --watch . -f mkdocs-dev.yml
+"${VENV_DIR}/bin/python3" -m mkdocs serve -f mkdocs-dev.yml --livereload --watch .

--- a/site/dev/serve.sh
+++ b/site/dev/serve.sh
@@ -23,4 +23,4 @@ set -e
 
 ./dev/lint.sh
 
-"${VENV_DIR}/bin/python3" -m mkdocs serve --dirty --watch .
+"${VENV_DIR}/bin/python3" -m mkdocs serve --livereload --watch .


### PR DESCRIPTION
Closes #14524

I found the [underlying issue](https://github.com/mkdocs/mkdocs/issues/4032#issuecomment-3591002290) while looking at a similar fix for pyiceberg (https://github.com/apache/iceberg-python/pull/2889)
This PR adds the `--livereload` flag to force live reload. 
This PR also removes the `--dirty` flag so reload works with changes to `site/mkdocs-dev.yml` and `site/overrides/`. Even after removing the `--dirty` flag, reloading takes ~10 seconds which is acceptable. 

I tested this manually by making changes to varies files and reloading :) 