### PR TITLE
Core, AWS: Allow stopping thread pools manually

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -39,6 +39,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.PositionOutputStream;
@@ -51,8 +53,9 @@ import org.apache.iceberg.relocated.com.google.common.base.Predicates;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.io.CountingOutputStream;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.internal.util.Mimetype;
@@ -109,8 +112,14 @@ class S3OutputStream extends PositionOutputStream {
       synchronized (S3OutputStream.class) {
         if (executorService == null) {
           executorService =
-              ThreadPools.newExitingWorkerPool(
-                  "iceberg-s3fileio-upload", s3FileIOProperties.multipartUploadThreads());
+              MoreExecutors.getExitingExecutorService(
+                  (ThreadPoolExecutor)
+                      Executors.newFixedThreadPool(
+                          s3FileIOProperties.multipartUploadThreads(),
+                          new ThreadFactoryBuilder()
+                              .setDaemon(true)
+                              .setNameFormat("iceberg-s3fileio-upload-%d")
+                              .build()));
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -217,11 +217,14 @@ public class ThreadPools {
       try {
         shutdownHook.setName("DelayedShutdownHook-iceberg");
       } catch (SecurityException e) {
-        // OK if we can't set the name in this environment.
         LOG.warn("Cannot set thread name for the shutdown hook", e);
       }
 
-      Runtime.getRuntime().addShutdownHook(shutdownHook);
+      try {
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+      } catch (SecurityException e) {
+        LOG.warn("Cannot install a shutdown hook for thread pools clean up", e);
+      }
     }
   }
 
@@ -235,7 +238,11 @@ public class ThreadPools {
   @SuppressWarnings("ShutdownHook")
   public static void removeShutdownHook() {
     if (shutdownHook != null) {
-      Runtime.getRuntime().removeShutdownHook(shutdownHook);
+      try {
+        Runtime.getRuntime().removeShutdownHook(shutdownHook);
+      } catch (SecurityException e) {
+        LOG.warn("Cannot remove the shutdown hook for thread pools clean up", e);
+      }
       shutdownHook = null;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -32,8 +32,11 @@ import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.SystemConfigs;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ThreadPools {
+  private static final Logger LOG = LoggerFactory.getLogger(ThreadPools.class);
 
   private ThreadPools() {}
 
@@ -215,6 +218,7 @@ public class ThreadPools {
         shutdownHook.setName("DelayedShutdownHook-iceberg");
       } catch (SecurityException e) {
         // OK if we can't set the name in this environment.
+        LOG.warn("Cannot set thread name for the shutdown hook", e);
       }
 
       Runtime.getRuntime().addShutdownHook(shutdownHook);

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -175,6 +175,14 @@ public class ThreadPools {
   /**
    * Force manual shutdown of the thread pools created via the {@link #newExitingWorkerPool(String,
    * int)}.
+   *
+   * <p>This method allows: (1) to stop thread pools manually, to avoid leaks in hot-reload
+   * environments; (2) opt-out of the standard shutdown mechanism to manage graceful service stops
+   * (and commit the last pending files, if the client application needs to react to shutdown hooks
+   * on its own).
+   *
+   * <p>Please only call this method at the end of the intended usage of the library, and NEVER
+   * before, as this method will stop thread pools required for normal library workflows.
    */
   public static void shutdownThreadPools() {
     removeShutdownHook();

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -19,18 +19,15 @@
 package org.apache.iceberg.util;
 
 import java.time.Duration;
-import java.util.ArrayDeque;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.SystemConfigs;
-import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,10 +45,12 @@ public class ThreadPools {
   public static final String WORKER_THREAD_POOL_SIZE_PROP =
       SystemConfigs.WORKER_THREAD_POOL_SIZE.propertyKey();
 
+  private static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(120);
+
   public static final int WORKER_THREAD_POOL_SIZE = SystemConfigs.WORKER_THREAD_POOL_SIZE.value();
 
-  private static final ConcurrentLinkedDeque<ExecutorService> THREAD_POOLS_TO_SHUTDOWN =
-      new ConcurrentLinkedDeque<>();
+  private static final List<ExecutorServiceWithTimeout> THREAD_POOLS_TO_SHUTDOWN =
+      Lists.newArrayList();
 
   private static final ExecutorService WORKER_POOL =
       newExitingWorkerPool("iceberg-worker-pool", WORKER_THREAD_POOL_SIZE);
@@ -64,8 +63,6 @@ public class ThreadPools {
 
   public static final int AUTH_REFRESH_THREAD_POOL_SIZE =
       SystemConfigs.AUTH_REFRESH_THREAD_POOL_SIZE.value();
-
-  private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(120);
 
   private static Thread shutdownHook;
 
@@ -115,16 +112,11 @@ public class ThreadPools {
   private static class AuthRefreshPoolHolder {
     private static final ScheduledExecutorService INSTANCE =
         ThreadPools.newExitingScheduledPool(
-            "auth-session-refresh", AUTH_REFRESH_THREAD_POOL_SIZE, Duration.ZERO);
+            "auth-session-refresh", AUTH_REFRESH_THREAD_POOL_SIZE, Duration.ofSeconds(10));
   }
 
   /**
-   * Creates a fixed-size thread pool that uses daemon threads. The pool is wrapped with {@link
-   * MoreExecutors#getExitingExecutorService(ThreadPoolExecutor)}, which registers a shutdown hook
-   * to ensure the pool terminates when the JVM exits. <b>Important:</b> Even if the pool is
-   * explicitly shut down using {@link ExecutorService#shutdown()}, the shutdown hook is <i>not</i>
-   * removed. This can lead to accumulation of shutdown hooks if this method is used repeatedly for
-   * short-lived thread pools.
+   * Creates a fixed-size thread pool that uses daemon threads.
    *
    * <p>For clarity and to avoid potential issues with shutdown hook accumulation, prefer using
    * either {@link #newExitingWorkerPool(String, int)} or {@link #newFixedThreadPool(String, int)},
@@ -140,12 +132,7 @@ public class ThreadPools {
   }
 
   /**
-   * Creates a fixed-size thread pool that uses daemon threads. The pool is wrapped with {@link
-   * MoreExecutors#getExitingExecutorService(ThreadPoolExecutor)}, which registers a shutdown hook
-   * to ensure the pool terminates when the JVM exits. <b>Important:</b> Even if the pool is
-   * explicitly shut down using {@link ExecutorService#shutdown()}, the shutdown hook is <i>not</i>
-   * removed. This can lead to accumulation of shutdown hooks if this method is used repeatedly for
-   * short-lived thread pools.
+   * Creates a fixed-size thread pool that uses daemon threads.
    *
    * <p>For clarity and to avoid potential issues with shutdown hook accumulation, prefer using
    * either {@link #newExitingWorkerPool(String, int)} or {@link #newFixedThreadPool(String, int)},
@@ -165,10 +152,10 @@ public class ThreadPools {
    * ensure the pool terminates when the JVM exits. This is suitable for long-lived thread pools
    * that should be automatically cleaned up on JVM shutdown.
    */
-  public static ExecutorService newExitingWorkerPool(String namePrefix, int poolSize) {
+  public static synchronized ExecutorService newExitingWorkerPool(String namePrefix, int poolSize) {
     ExecutorService service =
         Executors.unconfigurableExecutorService(newFixedThreadPool(namePrefix, poolSize));
-    THREAD_POOLS_TO_SHUTDOWN.add(service);
+    THREAD_POOLS_TO_SHUTDOWN.add(new ExecutorServiceWithTimeout(service, DEFAULT_SHUTDOWN_TIMEOUT));
     return service;
   }
 
@@ -184,28 +171,28 @@ public class ThreadPools {
    * <p>Please only call this method at the end of the intended usage of the library, and NEVER
    * before, as this method will stop thread pools required for normal library workflows.
    */
-  public static void shutdownThreadPools() {
+  public static synchronized void shutdownThreadPools() {
     removeShutdownHook();
     long startTime = System.nanoTime();
-    ExecutorService item;
-    Queue<ExecutorService> pendingShutdown = new ArrayDeque<>();
-    while ((item = THREAD_POOLS_TO_SHUTDOWN.poll()) != null) {
-      item.shutdown();
+    List<ExecutorServiceWithTimeout> pendingShutdown = Lists.newArrayList();
+    for (ExecutorServiceWithTimeout item : THREAD_POOLS_TO_SHUTDOWN) {
+      item.getService().shutdown();
       pendingShutdown.add(item);
     }
-    while ((item = pendingShutdown.poll()) != null) {
+    THREAD_POOLS_TO_SHUTDOWN.clear();
+    for (ExecutorServiceWithTimeout item : pendingShutdown) {
       long timeElapsed = System.nanoTime() - startTime;
-      long remainingTime = SHUTDOWN_TIMEOUT.toNanos() - timeElapsed;
+      long remainingTime = item.getTimeout().toNanos() - timeElapsed;
       if (remainingTime > 0) {
         try {
-          if (!item.awaitTermination(remainingTime, TimeUnit.NANOSECONDS)) {
-            item.shutdownNow();
+          if (!item.service.awaitTermination(remainingTime, TimeUnit.NANOSECONDS)) {
+            item.getService().shutdownNow();
           }
         } catch (InterruptedException ignored) {
           // We're shutting down anyway, so just ignore.
         }
       } else {
-        item.shutdownNow();
+        item.getService().shutdownNow();
       }
     }
   }
@@ -287,15 +274,33 @@ public class ThreadPools {
    * is suitable for long-lived thread pools that should be automatically cleaned up on JVM
    * shutdown.
    */
-  public static ScheduledExecutorService newExitingScheduledPool(
+  public static synchronized ScheduledExecutorService newExitingScheduledPool(
       String namePrefix, int poolSize, Duration terminationTimeout) {
-    return MoreExecutors.getExitingScheduledExecutorService(
-        (ScheduledThreadPoolExecutor) newScheduledPool(namePrefix, poolSize),
-        terminationTimeout.toMillis(),
-        TimeUnit.MILLISECONDS);
+    ScheduledExecutorService service =
+        Executors.unconfigurableScheduledExecutorService(newScheduledPool(namePrefix, poolSize));
+    THREAD_POOLS_TO_SHUTDOWN.add(new ExecutorServiceWithTimeout(service, terminationTimeout));
+    return service;
   }
 
   private static ThreadFactory newDaemonThreadFactory(String namePrefix) {
     return new ThreadFactoryBuilder().setDaemon(true).setNameFormat(namePrefix + "-%d").build();
+  }
+
+  static class ExecutorServiceWithTimeout {
+    private ExecutorService service;
+    private Duration timeout;
+
+    ExecutorServiceWithTimeout(ExecutorService service, Duration timeout) {
+      this.service = service;
+      this.timeout = timeout;
+    }
+
+    ExecutorService getService() {
+      return service;
+    }
+
+    Duration getTimeout() {
+      return timeout;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -215,7 +215,7 @@ public class ThreadPools {
    * #newExitingWorkerPool(String, int)}.
    */
   @SuppressWarnings("ShutdownHook")
-  private static void initShutdownHook() {
+  private static synchronized void initShutdownHook() {
     if (shutdownHook == null) {
       shutdownHook =
           Executors.defaultThreadFactory()
@@ -249,7 +249,7 @@ public class ThreadPools {
    * <p>Thread pools can still be stopped manually via the {@link #shutdownThreadPools()} method.
    */
   @SuppressWarnings("ShutdownHook")
-  public static void removeShutdownHook() {
+  public static synchronized void removeShutdownHook() {
     if (shutdownHook != null) {
       try {
         Runtime.getRuntime().removeShutdownHook(shutdownHook);

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -49,8 +49,7 @@ public class ThreadPools {
 
   public static final int WORKER_THREAD_POOL_SIZE = SystemConfigs.WORKER_THREAD_POOL_SIZE.value();
 
-  private static final List<ExecutorServiceWithTimeout> THREAD_POOLS_TO_SHUTDOWN =
-      Lists.newArrayList();
+  private static final ThreadPoolManager THREAD_POOL_MANAGER = new ThreadPoolManager();
 
   private static final ExecutorService WORKER_POOL =
       newExitingWorkerPool("iceberg-worker-pool", WORKER_THREAD_POOL_SIZE);
@@ -152,10 +151,10 @@ public class ThreadPools {
    * ensure the pool terminates when the JVM exits. This is suitable for long-lived thread pools
    * that should be automatically cleaned up on JVM shutdown.
    */
-  public static synchronized ExecutorService newExitingWorkerPool(String namePrefix, int poolSize) {
+  public static ExecutorService newExitingWorkerPool(String namePrefix, int poolSize) {
     ExecutorService service =
         Executors.unconfigurableExecutorService(newFixedThreadPool(namePrefix, poolSize));
-    THREAD_POOLS_TO_SHUTDOWN.add(new ExecutorServiceWithTimeout(service, DEFAULT_SHUTDOWN_TIMEOUT));
+    THREAD_POOL_MANAGER.addThreadPool(service, DEFAULT_SHUTDOWN_TIMEOUT);
     return service;
   }
 
@@ -171,30 +170,9 @@ public class ThreadPools {
    * <p>Please only call this method at the end of the intended usage of the library, and NEVER
    * before, as this method will stop thread pools required for normal library workflows.
    */
-  public static synchronized void shutdownThreadPools() {
+  public static void shutdownThreadPools() {
     removeShutdownHook();
-    long startTime = System.nanoTime();
-    List<ExecutorServiceWithTimeout> pendingShutdown = Lists.newArrayList();
-    for (ExecutorServiceWithTimeout item : THREAD_POOLS_TO_SHUTDOWN) {
-      item.getService().shutdown();
-      pendingShutdown.add(item);
-    }
-    THREAD_POOLS_TO_SHUTDOWN.clear();
-    for (ExecutorServiceWithTimeout item : pendingShutdown) {
-      long timeElapsed = System.nanoTime() - startTime;
-      long remainingTime = item.getTimeout().toNanos() - timeElapsed;
-      if (remainingTime > 0) {
-        try {
-          if (!item.service.awaitTermination(remainingTime, TimeUnit.NANOSECONDS)) {
-            item.getService().shutdownNow();
-          }
-        } catch (InterruptedException ignored) {
-          // We're shutting down anyway, so just ignore.
-        }
-      } else {
-        item.getService().shutdownNow();
-      }
-    }
+    THREAD_POOL_MANAGER.shutdownAll();
   }
 
   /**
@@ -278,12 +256,53 @@ public class ThreadPools {
       String namePrefix, int poolSize, Duration terminationTimeout) {
     ScheduledExecutorService service =
         Executors.unconfigurableScheduledExecutorService(newScheduledPool(namePrefix, poolSize));
-    THREAD_POOLS_TO_SHUTDOWN.add(new ExecutorServiceWithTimeout(service, terminationTimeout));
+    THREAD_POOL_MANAGER.addThreadPool(service, terminationTimeout);
     return service;
   }
 
   private static ThreadFactory newDaemonThreadFactory(String namePrefix) {
     return new ThreadFactoryBuilder().setDaemon(true).setNameFormat(namePrefix + "-%d").build();
+  }
+
+  /** Manages the lifecycle of thread pools that need to be shut down gracefully. */
+  static class ThreadPoolManager {
+    private final List<ExecutorServiceWithTimeout> threadPoolsToShutdown = Lists.newArrayList();
+
+    /**
+     * Add an executor service to the list of thread pools to be shut down.
+     *
+     * @param service the executor service to add
+     * @param timeout the timeout for shutdown operations
+     */
+    synchronized void addThreadPool(ExecutorService service, Duration timeout) {
+      threadPoolsToShutdown.add(new ExecutorServiceWithTimeout(service, timeout));
+    }
+
+    /** Shut down all registered thread pools. */
+    synchronized void shutdownAll() {
+      long startTime = System.nanoTime();
+      List<ExecutorServiceWithTimeout> pendingShutdown = Lists.newArrayList();
+      for (ExecutorServiceWithTimeout item : threadPoolsToShutdown) {
+        item.getService().shutdown();
+        pendingShutdown.add(item);
+      }
+      threadPoolsToShutdown.clear();
+      for (ExecutorServiceWithTimeout item : pendingShutdown) {
+        long timeElapsed = System.nanoTime() - startTime;
+        long remainingTime = item.getTimeout().toNanos() - timeElapsed;
+        if (remainingTime > 0) {
+          try {
+            if (!item.service.awaitTermination(remainingTime, TimeUnit.NANOSECONDS)) {
+              item.getService().shutdownNow();
+            }
+          } catch (InterruptedException ignored) {
+            // We're shutting down anyway, so just ignore.
+          }
+        } else {
+          item.getService().shutdownNow();
+        }
+      }
+    }
   }
 
   static class ExecutorServiceWithTimeout {

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -180,7 +180,7 @@ public class ThreadPools {
    * #newExitingWorkerPool(String, int)}.
    */
   @SuppressWarnings("ShutdownHook")
-  private static synchronized void initShutdownHook() {
+  static synchronized void initShutdownHook() {
     if (shutdownHook == null) {
       shutdownHook =
           Executors.defaultThreadFactory()
@@ -223,6 +223,15 @@ public class ThreadPools {
       }
       shutdownHook = null;
     }
+  }
+
+  /**
+   * Check if the shutdown hook has been registered.
+   *
+   * @return true if the shutdown hook is registered, false otherwise
+   */
+  public static synchronized boolean isShutdownHookRegistered() {
+    return shutdownHook != null;
   }
 
   /** Creates a fixed-size thread pool that uses daemon threads. */

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -216,11 +216,13 @@ public class ThreadPools {
   @SuppressWarnings("ShutdownHook")
   public static synchronized void removeShutdownHook() {
     if (shutdownHook != null) {
+
       try {
         Runtime.getRuntime().removeShutdownHook(shutdownHook);
       } catch (SecurityException e) {
         LOG.warn("Cannot remove the shutdown hook for thread pools clean up", e);
       }
+
       shutdownHook = null;
     }
   }
@@ -291,22 +293,28 @@ public class ThreadPools {
     synchronized void shutdownAll() {
       long startTime = System.nanoTime();
       List<ExecutorServiceWithTimeout> pendingShutdown = Lists.newArrayList();
+
       for (ExecutorServiceWithTimeout item : threadPoolsToShutdown) {
         item.getService().shutdown();
         pendingShutdown.add(item);
       }
+
       threadPoolsToShutdown.clear();
+
       for (ExecutorServiceWithTimeout item : pendingShutdown) {
         long timeElapsed = System.nanoTime() - startTime;
         long remainingTime = item.getTimeout().toNanos() - timeElapsed;
         if (remainingTime > 0) {
+
           try {
             if (!item.service.awaitTermination(remainingTime, TimeUnit.NANOSECONDS)) {
               item.getService().shutdownNow();
             }
-          } catch (InterruptedException ignored) {
+          } catch (InterruptedException e) {
             // We're shutting down anyway, so just ignore.
+            LOG.warn("Interrupted while shutting down, ignoring", e);
           }
+
         } else {
           item.getService().shutdownNow();
         }
@@ -314,20 +322,20 @@ public class ThreadPools {
     }
   }
 
-  static class ExecutorServiceWithTimeout {
+  private static class ExecutorServiceWithTimeout {
     private ExecutorService service;
     private Duration timeout;
 
-    ExecutorServiceWithTimeout(ExecutorService service, Duration timeout) {
+    private ExecutorServiceWithTimeout(ExecutorService service, Duration timeout) {
       this.service = service;
       this.timeout = timeout;
     }
 
-    ExecutorService getService() {
+    private ExecutorService getService() {
       return service;
     }
 
-    Duration getTimeout() {
+    private Duration getTimeout() {
       return timeout;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.SystemConfigs;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
@@ -111,7 +112,7 @@ public class ThreadPools {
   private static class AuthRefreshPoolHolder {
     private static final ScheduledExecutorService INSTANCE =
         ThreadPools.newExitingScheduledPool(
-            "auth-session-refresh", AUTH_REFRESH_THREAD_POOL_SIZE, Duration.ofSeconds(10));
+            "auth-session-refresh", AUTH_REFRESH_THREAD_POOL_SIZE, Duration.ZERO);
   }
 
   /**
@@ -216,7 +217,6 @@ public class ThreadPools {
   @SuppressWarnings("ShutdownHook")
   public static synchronized void removeShutdownHook() {
     if (shutdownHook != null) {
-
       try {
         Runtime.getRuntime().removeShutdownHook(shutdownHook);
       } catch (SecurityException e) {
@@ -232,7 +232,8 @@ public class ThreadPools {
    *
    * @return true if the shutdown hook is registered, false otherwise
    */
-  public static synchronized boolean isShutdownHookRegistered() {
+  @VisibleForTesting
+  static synchronized boolean isShutdownHookRegistered() {
     return shutdownHook != null;
   }
 
@@ -276,6 +277,7 @@ public class ThreadPools {
   }
 
   /** Manages the lifecycle of thread pools that need to be shut down gracefully. */
+  @VisibleForTesting
   static class ThreadPoolManager {
     private final List<ExecutorServiceWithTimeout> threadPoolsToShutdown = Lists.newArrayList();
 
@@ -285,11 +287,13 @@ public class ThreadPools {
      * @param service the executor service to add
      * @param timeout the timeout for shutdown operations
      */
+    @VisibleForTesting
     synchronized void addThreadPool(ExecutorService service, Duration timeout) {
       threadPoolsToShutdown.add(new ExecutorServiceWithTimeout(service, timeout));
     }
 
     /** Shut down all registered thread pools. */
+    @VisibleForTesting
     synchronized void shutdownAll() {
       long startTime = System.nanoTime();
       List<ExecutorServiceWithTimeout> pendingShutdown = Lists.newArrayList();

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -171,8 +171,8 @@ public class ThreadPools {
    * before, as this method will stop thread pools required for normal library workflows.
    */
   public static void shutdownThreadPools() {
-    removeShutdownHook();
     THREAD_POOL_MANAGER.shutdownAll();
+    removeShutdownHook();
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -311,7 +311,6 @@ public class ThreadPools {
               item.getService().shutdownNow();
             }
           } catch (InterruptedException e) {
-            // We're shutting down anyway, so just ignore.
             LOG.warn("Interrupted while shutting down, ignoring", e);
           }
 

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -181,6 +181,7 @@ public class ThreadPools {
    * #newExitingWorkerPool(String, int)}.
    */
   @SuppressWarnings("ShutdownHook")
+  @VisibleForTesting
   static synchronized void initShutdownHook() {
     if (shutdownHook == null) {
       shutdownHook =
@@ -287,13 +288,11 @@ public class ThreadPools {
      * @param service the executor service to add
      * @param timeout the timeout for shutdown operations
      */
-    @VisibleForTesting
     synchronized void addThreadPool(ExecutorService service, Duration timeout) {
       threadPoolsToShutdown.add(new ExecutorServiceWithTimeout(service, timeout));
     }
 
     /** Shut down all registered thread pools. */
-    @VisibleForTesting
     synchronized void shutdownAll() {
       long startTime = System.nanoTime();
       List<ExecutorServiceWithTimeout> pendingShutdown = Lists.newArrayList();

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -303,16 +303,12 @@ public class ThreadPools {
     /** Shut down all registered thread pools. */
     private synchronized void shutdownAll() {
       long startTime = System.nanoTime();
-      List<ExecutorServiceWithTimeout> pendingShutdown = Lists.newArrayList();
 
       for (ExecutorServiceWithTimeout item : threadPoolsToShutdown) {
         item.service().shutdown();
-        pendingShutdown.add(item);
       }
 
-      threadPoolsToShutdown.clear();
-
-      for (ExecutorServiceWithTimeout item : pendingShutdown) {
+      for (ExecutorServiceWithTimeout item : threadPoolsToShutdown) {
         long timeElapsed = System.nanoTime() - startTime;
         long remainingTime = item.timeout().toNanos() - timeElapsed;
         if (remainingTime > 0) {
@@ -327,6 +323,8 @@ public class ThreadPools {
           item.service().shutdownNow();
         }
       }
+
+      threadPoolsToShutdown.clear();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -133,7 +133,10 @@ public class ThreadPools {
   }
 
   /**
-   * Creates a fixed-size thread pool that uses daemon threads.
+   * Creates a fixed-size thread pool that uses daemon threads. The pool will be stopped by the
+   * shutdown hook to ensure the pool terminates when the JVM exits - unless `removeShutdownHook` is
+   * called, in which case it is user's responsibility to stop the threadpools using the
+   * `shutdownThreadPools` method.
    *
    * <p>For clarity and to avoid potential issues with shutdown hook accumulation, prefer using
    * either {@link #newExitingWorkerPool(String, int)} or {@link #newFixedThreadPool(String, int)},
@@ -149,9 +152,10 @@ public class ThreadPools {
   }
 
   /**
-   * Creates a fixed-size thread pool that uses daemon threads and registers a shutdown hook to
-   * ensure the pool terminates when the JVM exits. This is suitable for long-lived thread pools
-   * that should be automatically cleaned up on JVM shutdown.
+   * Creates a fixed-size thread pool that uses daemon threads. The pool will be stopped by the
+   * shutdown hook to ensure the pool terminates when the JVM exits - unless `removeShutdownHook` is
+   * called, in which case it is user's responsibility to stop the threadpools using the
+   * `shutdownThreadPools` method.
    */
   public static ExecutorService newExitingWorkerPool(String namePrefix, int poolSize) {
     ExecutorService service =

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -52,12 +52,12 @@ public class ThreadPools {
 
   private static final ThreadPoolManager THREAD_POOL_MANAGER = new ThreadPoolManager();
 
-  private static ExecutorService WORKER_POOL = createWorkerPool();
+  private static ExecutorService workerPool = createWorkerPool();
 
   public static final int DELETE_WORKER_THREAD_POOL_SIZE =
       SystemConfigs.DELETE_WORKER_THREAD_POOL_SIZE.value();
 
-  private static ExecutorService DELETE_WORKER_POOL = createDeleteWorkerPool();
+  private static ExecutorService deleteWorkerPool = createDeleteWorkerPool();
 
   public static final int AUTH_REFRESH_THREAD_POOL_SIZE =
       SystemConfigs.AUTH_REFRESH_THREAD_POOL_SIZE.value();
@@ -80,7 +80,7 @@ public class ThreadPools {
    * @return an {@link ExecutorService} that uses the worker pool
    */
   public static ExecutorService getWorkerPool() {
-    return WORKER_POOL;
+    return workerPool;
   }
 
   /**
@@ -96,7 +96,7 @@ public class ThreadPools {
    * @return an {@link ExecutorService} that uses the delete worker pool
    */
   public static ExecutorService getDeleteWorkerPool() {
-    return DELETE_WORKER_POOL;
+    return deleteWorkerPool;
   }
 
   /**
@@ -210,11 +210,11 @@ public class ThreadPools {
         LOG.warn("Cannot install a shutdown hook for thread pools clean up", e);
       }
     }
-    if (null == WORKER_POOL || WORKER_POOL.isShutdown()) {
-      WORKER_POOL = createWorkerPool();
+    if (null == workerPool || workerPool.isShutdown()) {
+      workerPool = createWorkerPool();
     }
-    if (null == DELETE_WORKER_POOL || DELETE_WORKER_POOL.isShutdown()) {
-      DELETE_WORKER_POOL = createDeleteWorkerPool();
+    if (null == deleteWorkerPool || deleteWorkerPool.isShutdown()) {
+      deleteWorkerPool = createDeleteWorkerPool();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -115,9 +115,9 @@ public class ThreadPools {
 
   /**
    * Creates a fixed-size thread pool that uses daemon threads. The pool will be stopped by the
-   * shutdown hook to ensure the pool terminates when the JVM exits - unless `removeShutdownHook` is
-   * called, in which case it is user's responsibility to stop the threadpools using the
-   * `shutdownThreadPools` method.
+   * shutdown hook to ensure the pool terminates when the JVM exits - unless {@link
+   * #removeShutdownHook()} is called, in which case it is user's responsibility to stop the
+   * threadpools using the {@link #shutdownThreadPools()} method.
    *
    * <p>For clarity and to avoid potential issues with shutdown hook accumulation, prefer using
    * either {@link #newExitingWorkerPool(String, int)} or {@link #newFixedThreadPool(String, int)},
@@ -134,9 +134,9 @@ public class ThreadPools {
 
   /**
    * Creates a fixed-size thread pool that uses daemon threads. The pool will be stopped by the
-   * shutdown hook to ensure the pool terminates when the JVM exits - unless `removeShutdownHook` is
-   * called, in which case it is user's responsibility to stop the threadpools using the
-   * `shutdownThreadPools` method.
+   * shutdown hook to ensure the pool terminates when the JVM exits - unless {@link
+   * #removeShutdownHook()} is called, in which case it is user's responsibility to stop the
+   * threadpools using the {@link #shutdownThreadPools()} method.
    *
    * <p>For clarity and to avoid potential issues with shutdown hook accumulation, prefer using
    * either {@link #newExitingWorkerPool(String, int)} or {@link #newFixedThreadPool(String, int)},
@@ -153,9 +153,9 @@ public class ThreadPools {
 
   /**
    * Creates a fixed-size thread pool that uses daemon threads. The pool will be stopped by the
-   * shutdown hook to ensure the pool terminates when the JVM exits - unless `removeShutdownHook` is
-   * called, in which case it is user's responsibility to stop the threadpools using the
-   * `shutdownThreadPools` method.
+   * shutdown hook to ensure the pool terminates when the JVM exits - unless {@link
+   * #removeShutdownHook()} is called, in which case it is user's responsibility to stop the
+   * threadpools using the {@link #shutdownThreadPools()} method.
    */
   public static ExecutorService newExitingWorkerPool(String namePrefix, int poolSize) {
     ExecutorService service =
@@ -178,8 +178,8 @@ public class ThreadPools {
    *
    * <p>Only call this method at the end of the intended usage of the iceberg operations. Calling it
    * earlier will stop thread pools required for normal data export workflows. Intended use cases
-   * are: the application has called `removeShutdownHook` intending to call this method at the end
-   * of it's own shutdown hook; the application calls this method after stopping all iceberg
+   * are: the application has called {@link #removeShutdownHook()} intending to call this method at
+   * the end of it's own shutdown hook; the application calls this method after stopping all iceberg
    * operations - before unloading the iceberg jar file in a hot-reload JVM environement.
    */
   public static void shutdownThreadPools() {

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -160,16 +160,19 @@ public class ThreadPools {
   }
 
   /**
-   * Force manual shutdown of the thread pools created via the {@link #newExitingWorkerPool(String,
-   * int)}.
+   * Shuts down all thread pools registered via {@link #newExitingWorkerPool(String, int)} or {@link
+   * #newExitingScheduledPool(String, int, Duration)} and removes the JVM shutdown hook.
    *
-   * <p>This method allows: (1) to stop thread pools manually, to avoid leaks in hot-reload
-   * environments; (2) opt-out of the standard shutdown mechanism to manage graceful service stops
-   * (and commit the last pending files, if the client application needs to react to shutdown hooks
-   * on its own).
+   * <p>This method is useful for:
    *
-   * <p>Please only call this method at the end of the intended usage of the library, and NEVER
-   * before, as this method will stop thread pools required for normal library workflows.
+   * <ul>
+   *   <li>Preventing thread pool leaks in hot-reload environments
+   *   <li>Managing graceful application shutdown when the application needs to handle its own
+   *       shutdown hooks (e.g. to commit pending files before exiting)
+   * </ul>
+   *
+   * <p>Only call this method at the end of the intended usage of the library. Calling it earlier
+   * will stop thread pools required for normal library workflows.
    */
   public static void shutdownThreadPools() {
     THREAD_POOL_MANAGER.shutdownAll();

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -52,14 +52,12 @@ public class ThreadPools {
 
   private static final ThreadPoolManager THREAD_POOL_MANAGER = new ThreadPoolManager();
 
-  private static final ExecutorService WORKER_POOL =
-      newExitingWorkerPool("iceberg-worker-pool", WORKER_THREAD_POOL_SIZE);
+  private static ExecutorService WORKER_POOL = createWorkerPool();
 
   public static final int DELETE_WORKER_THREAD_POOL_SIZE =
       SystemConfigs.DELETE_WORKER_THREAD_POOL_SIZE.value();
 
-  private static final ExecutorService DELETE_WORKER_POOL =
-      newExitingWorkerPool("iceberg-delete-worker-pool", DELETE_WORKER_THREAD_POOL_SIZE);
+  private static ExecutorService DELETE_WORKER_POOL = createDeleteWorkerPool();
 
   public static final int AUTH_REFRESH_THREAD_POOL_SIZE =
       SystemConfigs.AUTH_REFRESH_THREAD_POOL_SIZE.value();
@@ -67,7 +65,7 @@ public class ThreadPools {
   private static Thread shutdownHook;
 
   static {
-    initShutdownHook();
+    init();
   }
 
   /**
@@ -191,7 +189,7 @@ public class ThreadPools {
    */
   @SuppressWarnings("ShutdownHook")
   @VisibleForTesting
-  static synchronized void initShutdownHook() {
+  static synchronized void init() {
     if (shutdownHook == null) {
       shutdownHook =
           Executors.defaultThreadFactory()
@@ -212,6 +210,12 @@ public class ThreadPools {
       } catch (SecurityException e) {
         LOG.warn("Cannot install a shutdown hook for thread pools clean up", e);
       }
+    }
+    if (null == WORKER_POOL || WORKER_POOL.isShutdown()) {
+      WORKER_POOL = createWorkerPool();
+    }
+    if (null == DELETE_WORKER_POOL || DELETE_WORKER_POOL.isShutdown()) {
+      DELETE_WORKER_POOL = createDeleteWorkerPool();
     }
   }
 
@@ -328,4 +332,12 @@ public class ThreadPools {
   }
 
   private record ExecutorServiceWithTimeout(ExecutorService service, Duration timeout) {}
+
+  private static ExecutorService createWorkerPool() {
+    return newExitingWorkerPool("iceberg-worker-pool", WORKER_THREAD_POOL_SIZE);
+  }
+
+  private static ExecutorService createDeleteWorkerPool() {
+    return newExitingWorkerPool("iceberg-delete-worker-pool", DELETE_WORKER_THREAD_POOL_SIZE);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -216,7 +216,7 @@ public class ThreadPools {
   }
 
   /**
-   * Stop the shutdown hook for the thread pools created via the {@link
+   * Remove the shutdown hook for the thread pools created via the {@link
    * #newExitingWorkerPool(String, int)}.
    *
    * <p>Thread pools can still be stopped manually via the {@link #shutdownThreadPools()} method.

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -116,7 +116,10 @@ public class ThreadPools {
   }
 
   /**
-   * Creates a fixed-size thread pool that uses daemon threads.
+   * Creates a fixed-size thread pool that uses daemon threads. The pool will be stopped by the
+   * shutdown hook to ensure the pool terminates when the JVM exits - unless `removeShutdownHook` is
+   * called, in which case it is user's responsibility to stop the threadpools using the
+   * `shutdownThreadPools` method.
    *
    * <p>For clarity and to avoid potential issues with shutdown hook accumulation, prefer using
    * either {@link #newExitingWorkerPool(String, int)} or {@link #newFixedThreadPool(String, int)},
@@ -171,8 +174,11 @@ public class ThreadPools {
    *       shutdown hooks (e.g. to commit pending files before exiting)
    * </ul>
    *
-   * <p>Only call this method at the end of the intended usage of the library. Calling it earlier
-   * will stop thread pools required for normal library workflows.
+   * <p>Only call this method at the end of the intended usage of the iceberg operations. Calling it
+   * earlier will stop thread pools required for normal data export workflows. Intended use cases
+   * are: the application has called `removeShutdownHook` intending to call this method at the end
+   * of it's own shutdown hook; the application calls this method after stopping all iceberg
+   * operations - before unloading the iceberg jar file in a hot-reload JVM environement.
    */
   public static void shutdownThreadPools() {
     THREAD_POOL_MANAGER.shutdownAll();

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -195,8 +195,7 @@ public class ThreadPools {
           Executors.defaultThreadFactory()
               .newThread(
                   () -> {
-                    shutdownHook = null;
-                    shutdownThreadPools();
+                    THREAD_POOL_MANAGER.shutdownAll();
                   });
 
       try {

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -190,12 +190,9 @@ public class ThreadPools {
       shutdownHook =
           Executors.defaultThreadFactory()
               .newThread(
-                  new Runnable() {
-                    @Override
-                    public void run() {
-                      shutdownHook = null;
-                      shutdownThreadPools();
-                    }
+                  () -> {
+                    shutdownHook = null;
+                    shutdownThreadPools();
                   });
 
       try {
@@ -281,8 +278,7 @@ public class ThreadPools {
   }
 
   /** Manages the lifecycle of thread pools that need to be shut down gracefully. */
-  @VisibleForTesting
-  static class ThreadPoolManager {
+  private static class ThreadPoolManager {
     private final List<ExecutorServiceWithTimeout> threadPoolsToShutdown = Lists.newArrayList();
 
     /**
@@ -291,17 +287,17 @@ public class ThreadPools {
      * @param service the executor service to add
      * @param timeout the timeout for shutdown operations
      */
-    synchronized void addThreadPool(ExecutorService service, Duration timeout) {
+    private synchronized void addThreadPool(ExecutorService service, Duration timeout) {
       threadPoolsToShutdown.add(new ExecutorServiceWithTimeout(service, timeout));
     }
 
     /** Shut down all registered thread pools. */
-    synchronized void shutdownAll() {
+    private synchronized void shutdownAll() {
       long startTime = System.nanoTime();
       List<ExecutorServiceWithTimeout> pendingShutdown = Lists.newArrayList();
 
       for (ExecutorServiceWithTimeout item : threadPoolsToShutdown) {
-        item.getService().shutdown();
+        item.service().shutdown();
         pendingShutdown.add(item);
       }
 
@@ -309,39 +305,23 @@ public class ThreadPools {
 
       for (ExecutorServiceWithTimeout item : pendingShutdown) {
         long timeElapsed = System.nanoTime() - startTime;
-        long remainingTime = item.getTimeout().toNanos() - timeElapsed;
+        long remainingTime = item.timeout().toNanos() - timeElapsed;
         if (remainingTime > 0) {
 
           try {
             if (!item.service.awaitTermination(remainingTime, TimeUnit.NANOSECONDS)) {
-              item.getService().shutdownNow();
+              item.service().shutdownNow();
             }
           } catch (InterruptedException e) {
             LOG.warn("Interrupted while shutting down, ignoring", e);
           }
 
         } else {
-          item.getService().shutdownNow();
+          item.service().shutdownNow();
         }
       }
     }
   }
 
-  private static class ExecutorServiceWithTimeout {
-    private ExecutorService service;
-    private Duration timeout;
-
-    private ExecutorServiceWithTimeout(ExecutorService service, Duration timeout) {
-      this.service = service;
-      this.timeout = timeout;
-    }
-
-    private ExecutorService getService() {
-      return service;
-    }
-
-    private Duration getTimeout() {
-      return timeout;
-    }
-  }
+  private record ExecutorServiceWithTimeout(ExecutorService service, Duration timeout) {}
 }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -237,16 +237,6 @@ public class ThreadPools {
     }
   }
 
-  /**
-   * Check if the shutdown hook has been registered.
-   *
-   * @return true if the shutdown hook is registered, false otherwise
-   */
-  @VisibleForTesting
-  static synchronized boolean isShutdownHookRegistered() {
-    return shutdownHook != null;
-  }
-
   /** Creates a fixed-size thread pool that uses daemon threads. */
   public static ExecutorService newFixedThreadPool(String namePrefix, int poolSize) {
     return Executors.newFixedThreadPool(poolSize, newDaemonThreadFactory(namePrefix));

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -307,7 +307,6 @@ public class ThreadPools {
         long timeElapsed = System.nanoTime() - startTime;
         long remainingTime = item.timeout().toNanos() - timeElapsed;
         if (remainingTime > 0) {
-
           try {
             if (!item.service.awaitTermination(remainingTime, TimeUnit.NANOSECONDS)) {
               item.service().shutdownNow();
@@ -315,7 +314,6 @@ public class ThreadPools {
           } catch (InterruptedException e) {
             LOG.warn("Interrupted while shutting down, ignoring", e);
           }
-
         } else {
           item.service().shutdownNow();
         }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -308,6 +308,9 @@ public class ThreadPools {
         item.service().shutdown();
       }
 
+      threadPoolsToShutdown.sort(
+          (a, b) -> Long.compare(a.timeout().toNanos(), b.timeout().toNanos()));
+
       for (ExecutorServiceWithTimeout item : threadPoolsToShutdown) {
         long timeElapsed = System.nanoTime() - startTime;
         long remainingTime = item.timeout().toNanos() - timeElapsed;

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -79,9 +79,9 @@ public class TestThreadPools {
     Duration shortTimeout = Duration.ofMillis(50);
     manager.addThreadPool(slowExecutor, shortTimeout);
 
-    var start = System.nanoTime();
+    long start = System.nanoTime();
     manager.shutdownAll();
-    var end = System.nanoTime();
+    long end = System.nanoTime();
 
     assertThat(slowExecutor.isShutdown()).isTrue();
     assertThat(interrupted.get()).isTrue();

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -87,6 +87,8 @@ public class TestThreadPools {
         () -> {
           try {
             threadStarted.countDown();
+            // NOTE: the test is NOT actually waiting for 60s, as it will be interrupted
+            // after 50ms due to the `shutdownAll` call below
             Thread.sleep(60_000);
           } catch (InterruptedException e) {
             interrupted.set(true);

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+public class TestThreadPools {
+
+  @Test
+  public void testThreadPoolManagerAddAndShutdown() throws Exception {
+    ThreadPools.ThreadPoolManager manager = new ThreadPools.ThreadPoolManager();
+
+    ExecutorService testExecutor = Executors.newFixedThreadPool(2);
+
+    Duration timeout = Duration.ofSeconds(5);
+    manager.addThreadPool(testExecutor, timeout);
+
+    manager.shutdownAll();
+
+    assertThat(testExecutor.isShutdown()).isTrue();
+  }
+
+  @Test
+  public void testThreadPoolManagerMultipleShutdowns() throws Exception {
+    ThreadPools.ThreadPoolManager manager = new ThreadPools.ThreadPoolManager();
+
+    ExecutorService executor1 = Executors.newFixedThreadPool(1);
+    ExecutorService executor2 = Executors.newFixedThreadPool(1);
+
+    Duration timeout = Duration.ofSeconds(5);
+    manager.addThreadPool(executor1, timeout);
+    manager.addThreadPool(executor2, timeout);
+
+    manager.shutdownAll();
+
+    assertThat(executor1.isShutdown()).isTrue();
+    assertThat(executor2.isShutdown()).isTrue();
+  }
+
+  @Test
+  public void testThreadPoolManagerShutdownNowCalled() throws Exception {
+    ThreadPools.ThreadPoolManager manager = new ThreadPools.ThreadPoolManager();
+
+    final AtomicBoolean interrupted = new AtomicBoolean(false);
+    ExecutorService slowExecutor = Executors.newFixedThreadPool(1);
+
+    slowExecutor.submit(
+        () -> {
+          try {
+            Thread.sleep(2000);
+          } catch (InterruptedException e) {
+            interrupted.set(true);
+            Thread.currentThread().interrupt();
+          }
+        });
+
+    Duration shortTimeout = Duration.ofMillis(50);
+    manager.addThreadPool(slowExecutor, shortTimeout);
+
+    var start = System.nanoTime();
+    manager.shutdownAll();
+    var end = System.nanoTime();
+
+    assertThat(slowExecutor.isShutdown()).isTrue();
+    assertThat(interrupted.get()).isTrue();
+    assertThat(end - start).isGreaterThanOrEqualTo(50_000_000);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -21,12 +21,24 @@ package org.apache.iceberg.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 public class TestThreadPools {
+
+  @Test
+  public void testRemoveShutdownHook() {
+    try {
+      assertThat(ThreadPools.isShutdownHookRegistered()).isTrue();
+      ThreadPools.removeShutdownHook();
+      assertThat(ThreadPools.isShutdownHookRegistered()).isFalse();
+    } finally {
+      ThreadPools.initShutdownHook();
+    }
+  }
 
   @Test
   public void testThreadPoolManagerAddAndShutdown() throws Exception {
@@ -66,21 +78,28 @@ public class TestThreadPools {
     final AtomicBoolean interrupted = new AtomicBoolean(false);
     ExecutorService slowExecutor = Executors.newFixedThreadPool(1);
 
+    manager.addThreadPool(slowExecutor, Duration.ofMillis(50));
+
+    CountDownLatch threadStarted = new CountDownLatch(1);
+    CountDownLatch threadInterrupted = new CountDownLatch(1);
+
     slowExecutor.submit(
         () -> {
           try {
-            Thread.sleep(2000);
+            threadStarted.countDown();
+            Thread.sleep(60_000);
           } catch (InterruptedException e) {
             interrupted.set(true);
+            threadInterrupted.countDown();
             Thread.currentThread().interrupt();
           }
         });
 
-    Duration shortTimeout = Duration.ofMillis(50);
-    manager.addThreadPool(slowExecutor, shortTimeout);
+    threadStarted.await();
 
     long start = System.nanoTime();
     manager.shutdownAll();
+    threadInterrupted.await();
     long end = System.nanoTime();
 
     assertThat(slowExecutor.isShutdown()).isTrue();

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -23,72 +23,73 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-public class TestThreadPools {
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class TestThreadPools {
 
-  @Test
-  public void testRemoveShutdownHook() {
-    try {
-      assertThat(ThreadPools.isShutdownHookRegistered()).isTrue();
-      ThreadPools.removeShutdownHook();
-      assertThat(ThreadPools.isShutdownHookRegistered()).isFalse();
-    } finally {
-      ThreadPools.initShutdownHook();
-    }
+  @AfterEach
+  void restoreShutdownHook() {
+    ThreadPools.initShutdownHook();
   }
 
   @Test
-  public void testThreadPoolManagerAddAndShutdown() throws Exception {
-    ThreadPools.ThreadPoolManager manager = new ThreadPools.ThreadPoolManager();
-
-    ExecutorService testExecutor = Executors.newFixedThreadPool(2);
-
-    Duration timeout = Duration.ofSeconds(5);
-    manager.addThreadPool(testExecutor, timeout);
-
-    manager.shutdownAll();
-
-    assertThat(testExecutor.isShutdown()).isTrue();
+  void testRemoveShutdownHook() {
+    assertThat(ThreadPools.isShutdownHookRegistered()).isTrue();
+    ThreadPools.removeShutdownHook();
+    assertThat(ThreadPools.isShutdownHookRegistered()).isFalse();
   }
 
   @Test
-  public void testThreadPoolManagerMultipleShutdowns() throws Exception {
-    ThreadPools.ThreadPoolManager manager = new ThreadPools.ThreadPoolManager();
+  void testNewExitingWorkerPoolShutdown() {
+    ExecutorService pool = ThreadPools.newExitingWorkerPool("test-exiting-pool", 2);
 
-    ExecutorService executor1 = Executors.newFixedThreadPool(1);
-    ExecutorService executor2 = Executors.newFixedThreadPool(1);
+    ThreadPools.shutdownThreadPools();
 
-    Duration timeout = Duration.ofSeconds(5);
-    manager.addThreadPool(executor1, timeout);
-    manager.addThreadPool(executor2, timeout);
-
-    manager.shutdownAll();
-
-    assertThat(executor1.isShutdown()).isTrue();
-    assertThat(executor2.isShutdown()).isTrue();
+    assertThat(pool.isShutdown()).isTrue();
   }
 
   @Test
-  public void testThreadPoolManagerShutdownNowCalled() throws Exception {
-    ThreadPools.ThreadPoolManager manager = new ThreadPools.ThreadPoolManager();
+  void testMultipleExitingPoolsShutdown() {
+    ExecutorService pool1 = ThreadPools.newExitingWorkerPool("test-pool-1", 1);
+    ExecutorService pool2 = ThreadPools.newExitingWorkerPool("test-pool-2", 1);
 
+    ThreadPools.shutdownThreadPools();
+
+    assertThat(pool1.isShutdown()).isTrue();
+    assertThat(pool2.isShutdown()).isTrue();
+  }
+
+  @Test
+  void testExitingScheduledPoolShutdown() {
+    ExecutorService scheduled =
+        ThreadPools.newExitingScheduledPool("test-scheduled", 1, Duration.ofSeconds(5));
+
+    ThreadPools.shutdownThreadPools();
+
+    assertThat(scheduled.isShutdown()).isTrue();
+  }
+
+  @Test
+  void testShutdownThreadPoolsInterruptsRunningTasks() throws Exception {
     final AtomicBoolean interrupted = new AtomicBoolean(false);
-    ExecutorService slowExecutor = Executors.newFixedThreadPool(1);
-
-    manager.addThreadPool(slowExecutor, Duration.ofMillis(50));
+    // Use a short termination timeout so shutdownThreadPools will call shutdownNow
+    ExecutorService slowPool =
+        ThreadPools.newExitingScheduledPool("test-slow-pool", 1, Duration.ofMillis(50));
 
     CountDownLatch threadStarted = new CountDownLatch(1);
     CountDownLatch threadInterrupted = new CountDownLatch(1);
 
-    slowExecutor.submit(
+    slowPool.submit(
         () -> {
           try {
             threadStarted.countDown();
             // NOTE: the test is NOT actually waiting for 60s, as it will be interrupted
-            // after 50ms due to the `shutdownAll` call below
+            // after 50ms due to the `shutdownThreadPools` call below
             Thread.sleep(60_000);
           } catch (InterruptedException e) {
             interrupted.set(true);
@@ -100,11 +101,11 @@ public class TestThreadPools {
     threadStarted.await();
 
     long start = System.nanoTime();
-    manager.shutdownAll();
+    ThreadPools.shutdownThreadPools();
     threadInterrupted.await();
     long end = System.nanoTime();
 
-    assertThat(slowExecutor.isShutdown()).isTrue();
+    assertThat(slowPool.isShutdown()).isTrue();
     assertThat(interrupted.get()).isTrue();
     assertThat(end - start).isGreaterThanOrEqualTo(50_000_000);
   }

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -38,14 +38,22 @@ class TestThreadPools {
   }
 
   @Test
-  void testRemoveShutdownHook() {
+  void removeShutdownHook() {
     assertThat(ThreadPools.isShutdownHookRegistered()).isTrue();
     ThreadPools.removeShutdownHook();
     assertThat(ThreadPools.isShutdownHookRegistered()).isFalse();
   }
 
   @Test
-  void testNewExitingWorkerPoolShutdown() {
+  void staticPoolsAreShutdown() {
+    ThreadPools.shutdownThreadPools();
+
+    assertThat(ThreadPools.getWorkerPool().isShutdown()).isTrue();
+    assertThat(ThreadPools.getDeleteWorkerPool().isShutdown()).isTrue();
+  }
+
+  @Test
+  void newExitingWorkerPoolShutdown() {
     ExecutorService pool = ThreadPools.newExitingWorkerPool("test-exiting-pool", 2);
 
     ThreadPools.shutdownThreadPools();
@@ -54,7 +62,7 @@ class TestThreadPools {
   }
 
   @Test
-  void testMultipleExitingPoolsShutdown() {
+  void multipleExitingPoolsShutdown() {
     ExecutorService pool1 = ThreadPools.newExitingWorkerPool("test-pool-1", 1);
     ExecutorService pool2 = ThreadPools.newExitingWorkerPool("test-pool-2", 1);
 
@@ -65,7 +73,7 @@ class TestThreadPools {
   }
 
   @Test
-  void testExitingScheduledPoolShutdown() {
+  void exitingScheduledPoolShutdown() {
     ExecutorService scheduled =
         ThreadPools.newExitingScheduledPool("test-scheduled", 1, Duration.ofSeconds(5));
 
@@ -75,7 +83,7 @@ class TestThreadPools {
   }
 
   @Test
-  void testShutdownThreadPoolsInterruptsRunningTasks() throws Exception {
+  void shutdownThreadPoolsInterruptsRunningTasks() throws Exception {
     final AtomicBoolean interrupted = new AtomicBoolean(false);
     // Use a short termination timeout so shutdownThreadPools will call shutdownNow
     ExecutorService slowPool =

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -38,13 +38,6 @@ class TestThreadPools {
   }
 
   @Test
-  void removeShutdownHook() {
-    assertThat(ThreadPools.isShutdownHookRegistered()).isTrue();
-    ThreadPools.removeShutdownHook();
-    assertThat(ThreadPools.isShutdownHookRegistered()).isFalse();
-  }
-
-  @Test
   void staticPoolsAreShutdown() {
     assertThat(ThreadPools.getWorkerPool().isShutdown()).isFalse();
     assertThat(ThreadPools.getDeleteWorkerPool().isShutdown()).isFalse();

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -33,8 +33,8 @@ import org.junit.jupiter.api.Timeout;
 class TestThreadPools {
 
   @AfterEach
-  void restoreShutdownHook() {
-    ThreadPools.initShutdownHook();
+  void restoreThreadPoolsState() {
+    ThreadPools.init();
   }
 
   @Test
@@ -46,6 +46,9 @@ class TestThreadPools {
 
   @Test
   void staticPoolsAreShutdown() {
+    assertThat(ThreadPools.getWorkerPool().isShutdown()).isFalse();
+    assertThat(ThreadPools.getDeleteWorkerPool().isShutdown()).isFalse();
+
     ThreadPools.shutdownThreadPools();
 
     assertThat(ThreadPools.getWorkerPool().isShutdown()).isTrue();


### PR DESCRIPTION
# Control of static thread pools — manual shutdown and lifecycle management

This change introduces a centralized `ThreadPoolManager` that gives users explicit control over Iceberg's thread pool lifecycle.

## Motivation

The previous approach used Guava's `MoreExecutors.getExitingExecutorService`, which registered unremovable shutdown hooks that accumulated over time with short-lived pools. This new design replaces it with a central manager, enabling manual shutdown and opt-out of automatic hook registration.

This is needed when the application registers its own shutdown hooks, that need to commit the iceberg file upload cleanly. Because JVM does not allow control of the order in which the shutdown hooks get invoked, the problem with the current state is that iceberg kills its thread pools and is unable to complete the export. 

## Intended Use Cases

1. Stop thread pools manually to avoid leaks in hot-reload environments
2. Opt out of the standard JVM shutdown hook mechanism to manage graceful service stops (e.g., committing last pending files before exiting). 

## Key Changes

- **`shutdownThreadPools()`** — gracefully shuts down all registered pools and removes the JVM shutdown hook
- **`removeShutdownHook()`** — opt out of automatic shutdown hooks so applications can manage their own graceful shutdown sequence (within their shutdown hooks)


Fixes issue [#15039](https://github.com/apache/iceberg/issues/15031)