### PR TITLE
Docs: Fix publish_changes wap_id parameter type

### DIFF
--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -194,10 +194,10 @@ Only append and dynamic overwrite snapshots can be successfully published.
 
 #### Usage
 
-| Argument Name | Required? | Type | Description |
-|---------------|-----------|------|-------------|
+| Argument Name | Required? | Type   | Description |
+|---------------|-----------|--------|-------------|
 | `table`       | ✔️  | string | Name of the table to update |
-| `wap_id`      | ✔️  | long | The wap_id to be published from stage to prod |
+| `wap_id`      | ✔️  | string | The wap_id to be published from stage to prod |
 
 #### Output
 


### PR DESCRIPTION
Updates the Spark procedures documentation for `publish_changes` to reflect the correct `wap_id` parameter type (string, not long)