### PR TITLE
Flink: Backport: Dynamic Sink: Add case-insensitive field matching (#14729)

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -191,6 +191,7 @@ public class DynamicIcebergSink
     private int cacheMaximumSize = 100;
     private long cacheRefreshMs = 1_000;
     private int inputSchemasPerTableCacheMaximumSize = 10;
+    private boolean caseSensitive = true;
 
     Builder() {}
 
@@ -353,6 +354,15 @@ public class DynamicIcebergSink
       return this;
     }
 
+    /**
+     * Set whether schema field name matching should be case-sensitive. The default is to match the
+     * field names case-sensitive.
+     */
+    public Builder<T> caseSensitive(boolean newCaseSensitive) {
+      this.caseSensitive = newCaseSensitive;
+      return this;
+    }
+
     private String operatorName(String suffix) {
       return uidPrefix != null ? uidPrefix + "-" + suffix : suffix;
     }
@@ -399,11 +409,12 @@ public class DynamicIcebergSink
                       generator,
                       catalogLoader,
                       immediateUpdate,
-                      dropUnusedColumns,
                       cacheMaximumSize,
                       cacheRefreshMs,
                       inputSchemasPerTableCacheMaximumSize,
-                      tableCreator))
+                      tableCreator,
+                      caseSensitive,
+                      dropUnusedColumns))
               .uid(prefixIfNotNull(uidPrefix, "-generator"))
               .name(operatorName("generator"))
               .returns(type);
@@ -418,11 +429,12 @@ public class DynamicIcebergSink
               .map(
                   new DynamicTableUpdateOperator(
                       catalogLoader,
-                      dropUnusedColumns,
                       cacheMaximumSize,
                       cacheRefreshMs,
                       inputSchemasPerTableCacheMaximumSize,
-                      tableCreator))
+                      tableCreator,
+                      caseSensitive,
+                      dropUnusedColumns))
               .uid(prefixIfNotNull(uidPrefix, "-updater"))
               .name(operatorName("Updater"))
               .returns(type)

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
@@ -43,22 +43,25 @@ class DynamicTableUpdateOperator
   private final long cacheRefreshMs;
   private final int inputSchemasPerTableCacheMaximumSize;
   private final TableCreator tableCreator;
+  private final boolean caseSensitive;
 
   private transient TableUpdater updater;
 
   DynamicTableUpdateOperator(
       CatalogLoader catalogLoader,
-      boolean dropUnusedColumns,
       int cacheMaximumSize,
       long cacheRefreshMs,
       int inputSchemasPerTableCacheMaximumSize,
-      TableCreator tableCreator) {
+      TableCreator tableCreator,
+      boolean caseSensitive,
+      boolean dropUnusedColumns) {
     this.catalogLoader = catalogLoader;
-    this.dropUnusedColumns = dropUnusedColumns;
     this.cacheMaximumSize = cacheMaximumSize;
     this.cacheRefreshMs = cacheRefreshMs;
     this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
     this.tableCreator = tableCreator;
+    this.caseSensitive = caseSensitive;
+    this.dropUnusedColumns = dropUnusedColumns;
   }
 
   @Override
@@ -68,8 +71,14 @@ class DynamicTableUpdateOperator
     this.updater =
         new TableUpdater(
             new TableMetadataCache(
-                catalog, cacheMaximumSize, cacheRefreshMs, inputSchemasPerTableCacheMaximumSize),
+                catalog,
+                cacheMaximumSize,
+                cacheRefreshMs,
+                inputSchemasPerTableCacheMaximumSize,
+                caseSensitive,
+                dropUnusedColumns),
             catalog,
