### PR TITLE
Docs: Add documentation pointers in README files and fix typos in Spark quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ sudo setenforce Enforcing
 
 ---
 
+#### Documentation
+
+For information about building the documentation, see [here](site/README.md).
+
 ### Engine Compatibility
 
 See the [Multi-Engine Support](https://iceberg.apache.org/multi-engine-support/) page to know about Iceberg compatibility with different Spark, Flink and Hive versions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+For information about the documentation, please see [this README.md](../site/README.md)

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -326,8 +326,8 @@ If you already have a Spark environment, you can add Iceberg, using the `--packa
 
 !!! note
     If you want to include Iceberg in your Spark installation, add the Iceberg Spark runtime to Spark's `jars` folder.
-    You can download the runtime by visiting to the [Releases](releases.md) page.
+    You can download the runtime from the [Releases](releases.md) page.
 
 #### Learn More
 
-Now that you're up an running with Iceberg and Spark, check out the [Iceberg-Spark docs](docs/latest/spark-ddl.md) to learn more!
+Now that you're up and running with Iceberg and Spark, check out the [Iceberg-Spark docs](docs/latest/spark-ddl.md) to learn more!


### PR DESCRIPTION
Pulling these changes out of #15062 /cc @kevinjqliu.

- Add link to site/README.md in main README.md
- Create docs/README.md pointing to site/README.md
- Fix typos in spark-quickstart.md ("visiting to" -> "from", "up an" -> "up and")

