### PR TITLE
Core: Track & close FileIO used for remote scan planning

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.rest;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
 import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeException;
 import dev.failsafe.RetryPolicy;
@@ -58,6 +61,17 @@ class RESTTableScan extends DataTableScan {
   private static final long MAX_WAIT_TIME_MS = 5 * 60 * 1000; // Total maximum duration (5 minutes)
   private static final double SCALE_FACTOR = 2.0; // Exponential scale factor
   private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.io.ResolvingFileIO";
+  private static final Cache<RESTTableScan, FileIO> FILEIO_TRACKER =
+      Caffeine.newBuilder()
+          .weakKeys()
+          .removalListener(
+              (RemovalListener<RESTTableScan, FileIO>)
+                  (scan, io, cause) -> {
+                    if (null != io) {
+                      io.close();
+                    }
+                  })
+          .build();
 
   private final RESTClient client;
   private final Map<String, String> headers;
@@ -199,16 +213,19 @@ class RESTTableScan extends DataTableScan {
   }
 
   private FileIO fileIOForPlanId(List<Credential> storageCredentials) {
-    return CatalogUtil.loadFileIO(
-        catalogProperties.getOrDefault(CatalogProperties.FILE_IO_IMPL, DEFAULT_FILE_IO_IMPL),
-        ImmutableMap.<String, String>builder()
-            .putAll(catalogProperties)
-            .put(RESTCatalogProperties.REST_SCAN_PLAN_ID, planId)
-            .buildKeepingLast(),
-        hadoopConf,
-        storageCredentials.stream()
-            .map(c -> StorageCredential.create(c.prefix(), c.config()))
-            .collect(Collectors.toList()));
+    FileIO ioForScan =
+        CatalogUtil.loadFileIO(
+            catalogProperties.getOrDefault(CatalogProperties.FILE_IO_IMPL, DEFAULT_FILE_IO_IMPL),
+            ImmutableMap.<String, String>builder()
+                .putAll(catalogProperties)
+                .put(RESTCatalogProperties.REST_SCAN_PLAN_ID, planId)
+                .buildKeepingLast(),
+            hadoopConf,
+            storageCredentials.stream()
+                .map(c -> StorageCredential.create(c.prefix(), c.config()))
+                .collect(Collectors.toList()));
+    FILEIO_TRACKER.put(this, ioForScan);
+    return ioForScan;
   }
 
   private CloseableIterable<FileScanTask> fetchPlanningResult() {
@@ -236,7 +253,7 @@ class RESTTableScan extends DataTableScan {
                       "Polling for plan {} failed due to: {}",
                       planId,
                       e.getException().getMessage());
-                  cancelPlan();
+                  cleanupPlanResources();
                 })
             .build();
 
@@ -271,7 +288,7 @@ class RESTTableScan extends DataTableScan {
     } catch (Exception e) {
       // Catch any immediate non-retryable exceptions (e.g., I/O errors, auth errors)
       try {
-        cancelPlan();
+        cleanupPlanResources();
       } catch (Exception cancelException) {
         // Ignore cancellation failures during exception handling
         e.addSuppressed(cancelException);
@@ -297,6 +314,15 @@ class RESTTableScan extends DataTableScan {
             planExecutor(),
             parserContext),
         this::cancelPlan);
+  }
+
+  /** Cancels the plan on the server (if supported) and closes the plan-scoped FileIO */
+  private void cleanupPlanResources() {
+    cancelPlan();
+    if (null != fileIOForPlanId) {
+      FILEIO_TRACKER.invalidate(this);
+      this.fileIOForPlanId = null;
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This uses a similar approach to what we do in the `RESTSessionCatalog` with the `FileIOTracker` by wrapping the `RESTTableScan` in a `WeakReference` and close the attached `FileIO` instance when the `RESTTableScan` object is garbage-collected. We don't really have `close()` methods on either `Table` or `Scan`, so I can't think of an easier way to keep track of `FileIO` instances created inside `RESTTableScan` so that we properly close them before actually reaching the [finalizer](https://github.com/apache/iceberg/blob/fec9800bcc0c4073ca727f3b3bfdc2f34abb26a3/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java#L499-L510) in `S3FileIO`, which would then complain as can be seen below:

```
6/02/25 09:25:19 WARN ResolvingFileIO: Unclosed ResolvingFileIO instance created by:
	org.apache.iceberg.io.ResolvingFileIO.<init>(ResolvingFileIO.java:85)
	java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	org.apache.iceberg.common.DynConstructors$Ctor.newInstanceChecked(DynConstructors.java:51)
	org.apache.iceberg.common.DynConstructors$Ctor.newInstance(DynConstructors.java:64)
	org.apache.iceberg.CatalogUtil.loadFileIO(CatalogUtil.java:401)
	org.apache.iceberg.rest.RESTTableScan.fileIOForPlanId(RESTTableScan.java:202)
	org.apache.iceberg.rest.RESTTableScan.planTableScan(RESTTableScan.java:180)
	org.apache.iceberg.rest.RESTTableScan.planFiles(RESTTableScan.java:163)
	org.apache.iceberg.BatchScanAdapter.planFiles(BatchScanAdapter.java:125)
	org.apache.iceberg.spark.source.SparkPartitioningAwareScan.tasks(SparkPartitioningAwareScan.java:185)
	org.apache.iceberg.spark.source.SparkPartitioningAwareScan.taskGroups(SparkPartitioningAwareScan.java:213)
	org.apache.iceberg.spark.source.SparkPartitioningAwareScan.outputPartitioning(SparkPartitioningAwareScan.java:115)
	org.apache.spark.sql.execution.datasources.v2.V2ScanPartitioningAndOrdering$$anonfun$partitioning$1.applyOrElse(V2ScanPartitioningAndOrdering.scala:45)
	org.apache.spark.sql.execution.datasources.v2.V2ScanPartitioningAndOrdering$$anonfun$partitioning$1.applyOrElse(V2ScanPartitioningAndOrdering.scala:43)
	org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:491)
```

I have verified that this works in combination of https://github.com/apache/iceberg/pull/15368, where the `fileIOForPlanId` wasn't previously closed properly and was running into the WARN shown above.
I'm currently checking to see how to add a unit test for this to `TestRESTScanPlanning` but I think this is non-trivial (similar to how it was non-trivial to test this behavior in https://github.com/apache/iceberg/pull/7487)