### PR TITLE
API: Use correct method name in exception message

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RowDelta.java
+++ b/api/src/main/java/org/apache/iceberg/RowDelta.java
@@ -54,7 +54,7 @@ public interface RowDelta extends SnapshotUpdate<RowDelta> {
    */
   default RowDelta removeRows(DataFile file) {
     throw new UnsupportedOperationException(
-        getClass().getName() + " does not implement deleteFile");
+        getClass().getName() + " does not implement removeRows");
   }
 
   /**


### PR DESCRIPTION
I guess it is a typo that @RussellSpitzer forgot to change when he worked on #13184.
"deleteFile" as the method name was originally introduced by #12861 but changed by #13184.