### PR TITLE
Core: Support reading Avro local-timestamp-* logical types

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
@@ -82,9 +82,11 @@ abstract class BaseWriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {
           return ValueWriters.longs();
 
         case "timestamp-micros":
+        case "local-timestamp-micros":
           return ValueWriters.longs();
 
         case "timestamp-nanos":
+        case "local-timestamp-nanos":
           return ValueWriters.longs();
 
         case "decimal":

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -182,13 +182,16 @@ public class GenericAvroReader<T>
             return ValueReaders.longs();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
           case "timestamp-nanos":
-            // both are handled in memory as long values, using the type to track units
+          case "local-timestamp-nanos":
+            // all are handled in memory as long values, using the type to track units
             return ValueReaders.longs();
 
           case "decimal":

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -178,13 +178,16 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
             return ValueReaders.longs();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
           case "timestamp-nanos":
-            // both are handled in memory as long values, using the type to track units
+          case "local-timestamp-nanos":
+            // all are handled in memory as long values, using the type to track units
             return ValueReaders.longs();
 
           case "decimal":

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -192,22 +192,38 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       return Types.TimeType.get();
 
     } else if (logical instanceof LogicalTypes.TimestampMillis
-        || logical instanceof LogicalTypes.TimestampMicros) {
-      if (AvroSchemaUtil.isTimestamptz(primitive)) {
-        return Types.TimestampType.withZone();
-      } else {
-        return Types.TimestampType.withoutZone();
-      }
-
-    } else if (logical instanceof LogicalTypes.TimestampNanos) {
-      if (AvroSchemaUtil.isTimestamptz(primitive)) {
-        return Types.TimestampNanoType.withZone();
-      } else {
-        return Types.TimestampNanoType.withoutZone();
-      }
+        || logical instanceof LogicalTypes.TimestampMicros
+        || logical instanceof LogicalTypes.TimestampNanos
+        || logical instanceof LogicalTypes.LocalTimestampMillis
+        || logical instanceof LogicalTypes.LocalTimestampMicros
+        || logical instanceof LogicalTypes.LocalTimestampNanos) {
+      return timestampType(primitive, logical);
 
     } else if (LogicalTypes.uuid().getName().equals(name)) {
       return Types.UUIDType.get();
+    }
+
+    return null;
+  }
+
+  private Type timestampType(Schema primitive, LogicalType logical) {
+    if (logical instanceof LogicalTypes.LocalTimestampMillis
+        || logical instanceof LogicalTypes.LocalTimestampMicros) {
+      return Types.TimestampType.withoutZone();
+
+    } else if (logical instanceof LogicalTypes.LocalTimestampNanos) {
+      return Types.TimestampNanoType.withoutZone();
+
+    } else if (logical instanceof LogicalTypes.TimestampNanos) {
+      return AvroSchemaUtil.isTimestamptz(primitive)
+          ? Types.TimestampNanoType.withZone()
+          : Types.TimestampNanoType.withoutZone();
+
+    } else if (logical instanceof LogicalTypes.TimestampMillis
+        || logical instanceof LogicalTypes.TimestampMicros) {
+      return AvroSchemaUtil.isTimestamptz(primitive)
+          ? Types.TimestampType.withZone()
+          : Types.TimestampType.withoutZone();
     }
 
     return null;

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
@@ -152,6 +152,16 @@ public class DataReader<T> implements DatumReader<T>, SupportsRowPosition {
             }
             return GenericReaders.timestampMillis();
 
+          case "local-timestamp-millis":
+            // local-timestamp-* is always NTZ by definition; no adjust-to-utc check needed
+            return GenericReaders.timestampMillis();
+
+          case "local-timestamp-micros":
+            return GenericReaders.timestamps();
+
+          case "local-timestamp-nanos":
+            return GenericReaders.timestampNanos();
+
           case "decimal":
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),

--- a/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
@@ -160,6 +160,16 @@ public class PlannedDataReader<T> implements DatumReader<T>, SupportsRowPosition
             }
             return GenericReaders.timestampMillis();
 
+          case "local-timestamp-millis":
+            // local-timestamp-* is always NTZ by definition; no adjust-to-utc check needed
+            return GenericReaders.timestampMillis();
+
+          case "local-timestamp-micros":
+            return GenericReaders.timestamps();
+
+          case "local-timestamp-nanos":
+            return GenericReaders.timestampNanos();
+
           case "decimal":
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),

