### PR TITLE
Flink: Fix unclosed instance of File.IO from S3/RestCatalog

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.flink.sink.dynamic;
 
 import java.io.Closeable;
-import java.io.IOException;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.RichMapFunction;
@@ -108,8 +107,8 @@ class DynamicTableUpdateOperator
   @Override
   public void close() throws Exception {
     super.close();
-    if (catalog instanceof Closeable) {
-      ((Closeable) catalog).close();
+    if (catalog instanceof Closeable rc) {
+      rc.close();
     }
   }
 }


### PR DESCRIPTION
I'm still testing it; I don't believe it's the definitive solution.