### PR TITLE
[fix] Ensure AssumeRoleAwsClientFactory forwards region to STS builder

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -161,6 +161,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private StsClient sts() {
     return StsClient.builder()
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .region(Region.of(awsProperties.clientAssumeRoleRegion()))
         .build();
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+public class TestAssumeRoleAwsClientFactory {
+  @Test
+  public void testApplyAssumeRoleConfigurationsSetsRegion() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn:aws:iam::123456789012:role/test-role",
+            AwsProperties.CLIENT_ASSUME_ROLE_REGION, "ap-southeeast-1");
+
+    AssumeRoleAwsClientFactory factory = new AssumeRoleAwsClientFactory();
+    factory.initialize(properties);
+
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+
+    Mockito.when(mockBuilder.region(Mockito.any())).thenReturn(mockBuilder);
+    Mockito.when(mockBuilder.credentialsProvider(Mockito.any())).thenReturn(mockBuilder);
+
+    ArgumentCaptor<Region> regionCaptor = ArgumentCaptor.forClass(Region.class);
+
+    factory.applyAssumeRoleConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder).region(regionCaptor.capture());
+
+    Region captured = regionCaptor.getValue();
+    assertThat(captured.id())
+        .as("Region should match CLIENT_ASSUME_ROLE_REGION for cases outside AWS machines")
+        .isEqualTo("ap-southeeast-1");
+  }
+}


### PR DESCRIPTION
Goal is to make it work as soon as configuration is complete.
Currently, running outside AWS it leads to not be able to resolve the region until you do setup a profile (undesired in k8s clusters for ex), fake aws metadata endpoint or set aws.region system property (undesired since it makes it inconsistent with the overall iceberg configuration which already has the info anyway) - ref: `software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain#DefaultAwsRegionProviderChain()`.