### PR TITLE
Spark 4.1: Use enum conf parser for isolation level

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -449,9 +449,10 @@ public class SparkWriteConf {
   }
 
   public IsolationLevel isolationLevel() {
-    String isolationLevelName =
-        confParser.stringConf().option(SparkWriteOptions.ISOLATION_LEVEL).parseOptional();
-    return isolationLevelName != null ? IsolationLevel.fromName(isolationLevelName) : null;
+    return confParser
+        .enumConf(IsolationLevel::fromName)
+        .option(SparkWriteOptions.ISOLATION_LEVEL)
+        .parseOptional();
   }
 
   public boolean caseSensitive() {


### PR DESCRIPTION
This PR switches to enum conf parser for isolation level in Spark 4.1.