### PR TITLE
Build: Exclude roaringbitmap dependency from Spark and update LICENSE files

### DIFF
--- a/kafka-connect/kafka-connect-runtime/hive/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/hive/LICENSE
@@ -1665,7 +1665,7 @@ License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
 
 --------------------------------------------------------------------------------
 
-Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.3.0
+Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.6.10
 Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
 License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/kafka-connect/kafka-connect-runtime/main/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/main/LICENSE
@@ -1185,7 +1185,7 @@ License (from POM): MIT-0 - https://spdx.org/licenses/MIT-0.html
 
 --------------------------------------------------------------------------------
 
-Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.3.0
+Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.6.10
 Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
 License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/open-api/LICENSE
+++ b/open-api/LICENSE
@@ -547,7 +547,7 @@ License (from POM): The Apache License, Version 2.0 - https://www.apache.org/lic
 
 --------------------------------------------------------------------------------
 
-Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.3.0
+Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.6.10
 Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
 License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -256,7 +256,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     }
 
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark34.get()}"
+    integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark34.get()}") {
+      exclude group: 'org.roaringbitmap'
+    }
     integrationImplementation libs.junit.jupiter
     integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -258,7 +258,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     }
 
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark35.get()}"
+    integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark35.get()}") {
+      exclude group: 'org.roaringbitmap'
+    }
     integrationImplementation libs.junit.jupiter
     integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -267,7 +267,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     }
 
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark40.get()}"
+    integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark40.get()}") {
+      exclude group: 'org.roaringbitmap'
+    }
     integrationImplementation libs.junit.jupiter
     integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple

--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -269,7 +269,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     }
 
     integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
-    integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark41.get()}"
+    integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark41.get()}") {
+      exclude group: 'org.roaringbitmap'
+    }
     integrationImplementation libs.junit.jupiter
     integrationImplementation libs.junit.platform.launcher
     integrationImplementation libs.slf4j.simple


### PR DESCRIPTION
Closes #15370 as a follow-up of #15404

This PR prevents version conflicts by excluding roaringbitmap from Spark's transitive dependencies in integration tests.  LICENSE files are also updated to reflect RoaringBitmap version 1.6.10