### PR TITLE
Remove HEAD operation from AnalyticsAcceleratorUtil

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/AnalyticsAcceleratorUtil.java
@@ -28,7 +28,6 @@ import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.s3.analyticsaccelerator.ObjectClientConfiguration;
 import software.amazon.s3.analyticsaccelerator.S3SdkObjectClient;
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStream;
@@ -36,8 +35,6 @@ import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamConfiguratio
 import software.amazon.s3.analyticsaccelerator.S3SeekableInputStreamFactory;
 import software.amazon.s3.analyticsaccelerator.common.ConnectorConfiguration;
 import software.amazon.s3.analyticsaccelerator.request.ObjectClient;
-import software.amazon.s3.analyticsaccelerator.request.ObjectMetadata;
-import software.amazon.s3.analyticsaccelerator.util.OpenStreamInformation;
 import software.amazon.s3.analyticsaccelerator.util.S3URI;
 
 class AnalyticsAcceleratorUtil {
@@ -58,15 +55,6 @@ class AnalyticsAcceleratorUtil {
 
   public static SeekableInputStream newStream(S3InputFile inputFile) {
     S3URI uri = S3URI.of(inputFile.uri().bucket(), inputFile.uri().key());
-    HeadObjectResponse metadata = inputFile.getObjectMetadata();
-    OpenStreamInformation openStreamInfo =
-        OpenStreamInformation.builder()
-            .objectMetadata(
-                ObjectMetadata.builder()
-                    .contentLength(metadata.contentLength())
-                    .etag(metadata.eTag())
-                    .build())
-            .build();
 
     S3SeekableInputStreamFactory factory =
         STREAM_FACTORY_CACHE.get(
@@ -74,7 +62,7 @@ class AnalyticsAcceleratorUtil {
             AnalyticsAcceleratorUtil::createNewFactory);
 
     try {
-      S3SeekableInputStream seekableInputStream = factory.createStream(uri, openStreamInfo);
+      S3SeekableInputStream seekableInputStream = factory.createStream(uri);
       return new AnalyticsAcceleratorInputStreamWrapper(seekableInputStream);
     } catch (IOException e) {
       throw new RuntimeIOException(


### PR DESCRIPTION
Remove HEAD request handling from Iceberg S3FileIO since Analytics Accelerator Library (AAL) handles metadata caching internally. This reduces S3 HEAD requests.

Testing:
Validated this change through our internal benchmarking and performance tests using Iceberg with the Analytics Accelerator Library (AAL) enabled. Compared request patterns before and after removing the explicit HEAD and observed a significant reduction in S3 HEAD request counts. Since AAL already performs metadata caching internally.