### PR TITLE
ORC: Fix additional typos in ORCSchemaUtil, OrcMetrics, and others

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -268,7 +268,7 @@ public final class ORCSchemaUtil {
   }
 
   /**
-   * Convert an ORC schema to an Iceberg schema. This method handles the convertion from the
+   * Convert an ORC schema to an Iceberg schema. This method handles the conversion from the
    * original Iceberg column mapping IDs if present in the ORC column attributes, otherwise, ORC
    * columns with no Iceberg IDs will be ignored and skipped in the conversion.
    *

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
@@ -138,7 +138,7 @@ class OrcFileAppender<D> implements FileAppender<D> {
           e);
     }
 
-    // This value is estimated, not actual.
+    // This value is an estimate, not the actual length.
     return (long)
         Math.ceil(dataLength + (estimateMemory + (long) batch.size * avgRowByteSize) * 0.2);
   }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -172,7 +172,7 @@ public class OrcMetrics {
         if (statsColumns.contains(fieldId)) {
           // Since ORC does not track null values nor repeated ones, the value count for columns in
           // containers (maps, list) may be larger than what it actually is, however these are not
-          // used in expressions right now. For such cases, we use the value number of values
+          // used in expressions right now. For such cases, we use the number of values
           // directly stored in ORC.
           if (colStat.hasNull()) {
             nullCounts.put(fieldId, numOfRows - colStat.getNumberOfValues());


### PR DESCRIPTION
This PR follows up on #15214 to fix further minor typos, grammatical errors, and Javadoc formatting issues discovered in the ORC package to improve code quality and readability.

Key changes include:
- ORCSchemaUtil: Fixed "convertion" to "conversion" and standardized apostrophe usage in Javadoc.
- OrcMetrics: Removed a redundant word in comments ("value number of values" -> "number of values").
- OrcFileAppender: Improved the phrasing of an estimated length comment.