### PR TITLE
Spark 4.1: Add targetTable support to RewriteTablePath

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.actions;
 
 import java.util.concurrent.ExecutorService;
+import org.apache.iceberg.Table;
 
 /**
  * An action that rewrites the table's metadata files to a staging directory, replacing all source
@@ -99,6 +100,18 @@ public interface RewriteTablePath extends Action<RewriteTablePath, RewriteTableP
    */
   default RewriteTablePath createFileList(boolean createFileList) {
     return this;
+  }
+
+  /**
+   * Sets a target table to automatically determine the start version for incremental copy. The
+   * target table's current metadata version is matched against the source table's metadata log to
+   * find where to resume copying.
+   *
+   * @param targetTable the target table used to determine the start version
+   * @return this for method chaining
+   */
+  default RewriteTablePath targetTable(Table targetTable) {
+    throw new UnsupportedOperationException("This method is not implemented.");
   }
 
   /**

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -24,6 +24,8 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -57,6 +59,7 @@ import org.apache.iceberg.data.orc.GenericOrcWriter;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.io.CloseableIterable;
@@ -76,6 +79,7 @@ import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.api.java.function.ForeachFunction;
 import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.api.java.function.ReduceFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Dataset;
@@ -101,6 +105,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private String stagingDir;
   private boolean createFileList = true;
   private ExecutorService executorService;
+  private Table targetTable;
 
   private final Table table;
   private Broadcast<Table> tableBroadcast = null;
@@ -166,6 +171,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     return this;
   }
 
+  public RewriteTablePath targetTable(Table tgtTable) {
+    this.targetTable = tgtTable;
+    return this;
+  }
+
   @Override
   public Result execute() {
     validateInputs();
@@ -219,11 +229,135 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   private void validateAndSetStartVersion() {
+    Preconditions.checkArgument(
+        startVersionName == null || targetTable == null,
+        "Cannot set both startVersion and targetTable.");
+
     TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
 
-    if (startVersionName != null) {
+    if (targetTable != null) {
+      this.startVersionName = resolveStartVersionFromTargetTable(tableMetadata);
+    } else if (startVersionName != null) {
       this.startVersionName = validateVersion(tableMetadata, startVersionName);
     }
+  }
+
+  private String resolveStartVersionFromTargetTable(TableMetadata sourceMetadata) {
+    if (targetTable.currentSnapshot() == null) {
+      LOG.info("Target table has no snapshots. Doing a full copy.");
+      return null;
+    }
+
+    String targetVersionFullPath = currentMetadataPath(targetTable);
+    String sourceVersionFullPath = findVersion(targetVersionFullPath, sourceMetadata);
+
+    Preconditions.checkState(
+        sourceVersionFullPath != null,
+        "The current version of the target table (\"%s\") does not exist in the source table.",
+        RewriteTablePathUtil.fileName(targetVersionFullPath));
+
+    checkVersionAndAllFilesExistsOrThrow(targetVersionFullPath, targetTable);
+    return sourceVersionFullPath;
+  }
+
+  private String findVersion(String version, TableMetadata sourceMetadata) {
+    String currentSourceMetadataFile = sourceMetadata.metadataFileLocation();
+
+    if (isSameSnapshot(currentSourceMetadataFile, version)) {
+      return currentSourceMetadataFile;
+    }
+
+    for (MetadataLogEntry entry : sourceMetadata.previousFiles()) {
+      if (isSameSnapshot(entry.file(), version)) {
+        return entry.file();
+      }
+    }
+
+    return null;
+  }
+
+  private boolean isSameSnapshot(String sourceVersionPath, String targetVersionPath) {
+    Table staticSource = newStaticTable(sourceVersionPath, table.io());
+    Table staticTarget = newStaticTable(targetVersionPath, targetTable.io());
+    return Objects.equals(
+        Optional.ofNullable(staticSource.currentSnapshot()).map(Snapshot::snapshotId).orElse(null),
+        Optional.ofNullable(staticTarget.currentSnapshot()).map(Snapshot::snapshotId).orElse(null));
+  }
+
+  private boolean versionAndAllMetadataFilesExist(String versionPath, Table tbl) {
+    if (!fileExist(versionPath, tbl)) {
+      LOG.warn("Version file {} does not exist.", versionPath);
+      return false;
+    }
+
+    try {
+      StaticTableOperations ops = new StaticTableOperations(versionPath, tbl.io());
+      TableMetadata versionMetadata = ops.current();
+
+      List<ManifestFile> allManifestFiles = Lists.newArrayList();
+      for (Snapshot snapshot : versionMetadata.snapshots()) {
+        allManifestFiles.addAll(snapshot.allManifests(tbl.io()));
+      }
+
+      Set<String> uniqueManifestPaths =
+          allManifestFiles.stream().map(ManifestFile::path).collect(Collectors.toSet());
+
+      Broadcast<Table> serializableTable =
+          sparkContext().broadcast(SerializableTableWithSize.copyOf(tbl));
+      Dataset<String> manifestPathsDS =
+          spark().createDataset(Lists.newArrayList(uniqueManifestPaths), Encoders.STRING());
+      List<String> missingManifests =
+          manifestPathsDS
+              .mapPartitions(
+                  (MapPartitionsFunction<String, String>)
+                      paths -> {
+                        Table deserializedTable = serializableTable.value();
+                        Set<String> missing = Sets.newHashSet();
+                        while (paths.hasNext()) {
+                          String path = paths.next();
+                          if (!deserializedTable.io().newInputFile(path).exists()) {
+                            missing.add(path);
+                          }
+                        }
+
+                        return missing.iterator();
+                      },
+                  Encoders.STRING())
+              .collectAsList();
+
+      if (!missingManifests.isEmpty()) {
+        LOG.warn(
+            "Manifest files {} missing for version {}",
+            missingManifests,
+            RewriteTablePathUtil.fileName(versionPath));
+        return false;
+      }
+
+      return true;
+    } catch (NotFoundException e) {
+      LOG.warn("Manifest list file not found.", e);
+      return false;
+    }
+  }
+
+  private void checkVersionAndAllFilesExistsOrThrow(String versionFullPath, Table tbl) {
+    Preconditions.checkState(
+        versionAndAllMetadataFilesExist(versionFullPath, tbl),
+        "Table version \"%s\" has missing files. This is usually caused by snapshots contained "
+            + "in this version which have been expired in newer versions.",
+        RewriteTablePathUtil.fileName(versionFullPath));
+  }
+
+  private String currentMetadataPath(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+  }
+
+  private boolean fileExist(String path, Table tbl) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+
+    return tbl.io().newInputFile(path).exists();
   }
 
   private String validateVersion(TableMetadata tableMetadata, String versionFileName) {
@@ -374,7 +508,13 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   private RewriteResult<Snapshot> rewriteVersionFiles(TableMetadata endMetadata) {
     RewriteResult<Snapshot> result = new RewriteResult<>();
+    // Any snapshots contained in the start version will be filtered down the line
     result.toRewrite().addAll(endMetadata.snapshots());
+
+    if (endVersionName.equals(startVersionName)) {
+      return result;
+    }
+
     result.copyPlan().addAll(rewriteVersionFile(endMetadata, endVersionName));
 
     List<MetadataLogEntry> versions = endMetadata.previousFiles();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -42,6 +43,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -1353,6 +1355,236 @@ public class TestRewriteTablePathsAction extends TestBase {
     } finally {
       service.shutdown();
     }
+  }
+
+  @TestTemplate
+  public void testIncrementalCopyWithEmptyTargetTable() throws Exception {
+    String sourceLocation = newTableLocation();
+    String targetLocation = targetTableLocation();
+
+    Table sourceTable = createTableWithSnapshots(sourceLocation, 3);
+    Table emptyTarget = createTableWithSnapshots(targetLocation, 0);
+
+    assertThat(Lists.newArrayList(sourceTable.snapshots())).hasSize(3);
+    assertThat(Lists.newArrayList(emptyTarget.snapshots())).isEmpty();
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .targetTable(emptyTarget)
+            .rewriteLocationPrefix(sourceLocation, targetLocation)
+            .execute();
+
+    assertThat(result.latestVersion()).isEqualTo("v4.metadata.json");
+    // v1 (create) + v2, v3, v4 (3 appends) = 4 version files, 3 manifest lists, 3 manifests
+    checkFileNum(4, 3, 3, 13, result);
+  }
+
+  @TestTemplate
+  public void testIncrementalCopyWithTargetTable() throws Exception {
+    String sourceLocation = newTableLocation();
+    String targetLocation = targetTableLocation();
+
+    Table sourceTable = createTableWithSnapshots(sourceLocation, 3);
+    Table emptyTarget = createTableWithSnapshots(targetLocation, 0);
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .targetTable(emptyTarget)
+            .rewriteLocationPrefix(sourceLocation, targetLocation)
+            .execute();
+
+    checkFileNum(4, 3, 3, 13, result);
+    copyTableFiles(result);
+    Table loadedTarget = TABLES.load(targetLocation);
+
+    List<ThreeColumnRecord> records = Lists.newArrayList(new ThreeColumnRecord(42, "A", "B"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(sourceLocation);
+    sourceTable.refresh();
+
+    result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .targetTable(loadedTarget)
+            .rewriteLocationPrefix(sourceLocation, targetLocation)
+            .execute();
+
+    assertThat(result.latestVersion()).isEqualTo("v5.metadata.json");
+    checkFileNum(1, 1, 1, 4, result);
+  }
+
+  @TestTemplate
+  public void testIncrementalCopyNoOverlap() throws Exception {
+    String sourceLocation = newTableLocation();
+    String targetLocation = targetTableLocation();
+
+    Table sourceTable = createTableWithSnapshots(sourceLocation, 3);
+    Table targetTableNoOverlap = createTableWithSnapshots(targetLocation, 4);
+
+    assertThatThrownBy(
+            () ->
+                actions()
+                    .rewriteTablePath(sourceTable)
+                    .targetTable(targetTableNoOverlap)
+                    .rewriteLocationPrefix(sourceLocation, targetLocation)
+                    .execute())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not exist in the source table");
+  }
+
+  @TestTemplate
+  public void testIncrementalCopyAlreadyInSync() throws Exception {
+    String sourceLocation = newTableLocation();
+    String targetLocation = targetTableLocation();
+
+    Table sourceTable = createTableWithSnapshots(sourceLocation, 3);
+    Table emptyTarget = createTableWithSnapshots(targetLocation, 0);
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .targetTable(emptyTarget)
+            .rewriteLocationPrefix(sourceLocation, targetLocation)
+            .execute();
+
+    copyTableFiles(result);
+    Table loadedTarget = TABLES.load(targetLocation);
+
+    assertThat(Lists.newArrayList(loadedTarget.snapshots())).hasSize(3);
+
+    result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .targetTable(loadedTarget)
+            .rewriteLocationPrefix(sourceLocation, targetLocation)
+            .execute();
+
+    checkFileNum(0, 0, 0, 0, result);
+    assertThat(result.latestVersion()).isEqualTo("v4.metadata.json");
+  }
+
+  @TestTemplate
+  public void testIncrementalCopyWithExpiredSnapshot() throws Exception {
+    String sourceLocation = newTableLocation();
+    String targetLocation = targetTableLocation();
+
+    Table sourceTable = createTableWithSnapshots(sourceLocation, 2);
+    Table emptyTarget = createTableWithSnapshots(targetLocation, 0);
+
+    actions()
+        .expireSnapshots(sourceTable)
+        .retainLast(1)
+        .expireOlderThan(sourceTable.currentSnapshot().timestampMillis())
+        .execute();
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .targetTable(emptyTarget)
+            .rewriteLocationPrefix(sourceLocation, targetLocation)
+            .execute();
+
+    // 2 data files but only 1 manifest list due to expiry
+    // v1 (create) + v2 (append) + v3 (append) + v4 (expire) = 4 version files
+    checkFileNum(4, 1, 2, 9, result);
+  }
+
+  @TestTemplate
+  public void testIncrementalCopyWithMissingTargetManifest() throws Exception {
+    String sourceLocation = newTableLocation();
+    String targetLocation = targetTableLocation();
+
+    Table sourceTable = createTableWithSnapshots(sourceLocation, 2);
+    Table emptyTarget = createTableWithSnapshots(targetLocation, 0);
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .targetTable(emptyTarget)
+            .rewriteLocationPrefix(sourceLocation, targetLocation)
+            .execute();
+
+    copyTableFiles(result);
+    Table loadedTarget = TABLES.load(targetLocation);
+
+    ManifestFile manifestFile =
+        loadedTarget.currentSnapshot().allManifests(loadedTarget.io()).get(0);
+    loadedTarget.io().deleteFile(manifestFile.path());
+
+    Table finalTarget = loadedTarget;
+    assertThatThrownBy(
+            () ->
+                actions()
+                    .rewriteTablePath(sourceTable)
+                    .targetTable(finalTarget)
+                    .rewriteLocationPrefix(sourceLocation, targetLocation)
+                    .execute())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("has missing files");
+  }
+
+  @TestTemplate
+  public void testIncrementalCopyWithAppendOnTargetAndSourceTable() throws Exception {
+    String sourceLocation = newTableLocation();
+    String targetLocation = targetTableLocation();
+
+    Table sourceTable = createTableWithSnapshots(sourceLocation, 3);
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .rewriteLocationPrefix(sourceLocation, targetLocation)
+            .execute();
+
+    copyTableFiles(result);
+    Table loadedTarget = TABLES.load(targetLocation);
+
+    // Append to target table independently
+    spark
+        .createDataFrame(
+            Collections.singletonList(new ThreeColumnRecord(1, "AAAA", "AAAA")),
+            ThreeColumnRecord.class)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(targetLocation);
+    loadedTarget.refresh();
+
+    assertThatThrownBy(
+            () ->
+                actions()
+                    .rewriteTablePath(sourceTable)
+                    .targetTable(loadedTarget)
+                    .rewriteLocationPrefix(sourceLocation, targetLocation)
+                    .execute())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not exist in the source table");
+
+    // Append to source table
+    spark
+        .createDataFrame(
+            Collections.singletonList(new ThreeColumnRecord(1, "AAAA", "AAAA")),
+            ThreeColumnRecord.class)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(sourceLocation);
+    sourceTable.refresh();
+
+    assertThatThrownBy(
+            () ->
+                actions()
+                    .rewriteTablePath(sourceTable)
+                    .targetTable(loadedTarget)
+                    .rewriteLocationPrefix(sourceLocation, targetLocation)
+                    .execute())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(
+            "The current version of the target table (\"v5.metadata.json\") does not exist in the source table.");
   }
 
   protected void checkFileNum(


### PR DESCRIPTION
This enables incremental copy using the target table to automatically determine where to resume. We validate that source and target are in sync at the determined version by comparing snapshot IDs and checking that all manifest files exist.

Example:

```java
Table sourceTable = ...
Table targetTable = ...
actions()
    .rewriteTablePath(sourceTable)
    .rewriteLocationPrefix(sourceLocation, targetLocation)
    // Resolve startVersion from the targetTable
    .targetTable(targetTable)
    .execute();
```

The `targetTable()` parameter takes precedence over `startVersion(..)`.