### PR TITLE
Spark 4.1: Add test coverage for Hive View catalog

### DIFF
--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
@@ -61,7 +61,11 @@ public enum SparkCatalogConfig {
   SPARK_SESSION_WITH_VIEWS(
       "spark_catalog",
       SparkSessionCatalog.class.getName(),
-      ImmutableMap.of("type", "rest", "default-namespace", "default", "cache-enabled", "false"));
+      ImmutableMap.of("type", "rest", "default-namespace", "default", "cache-enabled", "false")),
+  SPARK_WITH_HIVE_VIEWS(
+      "spark_hive_with_views",
+      SparkCatalog.class.getName(),
+      ImmutableMap.of("type", "hive", "default-namespace", "default", "cache-enabled", "false"));
 
   private final String catalogName;
   private final String implementation;


### PR DESCRIPTION
I noticed that after adding view support to `HiveCatalog` we actually never updated `TestViews` to also verify the correct behavior