### PR TITLE
AWS: S3SignerServlet to strip out more request headers before signing

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
@@ -21,15 +21,14 @@ package org.apache.iceberg.aws.s3.signer;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.HttpMethod;
 import org.apache.iceberg.rest.RemoteSignerServlet;
 import org.apache.iceberg.rest.requests.RemoteSignRequest;
@@ -50,8 +49,29 @@ public class S3SignerServlet extends RemoteSignerServlet {
 
   static final Clock SIGNING_CLOCK = Clock.fixed(Instant.now(), ZoneId.of("UTC"));
   static final Set<String> UNSIGNED_HEADERS =
-      Sets.newHashSet(
-          Arrays.asList("range", "x-amz-date", "amz-sdk-invocation-id", "amz-sdk-retry"));
+      // Note: only Host and x-amz-* headers are required to be signed. Other headers are optional.
+      // Also see
+      // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#create-canonical-request
+      // for guidelines about headers that are safe to exclude from signing.
+      Set.of(
+          "connection",
+          "expect",
+          "if-match",
+          "if-modified-since",
+          "if-none-match",
+          "if-unmodified-since",
+          "keep-alive",
+          "proxy-authenticate",
+          "proxy-authorization",
+          "range",
+          "referer",
+          "te",
+          "trailer",
+          "transfer-encoding",
+          "upgrade",
+          "user-agent",
+          "x-amzn-trace-id",
+          "x-forwarded-for");
 
   /** A fake remote signing endpoint for testing purposes. */
   static final String S3_SIGNER_ENDPOINT = "v1/namespaces/ns1/tables/t1/sign";
@@ -75,6 +95,15 @@ public class S3SignerServlet extends RemoteSignerServlet {
     }
   }
 
+  static final Predicate<Map.Entry<String, List<String>>> UNSIGNED_HEADERS_PREDICATE =
+      e -> {
+        String name = e.getKey().toLowerCase(Locale.ROOT);
+        return name.startsWith("amz-sdk-") || UNSIGNED_HEADERS.contains(name);
+      };
+
+  static final Predicate<Map.Entry<String, List<String>>> SIGNED_HEADERS_PREDICATE =
+      UNSIGNED_HEADERS_PREDICATE.negate();
+
   @Override
   protected RemoteSignResponse signRequest(RemoteSignRequest request) {
     AwsS3V4SignerParams signingParams =
@@ -91,12 +120,12 @@ public class S3SignerServlet extends RemoteSignerServlet {
 
     Map<String, List<String>> unsignedHeaders =
         request.headers().entrySet().stream()
-            .filter(e -> UNSIGNED_HEADERS.contains(e.getKey().toLowerCase(Locale.ROOT)))
+            .filter(UNSIGNED_HEADERS_PREDICATE)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     Map<String, List<String>> signedHeaders =
         request.headers().entrySet().stream()
-            .filter(e -> !UNSIGNED_HEADERS.contains(e.getKey().toLowerCase(Locale.ROOT)))
+            .filter(SIGNED_HEADERS_PREDICATE)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     SdkHttpFullRequest sign =

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws.s3.signer;
 
+import static org.apache.iceberg.aws.s3.signer.S3SignerServlet.UNSIGNED_HEADERS_PREDICATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
@@ -27,7 +28,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.Collectors;
@@ -66,15 +66,20 @@ import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.auth.aws.signer.SignerConstant;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.utils.IoUtils;
 
 @Testcontainers
@@ -229,6 +234,12 @@ public class TestS3RestSigner {
   }
 
   @Test
+  public void validateDeleteSingleeObject() {
+    s3.deleteObject(
+        DeleteObjectRequest.builder().bucket(BUCKET).key("random/key").ifMatch("etag1").build());
+  }
+
+  @Test
   public void validateListPrefix() {
     s3.listObjectsV2(ListObjectsV2Request.builder().bucket(BUCKET).prefix("some/prefix/").build());
   }
@@ -252,22 +263,39 @@ public class TestS3RestSigner {
   }
 
   @Test
-  public void validatedUploadPart() {
+  public void validatedUploadMultiPart() {
+    final String key = "some/multipart-key";
     String multipartUploadId =
         s3.createMultipartUpload(
-                CreateMultipartUploadRequest.builder()
-                    .bucket(BUCKET)
-                    .key("some/multipart-key")
-                    .build())
+                CreateMultipartUploadRequest.builder().bucket(BUCKET).key(key).build())
             .uploadId();
-    s3.uploadPart(
-        UploadPartRequest.builder()
+    final UploadPartResponse response =
+        s3.uploadPart(
+            UploadPartRequest.builder()
+                .bucket(BUCKET)
+                .key(key)
+                .uploadId(multipartUploadId)
+                .partNumber(1)
+                .build(),
+            RequestBody.fromString("content"));
+    s3.completeMultipartUpload(
+        CompleteMultipartUploadRequest.builder()
             .bucket(BUCKET)
-            .key("some/multipart-key")
+            .key(key)
             .uploadId(multipartUploadId)
-            .partNumber(1)
-            .build(),
-        RequestBody.fromString("content"));
+            .multipartUpload(
+                CompletedMultipartUpload.builder()
+                    .parts(
+                        CompletedPart.builder()
+                            .partNumber(1)
+                            .eTag(response.eTag())
+                            .checksumCRC32(response.checksumCRC32())
+                            .checksumCRC32C(response.checksumCRC32C())
+                            .checksumSHA1(response.checksumSHA1())
+                            .checksumSHA256(response.checksumSHA256())
+                            .build())
+                    .build())
+            .build());
   }
 
   /**
@@ -349,16 +377,11 @@ public class TestS3RestSigner {
       // back after signing
       Map<String, List<String>> unsignedHeaders =
           request.headers().entrySet().stream()
-              .filter(
-                  e ->
-                      S3SignerServlet.UNSIGNED_HEADERS.contains(
-                          e.getKey().toLowerCase(Locale.ROOT)))
+              .filter(UNSIGNED_HEADERS_PREDICATE)
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
       SdkHttpFullRequest.Builder builder = request.toBuilder();
-      for (String unsignedHeader : S3SignerServlet.UNSIGNED_HEADERS) {
-        builder.removeHeader(unsignedHeader);
-      }
+      unsignedHeaders.forEach((k, v) -> builder.removeHeader(k));
 
       SdkHttpFullRequest awsResult = awsSigner.sign(builder.build(), signerParams);
       // append the unsigned headers back


### PR DESCRIPTION
Fixes #15417 

Expands the set of headers that the `S3SignerServlet` should ignore when signing to include 
1. all aws sdk headers
2. classic http headers that may be changed in different requests
3. if-modified/unless-modified conditional headers.

The intent is to reduce the risk of different requests having conflicting headers from any cached signature where the cache key is (verb, url, region), as seen in #15166. 

 