### PR TITLE
Infra: Optimize - Run CI workflows on fork compute via push triggers

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -21,13 +21,13 @@ name: "API Binary Compatibility Checks"
 on:
   push:
     branches:
-      - 'main'
-      - '0.*'
-      - '1.*'
-      - '2.*'
+      - '**'
+      - '!main'
+      - '!0.*'
+      - '!1.*'
+      - '!2.*'
     tags:
       - 'apache-iceberg-**'
-  pull_request:
     paths:
       - '.github/workflows/api-binary-compatibility.yml'
       - '*.gradle'
@@ -39,8 +39,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   revapi:
@@ -48,13 +48,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # fetch-depth of zero ensures that the tags are pulled in and we're not in a detached HEAD state
-          # revapi depends on the tags, specifically the tag from git describe, to find the relevant override
-          # in the .palantir/revapi.yml file
-          #
-          # See https://github.com/actions/checkout/issues/124
           fetch-depth: 0
           persist-credentials: false
+          repository: apache/iceberg
+          ref: main
+      - name: Sync fork branch with upstream main
+        if: github.repository != 'apache/iceberg'
+        run: |
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: zulu

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -21,13 +21,13 @@ name: "Delta Conversion CI"
 on:
   push:
     branches:
-      - 'main'
-      - '0.*'
-      - '1.*'
-      - '2.*'
+      - '**'
+      - '!main'
+      - '!0.*'
+      - '!1.*'
+      - '!2.*'
     tags:
       - 'apache-iceberg-**'
-  pull_request:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/workflows/api-binary-compatibility.yml'
@@ -69,8 +69,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   delta-conversion-scala-2-12-tests:
@@ -84,7 +84,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
+          repository: apache/iceberg
+          ref: main
+      - name: Sync fork branch with upstream main
+        if: github.repository != 'apache/iceberg'
+        run: |
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: zulu
@@ -113,7 +122,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
+          repository: apache/iceberg
+          ref: main
+      - name: Sync fork branch with upstream main
+        if: github.repository != 'apache/iceberg'
+        run: |
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: zulu

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -18,7 +18,13 @@
 #
 name: Docs Build CI
 on:
