### PR TITLE
Site: Remove redundant --watch flag from serve scripts

### DIFF
--- a/site/dev/serve-dev.sh
+++ b/site/dev/serve-dev.sh
@@ -32,4 +32,4 @@ echo ""
 
 ./dev/setup_env.sh
 
-"${VENV_DIR}/bin/python3" -m mkdocs serve -f mkdocs-dev.yml --livereload --watch .
+"${VENV_DIR}/bin/python3" -m mkdocs serve -f mkdocs-dev.yml --livereload

--- a/site/dev/serve.sh
+++ b/site/dev/serve.sh
@@ -34,4 +34,4 @@ echo ""
 
 ./dev/lint.sh
 
-"${VENV_DIR}/bin/python3" -m mkdocs serve --livereload --watch .
+"${VENV_DIR}/bin/python3" -m mkdocs serve --livereload


### PR DESCRIPTION
Remove the `--watch .` flag from `serve.sh` and `serve-dev.sh` since it's
unnecessary and counterproductive:

- MkDocs automatically watches the `docs_dir` and config file
- `mkdocs.yml` already configures specific watch paths (`nav.yml`, `overrides/`)
- Using `--watch .` watches everything including `.venv/`, causing excessive
  file monitoring and potential spurious rebuilds