### PR TITLE
chore(ci): add explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -35,6 +35,9 @@ on:
       - 'api/**'
       - '.palantir/revapi.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,9 @@ on:
   schedule:
     - cron: '16 4 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze Actions

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -63,6 +63,9 @@ on:
       - '**/NOTICE'
       - 'doap.rdf'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -25,6 +25,9 @@ on:
       - format/**
       - .github/workflows/docs-ci.yml
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -63,6 +63,9 @@ on:
     - '**/NOTICE'
     - 'doap.rdf'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -64,6 +64,9 @@ on:
     - '**/NOTICE'
     - 'doap.rdf'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -59,6 +59,9 @@ on:
     - '**/NOTICE'
     - 'doap.rdf'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/jmh-benchmarks.yml
+++ b/.github/workflows/jmh-benchmarks.yml
@@ -35,6 +35,9 @@ on:
         description: 'A list of comma-separated double-quoted Benchmark names, such as "IcebergSourceFlatParquetDataReadBenchmark", "IcebergSourceFlatParquetDataFilterBenchmark"'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   matrix:
     runs-on: ubuntu-24.04

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -63,6 +63,9 @@ on:
     - '**/NOTICE'
     - 'doap.rdf'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -20,6 +20,9 @@
 name: "Run License Check"
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   rat:
     runs-on: ubuntu-24.04

--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -32,6 +32,9 @@ on:
       - '.github/workflows/open-api.yml'
       - 'open-api/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -27,6 +27,9 @@ on:
     - cron: '0 2 * * *' # run at 2 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOCKER_IMAGE_TAG: iceberg-rest-fixture
   DOCKER_IMAGE_VERSION: latest

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -25,6 +25,9 @@ on:
     # we're publishing a new snapshot every night at 00:00 UTC
     - cron:  '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot:
     if: github.repository_owner == 'apache'

--- a/.github/workflows/recurring-jmh-benchmarks.yml
+++ b/.github/workflows/recurring-jmh-benchmarks.yml
@@ -25,6 +25,9 @@ on:
     # we're running benchmarks every Sunday at 00:00 UTC
     - cron:  '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   run-benchmark:
     if: github.repository_owner == 'apache'

--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -26,9 +26,15 @@ on:
       - site/**
       - format/**
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -63,6 +63,9 @@ on:
     - '**/NOTICE'
     - 'doap.rdf'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Added explicit permissions blocks to GitHub Actions workflows to satisfy CodeQL actions/missing-workflow-permissions. (See the [Security tab on Github](https://github.com/apache/iceberg/security/code-scanning))
Defaulted workflows to `contents: read`.

The one write permission
* `contents: write` is set only for the docs publish job in `site-ci.yml`, because that job pushes generated site content to the gh-pages branch.