+            caseSensitive,
             dropUnusedColumns);
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
@@ -33,6 +33,9 @@ import org.junit.jupiter.api.Test;
 
 class TestCompareSchemasVisitor {
 
+  private static final boolean CASE_SENSITIVE = true;
+  private static final boolean CASE_INSENSITIVE = false;
+
   private static final boolean DROP_COLUMNS = true;
   private static final boolean PRESERVE_COLUMNS = false;
 
@@ -47,7 +50,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", IntegerType.get(), "comment"),
                     optional(2, "data", StringType.get()),
-                    optional(3, "extra", StringType.get()))))
+                    optional(3, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -62,7 +67,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", IntegerType.get()),
                     optional(2, "data", StringType.get()),
-                    optional(3, "extra", StringType.get()))))
+                    optional(3, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -75,7 +82,9 @@ class TestCompareSchemasVisitor {
                     optional(1, "data", StringType.get()),
                     optional(2, "extra", StringType.get())),
                 new Schema(
-                    optional(0, "id", IntegerType.get()), optional(1, "data", StringType.get()))))
+                    optional(0, "id", IntegerType.get()), optional(1, "data", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -88,7 +97,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(0, "id", IntegerType.get()),
                     optional(1, "data", StringType.get()),
-                    optional(2, "extra", StringType.get()))))
+                    optional(2, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
@@ -99,7 +110,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", LongType.get()), optional(2, "extra", StringType.get())),
                 new Schema(
-                    optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()))))
+                    optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -110,7 +123,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get())),
                 new Schema(
-                    optional(1, "id", LongType.get()), optional(2, "extra", StringType.get()))))
+                    optional(1, "id", LongType.get()), optional(2, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
@@ -120,9 +135,11 @@ class TestCompareSchemasVisitor {
         new Schema(optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()));
     Schema tableSchema =
         new Schema(required(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()));
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
-    assertThat(CompareSchemasVisitor.visit(tableSchema, dataSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(tableSchema, dataSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -131,9 +148,11 @@ class TestCompareSchemasVisitor {
     Schema dataSchema = new Schema(optional(1, "id", IntegerType.get()));
     Schema tableSchema =
         new Schema(optional(1, "id", IntegerType.get()), required(2, "extra", StringType.get()));
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
-    assertThat(CompareSchemasVisitor.visit(tableSchema, dataSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(tableSchema, dataSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -142,7 +161,8 @@ class TestCompareSchemasVisitor {
     Schema dataSchema = new Schema(required(1, "id", IntegerType.get()));
     Schema tableSchema =
         new Schema(required(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()));
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
@@ -155,8 +175,9 @@ class TestCompareSchemasVisitor {
                     optional(2, "struct1", StructType.of(optional(3, "extra", IntegerType.get())))),
                 new Schema(
                     optional(0, "id", IntegerType.get()),
-                    optional(
-                        1, "struct1", StructType.of(optional(2, "extra", IntegerType.get()))))))
+                    optional(1, "struct1", StructType.of(optional(2, "extra", IntegerType.get())))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -169,8 +190,9 @@ class TestCompareSchemasVisitor {
                     optional(1, "struct1", StructType.of(optional(2, "extra", LongType.get())))),
                 new Schema(
                     optional(1, "id", IntegerType.get()),
-                    optional(
-                        2, "struct1", StructType.of(optional(3, "extra", IntegerType.get()))))))
+                    optional(2, "struct1", StructType.of(optional(3, "extra", IntegerType.get())))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -185,7 +207,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(0, "id", IntegerType.get()),
                     optional(
-                        1, "map1", MapType.ofOptional(2, 3, IntegerType.get(), StringType.get())))))
+                        1, "map1", MapType.ofOptional(2, 3, IntegerType.get(), StringType.get()))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -200,7 +224,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", IntegerType.get()),
                     optional(
-                        2, "map1", MapType.ofOptional(3, 4, IntegerType.get(), StringType.get())))))
+                        2, "map1", MapType.ofOptional(3, 4, IntegerType.get(), StringType.get()))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -213,7 +239,9 @@ class TestCompareSchemasVisitor {
                     optional(2, "list1", ListType.ofOptional(3, IntegerType.get()))),
                 new Schema(
                     optional(0, "id", IntegerType.get()),
-                    optional(1, "list1", ListType.ofOptional(2, IntegerType.get())))))
+                    optional(1, "list1", ListType.ofOptional(2, IntegerType.get()))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -226,8 +254,74 @@ class TestCompareSchemasVisitor {
                     optional(1, "list1", ListType.ofOptional(2, LongType.get()))),
                 new Schema(
                     optional(1, "id", IntegerType.get()),
-                    optional(2, "list1", ListType.ofOptional(3, IntegerType.get())))))
+                    optional(2, "list1", ListType.ofOptional(3, IntegerType.get()))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+  }
+
+  @Test
+  void testCaseInsensitiveFieldMatching() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "ID", IntegerType.get()),
+                    optional(2, "Data", StringType.get()),
+                    optional(3, "EXTRA", StringType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "extra", StringType.get())),
+                CASE_INSENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testCaseSensitiveFieldMatchingDefault() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "ID", IntegerType.get()),
+                    optional(2, "Data", StringType.get()),
+                    optional(3, "EXTRA", StringType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                DROP_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+  }
+
+  @Test
+  void testCaseInsensitiveNestedStruct() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "ID", IntegerType.get()),
+                    optional(2, "STRUCT1", StructType.of(optional(3, "NESTED", StringType.get())))),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "struct1", StructType.of(optional(3, "nested", StringType.get())))),
+                CASE_INSENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testCaseInsensitiveWithMoreColumns() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(0, "ID", IntegerType.get()), optional(1, "DATA", StringType.get())),
+                new Schema(
+                    optional(0, "id", IntegerType.get()),
+                    optional(1, "data", StringType.get()),
+                    optional(2, "extra", StringType.get())),
+                CASE_INSENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
   @Test
@@ -239,7 +333,7 @@ class TestCompareSchemasVisitor {
             optional(2, "data", StringType.get()),
             optional(3, "extra", StringType.get()));
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, DROP_COLUMNS))
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, DROP_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -249,7 +343,7 @@ class TestCompareSchemasVisitor {
     Schema tableSchema =
         new Schema(optional(1, "id", IntegerType.get()), required(2, "data", StringType.get()));
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, DROP_COLUMNS))
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, DROP_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -262,7 +356,7 @@ class TestCompareSchemasVisitor {
             optional(3, "extra", StringType.get()));
     Schema tableSchema = new Schema(optional(1, "id", IntegerType.get()));
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, DROP_COLUMNS))
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, DROP_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -282,10 +376,11 @@ class TestCompareSchemasVisitor {
                     optional(3, "field1", StringType.get()),
                     optional(4, "field2", IntegerType.get()))));
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, DROP_COLUMNS))
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, DROP_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, PRESERVE_COLUMNS))
+    assertThat(
+            CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
@@ -33,8 +33,16 @@ import org.apache.iceberg.flink.HadoopCatalogExtension;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class TestDynamicTableUpdateOperator {
+
+  private static final boolean CASE_SENSITIVE = true;
+  private static final boolean CASE_INSENSITIVE = false;
+
+  private static final boolean DROP_COLUMNS = true;
+  private static final boolean PRESERVE_COLUMNS = false;
 
   @RegisterExtension
   private static final HadoopCatalogExtension CATALOG_EXTENSION =
@@ -60,11 +68,12 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            false,
             cacheMaximumSize,
             cacheRefreshMs,
             inputSchemaCacheMaximumSize,
-            TableCreator.DEFAULT);
+            TableCreator.DEFAULT,
+            CASE_SENSITIVE,
+            PRESERVE_COLUMNS);
     operator.open((OpenContext) null);
 
     DynamicRecordInternal input =
@@ -94,11 +103,12 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            false,
             cacheMaximumSize,
             cacheRefreshMs,
             inputSchemaCacheMaximumSize,
-            TableCreator.DEFAULT);
+            TableCreator.DEFAULT,
+            CASE_SENSITIVE,
+            PRESERVE_COLUMNS);
     operator.open((OpenContext) null);
 
     catalog.createTable(table, SCHEMA1);
