### PR TITLE
REST Spec: clarify uniqueness of ETags for table metadata responses

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1946,7 +1946,7 @@ components:
         Implementations that support ETags should produce unique tags for responses that return
         different metadata content but represent the same version of table metadata.  For example,
         the `snapshots` query parameter may result in different metadata representations depending
-        on whether `refs` or `all` is provided, but should have distinct ETags.
+        on whether `refs` or `all` is provided, therefore should have distinct ETags.
       required: false
       schema:
         type: string


### PR DESCRIPTION
The ETag description indicates that an ETag should be unique for a specific table metadata version, but doesn't clearly call out that different representations should also return unique etags.  For example, if a table is loaded with `?snapshots=refs` vs `?snapshots=all`, the metadata version is the same, but the response body is different and should be handled separately by client side cache implementations.

The ETag is tied to the metadata specifically because other aspects of the response body can be different (e.g. headers, config bundle, etc) without compromising the ability reused cached metadata, but it is the Catalog's responsibility to define when the ETag should change.