### PR TITLE
Docs: add blog post for iceberg-rust 0.8.0 release

### DIFF
--- a/site/docs/blog/posts/2026-02-02-iceberg-rust-0.8.0-release.md
+++ b/site/docs/blog/posts/2026-02-02-iceberg-rust-0.8.0-release.md
@@ -45,12 +45,10 @@ This release introduces [support for Iceberg V3 metadata format](https://github.
 
 The DataFusion integration received significant improvements:
 
-- **INSERT INTO partitioned tables**: [Native support](https://github.com/apache/iceberg-rust/pull/1827) for inserting data into partitioned Iceberg tables
-- **Partition column projection**: [Implemented project node](https://github.com/apache/iceberg-rust/pull/1602) to efficiently add partition columns during query execution
-- **Repartitioning operator**: [Added partitioning operator](https://github.com/apache/iceberg-rust/pull/1620) to define output partitioning strategy based on the Iceberg table schema and metadata
+- **INSERT INTO partitioned tables**: [Native support](https://github.com/apache/iceberg-rust/pull/1827) for inserting data into partitioned Iceberg tables, with [partition column projection](https://github.com/apache/iceberg-rust/pull/1602) and [repartitioning operator](https://github.com/apache/iceberg-rust/pull/1620)
 - **Partition-aware sorting**: [New `sort_by_partition` operator](https://github.com/apache/iceberg-rust/pull/1618) to sort input data by partition values
 - **SQLLogicTest integration**: [Added comprehensive testing framework](https://github.com/apache/iceberg-rust/pull/1764) for DataFusion operations
-- **TaskWriter**: [Implemented writer interface](https://github.com/apache/iceberg-rust/pull/1769) for DataFusion execution
+- **Parallel writing**: [Implemented parallel writer interface](https://github.com/apache/iceberg-rust/pull/1769) for DataFusion execution
 
 ### Advanced Delete File Handling
 


### PR DESCRIPTION
Add a blog post about the recent `iceberg-rust` 0.8.0 release. 
Thank you to all the community members who helped with code contributions, reviews, and writing this blog post. 😄 ❤️ 


### Rendered locally
<img width="1535" height="995" alt="Screenshot 2026-02-02 at 12 48 29 PM" src="https://github.com/user-attachments/assets/f5d298cb-8adf-4cdc-801e-5888c4cfbb26" />
<img width="1540" height="857" alt="Screenshot 2026-02-02 at 12 48 44 PM" src="https://github.com/user-attachments/assets/252074b8-a923-472e-9fe8-1aee117995bf" />
<img width="1540" height="779" alt="Screenshot 2026-02-02 at 12 49 02 PM" src="https://github.com/user-attachments/assets/87c14b9b-0b58-4c33-8b14-ca2a28016e36" />
