### PR TITLE
API: Implement properties method in EncryptingFileIO

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -149,6 +149,11 @@ public class EncryptingFileIO implements FileIO, Serializable {
   }
 
   @Override
+  public Map<String, String> properties() {
+    return io.properties();
+  }
+
+  @Override
   public void close() {
     io.close();
 

--- a/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
+++ b/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import java.util.Map;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.SupportsPrefixOperations;
@@ -64,5 +65,15 @@ public class TestEncryptingFileIO {
 
     fileIO.deletePrefix(prefix);
     verify(delegate).deletePrefix(prefix);
+  }
+
+  @Test
+  public void properties() {
+    EncryptionManager em = mock(EncryptionManager.class);
+    FileIO io = mock(FileIO.class);
+    when(io.properties()).thenReturn(Map.of("key", "value"));
+
+    assertThat(EncryptingFileIO.combine(io, em).properties())
+        .containsExactly(Map.entry("key", "value"));
   }
 }


### PR DESCRIPTION
I suppose this is an oversight.

If we omit the override, it may cause an exception once we add support for table encryption in Trino/Starburst because of [ForwardingFileIo](https://github.com/trinodb/trino/blob/master/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java).