### PR TITLE
Spark Test: Fix flaky TestCopyOnWriteDelete tests

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -82,8 +85,16 @@ public class TestCopyOnWriteDelete extends TestDelete {
     createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
 
     sql(
-        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
-        tableName, DELETE_ISOLATION_LEVEL, "snapshot");
+        "ALTER TABLE %s SET TBLPROPERTIES('%s'='%s', '%s'='%s', '%s'='%s', '%s'='%s')",
+        tableName,
+        DELETE_ISOLATION_LEVEL,
+        "snapshot",
+        COMMIT_MIN_RETRY_WAIT_MS,
+        "10",
+        COMMIT_MAX_RETRY_WAIT_MS,
+        "1000",
+        COMMIT_NUM_RETRIES,
+        "7");
 
     sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
     createBranchIfNeeded();

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -112,7 +112,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
     Future<?> deleteFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < 20; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -133,7 +133,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < 20; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -82,8 +85,16 @@ public class TestCopyOnWriteDelete extends TestDelete {
     createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
 
     sql(
-        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
-        tableName, DELETE_ISOLATION_LEVEL, "snapshot");
+        "ALTER TABLE %s SET TBLPROPERTIES('%s'='%s', '%s'='%s', '%s'='%s', '%s'='%s')",
+        tableName,
+        DELETE_ISOLATION_LEVEL,
+        "snapshot",
+        COMMIT_MIN_RETRY_WAIT_MS,
+        "10",
+        COMMIT_MAX_RETRY_WAIT_MS,
+        "1000",
+        COMMIT_NUM_RETRIES,
+        "7");
 
     sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
     createBranchIfNeeded();

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -112,7 +112,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
     Future<?> deleteFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < 20; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -133,7 +133,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < 20; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -82,8 +85,16 @@ public class TestCopyOnWriteDelete extends TestDelete {
     createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
 
     sql(
-        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
-        tableName, DELETE_ISOLATION_LEVEL, "snapshot");
+        "ALTER TABLE %s SET TBLPROPERTIES('%s'='%s', '%s'='%s', '%s'='%s', '%s'='%s')",
+        tableName,
+        DELETE_ISOLATION_LEVEL,
+        "snapshot",
+        COMMIT_MIN_RETRY_WAIT_MS,
+        "10",
+        COMMIT_MAX_RETRY_WAIT_MS,
+        "1000",
+        COMMIT_NUM_RETRIES,
+        "7");
 
     sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
     createBranchIfNeeded();

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -112,7 +112,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
     Future<?> deleteFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < 20; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -133,7 +133,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < 20; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -82,8 +85,16 @@ public class TestCopyOnWriteDelete extends TestDelete {
     createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
 
     sql(
-        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
-        tableName, DELETE_ISOLATION_LEVEL, "snapshot");
+        "ALTER TABLE %s SET TBLPROPERTIES('%s'='%s', '%s'='%s', '%s'='%s', '%s'='%s')",
+        tableName,
+        DELETE_ISOLATION_LEVEL,
+        "snapshot",
+        COMMIT_MIN_RETRY_WAIT_MS,
+        "10",
+        COMMIT_MAX_RETRY_WAIT_MS,
+        "1000",
+        COMMIT_NUM_RETRIES,
+        "7");
 
     sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
     createBranchIfNeeded();

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -112,7 +112,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
     Future<?> deleteFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < 20; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -133,7 +133,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < 20; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
These test were timing out on our CI builds, doing some investigation this exact [issue](https://github.com/apache/iceberg/pull/11974) came out in a similar test, and applying the same fix worked

The test was also getting stuck locally when running:
```bash
./gradlew --stacktrace -Pquick=true -x javadoc :iceberg-spark:iceberg-spark-extensions-4.0_2.13:test -DscalaVersion=2.13 -DsparkVersions=4.0 \
 --tests "org.apache.iceberg.spark.extensions.TestCopyOnWriteDelete"
```

Note: I only saw this in spark 4.0, but seems harmless to backport it to all other versions