### PR TITLE
Core: Add BasicTLSConfigurer for custom keystore and truststore support

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.auth;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Map;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * A TLS configurer that supports custom keystore and truststore configuration.
+ */
+public class BasicTLSConfigurer implements TLSConfigurer {
+
+    public static final String TLS_KEYSTORE_PATH = "rest.client.tls.keystore.path";
+    public static final String TLS_KEYSTORE_PASSWORD = "rest.client.tls.keystore.password";
+    public static final String TLS_KEYSTORE_TYPE = "rest.client.tls.keystore.type";
+    public static final String TLS_TRUSTSTORE_PATH = "rest.client.tls.truststore.path";
+    public static final String TLS_TRUSTSTORE_PASSWORD = "rest.client.tls.truststore.password";
+    public static final String TLS_TRUSTSTORE_TYPE = "rest.client.tls.truststore.type";
+
+    private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
+    private static final String DEFAULT_SSL_PROTOCOL = "TLS";
+
+    private SSLContext sslContext;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+        String keystorePath = properties.get(TLS_KEYSTORE_PATH);
+        String keystorePassword = properties.get(TLS_KEYSTORE_PASSWORD);
+        String keystoreType = properties.getOrDefault(TLS_KEYSTORE_TYPE, DEFAULT_KEYSTORE_TYPE);
+        String truststorePath = properties.get(TLS_TRUSTSTORE_PATH);
+        String truststorePassword = properties.get(TLS_TRUSTSTORE_PASSWORD);
+        String truststoreType = properties.getOrDefault(TLS_TRUSTSTORE_TYPE, DEFAULT_KEYSTORE_TYPE);
+
+        try {
+            SSLContext context = SSLContext.getInstance(DEFAULT_SSL_PROTOCOL);
+
+            KeyManagerFactory keyManagerFactory = null;
+            if (keystorePath != null) {
+                KeyStore keyStore = loadKeyStore(keystorePath, keystorePassword, keystoreType);
+                keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                keyManagerFactory.init(keyStore, keystorePassword != null ? keystorePassword.toCharArray() : null);
+            }
+
+            TrustManagerFactory trustManagerFactory = null;
+            if (truststorePath != null) {
+                KeyStore trustStore = loadKeyStore(truststorePath, truststorePassword, truststoreType);
+                trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init(trustStore);
+            }
+
+            context.init(
+                    keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
+                    trustManagerFactory != null ? trustManagerFactory.getTrustManagers() : null,
+                    null);
+
+            this.sslContext = context;
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException | UnrecoverableKeyException e) {
+            throw new IllegalStateException("Failed to create SSL context", e);
+        }
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return sslContext != null ? sslContext : SSLContext.getDefault();
+    }
+
+    private KeyStore loadKeyStore(String path, String password, String type) {
+        try (FileInputStream fis = new FileInputStream(path)) {
+            KeyStore keyStore = KeyStore.getInstance(type);
+            keyStore.load(fis, password != null ? password.toCharArray() : null);
+            return keyStore;
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
+            throw new IllegalStateException(String.format("Failed to load keystore from path: %s", path), e);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
@@ -46,9 +46,10 @@ public class BasicTLSConfigurer implements TLSConfigurer {
   public static final String TLS_TRUSTSTORE_PATH = "rest.client.tls.truststore.path";
   public static final String TLS_TRUSTSTORE_PASSWORD = "rest.client.tls.truststore.password";
   public static final String TLS_TRUSTSTORE_TYPE = "rest.client.tls.truststore.type";
+  public static final String TLS_PROTOCOL = "rest.client.tls.protocol";
 
   private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
-  private static final String DEFAULT_SSL_PROTOCOL = "TLS";
+  private static final String DEFAULT_TLS_PROTOCOL = "TLS";
 
   private SSLContext sslContext;
 
@@ -60,10 +61,9 @@ public class BasicTLSConfigurer implements TLSConfigurer {
     String truststorePath = properties.get(TLS_TRUSTSTORE_PATH);
     String truststorePassword = properties.get(TLS_TRUSTSTORE_PASSWORD);
     String truststoreType = properties.getOrDefault(TLS_TRUSTSTORE_TYPE, DEFAULT_KEYSTORE_TYPE);
+    String protocol = properties.getOrDefault(TLS_PROTOCOL, DEFAULT_TLS_PROTOCOL);
 
     try {
-      SSLContext context = SSLContext.getInstance(DEFAULT_SSL_PROTOCOL);
-
       KeyManager[] keyManagers = null;
       if (!Strings.isNullOrEmpty(keystorePath)) {
         char[] keystorePasswordChars =
@@ -89,6 +89,7 @@ public class BasicTLSConfigurer implements TLSConfigurer {
       if (keyManagers == null && trustManagers == null) {
         this.sslContext = SSLContext.getDefault();
       } else {
+        SSLContext context = SSLContext.getInstance(protocol);
         context.init(keyManagers, trustManagers, null);
         this.sslContext = context;
       }

--- a/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
@@ -45,6 +45,7 @@ public class BasicTLSConfigurer implements TLSConfigurer {
   public static final String TLS_KEYSTORE_PATH = "rest.client.tls.keystore.path";
   public static final String TLS_KEYSTORE_PASSWORD = "rest.client.tls.keystore.password";
   public static final String TLS_KEYSTORE_TYPE = "rest.client.tls.keystore.type";
+  public static final String TLS_KEYSTORE_KEY_PASSWORD = "rest.client.tls.keystore.key-password";
   public static final String TLS_TRUSTSTORE_PATH = "rest.client.tls.truststore.path";
   public static final String TLS_TRUSTSTORE_PASSWORD = "rest.client.tls.truststore.password";
   public static final String TLS_TRUSTSTORE_TYPE = "rest.client.tls.truststore.type";
@@ -65,6 +66,8 @@ public class BasicTLSConfigurer implements TLSConfigurer {
     String keystorePath = properties.get(TLS_KEYSTORE_PATH);
     String keystorePassword = properties.get(TLS_KEYSTORE_PASSWORD);
     String keystoreType = properties.getOrDefault(TLS_KEYSTORE_TYPE, DEFAULT_KEYSTORE_TYPE);
+    // the private key may be protected by a password of its own; fall back to the keystore password
+    String keyPassword = properties.getOrDefault(TLS_KEYSTORE_KEY_PASSWORD, keystorePassword);
     String truststorePath = properties.get(TLS_TRUSTSTORE_PATH);
     String truststorePassword = properties.get(TLS_TRUSTSTORE_PASSWORD);
     String truststoreType = properties.getOrDefault(TLS_TRUSTSTORE_TYPE, DEFAULT_KEYSTORE_TYPE);
@@ -86,7 +89,7 @@ public class BasicTLSConfigurer implements TLSConfigurer {
         KeyStore keyStore = loadKeyStore(keystorePath, keystorePasswordChars, keystoreType);
         KeyManagerFactory keyManagerFactory =
             KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        keyManagerFactory.init(keyStore, keystorePasswordChars);
+        keyManagerFactory.init(keyStore, keyPassword != null ? keyPassword.toCharArray() : null);
         keyManagers = keyManagerFactory.getKeyManagers();
       }
 

--- a/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/BasicTLSConfigurer.java
@@ -28,6 +28,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.List;
 import java.util.Map;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -35,6 +36,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 
 /** A TLS configurer that supports custom keystore and truststore configuration. */
@@ -47,11 +49,16 @@ public class BasicTLSConfigurer implements TLSConfigurer {
   public static final String TLS_TRUSTSTORE_PASSWORD = "rest.client.tls.truststore.password";
   public static final String TLS_TRUSTSTORE_TYPE = "rest.client.tls.truststore.type";
   public static final String TLS_PROTOCOL = "rest.client.tls.protocol";
+  public static final String TLS_CIPHER_SUITES = "rest.client.tls.cipher-suites";
 
   private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
   private static final String DEFAULT_TLS_PROTOCOL = "TLS";
+  private static final Splitter CIPHER_SUITE_SPLITTER =
+      Splitter.on(',').trimResults().omitEmptyStrings();
 
   private SSLContext sslContext;
+  private String[] supportedProtocols;
+  private String[] supportedCipherSuites;
 
   @Override
   public void initialize(Map<String, String> properties) {
@@ -61,7 +68,15 @@ public class BasicTLSConfigurer implements TLSConfigurer {
     String truststorePath = properties.get(TLS_TRUSTSTORE_PATH);
     String truststorePassword = properties.get(TLS_TRUSTSTORE_PASSWORD);
     String truststoreType = properties.getOrDefault(TLS_TRUSTSTORE_TYPE, DEFAULT_KEYSTORE_TYPE);
-    String protocol = properties.getOrDefault(TLS_PROTOCOL, DEFAULT_TLS_PROTOCOL);
+    String protocol = properties.get(TLS_PROTOCOL);
+    String cipherSuites = properties.get(TLS_CIPHER_SUITES);
+
+    // An explicitly configured protocol is also pinned as the only enabled protocol. Passing it to
+    // SSLContext.getInstance alone is not enough: JSSE treats the context algorithm as a minimum,
+    // so SSLContext.getInstance("TLSv1.3") still leaves TLSv1.2 enabled on the socket.
+    this.supportedProtocols =
+        Strings.isNullOrEmpty(protocol) ? null : new String[] {protocol.trim()};
+    this.supportedCipherSuites = parseCipherSuites(cipherSuites);
 
     try {
       KeyManager[] keyManagers = null;
@@ -89,7 +104,9 @@ public class BasicTLSConfigurer implements TLSConfigurer {
       if (keyManagers == null && trustManagers == null) {
         this.sslContext = SSLContext.getDefault();
       } else {
-        SSLContext context = SSLContext.getInstance(protocol);
+        SSLContext context =
+            SSLContext.getInstance(
+                Strings.isNullOrEmpty(protocol) ? DEFAULT_TLS_PROTOCOL : protocol.trim());
         context.init(keyManagers, trustManagers, null);
         this.sslContext = context;
       }
@@ -107,14 +124,27 @@ public class BasicTLSConfigurer implements TLSConfigurer {
     return sslContext;
   }
 
+  /** Returns the configured protocol as the only enabled one, or null to use the JSSE defaults. */
   @Override
   public String[] supportedProtocols() {
-    return null;
+    return supportedProtocols == null ? null : supportedProtocols.clone();
   }
 
+  /** Returns the configured cipher suites, or null to use the JSSE defaults. */
   @Override
   public String[] supportedCipherSuites() {
-    return null;
+    return supportedCipherSuites == null ? null : supportedCipherSuites.clone();
+  }
+
+  private static String[] parseCipherSuites(String cipherSuites) {
+    if (Strings.isNullOrEmpty(cipherSuites)) {
+      return null;
+    }
+
+    List<String> suites = CIPHER_SUITE_SPLITTER.splitToList(cipherSuites);
+    Preconditions.checkArgument(
+        !suites.isEmpty(), "Invalid cipher suites: %s must not be blank", TLS_CIPHER_SUITES);
+    return suites.toArray(new String[0]);
   }
 
   private KeyStore loadKeyStore(String path, char[] password, String type) {

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestBasicTLSConfigurer {
+
+  @TempDir Path tempDir;
+
+  @Test
+  public void testBasicTLSConfigurerInitialization() {
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    configurer.initialize(ImmutableMap.of());
+
+    // Should return default SSL context when no custom configuration is provided
+    SSLContext sslContext = configurer.sslContext();
+    assertThat(sslContext).isNotNull();
+  }
+
+  @Test
+  public void testBasicTLSConfigurerWithBothKeystoreAndTruststore() throws Exception {
+    Path keystorePath = createTempKeyStore("keystore.jks", "keypass");
+    Path truststorePath = createTempKeyStore("truststore.jks", "trustpass");
+
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    Map<String, String> properties =
+        ImmutableMap.of(
+            BasicTLSConfigurer.TLS_KEYSTORE_PATH,
+            keystorePath.toString(),
+            BasicTLSConfigurer.TLS_KEYSTORE_PASSWORD,
+            "keypass",
+            BasicTLSConfigurer.TLS_TRUSTSTORE_PATH,
+            truststorePath.toString(),
+            BasicTLSConfigurer.TLS_TRUSTSTORE_PASSWORD,
+            "trustpass");
+
+    configurer.initialize(properties);
+
+    SSLContext sslContext = configurer.sslContext();
+    assertThat(sslContext).isNotNull();
+    assertThat(sslContext.getProtocol()).isEqualTo("TLS");
+  }
+
+  @Test
+  public void testBasicTLSConfigurerWithInvalidKeystorePath() {
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    Map<String, String> properties =
+        ImmutableMap.of(
+            BasicTLSConfigurer.TLS_KEYSTORE_PATH, "/nonexistent/path/keystore.jks",
+            BasicTLSConfigurer.TLS_KEYSTORE_PASSWORD, "password123");
+
+    assertThatThrownBy(() -> configurer.initialize(properties))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to load keystore from path");
+  }
+
+  /** Creates a temporary keystore file for testing purposes. */
+  private Path createTempKeyStore(String filename, String password) throws Exception {
+    Path keystorePath = tempDir.resolve(filename);
+
+    // Create an empty keystore
+    KeyStore keyStore = KeyStore.getInstance("JKS");
+    keyStore.load(null, password != null ? password.toCharArray() : null);
+
+    // Write the keystore to file
+    try (FileOutputStream fos = new FileOutputStream(keystorePath.toFile())) {
+      keyStore.store(fos, password != null ? password.toCharArray() : null);
+    }
+
+    return keystorePath;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
@@ -78,7 +78,7 @@ public class TestBasicTLSConfigurer {
 
     assertThatThrownBy(() -> configurer.initialize(properties))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Failed to load keystore from path");
+        .hasMessageContaining("Keystore file does not exist");
   }
 
   /** Creates a temporary keystore file for testing purposes. */

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
@@ -69,6 +69,38 @@ public class TestBasicTLSConfigurer {
   }
 
   @Test
+  public void testBasicTLSConfigurerWithCustomProtocol() throws Exception {
+    Path keystorePath = createTempKeyStore("keystore.jks", "keypass");
+
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    Map<String, String> properties =
+        ImmutableMap.of(
+            BasicTLSConfigurer.TLS_KEYSTORE_PATH, keystorePath.toString(),
+            BasicTLSConfigurer.TLS_KEYSTORE_PASSWORD, "keypass",
+            BasicTLSConfigurer.TLS_PROTOCOL, "TLSv1.3");
+
+    configurer.initialize(properties);
+
+    assertThat(configurer.sslContext().getProtocol()).isEqualTo("TLSv1.3");
+  }
+
+  @Test
+  public void testBasicTLSConfigurerWithUnsupportedProtocol() throws Exception {
+    Path keystorePath = createTempKeyStore("keystore.jks", "keypass");
+
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    Map<String, String> properties =
+        ImmutableMap.of(
+            BasicTLSConfigurer.TLS_KEYSTORE_PATH, keystorePath.toString(),
+            BasicTLSConfigurer.TLS_KEYSTORE_PASSWORD, "keypass",
+            BasicTLSConfigurer.TLS_PROTOCOL, "NotATLSProtocol");
+
+    assertThatThrownBy(() -> configurer.initialize(properties))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to create SSL context");
+  }
+
+  @Test
   public void testBasicTLSConfigurerWithInvalidKeystorePath() {
     BasicTLSConfigurer configurer = new BasicTLSConfigurer();
     Map<String, String> properties =

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
@@ -82,6 +82,44 @@ public class TestBasicTLSConfigurer {
     configurer.initialize(properties);
 
     assertThat(configurer.sslContext().getProtocol()).isEqualTo("TLSv1.3");
+    // the context algorithm alone would still leave TLSv1.2 enabled, so the protocol must also be
+    // pinned through supportedProtocols
+    assertThat(configurer.sslContext().getDefaultSSLParameters().getProtocols())
+        .contains("TLSv1.2");
+    assertThat(configurer.supportedProtocols()).containsExactly("TLSv1.3");
+  }
+
+  @Test
+  public void testBasicTLSConfigurerWithoutProtocolOrCipherSuites() {
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    configurer.initialize(ImmutableMap.of());
+
+    // null defers to the JSSE defaults
+    assertThat(configurer.supportedProtocols()).isNull();
+    assertThat(configurer.supportedCipherSuites()).isNull();
+  }
+
+  @Test
+  public void testBasicTLSConfigurerWithCipherSuites() {
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    configurer.initialize(
+        ImmutableMap.of(
+            BasicTLSConfigurer.TLS_CIPHER_SUITES,
+            "TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256"));
+
+    assertThat(configurer.supportedCipherSuites())
+        .containsExactly("TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256");
+  }
+
+  @Test
+  public void testBasicTLSConfigurerWithBlankCipherSuites() {
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+
+    assertThatThrownBy(
+            () ->
+                configurer.initialize(ImmutableMap.of(BasicTLSConfigurer.TLS_CIPHER_SUITES, " ,")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be blank");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestBasicTLSConfigurer.java
@@ -22,11 +22,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.FileOutputStream;
+import java.math.BigInteger;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.Map;
 import javax.net.ssl.SSLContext;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -139,6 +152,54 @@ public class TestBasicTLSConfigurer {
   }
 
   @Test
+  public void testBasicTLSConfigurerWithDistinctKeyPassword() throws Exception {
+    Path keystorePath = createKeyStoreWithKeyEntry("keystore.jks", "storepass", "keypass");
+
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    configurer.initialize(
+        ImmutableMap.of(
+            BasicTLSConfigurer.TLS_KEYSTORE_PATH, keystorePath.toString(),
+            BasicTLSConfigurer.TLS_KEYSTORE_PASSWORD, "storepass",
+            BasicTLSConfigurer.TLS_KEYSTORE_KEY_PASSWORD, "keypass"));
+
+    assertThat(configurer.sslContext()).isNotNull();
+  }
+
+  @Test
+  public void testBasicTLSConfigurerWithDistinctKeyPasswordMissing() throws Exception {
+    Path keystorePath = createKeyStoreWithKeyEntry("keystore.jks", "storepass", "keypass");
+
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    Map<String, String> properties =
+        ImmutableMap.of(
+            BasicTLSConfigurer.TLS_KEYSTORE_PATH,
+            keystorePath.toString(),
+            BasicTLSConfigurer.TLS_KEYSTORE_PASSWORD,
+            "storepass");
+
+    // without the key password the keystore password is used, which cannot unlock the private key
+    assertThatThrownBy(() -> configurer.initialize(properties))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to create SSL context")
+        .hasRootCauseInstanceOf(UnrecoverableKeyException.class);
+  }
+
+  @Test
+  public void testBasicTLSConfigurerKeyPasswordDefaultsToKeystorePassword() throws Exception {
+    Path keystorePath = createKeyStoreWithKeyEntry("keystore.jks", "samepass", "samepass");
+
+    BasicTLSConfigurer configurer = new BasicTLSConfigurer();
+    configurer.initialize(
+        ImmutableMap.of(
+            BasicTLSConfigurer.TLS_KEYSTORE_PATH,
+            keystorePath.toString(),
+            BasicTLSConfigurer.TLS_KEYSTORE_PASSWORD,
+            "samepass"));
+
+    assertThat(configurer.sslContext()).isNotNull();
+  }
+
+  @Test
   public void testBasicTLSConfigurerWithInvalidKeystorePath() {
     BasicTLSConfigurer configurer = new BasicTLSConfigurer();
     Map<String, String> properties =
@@ -149,6 +210,44 @@ public class TestBasicTLSConfigurer {
     assertThatThrownBy(() -> configurer.initialize(properties))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Keystore file does not exist");
+  }
+
+  /**
+   * Creates a keystore holding a self-signed key entry, where the private key is protected by a
+   * password that may differ from the keystore password.
+   */
+  private Path createKeyStoreWithKeyEntry(String filename, String storePassword, String keyPassword)
+      throws Exception {
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    keyPairGenerator.initialize(2048);
+    KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+    X500Name subject = new X500Name("CN=iceberg-test");
+    Instant now = Instant.now();
+    X509Certificate certificate =
+        new JcaX509CertificateConverter()
+            .getCertificate(
+                new JcaX509v3CertificateBuilder(
+                        subject,
+                        BigInteger.ONE,
+                        Date.from(now),
+                        Date.from(now.plus(1, ChronoUnit.DAYS)),
+                        subject,
+                        keyPair.getPublic())
+                    .build(
+                        new JcaContentSignerBuilder("SHA256withRSA").build(keyPair.getPrivate())));
+
+    KeyStore keyStore = KeyStore.getInstance("JKS");
+    keyStore.load(null, storePassword.toCharArray());
+    keyStore.setKeyEntry(
+        "client", keyPair.getPrivate(), keyPassword.toCharArray(), new Certificate[] {certificate});
+
+    Path keystorePath = tempDir.resolve(filename);
+    try (FileOutputStream fos = new FileOutputStream(keystorePath.toFile())) {
+      keyStore.store(fos, storePassword.toCharArray());
+    }
+
+    return keystorePath;
   }
 
   /** Creates a temporary keystore file for testing purposes. */


### PR DESCRIPTION
This is a follow up to https://github.com/apache/iceberg/pull/13190.

(I have an older PR https://github.com/apache/iceberg/pull/13483 but I don't think I have the rights to reopen)

Implements a `BasicTLSConfigurer` class that provides TLS configuration with custom keystore and truststore support for REST client authentication.

Property-based configuration with support for:
`rest.client.tls.keystore.path`
`rest.client.tls.keystore.password`
`rest.client.tls.keystore.key-password` - (default: the keystore password)
`rest.client.tls.keystore.type` - (default: JKS)
`rest.client.tls.truststore.path`
`rest.client.tls.truststore.password`
`rest.client.tls.truststore.type` - (default: JKS)
`rest.client.tls.protocol` - (default: TLS)
`rest.client.tls.cipher-suites` - comma separated, defaults to the JSSE defaults

If neither a keystore nor a truststore is configured, the default `SSLContext` is used.

### On `rest.client.tls.protocol` and `supportedProtocols()`

An explicitly configured protocol is used for `SSLContext.getInstance` **and** returned from
`supportedProtocols()` as the only enabled protocol.

Passing it to `SSLContext.getInstance` alone is not enough: JSSE treats the context algorithm as a
minimum rather than a pin. On JDK 17, `SSLContext.getInstance("TLSv1.3")` yields a context whose
default enabled protocols are `[TLSv1.3, TLSv1.2]`, so a user asking for TLSv1.3 would silently
still negotiate TLSv1.2. `supportedProtocols()` is what `HTTPClient` hands to
`DefaultClientTlsStrategy` → `SSLSocket.setEnabledProtocols`, so pinning there makes the property
mean what it says.

When the property is unset both `supportedProtocols()` and `supportedCipherSuites()` return null,
which is the interface default and defers to the JSSE defaults.

## Extra notes on the use-case
In environments where the REST catalog requires `mTLS`, `BasicTLSConfigurer` enables setting the client certificate and CA trust explicitly for the Iceberg RestCatalog.
This avoids configuring JVM-wide TLS settings via javaoptions, ensuring that certificates are limited in scope to Iceberg and do not impact other applications running in the same JVM.
