### PR TITLE
REST: Explicitly send purgeRequested=false when dropping table without purge

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -347,10 +347,17 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     try {
       AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+      // Explicitly send purgeRequested=false to ensure catalogs that default to purge=true
+      // (e.g., for Spark compatibility) preserve table data when drop without purge is intended.
+      // See: https://github.com/apache/iceberg/issues/11023
       client
           .withAuthSession(contextualSession)
           .delete(
-              paths.table(identifier), null, mutationHeaders, ErrorHandlers.tableErrorHandler());
+              paths.table(identifier),
+              ImmutableMap.of("purgeRequested", "false"),
+              null,
+              mutationHeaders,
+              ErrorHandlers.tableErrorHandler());
       return true;
     } catch (NoSuchTableException e) {
       return false;


### PR DESCRIPTION
## Summary

Modify `RESTSessionCatalog.dropTable()` to explicitly send `purgeRequested=false` instead of omitting the parameter.

## Problem

Currently, `dropTable(context, identifier)` sends a DELETE request without the `purgeRequested` parameter, relying on the server to default to `false`.

However, some catalogs default `purgeRequested=true` to work around Spark's bug where it doesn't forward `purgeRequested=true` even with `DROP TABLE ... PURGE` (#11023, #11317).

With such catalogs, calling `catalog.dropTable(identifier, false)` unexpectedly purges table data because the parameter is omitted and the server defaults to `true`.

## Solution

Explicitly send `purgeRequested=false`:

```java
client.delete(
    paths.table(identifier),
    ImmutableMap.of("purgeRequested", "false"),
    ...);
```

This ensures the client's intent is honored regardless of server defaults.

## Related Issues

- #11023 - deletion & purge improvements for undelete feature in REST catalog
- #11317 - Spark: add property to disable client-side purging in spark