### PR TITLE
#13924: in Iceberg catalog, JdbcTableOperations should catch and handle PostgresSQL's exception for duplicated keys

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -24,7 +24,6 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientConnectionException;
@@ -337,7 +336,6 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
         JdbcUtil.namespaceToString(namespace));
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
     if (from.equals(to)) {
@@ -363,9 +361,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     int updatedRecords =
         execute(
             err -> {
-              // SQLite doesn't set SQLState or throw SQLIntegrityConstraintViolationException
-              if (err instanceof SQLIntegrityConstraintViolationException
-                  || (err.getMessage() != null && err.getMessage().contains("constraint failed"))) {
+              if (JdbcUtil.isConstraintViolation(err)) {
                 throw new AlreadyExistsException("Table already exists: %s", to);
               }
             },
@@ -713,9 +709,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     int updatedRecords =
         execute(
             err -> {
-              // SQLite doesn't set SQLState or throw SQLIntegrityConstraintViolationException
-              if (err instanceof SQLIntegrityConstraintViolationException
-                  || (err.getMessage() != null && err.getMessage().contains("constraint failed"))) {
+              if (JdbcUtil.isConstraintViolation(err)) {
                 throw new AlreadyExistsException(
                     "Cannot rename %s to %s. View already exists", from, to);
               }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.file.Files;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.iceberg.catalog.Namespace;
@@ -142,6 +144,28 @@ public class TestJdbcUtil {
               "testLocation");
       assertThat(updated).isEqualTo(1);
     }
+  }
+
+  @Test
+  public void testIsConstraintViolationWithSQLIntegrityConstraintViolationException() {
+    assertThat(JdbcUtil.isConstraintViolation(new SQLIntegrityConstraintViolationException()))
+        .isTrue();
+  }
+
+  @Test
+  public void testIsConstraintViolationWithPostgresSQLState() {
+    assertThat(JdbcUtil.isConstraintViolation(new SQLException("unique violation", "23505")))
+        .isTrue();
+  }
+
+  @Test
+  public void testIsConstraintViolationWithConstraintFailedMessage() {
+    assertThat(JdbcUtil.isConstraintViolation(new SQLException("constraint failed"))).isTrue();
+  }
+
+  @Test
+  public void testIsConstraintViolationWithPlainSQLException() {
+    assertThat(JdbcUtil.isConstraintViolation(new SQLException("some other error"))).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/13924

Previously reviewed at https://github.com/apache/iceberg/pull/13925 (fixed all the suggestions in there)