### PR TITLE
Build: Bump roaringbitmap from 1.3.0 to 1.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ allprojects {
   repositories {
     mavenCentral()
     mavenLocal()
+    maven { url 'https://jitpack.io/' }
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,7 +80,7 @@ netty-buffer = "4.2.9.Final"
 object-client-bundle = "3.3.2"
 orc = "1.9.8"
 parquet = "1.17.0"
-roaringbitmap = "1.3.0"
+roaringbitmap = "1.6.0"
 scala-collection-compat = "2.14.0"
 slf4j = "2.0.17"
 snowflake-jdbc = "3.28.0"
@@ -170,7 +170,7 @@ orc-core = { module = "org.apache.orc:orc-core", version.ref = "orc" }
 parquet-avro = { module = "org.apache.parquet:parquet-avro", version.ref = "parquet" }
 parquet-column = { module = "org.apache.parquet:parquet-column", version.ref = "parquet" }
 parquet-hadoop = { module = "org.apache.parquet:parquet-hadoop", version.ref = "parquet" }
-roaringbitmap = { module = "org.roaringbitmap:RoaringBitmap", version.ref = "roaringbitmap" }
+roaringbitmap = { module = "com.github.RoaringBitmap.RoaringBitmap:roaringbitmap", version.ref = "roaringbitmap" }
 scala-collection-compat = { module = "org.scala-lang.modules:scala-collection-compat_2.13", version.ref = "scala-collection-compat"}
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }

--- a/kafka-connect/kafka-connect-runtime/hive/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/hive/LICENSE
@@ -1665,7 +1665,7 @@ License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
 
 --------------------------------------------------------------------------------
 
-Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.3.0
+Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.6.0
 Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
 License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/kafka-connect/kafka-connect-runtime/main/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/main/LICENSE
@@ -1185,7 +1185,7 @@ License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
 
 --------------------------------------------------------------------------------
 
-Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.3.0
+Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.6.0
 Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
 License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/open-api/LICENSE
+++ b/open-api/LICENSE
@@ -547,7 +547,7 @@ License (from POM): The Apache License, Version 2.0 - https://www.apache.org/lic
 
 --------------------------------------------------------------------------------
 
-Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.3.0
+Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.6.0
 Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
 License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -256,7 +256,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     }
 
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark34.get()}"
+    integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark34.get()}") {
+      exclude group: 'org.roaringbitmap'
+    }
     integrationImplementation libs.junit.jupiter
     integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -258,7 +258,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     }
 
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark35.get()}"
+    integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark35.get()}") {
+      exclude group: 'org.roaringbitmap'
+    }
     integrationImplementation libs.junit.jupiter
     integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -267,7 +267,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     }
 
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark40.get()}"
+    integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark40.get()}") {
+      exclude group: 'org.roaringbitmap'
+    }
     integrationImplementation libs.junit.jupiter
     integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple

--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -277,7 +277,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     }
 
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark41.get()}"
+    integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark41.get()}") {
+      exclude group: 'org.roaringbitmap'
+    }
     integrationImplementation libs.junit.jupiter
     integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple


### PR DESCRIPTION
roaringbitmap was no longer published to https://mvnrepository.com/artifact/org.roaringbitmap/RoaringBitmap after 1.3.0, but to https://jitpack.io as `com.github.RoaringBitmap.RoaringBitmap:roaringbitmap`