### PR TITLE
site: add slug to be explicit about blog url

### DIFF
--- a/site/docs/blog/posts/2026-01-10-iceberg-summit.md
+++ b/site/docs/blog/posts/2026-01-10-iceberg-summit.md
@@ -1,6 +1,7 @@
 ---
 date: 2026-01-10
 title: Announcing Iceberg Summit 2026
+slug: announcing-iceberg-summit-2026  # this is the url
 authors:
   - iceberg-pmc
 categories:

--- a/site/docs/blog/posts/2026-01-26-iceberg-cpp-0.2.0-release.md
+++ b/site/docs/blog/posts/2026-01-26-iceberg-cpp-0.2.0-release.md
@@ -1,6 +1,7 @@
 ---
 date: 2026-01-26
 title: Apache Iceberg C++ 0.2.0 Release
+slug: apache-iceberg-cpp-0.2.0-release  # this is the blog url
 authors:
   - iceberg-pmc
 categories:


### PR DESCRIPTION
the mkdoc blog plugin calculate [slug (blog url)](https://squidfunk.github.io/mkdocs-material/plugins/blog/#meta.slug) automatically just the title but [uses a weird scheme](https://squidfunk.github.io/mkdocs-material/plugins/blog/#config.post_slugify)

In #15141 it turned "Apache Iceberg C++ 0.2.0 Release" -> "apache-iceberg-c-020-release/", which removed the "++" and the version "."s

This PR makes slug explicit so we can set the final url.
Added slug to `site/docs/blog/posts/2026-01-10-iceberg-summit.md` just to be explicit 

I verified it locally
* http://127.0.0.1:8000/blog/announcing-iceberg-summit-2026/
* http://127.0.0.1:8000/blog/apache-iceberg-cpp-0.2.0-release/