### PR TITLE
Core: Add RegisterViewRequest, parser, and serializers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -52,11 +52,14 @@ import org.apache.iceberg.rest.requests.FetchScanTasksRequest;
 import org.apache.iceberg.rest.requests.FetchScanTasksRequestParser;
 import org.apache.iceberg.rest.requests.ImmutableCreateViewRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
+import org.apache.iceberg.rest.requests.ImmutableRegisterViewRequest;
 import org.apache.iceberg.rest.requests.ImmutableReportMetricsRequest;
 import org.apache.iceberg.rest.requests.PlanTableScanRequest;
 import org.apache.iceberg.rest.requests.PlanTableScanRequestParser;
 import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequestParser;
+import org.apache.iceberg.rest.requests.RegisterViewRequest;
+import org.apache.iceberg.rest.requests.RegisterViewRequestParser;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
@@ -131,6 +134,11 @@ public class RESTSerializers {
         .addSerializer(ImmutableLoadViewResponse.class, new LoadViewResponseSerializer<>())
         .addDeserializer(LoadViewResponse.class, new LoadViewResponseDeserializer<>())
         .addDeserializer(ImmutableLoadViewResponse.class, new LoadViewResponseDeserializer<>())
+        .addSerializer(RegisterViewRequest.class, new RegisterViewRequestSerializer<>())
+        .addDeserializer(RegisterViewRequest.class, new RegisterViewRequestDeserializer<>())
+        .addSerializer(ImmutableRegisterViewRequest.class, new RegisterViewRequestSerializer<>())
+        .addDeserializer(
+            ImmutableRegisterViewRequest.class, new RegisterViewRequestDeserializer<>())
         .addSerializer(ConfigResponse.class, new ConfigResponseSerializer<>())
         .addDeserializer(ConfigResponse.class, new ConfigResponseDeserializer<>())
         .addSerializer(LoadTableResponse.class, new LoadTableResponseSerializer<>())
@@ -441,6 +449,24 @@ public class RESTSerializers {
     public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
       return (T) LoadViewResponseParser.fromJson(jsonNode);
+    }
+  }
+
+  static class RegisterViewRequestSerializer<T extends RegisterViewRequest>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      RegisterViewRequestParser.toJson(request, gen);
+    }
+  }
+
+  static class RegisterViewRequestDeserializer<T extends RegisterViewRequest>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) RegisterViewRequestParser.fromJson(jsonNode);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterViewRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterViewRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import org.apache.iceberg.rest.RESTRequest;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface RegisterViewRequest extends RESTRequest {
+
+  String name();
+
+  String metadataLocation();
+
+  @Override
+  default void validate() {
+    // nothing to validate as it's not possible to create an invalid instance
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterViewRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterViewRequestParser.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class RegisterViewRequestParser {
+
+  private static final String NAME = "name";
+  private static final String METADATA_LOCATION = "metadata-location";
+
+  private RegisterViewRequestParser() {}
+
+  public static String toJson(RegisterViewRequest request) {
+    return toJson(request, false);
+  }
+
+  public static String toJson(RegisterViewRequest request, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+  }
+
+  public static void toJson(RegisterViewRequest request, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != request, "Invalid register view request: null");
+
+    gen.writeStartObject();
+
+    gen.writeStringField(NAME, request.name());
+    gen.writeStringField(METADATA_LOCATION, request.metadataLocation());
+
+    gen.writeEndObject();
+  }
+
+  public static RegisterViewRequest fromJson(String json) {
+    return JsonUtil.parse(json, RegisterViewRequestParser::fromJson);
+  }
+
+  public static RegisterViewRequest fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse register view request from null object");
+
+    String name = JsonUtil.getString(NAME, json);
+    String metadataLocation = JsonUtil.getString(METADATA_LOCATION, json);
+
+    return ImmutableRegisterViewRequest.builder()
+        .name(name)
+        .metadataLocation(metadataLocation)
+        .build();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestRegisterViewRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestRegisterViewRequestParser.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+public class TestRegisterViewRequestParser {
+
+  @Test
+  public void nullCheck() {
+    assertThatThrownBy(() -> RegisterViewRequestParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid register view request: null");
+
+    assertThatThrownBy(() -> RegisterViewRequestParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse register view request from null object");
+  }
+
+  @Test
+  public void missingFields() {
+    assertThatThrownBy(() -> RegisterViewRequestParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing string: name");
+
+    assertThatThrownBy(() -> RegisterViewRequestParser.fromJson("{\"name\" : \"test_vw\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing string: metadata-location");
+
+    assertThatThrownBy(
+            () ->
+                RegisterViewRequestParser.fromJson(
+                    "{\"metadata-location\" : \"file://tmp/NS/test_vw/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing string: name");
+  }
+
+  @Test
+  public void roundTripSerde() {
+    RegisterViewRequest request =
+        ImmutableRegisterViewRequest.builder()
+            .name("view_1")
+            .metadataLocation(
+                "file://tmp/NS/view_1/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json")
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"name\" : \"view_1\",\n"
+            + "  \"metadata-location\" : \"file://tmp/NS/view_1/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json\"\n"
+            + "}";
+
+    String json = RegisterViewRequestParser.toJson(request, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    assertThat(RegisterViewRequestParser.toJson(RegisterViewRequestParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+}


### PR DESCRIPTION
Add RegisterViewRequest class, RegisterViewRequestParser for JSON serialization/deserialization, and Jackson serializers/deserializers in RESTSerializers to support view registration in REST catalog.

This is used for view registration support.