### PR TITLE
Build: Enable JavaUtilDate ErrorProne rule

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -119,6 +119,7 @@ subprojects {
           '-Xep:InconsistentCapitalization:ERROR',
           '-Xep:InconsistentHashCode:ERROR',
           '-Xep:IntLongMath:ERROR',
+          '-Xep:JavaUtilDate:ERROR',
           '-Xep:JdkObsolete:ERROR',
           // prefer method references over lambdas
           '-Xep:LambdaMethodReference:ERROR',


### PR DESCRIPTION
The rule wasn't enforced though there are some `@SuppressWarnings("JavaUtilDate")` in the current codebase. 

The default severity of JavaUtilDate is warning: https://errorprone.info/bugpattern/JavaUtilDate