### PR TITLE
BigQuery: Add retry detection for idempotent commit handling

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClient.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClient.java
@@ -27,6 +27,7 @@ import com.google.api.services.bigquery.model.TableReference;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.gcp.bigquery.util.RetryDetector;
 
 /**
  * A client of Google BigQuery Metastore functions over the BigQuery service. Uses the Google
@@ -95,6 +96,14 @@ interface BigQueryMetastoreClient {
   Table create(Table table);
 
   /**
+   * Creates and returns a new table.
+   *
+   * @param table body of the table to create
+   * @param retryDetector detector to determine if a retry is needed
+   */
+  Table create(Table table, RetryDetector retryDetector);
+
+  /**
    * Returns a table.
    *
    * @param tableReference full table reference
@@ -108,6 +117,15 @@ interface BigQueryMetastoreClient {
    * @param table to patch
    */
   Table update(TableReference tableReference, Table table);
+
+  /**
+   * Updates the catalog table options of an Iceberg table and returns the updated table.
+   *
+   * @param tableReference full table reference
+   * @param table to patch
+   * @param retryDetector detector to determine if a retry is needed
+   */
+  Table update(TableReference tableReference, Table table, RetryDetector retryDetector);
 
   /**
    * Deletes a table.

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClient.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClient.java
@@ -99,7 +99,7 @@ interface BigQueryMetastoreClient {
    * Creates and returns a new table.
    *
    * @param table body of the table to create
-   * @param retryDetector detector to determine if a retry is needed
+   * @param retryDetector detector to track if retries occurred during the operation
    */
   Table create(Table table, RetryDetector retryDetector);
 
