### PR TITLE
Docs: Add informational properties section for table comment

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -129,12 +129,11 @@ The value of these properties are not persisted as a part of the table metadata.
 
 ### Informational properties
 
-Informational properties are not used by Iceberg operations, but can be set by engines to provide additional context about a table.
-These properties are persisted in table metadata and can be useful for documentation, discovery, and integration with external tools.
+Informational properties can be set to provide additional context about a table. They can be useful for documentation, discovery, and integration with external tools. They do not affect read/write behavior or query semantics.
 
 | Property | Default    | Description                                                                                                         |
 | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------- |
-| comment  | (not set)  | A human-readable description of the table. Engines like Spark and Flink set this via `COMMENT` in create table DDL. |
+| comment  | (not set)  | A table-level description that documents the business meaning and usage context. |
 
 ### Compatibility flags
 


### PR DESCRIPTION
- Adds a new "Informational properties" section to the table properties documentation
- Documents the `comment` property, which engines like Spark and Flink set via `COMMENT` in CREATE TABLE DDL
- This follows a discussion on the dev mailing list about standardizing documentation for properties like `comment` that provide semantic context about a table - https://lists.apache.org/thread/5q92y3dlnc3mb5b2cj72hzs6xmy3xtfl
- Ran locally and the section was rendered properly:
<img width="876" height="648" alt="image" src="https://github.com/user-attachments/assets/67ceda61-00b3-4d6a-ac19-d6608eea556d" />

