### PR TITLE
Fix inconsistent 404 handling in GCS and ADLS FileIO implementations

### DIFF
--- a/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
+++ b/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.azure.adlsv2;
 
 import static org.apache.iceberg.azure.AzureProperties.ADLS_SAS_TOKEN_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
@@ -42,6 +43,7 @@ import java.time.OffsetDateTime;
 import java.util.Iterator;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.azure.AzureProperties;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
@@ -95,6 +97,18 @@ public class TestADLSFileIO extends AzuriteTestBase {
 
     assertThat(AZURITE_CONTAINER.fileClient(path1).exists()).isFalse();
     assertThat(AZURITE_CONTAINER.fileClient(path2).exists()).isFalse();
+  }
+
+  @Test
+  public void testReadMissingLocation() {
+    String path = "path/to/data.parquet";
+    String location = AZURITE_CONTAINER.location(path);
+    ADLSFileIO io = createFileIO();
+    InputFile inputFile = io.newInputFile(location);
+
+    assertThatThrownBy(() -> inputFile.newStream().read())
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("does not exist");
   }
 
   @Test

--- a/gcp/src/integration/java/org/apache/iceberg/gcp/gcs/TestGcsFileIO.java
+++ b/gcp/src/integration/java/org/apache/iceberg/gcp/gcs/TestGcsFileIO.java
@@ -31,7 +31,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,6 +38,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.IOUtil;
@@ -227,9 +227,8 @@ public class TestGcsFileIO {
     InputFile in = fileIO.newInputFile(location);
 
     assertThatThrownBy(() -> in.newStream().read())
-        .isInstanceOf(IOException.class)
-        .hasCauseInstanceOf(StorageException.class)
-        .hasMessageContaining("404 Not Found");
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("does not exist");
   }
 
   @Test


### PR DESCRIPTION
Convert cloud-specific 404 errors to NotFoundException to match S3's behavior and prevent unnecessary retries in BaseMetastoreTableOperations.

- GCS: Convert StorageException with code 404 to NotFoundException
- ADLS: Convert DataLakeStorageException with status 404 to NotFoundException