@@ -123,6 +133,59 @@ class TestDynamicTableUpdateOperator {
     assertThat(catalog.loadTable(table).schema().schemaId()).isEqualTo(output.schema().schemaId());
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testCaseInSensitivity(boolean caseSensitive) throws Exception {
+    int cacheMaximumSize = 10;
+    int cacheRefreshMs = 1000;
+    int inputSchemaCacheMaximumSize = 10;
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier table = TableIdentifier.of(TABLE);
+
+    Schema initialSchema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    Schema caseSensitiveSchema =
+        new Schema(Types.NestedField.required(1, "Id", Types.IntegerType.get()));
+
+    DynamicTableUpdateOperator operator =
+        new DynamicTableUpdateOperator(
+            CATALOG_EXTENSION.catalogLoader(),
+            cacheMaximumSize,
+            cacheRefreshMs,
+            inputSchemaCacheMaximumSize,
+            TableCreator.DEFAULT,
+            caseSensitive,
+            PRESERVE_COLUMNS);
+    operator.open((OpenContext) null);
+
+    catalog.createTable(table, initialSchema);
+    DynamicRecordInternal input =
+        new DynamicRecordInternal(
+            TABLE,
+            "branch",
+            caseSensitiveSchema,
+            GenericRowData.of(1, "test"),
+            PartitionSpec.unpartitioned(),
+            42,
+            false,
+            Collections.emptySet());
+    DynamicRecordInternal output = operator.map(input);
+
+    if (caseSensitive) {
+      // Schema changes due to case sensitivity
+      Schema expectedSchema =
+          new Schema(
+              Types.NestedField.optional(2, "Id", Types.IntegerType.get()),
+              Types.NestedField.optional(1, "id", Types.IntegerType.get()));
+      Schema tableSchema = catalog.loadTable(table).schema();
+      assertThat(tableSchema.sameSchema(expectedSchema)).isTrue();
+      assertThat(output.schema().sameSchema(expectedSchema)).isTrue();
+    } else {
+      // No schema change due to case insensitivity
+      assertThat(catalog.loadTable(table).schema().sameSchema(initialSchema)).isTrue();
+      assertThat(output.schema().sameSchema(initialSchema)).isTrue();
+    }
+  }
+
   @Test
   void testDynamicTableUpdateOperatorPreserveUnusedColumns() throws Exception {
     int cacheMaximumSize = 10;
@@ -134,11 +197,12 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            false, // dropUnusedColumns = false (default)
             cacheMaximumSize,
             cacheRefreshMs,
             inputSchemaCacheMaximumSize,
-            TableCreator.DEFAULT);
+            TableCreator.DEFAULT,
+            CASE_SENSITIVE,
+            PRESERVE_COLUMNS);
     operator.open((OpenContext) null);
 
     catalog.createTable(table, SCHEMA2);
@@ -174,12 +238,12 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            // Drop unused columns
-            true,
             cacheMaximumSize,
             cacheRefreshMs,
             inputSchemaCacheMaximumSize,
-            TableCreator.DEFAULT);
+            TableCreator.DEFAULT,
+            CASE_INSENSITIVE,
+            DROP_COLUMNS);
     operator.open((OpenContext) null);
 
     catalog.createTable(table, SCHEMA2);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
@@ -50,6 +50,10 @@ import org.junit.jupiter.api.Test;
 public class TestEvolveSchemaVisitor {
 
   private static final TableIdentifier TABLE = TableIdentifier.of("table");
+
+  private static final boolean CASE_SENSITIVE = true;
+  private static final boolean CASE_INSENSITIVE = false;
+
   private static final boolean DROP_COLUMNS = true;
   private static final boolean PRESERVE_COLUMNS = false;
 
@@ -94,7 +98,8 @@ public class TestEvolveSchemaVisitor {
   public void testAddTopLevelPrimitives() {
     Schema targetSchema = new Schema(primitiveFields(0, primitiveTypes()));
     UpdateSchema updateApi = loadUpdateApi(new Schema());
-    EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(targetSchema.asStruct()).isEqualTo(updateApi.apply().asStruct());
   }
 
@@ -104,7 +109,8 @@ public class TestEvolveSchemaVisitor {
     assertThat(existingSchema.columns().stream().allMatch(Types.NestedField::isRequired)).isTrue();
 
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, new Schema(), PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, new Schema(), CASE_SENSITIVE, PRESERVE_COLUMNS);
     Schema newSchema = updateApi.apply();
     assertThat(newSchema.asStruct().fields()).hasSize(14);
     assertThat(newSchema.columns().stream().allMatch(Types.NestedField::isOptional)).isTrue();
@@ -129,7 +135,8 @@ public class TestEvolveSchemaVisitor {
             optional(2, "b", StructType.of(optional(5, "nested2", StringType.get()))));
 
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, DROP_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, DROP_COLUMNS);
 
     Schema newSchema = updateApi.apply();
     assertThat(newSchema.sameSchema(targetSchema)).isTrue();
@@ -151,7 +158,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema = new Schema(optional(1, "a", StringType.get()));
 
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
 
     Schema newSchema = updateApi.apply();
     assertThat(newSchema.sameSchema(existingSchema)).isTrue();
@@ -164,7 +172,8 @@ public class TestEvolveSchemaVisitor {
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
     Schema newSchema =
         new Schema(Arrays.asList(Types.NestedField.optional(-1, "myField", Types.LongType.get())));
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, newSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, newSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().sameSchema(existingSchema)).isTrue();
   }
 
@@ -177,7 +186,8 @@ public class TestEvolveSchemaVisitor {
         new Schema(
             Arrays.asList(optional(2, "b", StringType.get()), optional(1, "a", StringType.get())));
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -186,7 +196,8 @@ public class TestEvolveSchemaVisitor {
     for (PrimitiveType primitiveType : primitiveTypes()) {
       Schema targetSchema = new Schema(optional(1, "aList", ListType.ofOptional(2, primitiveType)));
       UpdateSchema updateApi = loadUpdateApi(new Schema());
-      EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
     }
   }
@@ -198,7 +209,8 @@ public class TestEvolveSchemaVisitor {
           new Schema(optional(1, "aList", ListType.ofRequired(2, primitiveType)));
       Schema targetSchema = new Schema();
       UpdateSchema updateApi = loadUpdateApi(existingSchema);
-      EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       Schema expectedSchema =
           new Schema(optional(1, "aList", ListType.ofRequired(2, primitiveType)));
       assertThat(updateApi.apply().asStruct()).isEqualTo(expectedSchema.asStruct());
@@ -211,7 +223,8 @@ public class TestEvolveSchemaVisitor {
       Schema targetSchema =
           new Schema(optional(1, "aMap", MapType.ofOptional(2, 3, primitiveType, primitiveType)));
       UpdateSchema updateApi = loadUpdateApi(new Schema());
-      EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
     }
   }
@@ -223,7 +236,8 @@ public class TestEvolveSchemaVisitor {
           new Schema(
               optional(1, "aStruct", StructType.of(optional(2, "primitive", primitiveType))));
       UpdateSchema updateApi = loadUpdateApi(new Schema());
-      EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), currentSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, new Schema(), currentSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(currentSchema.asStruct());
     }
   }
@@ -236,7 +250,8 @@ public class TestEvolveSchemaVisitor {
           new Schema(
               optional(1, "aStruct", StructType.of(optional(2, "primitive", primitiveType))));
       UpdateSchema updateApi = loadUpdateApi(currentSchema);
-      EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
     }
   }
@@ -251,7 +266,8 @@ public class TestEvolveSchemaVisitor {
           new Schema(
               optional(1, "aStruct", StructType.of(optional(2, "primitive", primitiveType))));
       UpdateSchema updateApi = loadUpdateApi(currentSchema);
-      EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
     }
   }
