### PR TITLE
Spec: Change UUID fields from string type to UUIDTypeValue

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -292,15 +292,6 @@ class BaseUpdate(BaseModel):
     action: str
 
 
-class AssignUUIDUpdate(BaseUpdate):
-    """
-    Assigning a UUID to a table/view should only be done when creating the table/view. It is not safe to re-assign the UUID if a table/view already has a UUID assigned
-    """
-
-    action: Literal['assign-uuid'] = Field('assign-uuid', const=True)
-    uuid: str
-
-
 class UpgradeFormatVersionUpdate(BaseUpdate):
     action: Literal['upgrade-format-version'] = Field(
         'upgrade-format-version', const=True
@@ -446,15 +437,6 @@ class AssertCreate(TableRequirement):
     type: Literal['assert-create'] = Field(..., const=True)
 
 
-class AssertTableUUID(TableRequirement):
-    """
-    The table UUID must match the requirement's `uuid`
-    """
-
-    type: Literal['assert-table-uuid'] = Field(..., const=True)
-    uuid: str
-
-
 class AssertRefSnapshotId(TableRequirement):
     """
     The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`.
@@ -523,15 +505,6 @@ class AssertDefaultSortOrderId(TableRequirement):
         'assert-default-sort-order-id', const=True
     )
     default_sort_order_id: int = Field(..., alias='default-sort-order-id')
-
-
-class AssertViewUUID(BaseModel):
-    """
-    The view UUID must match the requirement's `uuid`
-    """
-
-    type: Literal['assert-view-uuid'] = Field('assert-view-uuid', const=True)
-    uuid: str
 
 
 class StorageCredential(BaseModel):
@@ -1005,6 +978,15 @@ class TransformTerm(BaseModel):
     term: Reference
 
 
+class AssignUUIDUpdate(BaseUpdate):
+    """
+    Assigning a UUID to a table/view should only be done when creating the table/view. It is not safe to re-assign the UUID if a table/view already has a UUID assigned
+    """
+
+    action: Literal['assign-uuid'] = Field('assign-uuid', const=True)
+    uuid: UUIDTypeValue
+
+
 class SetPartitionStatisticsUpdate(BaseUpdate):
     action: Literal['set-partition-statistics'] = Field(
         'set-partition-statistics', const=True
@@ -1014,8 +996,22 @@ class SetPartitionStatisticsUpdate(BaseUpdate):
     )
 
 
-class ViewRequirement(BaseModel):
-    __root__: AssertViewUUID = Field(..., discriminator='type')
+class AssertTableUUID(TableRequirement):
+    """
+    The table UUID must match the requirement's `uuid`
+    """
+
+    type: Literal['assert-table-uuid'] = Field(..., const=True)
+    uuid: UUIDTypeValue
+
+
+class AssertViewUUID(BaseModel):
+    """
+    The view UUID must match the requirement's `uuid`
+    """
+
+    type: Literal['assert-view-uuid'] = Field('assert-view-uuid', const=True)
+    uuid: UUIDTypeValue
 
 
 class FailedPlanningResult(IcebergErrorResponse):
@@ -1109,6 +1105,10 @@ class SetStatisticsUpdate(BaseUpdate):
     statistics: StatisticsFile
 
 
+class ViewRequirement(BaseModel):
+    __root__: AssertViewUUID = Field(..., discriminator='type')
+
+
 class UnaryExpression(BaseModel):
     type: Literal['is-null', 'not-null', 'is-nan', 'not-nan']
     term: Term
@@ -1188,7 +1188,7 @@ class NotExpression(BaseModel):
 
 class TableMetadata(BaseModel):
     format_version: int = Field(..., alias='format-version', ge=1, le=3)
-    table_uuid: str = Field(..., alias='table-uuid')
+    table_uuid: UUIDTypeValue = Field(..., alias='table-uuid')
     location: str | None = None
     last_updated_ms: int | None = Field(None, alias='last-updated-ms')
     next_row_id: int | None = Field(
@@ -1219,7 +1219,7 @@ class TableMetadata(BaseModel):
 
 
 class ViewMetadata(BaseModel):
-    view_uuid: str = Field(..., alias='view-uuid')
+    view_uuid: UUIDTypeValue = Field(..., alias='view-uuid')
     format_version: int = Field(..., alias='format-version', ge=1, le=1)
     location: str
     current_version_id: int = Field(..., alias='current-version-id')

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2658,7 +2658,7 @@ components:
           minimum: 1
           maximum: 3
         table-uuid:
-          type: string
+          $ref: '#/components/schemas/UUIDTypeValue'
         location:
           type: string
         last-updated-ms:
@@ -2803,7 +2803,7 @@ components:
         - schemas
       properties:
         view-uuid:
-          type: string
+          $ref: '#/components/schemas/UUIDTypeValue'
         format-version:
           type: integer
           minimum: 1
@@ -2876,7 +2876,7 @@ components:
           type: string
           const: "assign-uuid"
         uuid:
-          type: string
+          $ref: '#/components/schemas/UUIDTypeValue'
 
     UpgradeFormatVersionUpdate:
       allOf:
@@ -3278,7 +3278,7 @@ components:
           type: string
           const: "assert-table-uuid"
         uuid:
-          type: string
+          $ref: '#/components/schemas/UUIDTypeValue'
 
     AssertRefSnapshotId:
       description: |
@@ -3390,7 +3390,7 @@ components:
           type: string
           const: "assert-view-uuid"
         uuid:
-          type: string
+          $ref: '#/components/schemas/UUIDTypeValue'
 
     StorageCredential:
       type: object


### PR DESCRIPTION
I noticed that we have several UUID fields in the REST Catalog that are just basic strings. Moving them over to UUIDTypeValue shows the proper validation + proper context, especially to OpenAPI tools that are consuming the spec.

This change should be a no-op, since these UUID restrictions already existed, but were never documented.