### PR TITLE
add envelopeTransform to transforms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,9 @@ allprojects {
   repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+      url "https://packages.confluent.io/maven/"
+    }
   }
 }
 

--- a/kafka-connect/Makefile
+++ b/kafka-connect/Makefile
@@ -1,0 +1,10 @@
+GRADLE := ../gradlew
+GRADLE_FLAGS := -x test -x integrationTest
+
+.PHONY: dist clean
+
+dist:
+	$(GRADLE) :iceberg-kafka-connect:iceberg-kafka-connect-runtime:installDist $(GRADLE_FLAGS)
+
+clean:
+	$(GRADLE) :iceberg-kafka-connect:iceberg-kafka-connect-runtime:clean

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -128,17 +128,13 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
     implementation 'software.amazon.awssdk:dynamodb'
     implementation 'software.amazon.awssdk:lakeformation'
 
-    implementation project(':iceberg-gcp')
-    implementation project(':iceberg-bigquery')
-    implementation platform(libs.google.libraries.bom)
-    implementation 'com.google.cloud:google-cloud-storage'
-    implementation 'com.google.cloud:google-cloud-bigquery'
-    implementation 'com.google.cloud:google-cloud-core'
+    // Confluent Schema Registry converters (Protobuf, Avro, JSON Schema)
+    // NOTE: Must come after AWS deps and before any GCP deps to avoid protobuf 4.x conflict
+    implementation 'io.confluent:kafka-connect-protobuf-converter:7.9.0'
 
-    implementation project(':iceberg-azure')
-    implementation platform(libs.azuresdk.bom)
-    implementation 'com.azure:azure-storage-file-datalake'
-    implementation 'com.azure:azure-identity'
+    // GCP and Azure removed — only AWS catalog (Glue) is needed.
+    // GCP's google-libraries-bom pulls protobuf-java 4.x which is binary-incompatible
+    // with Confluent's protobuf converter (compiled against protobuf 3.x).
 
     hive project(':iceberg-hive-metastore')
     hive(libs.hive2.metastore) {

--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/EnvelopeTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/EnvelopeTransform.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.transforms;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.Requirements;
+
+public class EnvelopeTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+
+  private static final String COL_OBJ = "obj";
+  private static final String COL_LOAD_TS = "load_ts";
+  private static final String COL_EVENT_TS = "event_ts";
+
+  public static final ConfigDef CONFIG_DEF = new ConfigDef();
+
+  private Cache<Schema, Schema> schemaUpdateCache;
+
+  @Override
+  public void configure(Map<String, ?> props) {
+    schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
+  }
+
+  @Override
+  public R apply(R record) {
+    if (record.value() == null) {
+      return record;
+    } else if (record.valueSchema() == null) {
+      return applySchemaless(record);
+    } else {
+      return applyWithSchema(record);
+    }
+  }
+
+  @SuppressWarnings("JavaUtilDate")
+  private R applySchemaless(R record) {
+    Map<String, Object> value = Requirements.requireMap(record.value(), "envelope transform");
+
+    Map<String, Object> envelope = Maps.newHashMap();
+    envelope.put(COL_OBJ, value);
+    envelope.put(COL_LOAD_TS, System.currentTimeMillis());
+    envelope.put(
+        COL_EVENT_TS, record.timestamp() != null ? new java.util.Date(record.timestamp()) : null);
+
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        null,
+        envelope,
+        record.timestamp());
+  }
+
+  @SuppressWarnings("JavaUtilDate")
+  private R applyWithSchema(R record) {
+    Struct value = Requirements.requireStruct(record.value(), "envelope transform");
+
+    Schema envelopeSchema = schemaUpdateCache.get(value.schema());
+    if (envelopeSchema == null) {
+      envelopeSchema = makeEnvelopeSchema(value.schema());
+      schemaUpdateCache.put(value.schema(), envelopeSchema);
+    }
+
+    Struct envelope = new Struct(envelopeSchema);
+    envelope.put(COL_OBJ, value);
+    envelope.put(COL_LOAD_TS, new java.util.Date(System.currentTimeMillis()));
+    envelope.put(
+        COL_EVENT_TS, record.timestamp() != null ? new java.util.Date(record.timestamp()) : null);
+
+    return record.newRecord(
+        record.topic(),
+        record.kafkaPartition(),
+        record.keySchema(),
+        record.key(),
+        envelopeSchema,
+        envelope,
+        record.timestamp());
+  }
+
+  private Schema makeEnvelopeSchema(Schema valueSchema) {
+    return SchemaBuilder.struct()
+        .field(COL_OBJ, valueSchema)
+        .field(COL_LOAD_TS, Timestamp.SCHEMA)
+        .field(COL_EVENT_TS, Timestamp.builder().optional().build())
+        .build();
+  }
+
+  @Override
+  public void close() {
+    schemaUpdateCache = null;
+  }
+
+  @Override
+  public ConfigDef config() {
+    return CONFIG_DEF;
+  }
+}

