### PR TITLE
API: Use Transform#isIdentity in PartitionSpec#identitySourceIds

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -315,7 +315,7 @@ public class PartitionSpec implements Serializable {
   public Set<Integer> identitySourceIds() {
     Set<Integer> sourceIds = Sets.newHashSet();
     for (PartitionField field : fields()) {
-      if ("identity".equals(field.transform().toString())) {
+      if (field.transform().isIdentity()) {
         sourceIds.add(field.sourceId());
       }
     }


### PR DESCRIPTION
Avoids the need to do a String conversion and comparision