### PR TITLE
Build: Remove JDK17 target configuration for Spark 4.1

### DIFF
--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -51,14 +51,6 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
   apply plugin: 'scala'
   apply plugin: 'com.github.alisiikh.scalastyle'
 
-  // Set target to JDK17 for Spark 4.1 to fix following error
-  // "spark/v4.1/spark/src/main/scala/org/apache/spark/sql/stats/ThetaSketchAgg.scala:52:12: Class java.lang.Record not found"
-  tasks.withType(ScalaCompile.class) {
-    sourceCompatibility = "17"
-    targetCompatibility = "17"
-    scalaCompileOptions.additionalParameters.add("-release:17")
-  }
-
   sourceSets {
     main {
       scala.srcDirs = ['src/main/scala', 'src/main/java']


### PR DESCRIPTION
This hack is no longer needed after dropping JDK11.