### PR TITLE
CI: Add CodeQL workflow for GitHub Actions security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
     name: Analyze Actions
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       packages: read
 


### PR DESCRIPTION
This adds a CodeQL workflow to scan GitHub Actions workflow files for security issues such as script injection, use of untrusted input, and other misconfigurations.

Reference: https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/

**Triggers:**
- Push and PR to `main`
- Weekly scheduled scan (Mondays at 4:16 UTC)


This is based on [Apache Infra recommendation](https://cwiki.apache.org/confluence/display/BUILDS/GitHub+Actions+Security),  

> IMPORTANT! You should enable CodeQL "actions" scanning in your repositories as described in  https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/  - this will scan and flag those issues described below and many more automatically for you