@@ -262,7 +278,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema =
         new Schema(optional(1, "aStruct", StructType.of(primitiveFields(1, primitiveTypes()))));
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -292,7 +309,8 @@ public class TestEvolveSchemaVisitor {
                                                 ListType.ofOptional(
                                                     10, DecimalType.of(11, 20))))))))))));
     UpdateSchema updateApi = loadUpdateApi(new Schema());
-    EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -331,7 +349,8 @@ public class TestEvolveSchemaVisitor {
                                                                 "aString",
                                                                 StringType.get()))))))))))))));
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -366,7 +385,8 @@ public class TestEvolveSchemaVisitor {
                                         12, 13, StringType.get(), StringType.get()))))))));
 
     UpdateSchema updateApi = loadUpdateApi(new Schema());
-    EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -382,6 +402,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aList.element: string -> long")
         .isInstanceOf(IllegalArgumentException.class);
@@ -403,6 +424,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aMap.value: string -> long")
         .isInstanceOf(IllegalArgumentException.class);
@@ -422,6 +444,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aMap.key: string -> uuid")
         .isInstanceOf(IllegalArgumentException.class);
@@ -434,7 +457,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema = new Schema(required(1, "aCol", LongType.get()));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     Schema applied = updateApi.apply();
     assertThat(applied.asStruct().fields()).hasSize(1);
     assertThat(applied.asStruct().fields().get(0).type()).isEqualTo(LongType.get());
@@ -447,7 +471,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema = new Schema(required(1, "aCol", DoubleType.get()));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     Schema applied = updateApi.apply();
     assertThat(applied.asStruct().fields()).hasSize(1);
     assertThat(applied.asStruct().fields().get(0).type()).isEqualTo(DoubleType.get());
@@ -464,6 +489,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aCol: double -> float")
         .isInstanceOf(IllegalArgumentException.class);
@@ -477,7 +503,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema = new Schema(required(1, "aCol", DecimalType.of(22, 1)));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -520,7 +547,8 @@ public class TestEvolveSchemaVisitor {
                                         optional(6, "time", TimeType.get())))))))));
 
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -536,6 +564,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aColumn: list<string> -> string")
         .isInstanceOf(IllegalArgumentException.class);
@@ -573,7 +602,8 @@ public class TestEvolveSchemaVisitor {
                     optional(7, "d1", StructType.of(optional(8, "d2", StringType.get()))))));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -625,7 +655,8 @@ public class TestEvolveSchemaVisitor {
                                                                 StringType.get()))))))))))))));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -645,7 +676,8 @@ public class TestEvolveSchemaVisitor {
                             optional(
                                 3, "s3", StructType.of(optional(4, "s4", StringType.get()))))))));
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(getNestedSchemaWithOptionalModifier(true).asStruct())
         .isEqualTo(updateApi.apply().asStruct());
   }
@@ -680,6 +712,82 @@ public class TestEvolveSchemaVisitor {
                                                     StructType.of(
                                                         optional(
                                                             9, "s4", StringType.get()))))))))))))));
+  }
+
+  @Test
+  public void testCaseInsensitiveAddField() {
+    Schema existingSchema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()));
+    Schema targetSchema =
+        new Schema(
+            Types.NestedField.optional(1, "ID", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "NAME", Types.StringType.get()),
+            Types.NestedField.optional(3, "AGE", Types.IntegerType.get()));
+
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_INSENSITIVE, PRESERVE_COLUMNS);
+    Schema result = updateApi.apply();
+    assertThat(result.columns()).hasSize(3);
+    assertThat(result.findField("AGE")).isNotNull();
+  }
+
+  @Test
+  public void testCaseInsensitiveMakeFieldOptional() {
+    Schema existingSchema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()));
+    Schema targetSchema = new Schema(Types.NestedField.optional(1, "ID", Types.IntegerType.get()));
+
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_INSENSITIVE, PRESERVE_COLUMNS);
+    Schema result = updateApi.apply();
+    assertThat(result.findField("name").isOptional()).isTrue();
+  }
+
+  @Test
+  public void testCaseInsensitiveNestedStructField() {
+    Schema existingSchema =
+        new Schema(
+            optional(1, "struct1", StructType.of(optional(2, "field1", Types.StringType.get()))));
+    Schema targetSchema =
+        new Schema(
+            optional(
+                1,
+                "STRUCT1",
+                StructType.of(
+                    optional(2, "FIELD1", Types.StringType.get()),
+                    optional(3, "FIELD2", Types.IntegerType.get()))));
+
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_INSENSITIVE, PRESERVE_COLUMNS);
+    Schema result = updateApi.apply();
+    Types.StructType struct = result.findField("struct1").type().asStructType();
+    assertThat(struct.fields()).hasSize(2);
+    assertThat(struct.field("FIELD2")).isNotNull();
+  }
+
+  @Test
+  public void testCaseSensitiveDoesNotMatch() {
+    Schema existingSchema =
+        new Schema(Types.NestedField.optional(1, "id", Types.IntegerType.get()));
+    Schema targetSchema =
+        new Schema(
+            Types.NestedField.optional(1, "ID", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()));
+
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    Schema result = updateApi.apply();
+    assertThat(result.columns()).hasSize(3);
+    assertThat(result.findField("ID")).isNotNull();
+    assertThat(result.findField("id")).isNotNull();
   }
 
   private static UpdateSchema loadUpdateApi(Schema schema) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -191,6 +191,7 @@ public class DynamicIcebergSink
     private int cacheMaximumSize = 100;
     private long cacheRefreshMs = 1_000;
     private int inputSchemasPerTableCacheMaximumSize = 10;
+    private boolean caseSensitive = true;
 
     Builder() {}
 
@@ -353,6 +354,15 @@ public class DynamicIcebergSink
       return this;
     }
 
+    /**
+     * Set whether schema field name matching should be case-sensitive. The default is to match the
+     * field names case-sensitive.
+     */
+    public Builder<T> caseSensitive(boolean newCaseSensitive) {
+      this.caseSensitive = newCaseSensitive;
+      return this;
+    }
+
     private String operatorName(String suffix) {
       return uidPrefix != null ? uidPrefix + "-" + suffix : suffix;
     }
@@ -399,11 +409,12 @@ public class DynamicIcebergSink
                       generator,
                       catalogLoader,
                       immediateUpdate,
-                      dropUnusedColumns,
                       cacheMaximumSize,
                       cacheRefreshMs,
                       inputSchemasPerTableCacheMaximumSize,
