### PR TITLE
Core: Invalidate ShreddedObject serialization cache on remove

### DIFF
--- a/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
@@ -85,6 +85,7 @@ public class ShreddedObject implements VariantObject {
   public void remove(String field) {
     shreddedFields.remove(field);
     removedFields.add(field);
+    this.serializationState = null;
   }
 
   public void put(String field, VariantValue value) {


### PR DESCRIPTION
`ShreddedObject` caches a `SerializationState` used by `sizeInBytes` and `writeTo`. `remove` mutates the object but didn’t clear the cache, so subsequent serialization could include removed fields. This PR invalidates the cache on `remove`