### PR TITLE
Spark: Backport #14933: Snapshot location overlap check to spark v3.4, v3.5, v4.0

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -124,16 +124,16 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
     StagedSparkTable stagedTable = stageDestTable();
     Table icebergTable = stagedTable.table();
 
-      String sourceTableLocation = sourceTableLocation();
-      String stagedTableLocation = icebergTable.location();
-      Preconditions.checkArgument(
-              !sourceTableLocation.equals(stagedTableLocation)
-                      && !stagedTableLocation.startsWith(sourceTableLocation + "/")
-                      && !sourceTableLocation.startsWith(stagedTableLocation + "/"),
-              "Cannot create a snapshot at location %s because it would overlap with source table location %s. "
-                      + "Overlapping snapshot and source would mix table files.",
-              stagedTableLocation,
-              sourceTableLocation);
+    String sourceTableLocation = sourceTableLocation();
+    String stagedTableLocation = icebergTable.location();
+    Preconditions.checkArgument(
+        !sourceTableLocation.equals(stagedTableLocation)
+            && !stagedTableLocation.startsWith(sourceTableLocation + "/")
+            && !sourceTableLocation.startsWith(stagedTableLocation + "/"),
+        "Cannot create a snapshot at location %s because it would overlap with source table location %s. "
+            + "Overlapping snapshot and source would mix table files.",
+        stagedTableLocation,
+        sourceTableLocation);
 
     boolean threw = true;
     try {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestSnapshotTableAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestSnapshotTableAction.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestSnapshotTableAction extends CatalogTestBase {
   private static final String SOURCE_NAME = "spark_catalog.default.source";
-    private static final String SOURCE = "source";
+  private static final String SOURCE = "source";
 
   @AfterEach
   public void removeTables() {
@@ -71,91 +71,91 @@ public class TestSnapshotTableAction extends CatalogTestBase {
     assertThat(snapshotThreadsIndex.get()).isEqualTo(2);
   }
 
-    @TestTemplate
-    public void testSnapshotWithOverlappingLocation() throws IOException {
-        //  Hadoop Catalogs do not Support Custom Table Locations
-        String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
-        assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
+  @TestTemplate
+  public void testSnapshotWithOverlappingLocation() throws IOException {
+    //  Hadoop Catalogs do not Support Custom Table Locations
+    String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
+    assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
 
-        String sourceLocation =
-                Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
-        sql(
-                "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-                SOURCE_NAME, sourceLocation);
-        sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
-        sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
-        String actualSourceLocation =
-                spark
-                        .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
-                        .filter("col_name = 'Location'")
-                        .select("data_type")
-                        .first()
-                        .getString(0);
+    String sourceLocation =
+        Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        SOURCE_NAME, sourceLocation);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
+    String actualSourceLocation =
+        spark
+            .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
+            .filter("col_name = 'Location'")
+            .select("data_type")
+            .first()
+            .getString(0);
 
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(actualSourceLocation)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith(
-                        "The snapshot table location cannot be same as the source table location.");
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(actualSourceLocation)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "The snapshot table location cannot be same as the source table location.");
 
-        String destAsSubdirectory = actualSourceLocation + "/nested";
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(destAsSubdirectory)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot create a snapshot at location");
+    String destAsSubdirectory = actualSourceLocation + "/nested";
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(destAsSubdirectory)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot create a snapshot at location");
 
-        String parentLocation =
-                actualSourceLocation.substring(0, actualSourceLocation.length() - ("/" + SOURCE).length());
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(parentLocation)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot create a snapshot at location");
-    }
+    String parentLocation =
+        actualSourceLocation.substring(0, actualSourceLocation.length() - ("/" + SOURCE).length());
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(parentLocation)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot create a snapshot at location");
+  }
 
-    @TestTemplate
-    public void testSnapshotWithNonOverlappingLocation() throws IOException {
-        //  Hadoop Catalogs do not Support Custom Table Locations
-        String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
-        assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
+  @TestTemplate
+  public void testSnapshotWithNonOverlappingLocation() throws IOException {
+    //  Hadoop Catalogs do not Support Custom Table Locations
+    String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
+    assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
 
-        String sourceLocation =
-                Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
-        sql(
-                "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-                SOURCE_NAME, sourceLocation);
-        sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
-        sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
-        String actualSourceLocation =
-                spark
-                        .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
-                        .filter("col_name = 'Location'")
-                        .select("data_type")
-                        .first()
-                        .getString(0);
+    String sourceLocation =
+        Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        SOURCE_NAME, sourceLocation);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
+    String actualSourceLocation =
+        spark
+            .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
+            .filter("col_name = 'Location'")
+            .select("data_type")
+            .first()
+            .getString(0);
 
-        String validDestLocation =
-                actualSourceLocation.substring(0, actualSourceLocation.length() - SOURCE.length())
-                        + "newDestination";
-        SparkActions.get()
-                .snapshotTable(SOURCE_NAME)
-                .as(tableName)
-                .tableLocation(validDestLocation)
-                .execute();
-        assertThat(sql("SELECT * FROM %s", tableName)).hasSize(2);
-    }
+    String validDestLocation =
+        actualSourceLocation.substring(0, actualSourceLocation.length() - SOURCE.length())
+            + "newDestination";
+    SparkActions.get()
+        .snapshotTable(SOURCE_NAME)
+        .as(tableName)
+        .tableLocation(validDestLocation)
+        .execute();
+    assertThat(sql("SELECT * FROM %s", tableName)).hasSize(2);
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -124,16 +124,16 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
     StagedSparkTable stagedTable = stageDestTable();
     Table icebergTable = stagedTable.table();
 
-      String sourceTableLocation = sourceTableLocation();
-      String stagedTableLocation = icebergTable.location();
-      Preconditions.checkArgument(
-              !sourceTableLocation.equals(stagedTableLocation)
-                      && !stagedTableLocation.startsWith(sourceTableLocation + "/")
-                      && !sourceTableLocation.startsWith(stagedTableLocation + "/"),
-              "Cannot create a snapshot at location %s because it would overlap with source table location %s. "
-                      + "Overlapping snapshot and source would mix table files.",
-              stagedTableLocation,
-              sourceTableLocation);
+    String sourceTableLocation = sourceTableLocation();
+    String stagedTableLocation = icebergTable.location();
+    Preconditions.checkArgument(
+        !sourceTableLocation.equals(stagedTableLocation)
+            && !stagedTableLocation.startsWith(sourceTableLocation + "/")
+            && !sourceTableLocation.startsWith(stagedTableLocation + "/"),
+        "Cannot create a snapshot at location %s because it would overlap with source table location %s. "
+            + "Overlapping snapshot and source would mix table files.",
+        stagedTableLocation,
+        sourceTableLocation);
 
     boolean threw = true;
     try {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSnapshotTableAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSnapshotTableAction.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestSnapshotTableAction extends CatalogTestBase {
   private static final String SOURCE_NAME = "spark_catalog.default.source";
-    private static final String SOURCE = "source";
+  private static final String SOURCE = "source";
 
   @AfterEach
   public void removeTables() {
@@ -71,91 +71,91 @@ public class TestSnapshotTableAction extends CatalogTestBase {
     assertThat(snapshotThreadsIndex.get()).isEqualTo(2);
   }
 
-    @TestTemplate
-    public void testSnapshotWithOverlappingLocation() throws IOException {
-        //  Hadoop Catalogs do not Support Custom Table Locations
-        String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
-        assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
+  @TestTemplate
+  public void testSnapshotWithOverlappingLocation() throws IOException {
+    //  Hadoop Catalogs do not Support Custom Table Locations
+    String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
+    assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
 
-        String sourceLocation =
-                Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
-        sql(
-                "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-                SOURCE_NAME, sourceLocation);
-        sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
-        sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
-        String actualSourceLocation =
-                spark
-                        .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
-                        .filter("col_name = 'Location'")
-                        .select("data_type")
-                        .first()
-                        .getString(0);
+    String sourceLocation =
+        Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        SOURCE_NAME, sourceLocation);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
+    String actualSourceLocation =
+        spark
+            .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
+            .filter("col_name = 'Location'")
+            .select("data_type")
+            .first()
+            .getString(0);
 
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(actualSourceLocation)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith(
-                        "The snapshot table location cannot be same as the source table location.");
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(actualSourceLocation)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "The snapshot table location cannot be same as the source table location.");
 
-        String destAsSubdirectory = actualSourceLocation + "/nested";
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(destAsSubdirectory)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot create a snapshot at location");
+    String destAsSubdirectory = actualSourceLocation + "/nested";
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(destAsSubdirectory)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot create a snapshot at location");
 
-        String parentLocation =
-                actualSourceLocation.substring(0, actualSourceLocation.length() - ("/" + SOURCE).length());
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(parentLocation)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot create a snapshot at location");
-    }
+    String parentLocation =
+        actualSourceLocation.substring(0, actualSourceLocation.length() - ("/" + SOURCE).length());
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(parentLocation)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot create a snapshot at location");
+  }
 
-    @TestTemplate
-    public void testSnapshotWithNonOverlappingLocation() throws IOException {
-        //  Hadoop Catalogs do not Support Custom Table Locations
-        String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
-        assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
+  @TestTemplate
+  public void testSnapshotWithNonOverlappingLocation() throws IOException {
+    //  Hadoop Catalogs do not Support Custom Table Locations
+    String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
+    assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
 
-        String sourceLocation =
-                Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
-        sql(
-                "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-                SOURCE_NAME, sourceLocation);
-        sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
-        sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
-        String actualSourceLocation =
-                spark
-                        .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
-                        .filter("col_name = 'Location'")
-                        .select("data_type")
-                        .first()
-                        .getString(0);
+    String sourceLocation =
+        Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        SOURCE_NAME, sourceLocation);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
+    String actualSourceLocation =
+        spark
+            .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
+            .filter("col_name = 'Location'")
+            .select("data_type")
+            .first()
+            .getString(0);
 
-        String validDestLocation =
-                actualSourceLocation.substring(0, actualSourceLocation.length() - SOURCE.length())
-                        + "newDestination";
-        SparkActions.get()
-                .snapshotTable(SOURCE_NAME)
-                .as(tableName)
-                .tableLocation(validDestLocation)
-                .execute();
-        assertThat(sql("SELECT * FROM %s", tableName)).hasSize(2);
-    }
+    String validDestLocation =
+        actualSourceLocation.substring(0, actualSourceLocation.length() - SOURCE.length())
+            + "newDestination";
+    SparkActions.get()
+        .snapshotTable(SOURCE_NAME)
+        .as(tableName)
+        .tableLocation(validDestLocation)
+        .execute();
+    assertThat(sql("SELECT * FROM %s", tableName)).hasSize(2);
+  }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -124,16 +124,16 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
     StagedSparkTable stagedTable = stageDestTable();
     Table icebergTable = stagedTable.table();
 
-      String sourceTableLocation = sourceTableLocation();
-      String stagedTableLocation = icebergTable.location();
-      Preconditions.checkArgument(
-              !sourceTableLocation.equals(stagedTableLocation)
-                      && !stagedTableLocation.startsWith(sourceTableLocation + "/")
-                      && !sourceTableLocation.startsWith(stagedTableLocation + "/"),
-              "Cannot create a snapshot at location %s because it would overlap with source table location %s. "
-                      + "Overlapping snapshot and source would mix table files.",
-              stagedTableLocation,
-              sourceTableLocation);
+    String sourceTableLocation = sourceTableLocation();
+    String stagedTableLocation = icebergTable.location();
+    Preconditions.checkArgument(
+        !sourceTableLocation.equals(stagedTableLocation)
+            && !stagedTableLocation.startsWith(sourceTableLocation + "/")
+            && !sourceTableLocation.startsWith(stagedTableLocation + "/"),
+        "Cannot create a snapshot at location %s because it would overlap with source table location %s. "
+            + "Overlapping snapshot and source would mix table files.",
+        stagedTableLocation,
+        sourceTableLocation);
 
     boolean threw = true;
     try {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestSnapshotTableAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestSnapshotTableAction.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestSnapshotTableAction extends CatalogTestBase {
   private static final String SOURCE_NAME = "spark_catalog.default.source";
-    private static final String SOURCE = "source";
+  private static final String SOURCE = "source";
 
   @AfterEach
   public void removeTables() {
@@ -71,91 +71,91 @@ public class TestSnapshotTableAction extends CatalogTestBase {
     assertThat(snapshotThreadsIndex.get()).isEqualTo(2);
   }
 
-    @TestTemplate
-    public void testSnapshotWithOverlappingLocation() throws IOException {
-        //  Hadoop Catalogs do not Support Custom Table Locations
-        String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
-        assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
+  @TestTemplate
+  public void testSnapshotWithOverlappingLocation() throws IOException {
+    //  Hadoop Catalogs do not Support Custom Table Locations
+    String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
+    assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
 
-        String sourceLocation =
-                Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
-        sql(
-                "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-                SOURCE_NAME, sourceLocation);
-        sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
-        sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
-        String actualSourceLocation =
-                spark
-                        .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
-                        .filter("col_name = 'Location'")
-                        .select("data_type")
-                        .first()
-                        .getString(0);
+    String sourceLocation =
+        Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        SOURCE_NAME, sourceLocation);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
+    String actualSourceLocation =
+        spark
+            .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
+            .filter("col_name = 'Location'")
+            .select("data_type")
+            .first()
+            .getString(0);
 
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(actualSourceLocation)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith(
-                        "The snapshot table location cannot be same as the source table location.");
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(actualSourceLocation)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "The snapshot table location cannot be same as the source table location.");
 
-        String destAsSubdirectory = actualSourceLocation + "/nested";
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(destAsSubdirectory)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot create a snapshot at location");
+    String destAsSubdirectory = actualSourceLocation + "/nested";
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(destAsSubdirectory)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot create a snapshot at location");
 
-        String parentLocation =
-                actualSourceLocation.substring(0, actualSourceLocation.length() - ("/" + SOURCE).length());
-        assertThatThrownBy(
-                () ->
-                        SparkActions.get()
-                                .snapshotTable(SOURCE_NAME)
-                                .as(tableName)
-                                .tableLocation(parentLocation)
-                                .execute())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot create a snapshot at location");
-    }
+    String parentLocation =
+        actualSourceLocation.substring(0, actualSourceLocation.length() - ("/" + SOURCE).length());
+    assertThatThrownBy(
+            () ->
+                SparkActions.get()
+                    .snapshotTable(SOURCE_NAME)
+                    .as(tableName)
+                    .tableLocation(parentLocation)
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot create a snapshot at location");
+  }
 
-    @TestTemplate
-    public void testSnapshotWithNonOverlappingLocation() throws IOException {
-        //  Hadoop Catalogs do not Support Custom Table Locations
-        String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
-        assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
+  @TestTemplate
+  public void testSnapshotWithNonOverlappingLocation() throws IOException {
+    //  Hadoop Catalogs do not Support Custom Table Locations
+    String catalogType = catalogConfig.get(ICEBERG_CATALOG_TYPE);
+    assumeThat(catalogType).isNotEqualTo(ICEBERG_CATALOG_TYPE_HADOOP);
 
-        String sourceLocation =
-                Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
-        sql(
-                "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-                SOURCE_NAME, sourceLocation);
-        sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
-        sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
-        String actualSourceLocation =
-                spark
-                        .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
-                        .filter("col_name = 'Location'")
-                        .select("data_type")
-                        .first()
-                        .getString(0);
+    String sourceLocation =
+        Files.createTempDirectory(temp, "junit").resolve(SOURCE).toFile().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        SOURCE_NAME, sourceLocation);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", SOURCE_NAME);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", SOURCE_NAME);
+    String actualSourceLocation =
+        spark
+            .sql(String.format("DESCRIBE EXTENDED %s", SOURCE_NAME))
+            .filter("col_name = 'Location'")
+            .select("data_type")
+            .first()
+            .getString(0);
 
-        String validDestLocation =
-                actualSourceLocation.substring(0, actualSourceLocation.length() - SOURCE.length())
-                        + "newDestination";
-        SparkActions.get()
-                .snapshotTable(SOURCE_NAME)
-                .as(tableName)
-                .tableLocation(validDestLocation)
-                .execute();
-        assertThat(sql("SELECT * FROM %s", tableName)).hasSize(2);
-    }
+    String validDestLocation =
+        actualSourceLocation.substring(0, actualSourceLocation.length() - SOURCE.length())
+            + "newDestination";
+    SparkActions.get()
+        .snapshotTable(SOURCE_NAME)
+        .as(tableName)
+        .tableLocation(validDestLocation)
+        .execute();
+    assertThat(sql("SELECT * FROM %s", tableName)).hasSize(2);
+  }
 }


### PR DESCRIPTION
Backport of https://github.com/apache/iceberg/pull/14933 to Spark v3.4, 3.5, 4.0

Implements location overlap validation for SnapshotTableAction to prevent destination table location from overlapping with source table location.

Resolves TODO comment in SnapshotTableSparkAction.java:127 in spark v3.4, v3.5, v4.0