--- a/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
+++ b/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.util.Utf8;
@@ -34,10 +37,50 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.RandomUtil;
+import org.junit.jupiter.params.provider.Arguments;
 
 public class RandomAvroData {
 
   private RandomAvroData() {}
+
+  public static Stream<Arguments> localTimestampRecords() {
+    Random random = new Random(42L);
+    long millis = (Long) RandomUtil.generatePrimitive(Types.LongType.get(), random);
+    long micros = (Long) RandomUtil.generatePrimitive(Types.LongType.get(), random);
+    long nanos = (Long) RandomUtil.generatePrimitive(Types.LongType.get(), random);
+    return Stream.of(
+        // millis written on disk; expected to be read back as micros (multiplied by 1000)
+        localTimestampArguments(
+            LogicalTypes.localTimestampMillis(),
+            Types.TimestampType.withoutZone(),
+            millis,
+            millis * 1_000L),
+        // micros written on disk; expected to be read back unchanged
+        localTimestampArguments(
+            LogicalTypes.localTimestampMicros(), Types.TimestampType.withoutZone(), micros, micros),
+        // nanos written on disk; expected to be read back unchanged
+        localTimestampArguments(
+            LogicalTypes.localTimestampNanos(),
+            Types.TimestampNanoType.withoutZone(),
+            nanos,
+            nanos));
+  }
+
+  private static Arguments localTimestampArguments(
+      LogicalType logicalType, Type icebergType, long writeValue, long expectedValue) {
+    org.apache.avro.Schema avroSchema =
+        AvroTestHelpers.record(
+            "r1",
+            AvroTestHelpers.optionalField(
+                1,
+                "ts",
+                logicalType.addToSchema(
+                    org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG))));
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("ts", writeValue);
+    Schema readSchema = new Schema(Types.NestedField.optional(1, "ts", icebergType));
+    return Arguments.of(record, readSchema, expectedValue);
+  }
 
   public static List<Record> generate(Schema schema, int numRecords, long seed) {
     RandomDataGenerator generator = new RandomDataGenerator(schema, seed);

--- a/core/src/test/java/org/apache/iceberg/avro/TestGenericAvro.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestGenericAvro.java
@@ -18,15 +18,23 @@
  */
 package org.apache.iceberg.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
+import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData.Record;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.DataTestBase;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestGenericAvro extends DataTestBase {
   @Override
@@ -42,6 +50,24 @@ public class TestGenericAvro extends DataTestBase {
   @Override
   protected boolean supportsVariant() {
     return true;
+  }
+
+  @ParameterizedTest(name = "{index} {0}")
+  @MethodSource("org.apache.iceberg.avro.RandomAvroData#localTimestampRecords")
+  public void testReadLocalTimestampType(Record avroRecord, Schema readSchema, long expectedValue)
+      throws IOException {
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (PositionOutputStream out = outputFile.createOrOverwrite();
+        DataFileWriter<Record> writer =
+            new DataFileWriter<>(new GenericDatumWriter<>(avroRecord.getSchema()))) {
+      writer.create(avroRecord.getSchema(), out);
+      writer.append(avroRecord);
+    }
+
+    try (AvroIterable<Record> reader =
+        Avro.read(outputFile.toInputFile()).project(readSchema).build()) {
+      assertThat(Iterables.getOnlyElement(reader).get("ts")).isEqualTo(expectedValue);
+    }
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/avro/TestInternalAvro.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestInternalAvro.java
@@ -18,8 +18,13 @@
  */
 package org.apache.iceberg.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.iceberg.InternalTestHelpers;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RandomInternalData;
@@ -29,9 +34,34 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestInternalAvro extends DataTestBase {
+  @ParameterizedTest(name = "{index} {0}")
+  @MethodSource("org.apache.iceberg.avro.RandomAvroData#localTimestampRecords")
+  public void testReadLocalTimestampType(
+      GenericData.Record avroRecord, Schema readSchema, long expectedValue) throws IOException {
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (PositionOutputStream out = outputFile.createOrOverwrite();
+        DataFileWriter<GenericData.Record> writer =
+            new DataFileWriter<>(new GenericDatumWriter<>(avroRecord.getSchema()))) {
+      writer.create(avroRecord.getSchema(), out);
+      writer.append(avroRecord);
+    }
+
+    try (AvroIterable<Record> reader =
+        Avro.read(outputFile.toInputFile())
+            .project(readSchema)
+            .createResolvingReader(InternalReader::create)
+            .build()) {
+      assertThat(Iterables.getOnlyElement(reader).getField("ts")).isEqualTo(expectedValue);
+    }
+  }
+
   @Override
   protected boolean supportsDefaultValues() {
     return true;

--- a/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
@@ -30,6 +30,8 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.stream.Stream;
+import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -39,6 +41,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestSchemaConversions {
   @Test
@@ -104,6 +109,23 @@ public class TestSchemaConversions {
     Schema avroType = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
 
     assertThat(AvroSchemaUtil.convert(avroType)).isEqualTo(expectedIcebergType);
+  }
+
+  static Stream<Arguments> localTimestampLogicalTypes() {
+    return Stream.of(
+        Arguments.of(LogicalTypes.localTimestampMillis(), Types.TimestampType.withoutZone()),
+        Arguments.of(LogicalTypes.localTimestampMicros(), Types.TimestampType.withoutZone()),
+        Arguments.of(LogicalTypes.localTimestampNanos(), Types.TimestampNanoType.withoutZone()));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("localTimestampLogicalTypes")
+  public void testAvroLocalTimestampTypeToIceberg(
+      LogicalType logicalType, Type expectedIcebergType) {
+    Schema avroSchema = logicalType.addToSchema(Schema.create(Schema.Type.LONG));
+    assertThat(AvroSchemaUtil.convert(avroSchema))
+        .as(logicalType.getName() + " should convert to " + expectedIcebergType)
+        .isEqualTo(expectedIcebergType);
   }
 
   private Schema addAdjustToUtc(Schema schema, boolean adjustToUTC) {

--- a/core/src/test/java/org/apache/iceberg/data/avro/TestDataReader.java
+++ b/core/src/test/java/org/apache/iceberg/data/avro/TestDataReader.java
@@ -200,6 +200,68 @@ class TestDataReader {
     }
   }
 
+  @Test
+  public void localTimestampDataReader() throws IOException {
+    org.apache.iceberg.Schema icebergSchema =
+        new org.apache.iceberg.Schema(
+            Types.NestedField.required(1, "local_ts_nanos", Types.TimestampNanoType.withoutZone()),
+            Types.NestedField.required(2, "local_ts_micros", Types.TimestampType.withoutZone()),
+            Types.NestedField.required(3, "local_ts_millis", Types.TimestampType.withoutZone()));
+
+    Schema avroSchema =
+        SchemaBuilder.record("test_programmatic")
+            .fields()
+            .name("local_ts_nanos")
+            .type(LogicalTypes.localTimestampNanos().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .name("local_ts_micros")
+            .type(LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .name("local_ts_millis")
+            .type(LogicalTypes.localTimestampMillis().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .endRecord();
+
+    avroSchema.getField("local_ts_nanos").addProp("field-id", 1);
+    avroSchema.getField("local_ts_micros").addProp("field-id", 2);
+    avroSchema.getField("local_ts_millis").addProp("field-id", 3);
+
+    DataReader<Record> reader = DataReader.create(icebergSchema, avroSchema);
+    reader.setSchema(avroSchema);
+
+    // post-epoch timestamps
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    LocalDateTime localNanos = LocalDateTime.of(2023, 10, 15, 14, 30, 45, 123456789);
+    LocalDateTime localMicros = LocalDateTime.of(2023, 10, 15, 14, 30, 45, 123456000);
+    LocalDateTime localMillis = LocalDateTime.of(2023, 10, 15, 14, 30, 45, 123000000);
+
+    avroRecord.put("local_ts_nanos", DateTimeUtil.nanosFromTimestamp(localNanos));
+    avroRecord.put("local_ts_micros", DateTimeUtil.microsFromTimestamp(localMicros));
+    avroRecord.put("local_ts_millis", DateTimeUtil.millisFromTimestamp(localMillis));
+
+    Record result = readRecord(reader, avroSchema, avroRecord);
+
+    assertThat(result.getField("local_ts_nanos")).isEqualTo(localNanos);
+    assertThat(result.getField("local_ts_micros")).isEqualTo(localMicros);
+    assertThat(result.getField("local_ts_millis")).isEqualTo(localMillis);
+
+    // pre-epoch timestamps
+    GenericRecord preEpochRecord = new GenericData.Record(avroSchema);
+    LocalDateTime preEpochNanos = LocalDateTime.of(1969, 1, 1, 10, 11, 12, 123456789);
+    LocalDateTime preEpochMicros = LocalDateTime.of(1968, 1, 1, 10, 11, 12, 123456000);
+    LocalDateTime preEpochMillis = LocalDateTime.of(1967, 1, 1, 10, 11, 12, 123000000);
+
+    preEpochRecord.put("local_ts_nanos", DateTimeUtil.nanosFromTimestamp(preEpochNanos));
+    preEpochRecord.put("local_ts_micros", DateTimeUtil.microsFromTimestamp(preEpochMicros));
+    preEpochRecord.put("local_ts_millis", DateTimeUtil.millisFromTimestamp(preEpochMillis));
+
+    Record preEpochResult = readRecord(reader, avroSchema, preEpochRecord);
+
+    assertThat(preEpochResult.getField("local_ts_nanos")).isEqualTo(preEpochNanos);
+    assertThat(preEpochResult.getField("local_ts_micros")).isEqualTo(preEpochMicros);
+    assertThat(preEpochResult.getField("local_ts_millis")).isEqualTo(preEpochMillis);
+  }
+
   private Schema utcAdjustedLongSchema() {
     Schema schema = Schema.create(Schema.Type.LONG);
     schema.addProp(ADJUST_TO_UTC_PROP, "true");

--- a/core/src/test/java/org/apache/iceberg/data/avro/TestPlannedDataReader.java
+++ b/core/src/test/java/org/apache/iceberg/data/avro/TestPlannedDataReader.java
@@ -336,6 +336,68 @@ public class TestPlannedDataReader {
     return results;
   }
 
+  @Test
+  public void localTimestampDataReader() throws IOException {
+    org.apache.iceberg.Schema icebergSchema =
+        new org.apache.iceberg.Schema(
+            Types.NestedField.required(1, "local_ts_nanos", Types.TimestampNanoType.withoutZone()),
+            Types.NestedField.required(2, "local_ts_micros", Types.TimestampType.withoutZone()),
+            Types.NestedField.required(3, "local_ts_millis", Types.TimestampType.withoutZone()));
+
+    Schema avroSchema =
+        SchemaBuilder.record("test_programmatic")
+            .fields()
+            .name("local_ts_nanos")
+            .type(LogicalTypes.localTimestampNanos().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .name("local_ts_micros")
+            .type(LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .name("local_ts_millis")
+            .type(LogicalTypes.localTimestampMillis().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .endRecord();
+
+    avroSchema.getField("local_ts_nanos").addProp("field-id", 1);
+    avroSchema.getField("local_ts_micros").addProp("field-id", 2);
+    avroSchema.getField("local_ts_millis").addProp("field-id", 3);
+
+    PlannedDataReader<Record> reader = PlannedDataReader.create(icebergSchema);
+    reader.setSchema(avroSchema);
+
+    // post-epoch timestamps
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    LocalDateTime localNanos = LocalDateTime.of(2023, 10, 15, 14, 30, 45, 123456789);
+    LocalDateTime localMicros = LocalDateTime.of(2023, 10, 15, 14, 30, 45, 123456000);
+    LocalDateTime localMillis = LocalDateTime.of(2023, 10, 15, 14, 30, 45, 123000000);
+
+    avroRecord.put("local_ts_nanos", DateTimeUtil.nanosFromTimestamp(localNanos));
+    avroRecord.put("local_ts_micros", DateTimeUtil.microsFromTimestamp(localMicros));
+    avroRecord.put("local_ts_millis", DateTimeUtil.millisFromTimestamp(localMillis));
+
+    Record result = readRecord(reader, avroSchema, avroRecord);
+
+    assertThat(result.getField("local_ts_nanos")).isEqualTo(localNanos);
+    assertThat(result.getField("local_ts_micros")).isEqualTo(localMicros);
+    assertThat(result.getField("local_ts_millis")).isEqualTo(localMillis);
+
+    // pre-epoch timestamps
+    GenericRecord preEpochRecord = new GenericData.Record(avroSchema);
+    LocalDateTime preEpochNanos = LocalDateTime.of(1969, 1, 1, 10, 11, 12, 123456789);
+    LocalDateTime preEpochMicros = LocalDateTime.of(1968, 1, 1, 10, 11, 12, 123456000);
+    LocalDateTime preEpochMillis = LocalDateTime.of(1967, 1, 1, 10, 11, 12, 123000000);
+
+    preEpochRecord.put("local_ts_nanos", DateTimeUtil.nanosFromTimestamp(preEpochNanos));
+    preEpochRecord.put("local_ts_micros", DateTimeUtil.microsFromTimestamp(preEpochMicros));
+    preEpochRecord.put("local_ts_millis", DateTimeUtil.millisFromTimestamp(preEpochMillis));
+
+    Record preEpochResult = readRecord(reader, avroSchema, preEpochRecord);
+
+    assertThat(preEpochResult.getField("local_ts_nanos")).isEqualTo(preEpochNanos);
+    assertThat(preEpochResult.getField("local_ts_micros")).isEqualTo(preEpochMicros);
+    assertThat(preEpochResult.getField("local_ts_millis")).isEqualTo(preEpochMillis);
+  }
+
   private Schema utcAdjustedLongSchema() {
     Schema schema = Schema.create(Schema.Type.LONG);
     schema.addProp(ADJUST_TO_UTC_PROP, "true");


### PR DESCRIPTION
Avro supports local-timestamp-millis and local-timestamp-micros since 1.10, and local-timestamp-nanos since 1.12. Adding support for those, so Iceberg can read Avro data with these types written outside Iceberg.