### PR TITLE
Core: Fix relativize() to handle path equal to prefix (#15172)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -746,10 +746,20 @@ public class RewriteTablePathUtil {
     return combinePaths(targetPrefix, relativize(path, sourcePrefix));
   }
 
-  /** Combine a base and relative path. */
+  /**
+   * Combine a base path and a relative path.
+   *
+   * <p>If the relative path is empty, returns the absolute path unchanged. Otherwise, ensures a
+   * separator between the base and relative path.
+   *
+   * @param absolutePath the base path
+   * @param relativePath the relative path to append (may be empty)
+   * @return the combined path, or absolutePath unchanged if relativePath is empty
+   */
   public static String combinePaths(String absolutePath, String relativePath) {
-    String base = maybeAppendFileSeparator(absolutePath);
-    return relativePath.isEmpty() ? base : base + relativePath;
+    return relativePath.isEmpty()
+        ? absolutePath
+        : maybeAppendFileSeparator(absolutePath) + relativePath;
   }
 
   /** Returns the file name of a path. */


### PR DESCRIPTION
### What
Fix `RewriteTablePathUtil.relativize()` to handle the edge case where `path` equals `prefix` exactly.

### Why
Currently, `relativize()` fails when a path equals the prefix (e.g., `write.data.path` set to the table root). This breaks `rewrite_table_path` for tables with properties pointing to the table location itself.

**Example failure:**
// Throws IllegalArgumentException instead of returning ""
RewriteTablePathUtil.relativize("/path/to/table", "/path/to/table"); 

**Use case:** 
Storage migration or replication where `write.data.path = table location`.

### How
Added a check for exact match after normalizing trailing separators:

```java
// Handle exact match where path equals prefix (without trailing separator)
if (maybeAppendFileSeparator(path).equals(toRemove)) {
  return "";
}
```

### Changes
- **`RewriteTablePathUtil.java`**: Fix `relativize()` + updated Javadoc for `relativize()` and `newPath()`
- **`TestRewriteTablePathUtil.java`**: Added 10 test methods covering:
  - Normal relativization
  - Path equals prefix (the fix)
  - Trailing separator variations
  - Invalid path rejection
  - Subdirectory scenarios (backup/restore)
  - Overlapping name rejection (`/table` vs `/table-old`)
  

### Testing

```bash
./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestRewriteTablePathUtil"
```
