### PR TITLE
PoC: Introduce column update metadata

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ColumnUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/ColumnUpdate.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.List;
+
+/**
+ * API for adding column update files to a table.
+ *
+ * <p>This API accumulates column update file additions and produces a new {@link Snapshot} of the
+ * table. Column update files contain updated values for specific columns in existing data files.
+ *
+ * <p>Each column update operation associates an update file with its corresponding base data file
+ * and the field IDs of the columns being updated. The update file contains the new values for the
+ * specified columns that will be applied when reading the base data file.
+ */
+public interface ColumnUpdate extends SnapshotUpdate<ColumnUpdate> {
+
+  ColumnUpdate withFieldIds(List<Integer> fieldIds);
+
+  // TODO gaborkaszab: Alternatively we can pass a path instead of DataFile for baseFile?
+  // Apparently, both are possible from Spark write. We'd loose a couple of verification
+  // opportunities if it wasn't a DataFile but other than the checks only the path is needed for
+  // baseFile.
+  ColumnUpdate addColumnUpdate(DataFile baseFile, DataFile updateFile);
+
+  // TODO gaborkaszab: We have to think about adding an API to detect conflicts before committing.
+  // Have to think through how to solve this, since this is an extensive operation that can conflict
+  // many ways.
+}

--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -168,6 +168,28 @@ public interface ContentFile<F> {
   }
 
   /**
+   * Returns the list of column update details associated with this file, or null if there are no
+   * column updates.
+   *
+   * <p>Column updates represent modifications to specific columns within the data file, such as
+   * updates applied via separate column update files. Each entry in the list contains the field IDs
+   * that were updated and the path to the corresponding column update file.
+   *
+   * @return a list of {@link ColumnUpdateDetails} describing the column updates, or null if none
+   */
+  default List<ColumnUpdateDetails> columnUpdateDetails() {
+    return null;
+  }
+
+  interface ColumnUpdateDetails {
+    /** Returns the field IDs updated by the column update. */
+    List<Integer> fieldIds();
+
+    /** Returns the file path of the column update file. */
+    String filePath();
+  }
+
+  /**
    * Returns the starting row ID to assign to new rows in the data file (with _row_id set to null).
    */
   default Long firstRowId() {

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -124,6 +124,18 @@ public interface DataFile extends ContentFile<DataFile> {
   String PARTITION_NAME = "partition";
   String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
 
+  // TODO gaborkaszab: made up IDs, TBD
+  Types.StructType COLUMN_UPDATE_ITEM =
+      Types.StructType.of(
+          required(202, "field_ids", ListType.ofRequired(203, IntegerType.get()), "doc"),
+          required(204, "file_path", StringType.get(), "The path of the column update file"));
+  Types.NestedField COLUMN_UPDATES =
+      optional(
+          200,
+          "column_updates",
+          ListType.ofRequired(201, COLUMN_UPDATE_ITEM),
+          "Details of the column updates");
+
   // NEXT ID TO ASSIGN: 146
 
   static StructType getType(StructType partitionType) {
@@ -149,7 +161,8 @@ public interface DataFile extends ContentFile<DataFile> {
         FIRST_ROW_ID,
         REFERENCED_DATA_FILE,
         CONTENT_OFFSET,
-        CONTENT_SIZE);
+        CONTENT_SIZE,
+        COLUMN_UPDATES);
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/DataOperations.java
+++ b/api/src/main/java/org/apache/iceberg/DataOperations.java
@@ -45,7 +45,8 @@ public class DataOperations {
   /**
    * New data is added to overwrite existing data.
    *
-   * <p>This operation is implemented by {@link OverwriteFiles} and {@link ReplacePartitions}.
+   * <p>This operation is implemented by {@link OverwriteFiles}, {@link ReplacePartitions} and
+   * {@link ColumnUpdate}.
    */
   public static final String OVERWRITE = "overwrite";
 

--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -240,6 +240,16 @@ public interface Table {
   }
 
   /**
+   * Create a new {@link ColumnUpdate column update API} to add column updates to data files.
+   *
+   * @return a new {@link ColumnUpdate}
+   */
+  default ColumnUpdate newColumnUpdate() {
+    throw new UnsupportedOperationException(
+        "Column update is not supported by " + getClass().getName());
+  }
+
+  /**
    * Create a new {@link RewriteFiles rewrite API} to replace files in this table and commit.
    *
    * @return a new {@link RewriteFiles}

--- a/core/src/main/java/org/apache/iceberg/BaseColumnUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/BaseColumnUpdate.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.events.CreateSnapshotEvent;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+
+/**
+ * Implementation of {@link ColumnUpdate} that overwrites columns in base data files with column
+ * update files.
+ */
+public class BaseColumnUpdate extends SnapshotProducer<ColumnUpdate> implements ColumnUpdate {
+  private final String tableName;
+  private final SnapshotSummary.Builder summaryBuilder = SnapshotSummary.builder();
+
+  // Mapping from base file path to new file that should replace some of its columns
+  private final Map<String, DataFile> addedColumnUpdates = Maps.newHashMap();
+
+  // Track new manifests written during apply
+  private final Set<ManifestFile> newManifests = Sets.newConcurrentHashSet();
+
+  private List<Integer> fieldIds = Lists.newArrayList();
+
+  BaseColumnUpdate(String tableName, TableOperations ops) {
+    super(ops);
+    this.tableName = tableName;
+  }
+
+  @Override
+  protected ColumnUpdate self() {
+    return this;
+  }
+
+  @Override
+  public ColumnUpdate set(String property, String value) {
+    summaryBuilder.set(property, value);
+    return this;
+  }
+
+  @Override
+  protected String operation() {
+    return DataOperations.OVERWRITE;
+  }
+
+  @Override
+  protected Map<String, String> summary() {
+    // TODO gaborkaszab: Could track the following: REPLACED_MANIFESTS_COUNT,
+    // PROCESSED_MANIFEST_ENTRY_COUNT. SnapshotProducer.buildManifestCountSummary()?
+    // New metrics: ADDED_COLUMN_UPDATE_FILES
+    summaryBuilder.setPartitionSummaryLimit(
+        ops()
+            .current()
+            .propertyAsInt(
+                TableProperties.WRITE_PARTITION_SUMMARY_LIMIT,
+                TableProperties.WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT));
+    return summaryBuilder.build();
+  }
+
+  @Override
+  public ColumnUpdate withFieldIds(List<Integer> newFieldIds) {
+    Preconditions.checkArgument(newFieldIds != null, "Invalid field IDs: null");
+    Preconditions.checkArgument(!newFieldIds.isEmpty(), "Invalid field IDs: empty");
+    Preconditions.checkState(fieldIds.isEmpty(), "Field IDs are already set");
+
+    this.fieldIds.addAll(newFieldIds);
+
+    return this;
+  }
+
+  @Override
+  public ColumnUpdate addColumnUpdate(DataFile baseFile, DataFile updateFile) {
+    Preconditions.checkArgument(baseFile != null, "Base file is null");
+    Preconditions.checkArgument(updateFile != null, "Column update file is null");
+    Preconditions.checkArgument(
+        baseFile.content() == FileContent.DATA, "Base file must be a data file");
+    Preconditions.checkArgument(
+        updateFile.content() == FileContent.DATA, "Column update file must be a data file");
+    Preconditions.checkArgument(
+        ops().current().formatVersion() >= 4, "Column updates are supported from V4");
+    Preconditions.checkArgument(
+        baseFile.specId() == updateFile.specId(),
+        "Base file spec ID (%s) doesn't match update file spec ID (%s)",
+        baseFile.specId(),
+        updateFile.specId());
+    Preconditions.checkArgument(
+        baseFile.recordCount() >= updateFile.recordCount(),
+        "Update file can't have more rows than the base file");
+
+    Preconditions.checkState(
+        !addedColumnUpdates.containsKey(baseFile.location()),
+        "Not allowed to add multiple column updates to the same base file in one commit");
+
+    addedColumnUpdates.put(baseFile.location(), updateFile);
+
+    // Track summary info
+    // summaryBuilder.addedFile(ops().current().spec(file.specId()), file);
+
+    return this;
+  }
+
+  // TODO gaborkaszab: reject column update if there are eq-deletes
+  @Override
+  public List<ManifestFile> apply(TableMetadata base, Snapshot snapshot) {
+    Preconditions.checkArgument(snapshot != null, "Column update is not supported on empty tables");
+    Preconditions.checkState(!fieldIds.isEmpty(), "No field IDs provided");
+
+    if (addedColumnUpdates.isEmpty()) {
+      return snapshot.allManifests(ops().io());
+    }
+
+    if (!newManifests.isEmpty()) {
+      newManifests.forEach(file -> deleteFile(file.path()));
+      newManifests.clear();
+    }
+
+    // TODO gaborkaszab: parallelism by manifest
+    Set<ManifestFile> intactManifests = Sets.newConcurrentHashSet();
+    Set<String> baseFilesToFind = Sets.newConcurrentHashSet();
+    baseFilesToFind.addAll(addedColumnUpdates.keySet());
+    for (ManifestFile manifest : snapshot.dataManifests(ops().io())) {
+      ManifestFile rewrittenManifest =
+          applyColumnUpdatesToManifest(
+              manifest, base.spec(manifest.partitionSpecId()), baseFilesToFind);
+      if (rewrittenManifest == manifest) {
+        intactManifests.add(manifest);
+      } else {
+        newManifests.add(rewrittenManifest);
+      }
+    }
+
+    if (!baseFilesToFind.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Unable to find base data file: " + baseFilesToFind.iterator().next());
+    }
+
+    return Lists.newArrayList(Sets.union(newManifests, intactManifests));
+  }
+
+  // TODO gaborkaszab: this follows the approach from the proposal where we clone the affected
+  // manifests and populate the column update part. The other approach where we write a delete
+  // manifest and a new, not cloned manifest file with the updates depends on the the V4 metadata
+  // tree code.
+  private ManifestFile applyColumnUpdatesToManifest(
+      ManifestFile manifest, PartitionSpec spec, Set<String> baseFilesToFind) {
+    ManifestWriter<DataFile> writer = null;
+    // Buffer entries seen until we find one that has to be updated
+    List<ManifestEntry<DataFile>> bufferedEntries = Lists.newArrayList();
+    boolean foundEntryToUpdate = false;
+
+    try (ManifestReader<DataFile> reader = newManifestReader(manifest)) {
+      try (CloseableIterable<ManifestEntry<DataFile>> entries = reader.entries()) {
+        for (ManifestEntry<DataFile> entry : entries) {
+          DataFile existingFile = entry.file();
+          DataFile columnUpdateFile = addedColumnUpdates.get(existingFile.location());
+
+          if (!foundEntryToUpdate && columnUpdateFile == null) {
+            bufferedEntries.add(entry);
+          } else {
+            if (!foundEntryToUpdate) {
+              // Found first entry to update. Create writer and flush buffered entries
+              foundEntryToUpdate = true;
+              writer = newManifestWriter(spec);
+              for (ManifestEntry<DataFile> buffered : bufferedEntries) {
+                writeEntry(writer, buffered);
+              }
+              bufferedEntries.clear();
+            }
+
+            if (columnUpdateFile == null) {
+              writeEntry(writer, entry);
+            } else {
+              updateAndWriteEntry(writer, entry, columnUpdateFile);
+              baseFilesToFind.remove(existingFile.location());
+            }
+          }
+        }
+      }
+
+      if (!foundEntryToUpdate) {
+        return manifest;
+      }
+
+      writer.close();
+      return writer.toManifestFile();
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to rewrite manifest: %s", manifest.path());
+    }
+  }
+
+  private void writeEntry(ManifestWriter<DataFile> writer, ManifestEntry<DataFile> entry) {
+    switch (entry.status()) {
+      case ADDED:
+        writer.addEntry(entry);
+        break;
+      case EXISTING:
+        writer.existing(
+            entry.file(),
+            entry.snapshotId(),
+            entry.dataSequenceNumber(),
+            entry.fileSequenceNumber());
+        break;
+      case DELETED:
+        writer.delete(entry.file(), entry.dataSequenceNumber(), entry.fileSequenceNumber());
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown manifest entry status: " + entry.status());
+    }
+  }
+
+  // TODO gaborkaszab: make sure column update file stats are reflected in manifest list stats too.
+  // Is see they have stats on partition fields. Check if update on partition field works, also
+  // check if the partition field stats in the manifest list is updated.
+
+  private void updateAndWriteEntry(
+      ManifestWriter<DataFile> writer, ManifestEntry<DataFile> entry, DataFile columnUpdateFile) {
+    DataFile existingFile = entry.file();
+
+    DataFile fileWithColumnUpdates =
+        DataFiles.builder(ops().current().spec())
+            .copy(existingFile)
+            .withColumnUpdates(
+                nonOverlappingColumnUpdates(existingFile.columnUpdateDetails(), columnUpdateFile))
+            .withMetrics(mergeMetrics(existingFile, columnUpdateFile))
+            .build();
+
+    // Create a new ManifestEntry with the same metadata but with the updated file
+    GenericManifestEntry<DataFile> newEntry =
+        new GenericManifestEntry<>(
+            ManifestEntry.getSchema(ops().current().spec().partitionType()).asStruct());
+
+    switch (entry.status()) {
+      case ADDED:
+        writer.addEntry(
+            newEntry.wrapAppend(
+                entry.snapshotId(), entry.dataSequenceNumber(), fileWithColumnUpdates));
+        break;
+      case EXISTING:
+        writer.existing(
+            newEntry.wrapExisting(
+                entry.snapshotId(),
+                entry.dataSequenceNumber(),
+                entry.fileSequenceNumber(),
+                fileWithColumnUpdates));
+        break;
+      case DELETED:
+        // TODO gaborkaszab: probably no need to add updates to deleted entries. Should we keep them
+        // or simply drop?
+        writer.delete(
+            newEntry.wrapDelete(
+                entry.snapshotId(),
+                entry.dataSequenceNumber(),
+                entry.fileSequenceNumber(),
+                fileWithColumnUpdates));
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown manifest entry status: " + entry.status());
+    }
+  }
+
+  private List<ContentFile.ColumnUpdateDetails> nonOverlappingColumnUpdates(
+      List<ContentFile.ColumnUpdateDetails> existingUpdates, DataFile updateFile) {
+    ContentFile.ColumnUpdateDetails newColumnUpdateDetails =
+        BaseFile.BaseColumnUpdateDetails.of(fieldIds, updateFile.location());
+
+    if (existingUpdates == null) {
+      return List.of(newColumnUpdateDetails);
+    }
+
+    List<ContentFile.ColumnUpdateDetails> result = Lists.newArrayList();
+    for (ContentFile.ColumnUpdateDetails existingUpdate : existingUpdates) {
+      List<Integer> nonOverlappingFiledIds = existingUpdate.fieldIds();
+      nonOverlappingFiledIds.removeAll(fieldIds);
+      if (!nonOverlappingFiledIds.isEmpty()) {
+        result.add(
+            BaseFile.BaseColumnUpdateDetails.of(nonOverlappingFiledIds, existingUpdate.filePath()));
+      }
+    }
+    result.add(newColumnUpdateDetails);
+
+    return result;
+  }
+
+  private Metrics mergeMetrics(DataFile baseFile, DataFile columnUpdateFile) {
+    return new Metrics(
+        baseFile.recordCount(),
+        mergeMetricMaps(baseFile.columnSizes(), columnUpdateFile.columnSizes()),
+        mergeMetricMaps(baseFile.valueCounts(), columnUpdateFile.valueCounts()),
+        mergeMetricMaps(baseFile.nullValueCounts(), columnUpdateFile.nullValueCounts()),
+        mergeMetricMaps(baseFile.nanValueCounts(), columnUpdateFile.nanValueCounts()),
+        mergeMetricMaps(baseFile.lowerBounds(), columnUpdateFile.lowerBounds()),
+        mergeMetricMaps(baseFile.upperBounds(), columnUpdateFile.upperBounds()));
+  }
+
+  private <V> Map<Integer, V> mergeMetricMaps(Map<Integer, V> baseMap, Map<Integer, V> updateMap) {
+    if (baseMap == null && updateMap == null) {
+      return null;
+    }
+
+    Map<Integer, V> merged = Maps.newHashMap();
+    if (baseMap != null) {
+      merged.putAll(baseMap);
+    }
+
+    // Remove the stats for fields that are being updated
+    fieldIds.forEach(merged::remove);
+
+    if (updateMap != null) {
+      fieldIds.forEach(
+          fieldId -> {
+            if (updateMap.containsKey(fieldId)) {
+              merged.put(fieldId, updateMap.get(fieldId));
+            }
+          });
+    }
+
+    return merged.isEmpty() ? null : merged;
+  }
+
+  @Override
+  public Object updateEvent() {
+    long snapshotId = snapshotId();
+    Snapshot snapshot = ops().current().snapshot(snapshotId);
+    long sequenceNumber = snapshot.sequenceNumber();
+    return new CreateSnapshotEvent(
+        tableName, operation(), snapshotId, sequenceNumber, snapshot.summary());
+  }
+
+  @Override
+  protected void cleanUncommitted(Set<ManifestFile> committed) {
+    deleteUncommitted(newManifests, committed, true /* clear manifests */);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -32,6 +32,7 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -54,6 +55,64 @@ abstract class BaseFile<F> extends SupportsIndexProjection
           return this; // this does not change
         }
       };
+
+  static class BaseColumnUpdateDetails extends SupportsIndexProjection
+      implements ColumnUpdateDetails {
+    private List<Integer> fieldIds;
+    private String filePath;
+
+    private BaseColumnUpdateDetails(List<Integer> fieldIds, String filePath) {
+      super(DataFile.COLUMN_UPDATE_ITEM.fields().size());
+      this.fieldIds = fieldIds;
+      this.filePath = filePath;
+    }
+
+    public static ColumnUpdateDetails of(List<Integer> fieldIds, String filePath) {
+      return new BaseColumnUpdateDetails(fieldIds, filePath);
+    }
+
+    @Override
+    public List<Integer> fieldIds() {
+      return fieldIds;
+    }
+
+    @Override
+    public String filePath() {
+      return filePath;
+    }
+
+    @Override
+    protected <T> T internalGet(int pos, Class<T> javaClass) {
+      return javaClass.cast(getByPos(pos));
+    }
+
+    private Object getByPos(int basePos) {
+      return switch (basePos) {
+        case 0 -> fieldIds;
+        case 1 -> filePath;
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
+      };
+    }
+
+    @Override
+    protected <T> void internalSet(int pos, T value) {
+      switch (pos) {
+        case 0:
+          this.fieldIds = (List<Integer>) value;
+          return;
+        case 1:
+          this.filePath = value.toString();
+          return;
+        default:
+          // ignore the object, it must be from a newer version of the format
+      }
+    }
+
+    @Override
+    public int size() {
+      return DataFile.COLUMN_UPDATE_ITEM.fields().size();
+    }
+  }
 
   private Types.StructType partitionType;
 
@@ -84,6 +143,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   private String referencedDataFile = null;
   private Long contentOffset = null;
   private Long contentSizeInBytes = null;
+  private List<ContentFile.ColumnUpdateDetails> columnUpdateDetails = null;
 
   // cached schema
   private transient Schema avroSchema = null;
@@ -116,7 +176,8 @@ abstract class BaseFile<F> extends SupportsIndexProjection
           DataFile.REFERENCED_DATA_FILE,
           DataFile.CONTENT_OFFSET,
           DataFile.CONTENT_SIZE,
-          MetadataColumns.ROW_POSITION);
+          MetadataColumns.ROW_POSITION,
+          DataFile.COLUMN_UPDATES);
 
   /** Used by Avro reflection to instantiate this class when reading manifest files. */
   BaseFile(Schema avroSchema) {
@@ -161,7 +222,8 @@ abstract class BaseFile<F> extends SupportsIndexProjection
       Long firstRowId,
       String referencedDataFile,
       Long contentOffset,
-      Long contentSizeInBytes) {
+      Long contentSizeInBytes,
+      List<ColumnUpdateDetails> columnUpdateDetails) {
     super(BASE_TYPE.fields().size());
     this.partitionSpecId = specId;
     this.content = content;
@@ -194,6 +256,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
     this.referencedDataFile = referencedDataFile;
     this.contentOffset = contentOffset;
     this.contentSizeInBytes = contentSizeInBytes;
+    this.columnUpdateDetails = columnUpdateDetails;
   }
 
   /**
@@ -250,6 +313,8 @@ abstract class BaseFile<F> extends SupportsIndexProjection
     this.referencedDataFile = toCopy.referencedDataFile;
     this.contentOffset = toCopy.contentOffset;
     this.contentSizeInBytes = toCopy.contentSizeInBytes;
+    this.columnUpdateDetails =
+        toCopy.columnUpdateDetails == null ? null : List.copyOf(toCopy.columnUpdateDetails);
   }
 
   /** Constructor for Java serialization. */
@@ -295,6 +360,48 @@ abstract class BaseFile<F> extends SupportsIndexProjection
 
   public void setFirstRowId(Long firstRowId) {
     this.firstRowId = firstRowId;
+  }
+
+  @Override
+  public List<ContentFile.ColumnUpdateDetails> columnUpdateDetails() {
+    return columnUpdateDetails;
+  }
+
+  /**
+   * Converts a value read from Avro to a ColumnUpdateDetails instance.
+   *
+   * <p>When reading from Avro, ColumnUpdateDetails are returned as a StructLike implementation.
+   * This method handles the conversion to ColumnUpdateDetails.
+   */
+  private static List<ColumnUpdateDetails> toColumnUpdateDetails(Object value) {
+    if (value == null) {
+      return null;
+    }
+
+    if (value instanceof List) {
+      List<Object> objectList = (List<Object>) value;
+
+      List<ColumnUpdateDetails> result = Lists.newArrayList();
+      for (Object item : objectList) {
+        if (item instanceof StructLike struct) {
+          List<Integer> fieldIds = (List<Integer>) struct.get(0, List.class);
+          String filePath = struct.get(1, String.class);
+          result.add(BaseColumnUpdateDetails.of(fieldIds, filePath));
+        } else {
+          throw new IllegalArgumentException(
+              "Cannot convert value of type "
+                  + item.getClass().getName()
+                  + " to ColumnUpdateDetails");
+        }
+      }
+
+      return result;
+    }
+
+    throw new IllegalArgumentException(
+        "Cannot convert value of type "
+            + value.getClass().getName()
+            + " to ColumnUpdateDetails list");
   }
 
   protected abstract Schema getAvroSchema(Types.StructType partitionStruct);
@@ -382,6 +489,9 @@ abstract class BaseFile<F> extends SupportsIndexProjection
       case 21:
         this.fileOrdinal = (long) value;
         return;
+      case 22:
+        this.columnUpdateDetails = toColumnUpdateDetails(value);
+        return;
       default:
         // ignore the object, it must be from a newer version of the format
     }
