### PR TITLE
Site: Add description field to blog posts for RSS feed

### DIFF
--- a/site/docs/blog/posts/2026-01-10-iceberg-summit.md
+++ b/site/docs/blog/posts/2026-01-10-iceberg-summit.md
@@ -2,6 +2,7 @@
 date: 2026-01-10
 title: Announcing Iceberg Summit 2026
 slug: announcing-iceberg-summit-2026  # this is the url
+description: Iceberg Summit returns April 8-9, 2026 in San Francisco.
 authors:
   - iceberg-pmc
 categories:

--- a/site/docs/blog/posts/2026-01-26-iceberg-cpp-0.2.0-release.md
+++ b/site/docs/blog/posts/2026-01-26-iceberg-cpp-0.2.0-release.md
@@ -2,6 +2,7 @@
 date: 2026-01-26
 title: Apache Iceberg C++ 0.2.0 Release
 slug: apache-iceberg-cpp-0.2.0-release  # this is the blog url
+description: Apache Iceberg C++ 0.2.0 release
 authors:
   - iceberg-pmc
 categories:

--- a/site/docs/blog/posts/2026-02-02-iceberg-rust-0.8.0-release.md
+++ b/site/docs/blog/posts/2026-02-02-iceberg-rust-0.8.0-release.md
@@ -2,6 +2,7 @@
 date: 2026-02-02
 title: Apache Iceberg Rust 0.8.0 Release
 slug: apache-iceberg-rust-0.8.0-release  # this is the blog url
+description: Apache Iceberg Rust 0.8.0 release
 authors:
   - iceberg-pmc
 categories:

--- a/site/docs/blog/posts/2026-02-10-iceberg-python-0.11.0-release.md
+++ b/site/docs/blog/posts/2026-02-10-iceberg-python-0.11.0-release.md
@@ -2,6 +2,7 @@
 date: 2026-02-10
 title: Apache Iceberg Python 0.11.0 Release
 slug: apache-iceberg-python-0.11.0-release
+description: Apache Iceberg Python 0.11.0 release
 authors:
   - iceberg-pmc
 categories:


### PR DESCRIPTION
Add explicit `description` fields to blog post to improve RSS feed quality.

The mkdocs-rss-plugin was rendering HTML comments (including the ASF license header) in the RSS feed description. By adding an explicit `description` field to each blog post's front matter, the plugin uses that instead of parsing the page content.

#### Before
<img width="1909" height="558" alt="Screenshot 2026-02-15 at 7 22 37 AM" src="https://github.com/user-attachments/assets/45b8cd30-b69b-4b6c-92b6-115ae4cec4c3" />

#### After
<img width="1909" height="646" alt="Screenshot 2026-02-15 at 7 28 30 AM" src="https://github.com/user-attachments/assets/4f1633f0-bd20-45ba-9907-fe7962ff0fa3" />
