### PR TITLE
Spark: Add session property for time-travel default timestamp

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -206,6 +206,7 @@ val spark = SparkSession.builder()
 | spark.sql.iceberg.merge-schema                         | false                                                          | Enables modifying the table schema to match the write schema. Only adds columns missing columns                                 |
 | spark.sql.iceberg.report-column-stats                  | true                                                           | Report Puffin Table Statistics if available to Spark's Cost Based Optimizer. CBO must be enabled for this to be effective       |
 | spark.sql.iceberg.async-micro-batch-planning-enabled   | false                                                          | Enables asynchronous microbatch planning to reduce planning latency by pre-fetching file scan tasks                             |
+| spark.sql.iceberg.read.as-of-timestamp                 | null                                                           | Default timestamp in milliseconds for time-travel queries; applies to all reads when no explicit snapshot-id, as-of-timestamp, branch, or tag is specified |
 
 ### Read options
 

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.SimpleRecord;
@@ -642,6 +643,10 @@ public class TestMetadataTables extends ExtensionsTestBase {
         .append();
 
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    Long previousSnapshotId = table.currentSnapshot().snapshotId();
+    // remember the time when the first snapshot was valid
+    long previousSnapshotTimestamp =
+        waitUntilAfter(table.currentSnapshot().timestampMillis() + 1000);
 
     table.updateSchema().addColumn("category", Types.StringType.get()).commit();
 
@@ -659,6 +664,16 @@ public class TestMetadataTables extends ExtensionsTestBase {
     table.refresh();
     Long currentSnapshotId = table.currentSnapshot().snapshotId();
 
+    // Test schema
+    Schema entriesTableSchema =
+        TypeUtil.selectNot(
+            Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema(),
+            Set.of(DataFile.FIRST_ROW_ID.fieldId()));
+    List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
+    List<Record> expectedFiles =
+        expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, null);
+
+    // Metadata for current snapshot
     Dataset<Row> actualFilesDs =
         spark.sql(
             "SELECT * FROM "
@@ -667,13 +682,6 @@ public class TestMetadataTables extends ExtensionsTestBase {
                 + currentSnapshotId
                 + " ORDER BY content");
     List<Row> actualFiles = TestHelpers.selectNonDerived(actualFilesDs).collectAsList();
-    Schema entriesTableSchema =
-        TypeUtil.selectNot(
-            Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema(),
-            Set.of(DataFile.FIRST_ROW_ID.fieldId()));
-    List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
-    List<Record> expectedFiles =
-        expectedEntries(table, FileContent.DATA, entriesTableSchema, expectedDataManifests, null);
 
     assertThat(actualFiles).as("actualFiles size should be 2").hasSize(2);
 
@@ -686,6 +694,33 @@ public class TestMetadataTables extends ExtensionsTestBase {
     assertThat(actualFiles)
         .as("expectedFiles and actualFiles size should be the same")
         .hasSameSizeAs(expectedFiles);
+
+    // Metadata for previous snapshot
+    Dataset<Row> actualFilesDs2 =
+        spark.sql(
+            "SELECT * FROM "
+                + tableName
+                + ".files VERSION AS OF "
+                + previousSnapshotId
+                + " ORDER BY content");
+    List<Row> actualFiles2 = TestHelpers.selectNonDerived(actualFilesDs2).collectAsList();
+
+    assertThat(actualFiles2).as("actualFiles size should be 1").hasSize(1);
+
+    TestHelpers.assertEqualsSafe(
+        TestHelpers.nonDerivedSchema(actualFilesDs2), expectedFiles.get(0), actualFiles.get(0));
+
+    // Using session-level time-travel
+    spark.conf().set(SparkSQLProperties.AS_OF_TIMESTAMP, previousSnapshotTimestamp);
+    Dataset<Row> actualFilesDs3 =
+        spark.sql("SELECT * FROM " + tableName + ".files" + " ORDER BY content");
+    List<Row> actualFiles3 = TestHelpers.selectNonDerived(actualFilesDs3).collectAsList();
+
+    assertThat(actualFiles3).as("actualFiles size should be 1").hasSize(1);
+
+    TestHelpers.assertEqualsSafe(
+        TestHelpers.nonDerivedSchema(actualFilesDs3), expectedFiles.get(0), actualFiles.get(0));
+    spark.conf().unset(SparkSQLProperties.AS_OF_TIMESTAMP);
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -91,7 +91,11 @@ public class SparkReadConf {
   }
 
   public Long asOfTimestamp() {
-    return confParser.longConf().option(SparkReadOptions.AS_OF_TIMESTAMP).parseOptional();
+    return confParser
+        .longConf()
+        .option(SparkReadOptions.AS_OF_TIMESTAMP)
+        .sessionConf(SparkSQLProperties.AS_OF_TIMESTAMP)
+        .parseOptional();
   }
 
   public Long startSnapshotId() {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -106,4 +106,8 @@ public class SparkSQLProperties {
 
   // Prefix for custom snapshot properties
   public static final String SNAPSHOT_PROPERTY_PREFIX = "spark.sql.iceberg.snapshot-property.";
+
+  // Session-level time-travel property; a timestamp in milliseconds.
+  // The snapshot used will be the snapshot current at this time.
+  public static final String AS_OF_TIMESTAMP = "spark.sql.iceberg.read.as-of-timestamp";
 }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -20,12 +20,15 @@ package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.PlanningMode.DISTRIBUTED;
 import static org.apache.iceberg.PlanningMode.LOCAL;
+import static org.apache.iceberg.TestHelpers.waitUntilAfter;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.InetAddress;
 import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -41,6 +44,7 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
@@ -49,6 +53,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -99,6 +104,11 @@ public class TestSnapshotSelection {
     SparkSession currentSpark = TestSnapshotSelection.spark;
     TestSnapshotSelection.spark = null;
     currentSpark.stop();
+  }
+
+  @AfterEach
+  public void cleanupSessionProperties() {
+    spark.conf().unset(SparkSQLProperties.AS_OF_TIMESTAMP);
   }
 
   @TestTemplate
@@ -586,5 +596,158 @@ public class TestSnapshotSelection {
     assertThat(deletedColumnTagSnapshotRecords)
         .as("Current snapshot rows should match")
         .isEqualTo(expectedRecords);
+  }
+
+  @TestTemplate
+  public void testSessionPropertyTimeTravel() {
+    String tableLocation = temp.resolve("iceberg-table").toFile().toString();
+    long timestampBeforeAnySnapshots = 1L;
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Table table = tables.create(SCHEMA, spec, properties, tableLocation);
+
+    // produce the first snapshot
+    List<SimpleRecord> firstBatchRecords =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+    Dataset<Row> firstDf = spark.createDataFrame(firstBatchRecords, SimpleRecord.class);
+    firstDf.select("id", "data").write().format("iceberg").mode("append").save(tableLocation);
+
+    // remember the time when the first snapshot was valid
+    long firstSnapshotTimestamp = waitUntilAfter(table.currentSnapshot().timestampMillis() + 1000);
+
+    // produce the second snapshot
+    List<SimpleRecord> secondBatchRecords =
+        Lists.newArrayList(
+            new SimpleRecord(4, "d"), new SimpleRecord(5, "e"), new SimpleRecord(6, "f"));
+    Dataset<Row> secondDf = spark.createDataFrame(secondBatchRecords, SimpleRecord.class);
+    secondDf.select("id", "data").write().format("iceberg").mode("append").save(tableLocation);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Expected 2 snapshots").hasSize(2);
+
+    // verify without session property, current snapshot is read
+    Dataset<Row> currentSnapshotResult = spark.read().format("iceberg").load(tableLocation);
+    List<SimpleRecord> currentSnapshotRecords =
+        currentSnapshotResult.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.addAll(firstBatchRecords);
+    expectedRecords.addAll(secondBatchRecords);
+    assertThat(currentSnapshotRecords)
+        .as("Current snapshot rows should match")
+        .isEqualTo(expectedRecords);
+
+    // verify with session property, only first snapshot data is read
+    spark.conf().set(SparkSQLProperties.AS_OF_TIMESTAMP, firstSnapshotTimestamp);
+    Dataset<Row> sessionPropertyResult = spark.read().format("iceberg").load(tableLocation);
+    List<SimpleRecord> sessionPropertyRecords =
+        sessionPropertyResult.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    assertThat(sessionPropertyRecords)
+        .as("First snapshot should be read when session property set.")
+        .isEqualTo(firstBatchRecords);
+
+    // verify session property with timestamp before any snapshots raises exception
+    spark.conf().set(SparkSQLProperties.AS_OF_TIMESTAMP, timestampBeforeAnySnapshots);
+    assertThatThrownBy(() -> spark.read().format("iceberg").load(tableLocation).collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find a snapshot older than");
+
+    // verify malformatted session property timestamp raises exception
+    String malformattedSessionTimestamp = "2020-01-01 10:00:00";
+    spark.conf().set(SparkSQLProperties.AS_OF_TIMESTAMP, malformattedSessionTimestamp);
+    assertThatThrownBy(() -> spark.read().format("iceberg").load(tableLocation).collectAsList())
+        .isInstanceOf(NumberFormatException.class)
+        .hasMessageContaining(
+            String.format("For input string: \"%s\"", malformattedSessionTimestamp));
+  }
+
+  @TestTemplate
+  public void testSessionPropertyWithTableSelectorThrowsException() {
+    String tableLocation = temp.resolve("iceberg-table").toFile().toString();
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Table table = tables.create(SCHEMA, spec, properties, tableLocation);
+
+    // produce the first snapshot
+    List<SimpleRecord> firstBatchRecords =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+    Dataset<Row> firstDf = spark.createDataFrame(firstBatchRecords, SimpleRecord.class);
+    firstDf.select("id", "data").write().format("iceberg").mode("append").save(tableLocation);
+
+    long snapshotId = table.currentSnapshot().snapshotId();
+    long firstSnapshotTimestamp = waitUntilAfter(table.currentSnapshot().timestampMillis() + 1000);
+    String tagName = "test_tag";
+    String branchName = "test_branch";
+
+    table.manageSnapshots().createTag(tagName, snapshotId).commit();
+    table.manageSnapshots().createBranch(branchName, snapshotId).commit();
+
+    // produce a second snapshot
+    List<SimpleRecord> secondBatchRecords =
+        Lists.newArrayList(
+            new SimpleRecord(4, "d"), new SimpleRecord(5, "e"), new SimpleRecord(6, "f"));
+    Dataset<Row> secondDf = spark.createDataFrame(secondBatchRecords, SimpleRecord.class);
+    secondDf.select("id", "data").write().format("iceberg").mode("append").save(tableLocation);
+
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+    // set session property so it is active for all assertions below
+    spark.conf().set(SparkSQLProperties.AS_OF_TIMESTAMP, firstSnapshotTimestamp);
+
+    // VERSION_AS_OF (snapshot ID) option combined with session property raises exception
+    assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.VERSION_AS_OF, snapshotId)
+                    .load(tableLocation)
+                    .collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    // TIMESTAMP_AS_OF option combined with session property raises exception
+    assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(
+                        SparkReadOptions.TIMESTAMP_AS_OF,
+                        sdf.format(new Date(firstSnapshotTimestamp)))
+                    .load(tableLocation)
+                    .collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    // VERSION_AS_OF (tag) option combined with session property raises exception
+    assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.VERSION_AS_OF, tagName)
+                    .load(tableLocation)
+                    .collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    // BRANCH option combined with session property raises exception
+    assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.BRANCH, branchName)
+                    .load(tableLocation)
+                    .collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot override ref, already set snapshot id=%s", snapshotId);
   }
 }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
@@ -46,6 +47,7 @@ import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -107,6 +109,7 @@ public class TestSelect extends CatalogTestBase {
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS %s", binaryTableName);
+    spark.conf().unset(SparkSQLProperties.AS_OF_TIMESTAMP);
   }
 
   @TestTemplate
@@ -769,5 +772,239 @@ public class TestSelect extends CatalogTestBase {
                 "SELECT id, try_variant_get(v2, '$.x', 'int') FROM %s WHERE try_variant_get(v2, '$.x', 'int') < 100",
                 tableName))
         .containsExactlyInAnyOrder(row(1L, 15), row(2L, 20));
