### PR TITLE
Spark 4.1: Remove unnecessary stats reporting from scan builder

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -51,12 +51,10 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 import org.apache.spark.sql.connector.read.Scan;
-import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.SupportsPushDownAggregates;
 import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
 import org.apache.spark.sql.connector.read.SupportsPushDownV2Filters;
-import org.apache.spark.sql.connector.read.SupportsReportStatistics;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
@@ -65,7 +63,6 @@ import org.slf4j.LoggerFactory;
 public class SparkScanBuilder extends BaseSparkScanBuilder
     implements SupportsPushDownV2Filters,
         SupportsPushDownRequiredColumns,
-        SupportsReportStatistics,
         SupportsPushDownLimit,
         SupportsPushDownAggregates {
 
@@ -542,16 +539,6 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
         expectedSchema,
         filters(),
         metricsReporter()::scanReport);
-  }
-
-  @Override
-  public Statistics estimateStatistics() {
-    return ((SupportsReportStatistics) build()).estimateStatistics();
-  }
-
-  @Override
-  public StructType readSchema() {
-    return build().readSchema();
   }
 
   private BatchScan newBatchScan() {


### PR DESCRIPTION
This PR removes unnecessary stats reporting from our scan builders in Spark 4.1. 

In general, `SupportsReportStatistics` is defined on `Scan`, not `ScanBuilder`. However, early versions of Spark had a bug that checked stats on the builder. That bug was fixed in 2022 and is no longer an issue ([SPARK-38962](https://issues.apache.org/jira/browse/SPARK-38962)).