-                      tableCreator))
+                      tableCreator,
+                      caseSensitive,
+                      dropUnusedColumns))
               .uid(prefixIfNotNull(uidPrefix, "-generator"))
               .name(operatorName("generator"))
               .returns(type);
@@ -418,11 +429,12 @@ public class DynamicIcebergSink
               .map(
                   new DynamicTableUpdateOperator(
                       catalogLoader,
-                      dropUnusedColumns,
                       cacheMaximumSize,
                       cacheRefreshMs,
                       inputSchemasPerTableCacheMaximumSize,
-                      tableCreator))
+                      tableCreator,
+                      caseSensitive,
+                      dropUnusedColumns))
               .uid(prefixIfNotNull(uidPrefix, "-updater"))
               .name(operatorName("Updater"))
               .returns(type)

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
@@ -43,22 +43,25 @@ class DynamicTableUpdateOperator
   private final long cacheRefreshMs;
   private final int inputSchemasPerTableCacheMaximumSize;
   private final TableCreator tableCreator;
+  private final boolean caseSensitive;
 
   private transient TableUpdater updater;
 
   DynamicTableUpdateOperator(
       CatalogLoader catalogLoader,
-      boolean dropUnusedColumns,
       int cacheMaximumSize,
       long cacheRefreshMs,
       int inputSchemasPerTableCacheMaximumSize,
-      TableCreator tableCreator) {
+      TableCreator tableCreator,
+      boolean caseSensitive,
+      boolean dropUnusedColumns) {
     this.catalogLoader = catalogLoader;
-    this.dropUnusedColumns = dropUnusedColumns;
     this.cacheMaximumSize = cacheMaximumSize;
     this.cacheRefreshMs = cacheRefreshMs;
     this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
     this.tableCreator = tableCreator;
+    this.caseSensitive = caseSensitive;
+    this.dropUnusedColumns = dropUnusedColumns;
   }
 
   @Override
@@ -68,8 +71,14 @@ class DynamicTableUpdateOperator
     this.updater =
         new TableUpdater(
             new TableMetadataCache(
-                catalog, cacheMaximumSize, cacheRefreshMs, inputSchemasPerTableCacheMaximumSize),
+                catalog,
+                cacheMaximumSize,
+                cacheRefreshMs,
+                inputSchemasPerTableCacheMaximumSize,
+                caseSensitive,
+                dropUnusedColumns),
             catalog,
+            caseSensitive,
             dropUnusedColumns);
   }
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestCompareSchemasVisitor.java
@@ -33,6 +33,9 @@ import org.junit.jupiter.api.Test;
 
 class TestCompareSchemasVisitor {
 
+  private static final boolean CASE_SENSITIVE = true;
+  private static final boolean CASE_INSENSITIVE = false;
+
   private static final boolean DROP_COLUMNS = true;
   private static final boolean PRESERVE_COLUMNS = false;
 
@@ -47,7 +50,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", IntegerType.get(), "comment"),
                     optional(2, "data", StringType.get()),
-                    optional(3, "extra", StringType.get()))))
+                    optional(3, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -62,7 +67,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", IntegerType.get()),
                     optional(2, "data", StringType.get()),
-                    optional(3, "extra", StringType.get()))))
+                    optional(3, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -75,7 +82,9 @@ class TestCompareSchemasVisitor {
                     optional(1, "data", StringType.get()),
                     optional(2, "extra", StringType.get())),
                 new Schema(
-                    optional(0, "id", IntegerType.get()), optional(1, "data", StringType.get()))))
+                    optional(0, "id", IntegerType.get()), optional(1, "data", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -88,7 +97,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(0, "id", IntegerType.get()),
                     optional(1, "data", StringType.get()),
-                    optional(2, "extra", StringType.get()))))
+                    optional(2, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
@@ -99,7 +110,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", LongType.get()), optional(2, "extra", StringType.get())),
                 new Schema(
-                    optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()))))
+                    optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -110,7 +123,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get())),
                 new Schema(
-                    optional(1, "id", LongType.get()), optional(2, "extra", StringType.get()))))
+                    optional(1, "id", LongType.get()), optional(2, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
@@ -120,9 +135,11 @@ class TestCompareSchemasVisitor {
         new Schema(optional(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()));
     Schema tableSchema =
         new Schema(required(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()));
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
-    assertThat(CompareSchemasVisitor.visit(tableSchema, dataSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(tableSchema, dataSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -131,9 +148,11 @@ class TestCompareSchemasVisitor {
     Schema dataSchema = new Schema(optional(1, "id", IntegerType.get()));
     Schema tableSchema =
         new Schema(optional(1, "id", IntegerType.get()), required(2, "extra", StringType.get()));
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
-    assertThat(CompareSchemasVisitor.visit(tableSchema, dataSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(tableSchema, dataSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -142,7 +161,8 @@ class TestCompareSchemasVisitor {
     Schema dataSchema = new Schema(required(1, "id", IntegerType.get()));
     Schema tableSchema =
         new Schema(required(1, "id", IntegerType.get()), optional(2, "extra", StringType.get()));
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema))
+    assertThat(
+            CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
@@ -155,8 +175,9 @@ class TestCompareSchemasVisitor {
                     optional(2, "struct1", StructType.of(optional(3, "extra", IntegerType.get())))),
                 new Schema(
                     optional(0, "id", IntegerType.get()),
-                    optional(
-                        1, "struct1", StructType.of(optional(2, "extra", IntegerType.get()))))))
+                    optional(1, "struct1", StructType.of(optional(2, "extra", IntegerType.get())))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -169,8 +190,9 @@ class TestCompareSchemasVisitor {
                     optional(1, "struct1", StructType.of(optional(2, "extra", LongType.get())))),
                 new Schema(
                     optional(1, "id", IntegerType.get()),
-                    optional(
-                        2, "struct1", StructType.of(optional(3, "extra", IntegerType.get()))))))
+                    optional(2, "struct1", StructType.of(optional(3, "extra", IntegerType.get())))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -185,7 +207,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(0, "id", IntegerType.get()),
                     optional(
-                        1, "map1", MapType.ofOptional(2, 3, IntegerType.get(), StringType.get())))))
+                        1, "map1", MapType.ofOptional(2, 3, IntegerType.get(), StringType.get()))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -200,7 +224,9 @@ class TestCompareSchemasVisitor {
                 new Schema(
                     optional(1, "id", IntegerType.get()),
                     optional(
-                        2, "map1", MapType.ofOptional(3, 4, IntegerType.get(), StringType.get())))))
+                        2, "map1", MapType.ofOptional(3, 4, IntegerType.get(), StringType.get()))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -213,7 +239,9 @@ class TestCompareSchemasVisitor {
                     optional(2, "list1", ListType.ofOptional(3, IntegerType.get()))),
                 new Schema(
                     optional(0, "id", IntegerType.get()),
-                    optional(1, "list1", ListType.ofOptional(2, IntegerType.get())))))
+                    optional(1, "list1", ListType.ofOptional(2, IntegerType.get()))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SAME);
   }
 