+  }
+
+  @TestTemplate
+  public void testSessionPropertyTimeTravel() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    long timestampBeforeAnySnapshots = 1L;
+    long snapshotTs = table.currentSnapshot().timestampMillis();
+    long timestamp = waitUntilAfter(snapshotTs + 2);
+
+    List<Object[]> expected = sql("SELECT * FROM %s ORDER BY id", tableName);
+
+    // create a second snapshot
+    sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
+
+    // session property with a valid timestamp works for simple SQL queries
+    spark.conf().set(SparkSQLProperties.AS_OF_TIMESTAMP, String.valueOf(timestamp));
+    List<Object[]> actualWithSessionProperty = sql("SELECT * FROM %s ORDER BY id", tableName);
+    assertEquals("Should time-travel using session property", expected, actualWithSessionProperty);
+
+    // session property with a valid timestamp works for DataFrame reads
+    Dataset<Row> dfSession = spark.read().format("iceberg").load(tableName).orderBy("id");
+    assertEquals(
+        "DataFrame should time-travel using session property",
+        expected,
+        rowsToJava(dfSession.collectAsList()));
+
+    // session property with timestamp before any snapshots raises exception
+    spark
+        .conf()
+        .set(SparkSQLProperties.AS_OF_TIMESTAMP, String.valueOf(timestampBeforeAnySnapshots));
+    assertThatThrownBy(() -> sql("SELECT * FROM %s", tableName))
+        .hasMessageContaining("Cannot find a snapshot older than")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @TestTemplate
+  public void testSessionPropertyWithTableSelectorThrowsException() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    long snapshotId = table.currentSnapshot().snapshotId();
+    String tagName = "test_tag";
+    String branchName = "test_branch";
+
+    table.manageSnapshots().createTag(tagName, snapshotId).commit();
+    table.manageSnapshots().createBranch(branchName, snapshotId).commit();
+
+    long snapshotTs = waitUntilAfter(table.currentSnapshot().timestampMillis() + 1000);
+    long timestampInSeconds = TimeUnit.MILLISECONDS.toSeconds(snapshotTs);
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    String formattedDate = sdf.format(new Date(snapshotTs));
+
+    // create a second snapshot
+    sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
+
+    // set session property so it is active for all assertions below
+    spark.conf().set(SparkSQLProperties.AS_OF_TIMESTAMP, String.valueOf(snapshotTs));
+
+    // snapshot_id_ SQL prefix combined with session property raises exception
+    assertThatThrownBy(() -> sql("SELECT * FROM %s.snapshot_id_%s", tableName, snapshotId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    // at_timestamp_ SQL prefix combined with session property raises exception
+    assertThatThrownBy(() -> sql("SELECT * FROM %s.at_timestamp_%s", tableName, snapshotTs))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    // VERSION AS OF snapshot SQL combined with session property raises exception
+    assertThatThrownBy(() -> sql("SELECT * FROM %s VERSION AS OF %s", tableName, snapshotId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    // VERSION_AS_OF DataFrame option combined with session property raises exception
+    assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.VERSION_AS_OF, snapshotId)
+                    .load(tableName)
+                    .collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    // VERSION AS OF tag SQL combined with session property raises exception
+    assertThatThrownBy(() -> sql("SELECT * FROM %s VERSION AS OF '%s'", tableName, tagName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    if (!"spark_catalog".equals(catalogName)) {
+      // tag_ SQL prefix combined with session property raises exception
+      assertThatThrownBy(() -> sql("SELECT * FROM %s.tag_%s", tableName, tagName))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining(
+              "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+    }
+
+    // VERSION AS OF branch SQL combined with session property raises exception
+    assertThatThrownBy(() -> sql("SELECT * FROM %s VERSION AS OF '%s'", tableName, branchName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot override ref, already set snapshot id=%s", snapshotId);
+
+    if (!"spark_catalog".equals(catalogName)) {
+      // branch_ SQL prefix combined with session property raises exception
+      assertThatThrownBy(() -> sql("SELECT * FROM %s.branch_%s", tableName, branchName))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Cannot override ref, already set snapshot id=%s", snapshotId);
+    }
+
+    // BRANCH DataFrame option combined with session property raises exception
+    assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.BRANCH, branchName)
+                    .load(tableName)
+                    .collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot override ref, already set snapshot id=%s", snapshotId);
+
+    // TIMESTAMP AS OF SQL combined with session property raises exception
+    assertThatThrownBy(
+            () -> sql("SELECT * FROM %s TIMESTAMP AS OF %s", tableName, timestampInSeconds))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+
+    // TIMESTAMP_AS_OF DataFrame option combined with session property raises exception
+    assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.TIMESTAMP_AS_OF, formattedDate)
+                    .load(tableName)
+                    .collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan");
+  }
+
+  @TestTemplate
+  public void testSessionPropertyWithMultiTableJoin() {
+    // Create two tables with initial data
+    String table1Name = tableName("table1");
+    TableIdentifier table1Identifier = TableIdentifier.of(Namespace.of("default"), "table1");
+    String table2Name = tableName("table2");
+    TableIdentifier table2Identifier = TableIdentifier.of(Namespace.of("default"), "table2");
+
+    sql("CREATE OR REPLACE TABLE %s (id bigint, data string) USING iceberg", table1Name);
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", table1Name);
+
+    sql("CREATE OR REPLACE TABLE %s (id bigint, value string) USING iceberg", table2Name);
+    sql("INSERT INTO %s VALUES (1, 'x'), (2, 'y')", table2Name);
+
+    // Capture timestamps after first snapshots
+    long timestamp1 =
+        waitUntilAfter(
+            validationCatalog.loadTable(table1Identifier).currentSnapshot().timestampMillis()
+                + 1000);
+    long timestamp2 =
+        waitUntilAfter(
+            validationCatalog.loadTable(table2Identifier).currentSnapshot().timestampMillis()
+                + 1000);
+    long timestampSnapshot1 = Long.max(timestamp1, timestamp2);
+
+    List<Object[]> expectedJoinSnapshot1 = ImmutableList.of(row(1L, "a", "x"), row(2L, "b", "y"));
+
+    // Add more data to both tables
+    sql("INSERT INTO %s VALUES (3, 'c'), (4, 'd')", table1Name);
+    sql("INSERT INTO %s VALUES (3, 'z'), (4, 'w')", table2Name);
+
+    // Capture timestamps after second snapshots
+    long timestamp3 =
+        waitUntilAfter(
+            validationCatalog.loadTable(table1Identifier).currentSnapshot().timestampMillis()
+                + 1000);
+    long timestamp4 =
+        waitUntilAfter(
+            validationCatalog.loadTable(table2Identifier).currentSnapshot().timestampMillis()
+                + 1000);
+    long timestampSnapshot2 = Long.max(timestamp3, timestamp4);
+
+    List<Object[]> expectedJoinSnapshot2 =
+        ImmutableList.of(
+            row(1L, "a", "x"), row(2L, "b", "y"), row(3L, "c", "z"), row(4L, "d", "w"));
+
+    List<Object[]> actual1 =
+        sql(
+            "SELECT t1.id, t1.data, t2.value FROM %s t1 FULL OUTER JOIN %s t2 ON t1.id = t2.id ORDER BY t1.id",
+            table1Name, table2Name);
+    assertEquals(
+        "Without session property, last snapshot for both table should be read.",
+        expectedJoinSnapshot2,
+        actual1);
+
+    spark.conf().set(SparkSQLProperties.AS_OF_TIMESTAMP, String.valueOf(timestampSnapshot1));
+
+    // Session property applies to both tables in join
+    List<Object[]> actual2 =
+        sql(
+            "SELECT t1.id, t1.data, t2.value FROM %s t1 FULL OUTER JOIN %s t2 ON t1.id = t2.id ORDER BY t1.id",
+            table1Name, table2Name);
+    assertEquals(
+        "Session property should apply to both tables in join", expectedJoinSnapshot1, actual2);
+
+    // Table-level option on any table together with session-level time-travel property raise
+    // Exception
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "SELECT t1.id, t1.data, t2.value FROM %s TIMESTAMP AS OF %s t1 FULL OUTER JOIN %s t2 ON t1.id = t2.id ORDER BY t1.id",
+                    table1Name, timestampSnapshot2 / 1000, table2Name))
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "SELECT t2.id, t1.data, t2.value FROM %s t1 FULL OUTER JOIN %s TIMESTAMP AS OF %s t2 ON t1.id = t2.id ORDER BY t2.id",
+                    table1Name, table2Name, timestampSnapshot2 / 1000))
+        .hasMessageContaining(
+            "Cannot set both snapshot-id and as-of-timestamp to select which table snapshot to scan")
+        .isInstanceOf(IllegalArgumentException.class);
+
+    // Cleanup
+    sql("DROP TABLE IF EXISTS %s", table1Name);
+    sql("DROP TABLE IF EXISTS %s", table2Name);
   }
 }


### PR DESCRIPTION
Adds spark.sql.iceberg.read.as-of-timestamp session property to allow setting a default timestamp for time-travel queries across all table reads when no explicit snapshot-id, as-of-timestamp, branch, or tag is specified.

Closes #15163