### PR TITLE
Spark: Support variant_get predicate pushdown for file skipping

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.Term;
+import org.apache.iceberg.expressions.UnboundExtract;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.expressions.UnboundTerm;
 import org.apache.iceberg.expressions.UnboundTransform;
@@ -714,6 +715,15 @@ public class Spark3Util {
       } else if (term instanceof UnboundTransform) {
         UnboundTransform<?, ?> transform = (UnboundTransform<?, ?>) term;
         return transform.transform().toString() + "(" + transform.ref().name() + ")";
+      } else if (term instanceof UnboundExtract) {
+        UnboundExtract<?> extract = (UnboundExtract<?>) term;
+        return "variant_get("
+            + extract.ref().name()
+            + ", '"
+            + extract.path()
+            + "', '"
+            + extract.type().toString()
+            + "')";
       } else {
         throw new UnsupportedOperationException("Cannot convert term to SQL: " + term);
       }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -60,6 +60,7 @@ import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.UserDefinedScalarFunc;
+import org.apache.spark.sql.connector.expressions.VariantGet;
 import org.apache.spark.sql.connector.expressions.filter.And;
 import org.apache.spark.sql.connector.expressions.filter.Not;
 import org.apache.spark.sql.connector.expressions.filter.Or;
@@ -354,21 +355,12 @@ public class SparkV2Filters {
 
   private static boolean canConvertToTerm(
       org.apache.spark.sql.connector.expressions.Expression expr) {
-    return isRef(expr) || isSystemFunc(expr) || isVariantGetFunc(expr);
+    return isRef(expr) || isSystemFunc(expr) || isVariantGetExpr(expr);
   }
 
-  private static boolean isVariantGetFunc(
+  private static boolean isVariantGetExpr(
       org.apache.spark.sql.connector.expressions.Expression expr) {
-    if (!(expr instanceof UserDefinedScalarFunc)) {
-      return false;
-    }
-    UserDefinedScalarFunc udf = (UserDefinedScalarFunc) expr;
-    String name = udf.name().toLowerCase(Locale.ROOT);
-    return ("variant_get".equals(name) || "try_variant_get".equals(name))
-        && udf.children().length == 3
-        && isRef(udf.children()[0])
-        && isLiteral(udf.children()[1])
-        && isLiteral(udf.children()[2]);
+    return expr instanceof VariantGet && isRef(((VariantGet) expr).child());
   }
 
   private static boolean isRef(org.apache.spark.sql.connector.expressions.Expression expr) {
@@ -453,11 +445,20 @@ public class SparkV2Filters {
   private static <T> UnboundTerm<Object> toTerm(T input) {
     if (input instanceof NamedReference) {
       return Expressions.ref(SparkUtil.toColumnName((NamedReference) input));
+    } else if (input instanceof VariantGet) {
+      return variantGetToTerm((VariantGet) input);
     } else if (input instanceof UserDefinedScalarFunc) {
       return udfToTerm((UserDefinedScalarFunc) input);
     } else {
       return null;
     }
+  }
+
+  private static UnboundTerm<Object> variantGetToTerm(VariantGet vg) {
+    String column = SparkUtil.toColumnName((NamedReference) vg.child());
+    String path = vg.path();
+    String type = toIcebergTypeName(vg.targetType().catalogString());
+    return Expressions.extract(column, path, type);
   }
 
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
@@ -489,19 +490,6 @@ public class SparkV2Filters {
           case "truncate":
             int width = (Integer) convertLiteral((Literal<?>) children[0]);
             return truncate(column, width);
-        }
-      }
-    } else if (children.length == 3) {
-      if (isRef(children[0]) && isLiteral(children[1]) && isLiteral(children[2])) {
-        String column = SparkUtil.toColumnName((NamedReference) children[0]);
-        String path = convertLiteral((Literal<?>) children[1]).toString();
-        String type = toIcebergTypeName(convertLiteral((Literal<?>) children[2]).toString());
-        switch (udfName) {
-          case "variant_get":
-          case "try_variant_get":
-            return Expressions.extract(column, path, type);
-          default:
-            break;
         }
       }
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -354,7 +354,21 @@ public class SparkV2Filters {
 
   private static boolean canConvertToTerm(
       org.apache.spark.sql.connector.expressions.Expression expr) {
-    return isRef(expr) || isSystemFunc(expr);
+    return isRef(expr) || isSystemFunc(expr) || isVariantGetFunc(expr);
+  }
+
+  private static boolean isVariantGetFunc(
+      org.apache.spark.sql.connector.expressions.Expression expr) {
+    if (!(expr instanceof UserDefinedScalarFunc)) {
+      return false;
+    }
+    UserDefinedScalarFunc udf = (UserDefinedScalarFunc) expr;
+    String name = udf.name().toLowerCase(Locale.ROOT);
+    return ("variant_get".equals(name) || "try_variant_get".equals(name))
+        && udf.children().length == 3
+        && isRef(udf.children()[0])
+        && isLiteral(udf.children()[1])
+        && isLiteral(udf.children()[2]);
   }
 
   private static boolean isRef(org.apache.spark.sql.connector.expressions.Expression expr) {
@@ -477,8 +491,31 @@ public class SparkV2Filters {
             return truncate(column, width);
         }
       }
+    } else if (children.length == 3) {
+      if (isRef(children[0]) && isLiteral(children[1]) && isLiteral(children[2])) {
+        String column = SparkUtil.toColumnName((NamedReference) children[0]);
+        String path = convertLiteral((Literal<?>) children[1]).toString();
+        String type = toIcebergTypeName(convertLiteral((Literal<?>) children[2]).toString());
+        switch (udfName) {
+          case "variant_get":
+          case "try_variant_get":
+            return Expressions.extract(column, path, type);
+          default:
+            break;
+        }
+      }
     }
 
     return null;
+  }
+
+  private static String toIcebergTypeName(String sparkTypeName) {
+    // Spark catalogString uses "bigint"; Iceberg expects "long".
+    switch (sparkTypeName.toLowerCase(Locale.ROOT)) {
+      case "bigint":
+        return "long";
+      default:
+        return sparkTypeName;
+    }
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
@@ -24,6 +24,7 @@ import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.expressions.Expressions.day;
 import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.extract;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.hour;
@@ -163,6 +164,21 @@ public class TestSpark3Util extends TestBase {
 
     Expression andExpression = and(refExpression, yearExpression);
     assertThat(Spark3Util.describe(andExpression)).isEqualTo("(id = 1 AND year(ts) > 10)");
+  }
+
+  @Test
+  public void testDescribeExtractExpression() {
+    Expression extractGt = greaterThan(extract("v", "$.city", "string"), "Boston");
+    assertThat(Spark3Util.describe(extractGt))
+        .isEqualTo("variant_get(v, '$['city']', 'string') > 'Boston'");
+
+    Expression extractEq = equal(extract("v", "$.event.id", "long"), 42L);
+    assertThat(Spark3Util.describe(extractEq))
+        .isEqualTo("variant_get(v, '$['event']['id']', 'long') = 42");
+
+    Expression extractIn = in(extract("v", "$.city", "string"), "NYC", "LA");
+    assertThat(Spark3Util.describe(extractIn))
+        .isEqualTo("variant_get(v, '$['city']', 'string') IN ('NYC', 'LA')");
   }
 
   private SortOrder buildSortOrder(String transform, Schema schema, int sourceId) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -44,6 +44,7 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
 import org.apache.spark.sql.connector.expressions.LiteralValue;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.UserDefinedScalarFunc;
+import org.apache.spark.sql.connector.expressions.VariantGet;
 import org.apache.spark.sql.connector.expressions.filter.And;
 import org.apache.spark.sql.connector.expressions.filter.Not;
 import org.apache.spark.sql.connector.expressions.filter.Or;
@@ -655,69 +656,35 @@ public class TestSparkV2Filters {
 
   @Test
   public void testVariantGet() {
-    UserDefinedScalarFunc udf =
-        new UserDefinedScalarFunc(
-            "variant_get",
-            "variant_get",
-            expressions(
-                FieldReference.apply("v"),
-                LiteralValue.apply(UTF8String.fromString("$.city"), DataTypes.StringType),
-                LiteralValue.apply(UTF8String.fromString("string"), DataTypes.StringType)));
-    testUDF(udf, Expressions.extract("v", "$.city", "string"), "NYC", DataTypes.StringType);
+    VariantGet vg = new VariantGet(FieldReference.apply("v"), "$.city", DataTypes.StringType, true, null);
+    testUDF(vg, Expressions.extract("v", "$.city", "string"), "NYC", DataTypes.StringType);
   }
 
   @Test
   public void testTryVariantGet() {
-    UserDefinedScalarFunc udf =
-        new UserDefinedScalarFunc(
-            "try_variant_get",
-            "try_variant_get",
-            expressions(
-                FieldReference.apply("v"),
-                LiteralValue.apply(UTF8String.fromString("$.city"), DataTypes.StringType),
-                LiteralValue.apply(UTF8String.fromString("string"), DataTypes.StringType)));
-    testUDF(udf, Expressions.extract("v", "$.city", "string"), "NYC", DataTypes.StringType);
+    VariantGet vg = new VariantGet(FieldReference.apply("v"), "$.city", DataTypes.StringType, false, null);
+    testUDF(vg, Expressions.extract("v", "$.city", "string"), "NYC", DataTypes.StringType);
   }
 
   @Test
   public void testVariantGetNestedPath() {
-    UserDefinedScalarFunc udf =
-        new UserDefinedScalarFunc(
-            "variant_get",
-            "variant_get",
-            expressions(
-                FieldReference.apply("v"),
-                LiteralValue.apply(UTF8String.fromString("$.event.id"), DataTypes.StringType),
-                LiteralValue.apply(UTF8String.fromString("long"), DataTypes.StringType)));
-    testUDF(udf, Expressions.extract("v", "$.event.id", "long"), 42L, DataTypes.LongType);
+    VariantGet vg = new VariantGet(FieldReference.apply("v"), "$.event.id", DataTypes.LongType, true, null);
+    testUDF(vg, Expressions.extract("v", "$.event.id", "long"), 42L, DataTypes.LongType);
   }
 
   @Test
   public void testVariantGetBigintTypeName() {
-    UserDefinedScalarFunc udf =
-        new UserDefinedScalarFunc(
-            "variant_get",
-            "variant_get",
-            expressions(
-                FieldReference.apply("v"),
-                LiteralValue.apply(UTF8String.fromString("$.event.id"), DataTypes.StringType),
-                LiteralValue.apply(UTF8String.fromString("bigint"), DataTypes.StringType)));
-    testUDF(udf, Expressions.extract("v", "$.event.id", "long"), 42L, DataTypes.LongType);
+    // LongType.catalogString() = "bigint"; toIcebergTypeName maps "bigint" -> "long"
+    VariantGet vg = new VariantGet(FieldReference.apply("v"), "$.event.id", DataTypes.LongType, true, null);
+    testUDF(vg, Expressions.extract("v", "$.event.id", "long"), 42L, DataTypes.LongType);
   }
 
   @Test
   public void testVariantGetInPredicate() {
-    UserDefinedScalarFunc udf =
-        new UserDefinedScalarFunc(
-            "variant_get",
-            "variant_get",
-            expressions(
-                FieldReference.apply("v"),
-                LiteralValue.apply(UTF8String.fromString("$.city"), DataTypes.StringType),
-                LiteralValue.apply(UTF8String.fromString("string"), DataTypes.StringType)));
+    VariantGet vg = new VariantGet(FieldReference.apply("v"), "$.city", DataTypes.StringType, true, null);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValues =
         expressions(
-            udf,
+            vg,
             LiteralValue.apply(UTF8String.fromString("NYC"), DataTypes.StringType),
             LiteralValue.apply(UTF8String.fromString("LA"), DataTypes.StringType));
     Predicate in = new Predicate("IN", attrAndValues);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -62,7 +62,8 @@ public class TestSparkV2Filters {
           Types.NestedField.optional(2, "tsCol", Types.TimestampType.withZone()),
           Types.NestedField.optional(3, "tsNtzCol", Types.TimestampType.withoutZone()),
           Types.NestedField.optional(4, "intCol", Types.IntegerType.get()),
-          Types.NestedField.optional(5, "strCol", Types.StringType.get()));
+          Types.NestedField.optional(5, "strCol", Types.StringType.get()),
+          Types.NestedField.optional(6, "v", Types.VariantType.get()));
 
   @SuppressWarnings("checkstyle:MethodLength")
   @Test
@@ -650,6 +651,79 @@ public class TestSparkV2Filters {
             expressions(
                 LiteralValue.apply(6, DataTypes.IntegerType), FieldReference.apply("strCol")));
     testUDF(udf, Expressions.truncate("strCol", 6), "prefix", DataTypes.StringType);
+  }
+
+  @Test
+  public void testVariantGet() {
+    UserDefinedScalarFunc udf =
+        new UserDefinedScalarFunc(
+            "variant_get",
+            "variant_get",
+            expressions(
+                FieldReference.apply("v"),
+                LiteralValue.apply(UTF8String.fromString("$.city"), DataTypes.StringType),
+                LiteralValue.apply(UTF8String.fromString("string"), DataTypes.StringType)));
+    testUDF(udf, Expressions.extract("v", "$.city", "string"), "NYC", DataTypes.StringType);
+  }
+
+  @Test
+  public void testTryVariantGet() {
+    UserDefinedScalarFunc udf =
+        new UserDefinedScalarFunc(
+            "try_variant_get",
+            "try_variant_get",
+            expressions(
+                FieldReference.apply("v"),
+                LiteralValue.apply(UTF8String.fromString("$.city"), DataTypes.StringType),
+                LiteralValue.apply(UTF8String.fromString("string"), DataTypes.StringType)));
+    testUDF(udf, Expressions.extract("v", "$.city", "string"), "NYC", DataTypes.StringType);
+  }
+
+  @Test
+  public void testVariantGetNestedPath() {
+    UserDefinedScalarFunc udf =
+        new UserDefinedScalarFunc(
+            "variant_get",
+            "variant_get",
+            expressions(
+                FieldReference.apply("v"),
+                LiteralValue.apply(UTF8String.fromString("$.event.id"), DataTypes.StringType),
+                LiteralValue.apply(UTF8String.fromString("long"), DataTypes.StringType)));
+    testUDF(udf, Expressions.extract("v", "$.event.id", "long"), 42L, DataTypes.LongType);
+  }
+
+  @Test
+  public void testVariantGetBigintTypeName() {
+    UserDefinedScalarFunc udf =
+        new UserDefinedScalarFunc(
+            "variant_get",
+            "variant_get",
+            expressions(
+                FieldReference.apply("v"),
+                LiteralValue.apply(UTF8String.fromString("$.event.id"), DataTypes.StringType),
+                LiteralValue.apply(UTF8String.fromString("bigint"), DataTypes.StringType)));
+    testUDF(udf, Expressions.extract("v", "$.event.id", "long"), 42L, DataTypes.LongType);
+  }
+
+  @Test
+  public void testVariantGetInPredicate() {
+    UserDefinedScalarFunc udf =
+        new UserDefinedScalarFunc(
+            "variant_get",
+            "variant_get",
+            expressions(
+                FieldReference.apply("v"),
+                LiteralValue.apply(UTF8String.fromString("$.city"), DataTypes.StringType),
+                LiteralValue.apply(UTF8String.fromString("string"), DataTypes.StringType)));
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValues =
+        expressions(
+            udf,
+            LiteralValue.apply(UTF8String.fromString("NYC"), DataTypes.StringType),
+            LiteralValue.apply(UTF8String.fromString("LA"), DataTypes.StringType));
+    Predicate in = new Predicate("IN", attrAndValues);
+    Expression actual = SparkV2Filters.convert(in);
+    Expression expected = Expressions.in(Expressions.extract("v", "$.city", "string"), "NYC", "LA");
+    assertEquals(expected, actual);
   }
 
   @Test


### PR DESCRIPTION
This is to support manifest-based file skipping for variant columns. 

Changes:
- SparkV2Filters: Convert new connector expression VariantGet  to Expressions.extract()
- Spark3Util.describe: Output extract terms as variant_get() for EXPLAIN

Tests:
- Added unit tests

**Do not merge**  this PR until the following two are merged: 
1.  #15384
2. [#54394](https://github.com/apache/spark/pull/54394), introuduced a new connector expression VariantGet and pushdown. 

Related issue: 
1. https://github.com/apache/iceberg/issues/10392

### CI status (expected until #15384)

CI fails because dependency PRs are not merged.  This PR will stay in **Draft** until that those merged. 