### PR TITLE
Core: Adding same view version as part of a concurrent update shouldn't fail

### DIFF
--- a/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
@@ -59,6 +59,13 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
           required(3, "id", Types.IntegerType.get(), "unique ID"),
           required(4, "data", Types.StringType.get()));
 
+  private static final Schema SCHEMA_WITH_EXTRA_COL =
+      new Schema(
+          9,
+          required(3, "id", Types.IntegerType.get(), "unique ID"),
+          required(4, "data", Types.StringType.get()),
+          required(8, "extra", Types.StringType.get()));
+
   private static final Schema OTHER_SCHEMA =
       new Schema(7, required(1, "some_id", Types.IntegerType.get()));
 
@@ -2149,5 +2156,91 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
         .hasMessageStartingWith("Table with same name already exists: ns.view");
 
     assertThat(tableCatalog().dropTable(identifier)).isTrue();
+  }
+
+  @Test
+  public void concurrentIdenticalUpdates() {
+    TableIdentifier identifier = TableIdentifier.of("ns", "view");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(identifier.namespace());
+    }
+
+    assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+
+    View view =
+        catalog()
+            .buildView(identifier)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(identifier.namespace())
+            .withQuery("spark", "select id, data from ns.tbl")
+            .create();
+    ViewVersion initialViewVersion = view.currentVersion();
+
+    assertThat(catalog().viewExists(identifier)).as("View should exist").isTrue();
+
+    ReplaceViewVersion replaceViewVersion =
+        view.replaceVersion()
+            .withQuery("spark", "select id, data, extra from ns.tbl")
+            .withSchema(SCHEMA_WITH_EXTRA_COL)
+            .withDefaultNamespace(identifier.namespace());
+
+    ViewOperations viewOps = ((BaseView) view).operations();
+    ViewMetadata current = viewOps.current();
+
+    // simulate a concurrent update with identical changes (expects idempotent behavior)
+    ViewMetadata update1 = ((ViewVersionReplace) replaceViewVersion).internalApply();
+    ViewMetadata update2 = ((ViewVersionReplace) replaceViewVersion).internalApply();
+
+    viewOps.commit(current, update1);
+
+    if (supportsServerSideRetry()) {
+      // retry should succeed and the changes should be applied
+      viewOps.commit(current, update2);
+    } else {
+      assertThatThrownBy(() -> viewOps.commit(current, update2))
+          .isInstanceOf(CommitFailedException.class)
+          .hasMessageContaining("Cannot commit");
+    }
+
+    View updatedView = catalog().loadView(identifier);
+    assertThat(updatedView.history()).hasSize(2);
+    assertThat(updatedView.currentVersion().operation()).isEqualTo("replace");
+    assertThat(updatedView.schema().schemaId()).isEqualTo(1);
+    assertThat(updatedView.schema().asStruct()).isEqualTo(SCHEMA_WITH_EXTRA_COL.asStruct());
+    assertThat(updatedView.schemas()).hasSize(2).containsKey(0).containsKey(1);
+    assertThat(updatedView.versions())
+        .hasSize(2)
+        .containsExactly(initialViewVersion, updatedView.currentVersion());
+
+    assertThat(initialViewVersion)
+        .isEqualTo(
+            ImmutableViewVersion.builder()
+                .timestampMillis(initialViewVersion.timestampMillis())
+                .versionId(1)
+                .schemaId(0)
+                .summary(initialViewVersion.summary())
+                .defaultNamespace(identifier.namespace())
+                .addRepresentations(
+                    ImmutableSQLViewRepresentation.builder()
+                        .sql("select id, data from ns.tbl")
+                        .dialect("spark")
+                        .build())
+                .build());
+
+    assertThat(updatedView.currentVersion())
+        .isEqualTo(
+            ImmutableViewVersion.builder()
+                .timestampMillis(updatedView.currentVersion().timestampMillis())
+                .versionId(2)
+                .schemaId(1)
+                .summary(updatedView.currentVersion().summary())
+                .defaultNamespace(identifier.namespace())
+                .addRepresentations(
+                    ImmutableSQLViewRepresentation.builder()
+                        .sql("select id, data, extra from ns.tbl")
+                        .dialect("spark")
+                        .build())
+                .build());
   }
 }


### PR DESCRIPTION
This fixes an issue that @haizhou-zhao brought up in https://github.com/apache/iceberg/pull/14334.
Basically the test added in https://github.com/apache/iceberg/pull/14334 performs a concurrent update of the same view version, but fails with
```
org.apache.iceberg.exceptions.ValidationException: Cannot set last added schema: no schema has been added
	at org.apache.iceberg.exceptions.ValidationException.check(ValidationException.java:49)
	at org.apache.iceberg.view.ViewMetadata$Builder.addVersionInternal(ViewMetadata.java:297)
	at org.apache.iceberg.view.ViewMetadata$Builder.addVersion(ViewMetadata.java:277)
	at org.apache.iceberg.MetadataUpdate$AddViewVersion.applyTo(MetadataUpdate.java:508)
	at org.apache.iceberg.rest.CatalogHandlers.lambda$commit$11(CatalogHandlers.java:624)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.apache.iceberg.rest.CatalogHandlers.lambda$commit$12(CatalogHandlers.java:624)
```

This is due to our internal state tracking of `lastAddedSchemaId`, which is then assumed to be set when adding the view version and checking
```
if (version.schemaId() == LAST_ADDED) {
  ValidationException.check(lastAddedSchemaId != null, "Cannot set last added schema: no schema has been added");
  version = ImmutableViewVersion.builder().from(version).schemaId(lastAddedSchemaId).build();
}
```

I added a reproducible test to `TestViewMetadata` where the schema ID is set to `-1`, indicating that the schema ID can be re-assigned.
Once we get this change in, we should also get https://github.com/apache/iceberg/pull/14334 in, as that reproduces the issue and has a good test for it.

@huaxingao, @singhpk234, @amogh-jahagirdar since you guys reviewed https://github.com/apache/iceberg/pull/14434 already, could you please review this one as well?