### PR TITLE
Core, AWS: Adapt code to S3 signing endpoint promotion

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
@@ -18,17 +18,6 @@
  */
 package org.apache.iceberg.aws.s3.signer;
 
-import static java.lang.String.format;
-import static org.apache.iceberg.rest.RESTCatalogAdapter.castRequest;
-import static org.apache.iceberg.rest.RESTCatalogAdapter.castResponse;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -37,23 +26,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.iceberg.exceptions.RESTException;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.relocated.com.google.common.io.CharStreams;
-import org.apache.iceberg.rest.RESTUtil;
-import org.apache.iceberg.rest.ResourcePaths;
-import org.apache.iceberg.rest.responses.ErrorResponse;
-import org.apache.iceberg.rest.responses.OAuthTokenResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.iceberg.rest.HttpMethod;
+import org.apache.iceberg.rest.RemoteSignerServlet;
+import org.apache.iceberg.rest.requests.RemoteSignRequest;
+import org.apache.iceberg.rest.responses.ImmutableRemoteSignResponse;
+import org.apache.iceberg.rest.responses.RemoteSignResponse;
 import software.amazon.awssdk.auth.signer.AwsS3V4Signer;
 import software.amazon.awssdk.auth.signer.params.AwsS3V4SignerParams;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -65,113 +46,37 @@ import software.amazon.awssdk.regions.Region;
  * {@link S3SignerServlet} provides a simple servlet implementation to emulate the server-side
  * behavior of signing S3 requests and handling OAuth.
  */
