### PR TITLE
Fix TableUpdate union to include partition statistics updates

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1259,6 +1259,8 @@ class TableUpdate(BaseModel):
         | RemovePropertiesUpdate
         | SetStatisticsUpdate
         | RemoveStatisticsUpdate
+        | SetPartitionStatisticsUpdate
+        | RemovePartitionStatisticsUpdate
         | RemovePartitionSpecsUpdate
         | RemoveSchemasUpdate
         | AddEncryptionKeyUpdate

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3219,6 +3219,8 @@ components:
         - $ref: '#/components/schemas/RemovePropertiesUpdate'
         - $ref: '#/components/schemas/SetStatisticsUpdate'
         - $ref: '#/components/schemas/RemoveStatisticsUpdate'
+        - $ref: '#/components/schemas/SetPartitionStatisticsUpdate'
+        - $ref: '#/components/schemas/RemovePartitionStatisticsUpdate'
         - $ref: '#/components/schemas/RemovePartitionSpecsUpdate'
         - $ref: '#/components/schemas/RemoveSchemasUpdate'
         - $ref: '#/components/schemas/AddEncryptionKeyUpdate'


### PR DESCRIPTION
fix: Include SetPartitionStatisticsUpdate and RemovePartitionStatisticsUpdate in TableUpdate union

The `SetPartitionStatisticsUpdate` and `RemovePartitionStatisticsUpdate` were defined in the OpenAPI spec but missing from the `TableUpdate` union. This caused the generated Python client and other consumers to not recognize these updates as valid table updates. This commit adds them to the `TableUpdate` union in `rest-catalog-open-api.yaml` and regenerates `rest-catalog-open-api.py`.

https://github.com/logesh45/iceberg/pull/1