### PR TITLE
Flink: Dynamic Sink: Fix partition field check in non-immediate update path

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.flink.sink.PartitionKeySelector;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,8 +152,9 @@ class HashKeyGenerator {
                 tableName, schema, equalityFields, writeParallelism, maxWriteParallelism);
           } else {
             for (PartitionField partitionField : spec.fields()) {
+              Types.NestedField sourceField = schema.findField(partitionField.sourceId());
               Preconditions.checkState(
-                  equalityFields.contains(partitionField.name()),
+                  sourceField != null && equalityFields.contains(sourceField.name()),
                   "%s: In 'hash' distribution mode with equality fields set, partition field '%s' "
                       + "should be included in equality fields: '%s'",
                   tableName,


### PR DESCRIPTION
The check to validate partition fields are contained in the equality fields isn't correct. We shouldn't be using the partition name, but the name of the source field. This affects the non-immediate update path of the Dynamic Sink.