### PR TITLE
Core: Add properties to InMemoryFileIO

### DIFF
--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -91,7 +91,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
     String warehouse = properties.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
     this.warehouseLocation = warehouse.replaceAll("/*$", "");
-    this.io = new InMemoryFileIO();
+    this.io = CatalogUtil.loadFileIO(InMemoryFileIO.class.getName(), properties, null);
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
@@ -24,12 +24,25 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.SerializableMap;
 
 public class InMemoryFileIO implements FileIO {
 
   private static final Map<String, byte[]> IN_MEMORY_FILES = Maps.newConcurrentMap();
   private boolean closed = false;
+  private SerializableMap<String, String> properties = SerializableMap.copyOf(ImmutableMap.of());
+
+  @Override
+  public void initialize(Map<String, String> props) {
+    this.properties = SerializableMap.copyOf(props);
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties.immutableMap();
+  }
 
   public void addFile(String location, byte[] contents) {
     Preconditions.checkState(!closed, "Cannot call addFile after calling close()");

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -24,9 +24,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 public class TestInMemoryFileIO {
@@ -127,6 +129,14 @@ public class TestInMemoryFileIO {
     assertThat(fileIO2.fileExists(location))
         .isTrue()
         .as("Files should be shared across all InMemoryFileIO instances");
+  }
+
+  @Test
+  public void properties() {
+    InMemoryFileIO io = new InMemoryFileIO();
+    Map<String, String> properties = ImmutableMap.of("key1", "value1", "key2", "value2");
+    io.initialize(properties);
+    assertThat(io.properties()).isEqualTo(properties);
   }
 
   private String randomLocation() {


### PR DESCRIPTION
Technically `InMemoryFileIO` doesn't have properties, so this is mainly being added to make testing FileIO properties easier/possible for https://github.com/apache/iceberg/pull/15368