### PR TITLE
AWS: Add S3 checksum policy configuration tied to s3.checksum-enabled

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -50,6 +50,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)
+        .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
         .applyMutation(
             s3ClientBuilder ->
                 s3FileIOProperties.applyCredentialConfigurations(
@@ -68,6 +69,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
           .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
           .build();
     }
@@ -76,6 +78,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
         .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+        .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
         .build();
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -35,6 +35,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -552,6 +554,46 @@ public class TestS3FileIOProperties {
     s3FileIOProperties.applyS3CrtConfigurations(mockS3CrtAsyncClientBuilder);
 
     Mockito.verify(mockS3CrtAsyncClientBuilder).maxConcurrency(Mockito.any(Integer.class));
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsDefault() {
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties();
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsEnabled() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "true");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_SUPPORTED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_SUPPORTED);
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsDisabled() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "false");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
   }
 
   @Test

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -433,10 +433,14 @@ If for any reason you have to use S3A, here are the instructions:
 3. Add [hadoop-aws](https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws) as a runtime dependency of your compute engine.
 4. Configure AWS settings based on [hadoop-aws documentation](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html) (make sure you check the version, S3A configuration varies a lot based on the version you use).  
 
-### S3 Write Checksum Verification
+### S3 Checksum Verification
 
 To ensure integrity of uploaded objects, checksum validations for S3 writes can be turned on by setting catalog property `s3.checksum-enabled` to `true`.
 This is turned off by default.
+
+This property controls both the Iceberg-level MD5 checksum validation for uploads and the AWS SDK's checksum calculation and validation policies.
+When set to `false` (default), the SDK's `requestChecksumCalculation` and `responseChecksumValidation` are set to `WHEN_REQUIRED`, avoiding unexpected checksum overhead.
+When set to `true`, these policies are set to `WHEN_SUPPORTED`, enabling checksums whenever the S3 service supports them.
 
 ### S3 Tags
 


### PR DESCRIPTION
The AWS SDK v2 defaults `requestChecksumCalculation` and `responseChecksumValidation` to `WHEN_SUPPORTED`, which automatically adds checksum headers to S3 requests. Some S3-compatible storage systems, notably Dell ECS, do not support these headers. This ties those SDK-level policies to the existing `s3.checksum-enabled` property, setting them to `WHEN_REQUIRED` when checksums are disabled.

This should addres #14439