### PR TITLE
Spark: Add sort_by parameter to rewrite_manifests procedure

### DIFF
--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -491,6 +491,7 @@ Data files in manifests are sorted by fields in the partition spec. This procedu
 | `table`       | ✔️  | string | Name of the table to update                                   |
 | `use_caching` | ️   | boolean | Use Spark caching during operation (defaults to false). Enabling caching can increase memory footprint on executors. |
 | `spec_id`     | ️   | int | Spec id of the manifests to rewrite (defaults to current spec id) |
+| `sort_by`     | ️   | array<string> | List of partition field names to cluster manifests by. Choosing frequently queried partition fields can reduce planning time by skipping unnecessary manifests. If not set, manifests will be sorted by all partition fields in spec order. |
 
 #### Output
 
@@ -509,6 +510,12 @@ CALL catalog_name.system.rewrite_manifests('db.sample');
 Rewrite the manifests on the partition spec `1` in table `db.sample`.
 ```sql
 CALL catalog_name.system.rewrite_manifests(table => 'db.sample', spec_id => 1);
+```
+
+Rewrite the manifests in table `db.sample` and cluster manifest entries by partition field `category`.
+This can improve scan planning performance when queries frequently filter on `category`.
+```sql
+CALL catalog_name.system.rewrite_manifests(table => 'db.sample', sort_by => array('category'));
 ```
 
 ### `rewrite_position_delete_files`

--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -491,7 +491,7 @@ Data files in manifests are sorted by fields in the partition spec. This procedu
 | `table`       | ✔️  | string | Name of the table to update                                   |
 | `use_caching` | ️   | boolean | Use Spark caching during operation (defaults to false). Enabling caching can increase memory footprint on executors. |
 | `spec_id`     | ️   | int | Spec id of the manifests to rewrite (defaults to current spec id) |
-| `sort_by`     | ️   | array<string> | List of partition field names to cluster manifests by. Choosing frequently queried partition fields can reduce planning time by skipping unnecessary manifests. If not set, manifests will be sorted by all partition fields in spec order. |
+| `sort_by`     | ️   | array<string> | List of partition transform names to cluster manifests by. Choosing frequently queried partition transforms can reduce planning time by skipping unnecessary manifests. If not set, manifests will be sorted by all partition transforms in spec order. |
 
 #### Output
 

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -395,6 +395,84 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteManifestsWithSortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string, category string) USING iceberg PARTITIONED BY (data, category)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b', 'y')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, 'c', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (4, 'd', 'y')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 4 manifests")
+        .hasSize(4);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('category', 'data'))",
+            catalogName, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(4, 1)), output);
+
+    table.refresh();
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 1 manifest")
+        .hasSize(1);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithSortBySingleColumn() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string, category string) USING iceberg PARTITIONED BY (data, category)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b', 'y')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, 'c', 'x')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (4, 'd', 'y')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 4 manifests")
+        .hasSize(4);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('category'))",
+            catalogName, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(4, 1)), output);
+
+    table.refresh();
+
+    assertThat(table.currentSnapshot().allManifests(table.io()))
+        .as("Must have 1 manifest")
+        .hasSize(1);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithInvalidSortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array('nonexistent'))",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not found in current partition spec");
+  }
+
+  @TestTemplate
   public void testPartitionStatsIncrementalCompute() throws IOException {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -473,6 +473,23 @@ public class TestRewriteManifestsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteManifestsWithEmptySortBy() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_manifests(table => '%s', sort_by => array())",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("sort_by must not be empty when provided");
+  }
+
+  @TestTemplate
   public void testPartitionStatsIncrementalCompute() throws IOException {
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)",

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteManifests;
@@ -54,9 +55,11 @@ class RewriteManifestsProcedure extends BaseProcedure {
       optionalInParameter("use_caching", DataTypes.BooleanType);
   private static final ProcedureParameter SPEC_ID_PARAM =
       optionalInParameter("spec_id", DataTypes.IntegerType);
+  private static final ProcedureParameter SORT_BY_PARAM =
+      optionalInParameter("sort_by", STRING_ARRAY);
 
   private static final ProcedureParameter[] PARAMETERS =
-      new ProcedureParameter[] {TABLE_PARAM, USE_CACHING_PARAM, SPEC_ID_PARAM};
+      new ProcedureParameter[] {TABLE_PARAM, USE_CACHING_PARAM, SPEC_ID_PARAM, SORT_BY_PARAM};
 
   // counts are not nullable since the action result is never null
   private static final StructType OUTPUT_TYPE =
@@ -96,6 +99,7 @@ class RewriteManifestsProcedure extends BaseProcedure {
     Identifier tableIdent = input.ident(TABLE_PARAM);
     Boolean useCaching = input.asBoolean(USE_CACHING_PARAM, null);
     Integer specId = input.asInt(SPEC_ID_PARAM, null);
+    String[] sortBy = input.asStringArray(SORT_BY_PARAM, null);
 
     return modifyIcebergTable(
         tableIdent,
@@ -108,6 +112,10 @@ class RewriteManifestsProcedure extends BaseProcedure {
 
           if (specId != null) {
             action.specId(specId);
+          }
+
+          if (sortBy != null) {
+            action.sortBy(Arrays.asList(sortBy));
           }
 
           RewriteManifests.Result result = action.execute();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.actions.RewriteManifestsSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
@@ -115,6 +116,8 @@ class RewriteManifestsProcedure extends BaseProcedure {
           }
 
           if (sortBy != null) {
+            Preconditions.checkArgument(
+                sortBy.length > 0, "sort_by must not be empty when provided");
             action.sortBy(Arrays.asList(sortBy));
           }
 


### PR DESCRIPTION
This PR adds the `sort_by` parameter to the `rewrite_manifests` stored procedure, exposing the `sortBy` functionality 
that was added to `RewriteManifestsSparkAction` . Currently, custom manifest clustering by partition fields 
is only accessible through the Java API. This change allows SQL users to specify which partition fields to cluster 
manifests by, which can reduce scan planning time by enabling Spark to skip manifests that don't contain relevant 
partition values.

Example:
CALL catalog.system.rewrite_manifests(table => 'db.sample', sort_by => array('category'));
