### PR TITLE
ci: replace pull_request_target with pull_request

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@
 #
 
 name: "Pull Request Labeler"
-on: pull_request_target
+on: pull_request
 
 permissions:
   contents: read


### PR DESCRIPTION
`pull_request_target` carries higher risk for untrusted PRs because it executes in the base repository context and can have broader token privileges.
Switching to `pull_request` provides a safer default security posture for external contributions.

The main tradeoff is that auto-labeling may not run for fork-based PRs, which is acceptable in our case.


ASF infra keeps on flagging this, so lets make the change