### PR TITLE
Api: Support variant extract and fix manifest bounds byte order

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundExtract.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundExtract.java
@@ -26,9 +26,13 @@ public class BoundExtract<T> implements BoundTerm<T> {
   private final String path;
   private final Type type;
 
+  /**
+   * @param path normalized extract path, as from {@link UnboundExtract#path()}; already validated
+   *     and canonical in {@link UnboundExtract#bind}.
+   */
   BoundExtract(BoundReference<?> ref, String path, Type type) {
     this.ref = ref;
-    this.path = PathUtil.toNormalizedPath(PathUtil.parse(path));
+    this.path = path;
     this.type = type;
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -243,6 +243,24 @@ public class ExpressionUtil {
       return ((NamedReference<?>) term).name();
     } else if (term instanceof BoundReference) {
       return ((BoundReference<?>) term).name();
+    } else if (term instanceof UnboundExtract) {
+      UnboundExtract<?> unboundExtract = (UnboundExtract<?>) term;
+      return "extract("
+          + describe(unboundExtract.ref())
+          + ", "
+          + unboundExtract.path()
+          + ", "
+          + unboundExtract.type()
+          + ")";
+    } else if (term instanceof BoundExtract) {
+      BoundExtract<?> boundExtract = (BoundExtract<?>) term;
+      return "extract("
+          + describe(boundExtract.ref())
+          + ", "
+          + boundExtract.path()
+          + ", "
+          + boundExtract.type()
+          + ")";
     } else {
       throw new UnsupportedOperationException("Unsupported term: " + term);
     }
@@ -254,6 +272,10 @@ public class ExpressionUtil {
       return Expressions.transform(bound.ref().name(), bound.transform());
     } else if (term instanceof BoundReference) {
       return Expressions.ref(((BoundReference<T>) term).name());
+    } else if (term instanceof BoundExtract) {
+      BoundExtract<T> bound = (BoundExtract<T>) term;
+      String dotPath = PathUtil.toDotNotation(bound.path());
+      return Expressions.extract(bound.ref().name(), dotPath, bound.type().toString());
     }
 
     throw new UnsupportedOperationException("Cannot unbind unsupported term: " + term);

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -274,8 +274,7 @@ public class ExpressionUtil {
       return Expressions.ref(((BoundReference<T>) term).name());
     } else if (term instanceof BoundExtract) {
       BoundExtract<T> bound = (BoundExtract<T>) term;
-      String dotPath = PathUtil.toDotNotation(bound.path());
-      return Expressions.extract(bound.ref().name(), dotPath, bound.type().toString());
+      return Expressions.extract(bound.ref().name(), bound.path(), bound.type().toString());
     }
 
     throw new UnsupportedOperationException("Cannot unbind unsupported term: " + term);

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -102,6 +102,12 @@ public class Expressions {
     return new UnboundTransform<>(ref(name), Transforms.truncate(width));
   }
 
+  /**
+   * Extract a field from a variant column. {@code path} is a small RFC 9535-style JSONPath: root
+   * {@code $}, then steps are {@code .name}, {@code ['name']} (RFC 9535 escapes inside quotes), or
+   * {@code [n]} for a zero-based array index. You can mix these ({@code $.a['b.c']}, {@code
+   * $.items[0].tags[1]}). {@link UnboundExtract#path()} returns the normalized string.
+   */
   public static <T> UnboundTerm<T> extract(String name, String path, String type) {
     return new UnboundExtract<>(ref(name), path, type);
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.expressions;
 import static org.apache.iceberg.expressions.Expressions.rewriteNot;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
@@ -632,6 +633,8 @@ public class InclusiveMetricsEvaluator {
   }
 
   private static VariantObject parseBounds(ByteBuffer buffer) {
-    return Variant.from(buffer).value().asObject();
+    // Explicitly use little-endian encoding for reading buffer
+    ByteBuffer littleEndian = buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+    return Variant.from(littleEndian).value().asObject();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
@@ -115,7 +115,6 @@ public class PathUtil {
     return builder.toString();
   }
 
-  @SuppressWarnings("StatementSwitchToExpressionSwitch")
   private static List<PathSegment> parseAfterRoot(String path) {
     List<PathSegment> segments = Lists.newArrayList();
     Matcher bracketMatcher = BRACKET_SEGMENT.matcher(path);
@@ -124,36 +123,39 @@ public class PathUtil {
 
     while (pos < len) {
       char ch = path.charAt(pos);
-      switch (ch) {
-        case '.':
-          pos = appendDotSegment(path, pos, segments);
-          break;
-
-        case '[':
-          pos = appendBracketOrIndexSegment(path, pos, segments, bracketMatcher);
-          break;
-
-        default:
-          throw new IllegalArgumentException(
-              String.format("Invalid path, expected '.' or '[' at position %s: %s", pos, path));
-      }
+      pos =
+          switch (ch) {
+            case '.' -> appendDotSegment(segments, path, pos);
+            case '[' -> appendBracketOrIndexSegment(segments, path, pos, bracketMatcher);
+            default ->
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Invalid path, expected '.' or '[' at position %s: %s", pos, path));
+          };
     }
 
     return segments;
   }
 
-  /** Consumes from {@code path[dotPos]} a leading {@code .} and RFC 9535 shorthand member name. */
-  private static int appendDotSegment(String path, int dotPos, List<PathSegment> segments) {
+  /**
+   * Appends a dot-style segment to {@code segments} by reading from {@code path[dotPos]}: a single
+   * leading {@code .} then an RFC 9535 shorthand name until the next {@code .} or {@code [}.
+   *
+   * @param segments output; segments parsed so far, updated in place
+   * @param path full path
+   * @param dotPos index of the {@code .} starting the segment
+   */
+  private static int appendDotSegment(List<PathSegment> segments, String path, int dotPos) {
     int pos = dotPos + 1;
-    int len = path.length();
-    Preconditions.checkArgument(pos < len, "Invalid path, trailing dot: %s", path);
+    int pathLen = path.length();
+    Preconditions.checkArgument(pos < pathLen, "Invalid path, trailing dot: %s", path);
     int start = pos;
-    while (pos < len) {
+    while (pos < pathLen) {
       char ch = path.charAt(pos);
       if (ch == '.' || ch == '[') {
         break;
       }
-      pos += 1;
+      pos++;
     }
 
     Preconditions.checkArgument(pos > start, "Invalid path, empty segment after '.': %s", path);
@@ -168,42 +170,72 @@ public class PathUtil {
   }
 
   /**
-   * Consumes either a numeric array index {@code [n]} or a quoted name {@code ['...']} starting at
-   * {@code path[bracketPos]}.
+   * Appends a bracket segment to {@code segments} starting at {@code path[bracketPos]}. If the next
+   * character is a digit, consumes a numeric array index {@code [n]}; otherwise consumes a quoted
+   * name {@code ['...']}. A lone {@code [} with no following quoted form (e.g. the path ends at
+   * {@code $[}) is rejected in {@link #appendQuotedBracketSegment} when the pattern does not match.
+   *
+   * @param segments output; segments parsed so far, updated in place
+   * @param path full path
+   * @param bracketPos index of the opening {@code [}
    */
   private static int appendBracketOrIndexSegment(
-      String path, int bracketPos, List<PathSegment> segments, Matcher bracketMatcher) {
+      List<PathSegment> segments, String path, int bracketPos, Matcher bracketMatcher) {
     Preconditions.checkArgument(
         bracketPos < path.length() && path.charAt(bracketPos) == '[', "Invalid path: %s", path);
     if (bracketPos + 1 < path.length() && isAsciiDigit(path.charAt(bracketPos + 1))) {
-      return appendArrayIndexSegment(path, bracketPos, segments);
+      return appendArrayIndexSegment(segments, path, bracketPos);
     }
-    return appendQuotedBracketSegment(path, bracketPos, segments, bracketMatcher);
+    return appendQuotedBracketSegment(segments, path, bracketPos, bracketMatcher);
   }
 
   private static boolean isAsciiDigit(char ch) {
     return ch >= '0' && ch <= '9';
   }
 
+  /**
+   * Appends a non-negative array index from {@code [n]} to {@code segments}, starting with {@code
+   * [} at {@code path[bracketPos]}.
+   *
+   * @param segments output; segments parsed so far, updated in place
+   * @param path full path
+   * @param bracketPos index of the opening {@code [} before the digits
+   */
   private static int appendArrayIndexSegment(
-      String path, int bracketPos, List<PathSegment> segments) {
+      List<PathSegment> segments, String path, int bracketPos) {
     int pos = bracketPos + 1;
     int len = path.length();
     int start = pos;
     while (pos < len && isAsciiDigit(path.charAt(pos))) {
-      pos += 1;
+      pos++;
     }
     Preconditions.checkArgument(pos > start, "Invalid path, empty array index in: %s", path);
     Preconditions.checkArgument(
         pos < len && path.charAt(pos) == ']', "Invalid path, unclosed array index in: %s", path);
-    int index = Integer.parseInt(path.substring(start, pos));
+    int index;
+    String digits = path.substring(start, pos);
+    try {
+      index = Integer.parseInt(digits);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid path, array index out of int range: %s", path), e);
+    }
     Preconditions.checkArgument(index >= 0, "Invalid path, negative array index in: %s", path);
     segments.add(new PathSegment.Index(index));
     return pos + 1;
   }
 
+  /**
+   * Appends a name from a {@code ['...']} segment to {@code segments} using the bracket matcher
+   * (inner text may use RFC 9535 escapes). Expects a full quoted bracket token at {@code
+   * path[bracketPos]}; otherwise the matcher or alignment checks throw.
+   *
+   * @param segments output; segments parsed so far, updated in place
+   * @param path full path
+   * @param bracketPos index of the opening {@code [} that must begin {@code ['}
+   */
   private static int appendQuotedBracketSegment(
-      String path, int bracketPos, List<PathSegment> segments, Matcher bracketMatcher) {
+      List<PathSegment> segments, String path, int bracketPos, Matcher bracketMatcher) {
     Preconditions.checkArgument(
         bracketMatcher.find(bracketPos), "Invalid path, malformed bracket segment: %s", path);
     Preconditions.checkArgument(

--- a/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
@@ -27,13 +27,22 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 
 public class PathUtil {
   private PathUtil() {}
+
+  /**
+   * One step in a variant JSONPath: an object member name or a zero-based array index (RFC 9535
+   * {@code [n]} selector).
+   */
+  sealed interface PathSegment permits PathSegment.Name, PathSegment.Index {
+    record Name(String name) implements PathSegment {}
+
+    record Index(int index) implements PathSegment {}
+  }
 
   private static final String RFC9535_NAME_FIRST =
       "[A-Za-z_\\x{0080}-\\x{D7FF}\\x{E000}-\\x{10FFFF}]";
@@ -42,66 +51,231 @@ public class PathUtil {
   private static final Predicate<String> RFC9535_MEMBER_NAME_SHORTHAND =
       Pattern.compile(RFC9535_NAME_FIRST + RFC9535_NAME_CHARS).asMatchPredicate();
 
+  /** Letters that follow {@code \} for control-character escapes in RFC 9535 quoted segments. */
+  private static final String RFC9535_SIMPLE_ESCAPE_LETTERS = "btnfr";
+
+  private static final String RFC9535_SIMPLE_ESCAPE_CHARS = "\b\t\n\f\r";
+
   private static final Pattern RFC9535_REQUIRES_ESCAPE =
       Pattern.compile(
           "[^\\x{0020}-\\x{0026}\\x{0028}-\\x{005B}\\x{005D}-\\x{D7FF}\\x{E000}-\\x{10FFFF}]");
 
+  /**
+   * Matches one bracket segment {@code ['...']} where inner text may contain RFC 9535 escapes
+   * (quote, backslash, control characters, and four-digit hex escapes).
+   */
+  private static final Pattern BRACKET_SEGMENT = Pattern.compile("\\['((?:[^'\\\\]|\\\\.)*)'\\]");
+
   private static final Map<Character, String> RFC9535_ESCAPE_REPLACEMENTS = buildReplacementMap();
 
-  private static final Splitter DOT = Splitter.on(".");
   private static final String ROOT = "$";
 
-  static List<String> parse(String path) {
+  /**
+   * Parses a path into segments. After the root {@code $}, each segment is either dot shorthand
+   * ({@code .name} per RFC 9535), a single-quoted bracket name ({@code ['...']}) with RFC 9535
+   * escapes, or a numeric array index ({@code [n]}). Forms may be mixed (e.g. {@code $.a['b.c']},
+   * {@code $.items[0].tags}, {@code $.matrix[0][1]}). Wildcards and recursive descent are not
+   * supported.
+   *
+   * <p>The root path {@code $} yields an empty segment list.
+   */
+  static List<PathSegment> parse(String path) {
     Preconditions.checkArgument(path != null, "Invalid path: null");
+    Preconditions.checkArgument(!path.isEmpty(), "Invalid path: empty");
     Preconditions.checkArgument(
-        !path.contains("[") && !path.contains("]"), "Unsupported path, contains bracket: %s", path);
-    Preconditions.checkArgument(
-        !path.contains("*"), "Unsupported path, contains wildcard: %s", path);
-    Preconditions.checkArgument(
-        !path.contains(".."), "Unsupported path, contains recursive descent: %s", path);
+        path.startsWith(ROOT), "Invalid path, does not start with %s: %s", ROOT, path);
 
-    List<String> parts = DOT.splitToList(path);
-    Preconditions.checkArgument(
-        ROOT.equals(parts.get(0)), "Invalid path, does not start with %s: %s", ROOT, path);
-
-    List<String> names = parts.subList(1, parts.size());
-    for (String name : names) {
-      Preconditions.checkArgument(
-          RFC9535_MEMBER_NAME_SHORTHAND.test(name),
-          "Invalid path: %s (%s has invalid characters)",
-          path,
-          name);
+    if (path.equals(ROOT)) {
+      return Lists.newArrayList();
     }
 
-    return names;
+    return parseAfterRoot(path);
   }
 
+  /** Normalizes object field names only (no array indices). */
   public static String toNormalizedPath(Iterable<String> fields) {
-    return ROOT
-        + Streams.stream(fields)
-            .map(PathUtil::rfc9535escape)
-            .map(name -> "['" + name + "']")
-            .collect(Collectors.joining(""));
+    return toNormalizedPath(
+        Streams.stream(fields).map(PathSegment.Name::new).collect(Collectors.toList()));
+  }
+
+  static String toNormalizedPath(List<PathSegment> segments) {
+    StringBuilder builder = new StringBuilder(ROOT);
+    for (PathSegment segment : segments) {
+      if (segment instanceof PathSegment.Name) {
+        String name = ((PathSegment.Name) segment).name();
+        builder.append("['").append(rfc9535escape(name)).append("']");
+      } else if (segment instanceof PathSegment.Index) {
+        int index = ((PathSegment.Index) segment).index();
+        Preconditions.checkArgument(index >= 0, "Invalid path, negative array index: %s", index);
+        builder.append('[').append(index).append(']');
+      } else {
+        throw new IllegalStateException("Unknown segment: " + segment);
+      }
+    }
+    return builder.toString();
+  }
+
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
+  private static List<PathSegment> parseAfterRoot(String path) {
+    List<PathSegment> segments = Lists.newArrayList();
+    Matcher bracketMatcher = BRACKET_SEGMENT.matcher(path);
+    int len = path.length();
+    int pos = ROOT.length();
+
+    while (pos < len) {
+      char ch = path.charAt(pos);
+      switch (ch) {
+        case '.':
+          pos = appendDotSegment(path, pos, segments);
+          break;
+
+        case '[':
+          pos = appendBracketOrIndexSegment(path, pos, segments, bracketMatcher);
+          break;
+
+        default:
+          throw new IllegalArgumentException(
+              String.format("Invalid path, expected '.' or '[' at position %s: %s", pos, path));
+      }
+    }
+
+    return segments;
+  }
+
+  /** Consumes from {@code path[dotPos]} a leading {@code .} and RFC 9535 shorthand member name. */
+  private static int appendDotSegment(String path, int dotPos, List<PathSegment> segments) {
+    int pos = dotPos + 1;
+    int len = path.length();
+    Preconditions.checkArgument(pos < len, "Invalid path, trailing dot: %s", path);
+    int start = pos;
+    while (pos < len) {
+      char ch = path.charAt(pos);
+      if (ch == '.' || ch == '[') {
+        break;
+      }
+      pos += 1;
+    }
+
+    Preconditions.checkArgument(pos > start, "Invalid path, empty segment after '.': %s", path);
+    String name = path.substring(start, pos);
+    Preconditions.checkArgument(
+        RFC9535_MEMBER_NAME_SHORTHAND.test(name),
+        "Invalid path: %s (%s has invalid characters)",
+        path,
+        name);
+    segments.add(new PathSegment.Name(name));
+    return pos;
   }
 
   /**
-   * Converts a normalized path (e.g. $['a']['b']) to dot notation (e.g. $.a.b). Used when unbinding
-   * BoundExtract so the result can be passed to Expressions.extract().
+   * Consumes either a numeric array index {@code [n]} or a quoted name {@code ['...']} starting at
+   * {@code path[bracketPos]}.
    */
-  static String toDotNotation(String normalizedPath) {
+  private static int appendBracketOrIndexSegment(
+      String path, int bracketPos, List<PathSegment> segments, Matcher bracketMatcher) {
     Preconditions.checkArgument(
-        normalizedPath != null && normalizedPath.startsWith(ROOT),
-        "Invalid normalized path: %s",
-        normalizedPath);
-    List<String> fields = Lists.newArrayList();
-    Matcher matcher = Pattern.compile("\\['([^']*)'\\]").matcher(normalizedPath);
-    while (matcher.find()) {
-      fields.add(matcher.group(1));
+        bracketPos < path.length() && path.charAt(bracketPos) == '[', "Invalid path: %s", path);
+    if (bracketPos + 1 < path.length() && isAsciiDigit(path.charAt(bracketPos + 1))) {
+      return appendArrayIndexSegment(path, bracketPos, segments);
     }
-    if (fields.isEmpty()) {
-      return ROOT;
+    return appendQuotedBracketSegment(path, bracketPos, segments, bracketMatcher);
+  }
+
+  private static boolean isAsciiDigit(char ch) {
+    return ch >= '0' && ch <= '9';
+  }
+
+  private static int appendArrayIndexSegment(
+      String path, int bracketPos, List<PathSegment> segments) {
+    int pos = bracketPos + 1;
+    int len = path.length();
+    int start = pos;
+    while (pos < len && isAsciiDigit(path.charAt(pos))) {
+      pos += 1;
     }
-    return ROOT + "." + String.join(".", fields);
+    Preconditions.checkArgument(pos > start, "Invalid path, empty array index in: %s", path);
+    Preconditions.checkArgument(
+        pos < len && path.charAt(pos) == ']', "Invalid path, unclosed array index in: %s", path);
+    int index = Integer.parseInt(path.substring(start, pos));
+    Preconditions.checkArgument(index >= 0, "Invalid path, negative array index in: %s", path);
+    segments.add(new PathSegment.Index(index));
+    return pos + 1;
+  }
+
+  private static int appendQuotedBracketSegment(
+      String path, int bracketPos, List<PathSegment> segments, Matcher bracketMatcher) {
+    Preconditions.checkArgument(
+        bracketMatcher.find(bracketPos), "Invalid path, malformed bracket segment: %s", path);
+    Preconditions.checkArgument(
+        bracketMatcher.start() == bracketPos,
+        "Invalid path, unexpected characters at position %s: %s",
+        bracketPos,
+        path);
+    segments.add(new PathSegment.Name(rfc9535unescape(bracketMatcher.group(1))));
+    return bracketMatcher.end();
+  }
+
+  /** Unescapes the inner text of a {@code ['...']} segment (inverse of {@link #rfc9535escape}). */
+  @VisibleForTesting
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
+  static String rfc9535unescape(String escaped) {
+    if (!escaped.contains("\\")) {
+      return escaped;
+    }
+
+    StringBuilder builder = new StringBuilder(escaped.length());
+    int cursor = 0;
+    while (cursor < escaped.length()) {
+      char ch = escaped.charAt(cursor);
+      if (ch != '\\') {
+        builder.append(ch);
+        cursor += 1;
+      } else {
+        Preconditions.checkArgument(
+            cursor + 1 < escaped.length(), "Invalid escape sequence at end of: %s", escaped);
+        char next = escaped.charAt(cursor + 1);
+        switch (next) {
+          case 'u':
+            Preconditions.checkArgument(
+                cursor + 5 < escaped.length(),
+                "Invalid \\uXXXX escape at position %s in: %s",
+                cursor,
+                escaped);
+            builder.append((char) Integer.parseInt(escaped.substring(cursor + 2, cursor + 6), 16));
+            cursor += 6;
+            break;
+          case 'b':
+          case 't':
+          case 'f':
+          case 'n':
+          case 'r':
+          case '\'':
+          case '\\':
+            builder.append(rfc9535SimpleEscapedChar(next));
+            cursor += 2;
+            break;
+          default:
+            throw new IllegalArgumentException(
+                "Invalid escape sequence \\" + next + " in: " + escaped);
+        }
+      }
+    }
+
+    return builder.toString();
+  }
+
+  private static char rfc9535SimpleEscapedChar(char next) {
+    int idx = RFC9535_SIMPLE_ESCAPE_LETTERS.indexOf(next);
+    if (idx >= 0) {
+      return RFC9535_SIMPLE_ESCAPE_CHARS.charAt(idx);
+    }
+    if (next == '\'') {
+      return '\'';
+    }
+    if (next == '\\') {
+      return '\\';
+    }
+    throw new IllegalArgumentException("Invalid simple escape: \\" + next);
   }
 
   @VisibleForTesting

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundExtract.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundExtract.java
@@ -29,10 +29,8 @@ public class UnboundExtract<T> implements UnboundTerm<T> {
 
   public UnboundExtract(NamedReference<?> ref, String path, String type) {
     this.ref = ref;
-    this.path = path;
+    this.path = PathUtil.toNormalizedPath(PathUtil.parse(path));
     this.type = Types.fromPrimitiveString(type);
-    // verify that the path is well-formed
-    PathUtil.parse(path);
   }
 
   @Override

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -64,6 +64,12 @@ public class TestExpressionBinding {
           optional(5, "nullable", Types.IntegerType.get()),
           optional(6, "always_null", Types.UnknownType.get()));
 
+  private static void assertBoundVariantLongExtractPath(String extractPath, String expectedPath) {
+    Expression bound = Binder.bind(STRUCT, lessThan(extract("var", extractPath, "long"), 100));
+    BoundExtract<?> term = (BoundExtract<?>) TestHelpers.assertAndUnwrap(bound).term();
+    assertThat(term.path()).isEqualTo(expectedPath);
+  }
+
   @Test
   public void testMissingReference() {
     Expression expr = and(equal("t", 5), equal("x", 7));
@@ -352,33 +358,23 @@ public class TestExpressionBinding {
 
   @Test
   public void testVariantExtractBindingPreservesBracketInputPath() {
-    Expression bound = Binder.bind(STRUCT, lessThan(extract("var", "$['event_id']", "long"), 100));
-    BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
-    BoundExtract<?> boundExtract = (BoundExtract<?>) pred.term();
-    assertThat(boundExtract.path()).isEqualTo("$['event_id']");
+    assertBoundVariantLongExtractPath("$['event_id']", "$['event_id']");
   }
 
   @Test
   public void testVariantExtractBindingMixedDotAndBracketPath() {
-    Expression bound =
-        Binder.bind(STRUCT, lessThan(extract("var", "$.employee['user.name']", "long"), 100));
-    BoundExtract<?> boundExtract = (BoundExtract<?>) TestHelpers.assertAndUnwrap(bound).term();
-    assertThat(boundExtract.path()).isEqualTo("$['employee']['user.name']");
+    assertBoundVariantLongExtractPath("$.employee['user.name']", "$['employee']['user.name']");
   }
 
   @Test
   public void testVariantExtractBindingBracketPathWithRfc9535Unescape() {
     // Inner segment is a'b after unescaping; normalized bracket form uses \' for the quote.
-    Expression bound = Binder.bind(STRUCT, lessThan(extract("var", "$['a\\'b']", "long"), 100));
-    BoundExtract<?> boundExtract = (BoundExtract<?>) TestHelpers.assertAndUnwrap(bound).term();
-    assertThat(boundExtract.path()).isEqualTo("$['a\\'b']");
+    assertBoundVariantLongExtractPath("$['a\\'b']", "$['a\\'b']");
   }
 
   @Test
   public void testVariantExtractBindingBracketPathWithUnicodeEscape() {
-    Expression bound = Binder.bind(STRUCT, lessThan(extract("var", "$['\\u00e9']", "long"), 100));
-    BoundExtract<?> boundExtract = (BoundExtract<?>) TestHelpers.assertAndUnwrap(bound).term();
-    assertThat(boundExtract.path()).isEqualTo("$['é']");
+    assertBoundVariantLongExtractPath("$['\\u00e9']", "$['é']");
   }
 
   @Test
@@ -422,6 +418,13 @@ public class TestExpressionBinding {
         .hasMessage("Cannot bind extract, not a variant: x");
   }
 
+  /**
+   * Param smoke list for "extract binds". Dot path normalization, keys with dots, mixed bracket
+   * form, and array index paths are covered in dedicated tests above (e.g. {@link
+   * #testVariantExtractBindingNormalizesDotPathToBracket}, {@link
+   * #testVariantExtractBindingBracketPathWithRfc9535Unescape}, array cases from {@link
+   * #testVariantExtractUnbindPreservesNormalizedPathAfterArrayAccesses}).
+   */
   private static final String[] VALID_PATHS =
       new String[] {
         "$", // root path

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -337,7 +337,7 @@ public class TestExpressionBinding {
   }
 
   @Test
-  public void testExtractExpressionBinding() {
+  public void testVariantExtractBindingNormalizesDotPathToBracket() {
     Expression bound = Binder.bind(STRUCT, lessThan(extract("var", "$.event_id", "long"), 100));
     TestHelpers.assertAllReferencesBound("BoundExtract", bound);
     BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
@@ -351,6 +351,71 @@ public class TestExpressionBinding {
   }
 
   @Test
+  public void testVariantExtractBindingPreservesBracketInputPath() {
+    Expression bound = Binder.bind(STRUCT, lessThan(extract("var", "$['event_id']", "long"), 100));
+    BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
+    BoundExtract<?> boundExtract = (BoundExtract<?>) pred.term();
+    assertThat(boundExtract.path()).isEqualTo("$['event_id']");
+  }
+
+  @Test
+  public void testVariantExtractBindingMixedDotAndBracketPath() {
+    Expression bound =
+        Binder.bind(STRUCT, lessThan(extract("var", "$.employee['user.name']", "long"), 100));
+    BoundExtract<?> boundExtract = (BoundExtract<?>) TestHelpers.assertAndUnwrap(bound).term();
+    assertThat(boundExtract.path()).isEqualTo("$['employee']['user.name']");
+  }
+
+  @Test
+  public void testVariantExtractBindingBracketPathWithRfc9535Unescape() {
+    // Inner segment is a'b after unescaping; normalized bracket form uses \' for the quote.
+    Expression bound = Binder.bind(STRUCT, lessThan(extract("var", "$['a\\'b']", "long"), 100));
+    BoundExtract<?> boundExtract = (BoundExtract<?>) TestHelpers.assertAndUnwrap(bound).term();
+    assertThat(boundExtract.path()).isEqualTo("$['a\\'b']");
+  }
+
+  @Test
+  public void testVariantExtractBindingBracketPathWithUnicodeEscape() {
+    Expression bound = Binder.bind(STRUCT, lessThan(extract("var", "$['\\u00e9']", "long"), 100));
+    BoundExtract<?> boundExtract = (BoundExtract<?>) TestHelpers.assertAndUnwrap(bound).term();
+    assertThat(boundExtract.path()).isEqualTo("$['é']");
+  }
+
+  @Test
+  public void testVariantExtractUnbindPreservesNormalizedPathForDotInSegmentName() {
+    Expression boundExpr = lessThan(extract("var", "$['a.b']", "long"), 100L).bind(STRUCT, true);
+    UnboundTerm<?> unbound = ExpressionUtil.unbind(((BoundPredicate<?>) boundExpr).term());
+    assertThat(unbound).isInstanceOf(UnboundExtract.class);
+    assertThat(((UnboundExtract<?>) unbound).path()).isEqualTo("$['a.b']");
+  }
+
+  @Test
+  public void testVariantExtractUnbindPreservesNormalizedPathAfterMixedPath() {
+    Expression boundExpr = lessThan(extract("var", "$.x['y.z']", "long"), 100L).bind(STRUCT, true);
+    UnboundTerm<?> unbound = ExpressionUtil.unbind(((BoundPredicate<?>) boundExpr).term());
+    assertThat(unbound).isInstanceOf(UnboundExtract.class);
+    assertThat(((UnboundExtract<?>) unbound).path()).isEqualTo("$['x']['y.z']");
+  }
+
+  @Test
+  public void testVariantExtractUnbindPreservesNormalizedPathAfterArrayAccesses() {
+    Expression boundExpr =
+        lessThan(extract("var", "$.items[0].tags[1]", "long"), 100L).bind(STRUCT, true);
+    UnboundTerm<?> unbound = ExpressionUtil.unbind(((BoundPredicate<?>) boundExpr).term());
+    assertThat(unbound).isInstanceOf(UnboundExtract.class);
+    assertThat(((UnboundExtract<?>) unbound).path()).isEqualTo("$['items'][0]['tags'][1]");
+  }
+
+  @Test
+  public void testVariantExtractUnbindPreservesNormalizedPathAfterBracketStyleArrayAccesses() {
+    Expression boundExpr =
+        lessThan(extract("var", "$['items'][0]['tags'][1]", "long"), 100L).bind(STRUCT, true);
+    UnboundTerm<?> unbound = ExpressionUtil.unbind(((BoundPredicate<?>) boundExpr).term());
+    assertThat(unbound).isInstanceOf(UnboundExtract.class);
+    assertThat(((UnboundExtract<?>) unbound).path()).isEqualTo("$['items'][0]['tags'][1]");
+  }
+
+  @Test
   public void testExtractExpressionNonVariant() {
     assertThatThrownBy(() -> Binder.bind(STRUCT, lessThan(extract("x", "$.event_id", "long"), 100)))
         .isInstanceOf(ValidationException.class)
@@ -361,12 +426,19 @@ public class TestExpressionBinding {
       new String[] {
         "$", // root path
         "$.event_id",
-        "$.event.id"
+        "$.event.id",
+        "$['event_id']",
+        "$.a['b.c']",
+        "$.matrix[0][1]",
+        "$.basket[0][2].a",
+        "$.items[0].tags[1]",
+        "$['items'][0]['tags'][1]",
+        "$.events[0].event_id"
       };
 
   @ParameterizedTest
   @FieldSource("VALID_PATHS")
-  public void testExtractExpressionBindingPaths(String path) {
+  public void testVariantExtractBindingAcceptsPaths(String path) {
     Expression bound = Binder.bind(STRUCT, lessThan(extract("var", path, "long"), 100));
     TestHelpers.assertAllReferencesBound("BoundExtract", bound);
     BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
@@ -378,15 +450,13 @@ public class TestExpressionBinding {
         null,
         "",
         "event_id", // missing root
-        "$['event_id']", // uses bracket notation
         "$..event_id", // uses recursive descent
-        "$.events[0].event_id", // uses position accessor
         "$.events.*" // uses wildcard
       };
 
   @ParameterizedTest
   @FieldSource("UNSUPPORTED_PATHS")
-  public void testExtractBindingWithInvalidPath(String path) {
+  public void testVariantExtractBindingRejectsInvalidPaths(String path) {
     assertThatThrownBy(() -> Binder.bind(STRUCT, lessThan(extract("var", path, "long"), 100)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageMatching("(Unsupported|Invalid) path.*");

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -374,6 +374,57 @@ public class TestExpressionUtil {
   }
 
   @Test
+  public void testSanitizeExtractTerm() {
+    Expression sanitized =
+        ExpressionUtil.sanitize(
+            Expressions.equal(Expressions.extract("var", "$.city", "string"), "Boston"));
+    assertThat(sanitized).isInstanceOf(UnboundPredicate.class);
+    UnboundPredicate<?> pred = (UnboundPredicate<?>) sanitized;
+    assertThat(pred.term()).isInstanceOf(UnboundExtract.class);
+    assertThat(pred.op()).isEqualTo(Expression.Operation.EQ);
+    assertThat(pred.literal().value().toString()).startsWith("(hash-").endsWith(")");
+
+    Expression boundSanitized =
+        ExpressionUtil.sanitize(
+            STRUCT,
+            Expressions.equal(Expressions.extract("var", "$.city", "string"), "Boston"),
+            true);
+    assertThat(boundSanitized).isInstanceOf(UnboundPredicate.class);
+    UnboundPredicate<?> boundPred = (UnboundPredicate<?>) boundSanitized;
+    assertThat(boundPred.term()).isInstanceOf(UnboundExtract.class);
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(
+                Expressions.equal(Expressions.extract("var", "$.city", "string"), "Boston")))
+        .as("Sanitized string for extract term")
+        .startsWith("extract(var, $.city, string) = (hash-")
+        .endsWith(")");
+
+    // Bound extract uses normalized path $['city'] in describe output
+    assertThat(
+            ExpressionUtil.toSanitizedString(
+                STRUCT,
+                Expressions.equal(Expressions.extract("var", "$.city", "string"), "Boston"),
+                true))
+        .as("Sanitized string for extract term (bound)")
+        .startsWith("extract(var, $['city'], string) = (hash-")
+        .endsWith(")");
+  }
+
+  @Test
+  public void testUnbindBoundExtract() {
+    Expression boundExpr =
+        Expressions.greaterThan(Expressions.extract("var", "$.city", "string"), "Boston")
+            .bind(STRUCT, true);
+    UnboundTerm<?> unbound = ExpressionUtil.unbind(((BoundPredicate<?>) boundExpr).term());
+    assertThat(unbound).isInstanceOf(UnboundExtract.class);
+    UnboundExtract<?> extract = (UnboundExtract<?>) unbound;
+    assertThat(extract.ref().name()).isEqualTo("var");
+    assertThat(extract.path()).isEqualTo("$.city");
+    assertThat(extract.type().toString()).isEqualTo("string");
+  }
+
+  @Test
   public void testSanitizeTransformedTerm() {
     assertEquals(
         Expressions.equal(Expressions.truncate("test", 2), "(2-digit-int)"),

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -397,7 +397,7 @@ public class TestExpressionUtil {
             ExpressionUtil.toSanitizedString(
                 Expressions.equal(Expressions.extract("var", "$.city", "string"), "Boston")))
         .as("Sanitized string for extract term")
-        .startsWith("extract(var, $.city, string) = (hash-")
+        .startsWith("extract(var, $['city'], string) = (hash-")
         .endsWith(")");
 
     // Bound extract uses normalized path $['city'] in describe output
@@ -420,8 +420,47 @@ public class TestExpressionUtil {
     assertThat(unbound).isInstanceOf(UnboundExtract.class);
     UnboundExtract<?> extract = (UnboundExtract<?>) unbound;
     assertThat(extract.ref().name()).isEqualTo("var");
-    assertThat(extract.path()).isEqualTo("$.city");
+    assertThat(extract.path()).isEqualTo("$['city']");
     assertThat(extract.type().toString()).isEqualTo("string");
+  }
+
+  @Test
+  public void testUnbindBoundExtractBracketStyle() {
+    Expression boundExpr =
+        Expressions.greaterThan(Expressions.extract("var", "$['user.name']", "string"), "x")
+            .bind(STRUCT, true);
+    UnboundTerm<?> unbound = ExpressionUtil.unbind(((BoundPredicate<?>) boundExpr).term());
+    assertThat(unbound).isInstanceOf(UnboundExtract.class);
+    UnboundExtract<?> extract = (UnboundExtract<?>) unbound;
+    assertThat(extract.ref().name()).isEqualTo("var");
+    assertThat(extract.path()).isEqualTo("$['user.name']");
+    assertThat(extract.type().toString()).isEqualTo("string");
+  }
+
+  @Test
+  public void testUnbindBoundExtractMixedStyle() {
+    Expression boundExpr =
+        Expressions.greaterThan(Expressions.extract("var", "$.a['b.c']", "long"), 1L)
+            .bind(STRUCT, true);
+    UnboundTerm<?> unbound = ExpressionUtil.unbind(((BoundPredicate<?>) boundExpr).term());
+    assertThat(unbound).isInstanceOf(UnboundExtract.class);
+    UnboundExtract<?> extract = (UnboundExtract<?>) unbound;
+    assertThat(extract.ref().name()).isEqualTo("var");
+    assertThat(extract.path()).isEqualTo("$['a']['b.c']");
+    assertThat(extract.type().toString()).isEqualTo("long");
+  }
+
+  @Test
+  public void testUnbindBoundExtractArrayIndex() {
+    Expression boundExpr =
+        Expressions.greaterThan(Expressions.extract("var", "$.items[0].tags[1]", "long"), 100L)
+            .bind(STRUCT, true);
+    UnboundTerm<?> unbound = ExpressionUtil.unbind(((BoundPredicate<?>) boundExpr).term());
+    assertThat(unbound).isInstanceOf(UnboundExtract.class);
+    UnboundExtract<?> extract = (UnboundExtract<?>) unbound;
+    assertThat(extract.ref().name()).isEqualTo("var");
+    assertThat(extract.path()).isEqualTo("$['items'][0]['tags'][1]");
+    assertThat(extract.type().toString()).isEqualTo("long");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
@@ -123,4 +123,42 @@ public class TestPathUtil {
   public void testPathEscaping(String name, String escaped) {
     assertThat(PathUtil.rfc9535escape(name)).isEqualTo(escaped);
   }
+
+  private static final String[][] TO_DOT_NOTATION_CASES =
+      new String[][] {
+        new String[] {"$", "$"},
+        new String[] {"$['a']", "$.a"},
+        new String[] {"$['a']['b']", "$.a.b"},
+        new String[] {"$['a']['b']['c']", "$.a.b.c"},
+        new String[] {"$['event_id']", "$.event_id"},
+        new String[] {"$['\u2603']", "$.\u2603"},
+        new String[] {"$['a\uD834\uDD1Eb']['x']", "$.a\uD834\uDD1Eb.x"},
+        new String[] {"$['user.name']", "$.user.name"},
+      };
+
+  @ParameterizedTest
+  @FieldSource("TO_DOT_NOTATION_CASES")
+  public void testToDotNotation(String normalizedPath, String expectedDotPath) {
+    assertThat(PathUtil.toDotNotation(normalizedPath)).isEqualTo(expectedDotPath);
+  }
+
+  @Test
+  public void testToDotNotationRoundTrip() {
+    for (String[] pair : NORMALIZED_PATHS) {
+      String dotPath = pair[0];
+      String normalizedPath = pair[1];
+      assertThat(PathUtil.toDotNotation(normalizedPath)).isEqualTo(dotPath);
+    }
+  }
+
+  private static final String[] INVALID_TO_DOT_NOTATION_INPUTS =
+      new String[] {null, "", "event_id"};
+
+  @ParameterizedTest
+  @FieldSource("INVALID_TO_DOT_NOTATION_INPUTS")
+  public void testToDotNotationInvalidInput(String path) {
+    assertThatThrownBy(() -> PathUtil.toDotNotation(path))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid normalized path");
+  }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
@@ -18,11 +18,14 @@
  */
 package org.apache.iceberg.expressions;
 
+import static org.apache.iceberg.expressions.PathUtil.PathSegment.Index;
+import static org.apache.iceberg.expressions.PathUtil.PathSegment.Name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
@@ -30,9 +33,13 @@ import org.junit.jupiter.params.provider.FieldSource;
 @SuppressWarnings({"AvoidEscapedUnicodeCharacters", "IllegalTokenText"})
 public class TestPathUtil {
 
+  private static List<PathUtil.PathSegment> names(String... names) {
+    return java.util.Arrays.stream(names).map(Name::new).collect(Collectors.toList());
+  }
+
   @Test
   public void testSimplePath() {
-    assertThat(PathUtil.parse("$.event.id")).isEqualTo(List.of("event", "id"));
+    assertThat(PathUtil.parse("$.event.id")).isEqualTo(names("event", "id"));
   }
 
   private static final String[] VALID_PATHS =
@@ -40,8 +47,18 @@ public class TestPathUtil {
         "$", // root path
         "$.event_id",
         "$.event.id",
+        "$['event_id']", // bracket form
+        "$.event['x.y']", // mixed: dot then bracket
+        "$['event']['id']", // bracket then bracket
+        "$['a'].b", // bracket then dot
         "$.\u2603", // snowman
         "$.\uD834\uDD1E", // surrogate pair, U+1D11E
+        "$.matrix[0][1]",
+        "$.basket[0][2].a",
+        "$.items[0].tags[1]",
+        "$['matrix'][0][1]",
+        "$['items'][0]['tags'][1]",
+        "$['basket'][0][2]['a']",
       };
 
   @ParameterizedTest
@@ -55,9 +72,7 @@ public class TestPathUtil {
         null,
         "",
         "event_id", // missing root
-        "$['event_id']", // uses bracket notation
         "$..event_id", // uses recursive descent
-        "$.events[0].event_id", // uses position accessor
         "$.events.*", // uses wildcard
         "$.0invalid", // starts with a digit
         "$._\uD834", // dangling high surrogate
@@ -79,6 +94,10 @@ public class TestPathUtil {
         new String[] {"$.a.b.c", "$['a']['b']['c']"},
         new String[] {"$.\u2603", "$['☃']"},
         new String[] {"$.a\uD834\uDD1Eb.x", "$['a\uD834\uDD1Eb']['x']"},
+        // Dot shorthand vs bracket form for names; array steps use unquoted [n] in both.
+        new String[] {"$.matrix[0][1]", "$['matrix'][0][1]"},
+        new String[] {"$.items[0].tags[1]", "$['items'][0]['tags'][1]"},
+        new String[] {"$.basket[0][2].a", "$['basket'][0][2]['a']"},
       };
 
   @ParameterizedTest
@@ -124,41 +143,156 @@ public class TestPathUtil {
     assertThat(PathUtil.rfc9535escape(name)).isEqualTo(escaped);
   }
 
-  private static final String[][] TO_DOT_NOTATION_CASES =
-      new String[][] {
-        new String[] {"$", "$"},
-        new String[] {"$['a']", "$.a"},
-        new String[] {"$['a']['b']", "$.a.b"},
-        new String[] {"$['a']['b']['c']", "$.a.b.c"},
-        new String[] {"$['event_id']", "$.event_id"},
-        new String[] {"$['\u2603']", "$.\u2603"},
-        new String[] {"$['a\uD834\uDD1Eb']['x']", "$.a\uD834\uDD1Eb.x"},
-        new String[] {"$['user.name']", "$.user.name"},
-      };
+  @ParameterizedTest
+  @FieldSource("ESCAPE_CASES")
+  public void testPathUnescapeRoundTrip(String name, String escaped) {
+    assertThat(PathUtil.rfc9535unescape(escaped)).isEqualTo(name);
+  }
 
   @ParameterizedTest
-  @FieldSource("TO_DOT_NOTATION_CASES")
-  public void testToDotNotation(String normalizedPath, String expectedDotPath) {
-    assertThat(PathUtil.toDotNotation(normalizedPath)).isEqualTo(expectedDotPath);
+  @FieldSource("NORMALIZED_PATHS")
+  public void testParseDotAndBracketAgree(String dotPath, String normalizedPath) {
+    assertThat(PathUtil.parse(dotPath)).isEqualTo(PathUtil.parse(normalizedPath));
   }
 
   @Test
-  public void testToDotNotationRoundTrip() {
-    for (String[] pair : NORMALIZED_PATHS) {
-      String dotPath = pair[0];
-      String normalizedPath = pair[1];
-      assertThat(PathUtil.toDotNotation(normalizedPath)).isEqualTo(dotPath);
+  public void testParseSingleSegmentWithDot() {
+    assertThat(PathUtil.parse("$['a.b']")).isEqualTo(names("a.b"));
+    assertThat(PathUtil.parse("$['user.name']")).isEqualTo(names("user.name"));
+  }
+
+  @Test
+  public void testParseDistinctFromDotSplit() {
+    assertThat(PathUtil.parse("$.a.b")).isEqualTo(names("a", "b"));
+    assertThat(PathUtil.parse("$['a.b']")).isEqualTo(names("a.b"));
+  }
+
+  @Test
+  public void testParseNormalizedRoundTrip() {
+    for (Object[] row : NORMALIZED_FIELD_LISTS) {
+      @SuppressWarnings("unchecked")
+      List<String> fields = (List<String>) row[0];
+      String normalized = (String) row[1];
+      assertThat(PathUtil.toNormalizedPath(PathUtil.parse(normalized))).isEqualTo(normalized);
+      assertThat(PathUtil.parse(normalized))
+          .isEqualTo(fields.stream().map(Name::new).collect(Collectors.toList()));
     }
   }
 
-  private static final String[] INVALID_TO_DOT_NOTATION_INPUTS =
-      new String[] {null, "", "event_id"};
+  @Test
+  public void testParseRoot() {
+    assertThat(PathUtil.parse("$")).isEqualTo(List.of());
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$"))).isEqualTo("$");
+  }
+
+  /**
+   * Bracket paths can represent keys that dot notation cannot (empty name, {@code []}, {@code ..}).
+   */
+  @Test
+  public void testParseSpecialFieldNames() {
+    assertThat(PathUtil.parse("$['']")).isEqualTo(names(""));
+    assertThat(PathUtil.parse("$['[]']")).isEqualTo(names("[]"));
+    assertThat(PathUtil.parse("$['..']")).isEqualTo(names(".."));
+    assertThat(PathUtil.parse("$['*']")).isEqualTo(names("*"));
+    assertThat(PathUtil.parse("$['[']")).isEqualTo(names("["));
+    assertThat(PathUtil.parse("$[']']")).isEqualTo(names("]"));
+
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$['']"))).isEqualTo("$['']");
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$['[]']"))).isEqualTo("$['[]']");
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$['..']"))).isEqualTo("$['..']");
+  }
+
+  @Test
+  public void testParseNestedWithSpecialMiddleSegment() {
+    assertThat(PathUtil.parse("$['a']['..']['b']")).isEqualTo(names("a", "..", "b"));
+    assertThat(PathUtil.toNormalizedPath(List.of("a", "..", "b"))).isEqualTo("$['a']['..']['b']");
+  }
+
+  @Test
+  public void testParseMixedDotAndBracket() {
+    assertThat(PathUtil.parse("$.a['b.c']")).isEqualTo(names("a", "b.c"));
+    assertThat(PathUtil.parse("$.events['user.name'].id"))
+        .isEqualTo(names("events", "user.name", "id"));
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$.a['b.c']"))).isEqualTo("$['a']['b.c']");
+  }
+
+  @Test
+  public void testParseMixedBracketThenDot() {
+    assertThat(PathUtil.parse("$['x.y'].z")).isEqualTo(names("x.y", "z"));
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$['x.y'].z"))).isEqualTo("$['x.y']['z']");
+  }
+
+  @Test
+  public void testParseArrayIndexSegments() {
+    assertThat(PathUtil.parse("$.matrix[0][1]"))
+        .isEqualTo(List.of(new Name("matrix"), new Index(0), new Index(1)));
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$.matrix[0][1]")))
+        .isEqualTo("$['matrix'][0][1]");
+
+    assertThat(PathUtil.parse("$.basket[0][2].a"))
+        .isEqualTo(List.of(new Name("basket"), new Index(0), new Index(2), new Name("a")));
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$.basket[0][2].a")))
+        .isEqualTo("$['basket'][0][2]['a']");
+
+    assertThat(PathUtil.parse("$.items[0].tags[1]"))
+        .isEqualTo(List.of(new Name("items"), new Index(0), new Name("tags"), new Index(1)));
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$.items[0].tags[1]")))
+        .isEqualTo("$['items'][0]['tags'][1]");
+
+    assertThat(PathUtil.parse("$.events[0].event_id"))
+        .isEqualTo(List.of(new Name("events"), new Index(0), new Name("event_id")));
+    assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$.events[0].event_id")))
+        .isEqualTo("$['events'][0]['event_id']");
+
+    assertThat(PathUtil.parse("$['items'][0]['tags'][1]"))
+        .isEqualTo(PathUtil.parse("$.items[0].tags[1]"));
+    assertThat(PathUtil.parse("$['matrix'][0][1]")).isEqualTo(PathUtil.parse("$.matrix[0][1]"));
+  }
+
+  @Test
+  public void testParseArrayIndexRoundTrip() {
+    // parse(toNormalizedPath(parse(x))) == parse(x) for paths with [n] segments
+    for (String[] pair : NORMALIZED_PATHS) {
+      String normalized = pair[1];
+      if (normalized.contains("[") && !normalized.contains("['")) {
+        // normalized path has array indices; round-trip must be stable
+        assertThat(PathUtil.parse(PathUtil.toNormalizedPath(PathUtil.parse(normalized))))
+            .isEqualTo(PathUtil.parse(normalized));
+      }
+    }
+    // explicit cases to be clear about what is covered
+    for (String path :
+        new String[] {
+          "$['matrix'][0][1]",
+          "$['items'][0]['tags'][1]",
+          "$['basket'][0][2]['a']",
+          "$['events'][0]['event_id']",
+        }) {
+      assertThat(PathUtil.parse(PathUtil.toNormalizedPath(PathUtil.parse(path))))
+          .isEqualTo(PathUtil.parse(path));
+    }
+  }
+
+  private static final String[] INVALID_PARSE_PATHS =
+      new String[] {
+        null,
+        "",
+        "event_id",
+        "$.a..b",
+        "$.events.*",
+        "$['a'", // unclosed
+        "$['a']x", // trailing junk
+        "$.['a']", // empty dot segment before bracket
+        "$a.b", // missing separator after $
+        "$.a[]", // empty array index
+        "$.a[-1]", // negative index (not valid JSONPath index syntax here)
+      };
 
   @ParameterizedTest
-  @FieldSource("INVALID_TO_DOT_NOTATION_INPUTS")
-  public void testToDotNotationInvalidInput(String path) {
-    assertThatThrownBy(() -> PathUtil.toDotNotation(path))
+  @FieldSource("INVALID_PARSE_PATHS")
+  public void testParseInvalid(String path) {
+    assertThatThrownBy(() -> PathUtil.parse(path))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid normalized path");
+        .hasMessageMatching("(Unsupported|Invalid) path.*");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
@@ -196,6 +196,8 @@ public class TestPathUtil {
     assertThat(PathUtil.parse("$['*']")).isEqualTo(names("*"));
     assertThat(PathUtil.parse("$['[']")).isEqualTo(names("["));
     assertThat(PathUtil.parse("$[']']")).isEqualTo(names("]"));
+    // RFC 9535 simple escape \f in a quoted segment (also covered in ESCAPE_CASES round-trips)
+    assertThat(PathUtil.parse("$['\\f']")).isEqualTo(List.of(new Name("\f")));
 
     assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$['']"))).isEqualTo("$['']");
     assertThat(PathUtil.toNormalizedPath(PathUtil.parse("$['[]']"))).isEqualTo("$['[]']");
@@ -280,11 +282,14 @@ public class TestPathUtil {
         "event_id",
         "$.a..b",
         "$.events.*",
+        "$$", // second $ is not a path step after root
         "$['a'", // unclosed
+        "$[", // [ without quoted ['...'] or index
         "$['a']x", // trailing junk
         "$.['a']", // empty dot segment before bracket
         "$a.b", // missing separator after $
         "$.a[]", // empty array index
+        "$.a[2147483648]", // index does not fit in int
         "$.a[-1]", // negative index (not valid JSONPath index syntax here)
       };
 
@@ -292,6 +297,7 @@ public class TestPathUtil {
   @FieldSource("INVALID_PARSE_PATHS")
   public void testParseInvalid(String path) {
     assertThatThrownBy(() -> PathUtil.parse(path))
+        .as("parse of %s", path)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageMatching("(Unsupported|Invalid) path.*");
   }


### PR DESCRIPTION
Changes:
- Add support for bracket style and mixed style of jsonpath, like $.user.name, or $['user']['name]. This change is needed to support dot or special characters in field names
- Handle UnboundExtract/BoundExtract in ExpressionUtil.describe and unbind
- Variant bounds fix: Use little-endian ByteBuffer in InclusiveMetricsEvaluator.parseBounds for variant bounds

Variant bound fix is required manifest-based file skipping for variant columns. The
ExpressionUtil and PathUtil changes allow variant extract terms to be
described and unbound for EXPLAIN and sanitization.

Testing:
- unit tests

Related Issues:
1. https://github.com/apache/iceberg/issues/10392