### PR TITLE
Core: Avoid exceptions for selecting schema for metadata tables in SnapshotUtil

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Function;
+import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.Schema;
@@ -395,11 +396,18 @@ public class SnapshotUtil {
   /**
    * Returns the schema of the table for the specified snapshot.
    *
+   * <p>Note that metadata tables may support time travel but don't inherit the snapshot schema,
+   * unlike normal data scans.
+   *
    * @param table a {@link Table}
    * @param snapshotId the ID of the snapshot
    * @return the schema
    */
   public static Schema schemaFor(Table table, long snapshotId) {
+    if (table instanceof BaseMetadataTable) {
+      return table.schema();
+    }
+
     Snapshot snapshot = table.snapshot(snapshotId);
     Preconditions.checkArgument(snapshot != null, "Cannot find snapshot with ID %s", snapshotId);
     Integer schemaId = snapshot.schemaId();


### PR DESCRIPTION
This PR avoids exceptions for selecting schema for metadata tables in `SnapshotUtil`.