### PR TITLE
Kafka Connect: Add Trivy CVE scan to CI

### DIFF
--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -37,6 +37,7 @@ on:
       - '.github/workflows/java-ci.yml'
       - '.github/workflows/jmh-benchmarks-ci.yml'
       - '.github/workflows/kafka-connect-ci.yml'
+      - '.github/workflows/kafka-connect-cve-scan.yml'
       - '.github/workflows/labeler.yml'
       - '.github/workflows/license-check.yml'
       - '.github/workflows/open-api.yml'

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -37,6 +37,7 @@ on:
     - '.github/workflows/java-ci.yml'
     - '.github/workflows/jmh-benchmarks-ci.yml'
     - '.github/workflows/kafka-connect-ci.yml'
+    - '.github/workflows/kafka-connect-cve-scan.yml'
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -37,6 +37,7 @@ on:
     - '.github/workflows/java-ci.yml'
     - '.github/workflows/jmh-benchmarks-ci.yml'
     - '.github/workflows/kafka-connect-ci.yml'
+    - '.github/workflows/kafka-connect-cve-scan.yml'
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -37,6 +37,7 @@ on:
     - '.github/workflows/hive-ci.yml'
     - '.github/workflows/jmh-benchmarks-ci.yml'
     - '.github/workflows/kafka-connect-ci.yml'
+    - '.github/workflows/kafka-connect-cve-scan.yml'
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -43,6 +43,7 @@ on:
     - '.github/workflows/publish-snapshot.yml'
     - '.github/workflows/recurring-jmh-benchmarks.yml'
     - '.github/workflows/site-ci.yml'
+    - '.github/workflows/kafka-connect-cve-scan.yml'
     - '.github/workflows/spark-ci.yml'
     - '.github/workflows/stale.yml'
     - '.gitignore'

--- a/.github/workflows/kafka-connect-cve-scan.yml
+++ b/.github/workflows/kafka-connect-cve-scan.yml
@@ -1,0 +1,136 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Kafka Connect CVE Scan"
+on:
+  push:
+    branches:
+    - 'main'
+    - '0.*'
+    - '1.*'
+    - '2.*'
+    tags:
+    - 'apache-iceberg-**'
+  pull_request:
+    paths-ignore:
+    - '.github/ISSUE_TEMPLATE/**'
+    - '.github/workflows/api-binary-compatibility.yml'
+    - '.github/workflows/delta-conversion-ci.yml'
+    - '.github/workflows/docs-ci.yml'
+    - '.github/workflows/flink-ci.yml'
+    - '.github/workflows/hive-ci.yml'
+    - '.github/workflows/java-ci.yml'
+    - '.github/workflows/jmh-benchmarks-ci.yml'
+    - '.github/workflows/labeler.yml'
+    - '.github/workflows/license-check.yml'
+    - '.github/workflows/open-api.yml'
+    - '.github/workflows/publish-snapshot.yml'
+    - '.github/workflows/recurring-jmh-benchmarks.yml'
+    - '.github/workflows/site-ci.yml'
+    - '.github/workflows/spark-ci.yml'
+    - '.github/workflows/kafka-connect-ci.yml'
+    - '.github/workflows/stale.yml'
+    - '.gitignore'
+    - '.asf.yaml'
+    - 'dev/**'
+    - 'docker/**'
+    - 'mr/**'
+    - 'flink/**'
+    - 'spark/**'
+    - 'docs/**'
+    - 'site/**'
+    - 'open-api/**'
+    - 'format/**'
+    - '.gitattributes'
+    - '**/README.md'
+    - 'CONTRIBUTING.md'
+    - '**/LICENSE'
+    - '**/NOTICE'
+    - 'doap.rdf'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+
+  # ------------------------------------------------------------------
+  # Trivy CVE scan — scans bundled jars for known vulnerabilities.
+  #
+  # Behaviour:
+  #   - If a CVE is found, the step will fail. However, since this job
+  #     is not a required check, it will not block merging.
+  #   - On push to main/release branches: results are uploaded as
+  #     SARIF to the GitHub Security tab for ongoing tracking.
+  #   - On PRs: SARIF upload is skipped because GitHub's Security
+  #     tab only accepts results from default/protected branches.
+  #     CVE findings are visible in the CI log output instead.
+  # ------------------------------------------------------------------
+  kafka-connect-cve-scan:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      with:
+        distribution: zulu
+        java-version: 21
+    - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5 # zizmor: ignore[cache-poisoning] -- cache writes are restricted to the default branch by setup-gradle
+    - name: Build Kafka Connect distribution for scanning
+      run: |
+        ./gradlew -DsparkVersions= -DflinkVersions= -DkafkaVersions=3 \
+          :iceberg-kafka-connect:iceberg-kafka-connect-runtime:distZip \
+          -Pquick=true -x test -x javadoc
+    - name: Unpack distribution for scanning
+      run: |
+        mkdir -p /tmp/kafka-connect-scan
+        unzip kafka-connect/kafka-connect-runtime/build/distributions/iceberg-kafka-connect-runtime-*.zip \
+          -d /tmp/kafka-connect-scan
+    - name: Run Trivy vulnerability scan
+      uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
+      with:
+        scan-type: 'rootfs'
+        scan-ref: '/tmp/kafka-connect-scan'
+        scanners: 'vuln'
+        severity: 'HIGH,CRITICAL'
+        limit-severities-for-sarif: true
+        exit-code: '1'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+    - name: Print Trivy scan results
+      if: always()
+      run: |
+        if [ -f trivy-results.sarif ]; then
+          echo "## Trivy CVE Scan Results"
+          jq -r '.runs[].results[] | "- \(.ruleId): \(.message.text)"' trivy-results.sarif 2>/dev/null || echo "No findings or unable to parse SARIF."
+        else
+          echo "No SARIF file found — scan may have failed to install."
+        fi
+    - name: Upload Trivy results to GitHub Security tab
+      if: always() && github.event_name == 'push'
+      uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -38,6 +38,7 @@ on:
     - '.github/workflows/java-ci.yml'
     - '.github/workflows/jmh-benchmarks-ci.yml'
     - '.github/workflows/kafka-connect-ci.yml'
+    - '.github/workflows/kafka-connect-cve-scan.yml'
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'


### PR DESCRIPTION
## Summary

- Adds a Trivy vulnerability scan to the Kafka Connect CI workflow
- Scans the bundled jars for CRITICAL/HIGH CVEs
- On push events (main, version branches, RC tags), uploads SARIF results to GitHub's Security tab
- On PRs, outputs scan results to CI logs for developer visibility
- Fails the job, but since the job is not a required status check, it will not block merging PRs.

## Context

Discussion on dev@ mailing list: https://lists.apache.org/thread/kbf98950pzstzgon92st7mh9vrbv5yhb

Confluent Marketplace requires a Trivy scan before listing connectors. This has previously caught CVEs that needed patching (e.g. #14985). Running the scan in CI catches vulnerabilities during development and — critically — on RC tags before the release vote starts, when fixes can still be applied.

This is independent of #15212 (adding the KC artifact to the release process) and can land in either order.