### PR TITLE
Spark: Include info about failed commits in the result of RewriteDataFilesAction

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -342,6 +342,14 @@ public class RewriteDataFilesSparkAction
     // stop commit service
     commitService.close();
 
+    for (RewriteFileGroup failedGroup : commitService.failures()) {
+      rewriteFailures.add(
+          ImmutableRewriteDataFiles.FileGroupFailureResult.builder()
+              .info(failedGroup.info())
+              .dataFilesCount(failedGroup.inputFileNum())
+              .build());
+    }
+
     int totalCommits = Math.min(plan.totalGroupCount(), maxCommits);
     int failedCommits = totalCommits - commitService.succeededCommits();
     if (failedCommits > 0 && failedCommits <= maxFailedCommits) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1389,6 +1389,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     // Commit 1: 4/4 + Commit 2 failed 0/4 + Commit 3: 2/2 == 6 out of 10 total groups committed
     assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
+    assertThat(result.rewriteFailures()).hasSize(4);
+    assertThat(result.failedDataFilesCount()).isEqualTo(8);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
     table.refresh();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -342,6 +342,14 @@ public class RewriteDataFilesSparkAction
     // stop commit service
     commitService.close();
 
+    for (RewriteFileGroup failedGroup : commitService.failures()) {
+      rewriteFailures.add(
+          ImmutableRewriteDataFiles.FileGroupFailureResult.builder()
+              .info(failedGroup.info())
+              .dataFilesCount(failedGroup.inputFileNum())
+              .build());
+    }
+
     int totalCommits = Math.min(plan.totalGroupCount(), maxCommits);
     int failedCommits = totalCommits - commitService.succeededCommits();
     if (failedCommits > 0 && failedCommits <= maxFailedCommits) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1389,6 +1389,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     // Commit 1: 4/4 + Commit 2 failed 0/4 + Commit 3: 2/2 == 6 out of 10 total groups committed
     assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
+    assertThat(result.rewriteFailures()).hasSize(4);
+    assertThat(result.failedDataFilesCount()).isEqualTo(8);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
     table.refresh();

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -342,6 +342,14 @@ public class RewriteDataFilesSparkAction
     // stop commit service
     commitService.close();
 
+    for (RewriteFileGroup failedGroup : commitService.failures()) {
+      rewriteFailures.add(
+          ImmutableRewriteDataFiles.FileGroupFailureResult.builder()
+              .info(failedGroup.info())
+              .dataFilesCount(failedGroup.inputFileNum())
+              .build());
+    }
+
     int totalCommits = Math.min(plan.totalGroupCount(), maxCommits);
     int failedCommits = totalCommits - commitService.succeededCommits();
     if (failedCommits > 0 && failedCommits <= maxFailedCommits) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1392,6 +1392,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     // Commit 1: 4/4 + Commit 2 failed 0/4 + Commit 3: 2/2 == 6 out of 10 total groups committed
     assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
+    assertThat(result.rewriteFailures()).hasSize(4);
+    assertThat(result.failedDataFilesCount()).isEqualTo(8);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
     table.refresh();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -342,6 +342,14 @@ public class RewriteDataFilesSparkAction
     // stop commit service
     commitService.close();
 
+    for (RewriteFileGroup failedGroup : commitService.failures()) {
+      rewriteFailures.add(
+          ImmutableRewriteDataFiles.FileGroupFailureResult.builder()
+              .info(failedGroup.info())
+              .dataFilesCount(failedGroup.inputFileNum())
+              .build());
+    }
+
     int totalCommits = Math.min(plan.totalGroupCount(), maxCommits);
     int failedCommits = totalCommits - commitService.succeededCommits();
     if (failedCommits > 0 && failedCommits <= maxFailedCommits) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1392,8 +1392,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     // Commit 1: 4/4 + Commit 2 failed 0/4 + Commit 3: 2/2 == 6 out of 10 total groups committed
     assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
-    assertThat(result.rewriteFailures()).hasSize(4);
-    assertThat(result.failedDataFilesCount()).isEqualTo(8);
+    assertThat(result.rewriteFailures()).as("Should have 4 failed fileGroups").hasSize(4);
+    assertThat(result.failedDataFilesCount()).as("Should have 8 failed data files").isEqualTo(8);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
     table.refresh();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1392,6 +1392,8 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     // Commit 1: 4/4 + Commit 2 failed 0/4 + Commit 3: 2/2 == 6 out of 10 total groups committed
     assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
+    assertThat(result.rewriteFailures()).hasSize(4);
+    assertThat(result.failedDataFilesCount()).isEqualTo(8);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
     table.refresh();


### PR DESCRIPTION
When partial progress is enabled and a commit fails, the file groups in that batch were previously lost. When looking at the result, `failedDataFilesCount` is `0` when commits failed.

When some commits failed and some succeeded, it's unclear by looking at the result that it is actually partial.

One choice I'm not sure about and am happy to get feedback on is that this change makes it so the creation of result objects now treats commit failures as other rewrite failures (both failure count and failed data files).
Given the aggregative nature of the result object, I couldn't think of a situation where the distinction is important enough to justify changing its structure, but I am open to changing it to be counted separately.

I haven't seen an AI policy, but FYI I used AI to implement tests and changed them manually to fit the style other similar tests in the same area.