### PR TITLE
AWS, Core: Switch Jetty to use new Compression API for GZIP

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
@@ -182,7 +182,6 @@ public class TestS3RestSigner {
         CreateMultipartUploadRequest.builder().bucket(BUCKET).key("random/multipart-key").build());
   }
 
-  @SuppressWarnings("removal")
   private static Server initHttpServer() throws Exception {
     S3SignerServlet.SignRequestValidator deleteObjectsWithBody =
         new S3SignerServlet.SignRequestValidator(
@@ -198,7 +197,7 @@ public class TestS3RestSigner {
     servletContext.addServlet(new ServletHolder(servlet), "/*");
     CompressionHandler compressionHandler = new CompressionHandler();
     compressionHandler.putCompression(new GzipCompression());
-    servletContext.setHandler(compressionHandler);
+    servletContext.insertHandler(compressionHandler);
 
     Server server = new Server(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
     server.setHandler(servletContext);

--- a/build.gradle
+++ b/build.gradle
@@ -396,8 +396,8 @@ project(':iceberg-core') {
 
     testImplementation libs.jetty.servlet
     testImplementation libs.jakarta.servlet
-    testImplementation libs.jetty.server
-    testImplementation libs.jetty.gzip
+    testImplementation libs.jetty.compression.server
+    testImplementation libs.jetty.compression.gzip
     testImplementation libs.mockserver.netty
     testImplementation libs.mockserver.client.java
     testImplementation libs.sqlite.jdbc
@@ -546,8 +546,8 @@ project(':iceberg-aws') {
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testImplementation libs.awaitility
     testImplementation libs.jetty.servlet
-    testImplementation libs.jetty.server
-    testImplementation libs.jetty.gzip
+    testImplementation libs.jetty.compression.server
+    testImplementation libs.jetty.compression.gzip
     testImplementation libs.mockito.junit.jupiter
   }
 
@@ -1106,8 +1106,8 @@ project(':iceberg-open-api') {
     testFixturesImplementation libs.slf4j.simple
 
     testFixturesImplementation libs.jetty.servlet
-    testFixturesImplementation libs.jetty.server
-    testFixturesImplementation libs.jetty.gzip
+    testFixturesImplementation libs.jetty.compression.server
+    testFixturesImplementation libs.jetty.compression.gzip
     testFixturesImplementation libs.sqlite.jdbc
 
     testFixturesCompileOnly libs.apiguardian

--- a/core/src/test/java/org/apache/iceberg/rest/TestBaseWithRESTServer.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestBaseWithRESTServer.java
@@ -34,6 +34,8 @@ import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.eclipse.jetty.compression.gzip.GzipCompression;
+import org.eclipse.jetty.compression.server.CompressionHandler;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
@@ -60,7 +62,15 @@ public abstract class TestBaseWithRESTServer {
 
   @TempDir private Path temp;
 
-  @SuppressWarnings("removal")
+  /**
+   * GZIP responses interfere with freshness-aware loading tests that assert on {@code ETag} and
+   * conditional requests. Subclasses may disable HTTP compression while keeping the default for
+   * other REST catalog tests.
+   */
+  protected boolean useHttpCompression() {
+    return true;
+  }
+
   @BeforeEach
   public void before() throws Exception {
     File warehouse = temp.toFile();
@@ -75,6 +85,12 @@ public abstract class TestBaseWithRESTServer {
         new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
     servletContext.addServlet(
         new ServletHolder(new RESTCatalogServlet(adapterForRESTServer)), "/*");
+    if (useHttpCompression()) {
+      CompressionHandler compressionHandler = new CompressionHandler();
+      compressionHandler.putCompression(new GzipCompression());
+      servletContext.insertHandler(compressionHandler);
+    }
+
     this.httpServer = new Server(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
     httpServer.setHandler(servletContext);
     httpServer.start();

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -67,6 +67,11 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
+  @Override
+  protected boolean useHttpCompression() {
+    return false;
+  }
+
   private static final ResourcePaths RESOURCE_PATHS =
       ResourcePaths.forCatalogProperties(
           ImmutableMap.of(

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -272,7 +272,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   private Server httpServer;
   private HeaderValidatingAdapter adapterForRESTServer;
 
-  @SuppressWarnings("removal")
   @BeforeEach
   public void createCatalog() throws Exception {
     File warehouse = temp.toFile();
@@ -306,7 +305,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         new ServletHolder(new RESTCatalogServlet(adapterForRESTServer)), "/*");
     CompressionHandler compressionHandler = new CompressionHandler();
     compressionHandler.putCompression(new GzipCompression());
-    servletContext.setHandler(compressionHandler);
+    servletContext.insertHandler(compressionHandler);
 
     this.httpServer = new Server(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
     httpServer.setHandler(servletContext);

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalog.java
@@ -79,7 +79,6 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
   protected InMemoryCatalog backendCatalog;
   protected Server httpServer;
 
-  @SuppressWarnings("removal")
   @BeforeEach
   public void createCatalog() throws Exception {
     File warehouse = temp.toFile();
@@ -118,7 +117,7 @@ public class TestRESTViewCatalog extends ViewCatalogTests<RESTCatalog> {
     servletContext.addServlet(new ServletHolder(new RESTCatalogServlet(adaptor)), "/*");
     CompressionHandler compressionHandler = new CompressionHandler();
     compressionHandler.putCompression(new GzipCompression());
-    servletContext.setHandler(compressionHandler);
+    servletContext.insertHandler(compressionHandler);
 
     this.httpServer = new Server(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
     httpServer.setHandler(servletContext);

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalogWithAssumedViewSupport.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTViewCatalogWithAssumedViewSupport.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.BeforeEach;
 
 public class TestRESTViewCatalogWithAssumedViewSupport extends TestRESTViewCatalog {
 
-  @SuppressWarnings("removal")
   @BeforeEach
   public void createCatalog() throws Exception {
     File warehouse = temp.toFile();
@@ -75,7 +74,7 @@ public class TestRESTViewCatalogWithAssumedViewSupport extends TestRESTViewCatal
     servletContext.addServlet(new ServletHolder(new RESTCatalogServlet(adaptor)), "/*");
     CompressionHandler compressionHandler = new CompressionHandler();
     compressionHandler.putCompression(new GzipCompression());
-    servletContext.setHandler(compressionHandler);
+    servletContext.insertHandler(compressionHandler);
 
     this.httpServer = new Server(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
     httpServer.setHandler(servletContext);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -202,8 +202,8 @@ flink21-test-utilsjunit = { module = "org.apache.flink:flink-test-utils-junit", 
 guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava" }
 jakarta-el-api = { module = "jakarta.el:jakarta.el-api", version.ref = "jakarta-el-api" }
 jakarta-servlet = {module = "jakarta.servlet:jakarta.servlet-api", version.ref = "jakarta-servlet-api"}
-jetty-server = { module = "org.eclipse.jetty.compression:jetty-compression-server", version.ref = "jetty" }
-jetty-gzip = { module = "org.eclipse.jetty.compression:jetty-compression-gzip", version.ref = "jetty" }
+jetty-compression-server = { module = "org.eclipse.jetty.compression:jetty-compression-server", version.ref = "jetty" }
+jetty-compression-gzip = { module = "org.eclipse.jetty.compression:jetty-compression-gzip", version.ref = "jetty" }
 jetty-servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", version.ref = "jetty" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }

--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
@@ -107,7 +107,6 @@ public class RESTCatalogServer {
         catalogProperties);
   }
 
-  @SuppressWarnings("removal")
   public void start(boolean join) throws Exception {
     CatalogContext catalogContext = initializeBackendCatalog();
 
@@ -119,7 +118,7 @@ public class RESTCatalogServer {
     context.addServlet(servletHolder, "/*");
     CompressionHandler compressionHandler = new CompressionHandler();
     compressionHandler.putCompression(new GzipCompression());
-    context.setHandler(compressionHandler);
+    context.insertHandler(compressionHandler);
 
     this.httpServer =
         new Server(


### PR DESCRIPTION
This currently depends on [Build: Bump Jetty to 12.1.5](https://github.com/apache/iceberg/pull/10837)