### PR TITLE
Build: Bump gradle-git-version to 4.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
     classpath "com.github.alisiikh:gradle-scalastyle-plugin:3.5.0"
     classpath 'org.revapi:gradle-revapi:1.8.0'
     classpath 'com.gorylenko.gradle-git-properties:gradle-git-properties:2.5.4'
-    classpath 'com.palantir.gradle.gitversion:gradle-git-version:3.4.0'
+    classpath 'com.palantir.gradle.gitversion:gradle-git-version:4.2.0'
     classpath 'org.openapitools:openapi-generator-gradle-plugin:7.19.0'
   }
 }


### PR DESCRIPTION
We were previously not able to upgrade because 4.x required JDK17+