-public class S3SignerServlet extends HttpServlet {
-
-  private static final Logger LOG = LoggerFactory.getLogger(S3SignerServlet.class);
+public class S3SignerServlet extends RemoteSignerServlet {
 
   static final Clock SIGNING_CLOCK = Clock.fixed(Instant.now(), ZoneId.of("UTC"));
   static final Set<String> UNSIGNED_HEADERS =
       Sets.newHashSet(
           Arrays.asList("range", "x-amz-date", "amz-sdk-invocation-id", "amz-sdk-retry"));
-  private static final String POST = "POST";
 
-  private static final Set<SdkHttpMethod> CACHEABLE_METHODS =
-      Stream.of(SdkHttpMethod.GET, SdkHttpMethod.HEAD).collect(Collectors.toSet());
+  /** A fake remote signing endpoint for testing purposes. */
+  static final String S3_SIGNER_ENDPOINT = "v1/namespaces/ns1/tables/t1/sign";
 
-  private final Map<String, String> responseHeaders =
-      ImmutableMap.of(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
-  private final ObjectMapper mapper;
+  public S3SignerServlet() {
+    super(S3_SIGNER_ENDPOINT);
+  }
 
-  private List<SignRequestValidator> s3SignRequestValidators = Lists.newArrayList();
-
-  /**
-   * SignRequestValidator is a wrapper class used for validating the contents of the S3SignRequest
-   * and thus verifying the behavior of the client during testing.
-   */
-  public static class SignRequestValidator {
-    private final Predicate<S3SignRequest> requestMatcher;
-    private final Predicate<S3SignRequest> requestExpectation;
-    private final String assertMessage;
-
-    public SignRequestValidator(
-        Predicate<S3SignRequest> requestExpectation,
-        Predicate<S3SignRequest> requestMatcher,
-        String assertMessage) {
-      this.requestExpectation = requestExpectation;
-      this.requestMatcher = requestMatcher;
-      this.assertMessage = assertMessage;
-    }
-
-    void validateRequest(S3SignRequest request) {
-      if (requestMatcher.test(request)) {
-        assertThat(requestExpectation.test(request)).as(assertMessage).isTrue();
-      }
+  @Override
+  protected void validateSignRequest(RemoteSignRequest request) {
+    Preconditions.checkArgument(
+        request.provider() == null || "s3".equalsIgnoreCase(request.provider()),
+        "Unsupported provider: %s",
+        request.provider());
+    if (HttpMethod.POST.name().equalsIgnoreCase(request.method())
+        && request.uri().getQuery().contains("delete")) {
+      String body = request.body();
+      Preconditions.checkArgument(
+          body != null && !body.isEmpty(),
+          "Sign request for delete objects should have a request body");
     }
   }
 
-  public S3SignerServlet(ObjectMapper mapper) {
-    this.mapper = mapper;
-  }
-
-  public S3SignerServlet(ObjectMapper mapper, List<SignRequestValidator> s3SignRequestValidators) {
-    this.mapper = mapper;
-    this.s3SignRequestValidators = s3SignRequestValidators;
-  }
-
   @Override
-  protected void doGet(HttpServletRequest request, HttpServletResponse response) {
-    execute(request, response);
-  }
-
-  @Override
-  protected void doHead(HttpServletRequest request, HttpServletResponse response) {
-    execute(request, response);
-  }
-
-  @Override
-  protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-    execute(request, response);
-  }
-
-  @Override
-  protected void doDelete(HttpServletRequest request, HttpServletResponse response) {
-    execute(request, response);
-  }
-
-  private OAuthTokenResponse handleOAuth(Map<String, String> requestMap) {
-    String grantType = requestMap.get("grant_type");
-    switch (grantType) {
-      case "client_credentials":
-        return castResponse(
-            OAuthTokenResponse.class,
-            OAuthTokenResponse.builder()
-                .withToken("client-credentials-token:sub=" + requestMap.get("client_id"))
-                .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
-                .withTokenType("Bearer")
-                .setExpirationInSeconds(10000)
-                .build());
-
-      case "urn:ietf:params:oauth:grant-type:token-exchange":
-        String actor = requestMap.get("actor_token");
-        String token =
-            String.format(
-                "token-exchange-token:sub=%s%s",
-                requestMap.get("subject_token"), actor != null ? ",act=" + actor : "");
-        return castResponse(
-            OAuthTokenResponse.class,
-            OAuthTokenResponse.builder()
-                .withToken(token)
-                .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
-                .withTokenType("Bearer")
-                .setExpirationInSeconds(10000)
-                .build());
-
-      default:
-        throw new UnsupportedOperationException("Unsupported grant_type: " + grantType);
-    }
-  }
-
-  private S3SignResponse signRequest(S3SignRequest request) {
+  protected RemoteSignResponse signRequest(RemoteSignRequest request) {
     AwsS3V4SignerParams signingParams =
         AwsS3V4SignerParams.builder()
             .awsCredentials(TestS3RestSigner.CREDENTIALS_PROVIDER.resolveCredentials())
@@ -207,59 +112,6 @@ public class S3SignerServlet extends HttpServlet {
     Map<String, List<String>> headers = Maps.newHashMap(sign.headers());
     headers.putAll(unsignedHeaders);
 
-    return ImmutableS3SignResponse.builder().uri(request.uri()).headers(headers).build();
-  }
-
-  protected void execute(HttpServletRequest request, HttpServletResponse response) {
-    response.setStatus(HttpServletResponse.SC_OK);
-    responseHeaders.forEach(response::setHeader);
-
-    String path = request.getRequestURI().substring(1);
-    Object requestBody;
-    try {
-      // we only need to handle oauth tokens & s3 sign request routes here as those are the only
-      // requests that are being done by the S3V4RestSignerClient
-      if (POST.equals(request.getMethod())
-          && S3V4RestSignerClient.S3_SIGNER_DEFAULT_ENDPOINT.equals(path)) {
-        S3SignRequest s3SignRequest =
-            castRequest(
-                S3SignRequest.class, mapper.readValue(request.getReader(), S3SignRequest.class));
-        s3SignRequestValidators.forEach(validator -> validator.validateRequest(s3SignRequest));
-        S3SignResponse s3SignResponse = signRequest(s3SignRequest);
-        if (CACHEABLE_METHODS.contains(SdkHttpMethod.fromValue(s3SignRequest.method()))) {
-          // tell the client this can be cached
-          response.setHeader(
-              S3V4RestSignerClient.CACHE_CONTROL, S3V4RestSignerClient.CACHE_CONTROL_PRIVATE);
-        } else {
-          response.setHeader(
-              S3V4RestSignerClient.CACHE_CONTROL, S3V4RestSignerClient.CACHE_CONTROL_NO_CACHE);
-        }
-
-        mapper.writeValue(response.getWriter(), s3SignResponse);
-      } else if (POST.equals(request.getMethod()) && ResourcePaths.tokens().equals(path)) {
-        try (Reader reader = new InputStreamReader(request.getInputStream())) {
-          requestBody = RESTUtil.decodeFormData(CharStreams.toString(reader));
-        }
-
-        OAuthTokenResponse oAuthTokenResponse =
-            handleOAuth((Map<String, String>) castRequest(Map.class, requestBody));
-        mapper.writeValue(response.getWriter(), oAuthTokenResponse);
-      } else {
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        mapper.writeValue(
-            response.getWriter(),
-            ErrorResponse.builder()
-                .responseCode(400)
-                .withType("BadRequestException")
-                .withMessage(format("No route for request: %s %s", request.getMethod(), path))
-                .build());
-      }
-    } catch (RESTException e) {
-      LOG.error("Error processing REST request", e);
-      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    } catch (Exception e) {
-      LOG.error("Unexpected exception when processing REST request", e);
-      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    }
+    return ImmutableRemoteSignResponse.builder().uri(request.uri()).headers(headers).build();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
@@ -33,8 +33,8 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.iceberg.aws.s3.MinioUtil;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.RESTCatalogProperties;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.util.ThreadPools;
 import org.eclipse.jetty.server.Server;
@@ -107,8 +107,10 @@ public class TestS3RestSigner {
             ImmutableS3V4RestSignerClient.builder()
                 .properties(
                     ImmutableMap.of(
-                        S3V4RestSignerClient.S3_SIGNER_URI,
+                        RESTCatalogProperties.SIGNER_URI,
                         httpServer.getURI().toString(),
+                        RESTCatalogProperties.SIGNER_ENDPOINT,
+                        S3SignerServlet.S3_SIGNER_ENDPOINT,
                         OAuth2Properties.CREDENTIAL,
                         "catalog:12345"))
                 .build(),
@@ -182,15 +184,7 @@ public class TestS3RestSigner {
   }
 
   private static Server initHttpServer() throws Exception {
-    S3SignerServlet.SignRequestValidator deleteObjectsWithBody =
-        new S3SignerServlet.SignRequestValidator(
-            (s3SignRequest) ->
-                "post".equalsIgnoreCase(s3SignRequest.method())
-                    && s3SignRequest.uri().getQuery().contains("delete"),
-            (s3SignRequest) -> s3SignRequest.body() != null && !s3SignRequest.body().isEmpty(),
-            "Sign request for delete objects should have a request body");
-    S3SignerServlet servlet =
-        new S3SignerServlet(S3ObjectMapper.mapper(), ImmutableList.of(deleteObjectsWithBody));
+    S3SignerServlet servlet = new S3SignerServlet();
     ServletContextHandler servletContext =
         new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
     servletContext.addServlet(new ServletHolder(servlet), "/*");

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3ObjectMapper.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3ObjectMapper.java
@@ -40,6 +40,10 @@ import org.apache.iceberg.rest.RESTSerializers.OAuthTokenResponseSerializer;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 
+/**
+ * @deprecated since 1.11.0, will be removed in 1.12.0; use {@code RESTObjectMapper} instead.
+ */
+@Deprecated
 public class S3ObjectMapper {
 
   private static final JsonFactory FACTORY = new JsonFactory();

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignRequest.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignRequest.java
@@ -18,31 +18,13 @@
  */
 package org.apache.iceberg.aws.s3.signer;
 
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import javax.annotation.Nullable;
-import org.apache.iceberg.rest.RESTRequest;
+import org.apache.iceberg.rest.requests.RemoteSignRequest;
 import org.immutables.value.Value;
 
+/**
+ * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link RemoteSignRequest} instead.
+ */
+@Deprecated
 @Value.Immutable
-public interface S3SignRequest extends RESTRequest {
-  String region();
-
-  String method();
-
-  URI uri();
-
-  Map<String, List<String>> headers();
-
-  Map<String, String> properties();
-
-  @Value.Default
-  @Nullable
-  default String body() {
-    return null;
-  }
-
-  @Override
-  default void validate() {}
-}
+@SuppressWarnings("immutables:subtype")
+public interface S3SignRequest extends RemoteSignRequest {}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignRequestParser.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignRequestParser.java
@@ -21,108 +21,47 @@ package org.apache.iceberg.aws.s3.signer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.rest.requests.RemoteSignRequest;
+import org.apache.iceberg.rest.requests.RemoteSignRequestParser;
 
+/**
+ * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link RemoteSignRequestParser} instead.
+ */
+@Deprecated
 public class S3SignRequestParser {
-
-  private static final String REGION = "region";
-  private static final String METHOD = "method";
-  private static final String URI = "uri";
-  private static final String HEADERS = "headers";
-  private static final String PROPERTIES = "properties";
-  private static final String BODY = "body";
 
   private S3SignRequestParser() {}
 
   public static String toJson(S3SignRequest request) {
-    return toJson(request, false);
+    return RemoteSignRequestParser.toJson(request, false);
   }
 
   public static String toJson(S3SignRequest request, boolean pretty) {
-    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+    return RemoteSignRequestParser.toJson(request, pretty);
   }
 
   public static void toJson(S3SignRequest request, JsonGenerator gen) throws IOException {
-    Preconditions.checkArgument(null != request, "Invalid s3 sign request: null");
-
-    gen.writeStartObject();
-
-    gen.writeStringField(REGION, request.region());
-    gen.writeStringField(METHOD, request.method());
-    gen.writeStringField(URI, request.uri().toString());
-    headersToJson(HEADERS, request.headers(), gen);
-
-    if (!request.properties().isEmpty()) {
-      JsonUtil.writeStringMap(PROPERTIES, request.properties(), gen);
-    }
-
-    if (request.body() != null && !request.body().isEmpty()) {
-      gen.writeStringField(BODY, request.body());
-    }
-
-    gen.writeEndObject();
+    RemoteSignRequestParser.toJson(request, gen);
   }
 
   public static S3SignRequest fromJson(String json) {
-    return JsonUtil.parse(json, S3SignRequestParser::fromJson);
+    RemoteSignRequest request = RemoteSignRequestParser.fromJson(json);
+    return ImmutableS3SignRequest.builder().from(request).build();
   }
 
   public static S3SignRequest fromJson(JsonNode json) {
-    Preconditions.checkArgument(null != json, "Cannot parse s3 sign request from null object");
-    Preconditions.checkArgument(
-        json.isObject(), "Cannot parse s3 sign request from non-object: %s", json);
-
-    String region = JsonUtil.getString(REGION, json);
-    String method = JsonUtil.getString(METHOD, json);
-    java.net.URI uri = java.net.URI.create(JsonUtil.getString(URI, json));
-    Map<String, List<String>> headers = headersFromJson(HEADERS, json);
-
-    ImmutableS3SignRequest.Builder builder =
-        ImmutableS3SignRequest.builder().region(region).method(method).uri(uri).headers(headers);
-
-    if (json.has(PROPERTIES)) {
-      builder.properties(JsonUtil.getStringMap(PROPERTIES, json));
-    }
-
-    if (json.has(BODY)) {
-      builder.body(JsonUtil.getString(BODY, json));
-    }
-
-    return builder.build();
+    RemoteSignRequest request = RemoteSignRequestParser.fromJson(json);
+    return ImmutableS3SignRequest.builder().from(request).build();
   }
 
   static void headersToJson(String property, Map<String, List<String>> headers, JsonGenerator gen)
       throws IOException {
-    gen.writeObjectFieldStart(property);
-    for (Entry<String, List<String>> entry : headers.entrySet()) {
-      gen.writeFieldName(entry.getKey());
-
-      gen.writeStartArray();
-      for (String val : entry.getValue()) {
-        gen.writeString(val);
-      }
-      gen.writeEndArray();
-    }
-    gen.writeEndObject();
+    RemoteSignRequestParser.headersToJson(property, headers, gen);
   }
 
   static Map<String, List<String>> headersFromJson(String property, JsonNode json) {
-    Map<String, List<String>> headers = Maps.newHashMap();
-    JsonNode headersNode = JsonUtil.get(property, json);
-    headersNode
-        .properties()
-        .forEach(
-            entry -> {
-              String key = entry.getKey();
-              List<String> values = Arrays.asList(JsonUtil.getStringArray(entry.getValue()));
-              headers.put(key, values);
-            });
-    return headers;
+    return RemoteSignRequestParser.headersFromJson(property, json);
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignResponseParser.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignResponseParser.java
@@ -21,49 +21,37 @@ package org.apache.iceberg.aws.s3.signer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.rest.responses.RemoteSignResponse;
+import org.apache.iceberg.rest.responses.RemoteSignResponseParser;
 
+/**
+ * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link RemoteSignResponseParser}
+ *     instead.
+ */
+@Deprecated
 public class S3SignResponseParser {
-
-  private static final String URI = "uri";
-  private static final String HEADERS = "headers";
 
   private S3SignResponseParser() {}
 
-  public static String toJson(S3SignResponse request) {
-    return toJson(request, false);
+  public static String toJson(S3SignResponse response) {
+    return RemoteSignResponseParser.toJson(response, false);
   }
 
-  public static String toJson(S3SignResponse request, boolean pretty) {
-    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+  public static String toJson(S3SignResponse response, boolean pretty) {
+    return RemoteSignResponseParser.toJson(response, pretty);
   }
 
   public static void toJson(S3SignResponse response, JsonGenerator gen) throws IOException {
-    Preconditions.checkArgument(null != response, "Invalid s3 sign response: null");
-
-    gen.writeStartObject();
-
-    gen.writeStringField(URI, response.uri().toString());
-    S3SignRequestParser.headersToJson(HEADERS, response.headers(), gen);
-
-    gen.writeEndObject();
+    RemoteSignResponseParser.toJson(response, gen);
   }
 
   public static S3SignResponse fromJson(String json) {
-    return JsonUtil.parse(json, S3SignResponseParser::fromJson);
+    RemoteSignResponse result = RemoteSignResponseParser.fromJson(json);
+    return ImmutableS3SignResponse.builder().from(result).build();
   }
 
   public static S3SignResponse fromJson(JsonNode json) {
-    Preconditions.checkArgument(null != json, "Cannot parse s3 sign response from null object");
-    Preconditions.checkArgument(
-        json.isObject(), "Cannot parse s3 sign response from non-object: %s", json);
-
-    java.net.URI uri = java.net.URI.create(JsonUtil.getString(URI, json));
-    Map<String, List<String>> headers = S3SignRequestParser.headersFromJson(HEADERS, json);
-
-    return ImmutableS3SignResponse.builder().uri(uri).headers(headers).build();
+    RemoteSignResponse result = RemoteSignResponseParser.fromJson(json);
+    return ImmutableS3SignResponse.builder().from(result).build();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -66,6 +66,8 @@ public class Endpoint {
       Endpoint.create("POST", ResourcePaths.V1_TABLE_METRICS);
   public static final Endpoint V1_TABLE_CREDENTIALS =
       Endpoint.create("GET", ResourcePaths.V1_TABLE_CREDENTIALS);
+  public static final Endpoint V1_TABLE_REMOTE_SIGN =
+      Endpoint.create("POST", ResourcePaths.V1_TABLE_REMOTE_SIGN);
 
   // table scan plan endpoints
   public static final Endpoint V1_SUBMIT_TABLE_SCAN_PLAN =

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.iceberg.CatalogProperties;
 
 public final class RESTCatalogProperties {
 
@@ -87,4 +88,16 @@ public final class RESTCatalogProperties {
                   .collect(Collectors.joining(", "))));
     }
   }
+
+  /**
+   * The base URI of the remote signer endpoint. Optional, defaults to {@link
+   * CatalogProperties#URI}.
+   */
+  public static final String SIGNER_URI = "signer.uri";
+
+  /**
+   * The endpoint path of the remote signer endpoint. If remote signing has been requested, this
+   * must be set.
+   */
+  public static final String SIGNER_ENDPOINT = "signer.endpoint";
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.rest.requests.FetchScanTasksRequestParser;
 import org.apache.iceberg.rest.requests.ImmutableCreateViewRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterViewRequest;
+import org.apache.iceberg.rest.requests.ImmutableRemoteSignRequest;
 import org.apache.iceberg.rest.requests.ImmutableReportMetricsRequest;
 import org.apache.iceberg.rest.requests.PlanTableScanRequest;
 import org.apache.iceberg.rest.requests.PlanTableScanRequestParser;
@@ -60,6 +61,8 @@ import org.apache.iceberg.rest.requests.RegisterTableRequest;
 import org.apache.iceberg.rest.requests.RegisterTableRequestParser;
 import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RegisterViewRequestParser;
+import org.apache.iceberg.rest.requests.RemoteSignRequest;
+import org.apache.iceberg.rest.requests.RemoteSignRequestParser;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
@@ -74,6 +77,7 @@ import org.apache.iceberg.rest.responses.FetchScanTasksResponse;
 import org.apache.iceberg.rest.responses.FetchScanTasksResponseParser;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
+import org.apache.iceberg.rest.responses.ImmutableRemoteSignResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponseParser;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
@@ -83,6 +87,8 @@ import org.apache.iceberg.rest.responses.LoadViewResponseParser;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponseParser;
+import org.apache.iceberg.rest.responses.RemoteSignResponse;
+import org.apache.iceberg.rest.responses.RemoteSignResponseParser;
 import org.apache.iceberg.util.JsonUtil;
 
 public class RESTSerializers {
@@ -160,7 +166,15 @@ public class RESTSerializers {
             ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseSerializer<>())
         .addDeserializer(LoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>())
         .addDeserializer(
-            ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>());
+            ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>())
+        .addSerializer(RemoteSignRequest.class, new RemoteSignRequestSerializer<>())
+        .addSerializer(ImmutableRemoteSignRequest.class, new RemoteSignRequestSerializer<>())
+        .addDeserializer(RemoteSignRequest.class, new RemoteSignRequestDeserializer<>())
+        .addDeserializer(ImmutableRemoteSignRequest.class, new RemoteSignRequestDeserializer<>())
+        .addSerializer(RemoteSignResponse.class, new RemoteSignResponseSerializer<>())
+        .addSerializer(ImmutableRemoteSignResponse.class, new RemoteSignResponseSerializer<>())
+        .addDeserializer(RemoteSignResponse.class, new RemoteSignResponseDeserializer<>())
+        .addDeserializer(ImmutableRemoteSignResponse.class, new RemoteSignResponseDeserializer<>());
 
     mapper.registerModule(module);
   }
@@ -648,6 +662,41 @@ public class RESTSerializers {
 
     boolean isCaseSensitive() {
       return caseSensitive;
+    }
+  }
+
+  static class RemoteSignRequestSerializer<T extends RemoteSignRequest> extends JsonSerializer<T> {
+    @Override
+    public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      RemoteSignRequestParser.toJson(request, gen);
+    }
+  }
+
+  static class RemoteSignRequestDeserializer<T extends RemoteSignRequest>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) RemoteSignRequestParser.fromJson(jsonNode);
+    }
+  }
+
+  static class RemoteSignResponseSerializer<T extends RemoteSignResponse>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T response, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      RemoteSignResponseParser.toJson(response, gen);
+    }
+  }
+
+  static class RemoteSignResponseDeserializer<T extends RemoteSignResponse>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) RemoteSignResponseParser.fromJson(jsonNode);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -35,6 +35,8 @@ public class ResourcePaths {
   public static final String V1_TABLE = "/v1/{prefix}/namespaces/{namespace}/tables/{table}";
   public static final String V1_TABLE_CREDENTIALS =
       "/v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials";
+  public static final String V1_TABLE_REMOTE_SIGN =
+      "/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign";
   public static final String V1_TABLE_REGISTER = "/v1/{prefix}/namespaces/{namespace}/register";
   public static final String V1_TABLE_METRICS =
       "/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics";
@@ -128,6 +130,17 @@ public class ResourcePaths {
         "tables",
         RESTUtil.encodeString(identifier.name()),
         "metrics");
+  }
+
+  public String remoteSign(TableIdentifier identifier) {
+    return SLASH.join(
+        "v1",
+        prefix,
+        "namespaces",
+        pathEncode(identifier.namespace()),
+        "tables",
+        RESTUtil.encodeString(identifier.name()),
+        "sign");
   }
 
   public String commitTransaction() {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RemoteSignRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RemoteSignRequest.java
@@ -16,15 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.aws.s3.signer;
+package org.apache.iceberg.rest.requests;
 
-import org.apache.iceberg.rest.responses.RemoteSignResponse;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.iceberg.rest.RESTRequest;
 import org.immutables.value.Value;
 
-/**
- * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link RemoteSignResponse} instead.
- */
-@Deprecated
 @Value.Immutable
-@SuppressWarnings("immutables:subtype")
-public interface S3SignResponse extends RemoteSignResponse {}
+public interface RemoteSignRequest extends RESTRequest {
+  String region();
+
+  String method();
+
+  URI uri();
+
+  Map<String, List<String>> headers();
+
+  Map<String, String> properties();
+
+  @Value.Default
+  @Nullable
+  default String body() {
+    return null;
+  }
+
+  @Nullable
+  String provider();
+
+  @Override
+  default void validate() {}
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/RemoteSignRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RemoteSignRequestParser.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.JsonUtil;
+
+public class RemoteSignRequestParser {
+
+  private static final String REGION = "region";
+  private static final String METHOD = "method";
+  private static final String URI = "uri";
+  private static final String HEADERS = "headers";
+  private static final String PROPERTIES = "properties";
+  private static final String BODY = "body";
+  private static final String PROVIDER = "provider";
+
+  private RemoteSignRequestParser() {}
+
+  public static String toJson(RemoteSignRequest request) {
+    return toJson(request, false);
+  }
+
+  public static String toJson(RemoteSignRequest request, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+  }
+
+  public static void toJson(RemoteSignRequest request, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != request, "Invalid remote sign request: null");
+
+    gen.writeStartObject();
+
+    gen.writeStringField(REGION, request.region());
+    gen.writeStringField(METHOD, request.method());
+    gen.writeStringField(URI, request.uri().toString());
+    headersToJson(HEADERS, request.headers(), gen);
+
+    if (!request.properties().isEmpty()) {
+      JsonUtil.writeStringMap(PROPERTIES, request.properties(), gen);
+    }
+
+    if (request.body() != null && !request.body().isEmpty()) {
+      gen.writeStringField(BODY, request.body());
+    }
+
+    if (request.provider() != null) {
+      gen.writeStringField(PROVIDER, request.provider());
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static RemoteSignRequest fromJson(String json) {
+    return JsonUtil.parse(json, RemoteSignRequestParser::fromJson);
+  }
+
+  public static RemoteSignRequest fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse remote sign request from null object");
+    Preconditions.checkArgument(
+        json.isObject(), "Cannot parse remote sign request from non-object: %s", json);
+
+    String region = JsonUtil.getString(REGION, json);
+    String method = JsonUtil.getString(METHOD, json);
+    java.net.URI uri = java.net.URI.create(JsonUtil.getString(URI, json));
+    Map<String, List<String>> headers = headersFromJson(HEADERS, json);
+
+    ImmutableRemoteSignRequest.Builder builder =
+        ImmutableRemoteSignRequest.builder()
+            .region(region)
+            .method(method)
+            .uri(uri)
+            .headers(headers);
+
+    if (json.has(PROPERTIES)) {
+      builder.properties(JsonUtil.getStringMap(PROPERTIES, json));
+    }
+
+    if (json.has(BODY)) {
+      builder.body(JsonUtil.getString(BODY, json));
+    }
+
+    if (json.has(PROVIDER)) {
+      builder.provider(JsonUtil.getString(PROVIDER, json));
+    }
+
+    return builder.build();
+  }
+
+  public static void headersToJson(
+      String property, Map<String, List<String>> headers, JsonGenerator gen) throws IOException {
+    gen.writeObjectFieldStart(property);
+    for (Entry<String, List<String>> entry : headers.entrySet()) {
+      gen.writeFieldName(entry.getKey());
+
+      gen.writeStartArray();
+      for (String val : entry.getValue()) {
+        gen.writeString(val);
+      }
+      gen.writeEndArray();
+    }
+    gen.writeEndObject();
+  }
+
+  public static Map<String, List<String>> headersFromJson(String property, JsonNode json) {
+    Map<String, List<String>> headers = Maps.newHashMap();
+    JsonNode headersNode = JsonUtil.get(property, json);
+    headersNode
+        .properties()
+        .forEach(
+            entry -> {
+              String key = entry.getKey();
+              List<String> values = Arrays.asList(JsonUtil.getStringArray(entry.getValue()));
+              headers.put(key, values);
+            });
+    return headers;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/RemoteSignResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/RemoteSignResponse.java
@@ -16,15 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.aws.s3.signer;
+package org.apache.iceberg.rest.responses;
 
-import org.apache.iceberg.rest.responses.RemoteSignResponse;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.rest.RESTResponse;
 import org.immutables.value.Value;
 
-/**
- * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link RemoteSignResponse} instead.
- */
-@Deprecated
 @Value.Immutable
-@SuppressWarnings("immutables:subtype")
-public interface S3SignResponse extends RemoteSignResponse {}
+public interface RemoteSignResponse extends RESTResponse {
+  URI uri();
+
+  Map<String, List<String>> headers();
+
+  @Override
+  default void validate() {}
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/RemoteSignResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/RemoteSignResponseParser.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.requests.RemoteSignRequestParser;
+import org.apache.iceberg.util.JsonUtil;
+
+public class RemoteSignResponseParser {
+
+  private static final String URI = "uri";
+  private static final String HEADERS = "headers";
+
+  private RemoteSignResponseParser() {}
+
+  public static String toJson(RemoteSignResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(RemoteSignResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(RemoteSignResponse response, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid remote sign response: null");
+
+    gen.writeStartObject();
+
+    gen.writeStringField(URI, response.uri().toString());
+    RemoteSignRequestParser.headersToJson(HEADERS, response.headers(), gen);
+
+    gen.writeEndObject();
+  }
+
+  public static RemoteSignResponse fromJson(String json) {
+    return JsonUtil.parse(json, RemoteSignResponseParser::fromJson);
+  }
+
+  public static RemoteSignResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse remote sign response from null object");
+    Preconditions.checkArgument(
+        json.isObject(), "Cannot parse remote sign response from non-object: %s", json);
+
+    java.net.URI uri = java.net.URI.create(JsonUtil.getString(URI, json));
+    Map<String, List<String>> headers = RemoteSignRequestParser.headersFromJson(HEADERS, json);
+
+    return ImmutableRemoteSignResponse.builder().uri(uri).headers(headers).build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/RemoteSignResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/RemoteSignResponseParser.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.rest.responses;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -29,7 +30,7 @@ import org.apache.iceberg.util.JsonUtil;
 
 public class RemoteSignResponseParser {
 
-  private static final String URI = "uri";
+  private static final String URI_FIELD = "uri";
   private static final String HEADERS = "headers";
 
   private RemoteSignResponseParser() {}
@@ -47,7 +48,7 @@ public class RemoteSignResponseParser {
 
     gen.writeStartObject();
 
-    gen.writeStringField(URI, response.uri().toString());
+    gen.writeStringField(URI_FIELD, response.uri().toString());
     RemoteSignRequestParser.headersToJson(HEADERS, response.headers(), gen);
 
     gen.writeEndObject();
@@ -62,7 +63,7 @@ public class RemoteSignResponseParser {
     Preconditions.checkArgument(
         json.isObject(), "Cannot parse remote sign response from non-object: %s", json);
 
-    java.net.URI uri = java.net.URI.create(JsonUtil.getString(URI, json));
+    URI uri = URI.create(JsonUtil.getString(URI_FIELD, json));
     Map<String, List<String>> headers = RemoteSignRequestParser.headersFromJson(HEADERS, json);
 
     return ImmutableRemoteSignResponse.builder().uri(uri).headers(headers).build();

--- a/core/src/test/java/org/apache/iceberg/rest/RemoteSignerServlet.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RemoteSignerServlet.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static java.lang.String.format;
+import static org.apache.iceberg.rest.RESTCatalogAdapter.castRequest;
+import static org.apache.iceberg.rest.RESTCatalogAdapter.castResponse;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.io.CharStreams;
+import org.apache.iceberg.rest.requests.RemoteSignRequest;
+import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.apache.iceberg.rest.responses.RemoteSignResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base servlet for remote signing tests. This servlet handles OAuth token requests and delegates
+ * signing to subclasses. It does not handle any other requests.
+ *
+ * <p>Subclasses must implement {@link #signRequest(RemoteSignRequest)} to provide the actual
+ * signing logic.
+ */
+public abstract class RemoteSignerServlet extends HttpServlet {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteSignerServlet.class);
+  private static final String POST = "POST";
+
+  private static final String CACHE_CONTROL = "Cache-Control";
+  private static final String CACHE_CONTROL_PRIVATE = "private";
+  private static final String CACHE_CONTROL_NO_CACHE = "no-cache";
+
+  private static final Set<String> CACHEABLE_METHODS = Set.of("GET", "HEAD");
+
+  private static final Map<String, String> RESPONSE_HEADERS =
+      ImmutableMap.of(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
+
+  private final String signEndpoint;
+
+  protected RemoteSignerServlet(String signEndpoint) {
+    this.signEndpoint = signEndpoint;
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+    execute(request, response);
+  }
+
+  @Override
+  protected void doHead(HttpServletRequest request, HttpServletResponse response) {
+    execute(request, response);
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+    execute(request, response);
+  }
+
+  @Override
+  protected void doDelete(HttpServletRequest request, HttpServletResponse response) {
+    execute(request, response);
+  }
+
+  /**
+   * Sign the given request and return the signed response.
+   *
+   * @param request the remote sign request
+   * @return the signed response
+   */
+  protected abstract RemoteSignResponse signRequest(RemoteSignRequest request);
+
+  /**
+   * Called after a sign request is parsed but before signing. Subclasses can override to add
+   * additional validation.
+   *
+   * @param request the remote sign request
+   */
+  protected void validateSignRequest(RemoteSignRequest request) {
+    // no-op by default
+  }
+
+  /**
+   * Called after signing to allow subclasses to add response headers (e.g., cache control). By
+   * default, this method adds cache control headers based on the request method.
+   *
+   * @param request the original sign request
+   * @param response the HTTP response to add headers to
+   */
+  protected void addSignResponseHeaders(RemoteSignRequest request, HttpServletResponse response) {
+    if (CACHEABLE_METHODS.contains(request.method().toUpperCase(Locale.ROOT))) {
+      // tell the client this can be cached
+      response.setHeader(CACHE_CONTROL, CACHE_CONTROL_PRIVATE);
+    } else {
+      response.setHeader(CACHE_CONTROL, CACHE_CONTROL_NO_CACHE);
+    }
+  }
+
+  private OAuthTokenResponse handleOAuth(Map<String, String> requestMap) {
+    String grantType = requestMap.get("grant_type");
+    switch (grantType) {
+      case "client_credentials":
+        return castResponse(
+            OAuthTokenResponse.class,
+            OAuthTokenResponse.builder()
+                .withToken("client-credentials-token:sub=" + requestMap.get("client_id"))
+                .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
+                .withTokenType("Bearer")
+                .setExpirationInSeconds(10000)
+                .build());
+
+      case "urn:ietf:params:oauth:grant-type:token-exchange":
+        String actor = requestMap.get("actor_token");
+        String token =
+            String.format(
+                "token-exchange-token:sub=%s%s",
+                requestMap.get("subject_token"), actor != null ? ",act=" + actor : "");
+        return castResponse(
+            OAuthTokenResponse.class,
+            OAuthTokenResponse.builder()
+                .withToken(token)
+                .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
+                .withTokenType("Bearer")
+                .setExpirationInSeconds(10000)
+                .build());
+
+      default:
+        throw new UnsupportedOperationException("Unsupported grant_type: " + grantType);
+    }
+  }
+
+  protected void execute(HttpServletRequest request, HttpServletResponse response) {
+    response.setStatus(HttpServletResponse.SC_OK);
+    RESPONSE_HEADERS.forEach(response::setHeader);
+
+    String path = request.getRequestURI().substring(1);
+    Object requestBody;
+    try {
+      if (POST.equals(request.getMethod()) && signEndpoint.equals(path)) {
+        RemoteSignRequest signRequest =
+            castRequest(
+                RemoteSignRequest.class,
+                RESTObjectMapper.mapper().readValue(request.getReader(), RemoteSignRequest.class));
+        validateSignRequest(signRequest);
+        RemoteSignResponse signResponse = signRequest(signRequest);
+        addSignResponseHeaders(signRequest, response);
+        RESTObjectMapper.mapper().writeValue(response.getWriter(), signResponse);
+      } else if (POST.equals(request.getMethod()) && ResourcePaths.tokens().equals(path)) {
+        try (Reader reader = new InputStreamReader(request.getInputStream())) {
+          requestBody = RESTUtil.decodeFormData(CharStreams.toString(reader));
+        }
+
+        @SuppressWarnings("unchecked")
+        OAuthTokenResponse oAuthTokenResponse =
+            handleOAuth((Map<String, String>) castRequest(Map.class, requestBody));
+        RESTObjectMapper.mapper().writeValue(response.getWriter(), oAuthTokenResponse);
+      } else {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        RESTObjectMapper.mapper()
+            .writeValue(
+                response.getWriter(),
+                org.apache.iceberg.rest.responses.ErrorResponse.builder()
+                    .responseCode(400)
+                    .withType("BadRequestException")
+                    .withMessage(format("No route for request: %s %s", request.getMethod(), path))
+                    .build());
+      }
+    } catch (RESTException e) {
+      LOG.error("Error processing REST request", e);
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    } catch (Exception e) {
+      LOG.error("Unexpected exception when processing REST request", e);
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -336,4 +336,20 @@ public class TestResourcePaths {
     assertThat(withoutPrefix.plan(complexId, "plan-xyz-789"))
         .isEqualTo("v1/namespaces/db%1Fschema/tables/my_table/plan/plan-xyz-789");
   }
+
+  @Test
+  public void testRemoteSign() {
+    TableIdentifier tableId = TableIdentifier.of("test_namespace", "test_table");
+    assertThat(withPrefix.remoteSign(tableId))
+        .isEqualTo("v1/ws/catalog/namespaces/test_namespace/tables/test_table/sign");
+    assertThat(withoutPrefix.remoteSign(tableId))
+        .isEqualTo("v1/namespaces/test_namespace/tables/test_table/sign");
+
+    // Test with different identifiers
+    TableIdentifier complexId = TableIdentifier.of(Namespace.of("db", "schema"), "my_table");
+    assertThat(withPrefix.remoteSign(complexId))
+        .isEqualTo("v1/ws/catalog/namespaces/db%1Fschema/tables/my_table/sign");
+    assertThat(withoutPrefix.remoteSign(complexId))
+        .isEqualTo("v1/namespaces/db%1Fschema/tables/my_table/sign");
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestRemoteSignRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestRemoteSignRequestParser.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.aws.s3.signer;
+package org.apache.iceberg.rest.requests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,37 +28,39 @@ import java.util.Collections;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
-public class TestS3SignRequestParser {
+public class TestRemoteSignRequestParser {
 
   @Test
   public void nullRequest() {
-    assertThatThrownBy(() -> S3SignRequestParser.fromJson((JsonNode) null))
+    assertThatThrownBy(() -> RemoteSignRequestParser.fromJson((JsonNode) null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse s3 sign request from null object");
+        .hasMessage("Cannot parse remote sign request from null object");
 
-    assertThatThrownBy(() -> S3SignRequestParser.toJson(null))
+    assertThatThrownBy(() -> RemoteSignRequestParser.toJson(null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid s3 sign request: null");
+        .hasMessage("Invalid remote sign request: null");
   }
 
   @Test
   public void missingFields() {
-    assertThatThrownBy(() -> S3SignRequestParser.fromJson("{}"))
+    assertThatThrownBy(() -> RemoteSignRequestParser.fromJson("{}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing string: region");
 
-    assertThatThrownBy(() -> S3SignRequestParser.fromJson("{\"region\":\"us-west-2\"}"))
+    assertThatThrownBy(() -> RemoteSignRequestParser.fromJson("{\"region\":\"us-west-2\"}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing string: method");
 
     assertThatThrownBy(
-            () -> S3SignRequestParser.fromJson("{\"region\":\"us-west-2\", \"method\" : \"PUT\"}"))
+            () ->
+                RemoteSignRequestParser.fromJson(
+                    "{\"region\":\"us-west-2\", \"method\" : \"PUT\"}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing string: uri");
 
     assertThatThrownBy(
             () ->
-                S3SignRequestParser.fromJson(
+                RemoteSignRequestParser.fromJson(
                     "{\n"
                         + "  \"region\" : \"us-west-2\",\n"
                         + "  \"method\" : \"PUT\",\n"
@@ -72,7 +74,7 @@ public class TestS3SignRequestParser {
   public void invalidMethod() {
     assertThatThrownBy(
             () ->
-                S3SignRequestParser.fromJson(
+                RemoteSignRequestParser.fromJson(
                     "{\n"
                         + "  \"region\" : \"us-west-2\",\n"
                         + "  \"method\" : 23,\n"
@@ -87,7 +89,7 @@ public class TestS3SignRequestParser {
   public void invalidUri() {
     assertThatThrownBy(
             () ->
-                S3SignRequestParser.fromJson(
+                RemoteSignRequestParser.fromJson(
                     "{\n"
                         + "  \"region\" : \"us-west-2\",\n"
                         + "  \"method\" : \"PUT\",\n"
@@ -102,7 +104,7 @@ public class TestS3SignRequestParser {
   public void invalidRegion() {
     assertThatThrownBy(
             () ->
-                S3SignRequestParser.fromJson(
+                RemoteSignRequestParser.fromJson(
                     "{\n"
                         + "  \"region\" : 23,\n"
                         + "  \"method\" : \"PUT\",\n"
@@ -115,8 +117,8 @@ public class TestS3SignRequestParser {
 
   @Test
   public void roundTripSerde() {
-    ImmutableS3SignRequest s3SignRequest =
-        ImmutableS3SignRequest.builder()
+    RemoteSignRequest request =
+        ImmutableRemoteSignRequest.builder()
             .uri(URI.create("http://localhost:49208/iceberg-signer-test"))
             .method("PUT")
             .region("us-west-2")
@@ -132,8 +134,8 @@ public class TestS3SignRequestParser {
                     Arrays.asList("aws-sdk-java/2.20.18", "Linux/5.4.0-126")))
             .build();
 
-    String json = S3SignRequestParser.toJson(s3SignRequest, true);
-    assertThat(S3SignRequestParser.fromJson(json)).isEqualTo(s3SignRequest);
+    String json = RemoteSignRequestParser.toJson(request, true);
+    assertThat(RemoteSignRequestParser.fromJson(json)).isEqualTo(request);
     assertThat(json)
         .isEqualTo(
             "{\n"
@@ -151,8 +153,8 @@ public class TestS3SignRequestParser {
 
   @Test
   public void roundTripSerdeWithProperties() {
-    ImmutableS3SignRequest s3SignRequest =
-        ImmutableS3SignRequest.builder()
+    RemoteSignRequest request =
+        ImmutableRemoteSignRequest.builder()
             .uri(URI.create("http://localhost:49208/iceberg-signer-test"))
             .method("PUT")
             .region("us-west-2")
@@ -169,8 +171,8 @@ public class TestS3SignRequestParser {
             .properties(ImmutableMap.of("k1", "v1"))
             .build();
 
-    String json = S3SignRequestParser.toJson(s3SignRequest, true);
-    assertThat(S3SignRequestParser.fromJson(json)).isEqualTo(s3SignRequest);
+    String json = RemoteSignRequestParser.toJson(request, true);
+    assertThat(RemoteSignRequestParser.fromJson(json)).isEqualTo(request);
     assertThat(json)
         .isEqualTo(
             "{\n"
@@ -191,8 +193,8 @@ public class TestS3SignRequestParser {
 
   @Test
   public void roundTripWithBody() {
-    ImmutableS3SignRequest s3SignRequest =
-        ImmutableS3SignRequest.builder()
+    RemoteSignRequest request =
+        ImmutableRemoteSignRequest.builder()
             .uri(URI.create("http://localhost:49208/iceberg-signer-test"))
             .method("PUT")
             .region("us-west-2")
@@ -210,8 +212,8 @@ public class TestS3SignRequestParser {
             .body("some-body")
             .build();
 
-    String json = S3SignRequestParser.toJson(s3SignRequest, true);
-    assertThat(S3SignRequestParser.fromJson(json)).isEqualTo(s3SignRequest);
+    String json = RemoteSignRequestParser.toJson(request, true);
+    assertThat(RemoteSignRequestParser.fromJson(json)).isEqualTo(request);
     assertThat(json)
         .isEqualTo(
             "{\n"
@@ -228,6 +230,48 @@ public class TestS3SignRequestParser {
                 + "    \"k1\" : \"v1\"\n"
                 + "  },\n"
                 + "  \"body\" : \"some-body\"\n"
+                + "}");
+  }
+
+  @Test
+  public void roundTripWithProvider() {
+    RemoteSignRequest request =
+        ImmutableRemoteSignRequest.builder()
+            .uri(URI.create("http://localhost:49208/iceberg-signer-test"))
+            .method("PUT")
+            .region("us-west-2")
+            .headers(
+                ImmutableMap.of(
+                    "amz-sdk-request",
+                    Arrays.asList("attempt=1", "max=4"),
+                    "Content-Length",
+                    Collections.singletonList("191"),
+                    "Content-Type",
+                    Collections.singletonList("application/json"),
+                    "User-Agent",
+                    Arrays.asList("aws-sdk-java/2.20.18", "Linux/5.4.0-126")))
+            .properties(ImmutableMap.of("k1", "v1"))
+            .provider("s3")
+            .build();
+
+    String json = RemoteSignRequestParser.toJson(request, true);
+    assertThat(RemoteSignRequestParser.fromJson(json)).isEqualTo(request);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"region\" : \"us-west-2\",\n"
+                + "  \"method\" : \"PUT\",\n"
+                + "  \"uri\" : \"http://localhost:49208/iceberg-signer-test\",\n"
+                + "  \"headers\" : {\n"
+                + "    \"amz-sdk-request\" : [ \"attempt=1\", \"max=4\" ],\n"
+                + "    \"Content-Length\" : [ \"191\" ],\n"
+                + "    \"Content-Type\" : [ \"application/json\" ],\n"
+                + "    \"User-Agent\" : [ \"aws-sdk-java/2.20.18\", \"Linux/5.4.0-126\" ]\n"
+                + "  },\n"
+                + "  \"properties\" : {\n"
+                + "    \"k1\" : \"v1\"\n"
+                + "  },\n"
+                + "  \"provider\" : \"s3\"\n"
                 + "}");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestRemoteSignResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestRemoteSignResponseParser.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.aws.s3.signer;
+package org.apache.iceberg.rest.responses;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,28 +28,28 @@ import java.util.Collections;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
-public class TestS3SignResponseParser {
+public class TestRemoteSignResponseParser {
 
   @Test
   public void nullResponse() {
-    assertThatThrownBy(() -> S3SignResponseParser.fromJson((JsonNode) null))
+    assertThatThrownBy(() -> RemoteSignResponseParser.fromJson((JsonNode) null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse s3 sign response from null object");
+        .hasMessage("Cannot parse remote sign response from null object");
 
-    assertThatThrownBy(() -> S3SignResponseParser.toJson(null))
+    assertThatThrownBy(() -> RemoteSignResponseParser.toJson(null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid s3 sign response: null");
+        .hasMessage("Invalid remote sign response: null");
   }
 
   @Test
   public void missingFields() {
-    assertThatThrownBy(() -> S3SignResponseParser.fromJson("{}"))
+    assertThatThrownBy(() -> RemoteSignResponseParser.fromJson("{}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing string: uri");
 
     assertThatThrownBy(
             () ->
-                S3SignResponseParser.fromJson(
+                RemoteSignResponseParser.fromJson(
                     "{\"uri\" : \"http://localhost:49208/iceberg-signer-test\"}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing field: headers");
@@ -57,15 +57,15 @@ public class TestS3SignResponseParser {
 
   @Test
   public void invalidUri() {
-    assertThatThrownBy(() -> S3SignResponseParser.fromJson("{\"uri\" : 45, \"headers\" : {}}}"))
+    assertThatThrownBy(() -> RemoteSignResponseParser.fromJson("{\"uri\" : 45, \"headers\" : {}}}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse to a string value: uri: 45");
   }
 
   @Test
   public void roundTripSerde() {
-    S3SignResponse s3SignResponse =
-        ImmutableS3SignResponse.builder()
+    RemoteSignResponse response =
+        ImmutableRemoteSignResponse.builder()
             .uri(URI.create("http://localhost:49208/iceberg-signer-test"))
             .headers(
                 ImmutableMap.of(
@@ -79,8 +79,8 @@ public class TestS3SignResponseParser {
                     Arrays.asList("aws-sdk-java/2.20.18", "Linux/5.4.0-126")))
             .build();
 
-    String json = S3SignResponseParser.toJson(s3SignResponse, true);
-    assertThat(S3SignResponseParser.fromJson(json)).isEqualTo(s3SignResponse);
+    String json = RemoteSignResponseParser.toJson(response, true);
+    assertThat(RemoteSignResponseParser.fromJson(json)).isEqualTo(response);
     assertThat(json)
         .isEqualTo(
             "{\n"


### PR DESCRIPTION
Dev ML discussion: https://lists.apache.org/thread/2kqdqb46j7jww36wwg4txv6pl2hqq9w7

This commit adapts the code base to the REST spec changes in #15450.

Summary of changes:

- Added new signer endpoint to `Endpoint` and `ResourcePaths`
- Added new remote signing properties to `RESTCatalogProperties`
- Introduced `RemoteSignRequest`, `RemoteSignRequestParser`, `RemoteSignResponse`, `RemoteSignResponseParser`
- Deprecated `S3SignRequest`, `S3SignRequestParser`, `S3SignResponse`, `S3SignResponseParser` for removal
- Deprecated `S3ObjectMapper` for removal
- Added new serializers to `RESTSerializers`
- Adapted `S3V4RestSignerClient`:
  - Deprecated public fields
  - Changed access methods and `check()` method to account for new properties and deprecated ones.
  - Included new `provider` request body parameter

Test changes:

- Refactored `S3SignerServlet` to extract a parent abstract class, `RemoteSignerServlet` (it can now be reused to test other providers)
- Moved JSON parser tests from AWS module to Core module
- Enhanced `TestS3V4RestSignerClient`