### PR TITLE
AWS: Add support for configuring custom S3 MetricPublisher

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -56,6 +56,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
                     awsClientProperties, s3ClientBuilder))
         .applyMutation(s3FileIOProperties::applySignerConfiguration)
         .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
+        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
         .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
         .build();

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3MetricsPublisherConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3MetricsPublisherConfigurations.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+/**
+ * Interface for configuring a custom {@link software.amazon.awssdk.metrics.MetricPublisher} on an
+ * S3 client.
+ *
+ * <p>Implementations must provide a static {@code create(Map<String, String>)} factory method that
+ * returns an instance of this interface.
+ *
+ * <p>Example implementation for Prometheus metrics:
+ *
+ * <pre>{@code
+ * public class PrometheusMetricsConfigurations implements S3MetricsPublisherConfigurations {
+ *   private MetricPublisher publisher;
+ *
+ *   public static PrometheusMetricsConfigurations create(Map<String, String> properties) {
+ *     PrometheusMetricsConfigurations config = new PrometheusMetricsConfigurations();
+ *     // Configure your Prometheus MetricPublisher using properties
+ *     config.publisher = new PrometheusMetricPublisher(properties);
+ *     return config;
+ *   }
+ *
+ *   @Override
+ *   public <T extends S3ClientBuilder> void configureS3ClientBuilder(T builder) {
+ *     ClientOverrideConfiguration.Builder configBuilder =
+ *         builder.overrideConfiguration() != null
+ *             ? builder.overrideConfiguration().toBuilder()
+ *             : ClientOverrideConfiguration.builder();
+ *     builder.overrideConfiguration(configBuilder.addMetricPublisher(publisher).build());
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>Then configure via property: {@code s3.metrics-publisher-impl=com.example.PrometheusMetricsConfigurations}
+ */
+public interface S3MetricsPublisherConfigurations {
+
+  /**
+   * Configure the S3 client builder with a custom metric publisher.
+   *
+   * @param builder the S3 client builder to configure
+   * @param <T> the type of S3 client builder
+   */
+  <T extends S3ClientBuilder> void configureS3ClientBuilder(T builder);
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOProperties.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.aws.s3.TestS3MetricsPublisherConfigurations;
 import org.apache.iceberg.aws.s3.signer.S3V4RestSignerClient;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -319,5 +320,30 @@ public class TestS3FileIOProperties {
     map.put(S3FileIOProperties.S3_DIRECTORY_BUCKET_LIST_PREFIX_AS_DIRECTORY, "false");
     S3FileIOProperties properties = new S3FileIOProperties(map);
     assertThat(properties.isS3DirectoryBucketListPrefixAsDirectory()).isEqualTo(false);
+  }
+
+  @Test
+  public void testMetricsPublisherEnabled() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            S3FileIOProperties.METRICS_PUBLISHER_IMPL,
+            TestS3MetricsPublisherConfigurations.class.getName());
+    S3FileIOProperties s3Properties = new S3FileIOProperties(properties);
+    S3ClientBuilder builder = S3Client.builder();
+
+    s3Properties.applyMetricsPublisherConfiguration(builder);
+
+    assertThat(builder.overrideConfiguration().metricPublishers()).hasSize(1);
+  }
+
+  @Test
+  public void testMetricsPublisherDisabled() {
+    Map<String, String> properties = ImmutableMap.of();
+    S3FileIOProperties s3Properties = new S3FileIOProperties(properties);
+    S3ClientBuilder builder = S3Client.builder();
+
+    s3Properties.applyMetricsPublisherConfiguration(builder);
+
+    assertThat(builder.overrideConfiguration().metricPublishers()).isEmpty();
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3MetricsPublisherConfigurations.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3MetricsPublisherConfigurations.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import java.util.Map;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+/** Test implementation of S3MetricsPublisherConfigurations for unit tests. */
+public class TestS3MetricsPublisherConfigurations implements S3MetricsPublisherConfigurations {
+
+  public static TestS3MetricsPublisherConfigurations create(Map<String, String> properties) {
+    return new TestS3MetricsPublisherConfigurations();
+  }
+
+  @Override
+  public <T extends S3ClientBuilder> void configureS3ClientBuilder(T builder) {
+    ClientOverrideConfiguration.Builder configBuilder =
+        builder.overrideConfiguration() != null
+            ? builder.overrideConfiguration().toBuilder()
+            : ClientOverrideConfiguration.builder();
+    builder.overrideConfiguration(configBuilder.addMetricPublisher(new NoOpMetricPublisher()).build());
+  }
+
+  private static class NoOpMetricPublisher implements MetricPublisher {
+    @Override
+    public void publish(MetricCollection metricCollection) {}
+
+    @Override
+    public void close() {}
+  }
+}


### PR DESCRIPTION
We want to be able to capture granular metrics the AWS SDK emits for various operations. Currently, this would require us to duplicate `DefaultS3FileIOAwsClientFactory` and add a one-liner to provide a custom metric provider following the AWS SDK interface. Even if we could extend the class, which is package private, we'd still pretty much have to redo the builder for just a one liner.

With this PR, adding an option so we can configure an implementation of the `S3MetricsPublisherConfigurations`. This can be implemented according to whatever framework is used to emit the metrics (for example micrometer).