### PR TITLE
Core: Fix incorrect partition bounds calculation in manifest on deletion

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -135,7 +135,8 @@ public class PartitionData
     }
 
     if (data[pos] instanceof byte[]) {
-      return ByteBuffer.wrap((byte[]) data[pos]);
+      byte[] copied = Arrays.copyOf((byte[]) data[pos], ((byte[]) data[pos]).length);
+      return ByteBuffer.wrap(copied);
     }
 
     return data[pos];


### PR DESCRIPTION
When deleting data files through `DeleteFiles.deleteFromRowFilter`, the manifest file was updated with incorrect partition boundary values if the target table is partitioned by columns of `binary` type.

This is mainly because in `PartitionSummary.updateFields`, the update of `PartitionFieldStats`'s min/max field directly references a byte array that could be reused by `ManifestReader` when reading multiple files.

This PR fixes it by preventing `PartitionFieldStats` from referencing arrays that could be reused and modified. The added test case can stably reproduce this issue.

Fix issue #15128 