@@ -226,8 +254,74 @@ class TestCompareSchemasVisitor {
                     optional(1, "list1", ListType.ofOptional(2, LongType.get()))),
                 new Schema(
                     optional(1, "id", IntegerType.get()),
-                    optional(2, "list1", ListType.ofOptional(3, IntegerType.get())))))
+                    optional(2, "list1", ListType.ofOptional(3, IntegerType.get()))),
+                CASE_SENSITIVE,
+                PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+  }
+
+  @Test
+  void testCaseInsensitiveFieldMatching() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "ID", IntegerType.get()),
+                    optional(2, "Data", StringType.get()),
+                    optional(3, "EXTRA", StringType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "extra", StringType.get())),
+                CASE_INSENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testCaseSensitiveFieldMatchingDefault() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "ID", IntegerType.get()),
+                    optional(2, "Data", StringType.get()),
+                    optional(3, "EXTRA", StringType.get())),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "data", StringType.get()),
+                    optional(3, "extra", StringType.get())),
+                CASE_SENSITIVE,
+                DROP_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
+  }
+
+  @Test
+  void testCaseInsensitiveNestedStruct() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(1, "ID", IntegerType.get()),
+                    optional(2, "STRUCT1", StructType.of(optional(3, "NESTED", StringType.get())))),
+                new Schema(
+                    optional(1, "id", IntegerType.get()),
+                    optional(2, "struct1", StructType.of(optional(3, "nested", StringType.get())))),
+                CASE_INSENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.SAME);
+  }
+
+  @Test
+  void testCaseInsensitiveWithMoreColumns() {
+    assertThat(
+            CompareSchemasVisitor.visit(
+                new Schema(
+                    optional(0, "ID", IntegerType.get()), optional(1, "DATA", StringType.get())),
+                new Schema(
+                    optional(0, "id", IntegerType.get()),
+                    optional(1, "data", StringType.get()),
+                    optional(2, "extra", StringType.get())),
+                CASE_INSENSITIVE,
+                PRESERVE_COLUMNS))
+        .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 
   @Test
@@ -239,7 +333,7 @@ class TestCompareSchemasVisitor {
             optional(2, "data", StringType.get()),
             optional(3, "extra", StringType.get()));
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, DROP_COLUMNS))
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, DROP_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -249,7 +343,7 @@ class TestCompareSchemasVisitor {
     Schema tableSchema =
         new Schema(optional(1, "id", IntegerType.get()), required(2, "data", StringType.get()));
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, DROP_COLUMNS))
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, DROP_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -262,7 +356,7 @@ class TestCompareSchemasVisitor {
             optional(3, "extra", StringType.get()));
     Schema tableSchema = new Schema(optional(1, "id", IntegerType.get()));
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, DROP_COLUMNS))
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, DROP_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
   }
 
@@ -282,10 +376,11 @@ class TestCompareSchemasVisitor {
                     optional(3, "field1", StringType.get()),
                     optional(4, "field2", IntegerType.get()))));
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, DROP_COLUMNS))
+    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, DROP_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.SCHEMA_UPDATE_NEEDED);
 
-    assertThat(CompareSchemasVisitor.visit(dataSchema, tableSchema, true, PRESERVE_COLUMNS))
+    assertThat(
+            CompareSchemasVisitor.visit(dataSchema, tableSchema, CASE_SENSITIVE, PRESERVE_COLUMNS))
         .isEqualTo(CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED);
   }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
@@ -32,8 +32,16 @@ import org.apache.iceberg.flink.HadoopCatalogExtension;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class TestDynamicTableUpdateOperator {
+
+  private static final boolean CASE_SENSITIVE = true;
+  private static final boolean CASE_INSENSITIVE = false;
+
+  private static final boolean DROP_COLUMNS = true;
+  private static final boolean PRESERVE_COLUMNS = false;
 
   @RegisterExtension
   private static final HadoopCatalogExtension CATALOG_EXTENSION =
@@ -59,11 +67,12 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            false,
             cacheMaximumSize,
             cacheRefreshMs,
             inputSchemaCacheMaximumSize,
-            TableCreator.DEFAULT);
+            TableCreator.DEFAULT,
+            CASE_SENSITIVE,
+            PRESERVE_COLUMNS);
     operator.open(null);
 
     DynamicRecordInternal input =
@@ -93,11 +102,12 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            false,
             cacheMaximumSize,
             cacheRefreshMs,
             inputSchemaCacheMaximumSize,
-            TableCreator.DEFAULT);
+            TableCreator.DEFAULT,
+            CASE_SENSITIVE,
+            PRESERVE_COLUMNS);
     operator.open(null);
 
     catalog.createTable(table, SCHEMA1);
