### PR TITLE
Spark: Add separate data and metadata file lists to RewriteTablePath

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
@@ -142,12 +142,12 @@ public interface RewriteTablePath extends Action<RewriteTablePath, RewriteTableP
 
     /** Location of the file list containing only data file paths. */
     default String dataFileListLocation() {
-      return null;
+      return "";
     }
 
     /** Location of the file list containing only metadata file paths. */
     default String metadataFileListLocation() {
-      return null;
+      return "";
     }
 
     /** Number of delete files with rewritten paths. */

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
@@ -142,12 +142,12 @@ public interface RewriteTablePath extends Action<RewriteTablePath, RewriteTableP
 
     /** Location of the file list containing only data file paths. */
     default String dataFileListLocation() {
-      return "";
+      throw new UnsupportedOperationException("This method is not implemented.");
     }
 
     /** Location of the file list containing only metadata file paths. */
     default String metadataFileListLocation() {
-      return "";
+      throw new UnsupportedOperationException("This method is not implemented.");
     }
 
     /** Number of delete files with rewritten paths. */

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
@@ -140,6 +140,16 @@ public interface RewriteTablePath extends Action<RewriteTablePath, RewriteTableP
     /** Name of latest metadata file version */
     String latestVersion();
 
+    /** Location of the file list containing only data file paths. */
+    default String dataFileListLocation() {
+      return null;
+    }
+
+    /** Location of the file list containing only metadata file paths. */
+    default String metadataFileListLocation() {
+      return null;
+    }
+
     /** Number of delete files with rewritten paths. */
     default int rewrittenDeleteFilePathsCount() {
       return 0;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteTablePath.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteTablePath.java
@@ -32,6 +32,18 @@ interface BaseRewriteTablePath extends RewriteTablePath {
   interface Result extends RewriteTablePath.Result {
     @Override
     @Value.Default
+    default String dataFileListLocation() {
+      return RewriteTablePath.Result.super.dataFileListLocation();
+    }
+
+    @Override
+    @Value.Default
+    default String metadataFileListLocation() {
+      return RewriteTablePath.Result.super.metadataFileListLocation();
+    }
+
+    @Override
+    @Value.Default
     default int rewrittenDeleteFilePathsCount() {
       return RewriteTablePath.Result.super.rewrittenDeleteFilePathsCount();
     }

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteTablePath.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteTablePath.java
@@ -31,16 +31,10 @@ interface BaseRewriteTablePath extends RewriteTablePath {
   @Value.Immutable
   interface Result extends RewriteTablePath.Result {
     @Override
-    @Value.Default
-    default String dataFileListLocation() {
-      return RewriteTablePath.Result.super.dataFileListLocation();
-    }
+    String dataFileListLocation();
 
     @Override
-    @Value.Default
-    default String metadataFileListLocation() {
-      return RewriteTablePath.Result.super.metadataFileListLocation();
-    }
+    String metadataFileListLocation();
 
     @Override
     @Value.Default

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteTablePath.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteTablePath.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.actions;
 
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 @Value.Enclosing
@@ -30,9 +31,11 @@ interface BaseRewriteTablePath extends RewriteTablePath {
 
   @Value.Immutable
   interface Result extends RewriteTablePath.Result {
+    @Nullable
     @Override
     String dataFileListLocation();
 
+    @Nullable
     @Override
     String metadataFileListLocation();
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -92,6 +92,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   private static final Logger LOG = LoggerFactory.getLogger(RewriteTablePathSparkAction.class);
   private static final String RESULT_LOCATION = "file-list";
+  private static final String DATA_FILE_LIST_DIR = "data-file-list";
+  private static final String METADATA_FILE_LIST_DIR = "metadata-file-list";
   static final String NOT_APPLICABLE = "N/A";
 
   private String sourcePrefix;
@@ -328,20 +330,37 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             .latestVersion(RewriteTablePathUtil.fileName(endVersionName));
 
     if (!createFileList) {
-      return builder.fileListLocation(NOT_APPLICABLE).build();
+      return builder
+          .fileListLocation(NOT_APPLICABLE)
+          .dataFileListLocation(NOT_APPLICABLE)
+          .metadataFileListLocation(NOT_APPLICABLE)
+          .build();
     }
 
-    Set<Pair<String, String>> copyPlan = Sets.newHashSet();
-    copyPlan.addAll(rewriteVersionResult.copyPlan());
-    copyPlan.addAll(rewriteManifestListResult.copyPlan());
-    copyPlan.addAll(rewriteManifestResult.copyPlan());
-    String fileListLocation = saveFileList(copyPlan);
+    Set<Pair<String, String>> metadataCopyPlan = Sets.newHashSet();
+    metadataCopyPlan.addAll(rewriteVersionResult.copyPlan());
+    metadataCopyPlan.addAll(rewriteManifestListResult.copyPlan());
 
-    return builder.fileListLocation(fileListLocation).build();
+    Set<Pair<String, String>> dataCopyPlan = Sets.newHashSet();
+    dataCopyPlan.addAll(rewriteManifestResult.copyPlan());
+
+    Set<Pair<String, String>> copyPlan = Sets.newHashSet();
+    copyPlan.addAll(metadataCopyPlan);
+    copyPlan.addAll(dataCopyPlan);
+
+    String fileListLocation = saveFileList(copyPlan, RESULT_LOCATION);
+    String dataFileListLocation = saveFileList(dataCopyPlan, DATA_FILE_LIST_DIR);
+    String metadataFileListLocation = saveFileList(metadataCopyPlan, METADATA_FILE_LIST_DIR);
+
+    return builder
+        .fileListLocation(fileListLocation)
+        .dataFileListLocation(dataFileListLocation)
+        .metadataFileListLocation(metadataFileListLocation)
+        .build();
   }
 
-  private String saveFileList(Set<Pair<String, String>> filesToMove) {
-    String fileListPath = stagingDir + RESULT_LOCATION;
+  private String saveFileList(Set<Pair<String, String>> filesToMove, String name) {
+    String fileListPath = stagingDir + name;
     OutputFile fileList = table.io().newOutputFile(fileListPath);
     writeAsCsv(filesToMove, fileList);
     return fileListPath;
@@ -538,10 +557,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
-    @Override
-    public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
-      this.copyPlan().addAll(r1.copyPlan());
-      this.toRewrite().addAll(r1.toRewrite());
+
+    public RewriteContentFileResult append(RewriteContentFileResult other) {
+      this.copyPlan().addAll(other.copyPlan());
+      this.toRewrite().addAll(other.toRewrite());
       return this;
     }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -1355,6 +1355,47 @@ public class TestRewriteTablePathsAction extends TestBase {
     }
   }
 
+  @TestTemplate
+  public void testSeparateDataAndMetadataFileLists() throws Exception {
+    String targetTableLocation = targetTableLocation();
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(table)
+            .rewriteLocationPrefix(tableLocation, targetTableLocation)
+            .execute();
+
+    checkFileNum(3, 2, 2, 9, result);
+
+    List<String> allFiles =
+        spark
+            .read()
+            .format("text")
+            .load(result.fileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    List<String> metadataFiles =
+        spark
+            .read()
+            .format("text")
+            .load(result.metadataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    List<String> dataFiles =
+        spark
+            .read()
+            .format("text")
+            .load(result.dataFileListLocation())
+            .as(Encoders.STRING())
+            .collectAsList();
+
+    assertThat(allFiles).hasSize(9);
+    assertThat(metadataFiles).allMatch(f -> f.contains("/metadata/")).hasSize(7);
+    assertThat(dataFiles).allMatch(f -> f.contains("/data/")).hasSize(2);
+  }
+
   protected void checkFileNum(
       int versionFileCount,
       int manifestListCount,


### PR DESCRIPTION
Downstream tools often need different copy strategies for data vs metadata files (e.g. different location, additional checks on data vs metadata files). This splits the file list into separate data and metadata lists while keeping the combined list for backward compatibility.