### PR TITLE
Core: Remove deprecation from ViewProperties.WRITE_METADATA_LOCATION

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
@@ -26,10 +26,7 @@ public class ViewProperties {
   public static final String METADATA_COMPRESSION = "write.metadata.compression-codec";
   public static final String METADATA_COMPRESSION_DEFAULT = "gzip";
 
-  /**
-   * @deprecated will be removed in 2.0.0, use {@link ViewBuilder#withLocation} instead.
-   */
-  @Deprecated public static final String WRITE_METADATA_LOCATION = "write.metadata.path";
+  public static final String WRITE_METADATA_LOCATION = "write.metadata.path";
 
   public static final String COMMENT = "comment";
   public static final String REPLACE_DROP_DIALECT_ALLOWED = "replace.drop-dialect.allowed";


### PR DESCRIPTION
The purpose of this setting is to have full control on where to put view metadata. E.g. to avoid using a metadata/ subfolder in the path.

dev@ conversation: https://lists.apache.org/thread/sysw46kvhl3wgoh7jn1m3bmwln1gn8kp