### PR TITLE
Spark 4.1: Use table IDs in scan equals/hashCode

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -253,6 +253,7 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
 
     SparkBatchQueryScan that = (SparkBatchQueryScan) o;
     return table().name().equals(that.table().name())
+        && Objects.equals(table().uuid(), that.table().uuid())
         && Objects.equals(branch(), that.branch())
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field ids
         && filtersDesc().equals(that.filtersDesc())
@@ -268,6 +269,7 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
   public int hashCode() {
     return Objects.hash(
         table().name(),
+        table().uuid(),
         branch(),
         readSchema(),
         filtersDesc(),

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -148,6 +148,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
 
     SparkChangelogScan that = (SparkChangelogScan) o;
     return table.name().equals(that.table.name())
+        && Objects.equals(table.uuid(), that.table.uuid())
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field IDs
         && filtersDesc().equals(that.filtersDesc())
         && Objects.equals(startSnapshotId, that.startSnapshotId)
@@ -156,7 +157,8 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
 
   @Override
   public int hashCode() {
-    return Objects.hash(table.name(), readSchema(), filtersDesc(), startSnapshotId, endSnapshotId);
+    return Objects.hash(
+        table.name(), table.uuid(), readSchema(), filtersDesc(), startSnapshotId, endSnapshotId);
   }
 
   private String filtersDesc() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -161,6 +161,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
 
     SparkCopyOnWriteScan that = (SparkCopyOnWriteScan) o;
     return table().name().equals(that.table().name())
+        && Objects.equals(table().uuid(), that.table().uuid())
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field ids
         && filtersDesc().equals(that.filtersDesc())
         && Objects.equals(snapshotId(), that.snapshotId())
@@ -170,7 +171,12 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
   @Override
   public int hashCode() {
     return Objects.hash(
-        table().name(), readSchema(), filtersDesc(), snapshotId(), filteredLocations);
+        table().name(),
+        table().uuid(),
+        readSchema(),
+        filtersDesc(),
+        snapshotId(),
+        filteredLocations);
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
@@ -91,6 +91,7 @@ class SparkStagedScan extends SparkScan {
 
     SparkStagedScan that = (SparkStagedScan) other;
     return table().name().equals(that.table().name())
+        && Objects.equals(table().uuid(), that.table().uuid())
         && Objects.equals(taskSetId, that.taskSetId)
         && readSchema().equals(that.readSchema())
         && splitSize == that.splitSize
@@ -101,7 +102,13 @@ class SparkStagedScan extends SparkScan {
   @Override
   public int hashCode() {
     return Objects.hash(
-        table().name(), taskSetId, readSchema(), splitSize, splitLookback, openFileCost);
+        table().name(),
+        table().uuid(),
+        taskSetId,
+        readSchema(),
+        splitSize,
+        splitLookback,
+        openFileCost);
   }
 
   @Override


### PR DESCRIPTION
This PR adds table IDs to scan equals/hashCode implementations.