### PR TITLE
AWS: Fix S3V4RestSignerClient cache key to include all request components

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
@@ -32,9 +32,7 @@ import java.io.Reader;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -46,7 +44,6 @@ import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.io.CharStreams;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.ResourcePaths;
@@ -70,9 +67,7 @@ public class S3SignerServlet extends HttpServlet {
   private static final Logger LOG = LoggerFactory.getLogger(S3SignerServlet.class);
 
   static final Clock SIGNING_CLOCK = Clock.fixed(Instant.now(), ZoneId.of("UTC"));
-  static final Set<String> UNSIGNED_HEADERS =
-      Sets.newHashSet(
-          Arrays.asList("range", "x-amz-date", "amz-sdk-invocation-id", "amz-sdk-retry"));
+
   private static final String POST = "POST";
 
   private static final Set<SdkHttpMethod> CACHEABLE_METHODS =
@@ -184,14 +179,16 @@ public class S3SignerServlet extends HttpServlet {
             .signingName("s3")
             .build();
 
+    // Note: the signer client is expected to remove headers it doesn't want us to sign;
+    // but older versions of the client don't do that, so we need to filter them out ourselves
     Map<String, List<String>> unsignedHeaders =
         request.headers().entrySet().stream()
-            .filter(e -> UNSIGNED_HEADERS.contains(e.getKey().toLowerCase(Locale.ROOT)))
+            .filter(S3V4RestSignerClient.UNSIGNED_HEADERS_PREDICATE)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     Map<String, List<String>> signedHeaders =
         request.headers().entrySet().stream()
-            .filter(e -> !UNSIGNED_HEADERS.contains(e.getKey().toLowerCase(Locale.ROOT)))
+            .filter(S3V4RestSignerClient.SIGNED_HEADERS_PREDICATE)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     SdkHttpFullRequest sign =
@@ -204,6 +201,7 @@ public class S3SignerServlet extends HttpServlet {
                     .build(),
                 signingParams);
 
+    // Put the unsigned headers back
     Map<String, List<String>> headers = Maps.newHashMap(sign.headers());
     headers.putAll(unsignedHeaders);
 
@@ -226,6 +224,9 @@ public class S3SignerServlet extends HttpServlet {
                 S3SignRequest.class, mapper.readValue(request.getReader(), S3SignRequest.class));
         s3SignRequestValidators.forEach(validator -> validator.validateRequest(s3SignRequest));
         S3SignResponse s3SignResponse = signRequest(s3SignRequest);
+
+        // Older versions of the client could break when caching methods other than GET and HEAD,
+        // so for safety we need to instruct the client to only cache those.
         if (CACHEABLE_METHODS.contains(SdkHttpMethod.fromValue(s3SignRequest.method()))) {
           // tell the client this can be cached
           response.setHeader(

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
@@ -27,7 +27,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.Collectors;
@@ -352,14 +351,11 @@ public class TestS3RestSigner {
       // back after signing
       Map<String, List<String>> unsignedHeaders =
           request.headers().entrySet().stream()
-              .filter(
-                  e ->
-                      S3SignerServlet.UNSIGNED_HEADERS.contains(
-                          e.getKey().toLowerCase(Locale.ROOT)))
+              .filter(S3V4RestSignerClient.UNSIGNED_HEADERS_PREDICATE)
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
       SdkHttpFullRequest.Builder builder = request.toBuilder();
-      for (String unsignedHeader : S3SignerServlet.UNSIGNED_HEADERS) {
+      for (String unsignedHeader : unsignedHeaders.keySet()) {
         builder.removeHeader(unsignedHeader);
       }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
@@ -24,10 +24,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -70,6 +74,47 @@ public abstract class S3V4RestSignerClient
   static final String CACHE_CONTROL = "Cache-Control";
   static final String CACHE_CONTROL_PRIVATE = "private";
   static final String CACHE_CONTROL_NO_CACHE = "no-cache";
+
+  /** Headers that are excluded from signing. */
+  private static final Set<String> UNSIGNED_HEADERS =
+      // Note: only Host and x-amz-* headers are required to be signed. Other headers are optional.
+      // Also see
+      // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#create-canonical-request
+      // for guidelines about headers that are safe to exclude from signing.
+      Set.of(
+          // Excluded by software.amazon.awssdk.http.auth.aws.internal.signer.V4CanonicalRequest
+          "connection",
+          "expect",
+          "transfer-encoding",
+          "user-agent",
+          "x-amzn-trace-id",
+          "x-forwarded-for",
+          // S3-specific headers
+          "range",
+          // Conditional headers
+          "if-match",
+          "if-modified-since",
+          "if-none-match",
+          "if-unmodified-since",
+          // Transient headers
+          "keep-alive",
+          "proxy-authenticate",
+          "proxy-authorization",
+          "referer",
+          "te",
+          "trailer",
+          "upgrade");
+
+  @VisibleForTesting
+  static final Predicate<Map.Entry<String, List<String>>> UNSIGNED_HEADERS_PREDICATE =
+      e -> {
+        String name = e.getKey().toLowerCase(Locale.ROOT);
+        return name.startsWith("amz-sdk-") || UNSIGNED_HEADERS.contains(name);
+      };
+
+  @VisibleForTesting
+  static final Predicate<Map.Entry<String, List<String>>> SIGNED_HEADERS_PREDICATE =
+      UNSIGNED_HEADERS_PREDICATE.negate();
 
   @VisibleForTesting
   static final Cache<S3SignRequest, S3SignResponse> SIGNED_RESPONSE_CACHE =
@@ -241,18 +286,24 @@ public abstract class S3V4RestSignerClient
     AwsS3V4SignerParams signerParams =
         extractSignerParams(AwsS3V4SignerParams.builder(), executionAttributes).build();
 
+    // Strip-off headers that should not be signed
+    Map<String, List<String>> headersToSign =
+        request.headers().entrySet().stream()
+            .filter(SIGNED_HEADERS_PREDICATE)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
     S3SignRequest remoteSigningRequest =
         ImmutableS3SignRequest.builder()
             .method(request.method().name())
             .region(signerParams.signingRegion().id())
             .uri(request.getUri())
-            .headers(request.headers())
+            .headers(headersToSign)
             .properties(requestPropertiesSupplier().get())
             .body(bodyAsString(request))
             .build();
 
-    S3SignResponse cachedResponse = SIGNED_RESPONSE_CACHE.getIfPresent(remoteSigningRequest);
     S3SignResponse signedResponse;
+    S3SignResponse cachedResponse = SIGNED_RESPONSE_CACHE.getIfPresent(remoteSigningRequest);
 
     if (null != cachedResponse) {
       signedResponse = cachedResponse;

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3V4RestSignerClient.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3V4RestSignerClient.java
@@ -214,7 +214,7 @@ class TestS3V4RestSignerClient {
 
   static Stream<Arguments> differentRequestPairs() {
     return Stream.of(
-        // Different x-amz-content-sha256 headers
+        // Different signed headers
         Arguments.of(
             ImmutableS3SignRequest.builder()
                 .method("PUT")
@@ -228,22 +228,6 @@ class TestS3V4RestSignerClient {
                 .region("us-east-1")
                 .uri(URI.create("s3://bucket/path/to/file.avro"))
                 .headers(Map.of("x-amz-content-sha256", List.of("def456")))
-                .properties(Map.of())
-                .build()),
-        // Different Range headers
-        Arguments.of(
-            ImmutableS3SignRequest.builder()
-                .method("GET")
-                .region("us-east-1")
-                .uri(URI.create("s3://bucket/path/to/file.parquet"))
-                .headers(Map.of("Range", List.of("bytes=0-99")))
-                .properties(Map.of())
-                .build(),
-            ImmutableS3SignRequest.builder()
-                .method("GET")
-                .region("us-east-1")
-                .uri(URI.create("s3://bucket/path/to/file.parquet"))
-                .headers(Map.of("Range", List.of("bytes=100-199")))
                 .properties(Map.of())
                 .build()),
         // Different methods


### PR DESCRIPTION
Fixes #15166.

The cache key for signed responses only included method, region, and URI, but not headers like `x-amz-content-sha256` that are part of the signature. This caused 403 errors when different content was uploaded to the same URI within the cache TTL.

This fix uses the full `S3SignRequest` as the cache key. This is the only 100% safe option because we cannot know which headers the server will sign and which ones it will ignore; any header included in the signature *must* be part of the cache key.

**This change reduces cache efficiency**; but that's the price to pay for correctness.