### PR TITLE
REST spec: Add Optional UUID for Namespaces to OpenAPI spec

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -731,6 +731,11 @@ class IcebergErrorResponse(BaseModel):
 
 class CreateNamespaceResponse(BaseModel):
     namespace: Namespace
+    namespace_uuid: str | None = Field(
+        None,
+        alias='namespace-uuid',
+        description='Optional UUID representing the unique identifier for the namespace.',
+    )
     properties: dict[str, str] | None = Field(
         {},
         description='Properties stored on the namespace, if supported by the server.',
@@ -740,6 +745,11 @@ class CreateNamespaceResponse(BaseModel):
 
 class GetNamespaceResponse(BaseModel):
     namespace: Namespace
+    namespace_uuid: str | None = Field(
+        None,
+        alias='namespace-uuid',
+        description='Optional UUID representing the unique identifier for the namespace.',
+    )
     properties: dict[str, str] | None = Field(
         {},
         description='Properties stored on the namespace, if supported by the server. If the server does not support namespace properties, it should return null for this field. If namespace properties are supported, but none are set, it should return an empty object.',

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -734,7 +734,7 @@ class CreateNamespaceResponse(BaseModel):
     namespace_uuid: str | None = Field(
         None,
         alias='namespace-uuid',
-        description='Optional UUID representing the unique identifier for the namespace.',
+        description='Optional UUID representing the unique identifier for the namespace. This is tied to the actual entity, not the name, which can be reused.',
     )
     properties: dict[str, str] | None = Field(
         {},
@@ -748,7 +748,7 @@ class GetNamespaceResponse(BaseModel):
     namespace_uuid: str | None = Field(
         None,
         alias='namespace-uuid',
-        description='Optional UUID representing the unique identifier for the namespace.',
+        description='Optional UUID representing the unique identifier for the namespace. This is tied to the actual entity, not the name, which can be reused.',
     )
     properties: dict[str, str] | None = Field(
         {},

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -80,16 +80,23 @@ class UpdateNamespacePropertiesRequest(BaseModel):
     updates: dict[str, str] | None = Field(None, example={'owner': 'Hank Bendickson'})
 
 
-class Namespace(BaseModel):
+class NamespaceObject(BaseModel):
     """
     Reference to one or more levels of a namespace
     """
-
-    __root__: list[str] = Field(
+    namespace: list[str] = Field(
         ...,
         description='Reference to one or more levels of a namespace',
         example=['accounting', 'tax'],
     )
+    namespace_uuid: str | None = Field(
+        None,
+        alias='namespace-uuid',
+        description='Optional UUID representing the unique identifier for the namespace.',
+    )
+
+
+Namespace = list[str] | NamespaceObject
 
 
 class PageToken(BaseModel):
@@ -731,11 +738,6 @@ class IcebergErrorResponse(BaseModel):
 
 class CreateNamespaceResponse(BaseModel):
     namespace: Namespace
-    namespace_uuid: str | None = Field(
-        None,
-        alias='namespace-uuid',
-        description='Optional UUID representing the unique identifier for the namespace. This is tied to the actual entity, not the name, which can be reused.',
-    )
     properties: dict[str, str] | None = Field(
         {},
         description='Properties stored on the namespace, if supported by the server.',
@@ -745,11 +747,6 @@ class CreateNamespaceResponse(BaseModel):
 
 class GetNamespaceResponse(BaseModel):
     namespace: Namespace
-    namespace_uuid: str | None = Field(
-        None,
-        alias='namespace-uuid',
-        description='Optional UUID representing the unique identifier for the namespace. This is tied to the actual entity, not the name, which can be reused.',
-    )
     properties: dict[str, str] | None = Field(
         {},
         description='Properties stored on the namespace, if supported by the server. If the server does not support namespace properties, it should return null for this field. If namespace properties are supported, but none are set, it should return an empty object.',

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4104,7 +4104,7 @@ components:
           $ref: '#/components/schemas/Namespace'
         namespace-uuid:
           type: string
-          description: "Optional UUID representing the unique identifier for the namespace."
+          description: "Optional UUID representing the unique identifier for the namespace. This is tied to the actual entity, not the name, which can be reused."
         properties:
           type: object
           additionalProperties:
@@ -4123,7 +4123,7 @@ components:
           $ref: '#/components/schemas/Namespace'
         namespace-uuid:
           type: string
-          description: "Optional UUID representing the unique identifier for the namespace."
+          description: "Optional UUID representing the unique identifier for the namespace. This is tied to the actual entity, not the name, which can be reused."
         properties:
           type: object
           description:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4102,6 +4102,9 @@ components:
       properties:
         namespace:
           $ref: '#/components/schemas/Namespace'
+        namespace-uuid:
+          type: string
+          description: "Optional UUID representing the unique identifier for the namespace."
         properties:
           type: object
           additionalProperties:
@@ -4118,6 +4121,9 @@ components:
       properties:
         namespace:
           $ref: '#/components/schemas/Namespace'
+        namespace-uuid:
+          type: string
+          description: "Optional UUID representing the unique identifier for the namespace."
         properties:
           type: object
           description:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2156,11 +2156,23 @@ components:
           $ref: '#/components/schemas/TableIdentifier'
 
     Namespace:
-      description: Reference to one or more levels of a namespace
-      type: array
-      items:
-        type: string
-      example: [ "accounting", "tax" ]
+      oneOf:
+        - type: array
+          items:
+            type: string
+          description: "Reference to one or more levels of a namespace"
+        - type: object
+          required:
+            - namespace
+          properties:
+            namespace:
+              type: array
+              items:
+                type: string
+              description: "Reference to one or more levels of a namespace"
+            namespace-uuid:
+              type: string
+              description: "Optional UUID representing the unique identifier for the namespace."
 
     PageToken:
       description:
@@ -4102,9 +4114,6 @@ components:
       properties:
         namespace:
           $ref: '#/components/schemas/Namespace'
-        namespace-uuid:
-          type: string
-          description: "Optional UUID representing the unique identifier for the namespace. This is tied to the actual entity, not the name, which can be reused."
         properties:
           type: object
           additionalProperties:
@@ -4121,9 +4130,6 @@ components:
       properties:
         namespace:
           $ref: '#/components/schemas/Namespace'
-        namespace-uuid:
-          type: string
-          description: "Optional UUID representing the unique identifier for the namespace. This is tied to the actual entity, not the name, which can be reused."
         properties:
           type: object
           description:


### PR DESCRIPTION
This PR adds an optional `namespace-uuid` to REST API namespace responses. This UUID uniquely identifies a namespace, allowing name reuse, and supports catalog synchronization. We discussed at last Catalog Sync.