### PR TITLE
Core: Fix compute_table_stats failures with concurrent writes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -57,8 +57,7 @@ public class SetStatistics implements UpdateStatistics {
 
   @Override
   public List<StatisticsFile> apply() {
-    TableMetadata current = ops.current();
-    return internalApply(current).statisticsFiles();
+    return internalApply(ops.current()).statisticsFiles();
   }
 
   @Override


### PR DESCRIPTION
compute_table_stats fails with CommitFailedException when concurrent writes modify table metadata during statistics computation.

