### PR TITLE
Fix(site): improve homepage responsiveness on smaller screens

### DIFF
--- a/site/docs/assets/stylesheets/extra.css
+++ b/site/docs/assets/stylesheets/extra.css
@@ -34,6 +34,10 @@
   z-index: 3;
 }
 
+.md-social__link{
+  height: auto;
+}
+
 /*hero*/
 .mdx-container {
   text-align: center;
@@ -448,3 +452,111 @@ p {
 .footer-icons img {
   max-width: 100%;
 }
+
+@media (max-width: 992px) {
+  .footer-links {
+    text-align: center;
+  }
+  
+  .footer-icons {
+    margin-top: 2rem;
+    text-align: center;
+  }
+  
+  .footer-icons img {
+    display: block;
+    margin: 0 auto;
+  }
+  
+  .footer-icons .d-flex {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 576px) {
+  #footer h4 {
+    font-size: 18px;
+    margin-bottom: 0.5rem;
+  }
+  
+  .footer-links {
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .mdx-container {
+    height: auto;
+    padding: 3rem 1rem;
+  }
+
+  .intro-message {
+    padding-top: 0;
+  }
+
+  .intro-message h1 {
+    font-size: 3rem;
+    line-height: 1.2;
+  }
+
+  .intro-message h3 {
+    font-size: 1.1rem;
+  }
+
+  .intro-divider {
+    width: 100%;
+  }
+
+  .content-section-a,
+  .content-section-b {
+    margin-top: 2.5rem;
+    margin-bottom: 2.5rem;
+  }
+
+  .section-heading {
+    float: none;
+    font-size: 24px;
+  }
+
+  .btn,
+  .btn-lg {
+    font-size: 14px;
+    padding: 0.6rem 1rem;
+  }
+
+  #termynal,
+  #termynal-expressive-sql,
+  #termynal-time-travel,
+  #termynal-data-compaction {
+    width: 100% !important;
+    max-width: 100%;
+  }
+
+  .termynal,
+  [data-termynal] {
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  lottie-player {
+    width: 100% !important;
+    max-width: 280px;
+    height: auto;
+    margin: 0 auto;
+  }
+
+  .footer-links,
+  .footer-icons {
+    text-align: center;
+  }
+
+  .footer-icons {
+    margin-top: 2rem;
+  }
+  .md-tabs__list {
+    justify-content: flex-start;
+    text-align: left;
+    padding-left: 0.5rem;
+  }
+}
+

--- a/site/overrides/home.html
+++ b/site/overrides/home.html
@@ -317,7 +317,7 @@
               data-ty-linedelay="500"
               style="width: 445px; min-height: 192.7px">
   
-              <span data-ty="input" data-ty-prompt="sql>">CALL system.rewrite_data_files("nyc.taxis");
+              <span data-ty="input" data-ty-prompt="sql>" style="word-wrap: break-word;">CALL system.rewrite_data_files("nyc.taxis");
               </span>
   
             </div>

--- a/site/overrides/partials/footer.html
+++ b/site/overrides/partials/footer.html
@@ -1,9 +1,9 @@
 <footer id="footer" class="footer">
   <div class="container-fluid footer-top">
-    <div class="d-flex justify-content-center pt-3 pb-3" >
+    <div class="row justify-content-center pt-3 pb-3" >
       
 
-      <div class="col-lg-2 col-md-2 footer-links">
+      <div class="col-lg-2 col-md-3 col-sm-6 col-12 footer-links mb-4 mb-lg-0">
         <h4>Features</h4>
         <ul>
           <li>
@@ -45,7 +45,7 @@
         </ul>
       </div>
 
-      <div class="col-lg-2 col-md-2 footer-links">
+      <div class="col-lg-2 col-md-3 col-sm-6 col-12 footer-links mb-4 mb-lg-0">
         <h4>Get Started</h4>
         <ul>
           <li><a href="/spark-quickstart">Spark Quickstart</a></li>
@@ -58,7 +58,7 @@
         <br />
       </div>
 
-      <div class="col-lg-2 col-md-2 footer-links">
+      <div class="col-lg-2 col-md-3 col-sm-6 col-12 footer-links mb-4 mb-lg-0">
         <h4>Community</h4>
         <ul>
           <li><a href="/community/#slack">Support</a></li>
@@ -73,7 +73,7 @@
         </ul>
       </div>
 
-      <div class="col-lg-2 col-md-2 footer-links">
+      <div class="col-lg-2 col-md-3 col-sm-6 col-12 footer-links mb-4 mb-lg-0">
         <h4>ASF</h4>
         <ul>
           <li>
@@ -92,14 +92,14 @@
         </ul>
       </div>
 
-      <div class="col-lg-2 col-md-2 mt-3 footer-icons">
+      <div class="col-lg-2 col-md-12 col-sm-12 col-12 mt-3 footer-icons text-center">
        
         <a href="https://iceberg.apache.org"
           ><img
             src="/assets/images/asf-estd-1999-logo.png"
             alt="apache software foundation logo"
         /></a>
-        <div class="d-flex justify-content-center">
+        <div class="d-flex justify-content-center mt-3">
           <div class="social-links d-flex ">
             {% if config.extra.social %} {% include "partials/social.html" %} {%
             endif %}
@@ -114,7 +114,7 @@
 
   <div class="container-fluid ">
     <div class="d-flex justify-content-center ">
-      <div class="col-md-8">
+      <div class="col-md-10 col-12">
         <p class="copyright-text m-4">
           Apache Iceberg, Iceberg, Apache, the Apache feather logo, and the
           Apache Iceberg project logo are either registered trademarks or


### PR DESCRIPTION
## Problem
- Footer columns were not stacking properly on smaller screens
- Hero section social buttons were getting overflowed
- Header social icons were not centred 
- Navigation tabs was not showing from the first link in smaller screens

## Changes
- made the footer responsive for smaller screens.
- made the header social icons centred
- navigation tabs now starts from first link on smaller screens
- fixed the overflow issue of button in hero section
- added word wrap to terminal text to prevent overflow

## Screenshots
|Before|After|
|-------|------|
|<img width="476" height="126" alt="Screenshot 2026-02-08 164444" src="https://github.com/user-attachments/assets/12c03d8e-7d7d-4d6e-9077-36dab74edb95" />|<img width="478" height="121" alt="Screenshot 2026-02-08 164453" src="https://github.com/user-attachments/assets/fc8700f8-f8da-43b0-9790-f0fe8e7695a4" />|
|<img width="534" height="452" alt="Screenshot 2026-02-08 164526" src="https://github.com/user-attachments/assets/ffa557ea-6559-4f45-8cfa-09b44c8ee7b2" />|<img width="530" height="600" alt="Screenshot 2026-02-08 164544" src="https://github.com/user-attachments/assets/33bb2471-38cf-404e-a7da-a4ba2e77b6a5" />|
|<img width="828" height="684" alt="Screenshot 2026-02-08 164024" src="https://github.com/user-attachments/assets/5c786f3c-87a7-486c-b213-72662fd9dad8" />|<img width="623" height="710" alt="Screenshot 2026-02-08 164301" src="https://github.com/user-attachments/assets/97189a93-26d3-4045-9e0f-859192d06618" />|
|<img width="396" height="575" alt="Screenshot 2026-02-08 170939" src="https://github.com/user-attachments/assets/1d02161c-ebeb-4ee0-b160-22e622bff716" />|<img width="396" height="426" alt="Screenshot 2026-02-08 170911" src="https://github.com/user-attachments/assets/07eeb8c6-9dec-475a-9a4a-a3567f45f679" />|