### PR TITLE
Core, REST: Add support for overwrite in RegisterTableRequest

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequest.java
@@ -28,6 +28,11 @@ public interface RegisterTableRequest extends RESTRequest {
 
   String metadataLocation();
 
+  @Value.Default
+  default boolean overwrite() {
+    return false;
+  }
+
   @Override
   default void validate() {
     // nothing to validate as it's not possible to create an invalid instance

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RegisterTableRequestParser.java
@@ -28,6 +28,7 @@ public class RegisterTableRequestParser {
 
   private static final String NAME = "name";
   private static final String METADATA_LOCATION = "metadata-location";
+  private static final String OVERWRITE = "overwrite";
 
   private RegisterTableRequestParser() {}
 
@@ -47,6 +48,10 @@ public class RegisterTableRequestParser {
     gen.writeStringField(NAME, request.name());
     gen.writeStringField(METADATA_LOCATION, request.metadataLocation());
 
+    if (request.overwrite()) {
+      gen.writeBooleanField(OVERWRITE, request.overwrite());
+    }
+
     gen.writeEndObject();
   }
 
@@ -61,9 +66,14 @@ public class RegisterTableRequestParser {
     String name = JsonUtil.getString(NAME, json);
     String metadataLocation = JsonUtil.getString(METADATA_LOCATION, json);
 
-    return ImmutableRegisterTableRequest.builder()
-        .name(name)
-        .metadataLocation(metadataLocation)
-        .build();
+    ImmutableRegisterTableRequest.Builder builder =
+        ImmutableRegisterTableRequest.builder().name(name).metadataLocation(metadataLocation);
+
+    Boolean overwrite = JsonUtil.getBoolOrNull(OVERWRITE, json);
+    if (overwrite != null) {
+      builder.overwrite(overwrite);
+    }
+
+    return builder.build();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestRegisterTableRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestRegisterTableRequestParser.java
@@ -76,4 +76,28 @@ public class TestRegisterTableRequestParser {
     assertThat(RegisterTableRequestParser.toJson(RegisterTableRequestParser.fromJson(json), true))
         .isEqualTo(expectedJson);
   }
+
+  @Test
+  public void roundTripSerdeWithOverwrite() {
+    RegisterTableRequest request =
+        ImmutableRegisterTableRequest.builder()
+            .name("table_1")
+            .metadataLocation(
+                "file://tmp/NS/test_tbl/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json")
+            .overwrite(true)
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"name\" : \"table_1\",\n"
+            + "  \"metadata-location\" : \"file://tmp/NS/test_tbl/metadata/00000-d4f60d2f-2ad2-408b-8832-0ed7fbd851ee.metadata.json\",\n"
+            + "  \"overwrite\" : true\n"
+            + "}";
+
+    String json = RegisterTableRequestParser.toJson(request, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    assertThat(RegisterTableRequestParser.toJson(RegisterTableRequestParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
 }


### PR DESCRIPTION
The "overwrite" parameter was added in #12239 to the REST spec and the Python client, but the Java `RegisterTableRequest` wasn't updated accordingly.