--- a/kafka-connect/kafka-connect-transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/kafka-connect/kafka-connect-transforms/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -15,6 +15,7 @@
 
 org.apache.iceberg.connect.transforms.CopyValue
 org.apache.iceberg.connect.transforms.DebeziumTransform
+org.apache.iceberg.connect.transforms.EnvelopeTransform
 org.apache.iceberg.connect.transforms.DmsTransform
 org.apache.iceberg.connect.transforms.JsonToMapTransform
 org.apache.iceberg.connect.transforms.KafkaMetadataTransform

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestEnvelopeTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestEnvelopeTransform.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.transforms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("JavaUtilDate")
+public class TestEnvelopeTransform {
+
+  @Test
+  public void testNullPassthrough() {
+    try (EnvelopeTransform<SinkRecord> smt = new EnvelopeTransform<>()) {
+      smt.configure(Collections.emptyMap());
+      SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
+      SinkRecord result = smt.apply(record);
+      assertThat(result.value()).isNull();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSchemaless() {
+    try (EnvelopeTransform<SinkRecord> smt = new EnvelopeTransform<>()) {
+      smt.configure(Collections.emptyMap());
+
+      Map<String, Object> value = Maps.newHashMap();
+      value.put("id", 123L);
+      value.put("data", "foobar");
+
+      long kafkaTs = 1700000000000L;
+      SinkRecord record = new SinkRecord("topic", 0, null, null, null, value, 0, kafkaTs, null);
+      SinkRecord result = smt.apply(record);
+
+      Map<String, Object> envelope = (Map<String, Object>) result.value();
+      assertThat(envelope).containsKey("obj");
+      assertThat(envelope).containsKey("load_ts");
+      assertThat(envelope).containsKey("event_ts");
+
+      Map<String, Object> obj = (Map<String, Object>) envelope.get("obj");
+      assertThat(obj.get("id")).isEqualTo(123L);
+      assertThat(obj.get("data")).isEqualTo("foobar");
+
+      assertThat(envelope.get("event_ts")).isEqualTo(new Date(kafkaTs));
+      assertThat(result.valueSchema()).isNull();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSchemalessNullTimestamp() {
+    try (EnvelopeTransform<SinkRecord> smt = new EnvelopeTransform<>()) {
+      smt.configure(Collections.emptyMap());
+
+      Map<String, Object> value = Maps.newHashMap();
+      value.put("id", 1L);
+
+      SinkRecord record = new SinkRecord("topic", 0, null, null, null, value, 0);
+      SinkRecord result = smt.apply(record);
+
+      Map<String, Object> envelope = (Map<String, Object>) result.value();
+      assertThat(envelope.get("event_ts")).isNull();
+    }
+  }
+
+  @Test
+  public void testWithSchema() {
+    try (EnvelopeTransform<SinkRecord> smt = new EnvelopeTransform<>()) {
+      smt.configure(Collections.emptyMap());
+
+      Schema schema =
+          SchemaBuilder.struct()
+              .field("id", Schema.INT64_SCHEMA)
+              .field("data", Schema.STRING_SCHEMA)
+              .build();
+
+      Struct value = new Struct(schema).put("id", 123L).put("data", "foobar");
+
+      long kafkaTs = 1700000000000L;
+      SinkRecord record = new SinkRecord("topic", 0, null, null, schema, value, 0, kafkaTs, null);
+      SinkRecord result = smt.apply(record);
+
+      Schema envelopeSchema = result.valueSchema();
+      assertThat(envelopeSchema.field("obj").schema()).isEqualTo(schema);
+      assertThat(envelopeSchema.field("load_ts").schema()).isEqualTo(Timestamp.SCHEMA);
+      assertThat(envelopeSchema.field("event_ts").schema().isOptional()).isTrue();
+
+      Struct envelope = (Struct) result.value();
+      Struct obj = envelope.getStruct("obj");
+      assertThat(obj.getInt64("id")).isEqualTo(123L);
+      assertThat(obj.getString("data")).isEqualTo("foobar");
+      assertThat(envelope.get("event_ts")).isEqualTo(new Date(kafkaTs));
+    }
+  }
+
+  @Test
+  public void testWithSchemaNullTimestamp() {
+    try (EnvelopeTransform<SinkRecord> smt = new EnvelopeTransform<>()) {
+      smt.configure(Collections.emptyMap());
+
+      Schema schema = SchemaBuilder.struct().field("id", Schema.INT64_SCHEMA).build();
+      Struct value = new Struct(schema).put("id", 1L);
+
+      SinkRecord record = new SinkRecord("topic", 0, null, null, schema, value, 0);
+      SinkRecord result = smt.apply(record);
+
+      Struct envelope = (Struct) result.value();
+      assertThat(envelope.get("event_ts")).isNull();
+    }
+  }
+
+  @Test
+  public void testSchemaCaching() {
+    try (EnvelopeTransform<SinkRecord> smt = new EnvelopeTransform<>()) {
+      smt.configure(Collections.emptyMap());
+
+      Schema schema = SchemaBuilder.struct().field("id", Schema.INT64_SCHEMA).build();
+      Struct value1 = new Struct(schema).put("id", 1L);
+      Struct value2 = new Struct(schema).put("id", 2L);
+
+      SinkRecord record1 = new SinkRecord("topic", 0, null, null, schema, value1, 0);
+      SinkRecord record2 = new SinkRecord("topic", 0, null, null, schema, value2, 1);
+
+      SinkRecord result1 = smt.apply(record1);
+      SinkRecord result2 = smt.apply(record2);
+
+      assertThat(result1.valueSchema()).isSameAs(result2.valueSchema());
+    }
+  }
+
+  @Test
+  public void testRecordMetadataPreserved() {
+    try (EnvelopeTransform<SinkRecord> smt = new EnvelopeTransform<>()) {
+      smt.configure(Collections.emptyMap());
+
+      Schema keySchema = Schema.STRING_SCHEMA;
+      String key = "my-key";
+      Schema valueSchema = SchemaBuilder.struct().field("id", Schema.INT64_SCHEMA).build();
+      Struct value = new Struct(valueSchema).put("id", 1L);
+
+      long kafkaTs = 1700000000000L;
+      SinkRecord record =
+          new SinkRecord("my-topic", 3, keySchema, key, valueSchema, value, 42, kafkaTs, null);
+      SinkRecord result = smt.apply(record);
+
+      assertThat(result.topic()).isEqualTo("my-topic");
+      assertThat(result.kafkaPartition()).isEqualTo(3);
+      assertThat(result.keySchema()).isEqualTo(keySchema);
+      assertThat(result.key()).isEqualTo("my-key");
+      assertThat(result.timestamp()).isEqualTo(kafkaTs);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -81,6 +81,17 @@ public class CommitterImpl implements Committer {
     }
 
     Collection<MemberDescription> members = groupDesc.members();
+
+    // During a rebalance, members may temporarily have no partition assignments.
+    // Check if any member has partitions assigned before determining the leader.
+    boolean anyAssigned =
+        members.stream()
+            .anyMatch(m -> !m.assignment().topicPartitions().isEmpty());
+    if (!anyAssigned) {
+      LOG.warn("No partitions assigned to any member yet (rebalance in progress), deferring leader election");
+      return false;
+    }
+
     if (containsFirstPartition(members, currentAssignedPartitions)) {
       membersWhenWorkerIsCoordinator = members;
       return true;


### PR DESCRIPTION
  ## Summary                                                                                                                                                             
                                                                                                                                                                         
  - **New `EnvelopeTransform` SMT** — wraps each record value in an envelope struct with three fields:                                                                   
    - `obj`: the original record value                                                                                                                                   
    - `load_ts`: wall-clock timestamp at transform time
    - `event_ts`: the Kafka record timestamp (nullable)

    Supports both schema and schemaless modes with an LRU schema cache.

  - **Fix leader election during rebalance** — `CommitterImpl.hasLeaderPartition()` now detects when no consumer group members have partition assignments (transient
  state during a rebalance) and defers leader election instead of making an incorrect determination.

  - **Remove GCP and Azure dependencies from runtime distribution** — only AWS catalog (Glue) is needed. This also resolves a binary incompatibility between GCP's
  `protobuf-java 4.x` and the Confluent protobuf converter which requires `3.x`.

  - **Add Confluent Schema Registry protobuf converter** (`kafka-connect-protobuf-converter:7.9.0`) to the runtime distribution for Protobuf-encoded topics.

  - **Add Confluent Maven repository** to the root `build.gradle`.

  - **Add `Makefile`** for building the kafka-connect distribution locally.

  ## Changes

  | Area | Files |
  |------|-------|
  | New SMT | `kafka-connect-transforms/.../EnvelopeTransform.java` |
  | Tests | `kafka-connect-transforms/.../TestEnvelopeTransform.java` |
  | SPI registration | `META-INF/services/org.apache.kafka.connect.transforms.Transformation` |
  | Rebalance fix | `kafka-connect/.../channel/CommitterImpl.java` |
  | Build | `build.gradle`, `kafka-connect/build.gradle`, `kafka-connect/Makefile` |