### PR TITLE
site infra: when running `make serve`, add a tip on using `make serve-dev` instead

### DIFF
--- a/site/dev/serve.sh
+++ b/site/dev/serve.sh
@@ -19,6 +19,17 @@
 source dev/common.sh
 set -e
 
+echo ""
+echo "**********************************************"
+echo "**                                          **"
+echo "**  💡 TIP: Use 'make serve-dev' instead!  **"
+echo "**                                          **"
+echo "**  It's FASTER for local development       **"
+echo "**  (only builds nightly and latest)        **"
+echo "**                                          **"
+echo "**********************************************"
+echo ""
+
 ./dev/setup_env.sh
 
 ./dev/lint.sh


### PR DESCRIPTION
So more ppl are aware of `make serve-dev` 

![Screenshot 2026-01-07 at 9 14 38 PM](https://github.com/user-attachments/assets/cf35a0bc-e99c-4e40-8138-16d77251c47a)
