### PR TITLE
Add start and end offset for each source topic partition in iceberg snapshot as a property

### DIFF
--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/TestEventSerialization.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/TestEventSerialization.java
@@ -77,8 +77,8 @@ public class TestEventSerialization {
             new DataComplete(
                 commitId,
                 Arrays.asList(
-                    new TopicPartitionOffset("topic", 1, 1L, EventTestUtil.now()),
-                    new TopicPartitionOffset("topic", 2, null, null))));
+                    new TopicPartitionOffset("topic", 1, 0L, 1L, EventTestUtil.now()),
+                    new TopicPartitionOffset("topic", 2, null, null, null))));
 
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -164,4 +164,15 @@ class CommitState {
     }
     return result;
   }
+
+  /**
+   * Returns a list of all topic partition offsets from the ready buffer for the current commit.
+   * Each TopicPartitionOffset contains topic, partition, startOffset, endOffset, and timestamp.
+   */
+  List<TopicPartitionOffset> topicPartitionOffsets() {
+    return readyBuffer.stream()
+        .filter(payload -> payload.commitId().equals(currentCommitId))
+        .flatMap(payload -> payload.assignments().stream())
+        .collect(Collectors.toList());
+  }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -86,7 +86,11 @@ class Worker extends Channel {
                     offset = Offset.NULL_OFFSET;
                   }
                   return new TopicPartitionOffset(
-                      tp.topic(), tp.partition(), offset.offset(), offset.timestamp());
+                      tp.topic(),
+                      tp.partition(),
+                      offset.startOffset(),
+                      offset.endOffset(),
+                      offset.timestamp());
                 })
             .collect(Collectors.toList());
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/Offset.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/Offset.java
@@ -23,18 +23,29 @@ import java.util.Objects;
 
 public class Offset implements Comparable<Offset> {
 
-  public static final Offset NULL_OFFSET = new Offset(null, null);
+  public static final Offset NULL_OFFSET = new Offset(null, null, null);
 
-  private final Long offset;
+  private final Long startOffset;
+  private final Long endOffset;
   private final OffsetDateTime timestamp;
 
-  public Offset(Long offset, OffsetDateTime timestamp) {
-    this.offset = offset;
+  public Offset(Long startOffset, Long endOffset, OffsetDateTime timestamp) {
+    this.startOffset = startOffset;
+    this.endOffset = endOffset;
     this.timestamp = timestamp;
   }
 
+  public Long startOffset() {
+    return startOffset;
+  }
+
+  public Long endOffset() {
+    return endOffset;
+  }
+
+  // For backward compatibility - returns the end offset
   public Long offset() {
-    return offset;
+    return endOffset;
   }
 
   public OffsetDateTime timestamp() {
@@ -43,10 +54,10 @@ public class Offset implements Comparable<Offset> {
 
   @Override
   public int compareTo(Offset other) {
-    if (Objects.equals(this.offset, other.offset)) {
+    if (Objects.equals(this.endOffset, other.endOffset)) {
       return 0;
     }
-    if (this.offset == null || (other.offset != null && other.offset > this.offset)) {
+    if (this.endOffset == null || (other.endOffset != null && other.endOffset > this.endOffset)) {
       return -1;
     }
     return 1;

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -199,7 +199,7 @@ public class TestCoordinator extends ChannelTestBase {
         new Event(
             config.connectGroupId(),
             new DataComplete(
-                commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts))));
+                commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 0L, 1L, ts))));
     bytes = AvroUtil.encode(commitReady);
     consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
@@ -73,7 +73,7 @@ public class TestWorker extends ChannelTestBase {
               StructType.of());
 
       Map<TopicPartition, Offset> offsets =
-          ImmutableMap.of(topicPartition, new Offset(1L, EventTestUtil.now()));
+          ImmutableMap.of(topicPartition, new Offset(0L, 1L, EventTestUtil.now()));
 
       SinkWriterResult sinkWriterResult =
           new SinkWriterResult(ImmutableList.of(writeResult), offsets);
@@ -110,7 +110,7 @@ public class TestWorker extends ChannelTestBase {
       DataComplete dataComplete = (DataComplete) event.payload();
       assertThat(dataComplete.commitId()).isEqualTo(commitId);
       assertThat(dataComplete.assignments()).hasSize(1);
-      assertThat(dataComplete.assignments().get(0).offset()).isEqualTo(1L);
+      assertThat(dataComplete.assignments().get(0).endOffset()).isEqualTo(1L);
     }
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
@@ -202,7 +202,10 @@ public class TestSinkWriter {
 
     Offset offset = result.sourceOffsets().get(new TopicPartition("topic", 1));
     assertThat(offset).isNotNull();
-    assertThat(offset.offset()).isEqualTo(101L); // should be 1 more than current offset
+    assertThat(offset.startOffset()).isEqualTo(100L); // start offset
+    assertThat(offset.endOffset()).isEqualTo(101L); // should be 1 more than current offset
+    assertThat(offset.offset())
+        .isEqualTo(101L); // backward compatibility - should be same as endOffset
     assertThat(offset.timestamp()).isEqualTo(now.atOffset(ZoneOffset.UTC));
 
     return result.writerResults();


### PR DESCRIPTION
## Summary

  This PR enhances the Kafka Connect sink to track offset ranges (start and end offsets) for each topic partition, providing better traceability of which source data was included in each Iceberg
  snapshot.

  ## Motivation

  Previously, the connector only tracked a single offset value per partition, which represented the next offset to consume. This made it difficult to determine the exact range of data that was
  committed in a particular snapshot. By tracking both start and end offsets, we can now:

  1. Precisely identify the range of Kafka messages included in each Iceberg snapshot
  2. Improve debugging and data lineage capabilities
  3. Enable better auditing and compliance tracking
  4. Facilitate data recovery and reprocessing scenarios
  5. Also this will enable switching to exact topic partition for Flink jobs if running in hybrid mode with model of iceberg -> kafka

  ## Changes

  ### Core Data Models

  **`TopicPartitionOffset` class:**
  - Changed from single `offset` field to `startOffset` and `endOffset` fields
  - Updated Iceberg schema to include both offset fields
  - Field IDs: `START_OFFSET = 10_702`, `END_OFFSET = 10_703`, `TIMESTAMP = 10_704`
  - Added getter methods: `startOffset()` and `endOffset()`

  **`Offset` class:**
  - Modified to track both `startOffset` and `endOffset` instead of a single offset
  - Added backward compatibility method `offset()` that returns `endOffset`
  - Updated constructor signature: `Offset(Long startOffset, Long endOffset, OffsetDateTime timestamp)`

  ### Offset Tracking

  **`SinkWriter` class:**
  - Enhanced `save()` method to track offset ranges per partition
  - For the first record in a partition: `startOffset = currentOffset`, `endOffset = currentOffset + 1`
  - For subsequent records: preserves original `startOffset`, updates `endOffset = currentOffset + 1`
  - Ensures accurate range tracking across multiple records in the same commit cycle

  **`Worker` class:**
  - Updated to pass both `startOffset` and `endOffset` when creating `TopicPartitionOffset` objects

  ### Snapshot Metadata

  **`CommitState` class:**
  - Added `topicPartitionOffsets()` method to extract all topic partition offsets from ready buffer
  - Returns complete offset information for the current commit

  **`Coordinator` class:**
  - Added new snapshot property: `kafka.connect.topic-partition-offsets`
  - Implemented `topicPartitionOffsetsToJson()` to serialize offset ranges to JSON
  - JSON format includes: `topic`, `partition`, `startOffset`, `endOffset`, and `timestamp` for each partition
  - Updated `commitToTable()` to store topic partition offsets in both append and delta operations

  ### Example Snapshot Metadata

  After this change, Iceberg snapshots will include metadata like:

  ```json
  {
    "kafka.connect.topic-partition-offsets": [
      {
        "topic": "events",
        "partition": 0,
        "startOffset": 100,
        "endOffset": 250,
        "timestamp": "2024-01-15T10:30:00Z"
      },
      {
        "topic": "events",
        "partition": 1,
        "startOffset": 50,
        "endOffset": 175,
        "timestamp": "2024-01-15T10:30:05Z"
      }
    ]
  }
