### PR TITLE
[Docs] Add V3 types to schemas.md

### DIFF
--- a/docs/docs/schemas.md
+++ b/docs/docs/schemas.md
@@ -34,9 +34,16 @@ Iceberg tables support the following types:
 | **`time`**         | Time of day without date, timezone                                       | Stored as microseconds                           |
 | **`timestamp`**    | Timestamp without timezone                                               | Stored as microseconds                           |
 | **`timestamptz`**  | Timestamp with timezone                                                  | Stored as microseconds                           |
+| **`timestamp_ns`** | Timestamp without timezone                                               | Stored as nanoseconds                            |
+| **`timestamptz_ns`**| Timestamp with timezone                                                  | Stored as nanoseconds                            |
 | **`string`**       | Arbitrary-length character sequences                                     | Encoded with UTF-8                               |
+| **`uuid`**         | Universally unique identifier                                            | Stored as 16-byte fixed                          |
 | **`fixed(L)`**     | Fixed-length byte array of length L                                      |                                                  |
 | **`binary`**       | Arbitrary-length byte array                                              |                                                  |
+| **`unknown`**      | Unknown type                                                             |                                                  |
+| **`variant`**      | Semi-structured data                                                     |                                                  |
+| **`geometry`**     | Geometry data                                                            |                                                  |
+| **`geography`**    | Geography data                                                           |                                                  |
 | **`struct<...>`**  | A record with named fields of any data type                              |                                                  |
 | **`list<E>`**      | A list with elements of any data type                                    |                                                  |
 | **`map<K, V>`**    | A map with keys and values of any data type                              |                                                  |


### PR DESCRIPTION
Added documentation for new V3 types (timestamp_ns, timestamptz_ns, variant, geometry, geography) as per issue #14874.