### PR TITLE
Spark 4.1: Rename expectedSchema to projection for clarity

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -53,7 +53,7 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
     this(
         partition.table(),
         partition.taskGroup(),
-        partition.expectedSchema(),
+        partition.projection(),
         partition.isCaseSensitive(),
         parquetBatchReadConf,
         orcBatchReadConf,

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -51,7 +51,7 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
     this(
         partition.table(),
         partition.taskGroup(),
-        partition.expectedSchema(),
+        partition.projection(),
         partition.isCaseSensitive(),
         partition.cacheDeleteFilesOnExecutors());
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
@@ -49,7 +49,7 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
     this(
         partition.table(),
         partition.taskGroup(),
-        partition.expectedSchema(),
+        partition.projection(),
         partition.isCaseSensitive(),
         partition.cacheDeleteFilesOnExecutors());
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -48,7 +48,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
     this(
         partition.table(),
         partition.taskGroup(),
-        partition.expectedSchema(),
+        partition.projection(),
         partition.isCaseSensitive(),
         partition.cacheDeleteFilesOnExecutors());
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -52,7 +52,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
   private final Table table;
   private final IncrementalChangelogScan scan;
   private final SparkReadConf readConf;
-  private final Schema expectedSchema;
+  private final Schema projection;
   private final List<Expression> filters;
   private final Long startSnapshotId;
   private final Long endSnapshotId;
@@ -66,17 +66,17 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
       Table table,
       IncrementalChangelogScan scan,
       SparkReadConf readConf,
-      Schema expectedSchema,
+      Schema projection,
       List<Expression> filters,
       boolean emptyScan) {
 
-    SparkSchemaUtil.validateMetadataColumnReferences(table.schema(), expectedSchema);
+    SparkSchemaUtil.validateMetadataColumnReferences(table.schema(), projection);
 
     this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
     this.table = table;
     this.scan = scan;
     this.readConf = readConf;
-    this.expectedSchema = expectedSchema;
+    this.projection = projection;
     this.filters = filters != null ? filters : Collections.emptyList();
     this.startSnapshotId = readConf.startSnapshotId();
     this.endSnapshotId = readConf.endSnapshotId();
@@ -95,7 +95,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
   @Override
   public StructType readSchema() {
     if (expectedSparkType == null) {
-      this.expectedSparkType = SparkSchemaUtil.convert(expectedSchema);
+      this.expectedSparkType = SparkSchemaUtil.convert(projection);
     }
 
     return expectedSparkType;
@@ -109,7 +109,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
         readConf,
         EMPTY_GROUPING_KEY_TYPE,
         taskGroups(),
-        expectedSchema,
+        projection,
         hashCode());
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -58,10 +58,10 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
       SparkSession spark,
       Table table,
       SparkReadConf readConf,
-      Schema expectedSchema,
+      Schema projection,
       List<Expression> filters,
       Supplier<ScanReport> scanReportSupplier) {
-    this(spark, table, null, null, readConf, expectedSchema, filters, scanReportSupplier);
+    this(spark, table, null, null, readConf, projection, filters, scanReportSupplier);
   }
 
   SparkCopyOnWriteScan(
@@ -70,10 +70,10 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
       BatchScan scan,
       Snapshot snapshot,
       SparkReadConf readConf,
-      Schema expectedSchema,
+      Schema projection,
       List<Expression> filters,
       Supplier<ScanReport> scanReportSupplier) {
-    super(spark, table, scan, readConf, expectedSchema, filters, scanReportSupplier);
+    super(spark, table, scan, readConf, projection, filters, scanReportSupplier);
 
     this.snapshot = snapshot;
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkInputPartition.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkInputPartition.java
@@ -34,25 +34,25 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
   private final Types.StructType groupingKeyType;
   private final ScanTaskGroup<?> taskGroup;
   private final Broadcast<Table> tableBroadcast;
-  private final String expectedSchemaString;
+  private final String projectionString;
   private final boolean caseSensitive;
   private final transient String[] preferredLocations;
   private final boolean cacheDeleteFilesOnExecutors;
 
-  private transient Schema expectedSchema = null;
+  private transient Schema projection = null;
 
   SparkInputPartition(
       Types.StructType groupingKeyType,
       ScanTaskGroup<?> taskGroup,
       Broadcast<Table> tableBroadcast,
-      String expectedSchemaString,
+      String projectionString,
       boolean caseSensitive,
       String[] preferredLocations,
       boolean cacheDeleteFilesOnExecutors) {
     this.groupingKeyType = groupingKeyType;
     this.taskGroup = taskGroup;
     this.tableBroadcast = tableBroadcast;
-    this.expectedSchemaString = expectedSchemaString;
+    this.projectionString = projectionString;
     this.caseSensitive = caseSensitive;
     this.preferredLocations = preferredLocations;
     this.cacheDeleteFilesOnExecutors = cacheDeleteFilesOnExecutors;
@@ -89,11 +89,11 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
     return cacheDeleteFilesOnExecutors;
   }
 
-  public Schema expectedSchema() {
-    if (expectedSchema == null) {
-      this.expectedSchema = SchemaParser.fromJson(expectedSchemaString);
+  public Schema projection() {
+    if (projection == null) {
+      this.projection = SchemaParser.fromJson(projectionString);
     }
 
-    return expectedSchema;
+    return projection;
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -61,7 +61,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
   private final Table table;
   private final SparkReadConf readConf;
   private final boolean caseSensitive;
-  private final String expectedSchema;
+  private final String projection;
   private final Broadcast<Table> tableBroadcast;
   private final long splitSize;
   private final int splitLookback;
@@ -79,12 +79,12 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
       JavaSparkContext sparkContext,
       Table table,
       SparkReadConf readConf,
-      Schema expectedSchema,
+      Schema projection,
       String checkpointLocation) {
     this.table = table;
     this.readConf = readConf;
     this.caseSensitive = readConf.caseSensitive();
-    this.expectedSchema = SchemaParser.toJson(expectedSchema);
+    this.projection = SchemaParser.toJson(projection);
     this.localityPreferred = readConf.localityEnabled();
     this.tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     this.splitSize = readConf.splitSize();
@@ -155,7 +155,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
               EMPTY_GROUPING_KEY_TYPE,
               combinedScanTasks.get(index),
               tableBroadcast,
-              expectedSchema,
+              projection,
               caseSensitive,
               locations != null ? locations[index] : SparkPlanningUtil.NO_LOCATION_PREFERENCE,
               cacheDeleteFilesOnExecutors);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -76,10 +76,10 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
       Table table,
       Scan<?, ? extends ScanTask, ? extends ScanTaskGroup<?>> scan,
       SparkReadConf readConf,
-      Schema expectedSchema,
+      Schema projection,
       List<Expression> filters,
       Supplier<ScanReport> scanReportSupplier) {
-    super(spark, table, readConf, expectedSchema, filters, scanReportSupplier);
+    super(spark, table, readConf, projection, filters, scanReportSupplier);
 
     this.scan = scan;
     this.preserveDataGrouping = readConf.preserveDataGrouping();
@@ -129,7 +129,7 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
   }
 
   private StructType computeGroupingKeyType() {
-    return org.apache.iceberg.Partitioning.groupingKeyType(expectedSchema(), specs());
+    return org.apache.iceberg.Partitioning.groupingKeyType(projection(), specs());
   }
 
   private Transform[] groupingKeyTransforms() {


### PR DESCRIPTION
This PR renames `expectedSchema` to `projection` for clarity in Spark 4.1. The new name follows what we do in core and helps us to avoid confusion as we about to capture and pin `schema` in many of these classes.