### PR TITLE
Kafka Connect: Handle java.util.Date in RecordConverter.convertLong()

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -318,11 +318,14 @@ class RecordConverter {
     throw new IllegalArgumentException("Cannot convert to int: " + value.getClass().getName());
   }
 
+  @SuppressWarnings("JavaUtilDate")
   protected long convertLong(Object value) {
     if (value instanceof Number) {
       return ((Number) value).longValue();
     } else if (value instanceof String) {
       return Long.parseLong((String) value);
+    } else if (value instanceof Date) {
+      return ((Date) value).getTime();
     }
     throw new IllegalArgumentException("Cannot convert to long: " + value.getClass().getName());
   }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -444,6 +444,10 @@ public class TestRecordConverter {
               long val = converter.convertLong(input);
               assertThat(val).isEqualTo(expectedLong);
             });
+
+    // java.util.Date (e.g. from Confluent Avro converter for timestamp-millis)
+    long dateMillis = 1684393200000L;
+    assertThat(converter.convertLong(new Date(dateMillis))).isEqualTo(dateMillis);
   }
 
   @Test


### PR DESCRIPTION
The Confluent Avro converter deserializes timestamp-millis logical type fields as java.util.Date, but convertLong() only handled Number and String, throwing IllegalArgumentException.

Add instanceof Date branch that calls Date.getTime() to extract epoch millis, consistent with other conversion methods in RecordConverter.

Closes #15344