### PR TITLE
Spark 4.1: Fix spark 4.1 test for unlink table metadata's last-updated timestamp

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -579,7 +579,7 @@ public class TestMetadataTables extends ExtensionsTestBase {
                 parentSnapshot.schemaId(),
                 parentSnapshot.sequenceNumber()),
             row(
-                DateTimeUtils.toJavaTimestamp(currentSnapshot.timestampMillis() * 1000),
+                DateTimeUtils.toJavaTimestamp(tableMetadata.lastUpdatedMillis() * 1000),
                 tableMetadata.metadataFileLocation(),
                 currentSnapshot.snapshotId(),
                 currentSnapshot.schemaId(),
@@ -598,8 +598,7 @@ public class TestMetadataTables extends ExtensionsTestBase {
         "Result should match the latest snapshot entry",
         ImmutableList.of(
             row(
-                DateTimeUtils.toJavaTimestamp(
-                    tableMetadata.currentSnapshot().timestampMillis() * 1000),
+                DateTimeUtils.toJavaTimestamp(tableMetadata.lastUpdatedMillis() * 1000),
                 tableMetadata.metadataFileLocation(),
                 tableMetadata.currentSnapshot().snapshotId(),
                 tableMetadata.currentSnapshot().schemaId(),

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -46,6 +46,7 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -821,6 +822,10 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     // rollback the table state to the first snapshot
     table.manageSnapshots().rollbackTo(firstSnapshotId).commit();
     long rollbackTimestamp = Iterables.getLast(table.history()).timestampMillis();
+    assertThat(rollbackTimestamp)
+        .as("Rollback history timestamp should be greater than first snapshot timestamp")
+        .isEqualTo(((HasTableOperations) table).operations().current().lastUpdatedMillis())
+        .isGreaterThan(firstSnapshotTimestamp);
 
     inputDf
         .select("id", "data")


### PR DESCRIPTION
backport changes of https://github.com/apache/iceberg/pull/14504 to spark 4.1 as it's now default for spark tests


CC @huaxingao @singhpk234 @RussellSpitzer 

