### PR TITLE
(Ignore: regression test of hadoop 3.4.3 RC0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,10 @@ allprojects {
     mavenCentral()
     mavenLocal()
     maven { url 'https://jitpack.io/' }
+    maven {
+      name = "asfStaging"
+      url = uri("https://repository.apache.org/content/groups/staging/")
+    }
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ flink21 = { strictly = "2.1.0"}
 google-libraries-bom = "26.74.0"
 gcs-analytics-core = "1.2.3"
 guava = "33.5.0-jre"
-hadoop3 = "3.4.2"
+hadoop3 = "3.4.3"
 httpcomponents-httpclient5 = "5.6"
 hive2 = { strictly = "2.3.10"} # see rich version usage explanation above
 immutables-value = "2.12.1"


### PR DESCRIPTION
This is an automated regression test of the hadoop 3.4.3 RC0 release; not to be merged. Spark's had the same and passed. 