### PR TITLE
Build: Downgrade hadoop version to 3.3.4 for Spark 3.x compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,9 @@ flink21 = { strictly = "2.1.0"}
 google-libraries-bom = "26.74.0"
 gcs-analytics-core = "1.2.3"
 guava = "33.5.0-jre"
-hadoop3 = "3.4.2"
+# keep at the same version as the oldest supported spark release, to ensure
+# API/link compatibility.
+hadoop3 = "3.3.4"
 httpcomponents-httpclient5 = "5.6"
 hive2 = { strictly = "2.3.10"} # see rich version usage explanation above
 immutables-value = "2.12.1"


### PR DESCRIPTION
- Downgrades the hadoop version
- Adds a comment to libs.versions saying why it needs to be kept down and hence when it can be upgraded.

Fixes #15100