### PR TITLE
Build: Bump spotless gradle plugin to 8.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
   dependencies {
     classpath 'com.gradleup.shadow:shadow-gradle-plugin:8.3.9'
     classpath 'com.palantir.baseline:gradle-baseline-java:5.72.0'
-    classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
+    classpath 'com.diffplug.spotless:spotless-plugin-gradle:8.2.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
     classpath 'me.champeau.jmh:jmh-gradle-plugin:0.7.3'
     classpath 'gradle.plugin.io.morethan.jmhreport:gradle-jmh-report:0.9.6'


### PR DESCRIPTION
In the past we haven't been able to use the latest version of the plugin because we were still on JDK11