@@ -123,7 +123,7 @@ interface BigQueryMetastoreClient {
    *
    * @param tableReference full table reference
    * @param table to patch
-   * @param retryDetector detector to determine if a retry is needed
+   * @param retryDetector detector to track if retries occurred during the operation
    */
   Table update(TableReference tableReference, Table table, RetryDetector retryDetector);
 

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
@@ -22,7 +22,6 @@ import com.google.api.services.bigquery.model.ExternalCatalogTableOptions;
 import com.google.api.services.bigquery.model.Table;
 import com.google.api.services.bigquery.model.TableReference;
 import java.util.Map;
-import org.apache.iceberg.BaseMetastoreOperations;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.TableMetadata;
@@ -31,8 +30,11 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.gcp.bigquery.util.RetryDetector;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.slf4j.Logger;
@@ -82,48 +84,45 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
   // atomically
   @Override
   public void doCommit(TableMetadata base, TableMetadata metadata) {
-    String newMetadataLocation =
-        base == null && metadata.metadataFileLocation() != null
-            ? metadata.metadataFileLocation()
-            : writeNewMetadata(metadata, currentVersion() + 1);
-    BaseMetastoreOperations.CommitStatus commitStatus =
-        BaseMetastoreOperations.CommitStatus.FAILURE;
+    CommitStatus commitStatus = CommitStatus.FAILURE;
+    RetryDetector retryDetector = new RetryDetector();
+
+    String newMetadataLocation = null;
     try {
-      if (base == null) {
-        createTable(newMetadataLocation, metadata);
+      boolean newTable = base == null;
+      newMetadataLocation = writeNewMetadataIfRequired(newTable, metadata);
+
+      if (newTable) {
+        createTable(newMetadataLocation, metadata, retryDetector);
       } else {
-        updateTable(newMetadataLocation, metadata);
+        updateTable(newMetadataLocation, metadata, retryDetector);
       }
-      commitStatus = BaseMetastoreOperations.CommitStatus.SUCCESS;
-    } catch (CommitFailedException | CommitStateUnknownException e) {
+      commitStatus = CommitStatus.SUCCESS;
+    } catch (CommitFailedException | AlreadyExistsException e) {
       throw e;
     } catch (Throwable e) {
       LOG.error("Exception thrown on commit: ", e);
-      if (e instanceof AlreadyExistsException) {
-        throw e;
+      boolean isRuntimeIOException = e instanceof RuntimeIOException;
+
+      // If retries occurred, an earlier attempt may have succeeded. If we got a
+      // RuntimeIOException, we have no way of knowing if the request reached the server.
+      // In either case, check whether the commit actually succeeded.
+      if (isRuntimeIOException || retryDetector.retried()) {
+        LOG.warn(
+            "Received unexpected failure when committing to {}, validating if commit ended up succeeding.",
+            tableName(),
+            e);
+        commitStatus = checkCommitStatus(newMetadataLocation, metadata);
       }
-      commitStatus =
-          BaseMetastoreOperations.CommitStatus.valueOf(
-              checkCommitStatus(newMetadataLocation, metadata).name());
-      if (commitStatus == BaseMetastoreOperations.CommitStatus.FAILURE) {
+
+      if (commitStatus == CommitStatus.FAILURE) {
         throw new CommitFailedException(e, "Failed to commit");
       }
-      if (commitStatus == BaseMetastoreOperations.CommitStatus.UNKNOWN) {
+      if (commitStatus == CommitStatus.UNKNOWN) {
         throw new CommitStateUnknownException(e);
       }
     } finally {
-      try {
-        if (commitStatus == BaseMetastoreOperations.CommitStatus.FAILURE) {
-          LOG.warn("Failed to commit updates to table {}", tableName());
-          io().deleteFile(newMetadataLocation);
-        }
-      } catch (RuntimeException e) {
-        LOG.error(
-            "Failed to cleanup metadata file at {} for table {}",
-            newMetadataLocation,
-            tableName(),
-            e);
-      }
+      cleanupMetadata(commitStatus, newMetadataLocation);
     }
   }
 
@@ -137,13 +136,14 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
     return fileIO;
   }
 
-  private void createTable(String newMetadataLocation, TableMetadata metadata) {
+  private void createTable(
+      String newMetadataLocation, TableMetadata metadata, RetryDetector retryDetector) {
     LOG.debug("Creating a new Iceberg table: {}", tableName());
     Table tableBuilder = makeNewTable(metadata, newMetadataLocation);
     tableBuilder.setTableReference(tableReference);
     addConnectionIfProvided(tableBuilder, metadata.properties());
 
-    client.create(tableBuilder);
+    client.create(tableBuilder, retryDetector);
   }
 
   private void addConnectionIfProvided(Table tableBuilder, Map<String, String> metadataProperties) {
@@ -155,7 +155,8 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
   }
 
   /** Update table properties with concurrent update detection using etag. */
-  private void updateTable(String newMetadataLocation, TableMetadata metadata) {
+  private void updateTable(
+      String newMetadataLocation, TableMetadata metadata, RetryDetector retryDetector) {
     Preconditions.checkState(
         metastoreTable != null,
         "Table %s must be loaded during refresh before commit",
@@ -171,7 +172,7 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
     addConnectionIfProvided(metastoreTable, metadata.properties());
 
     options.setParameters(buildTableParameters(newMetadataLocation, metadata));
-    client.update(tableReference, metastoreTable);
+    client.update(tableReference, metastoreTable, retryDetector);
     this.metastoreTable = null;
   }
 
@@ -240,5 +241,20 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
     }
 
     return tableOptions.getParameters().get(METADATA_LOCATION_PROP);
+  }
+
+  @VisibleForTesting
+  void cleanupMetadata(CommitStatus commitStatus, String metadataLocation) {
+    try {
+      if (commitStatus == CommitStatus.FAILURE
+          && metadataLocation != null
+          && !metadataLocation.isEmpty()) {
+        // if anything went wrong, clean up the uncommitted metadata file
+        io().deleteFile(metadataLocation);
+      }
+    } catch (RuntimeException e) {
+      LOG.error(
+          "Failed to cleanup metadata file at {} for table {}", metadataLocation, tableName(), e);
+    }
   }
 }

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
@@ -108,7 +108,7 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
       // If retries occurred, an earlier attempt may have succeeded. If we got a
       // RuntimeIOException, we have no way of knowing if the request reached the server.
       // In either case, check whether the commit actually succeeded.
-      if (isRuntimeIOException || retryDetector.retried()) {
+      if ((isRuntimeIOException || retryDetector.retried()) && newMetadataLocation != null) {
         LOG.warn(
             "Received unexpected failure when committing to {}, validating if commit ended up succeeding.",
             tableName(),

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryTableOperations.java
@@ -99,7 +99,7 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
       }
       commitStatus = CommitStatus.SUCCESS;
     } catch (CommitFailedException e) {
-      throw e;
+      commitStatus = handleCommitFailure(e, newMetadataLocation, metadata, retryDetector);
     } catch (Throwable e) {
       LOG.error("Exception thrown on commit: ", e);
       boolean isAlreadyExistsException = e instanceof AlreadyExistsException;
@@ -260,5 +260,26 @@ final class BigQueryTableOperations extends BaseMetastoreTableOperations {
       LOG.error(
           "Failed to cleanup metadata file at {} for table {}", metadataLocation, tableName(), e);
     }
+  }
+
+  private CommitStatus handleCommitFailure(
+      CommitFailedException exception,
+      String newMetadataLocation,
+      TableMetadata metadata,
+      RetryDetector retryDetector) {
+    // A retry may have hit 412 Precondition Failed because the first attempt already
+    // succeeded and bumped the etag. Verify before reporting failure.
+    if (retryDetector.retried() && newMetadataLocation != null) {
+      LOG.warn(
+          "Commit to {} failed after retries, validating if an earlier attempt succeeded.",
+          tableName(),
+          exception);
+      CommitStatus status = checkCommitStatus(newMetadataLocation, metadata);
+      if (status != CommitStatus.SUCCESS) {
+        throw exception;
+      }
+      return status;
+    }
+    throw exception;
   }
 }

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/util/RetryDetector.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/util/RetryDetector.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.bigquery.util;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Detects retries by counting callable invocations. */
+public class RetryDetector {
+  private final AtomicInteger attempts = new AtomicInteger(0);
+
+  public <T> Callable<T> wrap(Callable<T> delegate) {
+    return () -> {
+      attempts.getAndIncrement();
+      return delegate.call();
+    };
+  }
+
+  public boolean retried() {
+    return attempts.get() > 1;
+  }
+
+  public int attempts() {
+    return attempts.get();
+  }
+}

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/FakeBigQueryMetastoreClient.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/FakeBigQueryMetastoreClient.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.gcp.bigquery.util.RetryDetector;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class FakeBigQueryMetastoreClient implements BigQueryMetastoreClient {
@@ -150,6 +151,11 @@ public class FakeBigQueryMetastoreClient implements BigQueryMetastoreClient {
   }
 
   @Override
+  public Table create(Table table, RetryDetector retryDetector) {
+    return create(table);
+  }
+
+  @Override
   public Table create(Table table) {
     if (tables.containsKey(table.getTableReference())) {
       throw new AlreadyExistsException("Table already exists: %s", table.getTableReference());
@@ -168,6 +174,11 @@ public class FakeBigQueryMetastoreClient implements BigQueryMetastoreClient {
     }
 
     return table;
+  }
+
+  @Override
+  public Table update(TableReference tableReference, Table table, RetryDetector retryDetector) {
+    return update(tableReference, table);
   }
 
   @Override

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryTableOperations.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryTableOperations.java
@@ -305,7 +305,8 @@ public class TestBigQueryTableOperations {
   }
 
   @Test
-  public void testKnownExceptionWithoutRetryDoesNotCallCheckCommitStatus() {
+  public void testCommitFailedExceptionThrowsDirectly() {
+    // CommitFailedException should fail immediately without retry or status checks
     when(client.load(TABLE_REFERENCE)).thenThrow(new NoSuchTableException("Table not found"));
     when(client.create(any(), any())).thenThrow(new CommitFailedException("Commit rejected"));
 
@@ -321,8 +322,8 @@ public class TestBigQueryTableOperations {
 
   @Test
   public void testRuntimeIOExceptionTriggersCommitStatusCheck() {
+    // RuntimeIOException should trigger commit status check as the commit may have succeeded
     when(client.load(TABLE_REFERENCE)).thenThrow(new NoSuchTableException("Table not found"));
-
     when(client.create(any(), any())).thenThrow(new RuntimeIOException("Network error"));
 
     tableOps.refresh();

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryTableOperations.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryTableOperations.java
@@ -43,6 +43,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.hadoop.conf.Configuration;
@@ -52,6 +53,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -64,6 +66,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
 
 public class TestBigQueryTableOperations {
 
@@ -304,6 +307,23 @@ public class TestBigQueryTableOperations {
         ImmutableMap.of());
   }
 
+  private Answer<Table> retriedCommitFailure() {
+    return invocation -> {
+      RetryDetector detector = invocation.getArgument(2);
+      Callable<Table> callable =
+          detector.wrap(
+              () -> {
+                throw new CommitFailedException("Cannot commit: Etag mismatch");
+              });
+      try {
+        callable.call();
+      } catch (Exception ignored) {
+        // first attempt fails, triggering the retry
+      }
+      return callable.call();
+    };
+  }
+
   @Test
   public void testCommitFailedExceptionThrowsDirectly() {
     // CommitFailedException should fail immediately without retry or status checks
@@ -318,6 +338,54 @@ public class TestBigQueryTableOperations {
 
     verify(client, times(1)).create(any(Table.class), any(RetryDetector.class));
     verify(client, times(1)).load(TABLE_REFERENCE);
+  }
+
+  @Test
+  public void testAlreadyExistsExceptionIsRethrown() {
+    when(client.load(TABLE_REFERENCE)).thenThrow(new NoSuchTableException("Table not found"));
+    when(client.create(any(), any())).thenThrow(new AlreadyExistsException("Table already exists"));
+
+    tableOps.refresh();
+
+    assertThatThrownBy(() -> tableOps.commit(null, createTestMetadata()))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("already exists");
+  }
+
+  @Test
+  public void testCommitFailedAfterRetrySucceedsWhenEarlierAttemptCommitted() throws Exception {
+    Table tableWithEtag = createTestTable().setEtag("etag");
+    reset(client);
+    when(client.load(TABLE_REFERENCE)).thenReturn(tableWithEtag);
+
+    org.apache.iceberg.Table loadedTable = catalog.loadTable(IDENTIFIER);
+
+    when(client.update(any(), any(), any())).thenAnswer(retriedCommitFailure());
+
+    assertThatNoException()
+        .isThrownBy(
+            () -> loadedTable.updateSchema().addColumn("n", Types.IntegerType.get()).commit());
+  }
+
+  @Test
+  public void testCommitFailedAfterRetryRethrowsOnConcurrentConflict() throws Exception {
+    Table tableWithEtag = createTestTable().setEtag("etag");
+
+    reset(client);
+    // First load serves loadTable, the table is then absent, so checkCommitStatus reports FAILURE
+    // and the conflict is rethrown.
+    when(client.load(TABLE_REFERENCE))
+        .thenReturn(tableWithEtag)
+        .thenThrow(new NoSuchTableException("Table not found"));
+
+    org.apache.iceberg.Table loadedTable = catalog.loadTable(IDENTIFIER);
+
+    when(client.update(any(), any(), any())).thenAnswer(retriedCommitFailure());
+
+    assertThatThrownBy(
+            () -> loadedTable.updateSchema().addColumn("n", Types.IntegerType.get()).commit())
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("Etag mismatch");
   }
 
   @Test

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/util/TestRetryDetector.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/util/TestRetryDetector.java
@@ -39,6 +39,24 @@ public class TestRetryDetector {
   }
 
   @Test
+  public void testAttemptCountedOnException() {
+    RetryDetector detector = new RetryDetector();
+    try {
+      detector
+          .wrap(
+              () -> {
+                throw new RuntimeException("test error");
+              })
+          .call();
+    } catch (Exception e) {
+      // an exception is expected, we're verifying the counter increments before the callable
+      // executes
+    }
+    assertThat(detector.attempts()).isEqualTo(1);
+    assertThat(detector.retried()).isFalse();
+  }
+
+  @Test
   public void testMultipleAttempts() throws Exception {
     RetryDetector detector = new RetryDetector();
     var wrapped = detector.wrap(() -> "result");

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/util/TestRetryDetector.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/util/TestRetryDetector.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.bigquery.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class TestRetryDetector {
+  @Test
+  public void testNoAttempts() {
+    RetryDetector detector = new RetryDetector();
+    assertThat(detector.retried()).isFalse();
+    assertThat(detector.attempts()).isEqualTo(0);
+  }
+
+  @Test
+  public void testSingleAttempt() throws Exception {
+    RetryDetector detector = new RetryDetector();
+    detector.wrap(() -> "result").call();
+    assertThat(detector.retried()).isFalse();
+    assertThat(detector.attempts()).isEqualTo(1);
+  }
+
+  @Test
+  public void testMultipleAttempts() throws Exception {
+    RetryDetector detector = new RetryDetector();
+    var wrapped = detector.wrap(() -> "result");
+    wrapped.call();
+    wrapped.call();
+    assertThat(detector.retried()).isTrue();
+    assertThat(detector.attempts()).isEqualTo(2);
+  }
+
+  @Test
+  public void testWrappedCallableReturnsValue() throws Exception {
+    RetryDetector detector = new RetryDetector();
+    String result = detector.wrap(() -> "expected").call();
+    assertThat(result).isEqualTo("expected");
+  }
+}

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/util/TestRetryDetector.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/util/TestRetryDetector.java
@@ -49,8 +49,8 @@ public class TestRetryDetector {
               })
           .call();
     } catch (Exception e) {
-      // an exception is expected, we're verifying the counter increments before the callable
-      // executes
+      // an exception is expected, we're verifying the counter increments even when the callable
+      // throws an exception
     }
     assertThat(detector.attempts()).isEqualTo(1);
     assertThat(detector.retried()).isFalse();


### PR DESCRIPTION
**Description**

Adds retry detection to BigQuery Metastore table commits to handle cases where a commit might have succeeded but we received an error, for example, a network timeout after the request reached the server.

When retries occur during `create` or `update`, an earlier attempt may have actually succeeded. Without checking, we might incorrectly report failure or attempt duplicate commits. This addresses the [existing TODO](https://github.com/apache/iceberg/blob/444e381dc786d6b61d8325e9526b816f881307cc/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java#L330) in the codebase.

---
**Changes**
- Added `RetryDetector` utility that wraps callables and counts invocations
- Added overloaded `create(Table, RetryDetector)` and `update(TableReference, Table, RetryDetector)` methods to `BigQueryMetastoreClient`
- Updated `BigQueryTableOperations.doCommit()` to use `checkCommitStatus` when needed
- Extracted `cleanupMetadata()` helper method

---
**Notes for Reviewers**

1. I wanted to implement idempotency for BQMS tables during create/update, so I was checking other patterns and noticed that [GlueCatalog](https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java) has a [RetryDetector](https://github.com/apache/iceberg/blob/444e381dc786d6b61d8325e9526b816f881307cc/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java#L147) mechanism. But that one is based on AWS [MetricPublisher](https://github.com/apache/iceberg/blob/444e381dc786d6b61d8325e9526b816f881307cc/aws/src/main/java/org/apache/iceberg/aws/util/RetryDetector.java#L24C39-L24C54).
2. Turns out, [BigQueryRetryHelper](https://github.com/googleapis/java-bigquery/blob/ad438dc626b69f3bddda47ccf6b7a97d9053c047/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryRetryHelper.java) ([used in BQMS](https://github.com/apache/iceberg/blob/444e381dc786d6b61d8325e9526b816f881307cc/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java#L49)) does not return number of retries. So I wrote a custom `RetryDetector` which wraps the create and update callables to count invocations.
3. Since I needed to pass the `RetryDetector` object to `create` and `update` calls, I added overloaded methods in [BigQueryMetastoreClient.java](https://github.com/apache/iceberg/blob/main/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClient.java). The 1-arg versions delegate to the 2-arg versions.
4. Only checking `RuntimeIOException` because [convertExceptionIfUnsuccessful()](https://github.com/apache/iceberg/blob/444e381dc786d6b61d8325e9526b816f881307cc/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java#L621) already converts HTTP errors to specific Iceberg exceptions. `RuntimeIOException` wraps `IOException`, which are network failures where we don't know if the request reached the server. Other exceptions like `CommitFailedException` or `AlreadyExistsException` are definitive server responses, so no need to check commit status for those.