### PR TITLE
REST spec: add list/load function endpoints to OpenAPI spec

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1724,10 +1724,12 @@ class FunctionMetadata(BaseModel):
         alias='function-uuid',
         description='A UUID that identifies this UDF, generated once at creation.',
     )
-    format_version: Literal[1] = Field(
+    format_version: int = Field(
         ...,
         alias='format-version',
         description='UDF specification format version (must be 1).',
+        ge=1,
+        le=1,
     )
     definitions: list[FunctionDefinition] = Field(
         ..., description='List of function definition entities.'
@@ -1773,7 +1775,9 @@ class FunctionDefinition(BaseModel):
         description='Identifier of the current version for this definition.',
     )
     function_type: Literal['udf', 'udtf'] = Field(
-        ..., alias='function-type', description='Function type.'
+        ...,
+        alias='function-type',
+        description='Function type. When set to "udtf", "return-type" must be a struct describing the output schema.',
     )
     doc: str | None = Field(None, description='Documentation string.')
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -817,7 +817,7 @@ class ListNamespacesResponse(BaseModel):
     namespaces: list[Namespace] | None = None
 
 
-class FunctionSqlRepresentation(BaseModel):
+class FunctionSQLRepresentation(BaseModel):
     type: Literal['sql']
     dialect: str = Field(
         ..., description='SQL dialect identifier (e.g., "spark", "trino").'
@@ -1157,8 +1157,8 @@ class ReportMetricsRequest2(CommitReport):
     report_type: str = Field(..., alias='report-type')
 
 
-class FunctionRepresentation(RootModel[FunctionSqlRepresentation]):
-    root: FunctionSqlRepresentation = Field(
+class FunctionRepresentation(RootModel[FunctionSQLRepresentation]):
+    root: FunctionSQLRepresentation = Field(
         ..., description='UDF implementation representation.'
     )
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -807,9 +807,27 @@ class ListTablesResponse(BaseModel):
     identifiers: list[TableIdentifier] | None = None
 
 
+class ListFunctionsResponse(BaseModel):
+    next_page_token: PageToken | None = Field(None, alias='next-page-token')
+    identifiers: list[CatalogObjectIdentifier] | None = None
+
+
 class ListNamespacesResponse(BaseModel):
     next_page_token: PageToken | None = Field(None, alias='next-page-token')
     namespaces: list[Namespace] | None = None
+
+
+class FunctionSqlRepresentation(BaseModel):
+    type: Literal['sql']
+    dialect: str = Field(
+        ..., description='SQL dialect identifier (e.g., "spark", "trino").'
+    )
+    sql: str = Field(..., description='SQL expression text.')
+
+
+class FunctionDefinitionVersionRef(BaseModel):
+    definition_id: str = Field(..., alias='definition-id')
+    version_id: int = Field(..., alias='version-id')
 
 
 class UpdateNamespacePropertiesResponse(BaseModel):
@@ -1139,6 +1157,25 @@ class ReportMetricsRequest2(CommitReport):
     report_type: str = Field(..., alias='report-type')
 
 
+class FunctionRepresentation(RootModel[FunctionSqlRepresentation]):
+    root: FunctionSqlRepresentation = Field(
+        ..., description='UDF implementation representation.'
+    )
+
+
+class FunctionDefinitionLogEntry(BaseModel):
+    timestamp_ms: int = Field(
+        ...,
+        alias='timestamp-ms',
+        description='Timestamp when the function was updated to use the definition versions.',
+    )
+    definition_versions: list[FunctionDefinitionVersionRef] = Field(
+        ...,
+        alias='definition-versions',
+        description='Mapping of each definition to its selected version at this time.',
+    )
+
+
 class StatisticsFile(BaseModel):
     snapshot_id: int = Field(..., alias='snapshot-id')
     statistics_path: str = Field(..., alias='statistics-path')
@@ -1214,6 +1251,30 @@ class SetStatisticsUpdate(BaseUpdate):
         description='This optional field is **DEPRECATED for REMOVAL** since it contains redundant information. Clients should use the `statistics.snapshot-id` field instead.',
     )
     statistics: StatisticsFile
+
+
+class FunctionDefinitionVersion(BaseModel):
+    version_id: int = Field(
+        ...,
+        alias='version-id',
+        description='Monotonically increasing identifier of the definition version.',
+    )
+    representations: list[FunctionRepresentation] = Field(
+        ..., description='UDF implementations.'
+    )
+    deterministic: bool | None = Field(
+        False, description='Whether the function is deterministic.'
+    )
+    on_null_input: Literal['return-null', 'call'] | None = Field(
+        'call',
+        alias='on-null-input',
+        description='Defines how the UDF behaves when any input parameter is NULL.',
+    )
+    timestamp_ms: int = Field(
+        ...,
+        alias='timestamp-ms',
+        description='Creation timestamp of this version (unix epoch millis).',
+    )
 
 
 class UnaryExpression(BaseModel):
@@ -1634,6 +1695,132 @@ class ScanReport(BaseModel):
     metadata: dict[str, str] | None = None
 
 
+class LoadFunctionResult(BaseModel):
+    """
+    Result returned when a function is loaded from the catalog.
+
+
+    The function metadata JSON is returned in the `metadata` field. The location of the metadata
+    file is returned in the `metadata-location` field, if available.
+
+    """
+
+    metadata_location: str | None = Field(None, alias='metadata-location')
+    metadata: FunctionMetadata
+
+
+class FunctionMetadata(BaseModel):
+    """
+    Portable UDF metadata format.
+
+
+    Each function is represented by a self-contained metadata file. The `format-version` field
+    identifies the UDF metadata format.
+
+    """
+
+    function_uuid: UUID = Field(
+        ...,
+        alias='function-uuid',
+        description='A UUID that identifies this UDF, generated once at creation.',
+    )
+    format_version: Literal[1] = Field(
+        ...,
+        alias='format-version',
+        description='UDF specification format version (must be 1).',
+    )
+    definitions: list[FunctionDefinition] = Field(
+        ..., description='List of function definition entities.'
+    )
+    definition_log: list[FunctionDefinitionLogEntry] = Field(
+        ...,
+        alias='definition-log',
+        description="History of versions within the function's definitions.",
+    )
+    location: str | None = Field(
+        None,
+        description="The function's base location. This is used to store function metadata files.",
+    )
+    properties: dict[str, str] | None = Field(
+        None, description='A string-to-string map of properties.'
+    )
+    secure: bool | None = Field(False, description='Whether it is a secure function.')
+    doc: str | None = Field(None, description='Documentation string.')
+
+
+class FunctionDefinition(BaseModel):
+    definition_id: str = Field(
+        ...,
+        alias='definition-id',
+        description='A canonical string derived from the parameter types, formatted as a comma-separated list with no spaces.',
+    )
+    parameters: list[FunctionParameter] = Field(
+        ...,
+        description='Ordered list of function parameters. Invocation order must match this list.',
+    )
+    return_type: FunctionDataType = Field(..., alias='return-type')
+    return_nullable: bool | None = Field(
+        True,
+        alias='return-nullable',
+        description='A hint to indicate whether the return value is nullable or not.',
+    )
+    versions: list[FunctionDefinitionVersion] = Field(
+        ..., description='Versioned implementations of this definition.'
+    )
+    current_version_id: int = Field(
+        ...,
+        alias='current-version-id',
+        description='Identifier of the current version for this definition.',
+    )
+    function_type: Literal['udf', 'udtf'] = Field(
+        ..., alias='function-type', description='Function type.'
+    )
+    doc: str | None = Field(None, description='Documentation string.')
+
+
+class FunctionParameter(BaseModel):
+    type: FunctionDataType
+    name: str
+    doc: str | None = Field(None, description='Parameter documentation.')
+
+
+class FunctionListType(BaseModel):
+    """
+    UDF list type object.
+    """
+
+    type: Literal['list']
+    element: FunctionDataType
+
+
+class FunctionMapType(BaseModel):
+    """
+    UDF map type object.
+    """
+
+    type: Literal['map']
+    key: FunctionDataType
+    value: FunctionDataType
+
+
+class FunctionStructType(BaseModel):
+    """
+    UDF struct type object.
+    """
+
+    type: Literal['struct']
+    fields: list[FunctionStructField]
+
+
+class FunctionStructField(BaseModel):
+    """
+    UDF struct field.
+    """
+
+    name: str
+    type: FunctionDataType
+
+
 class CommitTableResponse(BaseModel):
     metadata_location: str = Field(..., alias='metadata-location')
     metadata: TableMetadata
@@ -1831,6 +2018,15 @@ class ReportMetricsRequest1(ScanReport):
     report_type: str = Field(..., alias='report-type')
 
 
+class FunctionDataType(
+    RootModel[str | FunctionListType | FunctionMapType | FunctionStructType]
+):
+    root: str | FunctionListType | FunctionMapType | FunctionStructType = Field(
+        ...,
+        description='A type for function parameters or return value. It is encoded either as a type string or as a JSON object for nested types (struct, list, map) following the UDF spec Types section.\n\nPrimitive and semi-structured type strings are encoded based on the Iceberg type JSON representation (e.g., "int", "string", "timestamp", "decimal(9,2)", "variant"). Type strings must contain no spaces or quote characters.\n\nNested types are based on the Iceberg type JSON representation, but the UDF spec only requires a subset of fields (e.g., list requires `type` and `element`; map requires `type`, `key`, and `value`; struct requires `type` and `fields`). Any other fields must be ignored.\n',
+    )
+
+
 class CompletedPlanningWithIDResult(CompletedPlanningResult):
     plan_id: str = Field(
         ..., alias='plan-id', description='ID used to track a planning request'
@@ -1886,6 +2082,14 @@ CommitViewRequest.model_rebuild()
 CreateTableRequest.model_rebuild()
 CreateViewRequest.model_rebuild()
 ScanReport.model_rebuild()
+LoadFunctionResult.model_rebuild()
+FunctionMetadata.model_rebuild()
+FunctionDefinition.model_rebuild()
+FunctionParameter.model_rebuild()
+FunctionListType.model_rebuild()
+FunctionMapType.model_rebuild()
+FunctionStructType.model_rebuild()
+FunctionStructField.model_rebuild()
 PlanTableScanRequest.model_rebuild()
 FileScanTask.model_rebuild()
 CompletedPlanningResult.model_rebuild()

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -622,6 +622,89 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+  /v1/{prefix}/namespaces/{namespace}/functions:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+
+    get:
+      tags:
+        - Catalog API
+      summary: List all functions underneath a given namespace
+      description: Return all function identifiers under this namespace
+      operationId: listFunctions
+      parameters:
+        - $ref: '#/components/parameters/page-token'
+        - $ref: '#/components/parameters/page-size'
+      responses:
+        200:
+          $ref: '#/components/responses/ListFunctionsResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description: Not Found - The namespace specified does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                NamespaceNotFound:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+  /v1/{prefix}/namespaces/{namespace}/functions/{function}:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/function'
+
+    get:
+      tags:
+        - Catalog API
+      summary: Load a function from the catalog
+      description:
+        Load a function from the catalog.
+
+        The response contains function metadata.
+        All overloaded definitions are included in a single response.
+
+      operationId: loadFunction
+      responses:
+        200:
+          $ref: '#/components/responses/LoadFunctionResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description: Not Found - Function or namespace not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                NamespaceNotFound:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+                FunctionNotFound:
+                  $ref: '#/components/examples/NoSuchFunctionError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
   /v1/{prefix}/namespaces/{namespace}/tables/{table}/plan:
     parameters:
       - $ref: '#/components/parameters/prefix'
@@ -2029,6 +2112,15 @@ components:
       schema:
         type: string
       example: "sales"
+
+    function:
+      name: function
+      in: path
+      description: A function name
+      required: true
+      schema:
+        type: string
+      example: "add_one"
 
     plan-id:
       name: plan-id
@@ -4296,6 +4388,17 @@ components:
           items:
             $ref: '#/components/schemas/TableIdentifier'
 
+    ListFunctionsResponse:
+      type: object
+      properties:
+        next-page-token:
+          $ref: '#/components/schemas/PageToken'
+        identifiers:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/CatalogObjectIdentifier'
+
     ListNamespacesResponse:
       type: object
       properties:
@@ -4306,6 +4409,278 @@ components:
           uniqueItems: true
           items:
             $ref: '#/components/schemas/Namespace'
+
+    LoadFunctionResult:
+      description: |
+        Result returned when a function is loaded from the catalog.
+
+
+        The function metadata JSON is returned in the `metadata` field. The location of the metadata
+        file is returned in the `metadata-location` field, if available.
+      type: object
+      required:
+        - metadata
+      properties:
+        metadata-location:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/FunctionMetadata'
+
+    FunctionMetadata:
+      description: |
+        Portable UDF metadata format.
+
+
+        Each function is represented by a self-contained metadata file. The `format-version` field
+        identifies the UDF metadata format.
+      type: object
+      required:
+        - function-uuid
+        - format-version
+        - definitions
+        - definition-log
+      properties:
+        function-uuid:
+          type: string
+          format: uuid
+          description: A UUID that identifies this UDF, generated once at creation.
+        format-version:
+          type: integer
+          description: UDF specification format version (must be 1).
+          enum: [1]
+        definitions:
+          type: array
+          description: List of function definition entities.
+          items:
+            $ref: '#/components/schemas/FunctionDefinition'
+        definition-log:
+          type: array
+          description: History of versions within the function's definitions.
+          items:
+            $ref: '#/components/schemas/FunctionDefinitionLogEntry'
+        location:
+          type: string
+          description: The function's base location. This is used to store function metadata files.
+        properties:
+          type: object
+          description: A string-to-string map of properties.
+          additionalProperties:
+            type: string
+        secure:
+          type: boolean
+          description: Whether it is a secure function.
+          default: false
+        doc:
+          type: string
+          description: Documentation string.
+
+    FunctionDefinition:
+      type: object
+      required:
+        - definition-id
+        - parameters
+        - return-type
+        - versions
+        - current-version-id
+        - function-type
+      properties:
+        definition-id:
+          type: string
+          description: A canonical string derived from the parameter types, formatted as a comma-separated list with no spaces.
+        parameters:
+          type: array
+          description: Ordered list of function parameters. Invocation order must match this list.
+          items:
+            $ref: '#/components/schemas/FunctionParameter'
+        return-type:
+          $ref: '#/components/schemas/FunctionDataType'
+        return-nullable:
+          type: boolean
+          description: A hint to indicate whether the return value is nullable or not.
+          default: true
+        versions:
+          type: array
+          description: Versioned implementations of this definition.
+          items:
+            $ref: '#/components/schemas/FunctionDefinitionVersion'
+        current-version-id:
+          type: integer
+          description: Identifier of the current version for this definition.
+        function-type:
+          type: string
+          description: Function type.
+          enum: ["udf", "udtf"]
+        doc:
+          type: string
+          description: Documentation string.
+
+    FunctionParameter:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          $ref: '#/components/schemas/FunctionDataType'
+        name:
+          type: string
+        doc:
+          type: string
+          description: Parameter documentation.
+
+    FunctionDataType:
+      description: >
+        A type for function parameters or return value. It is encoded either as a type string
+        or as a JSON object for nested types (struct, list, map) following the UDF spec Types section.
+
+
+        Primitive and semi-structured type strings are encoded based on the Iceberg type JSON
+        representation (e.g., "int", "string", "timestamp", "decimal(9,2)", "variant"). Type
+        strings must contain no spaces or quote characters.
+
+
+        Nested types are based on the Iceberg type JSON representation, but the UDF spec only
+        requires a subset of fields (e.g., list requires `type` and `element`; map requires `type`,
+        `key`, and `value`; struct requires `type` and `fields`). Any other fields must be ignored.
+      oneOf:
+        - type: string
+        - $ref: '#/components/schemas/FunctionListType'
+        - $ref: '#/components/schemas/FunctionMapType'
+        - $ref: '#/components/schemas/FunctionStructType'
+
+    FunctionListType:
+      description: UDF list type object.
+      type: object
+      required:
+        - type
+        - element
+      properties:
+        type:
+          type: string
+          const: "list"
+        element:
+          $ref: '#/components/schemas/FunctionDataType'
+
+    FunctionMapType:
+      description: UDF map type object.
+      type: object
+      required:
+        - type
+        - key
+        - value
+      properties:
+        type:
+          type: string
+          const: "map"
+        key:
+          $ref: '#/components/schemas/FunctionDataType'
+        value:
+          $ref: '#/components/schemas/FunctionDataType'
+
+    FunctionStructType:
+      description: UDF struct type object.
+      type: object
+      required:
+        - type
+        - fields
+      properties:
+        type:
+          type: string
+          const: "struct"
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/FunctionStructField'
+
+    FunctionStructField:
+      description: UDF struct field.
+      type: object
+      required:
+        - name
+        - type
+      properties:
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/FunctionDataType'
+
+    FunctionDefinitionVersion:
+      type: object
+      required:
+        - version-id
+        - representations
+        - timestamp-ms
+      properties:
+        version-id:
+          type: integer
+          description: Monotonically increasing identifier of the definition version.
+        representations:
+          type: array
+          description: UDF implementations.
+          items:
+            $ref: '#/components/schemas/FunctionRepresentation'
+        deterministic:
+          type: boolean
+          description: Whether the function is deterministic.
+          default: false
+        on-null-input:
+          type: string
+          description: Defines how the UDF behaves when any input parameter is NULL.
+          enum: ["return-null", "call"]
+          default: "call"
+        timestamp-ms:
+          type: integer
+          format: int64
+          description: Creation timestamp of this version (unix epoch millis).
+
+    FunctionRepresentation:
+      description: UDF implementation representation.
+      oneOf:
+        - $ref: '#/components/schemas/FunctionSqlRepresentation'
+
+    FunctionSqlRepresentation:
+      type: object
+      required:
+        - type
+        - dialect
+        - sql
+      properties:
+        type:
+          type: string
+          const: "sql"
+        dialect:
+          type: string
+          description: SQL dialect identifier (e.g., "spark", "trino").
+        sql:
+          type: string
+          description: SQL expression text.
+
+    FunctionDefinitionLogEntry:
+      type: object
+      required:
+        - timestamp-ms
+        - definition-versions
+      properties:
+        timestamp-ms:
+          type: integer
+          format: int64
+          description: Timestamp when the function was updated to use the definition versions.
+        definition-versions:
+          type: array
+          description: Mapping of each definition to its selected version at this time.
+          items:
+            $ref: '#/components/schemas/FunctionDefinitionVersionRef'
+
+    FunctionDefinitionVersionRef:
+      type: object
+      required:
+        - definition-id
+        - version-id
+      properties:
+        definition-id:
+          type: string
+        version-id:
+          type: integer
 
     UpdateNamespacePropertiesResponse:
       type: object
@@ -5009,6 +5384,18 @@ components:
             ListTablesResponseEmpty:
               $ref: '#/components/examples/ListTablesEmptyExample'
 
+    ListFunctionsResponse:
+      description: A list of function identifiers
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListFunctionsResponse'
+          examples:
+            ListFunctionsResponseNonEmpty:
+              $ref: '#/components/examples/ListFunctionsNonEmptyExample'
+            ListFunctionsResponseEmpty:
+              $ref: '#/components/examples/ListFunctionsEmptyExample'
+
     ListNamespacesResponse:
       description: A list of namespaces
       content:
@@ -5133,6 +5520,13 @@ components:
           schema:
             $ref: '#/components/schemas/UnregisterTableResult'
 
+    LoadFunctionResponse:
+      description: Function metadata result when loading a function
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/LoadFunctionResult'
+
     LoadViewResponse:
       description: View metadata result when loading a view
       content:
@@ -5204,6 +5598,21 @@ components:
         ]
       }
 
+    ListFunctionsEmptyExample:
+      summary: An empty list for a namespace with no functions
+      value: {
+        "identifiers": [ ]
+      }
+
+    ListFunctionsNonEmptyExample:
+      summary: A non-empty list of function identifiers
+      value: {
+        "identifiers": [
+          { "namespace": ["analytics"], "name": "add_one" },
+          { "namespace": ["analytics"], "name": "to_celsius" }
+        ]
+      }
+
     MultipartNamespaceAsPathVariable:
       summary: A multi-part namespace, as represented in a path parameter
       value: "accounting%1Ftax"
@@ -5268,6 +5677,16 @@ components:
         "error": {
           "message": "The given warehouse does not exist",
           "type": "NoSuchWarehouseException",
+          "code": 404
+        }
+      }
+
+    NoSuchFunctionError:
+      summary: The requested function does not exist
+      value: {
+        "error": {
+          "message": "The requested function does not exist",
+          "type": "NoSuchFunctionException",
           "code": 404
         }
       }

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4447,7 +4447,8 @@ components:
         format-version:
           type: integer
           description: UDF specification format version (must be 1).
