### PR TITLE
Fix bullet list formatting in fileio documentation

### DIFF
--- a/docs/docs/fileio.md
+++ b/docs/docs/fileio.md
@@ -33,6 +33,7 @@ The metadata for an Iceberg table tracks the absolute path for data files which 
 The responsibility of reading and writing data files lies with the processing engines and happens during task execution. However, after data files are written, processing engines use FileIO to write new Iceberg metadata files that capture the new state of the table.
 
 Different FileIO implementations are used depending on the type of storage. Iceberg comes with a set of FileIO implementations for popular storage providers.
+
 - Amazon S3
 - Google Cloud Storage
 - Object Service Storage (including https)


### PR DESCRIPTION
Fixes #15102

Added a blank line between the paragraph and bullet list in the "Usage in Processing Engines" section of the fileio documentation to ensure proper Markdown rendering.

Changes:
- Added blank line before the bullet list in 'docs/docs/fileio.md'