### PR TITLE
ORC: Fix typos in IdToOrcName and ORC JavaDoc

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/IdToOrcName.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/IdToOrcName.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.types.Types;
 /**
  * Generates mapping from field IDs to ORC qualified names.
  *
- * <p>This visitor also enclose column names in backticks i.e. ` so that ORC can correctly parse
+ * <p>This visitor also encloses column names in backticks i.e. ` so that ORC can correctly parse
  * column names with special characters. A comparison of ORC convention with Iceberg convention is
  * provided below
  *

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -179,7 +179,7 @@ public class ORC {
       return this;
     }
 
-    // supposed to always be a private method used strictly by data and delete write builders
+    // Supposed to always be a private method used strictly by data and delete write builders
     private WriteBuilder createContextFunc(
         Function<Map<String, String>, Context> newCreateContextFunc) {
       this.createContextFunc = newCreateContextFunc;


### PR DESCRIPTION
This PR fixes a few minor typos in the ORC package:
- Corrected "enclose" to "encloses" in IdToOrcName JavaDoc.
- Capitalized "supposed" in ORC.java WriteBuilder comment.