### PR TITLE
Spark 4.1: Simplify description and toString in scans

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -3014,7 +3014,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
           assertThat(planAsString)
               .as("Pushed filters must match")
-              .contains("filters=" + icebergFilters + ",");
+              .contains(", filters=" + icebergFilters + ",");
         });
   }
 

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -3014,7 +3014,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
           assertThat(planAsString)
               .as("Pushed filters must match")
-              .contains("[filters=" + icebergFilters + ",");
+              .contains("filters=" + icebergFilters + ",");
         });
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -255,8 +255,8 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
     return table().name().equals(that.table().name())
         && Objects.equals(branch(), that.branch())
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field ids
-        && filterExpressions().toString().equals(that.filterExpressions().toString())
-        && runtimeFilterExpressions.toString().equals(that.runtimeFilterExpressions.toString())
+        && filtersDesc().equals(that.filtersDesc())
+        && runtimeFiltersDesc().equals(that.runtimeFiltersDesc())
         && Objects.equals(snapshotId, that.snapshotId)
         && Objects.equals(startSnapshotId, that.startSnapshotId)
         && Objects.equals(endSnapshotId, that.endSnapshotId)
@@ -270,8 +270,8 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
         table().name(),
         branch(),
         readSchema(),
-        filterExpressions().toString(),
-        runtimeFilterExpressions.toString(),
+        filtersDesc(),
+        runtimeFiltersDesc(),
         snapshotId,
         startSnapshotId,
         endSnapshotId,
