### PR TITLE
Build/Release: use RAT collection for ignore file patterns

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -6,10 +6,7 @@ iceberg-build.properties
 books.json
 new-books.json
 **/build/**
-.gitignore
-.git/**
 .gradle/**
-.idea/**
 dev/.rat-excludes
 **/LICENSE
 **/NOTICE
@@ -18,8 +15,6 @@ gradlew
 examples/**
 gradle/**
 **/*.sql
-**/*.iml
-**/*.iws
 **/*.html
 **/*.css
 **/*.js

--- a/dev/check-license
+++ b/dev/check-license
@@ -69,6 +69,7 @@ mkdir -p "$FWDIR"/lib
 
 $java_cmd -jar "$rat_jar" \
   --input-exclude-file "$FWDIR"/dev/.rat-excludes \
+  --input-exclude-std GIT IDEA MAC -- \
   --input-include-std HIDDEN_DIR \
   --output-style missing-headers \
   --log-level ERROR \


### PR DESCRIPTION
Following up to #15145
RAT 0.17 now has the concept of collections for ignore file patterns https://creadur.apache.org/rat/apache-rat/standard_collections.html

We're already using `HIDDEN_DIR `, we can use a few more: 
- `GIT` matches `**/.git/**`, `**/.gitignore`
- `IDEA` matches `**/*.iws`, `**/*.iml`, `**/*.ipr`, `**/.idea/**`
- `MAC` matches `**/.DS_Store`