### PR TITLE
[Fix] Stop RewriteOperationForRowLineage from throwing on other table types

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteOperationForRowLineage.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteOperationForRowLineage.scala
@@ -42,6 +42,7 @@ trait RewriteOperationForRowLineage extends RewriteRowLevelIcebergCommand {
         r.table match {
           case sparkTable: SparkTable =>
             TableUtil.supportsRowLineage(sparkTable.table())
+          case _ => false
         }
       case _ => false
     }

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteOperationForRowLineage.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteOperationForRowLineage.scala
@@ -42,6 +42,7 @@ trait RewriteOperationForRowLineage extends RewriteRowLevelCommand {
         r.table match {
           case sparkTable: SparkTable =>
             TableUtil.supportsRowLineage(sparkTable.table())
+          case _ => false
         }
       case _ => false
     }


### PR DESCRIPTION
When having the `IcebergSparkSessionExtension` on your spark session and trying to `UPDATE SET ... WHERE ...` a Delta table. We run into the following error:

<details>

<summary>Error here</summary>


```
DeltaTableV2(org.apache.spark.sql.SparkSession@5b6ddd5d,file:/var/folders/h9/_tv85syj43d9lr1lgbxqm6v508fh8r/T/bc027d17_7885_4b16_a7cf_110ae549cb62,Some(CatalogTable(
Catalog: spark_catalog
Database: default
Table: bc027d17_7885_4b16_a7cf_110ae549cb62
Created Time: Mon Jan 12 10:07:19 GMT 2026
Last Access: UNKNOWN
Created By: Spark 
Type: MANAGED
Provider: delta
Table Properties: [delta.enableChangeDataFeed=true, delta.feature.appendOnly=supported, delta.feature.changeDataFeed=supported, delta.feature.invariants=supported, delta.lastCommitTimestamp=1768212440690, delta.lastUpdateVersion=2, delta.minReaderVersion=1, delta.minWriterVersion=7]
Location: file:/var/folders/h9/_tv85syj43d9lr1lgbxqm6v508fh8r/T/bc027d17_7885_4b16_a7cf_110ae549cb62
Schema: root
 |-- a: string (nullable = true)
 |-- b: long (nullable = true)
 |-- c: string (nullable = true)
)),Some(default.bc027d17_7885_4b16_a7cf_110ae549cb62),None,Map()) (of class org.apache.spark.sql.delta.catalog.DeltaTableV2)
scala.MatchError: DeltaTableV2(org.apache.spark.sql.SparkSession@5b6ddd5d,file:/var/folders/h9/_tv85syj43d9lr1lgbxqm6v508fh8r/T/bc027d17_7885_4b16_a7cf_110ae549cb62,Some(CatalogTable(
Catalog: spark_catalog
Database: default
Table: bc027d17_7885_4b16_a7cf_110ae549cb62
Created Time: Mon Jan 12 10:07:19 GMT 2026
Last Access: UNKNOWN
Created By: Spark 
Type: MANAGED
Provider: delta
Table Properties: [delta.enableChangeDataFeed=true, delta.feature.appendOnly=supported, delta.feature.changeDataFeed=supported, delta.feature.invariants=supported, delta.lastCommitTimestamp=1768212440690, delta.lastUpdateVersion=2, delta.minReaderVersion=1, delta.minWriterVersion=7]
Location: file:/var/folders/h9/_tv85syj43d9lr1lgbxqm6v508fh8r/T/bc027d17_7885_4b16_a7cf_110ae549cb62
Schema: root
 |-- a: string (nullable = true)
 |-- b: long (nullable = true)
 |-- c: string (nullable = true)
)),Some(default.bc027d17_7885_4b16_a7cf_110ae549cb62),None,Map()) (of class org.apache.spark.sql.delta.catalog.DeltaTableV2)
	at org.apache.spark.sql.catalyst.analysis.RewriteOperationForRowLineage.shouldUpdatePlan(RewriteOperationForRowLineage.scala:42)
	at org.apache.spark.sql.catalyst.analysis.RewriteOperationForRowLineage.shouldUpdatePlan$(RewriteOperationForRowLineage.scala:39)
	at org.apache.spark.sql.catalyst.analysis.RewriteUpdateTableForRowLineage$.shouldUpdatePlan(RewriteUpdateTableForRowLineage.scala:29)
	at org.apache.spark.sql.catalyst.analysis.RewriteUpdateTableForRowLineage$$anonfun$apply$1.applyOrElse(RewriteUpdateTableForRowLineage.scala:33)
	at org.apache.spark.sql.catalyst.analysis.RewriteUpdateTableForRowLineage$$anonfun$apply$1.applyOrElse(RewriteUpdateTableForRowLineage.scala:32)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsDownWithPruning$2(AnalysisHelper.scala:170)
```

</details>

Note: This spark session has both the iceberg and delta spark session extensions configured.

This PR fixes the above by returning false if the updated table does not match `SparkTable`. Which `DeltaTableV2` does not.