### PR TITLE
infra: add gradle cache to github workflows

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -55,6 +55,13 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - run: |
           echo "Using the old version tag, as per git describe, of $(git describe)";
       - run: ./gradlew revapi --rerun-tasks

--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -42,6 +42,13 @@ jobs:
       with:
         distribution: zulu
         java-version: 21
+    - uses: actions/cache@v5
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: ${{ runner.os }}-gradle-
     - name: Build Iceberg Open API project
       run: ./gradlew :iceberg-open-api:shadowJar
     - name: Login to Docker Hub

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - run: |
           ./gradlew printVersion
           ./gradlew -DallModules publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}


### PR DESCRIPTION
Closes #14950, `.github/workflows/publish-iceberg-rest-fixture-docker.yml` periodically timeout due to issue downloading jars. Adding a gradle cache hopefully can alleviate the issue.

These 3 github workflows are the only ones missing gradle cache, it doesnt hurt to add it. 
Copied gradle cache over from 
https://github.com/apache/iceberg/blob/a7b8a08b2abb6125ffbe6ea61817e5826db61ab2/.github/workflows/spark-ci.yml#L99-L105
