### PR TITLE
Spark 4.1: Use scan filter for conflict detection

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/source/PlanUtils.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/source/PlanUtils.java
@@ -49,7 +49,7 @@ public class PlanUtils {
               }
 
               SparkBatchQueryScan batchQueryScan = (SparkBatchQueryScan) scanRelation.scan();
-              return batchQueryScan.filterExpressions().stream();
+              return batchQueryScan.filters().stream();
             })
         .collect(Collectors.toList());
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -52,7 +52,6 @@ import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.BasePositionDeltaWriter;
 import org.apache.iceberg.io.ClusteredDataWriter;
 import org.apache.iceberg.io.ClusteredPositionDeleteWriter;
@@ -247,7 +246,7 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
       // the scan may be null if the optimizer replaces it with an empty relation
       // no validation is needed in this case as the command is independent of the table state
       if (scan != null) {
-        Expression conflictDetectionFilter = conflictDetectionFilter(scan);
+        Expression conflictDetectionFilter = scan.filter();
         rowDelta.conflictDetectionFilter(conflictDetectionFilter);
 
         rowDelta.validateDataFilesExist(referencedDataFiles);
@@ -289,16 +288,6 @@ class SparkPositionDeltaWrite extends BaseSparkWrite
                 addedDeleteFilesCount);
         commitOperation(rowDelta, commitMsg, summary);
       }
-    }
-
-    private Expression conflictDetectionFilter(SparkBatchQueryScan queryScan) {
-      Expression filter = Expressions.alwaysTrue();
-
-      for (Expression expr : queryScan.filterExpressions()) {
-        filter = Expressions.and(filter, expr);
-      }
-
-      return filter;
     }
 
     @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -105,7 +106,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   private final SparkReadConf readConf;
   private final boolean caseSensitive;
   private final Schema expectedSchema;
-  private final List<Expression> filterExpressions;
+  private final List<Expression> filters;
   private final String branch;
   private final Supplier<ScanReport> scanReportSupplier;
 
@@ -128,7 +129,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     this.readConf = readConf;
     this.caseSensitive = readConf.caseSensitive();
     this.expectedSchema = expectedSchema;
-    this.filterExpressions = filters != null ? filters : Collections.emptyList();
+    this.filters = filters != null ? filters : Collections.emptyList();
     this.branch = readConf.branch();
     this.scanReportSupplier = scanReportSupplier;
   }
@@ -149,12 +150,16 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     return expectedSchema;
   }
 
-  protected List<Expression> filterExpressions() {
-    return filterExpressions;
+  protected List<Expression> filters() {
+    return filters;
+  }
+
+  protected Expression filter() {
+    return filters.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
   }
 
   protected String filtersDesc() {
-    return Spark3Util.describe(filterExpressions);
+    return Spark3Util.describe(filters);
   }
 
   protected Types.StructType groupingKeyType() {
@@ -240,7 +245,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
 
     // estimate stats using snapshot summary only for partitioned tables
     // (metadata tables are unpartitioned)
-    if (!table.spec().isUnpartitioned() && filterExpressions.isEmpty()) {
+    if (!table.spec().isUnpartitioned() && filters.isEmpty()) {
       LOG.debug(
           "Using snapshot {} metadata to estimate statistics for table {}",
           snapshot.snapshotId(),

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -23,7 +23,6 @@ import static org.apache.iceberg.IsolationLevel.SNAPSHOT;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
@@ -428,19 +427,6 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
       }
     }
 
-    private Expression conflictDetectionFilter() {
-      // the list of filter expressions may be empty but is never null
-      List<Expression> scanFilterExpressions = scan.filterExpressions();
-
-      Expression filter = Expressions.alwaysTrue();
-
-      for (Expression expr : scanFilterExpressions) {
-        filter = Expressions.and(filter, expr);
-      }
-
-      return filter;
-    }
-
     @Override
     public void commit(WriterCommitMessage[] messages) {
       commit(messages, null);
@@ -496,7 +482,7 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
         overwriteFiles.validateFromSnapshot(scanSnapshotId);
       }
 
-      Expression conflictDetectionFilter = conflictDetectionFilter();
+      Expression conflictDetectionFilter = scan.filter();
       overwriteFiles.conflictDetectionFilter(conflictDetectionFilter);
       overwriteFiles.validateNoConflictingData();
       overwriteFiles.validateNoConflictingDeletes();
@@ -522,7 +508,7 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
         overwriteFiles.validateFromSnapshot(scanSnapshotId);
       }
 
-      Expression conflictDetectionFilter = conflictDetectionFilter();
+      Expression conflictDetectionFilter = scan.filter();
       overwriteFiles.conflictDetectionFilter(conflictDetectionFilter);
       overwriteFiles.validateNoConflictingDeletes();
 


### PR DESCRIPTION
This PR avoids duplicated logic for deriving conflict detection filters from scan by moving it into the scan itself.