### PR TITLE
Test: Fix typo in variable name spaceSeparatedPlanId

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -319,14 +319,14 @@ public class TestResourcePaths {
         .isEqualTo("v1/namespaces/test_namespace/tables/test_table/plan/plan-abc-123");
 
     // The planId contains a space which needs to be encoded
-    String spaceSeperatedPlanId = "plan with spaces";
+    String spaceSeparatedPlanId = "plan with spaces";
     // The expected encoded version of the planId
     String encodedPlanId = "plan+with+spaces";
 
-    assertThat(withPrefix.plan(tableId, spaceSeperatedPlanId))
+    assertThat(withPrefix.plan(tableId, spaceSeparatedPlanId))
         .isEqualTo(
             "v1/ws/catalog/namespaces/test_namespace/tables/test_table/plan/" + encodedPlanId);
-    assertThat(withoutPrefix.plan(tableId, spaceSeperatedPlanId))
+    assertThat(withoutPrefix.plan(tableId, spaceSeparatedPlanId))
         .isEqualTo("v1/namespaces/test_namespace/tables/test_table/plan/" + encodedPlanId);
 
     // Test with different identifiers


### PR DESCRIPTION
Fixed a typo in the variable name `spaceSeperatedPlanId` -> `spaceSeparatedPlanId` in `TestResourcePaths.java`.
This change improves code readability and does not affect logic.