-          enum: [1]
+          minimum: 1
+          maximum: 1
         definitions:
           type: array
           description: List of function definition entities.
@@ -4508,7 +4509,7 @@ components:
           description: Identifier of the current version for this definition.
         function-type:
           type: string
-          description: Function type.
+          description: Function type. When set to "udtf", "return-type" must be a struct describing the output schema.
           enum: ["udf", "udtf"]
         doc:
           type: string
@@ -5608,8 +5609,8 @@ components:
       summary: A non-empty list of function identifiers
       value: {
         "identifiers": [
-          { "namespace": ["analytics"], "name": "add_one" },
-          { "namespace": ["analytics"], "name": "to_celsius" }
+          ["analytics", "add_one"],
+          ["analytics", "to_celsius"]
         ]
       }
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -674,7 +674,6 @@ paths:
       description:
         Load a function from the catalog.
 
-        The response contains function metadata.
         All overloaded definitions are included in a single response.
 
       operationId: loadFunction
@@ -4637,9 +4636,9 @@ components:
     FunctionRepresentation:
       description: UDF implementation representation.
       oneOf:
-        - $ref: '#/components/schemas/FunctionSqlRepresentation'
+        - $ref: '#/components/schemas/FunctionSQLRepresentation'
 
-    FunctionSqlRepresentation:
+    FunctionSQLRepresentation:
       type: object
       required:
         - type


### PR DESCRIPTION
This PR updates `open-api/rest-catalog-open-api.yaml` to define read-only REST catalog support for functions.

Add function endpoints:

- GET /v1/{prefix}/namespaces/{namespace}/functions
- GET /v1/{prefix}/namespaces/{namespace}/functions/{function}

Add OpenAPI components for the responses and parameters:

- ListFunctionsResponse
- LoadFunctionResponse
- function path parameter
- NoSuchFunctionError example

Update the /v1/config “default endpoints” list to include the function endpoints.

Scope
Read-only only (list + load). No create/replace/drop in this PR.

This is intended as the Stage 1 spec surface; function CRUD can be proposed/voted in a follow-up

Follow-up work to implement these endpoints in the Spark 4.1 integration is tracked in [#14954](https://github.com/apache/iceberg/pull/14954)