@@ -122,6 +132,59 @@ class TestDynamicTableUpdateOperator {
     assertThat(catalog.loadTable(table).schema().schemaId()).isEqualTo(output.schema().schemaId());
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testCaseInSensitivity(boolean caseSensitive) throws Exception {
+    int cacheMaximumSize = 10;
+    int cacheRefreshMs = 1000;
+    int inputSchemaCacheMaximumSize = 10;
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier table = TableIdentifier.of(TABLE);
+
+    Schema initialSchema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    Schema caseSensitiveSchema =
+        new Schema(Types.NestedField.required(1, "Id", Types.IntegerType.get()));
+
+    DynamicTableUpdateOperator operator =
+        new DynamicTableUpdateOperator(
+            CATALOG_EXTENSION.catalogLoader(),
+            cacheMaximumSize,
+            cacheRefreshMs,
+            inputSchemaCacheMaximumSize,
+            TableCreator.DEFAULT,
+            caseSensitive,
+            PRESERVE_COLUMNS);
+    operator.open(null);
+
+    catalog.createTable(table, initialSchema);
+    DynamicRecordInternal input =
+        new DynamicRecordInternal(
+            TABLE,
+            "branch",
+            caseSensitiveSchema,
+            GenericRowData.of(1, "test"),
+            PartitionSpec.unpartitioned(),
+            42,
+            false,
+            Collections.emptySet());
+    DynamicRecordInternal output = operator.map(input);
+
+    if (caseSensitive) {
+      // Schema changes due to case sensitivity
+      Schema expectedSchema =
+          new Schema(
+              Types.NestedField.optional(2, "Id", Types.IntegerType.get()),
+              Types.NestedField.optional(1, "id", Types.IntegerType.get()));
+      Schema tableSchema = catalog.loadTable(table).schema();
+      assertThat(tableSchema.sameSchema(expectedSchema)).isTrue();
+      assertThat(output.schema().sameSchema(expectedSchema)).isTrue();
+    } else {
+      // No schema change due to case insensitivity
+      assertThat(catalog.loadTable(table).schema().sameSchema(initialSchema)).isTrue();
+      assertThat(output.schema().sameSchema(initialSchema)).isTrue();
+    }
+  }
+
   @Test
   void testDynamicTableUpdateOperatorPreserveUnusedColumns() throws Exception {
     int cacheMaximumSize = 10;
@@ -133,11 +196,12 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            false, // dropUnusedColumns = false (default)
             cacheMaximumSize,
             cacheRefreshMs,
             inputSchemaCacheMaximumSize,
-            TableCreator.DEFAULT);
+            TableCreator.DEFAULT,
+            CASE_SENSITIVE,
+            PRESERVE_COLUMNS);
     operator.open(null);
 
     catalog.createTable(table, SCHEMA2);
@@ -173,12 +237,12 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            // Drop unused columns
-            true,
             cacheMaximumSize,
             cacheRefreshMs,
             inputSchemaCacheMaximumSize,
-            TableCreator.DEFAULT);
+            TableCreator.DEFAULT,
+            CASE_INSENSITIVE,
+            DROP_COLUMNS);
     operator.open(null);
 
     catalog.createTable(table, SCHEMA2);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestEvolveSchemaVisitor.java
@@ -50,6 +50,10 @@ import org.junit.jupiter.api.Test;
 public class TestEvolveSchemaVisitor {
 
   private static final TableIdentifier TABLE = TableIdentifier.of("table");
+
+  private static final boolean CASE_SENSITIVE = true;
+  private static final boolean CASE_INSENSITIVE = false;
+
   private static final boolean DROP_COLUMNS = true;
   private static final boolean PRESERVE_COLUMNS = false;
 
@@ -94,7 +98,8 @@ public class TestEvolveSchemaVisitor {
   public void testAddTopLevelPrimitives() {
     Schema targetSchema = new Schema(primitiveFields(0, primitiveTypes()));
     UpdateSchema updateApi = loadUpdateApi(new Schema());
-    EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(targetSchema.asStruct()).isEqualTo(updateApi.apply().asStruct());
   }
 
@@ -104,7 +109,8 @@ public class TestEvolveSchemaVisitor {
     assertThat(existingSchema.columns().stream().allMatch(Types.NestedField::isRequired)).isTrue();
 
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, new Schema(), PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, new Schema(), CASE_SENSITIVE, PRESERVE_COLUMNS);
     Schema newSchema = updateApi.apply();
     assertThat(newSchema.asStruct().fields()).hasSize(14);
     assertThat(newSchema.columns().stream().allMatch(Types.NestedField::isOptional)).isTrue();
@@ -129,7 +135,8 @@ public class TestEvolveSchemaVisitor {
             optional(2, "b", StructType.of(optional(5, "nested2", StringType.get()))));
 
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, DROP_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, DROP_COLUMNS);
 
     Schema newSchema = updateApi.apply();
     assertThat(newSchema.sameSchema(targetSchema)).isTrue();
@@ -151,7 +158,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema = new Schema(optional(1, "a", StringType.get()));
 
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
 
     Schema newSchema = updateApi.apply();
     assertThat(newSchema.sameSchema(existingSchema)).isTrue();
@@ -164,7 +172,8 @@ public class TestEvolveSchemaVisitor {
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
     Schema newSchema =
         new Schema(Arrays.asList(Types.NestedField.optional(-1, "myField", Types.LongType.get())));
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, newSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, newSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().sameSchema(existingSchema)).isTrue();
   }
 
@@ -177,7 +186,8 @@ public class TestEvolveSchemaVisitor {
         new Schema(
             Arrays.asList(optional(2, "b", StringType.get()), optional(1, "a", StringType.get())));
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -186,7 +196,8 @@ public class TestEvolveSchemaVisitor {
     for (PrimitiveType primitiveType : primitiveTypes()) {
       Schema targetSchema = new Schema(optional(1, "aList", ListType.ofOptional(2, primitiveType)));
       UpdateSchema updateApi = loadUpdateApi(new Schema());
-      EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
     }
   }
@@ -198,7 +209,8 @@ public class TestEvolveSchemaVisitor {
           new Schema(optional(1, "aList", ListType.ofRequired(2, primitiveType)));
       Schema targetSchema = new Schema();
       UpdateSchema updateApi = loadUpdateApi(existingSchema);
-      EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       Schema expectedSchema =
           new Schema(optional(1, "aList", ListType.ofRequired(2, primitiveType)));
       assertThat(updateApi.apply().asStruct()).isEqualTo(expectedSchema.asStruct());
@@ -211,7 +223,8 @@ public class TestEvolveSchemaVisitor {
       Schema targetSchema =
           new Schema(optional(1, "aMap", MapType.ofOptional(2, 3, primitiveType, primitiveType)));
       UpdateSchema updateApi = loadUpdateApi(new Schema());
-      EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
     }
   }
@@ -223,7 +236,8 @@ public class TestEvolveSchemaVisitor {
           new Schema(
               optional(1, "aStruct", StructType.of(optional(2, "primitive", primitiveType))));
       UpdateSchema updateApi = loadUpdateApi(new Schema());
-      EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), currentSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, new Schema(), currentSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(currentSchema.asStruct());
     }
   }
@@ -236,7 +250,8 @@ public class TestEvolveSchemaVisitor {
           new Schema(
               optional(1, "aStruct", StructType.of(optional(2, "primitive", primitiveType))));
       UpdateSchema updateApi = loadUpdateApi(currentSchema);
-      EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
     }
   }
@@ -251,7 +266,8 @@ public class TestEvolveSchemaVisitor {
           new Schema(
               optional(1, "aStruct", StructType.of(optional(2, "primitive", primitiveType))));
       UpdateSchema updateApi = loadUpdateApi(currentSchema);
-      EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+      EvolveSchemaVisitor.visit(
+          TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
       assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
     }
   }