-  pull_request:
+  push:
+    branches:
+      - '**'
+      - '!main'
+      - '!0.*'
+      - '!1.*'
+      - '!2.*'
     paths:
       - docs/**
       - site/**
@@ -27,6 +33,10 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-docs:
@@ -38,7 +48,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
+          repository: apache/iceberg
+          ref: main
+      - name: Sync fork branch with upstream main
+        if: github.repository != 'apache/iceberg'
+        run: |
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -21,13 +21,13 @@ name: "Flink CI"
 on:
   push:
     branches:
-    - 'main'
-    - '0.*'
-    - '1.*'
-    - '2.*'
+    - '**'
+    - '!main'
+    - '!0.*'
+    - '!1.*'
+    - '!2.*'
     tags:
     - 'apache-iceberg-**'
-  pull_request:
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -69,8 +69,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
@@ -88,7 +88,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
+        repository: apache/iceberg
+        ref: main
+    - name: Sync fork branch with upstream main
+      if: github.repository != 'apache/iceberg'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: zulu

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -21,13 +21,13 @@ name: "Hive CI"
 on:
   push:
     branches:
-    - 'main'
-    - '0.*'
-    - '1.*'
-    - '2.*'
+    - '**'
+    - '!main'
+    - '!0.*'
+    - '!1.*'
+    - '!2.*'
     tags:
     - 'apache-iceberg-**'
-  pull_request:
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -70,8 +70,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   hive2-tests:
@@ -85,7 +85,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
+        repository: apache/iceberg
+        ref: main
+    - name: Sync fork branch with upstream main
+      if: github.repository != 'apache/iceberg'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: zulu

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -21,13 +21,13 @@ name: "Java CI"
 on:
   push:
     branches:
-    - 'main'
-    - '0.*'
-    - '1.*'
-    - '2.*'
+    - '**'
+    - '!main'
+    - '!0.*'
+    - '!1.*'
+    - '!2.*'
     tags:
     - 'apache-iceberg-**'
-  pull_request:
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -65,8 +65,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   core-tests:
@@ -80,7 +80,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
+        repository: apache/iceberg
+        ref: main
+    - name: Sync fork branch with upstream main
+      if: github.repository != 'apache/iceberg'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: zulu
@@ -107,7 +116,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
+        repository: apache/iceberg
+        ref: main
+    - name: Sync fork branch with upstream main
+      if: github.repository != 'apache/iceberg'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: zulu
@@ -127,7 +145,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
+        repository: apache/iceberg
+        ref: main
+    - name: Sync fork branch with upstream main
+      if: github.repository != 'apache/iceberg'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: zulu
@@ -143,7 +170,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
+        repository: apache/iceberg
+        ref: main
+    - name: Sync fork branch with upstream main
+      if: github.repository != 'apache/iceberg'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: zulu

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -21,13 +21,13 @@ name: "Kafka Connect CI"
 on:
   push:
     branches:
-    - 'main'
-    - '0.*'
-    - '1.*'
-    - '2.*'
+    - '**'
+    - '!main'
+    - '!0.*'
+    - '!1.*'
+    - '!2.*'
     tags:
     - 'apache-iceberg-**'
-  pull_request:
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -69,8 +69,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
@@ -85,7 +85,16 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
+        repository: apache/iceberg
+        ref: main
+    - name: Sync fork branch with upstream main
+      if: github.repository != 'apache/iceberg'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: zulu

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -18,10 +18,21 @@
 #
 
 name: "Run License Check"
-on: pull_request
+on:
+  push:
+    branches:
+    - '**'
+    - '!main'
+    - '!0.*'
+    - '!1.*'
+    - '!2.*'
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   rat:
@@ -29,6 +40,15 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        fetch-depth: 0
         persist-credentials: false
+        repository: apache/iceberg
+        ref: main
+    - name: Sync fork branch with upstream main
+      if: github.repository != 'apache/iceberg'
+      run: |
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
     - run: |
         dev/check-license

--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -1,0 +1,191 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Bridges fork-compute CI back to the apache/iceberg PR page.
+#
+# CI for PRs runs on the contributor's fork (push trigger), so the apache/iceberg
+# PR commit has no checks attached. This workflow runs on apache/iceberg in
+# response to PR events, discovers each fork-compute workflow run for the PR's
+# head SHA, and posts a check on the PR commit linking to that run.
+#
+# Adapted from apache/spark's .github/workflows/notify_test_workflow.yml.
+name: On pull request update
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Notify test workflow
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      checks: write
+    steps:
+      - name: Notify fork-compute test workflows
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Workflow files we expect to fire on the fork for every PR push.
+            // Keep in sync with the workflows that use the fork-compute push trigger.
+            const tracked = [
+              { id: 'api-binary-compatibility.yml', name: 'API Binary Compatibility Checks' },
+              { id: 'delta-conversion-ci.yml',     name: 'Delta Conversion CI' },
+              { id: 'docs-ci.yml',                 name: 'Docs Build CI' },
+              { id: 'flink-ci.yml',                name: 'Flink CI' },
+              { id: 'hive-ci.yml',                 name: 'Hive CI' },
+              { id: 'java-ci.yml',                 name: 'Java CI' },
+              { id: 'kafka-connect-ci.yml',        name: 'Kafka Connect CI' },
+              { id: 'license-check.yml',           name: 'Run License Check' },
+              { id: 'open-api.yml',                name: 'Open-API' },
+              { id: 'spark-ci.yml',                name: 'Spark CI' },
+            ];
+
+            const headSha = context.payload.pull_request.head.sha;
+            const forkOwner = context.payload.pull_request.head.repo.owner.login;
+            const forkRepo = context.payload.pull_request.head.repo.name;
+            const forkBranch = context.payload.pull_request.head.ref;
+            const forkFullName = context.payload.pull_request.head.repo.full_name;
+
+            console.log(`PR head SHA: ${headSha}`);
+            console.log(`Fork: ${forkFullName}, branch: ${forkBranch}`);
+
+            // Wait briefly for the fork's push event to register workflow runs.
+            await new Promise(r => setTimeout(r, 3000));
+
+            const runsEndpoint = 'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs';
+
+            // Find a workflow run whose head_sha matches the PR's head SHA.
+            // The fork may not have all runs registered yet; retry a few times.
+            // Returns { matched: <run|null>, anyRuns: <bool> }.
+            async function findMatchingRun(workflowId) {
+              for (let attempt = 0; attempt < 3; attempt++) {
+                let runs;
+                try {
+                  runs = await github.request(runsEndpoint, {
+                    owner: forkOwner,
+                    repo: forkRepo,
+                    workflow_id: workflowId,
+                    branch: forkBranch,
+                  });
+                } catch (error) {
+                  // 404s here usually mean the workflow file does not exist on the
+                  // fork branch yet (e.g. branch predates the workflow). Skip.
+                  console.log(`${workflowId}: request failed: ${error.message}`);
+                  return { matched: null, anyRuns: false };
+                }
+                const list = runs.data.workflow_runs;
+                if (list.length > 0) {
+                  const matched = list.find(r => r.head_sha === headSha);
+                  if (matched) {
+                    return { matched, anyRuns: true };
+                  }
+                  // Saw runs but none for this SHA yet.
+                  if (attempt < 2) {
+                    await new Promise(r => setTimeout(r, 3000));
+                  } else {
+                    return { matched: null, anyRuns: true };
+                  }
+                } else {
+                  // No runs at all for this workflow on this branch.
+                  if (attempt < 2) {
+                    await new Promise(r => setTimeout(r, 3000));
+                  } else {
+                    return { matched: null, anyRuns: false };
+                  }
+                }
+              }
+              return { matched: null, anyRuns: false };
+            }
+
+            // Process workflows in parallel.
+            const results = await Promise.all(
+              tracked.map(async (wf) => ({ wf, ...(await findMatchingRun(wf.id)) }))
+            );
+
+            const anyMatched = results.some(r => r.matched);
+
+            // If no fork run was found for ANY workflow, post a single
+            // "action required" check explaining the likely cause once.
+            if (!anyMatched) {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'Iceberg CI',
+                head_sha: headSha,
+                status: 'completed',
+                conclusion: 'action_required',
+                output: {
+                  title: 'Workflow run detection failed',
+                  summary: [
+                    'No fork-compute CI runs were found for this commit.',
+                    '',
+                    'Likely causes:',
+                    '1. GitHub Actions is not enabled on your fork. Enable it under',
+                    '   Settings -> Actions on your forked repository.',
+                    '2. Your branch predates the fork-compute trigger change. Rebase',
+                    '   onto the latest `apache/iceberg` `main` and force-push.',
+                    '',
+                    'Once fixed, push a new commit (or amend and force-push) to',
+                    'retrigger this notification.',
+                  ].join('\n'),
+                },
+              });
+              return;
+            }
+
+            // For each tracked workflow, post a check on the PR commit.
+            // Skip workflows where the fork only had stale runs (newer commit
+            // pushed mid-flight); a fresh notify run will pick those up.
+            for (const { wf, matched, anyRuns } of results) {
+              if (!matched) {
+                if (anyRuns) {
+                  console.log(`${wf.id}: stale runs only; skipping (a newer commit was pushed?)`);
+                } else {
+                  console.log(`${wf.id}: no runs on fork branch; skipping`);
+                }
+                continue;
+              }
+
+              const runUrl = `https://github.com/${forkFullName}/actions/runs/${matched.id}`;
+              console.log(`${wf.id}: posting check -> ${runUrl}`);
+
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: wf.name,
+                head_sha: headSha,
+                status: 'queued',
+                details_url: runUrl,
+                output: {
+                  title: 'Test results',
+                  summary: [
+                    `[See test results](${runUrl})`,
+                    '',
+                    'CI for this PR runs on the contributor\'s fork.',
+                    'If tests fail for reasons unrelated to the PR, rerun the',
+                    'workflow in your forked repository.',
+                  ].join('\n'),
+                },
+              });
+            }

--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -21,13 +21,13 @@ name: "Open-API"
 on:
   push:
     branches:
-      - 'main'
-      - '0.*'
-      - '1.*'
-      - '2.*'
+      - '**'
+      - '!main'
+      - '!0.*'
+      - '!1.*'
+      - '!2.*'
     tags:
       - 'apache-iceberg-**'
-  pull_request:
     paths:
       - '.github/workflows/open-api.yml'
       - 'open-api/**'
@@ -36,8 +36,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   openapi-spec-validator:
@@ -46,7 +46,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
+          repository: apache/iceberg
+          ref: main
+      - name: Sync fork branch with upstream main
+        if: github.repository != 'apache/iceberg'
+        run: |
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -21,13 +21,13 @@ name: "Spark CI"
 on:
   push:
     branches:
-    - 'main'
-    - '0.*'
-    - '1.*'
-    - '2.*'
+    - '**'
+    - '!main'
+    - '!0.*'
+    - '!1.*'
+    - '!2.*'
     tags:
     - 'apache-iceberg-**'
-  pull_request:
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -69,8 +69,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.repository == 'apache/iceberg' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   spark-tests:
@@ -99,7 +99,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
+          repository: apache/iceberg
+          ref: main
+      - name: Sync fork branch with upstream main
+        if: github.repository != 'apache/iceberg'
+        run: |
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Iceberg' -c user.email='iceberg-ci@apache.org' commit -m "Merged commit" --allow-empty
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: zulu


### PR DESCRIPTION
  ## Summary                                                                                                                                                                     

  - Switch all 10 CI workflows from `pull_request` to `push` triggers on all branches (excluding `main` and release branches) so CI runs on the fork's GitHub Actions quota
  instead of upstream ASF shared resources
  - Each workflow checks out `apache/iceberg` `main` first, then fast-forward merges the fork branch on top, ensuring tests always run against changes merged with latest
  upstream
  - Concurrency updated to always cancel in-progress runs on the same branch

  ## Motivation

  GitHub Actions minutes for public forks are free and unlimited. By shifting CI execution from `pull_request` (which runs on the upstream repo's quota) to `push` (which runs on
   the fork's quota), we avoid consuming shared ASF runner resources. This is the same pattern used by [Apache Spark](https://github.com/apache/spark/pull/32092).

  For each workflow:
  1. **Trigger**: `pull_request` replaced with `push` to `**` excluding `main`, `0.*`, `1.*`, `2.*`
  2. **Checkout**: Now checks out `apache/iceberg` `main` with `fetch-depth: 0`, then merges the fork branch via fast-forward
  3. **Sync guard**: `if: github.repository != 'apache/iceberg'` ensures the merge step only runs on forks
  4. **Path filters**: All original `paths-ignore`/`paths` filters preserved
  5. **Concurrency**: `cancel-in-progress: true` (always, not just on PR events)




DISCLAIMER: Coded via Claude, testing in progress.