### PR TITLE
API, Hive, Spark: Fix typos in comments and error messages

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Snapshot.java
+++ b/api/src/main/java/org/apache/iceberg/Snapshot.java
@@ -175,7 +175,7 @@ public interface Snapshot extends Serializable {
   /**
    * The row-id of the first newly added row in this snapshot. All rows added in this snapshot will
    * have a row-id assigned to them greater than this value. All rows with a row-id less than this
-   * value were created in a snapshot that was added to the table (but not necessarily commited to
+   * value were created in a snapshot that was added to the table (but not necessarily committed to
    * this branch) in the past.
    *
    * @return the first row-id to be used in this snapshot or null when row lineage is not supported

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -144,7 +144,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
     if (tableKeyId != null) {
       if (keyManagementClient == null) {
         throw new RuntimeException(
-            "Cant create encryption manager, because key management client is not set");
+            "Can't create encryption manager, because key management client is not set");
       }
 
       Map<String, String> encryptionProperties = Maps.newHashMap();

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -116,13 +116,13 @@ public class IcebergSource
         return ((TableCatalog) catalog).loadTable(ident);
       }
     } catch (NoSuchTableException e) {
-      // throwing an iceberg NoSuchTableException because the Spark one is typed and cant be thrown
+      // throwing an iceberg NoSuchTableException because the Spark one is typed and can't be thrown
       // from this interface
       throw new org.apache.iceberg.exceptions.NoSuchTableException(
           e, "Cannot find table for %s.", ident);
     }
 
-    // throwing an iceberg NoSuchTableException because the Spark one is typed and cant be thrown
+    // throwing an iceberg NoSuchTableException because the Spark one is typed and can't be thrown
     // from this interface
     throw new org.apache.iceberg.exceptions.NoSuchTableException(
         "Cannot find table for %s.", ident);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -116,13 +116,13 @@ public class IcebergSource
         return ((TableCatalog) catalog).loadTable(ident);
       }
     } catch (NoSuchTableException e) {
-      // throwing an iceberg NoSuchTableException because the Spark one is typed and cant be thrown
+      // throwing an iceberg NoSuchTableException because the Spark one is typed and can't be thrown
       // from this interface
       throw new org.apache.iceberg.exceptions.NoSuchTableException(
           e, "Cannot find table for %s.", ident);
     }
 
-    // throwing an iceberg NoSuchTableException because the Spark one is typed and cant be thrown
+    // throwing an iceberg NoSuchTableException because the Spark one is typed and can't be thrown
     // from this interface
     throw new org.apache.iceberg.exceptions.NoSuchTableException(
         "Cannot find table for %s.", ident);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -116,13 +116,13 @@ public class IcebergSource
         return ((TableCatalog) catalog).loadTable(ident);
       }
     } catch (NoSuchTableException e) {
-      // throwing an iceberg NoSuchTableException because the Spark one is typed and cant be thrown
+      // throwing an iceberg NoSuchTableException because the Spark one is typed and can't be thrown
       // from this interface
       throw new org.apache.iceberg.exceptions.NoSuchTableException(
           e, "Cannot find table for %s.", ident);
     }
 
-    // throwing an iceberg NoSuchTableException because the Spark one is typed and cant be thrown
+    // throwing an iceberg NoSuchTableException because the Spark one is typed and can't be thrown
     // from this interface
     throw new org.apache.iceberg.exceptions.NoSuchTableException(
         "Cannot find table for %s.", ident);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -116,13 +116,13 @@ public class IcebergSource
         return ((TableCatalog) catalog).loadTable(ident);
       }
     } catch (NoSuchTableException e) {
-      // throwing an iceberg NoSuchTableException because the Spark one is typed and cant be thrown
+      // throwing an iceberg NoSuchTableException because the Spark one is typed and can't be thrown
       // from this interface
       throw new org.apache.iceberg.exceptions.NoSuchTableException(
           e, "Cannot find table for %s.", ident);
     }
 
-    // throwing an iceberg NoSuchTableException because the Spark one is typed and cant be thrown
+    // throwing an iceberg NoSuchTableException because the Spark one is typed and can't be thrown
     // from this interface
     throw new org.apache.iceberg.exceptions.NoSuchTableException(
         "Cannot find table for %s.", ident);


### PR DESCRIPTION
Fixed the following typos:
- "cant" -> "can't" in IcebergSource.java (all Spark versions)
- "cant" -> "can't" in HiveTableOperations.java
- "commited" -> "committed" in Snapshot.java

🤖 Generated with [Claude Code](https://claude.com/claude-code)