@@ -262,7 +278,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema =
         new Schema(optional(1, "aStruct", StructType.of(primitiveFields(1, primitiveTypes()))));
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -292,7 +309,8 @@ public class TestEvolveSchemaVisitor {
                                                 ListType.ofOptional(
                                                     10, DecimalType.of(11, 20))))))))))));
     UpdateSchema updateApi = loadUpdateApi(new Schema());
-    EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -331,7 +349,8 @@ public class TestEvolveSchemaVisitor {
                                                                 "aString",
                                                                 StringType.get()))))))))))))));
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -366,7 +385,8 @@ public class TestEvolveSchemaVisitor {
                                         12, 13, StringType.get(), StringType.get()))))))));
 
     UpdateSchema updateApi = loadUpdateApi(new Schema());
-    EvolveSchemaVisitor.visit(TABLE, updateApi, new Schema(), targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, new Schema(), targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -382,6 +402,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aList.element: string -> long")
         .isInstanceOf(IllegalArgumentException.class);
@@ -403,6 +424,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aMap.value: string -> long")
         .isInstanceOf(IllegalArgumentException.class);
@@ -422,6 +444,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aMap.key: string -> uuid")
         .isInstanceOf(IllegalArgumentException.class);
@@ -434,7 +457,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema = new Schema(required(1, "aCol", LongType.get()));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     Schema applied = updateApi.apply();
     assertThat(applied.asStruct().fields()).hasSize(1);
     assertThat(applied.asStruct().fields().get(0).type()).isEqualTo(LongType.get());
@@ -447,7 +471,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema = new Schema(required(1, "aCol", DoubleType.get()));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     Schema applied = updateApi.apply();
     assertThat(applied.asStruct().fields()).hasSize(1);
     assertThat(applied.asStruct().fields().get(0).type()).isEqualTo(DoubleType.get());
@@ -464,6 +489,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aCol: double -> float")
         .isInstanceOf(IllegalArgumentException.class);
@@ -477,7 +503,8 @@ public class TestEvolveSchemaVisitor {
     Schema targetSchema = new Schema(required(1, "aCol", DecimalType.of(22, 1)));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -520,7 +547,8 @@ public class TestEvolveSchemaVisitor {
                                         optional(6, "time", TimeType.get())))))))));
 
     UpdateSchema updateApi = loadUpdateApi(existingSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, existingSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -536,6 +564,7 @@ public class TestEvolveSchemaVisitor {
                     loadUpdateApi(currentSchema),
                     currentSchema,
                     targetSchema,
+                    true,
                     PRESERVE_COLUMNS))
         .hasMessage("Cannot change column type: aColumn: list<string> -> string")
         .isInstanceOf(IllegalArgumentException.class);
@@ -573,7 +602,8 @@ public class TestEvolveSchemaVisitor {
                     optional(7, "d1", StructType.of(optional(8, "d2", StringType.get()))))));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -625,7 +655,8 @@ public class TestEvolveSchemaVisitor {
                                                                 StringType.get()))))))))))))));
 
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(updateApi.apply().asStruct()).isEqualTo(targetSchema.asStruct());
   }
 
@@ -645,7 +676,8 @@ public class TestEvolveSchemaVisitor {
                             optional(
                                 3, "s3", StructType.of(optional(4, "s4", StringType.get()))))))));
     UpdateSchema updateApi = loadUpdateApi(currentSchema);
-    EvolveSchemaVisitor.visit(TABLE, updateApi, currentSchema, targetSchema, PRESERVE_COLUMNS);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, currentSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
     assertThat(getNestedSchemaWithOptionalModifier(true).asStruct())
         .isEqualTo(updateApi.apply().asStruct());
   }
@@ -680,6 +712,82 @@ public class TestEvolveSchemaVisitor {
                                                     StructType.of(
                                                         optional(
                                                             9, "s4", StringType.get()))))))))))))));
+  }
+
+  @Test
+  public void testCaseInsensitiveAddField() {
+    Schema existingSchema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()));
+    Schema targetSchema =
+        new Schema(
+            Types.NestedField.optional(1, "ID", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "NAME", Types.StringType.get()),
+            Types.NestedField.optional(3, "AGE", Types.IntegerType.get()));
+
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_INSENSITIVE, PRESERVE_COLUMNS);
+    Schema result = updateApi.apply();
+    assertThat(result.columns()).hasSize(3);
+    assertThat(result.findField("AGE")).isNotNull();
+  }
+
+  @Test
+  public void testCaseInsensitiveMakeFieldOptional() {
+    Schema existingSchema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "name", Types.StringType.get()));
+    Schema targetSchema = new Schema(Types.NestedField.optional(1, "ID", Types.IntegerType.get()));
+
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_INSENSITIVE, PRESERVE_COLUMNS);
+    Schema result = updateApi.apply();
+    assertThat(result.findField("name").isOptional()).isTrue();
+  }
+
+  @Test
+  public void testCaseInsensitiveNestedStructField() {
+    Schema existingSchema =
+        new Schema(
+            optional(1, "struct1", StructType.of(optional(2, "field1", Types.StringType.get()))));
+    Schema targetSchema =
+        new Schema(
+            optional(
+                1,
+                "STRUCT1",
+                StructType.of(
+                    optional(2, "FIELD1", Types.StringType.get()),
+                    optional(3, "FIELD2", Types.IntegerType.get()))));
+
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_INSENSITIVE, PRESERVE_COLUMNS);
+    Schema result = updateApi.apply();
+    Types.StructType struct = result.findField("struct1").type().asStructType();
+    assertThat(struct.fields()).hasSize(2);
+    assertThat(struct.field("FIELD2")).isNotNull();
+  }
+
+  @Test
+  public void testCaseSensitiveDoesNotMatch() {
+    Schema existingSchema =
+        new Schema(Types.NestedField.optional(1, "id", Types.IntegerType.get()));
+    Schema targetSchema =
+        new Schema(
+            Types.NestedField.optional(1, "ID", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()));
+
+    UpdateSchema updateApi = loadUpdateApi(existingSchema);
+    EvolveSchemaVisitor.visit(
+        TABLE, updateApi, existingSchema, targetSchema, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    Schema result = updateApi.apply();
+    assertThat(result.columns()).hasSize(3);
+    assertThat(result.findField("ID")).isNotNull();
+    assertThat(result.findField("id")).isNotNull();
   }
 
   private static UpdateSchema loadUpdateApi(Schema schema) {


### PR DESCRIPTION
This is a clean backport of #14729 for Flink 1.20 and 2.0.