### PR TITLE
Spark: Support reading Avro local-timestamp-* logical types

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
@@ -136,11 +136,13 @@ public class SparkPlannedAvroReader implements DatumReader<InternalRow>, Support
             return ValueReaders.ints();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             // Spark uses the same representation
             return ValueReaders.longs();
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -23,16 +23,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkAvroReader extends AvroDataTestBase {
   @Override
@@ -79,6 +90,48 @@ public class TestSparkAvroReader extends AvroDataTestBase {
     writeAndValidate(writeSchema, expectedSchema, expected);
   }
 
+  @Test
+  public void testReadLocalTimestampType() throws IOException {
+    org.apache.avro.Schema avroSchema =
+        org.apache.avro.Schema.createRecord(
+            "r1",
+            null,
+            null,
+            false,
+            List.of(
+                localTimestampField("ts_millis", 1, LogicalTypes.localTimestampMillis()),
+                localTimestampField("ts_micros", 2, LogicalTypes.localTimestampMicros())));
+
+    Schema readSchema =
+        new Schema(
+            Types.NestedField.optional(1, "ts_millis", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(2, "ts_micros", Types.TimestampType.withoutZone()));
+
+    long millisValue = 1_000L;
+    long microsValue = 2_000_000L;
+
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("ts_millis", millisValue);
+    record.put("ts_micros", microsValue);
+
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (DataFileWriter<GenericData.Record> writer =
+        new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      writer.create(avroSchema, outputFile.createOrOverwrite());
+      writer.append(record);
+    }
+
+    try (AvroIterable<InternalRow> reader =
+        Avro.read(outputFile.toInputFile())
+            .project(readSchema)
+            .createResolvingReader(schema -> SparkPlannedAvroReader.create(schema, Map.of()))
+            .build()) {
+      InternalRow row = Iterables.getOnlyElement(reader);
+      assertThat(row.getLong(0)).isEqualTo(millisValue * 1_000L);
+      assertThat(row.getLong(1)).isEqualTo(microsValue);
+    }
+  }
+
   @Override
   protected boolean supportsDefaultValues() {
     return true;
@@ -87,5 +140,14 @@ public class TestSparkAvroReader extends AvroDataTestBase {
   @Override
   protected boolean supportsRowLineage() {
     return true;
+  }
+
+  private static org.apache.avro.Schema.Field localTimestampField(
+      String name, int id, LogicalType logicalType) {
+    org.apache.avro.Schema type =
+        logicalType.addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+    org.apache.avro.Schema.Field field = new org.apache.avro.Schema.Field(name, type);
+    field.addProp(AvroSchemaUtil.FIELD_ID_PROP, id);
+    return field;
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
@@ -136,11 +136,13 @@ public class SparkPlannedAvroReader implements DatumReader<InternalRow>, Support
             return ValueReaders.ints();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             // Spark uses the same representation
             return ValueReaders.longs();
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -23,16 +23,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkAvroReader extends AvroDataTestBase {
   @Override
@@ -79,6 +90,48 @@ public class TestSparkAvroReader extends AvroDataTestBase {
     writeAndValidate(writeSchema, expectedSchema, expected);
   }
 
+  @Test
+  public void testReadLocalTimestampType() throws IOException {
+    org.apache.avro.Schema avroSchema =
+        org.apache.avro.Schema.createRecord(
+            "r1",
+            null,
+            null,
+            false,
+            List.of(
+                localTimestampField("ts_millis", 1, LogicalTypes.localTimestampMillis()),
+                localTimestampField("ts_micros", 2, LogicalTypes.localTimestampMicros())));
+
+    Schema readSchema =
+        new Schema(
+            Types.NestedField.optional(1, "ts_millis", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(2, "ts_micros", Types.TimestampType.withoutZone()));
+
+    long millisValue = 1_000L;
+    long microsValue = 2_000_000L;
+
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("ts_millis", millisValue);
+    record.put("ts_micros", microsValue);
+
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (DataFileWriter<GenericData.Record> writer =
+        new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      writer.create(avroSchema, outputFile.createOrOverwrite());
+      writer.append(record);
+    }
+
+    try (AvroIterable<InternalRow> reader =
+        Avro.read(outputFile.toInputFile())
+            .project(readSchema)
+            .createResolvingReader(schema -> SparkPlannedAvroReader.create(schema, Map.of()))
+            .build()) {
+      InternalRow row = Iterables.getOnlyElement(reader);
+      assertThat(row.getLong(0)).isEqualTo(millisValue * 1_000L);
+      assertThat(row.getLong(1)).isEqualTo(microsValue);
+    }
+  }
+
   @Override
   protected boolean supportsDefaultValues() {
     return true;
@@ -87,5 +140,14 @@ public class TestSparkAvroReader extends AvroDataTestBase {
   @Override
   protected boolean supportsRowLineage() {
     return true;
+  }
+
+  private static org.apache.avro.Schema.Field localTimestampField(
+      String name, int id, LogicalType logicalType) {
+    org.apache.avro.Schema type =
+        logicalType.addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+    org.apache.avro.Schema.Field field = new org.apache.avro.Schema.Field(name, type);
+    field.addProp(AvroSchemaUtil.FIELD_ID_PROP, id);
+    return field;
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
@@ -142,11 +142,13 @@ public class SparkPlannedAvroReader implements DatumReader<InternalRow>, Support
             return ValueReaders.ints();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             // Spark uses the same representation
             return ValueReaders.longs();
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -23,16 +23,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkAvroReader extends AvroDataTestBase {
   @Override
@@ -79,6 +90,48 @@ public class TestSparkAvroReader extends AvroDataTestBase {
     writeAndValidate(writeSchema, expectedSchema, expected);
   }
 
+  @Test
+  public void testReadLocalTimestampType() throws IOException {
+    org.apache.avro.Schema avroSchema =
+        org.apache.avro.Schema.createRecord(
+            "r1",
+            null,
+            null,
+            false,
+            List.of(
+                localTimestampField("ts_millis", 1, LogicalTypes.localTimestampMillis()),
+                localTimestampField("ts_micros", 2, LogicalTypes.localTimestampMicros())));
+
+    Schema readSchema =
+        new Schema(
+            Types.NestedField.optional(1, "ts_millis", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(2, "ts_micros", Types.TimestampType.withoutZone()));
+
+    long millisValue = 1_000L;
+    long microsValue = 2_000_000L;
+
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("ts_millis", millisValue);
+    record.put("ts_micros", microsValue);
+
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (DataFileWriter<GenericData.Record> writer =
+        new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      writer.create(avroSchema, outputFile.createOrOverwrite());
+      writer.append(record);
+    }
+
+    try (AvroIterable<InternalRow> reader =
+        Avro.read(outputFile.toInputFile())
+            .project(readSchema)
+            .createResolvingReader(schema -> SparkPlannedAvroReader.create(schema, Map.of()))
+            .build()) {
+      InternalRow row = Iterables.getOnlyElement(reader);
+      assertThat(row.getLong(0)).isEqualTo(millisValue * 1_000L);
+      assertThat(row.getLong(1)).isEqualTo(microsValue);
+    }
+  }
+
   @Override
   protected boolean supportsDefaultValues() {
     return true;
@@ -87,5 +140,14 @@ public class TestSparkAvroReader extends AvroDataTestBase {
   @Override
   protected boolean supportsRowLineage() {
     return true;
+  }
+
+  private static org.apache.avro.Schema.Field localTimestampField(
+      String name, int id, LogicalType logicalType) {
+    org.apache.avro.Schema type =
+        logicalType.addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+    org.apache.avro.Schema.Field field = new org.apache.avro.Schema.Field(name, type);
+    field.addProp(AvroSchemaUtil.FIELD_ID_PROP, id);
+    return field;
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
@@ -142,11 +142,13 @@ public class SparkPlannedAvroReader implements DatumReader<InternalRow>, Support
             return ValueReaders.ints();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             // Spark uses the same representation
             return ValueReaders.longs();
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkAvroReader.java
@@ -23,16 +23,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.jupiter.api.Test;
 
 public class TestSparkAvroReader extends AvroDataTestBase {
   @Override
@@ -79,6 +90,48 @@ public class TestSparkAvroReader extends AvroDataTestBase {
     writeAndValidate(writeSchema, expectedSchema, expected);
   }
 
+  @Test
+  public void testReadLocalTimestampType() throws IOException {
+    org.apache.avro.Schema avroSchema =
+        org.apache.avro.Schema.createRecord(
+            "r1",
+            null,
+            null,
+            false,
+            List.of(
+                localTimestampField("ts_millis", 1, LogicalTypes.localTimestampMillis()),
+                localTimestampField("ts_micros", 2, LogicalTypes.localTimestampMicros())));
+
+    Schema readSchema =
+        new Schema(
+            Types.NestedField.optional(1, "ts_millis", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(2, "ts_micros", Types.TimestampType.withoutZone()));
+
+    long millisValue = 1_000L;
+    long microsValue = 2_000_000L;
+
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("ts_millis", millisValue);
+    record.put("ts_micros", microsValue);
+
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (DataFileWriter<GenericData.Record> writer =
+        new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      writer.create(avroSchema, outputFile.createOrOverwrite());
+      writer.append(record);
+    }
+
+    try (AvroIterable<InternalRow> reader =
+        Avro.read(outputFile.toInputFile())
+            .project(readSchema)
+            .createResolvingReader(schema -> SparkPlannedAvroReader.create(schema, Map.of()))
+            .build()) {
+      InternalRow row = Iterables.getOnlyElement(reader);
+      assertThat(row.getLong(0)).isEqualTo(millisValue * 1_000L);
+      assertThat(row.getLong(1)).isEqualTo(microsValue);
+    }
+  }
+
   @Override
   protected boolean supportsDefaultValues() {
     return true;
@@ -87,5 +140,14 @@ public class TestSparkAvroReader extends AvroDataTestBase {
   @Override
   protected boolean supportsRowLineage() {
     return true;
+  }
+
+  private static org.apache.avro.Schema.Field localTimestampField(
+      String name, int id, LogicalType logicalType) {
+    org.apache.avro.Schema type =
+        logicalType.addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+    org.apache.avro.Schema.Field field = new org.apache.avro.Schema.Field(name, type);
+    field.addProp(AvroSchemaUtil.FIELD_ID_PROP, id);
+    return field;
   }
 }


### PR DESCRIPTION
Adds support for local-timestamp-millis and local-timestamp-micros to SparkPlannedAvroReader.

Partially related to https://github.com/apache/iceberg/issues/12751