### PR TITLE
Flink: Add extensibility support to IcebergSink for downstream composition

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CachingTableSupplier.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CachingTableSupplier.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * table loader should be used carefully when used with writer tasks. It could result in heavy load
  * on a catalog for jobs with many writers.
  */
-class CachingTableSupplier implements SerializableSupplier<Table> {
+public class CachingTableSupplier implements SerializableSupplier<Table> {
 
   private static final Logger LOG = LoggerFactory.getLogger(CachingTableSupplier.class);
 
@@ -43,7 +43,7 @@ class CachingTableSupplier implements SerializableSupplier<Table> {
   private long lastLoadTimeMillis;
   private transient Table table;
 
-  CachingTableSupplier(
+  public CachingTableSupplier(
       SerializableTable initialTable, TableLoader tableLoader, Duration tableRefreshInterval) {
     Preconditions.checkArgument(initialTable != null, "initialTable cannot be null");
     Preconditions.checkArgument(tableLoader != null, "tableLoader cannot be null");

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CommittableMetadata.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CommittableMetadata.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.Serializable;
+
+/**
+ * Marker interface for custom metadata that flows through the Iceberg sink pipeline.
+ *
+ * <p>This interface allows users to attach arbitrary metadata to committables as they flow from
+ * writers through aggregators to committers. Implementations can carry custom information such as
+ * watermarks or other application-specific data.
+ *
+ * <p>Metadata serialization is handled by {@link CommittableMetadataSerializer} implementations
+ * registered via {@link CommittableMetadataRegistry}.
+ *
+ * @see CommittableMetadataSerializer
+ * @see CommittableMetadataRegistry
+ */
+public interface CommittableMetadata extends Serializable {}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CommittableMetadataRegistry.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CommittableMetadataRegistry.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import javax.annotation.Nullable;
+
+/**
+ * Global registry for {@link CommittableMetadataSerializer} implementations.
+ *
+ * <p>This registry provides a location to register custom serializers for {@link
+ * CommittableMetadata}. The registered serializer is used by {@link IcebergCommittableSerializer}
+ * and {@link WriteResultSerializer} to serialize/deserialize metadata flowing through the pipeline.
+ *
+ * @see CommittableMetadata
+ * @see CommittableMetadataSerializer
+ */
+public class CommittableMetadataRegistry {
+  private static volatile CommittableMetadataSerializer serializer = null;
+
+  private CommittableMetadataRegistry() {}
+
+  /**
+   * Register a metadata serializer.
+   *
+   * <p>This should be called before any Iceberg sinks are created.
+   *
+   * @param metadataSerializer The serializer to register (can be null to clear registration)
+   */
+  public static void register(@Nullable CommittableMetadataSerializer metadataSerializer) {
+    serializer = metadataSerializer;
+  }
+
+  /**
+   * Get the registered metadata serializer.
+   *
+   * @return The registered serializer, or null if none is registered
+   */
+  @Nullable
+  public static CommittableMetadataSerializer get() {
+    return serializer;
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CommittableMetadataSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CommittableMetadataSerializer.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.IOException;
+import java.io.Serializable;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer for {@link CommittableMetadata} implementations.
+ *
+ * <p>Responsible for serializing and deserializing custom metadata that flows through the Iceberg
+ * sink pipeline. The serializer must be registered via {@link CommittableMetadataRegistry} to be
+ * used by the sink's serialization infrastructure.
+ *
+ * @see CommittableMetadata
+ * @see CommittableMetadataRegistry
+ */
+public interface CommittableMetadataSerializer extends Serializable {
+  /**
+   * Serialize the given metadata to the output stream.
+   *
+   * @param metadata The metadata to serialize (never null)
+   * @param out The output stream to write to
+   * @throws IOException If serialization fails
+   */
+  void write(CommittableMetadata metadata, DataOutputView out) throws IOException;
+
+  /**
+   * Deserialize metadata from the input stream.
+   *
+   * @param in The input stream to read from
+   * @return The deserialized metadata (never null)
+   * @throws IOException If deserialization fails
+   */
+  CommittableMetadata read(DataInputView in) throws IOException;
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommittable.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommittable.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
 /**
@@ -31,33 +32,49 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
  * <p>{@link IcebergCommittableSerializer} is used for serializing the objects between the Writer
  * and the Aggregator operator and between the Aggregator and the Committer as well.
  */
-class IcebergCommittable implements Serializable {
+public class IcebergCommittable implements Serializable {
   private final byte[] manifest;
   private final String jobId;
   private final String operatorId;
   private final long checkpointId;
+  @Nullable private final CommittableMetadata metadata;
 
-  IcebergCommittable(byte[] manifest, String jobId, String operatorId, long checkpointId) {
+  public IcebergCommittable(byte[] manifest, String jobId, String operatorId, long checkpointId) {
+    this(manifest, jobId, operatorId, checkpointId, null);
+  }
+
+  public IcebergCommittable(
+      byte[] manifest,
+      String jobId,
+      String operatorId,
+      long checkpointId,
+      @Nullable CommittableMetadata metadata) {
     this.manifest = manifest;
     this.jobId = jobId;
     this.operatorId = operatorId;
     this.checkpointId = checkpointId;
+    this.metadata = metadata;
   }
 
-  byte[] manifest() {
+  public byte[] manifest() {
     return manifest;
   }
 
-  String jobId() {
+  public String jobId() {
     return jobId;
   }
 
-  String operatorId() {
+  public String operatorId() {
     return operatorId;
   }
 
-  Long checkpointId() {
+  public Long checkpointId() {
     return checkpointId;
+  }
+
+  @Nullable
+  public CommittableMetadata metadata() {
+    return metadata;
   }
 
   @Override
@@ -66,6 +83,7 @@ class IcebergCommittable implements Serializable {
         .add("jobId", jobId)
         .add("checkpointId", checkpointId)
         .add("operatorId", operatorId)
+        .add("metadata", metadata)
         .toString();
   }
 
@@ -83,12 +101,13 @@ class IcebergCommittable implements Serializable {
     return checkpointId == that.checkpointId
         && Arrays.equals(manifest, that.manifest)
         && Objects.equals(jobId, that.jobId)
-        && Objects.equals(operatorId, that.operatorId);
+        && Objects.equals(operatorId, that.operatorId)
+        && Objects.equals(metadata, that.metadata);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(jobId, operatorId, checkpointId);
+    int result = Objects.hash(jobId, operatorId, checkpointId, metadata);
     result = 31 * result + Arrays.hashCode(manifest);
     return result;
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  *       same jobId-operatorId-checkpointId triplet
  * </ul>
  */
-class IcebergCommitter implements Committer<IcebergCommittable> {
+public class IcebergCommitter implements Committer<IcebergCommittable> {
   private static final Logger LOG = LoggerFactory.getLogger(IcebergCommitter.class);
   private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
   public static final WriteResult EMPTY_WRITE_RESULT =
@@ -80,7 +80,7 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
   private int continuousEmptyCheckpoints = 0;
   private boolean compactMode = false;
 
-  IcebergCommitter(
+  public IcebergCommitter(
       TableLoader tableLoader,
       String branch,
       Map<String, String> snapshotProperties,

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -167,7 +167,7 @@ public class IcebergSink
   // equalityFieldIds instead.
   private final Set<String> equalityFieldColumns;
 
-  private IcebergSink(
+  protected IcebergSink(
       TableLoader tableLoader,
       Table table,
       Map<String, String> snapshotProperties,
@@ -203,6 +203,75 @@ public class IcebergSink
     this.compactMode = flinkWriteConf.compactMode();
     this.flinkMaintenanceConfig = flinkMaintenanceConfig;
     this.equalityFieldColumns = equalityFieldColumns;
+  }
+
+  // Protected getters for subclass access
+  protected TableLoader getTableLoader() {
+    return tableLoader;
+  }
+
+  protected Table getTable() {
+    return table;
+  }
+
+  protected Map<String, String> getSnapshotProperties() {
+    return snapshotProperties;
+  }
+
+  protected String getUidSuffix() {
+    return uidSuffix;
+  }
+
+  protected String getSinkId() {
+    return sinkId;
+  }
+
+  protected Map<String, String> getWriteProperties() {
+    return writeProperties;
+  }
+
+  protected RowType getFlinkRowType() {
+    return flinkRowType;
+  }
+
+  protected SerializableSupplier<Table> getTableSupplier() {
+    return tableSupplier;
+  }
+
+  protected FlinkWriteConf getFlinkWriteConf() {
+    return flinkWriteConf;
+  }
+
+  protected Set<Integer> getEqualityFieldIds() {
+    return equalityFieldIds;
+  }
+
+  protected boolean isUpsertMode() {
+    return upsertMode;
+  }
+
+  protected FileFormat getDataFileFormat() {
+    return dataFileFormat;
+  }
+
+  protected long getTargetDataFileSize() {
+    return targetDataFileSize;
+  }
+
+  protected String getBranch() {
+    return branch;
+  }
+
+  protected boolean isOverwriteMode() {
+    return overwriteMode;
+  }
+
+  protected int getWorkerPoolSize() {
+    return workerPoolSize;
+  }
+
+  protected boolean isCompactMode() {
+    return compactMode;
   }
 
   @Override
@@ -339,7 +408,7 @@ public class IcebergSink
     private ReadableConfig readableConfig = new Configuration();
     private List<String> equalityFieldColumns = null;
 
-    private Builder() {}
+    protected Builder() {}
 
     private Builder forRowData(DataStream<RowData> newRowDataInput) {
       this.inputCreator = ignored -> newRowDataInput;
@@ -732,7 +801,7 @@ public class IcebergSink
     return uidSuffix;
   }
 
-  private static SerializableTable checkAndGetTable(TableLoader tableLoader, Table table) {
+  public static SerializableTable checkAndGetTable(TableLoader tableLoader, Table table) {
     if (table == null) {
       if (!tableLoader.isOpen()) {
         tableLoader.open();
@@ -851,7 +920,7 @@ public class IcebergSink
     }
   }
 
-  private int resolveWriterParallelism(DataStream<RowData> input) {
+  protected int resolveWriterParallelism(DataStream<RowData> input) {
     // if the writeParallelism is not specified, we set the default to the input parallelism to
     // encourage chaining.
     return Optional.ofNullable(flinkWriteConf.writeParallelism()).orElseGet(input::getParallelism);

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSinkBuilder.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSinkBuilder.java
@@ -39,7 +39,7 @@ import org.apache.iceberg.flink.TableLoader;
  * be replaced by direct {@link IcebergSink} usage.
  */
 @Internal
-interface IcebergSinkBuilder<T extends IcebergSinkBuilder<?>> {
+public interface IcebergSinkBuilder<T extends IcebergSinkBuilder<?>> {
 
   /**
    * @deprecated Use {@link #resolvedSchema(ResolvedSchema)} instead.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSinkWriter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSinkWriter.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * emits a single {@link WriteResult} at every checkpoint for every data/delete file created by this
  * writer.
  */
-class IcebergSinkWriter implements CommittingSinkWriter<RowData, WriteResult> {
+public class IcebergSinkWriter implements CommittingSinkWriter<RowData, WriteResult> {
   private static final Logger LOG = LoggerFactory.getLogger(IcebergSinkWriter.class);
 
   private final String fullTableName;
@@ -47,7 +47,7 @@ class IcebergSinkWriter implements CommittingSinkWriter<RowData, WriteResult> {
   private final int subTaskId;
   private final int attemptId;
 
-  IcebergSinkWriter(
+  public IcebergSinkWriter(
       String fullTableName,
       TaskWriterFactory<RowData> taskWriterFactory,
       IcebergStreamWriterMetrics metrics,

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergWriteAggregator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergWriteAggregator.java
@@ -43,7 +43,8 @@ import org.slf4j.LoggerFactory;
  * IcebergCommittable} per checkpoint (storing the serialized {@link
  * org.apache.iceberg.flink.sink.DeltaManifests}, jobId, operatorId, checkpointId)
  */
-class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<IcebergCommittable>>
+public class IcebergWriteAggregator
+    extends AbstractStreamOperator<CommittableMessage<IcebergCommittable>>
     implements OneInputStreamOperator<
         CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>> {
 
@@ -58,7 +59,7 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
   private transient ManifestOutputFileFactory icebergManifestOutputFileFactory;
   private transient Table table;
 
-  IcebergWriteAggregator(TableLoader tableLoader) {
+  public IcebergWriteAggregator(TableLoader tableLoader) {
     this.results = Sets.newHashSet();
     this.tableLoader = tableLoader;
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -249,6 +249,26 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     }
   }
 
+  protected Supplier<Table> getTableSupplier() {
+    return tableSupplier;
+  }
+
+  protected PartitionSpec getSpec() {
+    return spec;
+  }
+
+  protected FileFormat getFormat() {
+    return format;
+  }
+
+  protected OutputFileFactory getOutputFileFactory() {
+    return outputFileFactory;
+  }
+
+  protected void setOutputFileFactory(OutputFileFactory outputFileFactory) {
+    this.outputFileFactory = outputFileFactory;
+  }
+
   private static class RowDataPartitionedFanoutWriter extends PartitionedFanoutWriter<RowData> {
 
     private final PartitionKey partitionKey;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/SinkUtil.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/SinkUtil.java
@@ -54,7 +54,8 @@ public class SinkUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(SinkUtil.class);
 
-  static Set<Integer> checkAndGetEqualityFieldIds(Table table, List<String> equalityFieldColumns) {
+  public static Set<Integer> checkAndGetEqualityFieldIds(
+      Table table, List<String> equalityFieldColumns) {
     Set<Integer> equalityFieldIds = Sets.newHashSet(table.schema().identifierFieldIds());
     if (equalityFieldColumns != null && !equalityFieldColumns.isEmpty()) {
       Set<Integer> equalityFieldSet = Sets.newHashSetWithExpectedSize(equalityFieldColumns.size());


### PR DESCRIPTION
## Summary

- Add `CommittableMetadata` framework: a composition-based extension point allowing downstream to
  attach custom metadata to committables flowing through the sink pipeline
- Widen access modifiers on sink classes to enable downstream connector implementations to compose
  with (reference, wrap, delegate to) Iceberg's existing sink infrastructure

Resolves #15315.

## Changes

### New files (3, in both v2.0 and v2.1)
- `CommittableMetadata.java` — `Serializable` marker interface for custom metadata
- `CommittableMetadataSerializer.java` — serializer interface for metadata
- `CommittableMetadataRegistry.java` — global registry (downstream calls `register()` before
  sink creation)

### Modified files (in both v2.0 and v2.1)
- `IcebergCommittable` — public class, public accessors, optional `@Nullable metadata` field,
  backward-compatible constructor chaining
- `IcebergCommittableSerializer` — writes boolean metadata flag + delegates serialization
- `IcebergCommitter` — public class + constructor
- `IcebergSinkWriter` — public class + constructor
- `IcebergWriteAggregator` — public class + constructor
- `IcebergSinkBuilder` — public interface
- `IcebergSink` — protected constructor, protected getters, protected `Builder()`
- `CachingTableSupplier` — public class + constructor
- `RowDataTaskWriterFactory` — protected getters for spec/format/outputFileFactory
- `SinkUtil` — public `checkAndGetEqualityFieldIds()`

### Backward compatibility
- All existing constructors still work (new `IcebergCommittable` constructor chains with
  `metadata = null`)
- Serialization is backward-compatible (boolean flag distinguishes metadata presence)
- No behavioral changes to any existing code path

## Test plan
- [ ] Existing `TestIcebergCommitter` passes
- [ ] Existing `TestIcebergSink*` tests pass
- [ ] Serialization backward compatibility: old serialized data (no metadata flag) still
      deserializes correctly