### PR TITLE
AWS: Add support for configuring custom S3 MetricPublisher

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -56,6 +56,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
                     awsClientProperties, s3ClientBuilder))
         .applyMutation(s3FileIOProperties::applySignerConfiguration)
         .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
+        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
         .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
         .build();
@@ -76,6 +77,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
         .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
         .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -49,6 +49,7 @@ import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
 import software.amazon.awssdk.core.retry.conditions.TokenBucketRetryCondition;
+import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -65,6 +66,14 @@ public class S3FileIOProperties implements Serializable {
    * provide backward compatibility.
    */
   public static final String CLIENT_FACTORY = "s3.client-factory-impl";
+
+  /**
+   * This property is used to configure a custom {@link
+   * software.amazon.awssdk.metrics.MetricPublisher} for the S3 client. The class must implement
+   * {@link software.amazon.awssdk.metrics.MetricPublisher} and provide either a static {@code
+   * create(Map<String, String>)} factory method or a no-arg constructor.
+   */
+  public static final String METRICS_PUBLISHER_IMPL = "s3.metrics-publisher-impl";
 
   /**
    * This property is used to enable using the S3 Access Grants product to control authorization to
@@ -534,6 +543,7 @@ public class S3FileIOProperties implements Serializable {
   private long s3RetryMaxWaitMs;
 
   private boolean s3DirectoryBucketListPrefixAsDirectory;
+  private final String metricsPublisherImpl;
   private final Map<String, String> allProperties;
 
   public S3FileIOProperties() {
@@ -576,6 +586,7 @@ public class S3FileIOProperties implements Serializable {
     this.s3AnalyticsacceleratorProperties = Maps.newHashMap();
     this.isS3CRTEnabled = S3_CRT_ENABLED_DEFAULT;
     this.s3CrtMaxConcurrency = S3_CRT_MAX_CONCURRENCY_DEFAULT;
+    this.metricsPublisherImpl = null;
     this.allProperties = Maps.newHashMap();
 
     ValidationException.check(
@@ -698,6 +709,7 @@ public class S3FileIOProperties implements Serializable {
     this.s3CrtMaxConcurrency =
         PropertyUtil.propertyAsInt(
             properties, S3_CRT_MAX_CONCURRENCY, S3_CRT_MAX_CONCURRENCY_DEFAULT);
+    this.metricsPublisherImpl = properties.get(METRICS_PUBLISHER_IMPL);
 
     ValidationException.check(
         keyIdAccessKeyBothConfigured(),
@@ -1132,6 +1144,49 @@ public class S3FileIOProperties implements Serializable {
               S3AccessGrantsPluginConfigurations.class.getName(), allProperties);
       s3AccessGrantsPluginConfigurations.configureS3ClientBuilder(builder);
     }
+  }
+
+  public <T extends S3BaseClientBuilder<T, ?>> void applyMetricsPublisherConfiguration(T builder) {
+    if (metricsPublisherImpl != null) {
+      MetricPublisher metricPublisher = loadMetricPublisher(metricsPublisherImpl, allProperties);
+      ClientOverrideConfiguration.Builder configBuilder =
+          builder.overrideConfiguration() != null
+              ? builder.overrideConfiguration().toBuilder()
+              : ClientOverrideConfiguration.builder();
+      builder.overrideConfiguration(configBuilder.addMetricPublisher(metricPublisher).build());
+    }
+  }
+
+  /**
+   * Load a MetricPublisher implementation. Tries static create(Map) factory method first, falls
+   * back to no-arg constructor.
+   */
+  private MetricPublisher loadMetricPublisher(String impl, Map<String, String> properties) {
+    try {
+      try {
+        return DynMethods.builder("create")
+            .hiddenImpl(impl, Map.class)
+            .buildStaticChecked()
+            .invoke(properties);
+      } catch (NoSuchMethodException e) {
+        return Class.forName(impl)
+            .asSubclass(MetricPublisher.class)
+            .getDeclaredConstructor()
+            .newInstance();
+      }
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot instantiate MetricPublisher %s. "
+                  + "Class must have either a static create(Map<String, String>) method "
+                  + "or a no-arg constructor.",
+              impl),
+          e);
+    }
+  }
+
+  public String metricsPublisherImpl() {
+    return metricsPublisherImpl;
   }
 
   public <T extends S3ClientBuilder> void applyUserAgentConfigurations(T builder) {

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -659,6 +659,25 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
 
 For more details on using S3 Dual-stack, please refer [Using dual-stack endpoints from the AWS CLI and the AWS SDKs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/dual-stack-endpoints.html#dual-stack-endpoints-cli)
 
+### S3 Metrics Publisher
+
+`S3FileIO` supports configuring a custom [MetricPublisher](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/metrics/MetricPublisher.html) to capture metrics emitted by the AWS SDK for S3 operations. Note that this is not supported when using the [S3 CRT client](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/crt-based-s3-client.html) (`s3.crt.enabled=true`).
+
+To enable, set `s3.metrics-publisher-impl` to a class implementing `MetricPublisher`. The class must provide either a static `create(Map<String, String>)` factory method or a no-arg constructor.
+
+| Property                   | Default | Description                                                                 |
+| -------------------------- | ------- | --------------------------------------------------------------------------- |
+| s3.metrics-publisher-impl  | null    | Fully qualified class name of a `MetricPublisher` implementation |
+
+For example, to use a custom metrics publisher with Spark 3.5:
+```
+spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
+    --conf spark.sql.catalog.my_catalog.type=glue \
+    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --conf spark.sql.catalog.my_catalog.s3.metrics-publisher-impl=com.example.MyMetricPublisher
+```
+
 ## AWS Client Customization
 
 Many organizations have customized their way of configuring AWS clients with their own credential provider, access proxy, retry strategy, etc.


### PR DESCRIPTION
We want to be able to capture granular metrics the AWS SDK emits for various operations. Currently, this would require us to duplicate DefaultS3FileIOAwsClientFactory and add a one-liner to provide a custom metric provider following the AWS SDK interface. Even if we could extend the class, which is package private, we'd still pretty much have to redo the builder for just a one liner.

With this PR, adding an option so we can configure an implementation of the S3MetricsPublisherConfigurations. This can be implemented according to whatever framework is used to emit the metrics (for example micrometer).