@@ -280,14 +280,13 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
-  public String toString() {
+  public String description() {
     return String.format(
-        "IcebergScan(table=%s, branch=%s, type=%s, filters=%s, runtimeFilters=%s, caseSensitive=%s)",
-        table(),
-        branch(),
-        expectedSchema().asStruct(),
-        filterExpressions(),
-        runtimeFilterExpressions,
-        caseSensitive());
+        "IcebergScan(table=%s, branch=%s, filters=%s, runtimeFilters=%s, groupedBy=%s)",
+        table(), branch(), filtersDesc(), runtimeFiltersDesc(), groupingKeyDesc());
+  }
+
+  private String runtimeFiltersDesc() {
+    return Spark3Util.describe(runtimeFilterExpressions);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -280,7 +280,7 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
-  public String toString() {
+  public String description() {
     return String.format(
         "IcebergScan(table=%s, branch=%s, filters=%s, runtimeFilters=%s, groupedBy=%s)",
         table(), branch(), filtersDesc(), runtimeFiltersDesc(), groupingKeyDesc());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -280,7 +280,7 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   }
 
   @Override
-  public String description() {
+  public String toString() {
     return String.format(
         "IcebergScan(table=%s, branch=%s, filters=%s, runtimeFilters=%s, groupedBy=%s)",
         table(), branch(), filtersDesc(), runtimeFiltersDesc(), groupingKeyDesc());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -126,7 +126,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
   }
 
   @Override
-  public String toString() {
+  public String description() {
     return String.format(
         Locale.ROOT,
         "IcebergChangelogScan(table=%s, fromSnapshotId=%d, toSnapshotId=%d, filters=%s)",

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -126,7 +126,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
   }
 
   @Override
-  public String description() {
+  public String toString() {
     return String.format(
         Locale.ROOT,
         "IcebergChangelogScan(table=%s, fromSnapshotId=%d, toSnapshotId=%d, filters=%s)",

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -129,23 +129,11 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
   public String description() {
     return String.format(
         Locale.ROOT,
-        "%s [fromSnapshotId=%d, toSnapshotId=%d, filters=%s]",
+        "IcebergChangelogScan(table=%s, fromSnapshotId=%d, toSnapshotId=%d, filters=%s)",
         table,
         startSnapshotId,
         endSnapshotId,
-        Spark3Util.describe(filters));
-  }
-
-  @Override
-  public String toString() {
-    return String.format(
-        Locale.ROOT,
-        "IcebergChangelogScan(table=%s, type=%s, fromSnapshotId=%d, toSnapshotId=%d, filters=%s)",
-        table,
-        expectedSchema.asStruct(),
-        startSnapshotId,
-        endSnapshotId,
-        Spark3Util.describe(filters));
+        filtersDesc());
   }
 
   @Override
@@ -161,14 +149,17 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
     SparkChangelogScan that = (SparkChangelogScan) o;
     return table.name().equals(that.table.name())
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field IDs
-        && filters.toString().equals(that.filters.toString())
+        && filtersDesc().equals(that.filtersDesc())
         && Objects.equals(startSnapshotId, that.startSnapshotId)
         && Objects.equals(endSnapshotId, that.endSnapshotId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-        table.name(), readSchema(), filters.toString(), startSnapshotId, endSnapshotId);
+    return Objects.hash(table.name(), readSchema(), filtersDesc(), startSnapshotId, endSnapshotId);
+  }
+
+  private String filtersDesc() {
+    return Spark3Util.describe(filters);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -174,7 +174,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
   }
 
   @Override
-  public String toString() {
+  public String description() {
     return String.format(
         "IcebergCopyOnWriteScan(table=%s, filters=%s, groupedBy=%s)",
         table(), filtersDesc(), groupingKeyDesc());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -174,7 +174,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
   }
 
   @Override
-  public String description() {
+  public String toString() {
     return String.format(
         "IcebergCopyOnWriteScan(table=%s, filters=%s, groupedBy=%s)",
         table(), filtersDesc(), groupingKeyDesc());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -162,7 +162,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
     SparkCopyOnWriteScan that = (SparkCopyOnWriteScan) o;
     return table().name().equals(that.table().name())
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field ids
-        && filterExpressions().toString().equals(that.filterExpressions().toString())
+        && filtersDesc().equals(that.filtersDesc())
         && Objects.equals(snapshotId(), that.snapshotId())
         && Objects.equals(filteredLocations, that.filteredLocations);
   }
@@ -170,18 +170,14 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
   @Override
   public int hashCode() {
     return Objects.hash(
-        table().name(),
-        readSchema(),
-        filterExpressions().toString(),
-        snapshotId(),
-        filteredLocations);
+        table().name(), readSchema(), filtersDesc(), snapshotId(), filteredLocations);
   }
 
   @Override
-  public String toString() {
+  public String description() {
     return String.format(
-        "IcebergCopyOnWriteScan(table=%s, type=%s, filters=%s, caseSensitive=%s)",
-        table(), expectedSchema().asStruct(), filterExpressions(), caseSensitive());
+        "IcebergCopyOnWriteScan(table=%s, filters=%s, groupedBy=%s)",
+        table(), filtersDesc(), groupingKeyDesc());
   }
 
   private Long currentSnapshotId() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkLocalScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkLocalScan.java
@@ -52,13 +52,8 @@ class SparkLocalScan implements LocalScan {
   }
 
   @Override
-  public String description() {
+  public String toString() {
     String filtersDesc = Spark3Util.describe(filterExpressions);
     return String.format("IcebergLocalScan(table=%s, filters=%s)", table, filtersDesc);
-  }
-
-  @Override
-  public String toString() {
-    return description();
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkLocalScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkLocalScan.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.spark.Spark3Util;
-import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.LocalScan;
 import org.apache.spark.sql.types.StructType;
@@ -54,13 +53,12 @@ class SparkLocalScan implements LocalScan {
 
   @Override
   public String description() {
-    return String.format("%s [filters=%s]", table, Spark3Util.describe(filterExpressions));
+    String filtersDesc = Spark3Util.describe(filterExpressions);
+    return String.format("IcebergLocalScan(table=%s, filters=%s)", table, filtersDesc);
   }
 
   @Override
   public String toString() {
-    return String.format(
-        "IcebergLocalScan(table=%s, type=%s, filters=%s)",
-        table, SparkSchemaUtil.convert(readSchema).asStruct(), filterExpressions);
+    return description();
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkLocalScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkLocalScan.java
@@ -52,8 +52,13 @@ class SparkLocalScan implements LocalScan {
   }
 
   @Override
-  public String toString() {
+  public String description() {
     String filtersDesc = Spark3Util.describe(filterExpressions);
     return String.format("IcebergLocalScan(table=%s, filters=%s)", table, filtersDesc);
+  }
+
+  @Override
+  public String toString() {
+    return description();
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -250,4 +250,10 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
 
     return keys;
   }
+
+  protected String groupingKeyDesc() {
+    return groupingKeyType().fields().stream()
+        .map(org.apache.iceberg.types.Types.NestedField::name)
+        .collect(Collectors.joining(", "));
+  }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.StructLikeSet;
@@ -253,7 +254,7 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
 
   protected String groupingKeyDesc() {
     return groupingKeyType().fields().stream()
-        .map(org.apache.iceberg.types.Types.NestedField::name)
+        .map(NestedField::name)
         .collect(Collectors.joining(", "));
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -153,6 +153,10 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     return filterExpressions;
   }
 
+  protected String filtersDesc() {
+    return Spark3Util.describe(filterExpressions);
+  }
+
   protected Types.StructType groupingKeyType() {
     return Types.StructType.of();
   }
@@ -257,15 +261,8 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   }
 
   @Override
-  public String description() {
-    String groupingKeyFieldNamesAsString =
-        groupingKeyType().fields().stream()
-            .map(Types.NestedField::name)
-            .collect(Collectors.joining(", "));
-
-    return String.format(
-        "%s (branch=%s) [filters=%s, groupedBy=%s]",
-        table(), branch(), Spark3Util.describe(filterExpressions), groupingKeyFieldNamesAsString);
+  public String toString() {
+    return description();
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -261,6 +261,11 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   }
 
   @Override
+  public String toString() {
+    return description();
+  }
+
+  @Override
   public CustomTaskMetric[] reportDriverMetrics() {
     ScanReport scanReport = scanReportSupplier != null ? scanReportSupplier.get() : null;
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -261,11 +261,6 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   }
 
   @Override
-  public String toString() {
-    return description();
-  }
-
-  @Override
   public CustomTaskMetric[] reportDriverMetrics() {
     ScanReport scanReport = scanReportSupplier != null ? scanReportSupplier.get() : null;
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
@@ -90,7 +90,7 @@ class SparkStagedScan extends SparkScan {
   }
 
   @Override
-  public String toString() {
+  public String description() {
     return String.format("IcebergStagedScan(table=%s, taskSetID=%s)", table(), taskSetId);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
@@ -90,7 +90,7 @@ class SparkStagedScan extends SparkScan {
   }
 
   @Override
-  public String description() {
+  public String toString() {
     return String.format("IcebergStagedScan(table=%s, taskSetID=%s)", table(), taskSetId);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
@@ -86,13 +86,11 @@ class SparkStagedScan extends SparkScan {
   @Override
   public int hashCode() {
     return Objects.hash(
-        table().name(), taskSetId, readSchema(), splitSize, splitSize, openFileCost);
+        table().name(), taskSetId, readSchema(), splitSize, splitLookback, openFileCost);
   }
 
   @Override
-  public String toString() {
-    return String.format(
-        "IcebergStagedScan(table=%s, type=%s, taskSetID=%s, caseSensitive=%s)",
-        table(), expectedSchema().asStruct(), taskSetId, caseSensitive());
+  public String description() {
+    return String.format("IcebergStagedScan(table=%s, taskSetID=%s)", table(), taskSetId);
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
@@ -676,7 +676,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     assertThat(planAsString)
         .as("Pushed filters must match")
-        .contains("[filters=" + icebergFilters + ",");
+        .contains("filters=" + icebergFilters + ",");
   }
 
   private Timestamp timestamp(String timestampAsString) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
@@ -676,7 +676,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     assertThat(planAsString)
         .as("Pushed filters must match")
-        .contains("filters=" + icebergFilters + ",");
+        .contains(", filters=" + icebergFilters + ",");
   }
 
   private Timestamp timestamp(String timestampAsString) {


### PR DESCRIPTION
This PR contains a subset of changes for #15240 that moves around some scan objects.

A few notable changes:
- Standardize on `description()` that is actually used in Spark plans. No need for almost identical unused `toString()`. 
- No need to include the schema as it is already supplied by Spark. [See](https://github.com/apache/spark/blob/3cf6e6b1020ec8a1462fdc036c3b5f7f7a6cc50e/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java#L63) Javadoc.
- No need to include useless info like case sensitivity.