### PR TITLE
Core: CatalogTests: invalidate cache after renaming metadata file

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -990,6 +990,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             : Paths.get(metadataFileLocation);
     try {
       Files.move(metadataFilePath, renamedMetadataFile, StandardCopyOption.REPLACE_EXISTING);
+      // Invalidate any cache to force a fresh load from the catalog
+      catalog.invalidateTable(TBL);
       assertThatThrownBy(() -> catalog.loadTable(TBL))
           .isInstanceOf(NotFoundException.class)
           .hasMessageContaining("Failed to open input stream for file: " + metadataFileLocation);


### PR DESCRIPTION
This fix prevents test failures when catalogs have a table cache. This issue may arise e.g. with `RESTCatalog` since the recent introduction of `RESTTableCache` in 72d5fd66c527c27c79880e051b7eaf46deb2fed6.