### PR TITLE
Build: Remove unused jackson versions in libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ immutables-value = "2.12.1"
 jackson-annotations = "2.21"
 jackson-bom = "2.21.0"
 jackson214 = { strictly = "2.14.2"}
-jackson215 = { strictly = "2.15.2"}
+jackson215 = { strictly = "2.15.2"} # see rich version usage explanation above
 jakarta-el-api = "3.0.3"
 jakarta-servlet-api = "6.1.0"
 jaxb-api = "2.3.1"


### PR DESCRIPTION
This PR removes unused Jackson version aliases (jackson211, jackson212, jackson213) and their BOM entries from gradle/libs.versions.toml.

These versions and BOMs were not referenced anywhere in the project.

Verification:
- ./gradlew help --no-daemon

Closes #15294