### PR TITLE
Spark 4.1: Introduce constants for Spark metadata columns

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogTable.java
@@ -20,8 +20,6 @@ package org.apache.iceberg.spark.source;
 
 import java.util.Set;
 import org.apache.iceberg.ChangelogUtil;
-import org.apache.iceberg.MetadataColumns;
-import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.spark.SparkSchemaUtil;
@@ -33,8 +31,6 @@ import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
@@ -108,33 +104,12 @@ public class SparkChangelogTable implements Table, SupportsRead, SupportsMetadat
 
   @Override
   public MetadataColumn[] metadataColumns() {
-    DataType sparkPartitionType = SparkSchemaUtil.convert(Partitioning.partitionType(icebergTable));
     return new MetadataColumn[] {
-      SparkMetadataColumn.builder()
-          .name(MetadataColumns.SPEC_ID.name())
-          .dataType(DataTypes.IntegerType)
-          .withNullability(true)
-          .build(),
-      SparkMetadataColumn.builder()
-          .name(MetadataColumns.PARTITION_COLUMN_NAME)
-          .dataType(sparkPartitionType)
-          .withNullability(true)
-          .build(),
-      SparkMetadataColumn.builder()
-          .name(MetadataColumns.FILE_PATH.name())
-          .dataType(DataTypes.StringType)
-          .withNullability(false)
-          .build(),
-      SparkMetadataColumn.builder()
-          .name(MetadataColumns.ROW_POSITION.name())
-          .dataType(DataTypes.LongType)
-          .withNullability(false)
-          .build(),
-      SparkMetadataColumn.builder()
-          .name(MetadataColumns.IS_DELETED.name())
-          .dataType(DataTypes.BooleanType)
-          .withNullability(false)
-          .build(),
+      SparkMetadataColumns.SPEC_ID,
+      SparkMetadataColumns.partition(icebergTable),
+      SparkMetadataColumns.FILE_PATH,
+      SparkMetadataColumns.ROW_POSITION,
+      SparkMetadataColumns.IS_DELETED,
     };
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMetadataColumns.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMetadataColumns.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Partitioning;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.spark.sql.types.DataTypes;
+
+public class SparkMetadataColumns {
+
+  private SparkMetadataColumns() {}
+
+  public static final SparkMetadataColumn SPEC_ID =
+      SparkMetadataColumn.builder()
+          .name(MetadataColumns.SPEC_ID.name())
+          .dataType(DataTypes.IntegerType)
+          .withNullability(true)
+          .build();
+
+  public static final SparkMetadataColumn FILE_PATH =
+      SparkMetadataColumn.builder()
+          .name(MetadataColumns.FILE_PATH.name())
+          .dataType(DataTypes.StringType)
+          .withNullability(false)
+          .build();
+
+  public static final SparkMetadataColumn ROW_POSITION =
+      SparkMetadataColumn.builder()
+          .name(MetadataColumns.ROW_POSITION.name())
+          .dataType(DataTypes.LongType)
+          .withNullability(false)
+          .build();
+
+  public static final SparkMetadataColumn IS_DELETED =
+      SparkMetadataColumn.builder()
+          .name(MetadataColumns.IS_DELETED.name())
+          .dataType(DataTypes.BooleanType)
+          .withNullability(false)
+          .build();
+
+  public static final SparkMetadataColumn ROW_ID =
+      SparkMetadataColumn.builder()
+          .name(MetadataColumns.ROW_ID.name())
+          .dataType(DataTypes.LongType)
+          .withNullability(true)
+          .preserveOnReinsert(true)
+          .preserveOnUpdate(true)
+          .preserveOnDelete(false)
+          .build();
+
+  public static final SparkMetadataColumn LAST_UPDATED_SEQUENCE_NUMBER =
+      SparkMetadataColumn.builder()
+          .name(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.name())
+          .dataType(DataTypes.LongType)
+          .withNullability(true)
+          .preserveOnReinsert(false)
+          .preserveOnUpdate(false)
+          .preserveOnDelete(false)
+          .build();
+
+  public static SparkMetadataColumn partition(Table table) {
+    return SparkMetadataColumn.builder()
+        .name(MetadataColumns.PARTITION_COLUMN_NAME)
+        .dataType(SparkSchemaUtil.convert(Partitioning.partitionType(table)))
+        .withNullability(true)
+        .build();
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.TableProperties.CURRENT_SNAPSHOT_ID;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.BaseMetadataTable;
@@ -31,7 +32,6 @@ import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.PositionDeletesTable;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
@@ -49,10 +49,10 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.Spark3Util;
@@ -78,8 +78,6 @@ import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
 import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
@@ -273,58 +271,20 @@ public class SparkTable
 
   @Override
   public MetadataColumn[] metadataColumns() {
-    DataType sparkPartitionType = SparkSchemaUtil.convert(Partitioning.partitionType(table()));
-    ImmutableList.Builder<SparkMetadataColumn> metadataColumns = ImmutableList.builder();
-    metadataColumns.add(
-        SparkMetadataColumn.builder()
-            .name(MetadataColumns.SPEC_ID.name())
-            .dataType(DataTypes.IntegerType)
-            .withNullability(true)
-            .build(),
-        SparkMetadataColumn.builder()
-            .name(MetadataColumns.PARTITION_COLUMN_NAME)
-            .dataType(sparkPartitionType)
-            .withNullability(true)
-            .build(),
-        SparkMetadataColumn.builder()
-            .name(MetadataColumns.FILE_PATH.name())
-            .dataType(DataTypes.StringType)
-            .withNullability(false)
-            .build(),
-        SparkMetadataColumn.builder()
-            .name(MetadataColumns.ROW_POSITION.name())
-            .dataType(DataTypes.LongType)
-            .withNullability(false)
-            .build(),
-        SparkMetadataColumn.builder()
-            .name(MetadataColumns.IS_DELETED.name())
-            .dataType(DataTypes.BooleanType)
-            .withNullability(false)
-            .build());
+    List<SparkMetadataColumn> cols = Lists.newArrayList();
+
+    cols.add(SparkMetadataColumns.SPEC_ID);
+    cols.add(SparkMetadataColumns.partition(icebergTable));
+    cols.add(SparkMetadataColumns.FILE_PATH);
+    cols.add(SparkMetadataColumns.ROW_POSITION);
+    cols.add(SparkMetadataColumns.IS_DELETED);
 
     if (TableUtil.supportsRowLineage(icebergTable)) {
-      metadataColumns.add(
-          SparkMetadataColumn.builder()
-              .name(MetadataColumns.ROW_ID.name())
-              .dataType(DataTypes.LongType)
-              .withNullability(true)
-              .preserveOnReinsert(true)
-              .preserveOnUpdate(true)
-              .preserveOnDelete(false)
-              .build());
-
-      metadataColumns.add(
-          SparkMetadataColumn.builder()
-              .name(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.name())
-              .dataType(DataTypes.LongType)
-              .withNullability(true)
-              .preserveOnReinsert(false)
-              .preserveOnUpdate(false)
-              .preserveOnDelete(false)
-              .build());
+      cols.add(SparkMetadataColumns.ROW_ID);
+      cols.add(SparkMetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER);
     }
 
-    return metadataColumns.build().toArray(SparkMetadataColumn[]::new);
+    return cols.toArray(SparkMetadataColumn[]::new);
   }
 
   @Override


### PR DESCRIPTION
This PR introduces constants for Spark metadata columns to reduce noise in main classes.