### PR TITLE
API: Optimize NOT IN and != predicates for single-value partition manifests

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -418,17 +418,22 @@ public class ManifestEvaluator {
 
     /**
      * Returns the partition field's single value if all partitions contain the same value. Defined
-     * as a partition field with no nulls, no NaNs, and lower bound equals upper bound. Returns null
-     * otherwise.
+     * as a partition field with no nulls, no NaNs (for floating-point types), and lower bound
+     * equals upper bound. Returns null otherwise.
      */
     private <T> T uniqueValue(BoundReference<T> ref) {
       int pos = Accessors.toPosition(ref.accessor());
       PartitionFieldSummary fieldStats = stats.get(pos);
 
-      if (fieldStats.containsNull()
-          || fieldStats.containsNaN() == null
-          || fieldStats.containsNaN()) {
+      if (fieldStats.containsNull()) {
         return null;
+      }
+
+      Type.TypeID typeId = ref.type().typeId();
+      if (Type.TypeID.FLOAT.equals(typeId) || Type.TypeID.DOUBLE.equals(typeId)) {
+        if (fieldStats.containsNaN() == null || fieldStats.containsNaN()) {
+          return null;
+        }
       }
 
       ByteBuffer lowerBound = fieldStats.lowerBound();


### PR DESCRIPTION
## Summary
This PR adds manifest pruning optimization for `NOT IN` and `!=` predicates when a manifest contains a single distinct partition value (i.e., when `lower == upper`).

## Problem
Currently, [ManifestEvaluator](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java) cannot prune manifests for `NOT IN` and `!=` predicates, even when the manifest provably contains no matching partitions.

## Solution
When `lower == upper` and the manifest has no nulls or NaNs, we can safely prune if:
* For `NOT IN`: the single partition value is in the exclusion list
* For `!=`: the single partition value equals the literal

This mirrors the optimization added in #14593 for [InclusiveMetricsEvaluator](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java), but applied at the manifest level for partition pruning.

## Testing
* Added unit tests for both `notIn` and `notEq` optimizations

Fixes #15063