### PR TITLE
Core: Add org.apache.iceberg.DataFiles.Builder#withSortOrderId

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -321,6 +321,11 @@ public class DataFiles {
       return this;
     }
 
+    public Builder withSortOrderId(int newSortOrderId) {
+      this.sortOrderId = newSortOrderId;
+      return this;
+    }
+
     public Builder withFirstRowId(Long nextRowId) {
       this.firstRowId = nextRowId;
       return this;

--- a/core/src/test/java/org/apache/iceberg/ScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/ScanTestBase.java
@@ -238,6 +238,17 @@ public abstract class ScanTestBase<
                 .build())
         .commit();
 
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data/b.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(1)
+                .withSortOrderId(1)
+                .build())
+        .commit();
+
     TableScan scan = table.newScan();
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       for (FileScanTask fileScanTask : tasks) {


### PR DESCRIPTION
Since sort id is the relevant field here, there should be an API to specify it directly instead of going through SortOrder object.