### PR TITLE
API: Support timestamp types in Conversions.fromPartitionString

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -71,6 +71,16 @@ public class Conversions {
         return new BigDecimal(asString);
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
+      case TIMESTAMP:
+        if (type.equals(Types.TimestampType.withoutZone())) {
+          return Literal.of(asString).to(type).value();
+        }
+        // fall through
+      case TIMESTAMP_NANO:
+        if (type.equals(Types.TimestampNanoType.withoutZone())) {
+          return Literal.of(asString).to(type).value();
+        }
+        // fall through
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);


### PR DESCRIPTION
This method is primarily used to infer partition values from Hive partition paths. 
This PR adds support for the timestamp type to maintain compatibility with Hive. 
I expect it is rarely used for partitions, though.