@@ -438,6 +548,8 @@ abstract class BaseFile<F> extends SupportsIndexProjection
         return contentSizeInBytes;
       case 21:
         return fileOrdinal;
+      case 22:
+        return columnUpdateDetails;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
     }
@@ -630,6 +742,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
         .add("referenced_data_file", referencedDataFile == null ? "null" : referencedDataFile)
         .add("content_offset", contentOffset == null ? "null" : contentOffset)
         .add("content_size_in_bytes", contentSizeInBytes == null ? "null" : contentSizeInBytes)
+        // TODO gaborkaszab: add column updates
         .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -50,7 +50,8 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
           "partition",
           "key_metadata",
           "split_offsets",
-          "sort_order_id");
+          "sort_order_id",
+          "column_updates");
 
   private static final List<String> STATS_COLUMNS =
       ImmutableList.of(

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -197,6 +197,11 @@ public class BaseTable
   }
 
   @Override
+  public ColumnUpdate newColumnUpdate() {
+    return new BaseColumnUpdate(name, ops).reportWith(reporter);
+  }
+
+  @Override
   public RewriteFiles newRewrite() {
     return new BaseRewriteFiles(name, ops).reportWith(reporter);
   }

--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -175,6 +175,7 @@ public class ContentFileParser {
     Long contentOffset = JsonUtil.getLongOrNull(CONTENT_OFFSET, jsonNode);
     Long contentSizeInBytes = JsonUtil.getLongOrNull(CONTENT_SIZE, jsonNode);
 
+    // TODO gaborkaszab: should I pass column updates too?
     if (fileContent == FileContent.DATA) {
       return new GenericDataFile(
           specId,
@@ -186,7 +187,8 @@ public class ContentFileParser {
           keyMetadata,
           splitOffsets,
           sortOrderId,
-          firstRowId);
+          firstRowId,
+          null /* column update details */);
     } else {
       return new GenericDeleteFile(
           specId,

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -157,6 +157,7 @@ public class DataFiles {
     private List<Long> splitOffsets = null;
     private Integer sortOrderId = SortOrder.unsorted().orderId();
     private Long firstRowId = null;
+    private List<ContentFile.ColumnUpdateDetails> columnUpdateDetails = null;
 
     public Builder(PartitionSpec spec) {
       this.spec = spec;
@@ -182,6 +183,7 @@ public class DataFiles {
       this.splitOffsets = null;
       this.sortOrderId = SortOrder.unsorted().orderId();
       this.firstRowId = null;
+      this.columnUpdateDetails = null;
     }
 
     public Builder copy(DataFile toCopy) {
@@ -206,6 +208,7 @@ public class DataFiles {
           toCopy.splitOffsets() == null ? null : ImmutableList.copyOf(toCopy.splitOffsets());
       this.sortOrderId = toCopy.sortOrderId();
       this.firstRowId = toCopy.firstRowId();
+      this.columnUpdateDetails = toCopy.columnUpdateDetails();
       return this;
     }
 
@@ -331,6 +334,11 @@ public class DataFiles {
       return this;
     }
 
+    public Builder withColumnUpdates(List<ContentFile.ColumnUpdateDetails> newColumnUpdateDetails) {
+      this.columnUpdateDetails = newColumnUpdateDetails;
+      return this;
+    }
+
     public DataFile build() {
       Preconditions.checkArgument(filePath != null, "File path is required");
       if (format == null) {
@@ -358,7 +366,8 @@ public class DataFiles {
           keyMetadata,
           splitOffsets,
           sortOrderId,
-          firstRowId);
+          firstRowId,
+          columnUpdateDetails);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/Delegates.java
+++ b/core/src/main/java/org/apache/iceberg/Delegates.java
@@ -278,6 +278,11 @@ class Delegates {
     }
 
     @Override
+    public List<ColumnUpdateDetails> columnUpdateDetails() {
+      return wrapped.columnUpdateDetails();
+    }
+
+    @Override
     public F copy() {
       throw new IllegalArgumentException("Cannot copy wrapped DataFile");
     }

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -47,7 +47,8 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
       ByteBuffer keyMetadata,
       List<Long> splitOffsets,
       Integer sortOrderId,
-      Long firstRowId) {
+      Long firstRowId,
+      List<ContentFile.ColumnUpdateDetails> columnUpdateDetails) {
     super(
         specId,
         FileContent.DATA,
@@ -69,7 +70,8 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
         firstRowId,
         null /* no referenced data file */,
         null /* no content offset */,
-        null /* no content size */);
+        null /* no content size */,
+        columnUpdateDetails);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -73,7 +73,8 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
         null /* delete files do not use first-row-id */,
         referencedDataFile,
         contentOffset,
-        contentSizeInBytes);
+        contentSizeInBytes,
+        null /* delete files do not use column update details */);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/V4Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V4Metadata.java
@@ -299,7 +299,8 @@ class V4Metadata {
         DataFile.FIRST_ROW_ID,
         DataFile.REFERENCED_DATA_FILE,
         DataFile.CONTENT_OFFSET,
-        DataFile.CONTENT_SIZE);
+        DataFile.CONTENT_SIZE,
+        DataFile.COLUMN_UPDATES);
   }
 
   static class ManifestEntryWrapper<F extends ContentFile<F>>
@@ -506,6 +507,12 @@ class V4Metadata {
         case 19:
           if (wrapped.content() == FileContent.POSITION_DELETES) {
             return ((DeleteFile) wrapped).contentSizeInBytes();
+          } else {
+            return null;
+          }
+        case 20:
+          if (wrapped.content() == FileContent.DATA) {
+            return wrapped.columnUpdateDetails();
           } else {
             return null;
           }

--- a/core/src/test/java/org/apache/iceberg/DataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DataTableScanTestBase.java
@@ -27,10 +27,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceMap;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -309,5 +313,88 @@ public abstract class DataTableScanTestBase<
             .collect(Collectors.toList())
             .get(0);
     assertThat(deletes.get(0).manifestLocation()).isEqualTo(deleteManifest.path());
+  }
+
+  @TestTemplate
+  public void testManifestEntriesWithColumnUpdates() throws IOException {
+    assumeThat(formatVersion).isEqualTo(4);
+
+    DataFile dataFileToUpdate =
+        DataFiles.builder(table.spec())
+            .withPath("/path/to/data-with-stats-" + UUID.randomUUID() + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(100)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(10)
+            .withMetrics(
+                new Metrics(
+                    10L,
+                    null, // column sizes
+                    null, // value counts
+                    null, // null value counts
+                    null, // nan value counts
+                    ImmutableMap.of(
+                        1, Conversions.toByteBuffer(Types.IntegerType.get(), 5)), // lower bounds
+                    ImmutableMap.of(
+                        1, Conversions.toByteBuffer(Types.IntegerType.get(), 15)))) // upper bounds
+            .build();
+
+    DataFile dataFileNotToUpdate =
+        DataFiles.builder(table.spec())
+            .withPath("/path/to/other-data-with-stats-" + UUID.randomUUID() + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(100)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(10)
+            .withMetrics(
+                new Metrics(
+                    10L,
+                    null, // column sizes
+                    null, // value counts
+                    null, // null value counts
+                    null, // nan value counts
+                    ImmutableMap.of(
+                        1, Conversions.toByteBuffer(Types.IntegerType.get(), 9)), // lower bounds
+                    ImmutableMap.of(
+                        1, Conversions.toByteBuffer(Types.IntegerType.get(), 11)))) // upper bounds
+            .build();
+
+    table.newFastAppend().appendFile(dataFileToUpdate).appendFile(dataFileNotToUpdate).commit();
+
+    DataFile updateFile =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-update.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .withMetrics(
+                new Metrics(
+                    1L,
+                    null, // column sizes
+                    null, // value counts
+                    null, // null value counts
+                    null, // nan value counts
+                    ImmutableMap.of(
+                        1, Conversions.toByteBuffer(Types.IntegerType.get(), 2)), // lower bounds
+                    ImmutableMap.of(
+                        1, Conversions.toByteBuffer(Types.IntegerType.get(), 5)))) // upper bounds
+            .build();
+
+    table
+        .newColumnUpdate()
+        .withFieldIds(List.of(1))
+        .addColumnUpdate(dataFileToUpdate, updateFile)
+        .commit();
+
+    ScanT scan = newScan().filter(Expressions.equal("id", 10));
+    try (CloseableIterable<T> scanTasks = scan.planFiles()) {
+      List<T> tasks = Lists.newArrayList(scanTasks);
+      assertThat(tasks).as("Should have one file matching the filter").hasSize(1);
+      for (T task : tasks) {
+        FileScanTask fileScanTask = (FileScanTask) task;
+        assertThat(fileScanTask).isNotNull();
+        assertThat(fileScanTask.file().location()).isEqualTo(dataFileNotToUpdate.location());
+      }
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestColumnUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestColumnUpdate.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestColumnUpdate extends TestBase {
+  private static final int FORMAT_VERSION = 4;
+  @TempDir private File tablePath;
+
+  @Test
+  public void invalidParameters() {
+    BaseTable table =
+        TestTables.create(tablePath, "invalid_params_test", SCHEMA, SPEC, FORMAT_VERSION);
+    table.newAppend().appendFile(FILE_A).commit();
+
+    DataFile updateFile =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-update.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    assertThatThrownBy(() -> table.newColumnUpdate().addColumnUpdate(FILE_A, updateFile).commit())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("No field IDs provided");
+
+    assertThatThrownBy(() -> table.newColumnUpdate().withFieldIds(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid field IDs: null");
+
+    assertThatThrownBy(() -> table.newColumnUpdate().withFieldIds(List.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid field IDs: empty");
+
+    assertThatThrownBy(
+            () ->
+                table.newColumnUpdate().withFieldIds(List.of(1)).addColumnUpdate(null, updateFile))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Base file is null");
+
+    assertThatThrownBy(
+            () -> table.newColumnUpdate().withFieldIds(List.of(1)).addColumnUpdate(FILE_A, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Column update file is null");
+
+    // Test mismatched spec IDs
+    PartitionSpec specWithDifferentId =
+        PartitionSpec.builderFor(SCHEMA).withSpecId(99).bucket("data", BUCKETS_NUMBER).build();
+    DataFile updateFileDifferentSpec =
+        DataFiles.builder(specWithDifferentId)
+            .withPath("/path/to/data-update-different-spec.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                table
+                    .newColumnUpdate()
+                    .withFieldIds(List.of(1))
+                    .addColumnUpdate(FILE_A, updateFileDifferentSpec))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Base file spec ID")
+        .hasMessageContaining("doesn't match update file spec ID");
+
+    DataFile updateFileMoreRows =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-update-more-rows.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(100) // more rows than FILE_A
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                table
+                    .newColumnUpdate()
+                    .withFieldIds(List.of(1))
+                    .addColumnUpdate(FILE_A, updateFileMoreRows))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Update file can't have more rows than the base file");
+  }
+
+  @TestTemplate
+  public void unsupportedFormatVersions() {
+    assumeThat(formatVersion).isLessThan(4);
+
+    File tableDir = new File(tablePath, "v" + formatVersion);
+    BaseTable table =
+        TestTables.create(
+            tableDir, "old_format_test_v" + formatVersion, SCHEMA, SPEC, formatVersion);
+    table.newAppend().appendFile(FILE_A).commit();
+
+    DataFile updateFile =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-update.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                table
+                    .newColumnUpdate()
+                    .withFieldIds(List.of(1))
+                    .addColumnUpdate(FILE_A, updateFile)
+                    .commit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Column updates are supported from V4");
+  }
+
+  @Test
+  public void updateOnEmptyTable() {
+    BaseTable table =
+        TestTables.create(tablePath, "empty_table_test", SCHEMA, SPEC, FORMAT_VERSION);
+
+    assertThatThrownBy(
+            () ->
+                table
+                    .newColumnUpdate()
+                    .withFieldIds(List.of(1))
+                    .addColumnUpdate(FILE_A, FILE_B)
+                    .commit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Column update is not supported on empty tables");
+  }
+
+  @Test
+  public void fileToUpdateNotFound() {
+    BaseTable table =
+        TestTables.create(
+            tablePath, "referenced_file_not_found_test", SCHEMA, SPEC, FORMAT_VERSION);
+    table.newAppend().appendFile(FILE_A).commit();
+
+    DataFile updateFile =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-a_update1.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                table
+                    .newColumnUpdate()
+                    .withFieldIds(List.of(1))
+                    .addColumnUpdate(FILE_B, updateFile)
+                    .commit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unable to find base data file: /path/to/data-b.parquet");
+  }
+
+  @Test
+  public void noUpdateFilesProvided() {
+    BaseTable table =
+        TestTables.create(tablePath, "no_update_files_test", SCHEMA, SPEC, FORMAT_VERSION);
+    table.newAppend().appendFile(FILE_A).commit();
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
+    ManifestFile manifestBeforeUpdate = table.currentSnapshot().allManifests(table.io()).get(0);
+
+    table.newColumnUpdate().withFieldIds(List.of(1)).commit();
+
+    assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
+    ManifestFile manifestAfterUpdate = table.currentSnapshot().allManifests(table.io()).get(0);
+    assertThat(manifestBeforeUpdate).isEqualTo(manifestAfterUpdate);
+  }
+
+  @Test
+  public void updateSingleColumn() throws IOException {
+    BaseTable table =
+        TestTables.create(tablePath, "update_column_test", SCHEMA, SPEC, FORMAT_VERSION);
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newAppend().appendFile(FILE_B).commit();
+
+    List<ManifestFile> manifestsBeforeUpdate = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifestsBeforeUpdate).hasSize(2);
+
+    ManifestFile manifestToKeepIntact = null;
+    ManifestEntry<DataFile> fileAEntryBeforeUpdate = null;
+    ManifestEntry<DataFile> fileBEntryBeforeUpdate = null;
+    for (ManifestFile manifest : manifestsBeforeUpdate) {
+      if (manifest.addedFilesCount() == 2) {
+        fileAEntryBeforeUpdate = findEntryInManifest(manifest, FILE_A.location(), table.io());
+        fileBEntryBeforeUpdate = findEntryInManifest(manifest, FILE_B.location(), table.io());
+      } else {
+        manifestToKeepIntact = manifest;
+      }
+    }
+
+    DataFile updateFileA =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-a_update1.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    table.newColumnUpdate().withFieldIds(List.of(1)).addColumnUpdate(FILE_A, updateFileA).commit();
+
+    List<ManifestFile> manifestsAfterUpdate = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifestsAfterUpdate).hasSize(2);
+    // One manifest should be entirely unchanged
+    assertThat(manifestsAfterUpdate).contains(manifestToKeepIntact);
+
+    ManifestFile tmpManifest = manifestToKeepIntact;
+    ManifestFile updatedManifest =
+        manifestsAfterUpdate.stream().filter(m -> !m.equals(tmpManifest)).findFirst().get();
+    List<ManifestEntry<DataFile>> entriesAfterUpdate = Lists.newArrayList();
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(updatedManifest, table.io())) {
+      for (ManifestEntry<DataFile> entry : reader.entries()) {
+        entriesAfterUpdate.add(entry.copy());
+      }
+    }
+    assertThat(entriesAfterUpdate).hasSize(2);
+
+    ManifestEntry<DataFile> fileAEntryAfterUpdate =
+        findEntryInManifest(updatedManifest, FILE_A.location(), table.io());
+    ManifestEntry<DataFile> fileBEntryAfterUpdate =
+        findEntryInManifest(updatedManifest, FILE_B.location(), table.io());
+
+    // FILE_B entry should be unchanged
+    assertThat(fileBEntryAfterUpdate.status()).isEqualTo(fileBEntryBeforeUpdate.status());
+    assertThat(fileBEntryAfterUpdate.snapshotId()).isEqualTo(fileBEntryBeforeUpdate.snapshotId());
+    assertThat(fileBEntryAfterUpdate.file().columnUpdateDetails())
+        .isEqualTo(fileBEntryBeforeUpdate.file().columnUpdateDetails());
+
+    // FILE_A entry should have column update details set
+    assertThat(fileAEntryBeforeUpdate.file().columnUpdateDetails()).isNull();
+    assertThat(fileAEntryAfterUpdate.file().columnUpdateDetails()).isNotNull();
+    assertThat(fileAEntryAfterUpdate.file().columnUpdateDetails()).hasSize(1);
+    assertThat(fileAEntryAfterUpdate.file().columnUpdateDetails().get(0).fieldIds())
+        .isEqualTo(List.of(1));
+    assertThat(fileAEntryAfterUpdate.file().columnUpdateDetails().get(0).filePath())
+        .isEqualTo(updateFileA.location());
+  }
+
+  @Test
+  public void updateColumnWithFieldIdOverlap() throws IOException {
+    BaseTable table =
+        TestTables.create(tablePath, "update_column_overlap_test", SCHEMA, SPEC, FORMAT_VERSION);
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    DataFile updateFileA =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-a_update1.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    table
+        .newColumnUpdate()
+        .withFieldIds(List.of(1, 2))
+        .addColumnUpdate(FILE_A, updateFileA)
+        .commit();
+
+    DataFile updateFileB =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-a_update2.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    table
+        .newColumnUpdate()
+        .withFieldIds(List.of(2, 3))
+        .addColumnUpdate(FILE_A, updateFileB)
+        .commit();
+
+    List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifests).hasSize(1);
+
+    ManifestEntry<DataFile> fileAEntry =
+        findEntryInManifest(manifests.iterator().next(), FILE_A.location(), table.io());
+    assertThat(fileAEntry.file().columnUpdateDetails()).hasSize(2);
+    assertThat(fileAEntry.file().columnUpdateDetails().get(0).fieldIds()).isEqualTo(List.of(1));
+    assertThat(fileAEntry.file().columnUpdateDetails().get(0).filePath())
+        .isEqualTo(updateFileA.location());
+    assertThat(fileAEntry.file().columnUpdateDetails().get(1).fieldIds()).isEqualTo(List.of(2, 3));
+    assertThat(fileAEntry.file().columnUpdateDetails().get(1).filePath())
+        .isEqualTo(updateFileB.location());
+  }
+
+  @Test
+  public void updateColumnWithSameFieldIds() throws IOException {
+    BaseTable table =
+        TestTables.create(tablePath, "update_same_columns_test", SCHEMA, SPEC, FORMAT_VERSION);
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    DataFile updateFileA1 =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-a_update1.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    table
+        .newColumnUpdate()
+        .withFieldIds(List.of(1, 2))
+        .addColumnUpdate(FILE_A, updateFileA1)
+        .commit();
+
+    DataFile updateFileA2 =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-a_update2.parquet")
+            .withFileSizeInBytes(2)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    table
+        .newColumnUpdate()
+        .withFieldIds(List.of(1, 2))
+        .addColumnUpdate(FILE_A, updateFileA2)
+        .commit();
+
+    List<ManifestFile> manifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(manifests).hasSize(1);
+
+    ManifestEntry<DataFile> fileAEntry =
+        findEntryInManifest(manifests.iterator().next(), FILE_A.location(), table.io());
+    assertThat(fileAEntry.file().columnUpdateDetails()).hasSize(1);
+    assertThat(fileAEntry.file().columnUpdateDetails().get(0).fieldIds()).isEqualTo(List.of(1, 2));
+    assertThat(fileAEntry.file().columnUpdateDetails().get(0).filePath())
+        .isEqualTo(updateFileA2.location());
+  }
+
+  private ManifestEntry<DataFile> findEntryInManifest(
+      ManifestFile manifest, String fileLocation, FileIO io) throws IOException {
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io)) {
+      for (ManifestEntry<DataFile> entry : reader.entries()) {
+        if (entry.file().location().equals(fileLocation)) {
+          return entry.copy();
+        }
+      }
+    }
+    throw new IllegalStateException("No manifest found containing file: " + fileLocation);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -87,7 +87,17 @@ public class TestManifestWriterVersions {
 
   private static final DataFile DATA_FILE =
       new GenericDataFile(
-          0, PATH, FORMAT, PARTITION, 150972L, METRICS, null, OFFSETS, SORT_ORDER_ID, FIRST_ROW_ID);
+          0,
+          PATH,
+          FORMAT,
+          PARTITION,
+          150972L,
+          METRICS,
+          null,
+          OFFSETS,
+          SORT_ORDER_ID,
+          FIRST_ROW_ID,
+          null);
 
   private static final List<Integer> EQUALITY_IDS = ImmutableList.of(1);
   private static final int[] EQUALITY_ID_ARR = new int[] {1};


### PR DESCRIPTION
Content:
  - Column update table metadata
  - API to write column update metadata
  - Changes to read and write column update metadata to manifest entries
  - Bunch of TODOs :)

Details:
  - No overlap in field IDs across column updates. Overlapping field IDs removed from older column updates when committing a new one
  - Column updates covers entire data files (no partial column updates)
  - Follow the approach from [the proposal](https://docs.google.com/document/d/1Bd7JVzgajA8-DozzeEE24mID_GLuz6iwj0g4TlcVJcs/edit?usp=sharing) where manifests are cloned with same content but new column update metadata
  - Other approach (delete manifest + new manifest file) depends on V4, not covered now
  - Integrated into V3 metadata with made up field IDs. Will have to adjust for V4 once available