### PR TITLE
Parquet: Fix typo in BaseParquetReaders and BaseParquet…

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -128,7 +128,7 @@ abstract class BaseParquetReaders<T> {
     @Override
     public ParquetValueReader<?> struct(
         Types.StructType expected, GroupType struct, List<ParquetValueReader<?>> fieldReaders) {
-      // the expected struct is ignored because nested fields are never found when the
+      // the expected struct is ignored because nested fields are never found when the ID is missing
       List<ParquetValueReader<?>> newFields =
           Lists.newArrayListWithExpectedSize(fieldReaders.size());
       List<Type> fields = struct.getFields();

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -245,7 +245,7 @@ abstract class BaseParquetWriter<T> {
         LogicalTypeAnnotation.IntLogicalTypeAnnotation intType) {
       Preconditions.checkArgument(
           intType.isSigned() || intType.getBitWidth() < 64,
-          "Cannot read uint64: not a supported Java type");
+          "Cannot write uint64: not a supported Java type");
       if (intType.getBitWidth() < 64) {
         return Optional.of(ParquetValueWriters.ints(desc));
       } else {


### PR DESCRIPTION
Summary
This PR cleans up documentation, fixes typos, and corrects inconsistent error messages in the Parquet data package, specifically within BaseParquetReaders and BaseParquetWriter.

Changes
BaseParquetWriter: Fixed an error message in the visit(IntLogicalTypeAnnotation) method where it incorrectly used "read" instead of "write" when handling uint64.

BaseParquetReaders: Completed an unfinished comment regarding missing nested field IDs and fixed minor typos.