### PR TITLE
Flink: SQL: Add variant avro dynamic record generator

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -336,6 +336,7 @@ This product includes code from Apache Flink.
 * Parameter provider annotation for parameterized tests in Parameters.java
 * Parameter field annotation for parameterized tests in Parameter.java
 * Primary key validation logic in FlinkSchemaUtil.java
+* Binary variant accessor utility methods in BinaryVariantAccessorUtils.java
 
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://flink.apache.org/

--- a/flink/v2.1/flink/src/main/java/org/apache/flink/types/variant/BinaryVariantAccessorUtils.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/flink/types/variant/BinaryVariantAccessorUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flink.types.variant;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * These Accessor utils should be part of Flink Variant interface itself. Added in the PR, <a
+ * href="https://github.com/apache/flink/pull/27600">...</a>. This is a workaround until we upgrade
+ * Flink to a release version with above changes.
+ */
+public class BinaryVariantAccessorUtils extends BinaryVariantUtil {
+  /**
+   * Get the size of an array variant.
+   *
+   * @return Number of elements if this variant is an instance of BinaryVariant and an array
+   * @throws IllegalArgumentException If this variant is not an instance of BinaryVariant or not an
+   *     array.
+   */
+  public static int arraySize(Variant variant) {
+    Preconditions.checkArgument(
+        variant instanceof BinaryVariant,
+        "Invalid variant implementation instance:%s. Only BinaryVariant is supported.",
+        variant.getClass().getName());
+
+    Preconditions.checkArgument(
+        variant.getType() == Variant.Type.ARRAY,
+        "Invalid variant type:%s. Expecting ARRAY variant type.",
+        variant.getType());
+
+    BinaryVariant binaryArrayVariant = (BinaryVariant) variant;
+    return handleArray(
+        binaryArrayVariant.getValue(), 0, (size, offsetSize, offsetStart, dataStart) -> size);
+  }
+
+  /**
+   * Get the field names of an object variant only at top level. Doesn't include the nested fields.
+   *
+   * @return List of field names if this is an instance of BinaryVariant and is an object
+   * @throws IllegalArgumentException If this variant is not an instance of BinaryVariant or not an
+   *     array.
+   */
+  public static List<String> fieldNames(Variant variant) {
+    Preconditions.checkArgument(
+        variant instanceof BinaryVariant,
+        "Invalid variant implementation instance:%s. Only BinaryVariant is supported.",
+        variant.getClass().getName());
+
+    Preconditions.checkArgument(
+        variant.getType() == Variant.Type.OBJECT,
+        "Invalid variant type:%s. Expecting OBJECT variant type.",
+        variant.getType());
+
+    BinaryVariant binaryArrayVariant = (BinaryVariant) variant;
+    return BinaryVariantUtil.handleObject(
+        binaryArrayVariant.getValue(),
+        0,
+        (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
+          List<String> fieldNames = Lists.newArrayList();
+          for (int i = 0; i < size; i++) {
+            int id = readUnsigned(binaryArrayVariant.getValue(), idStart + idSize * i, idSize);
+            String fieldName = getMetadataKey(binaryArrayVariant.getMetadata(), id);
+            fieldNames.add(fieldName);
+          }
+          return fieldNames;
+        });
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.util.JsonUtil;
 
-class FlinkCreateTableOptions {
+public class FlinkCreateTableOptions {
   private final String catalogName;
   private final String catalogDb;
   private final String catalogTable;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -19,10 +19,12 @@
 package org.apache.iceberg.flink;
 
 import java.util.Map;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.util.JsonUtil;
 
+@Internal
 public class FlinkCreateTableOptions {
   private final String catalogName;
   private final String catalogDb;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -91,4 +91,11 @@ public class FlinkWriteOptions {
   //  specify the uidSuffix to be used for the underlying IcebergSink
   public static final ConfigOption<String> UID_SUFFIX =
       ConfigOptions.key("uid-suffix").stringType().defaultValue("");
+
+  public static final ConfigOption<Integer> CACHE_MAX_SIZE =
+      ConfigOptions.key("cache-max-size")
+          .intType()
+          .defaultValue(100)
+          .withDescription(
+              "Maximum size of the caches used in Dynamic Sink for table data and serializers.");
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -284,9 +284,9 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
       ctor =
           DynConstructors.builder(DynamicTableRecordGenerator.class)
               .loader(IcebergTableSink.class.getClassLoader())
-              .impl(generatorImpl, RowType.class)
+              .impl(generatorImpl, RowType.class, Map.class)
               .buildChecked();
-      return ctor.newInstance(rowType);
+      return ctor.newInstance(rowType, writeProps);
     } catch (ClassCastException e) {
       throw new IllegalArgumentException(
           String.format("Class %s does not implement DynamicRecordGeneratorSQL", generatorImpl), e);

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.data;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
+
+public class VariantRowDataWrapper implements RowData {
+
+  private final RowType rowType;
+  private RowKind rowKind;
+  private Variant variantData;
+
+  public VariantRowDataWrapper(RowType rowType) {
+    this(rowType, RowKind.INSERT);
+  }
+
+  public VariantRowDataWrapper(RowType rowType, RowKind rowKind) {
+    this.rowType = rowType;
+    this.rowKind = rowKind;
+  }
+
+  public VariantRowDataWrapper wrap(Variant variant) {
+    this.variantData = variant;
+    return this;
+  }
+
+  @Override
+  public int getArity() {
+    return rowType.getFieldCount();
+  }
+
+  @Override
+  public RowKind getRowKind() {
+    return rowKind;
+  }
+
+  @Override
+  public void setRowKind(RowKind rowKind) {
+    this.rowKind = rowKind;
+  }
+
+  @Override
+  public boolean isNullAt(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    Variant value = variantData.getField(fieldName);
+    return value == null || value.isNull();
+  }
+
+  @Override
+  public boolean getBoolean(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getBoolean();
+  }
+
+  @Override
+  public byte getByte(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getByte();
+  }
+
+  @Override
+  public short getShort(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getShort();
+  }
+
+  @Override
+  public int getInt(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return getIntValue(variantData.getField(fieldName));
+  }
+
+  @Override
+  public long getLong(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return getLongValue(variantData.getField(fieldName));
+  }
+
+  @Override
+  public float getFloat(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getFloat();
+  }
+
+  @Override
+  public double getDouble(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return getDoubleValue(variantData.getField(fieldName));
+  }
+
+  @Override
+  public StringData getString(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return isNullAt(pos)
+        ? null
+        : StringData.fromString(variantData.getField(fieldName).getString());
+  }
+
+  @Override
+  public DecimalData getDecimal(int pos, int precision, int scale) {
+    String fieldName = getFieldNameByIndex(pos);
+    return isNullAt(pos)
+        ? null
+        : DecimalData.fromBigDecimal(
+            variantData.getField(fieldName).getDecimal(), precision, scale);
+  }
+
+  @Override
+  public TimestampData getTimestamp(int pos, int precision) {
+    String fieldName = getFieldNameByIndex(pos);
+    return isNullAt(pos) ? null : getTimestamp(variantData.getField(fieldName));
+  }
+
+  @Override
+  public <T> RawValueData<T> getRawValue(int pos) {
+    throw new UnsupportedOperationException("RawValue in Variant column is not supported.");
+  }
+
+  @Override
+  public byte[] getBinary(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getBytes();
+  }
+
+  @Override
+  public ArrayData getArray(int pos) {
+    //    ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
+    //    LogicalType elementType = arrayType.getElementType();
+    //
+    //    String fieldName = getFieldNameByIndex(pos);
+    //    Variant arrayVariant = variantData.getField(fieldName);
+    //
+    //    if (arrayVariant != null) {
+    //        Preconditions.checkArgument(arrayVariant.getType().equals(Variant.Type.ARRAY),
+    //                "Expected Array type, but got " + arrayVariant.getType());
+    //        int arraySize = arrayVariant.getArraySize();
+    //        Object[] elements = new Object[arraySize];
+    //
+    //        for (int i=0;i< arraySize;i++) {
+    //            Variant element = arrayVariant.getElement(i);
+    //            elements[i] = element == null ? null : getElementValue(elementType, element);
+    //        }
+    //
+    //        return new GenericArrayData(elements);
+    //    }
+    //
+    //    return null;
+    throw new UnsupportedOperationException("Array Type is not supported yet.");
+  }
+
+  @Override
+  public MapData getMap(int pos) {
+    //    MapType mapType = (MapType) rowType.getTypeAt(pos);
+    //    LogicalType keyType = mapType.getKeyType();
+    //    LogicalType valueType = mapType.getValueType();
+    //
+    //    Preconditions.checkArgument(keyType instanceof VarCharType,
+    //            "Map with STRING key types are only supported in Variant to RowData conversion");
+    //
+    //    String mapFieldName = getFieldNameByIndex(pos);
+    //    Variant mapVariant = variantData.getField(mapFieldName);
+    //
+    //    Map<Object, Object> mapData = Maps.newHashMap();
+    //    if (mapVariant != null) {
+    //        List<String> keys = mapVariant.getFieldNames();
+    //        for (String key: keys) {
+    //            mapData.put(StringData.fromString(key), getElementValue(valueType,
+    // mapVariant.getField(key)));
+    //        }
+    //
+    //        return new GenericMapData(mapData);
+    //    }
+    //
+    //    return null;
+    throw new UnsupportedOperationException("Map Type is not supported yet.");
+  }
+
+  @Override
+  public RowData getRow(int pos, int numFields) {
+    String fieldName = getFieldNameByIndex(pos);
+    VariantRowDataWrapper rowDataWrapper =
+        new VariantRowDataWrapper((RowType) rowType.getTypeAt(pos));
+    return rowDataWrapper.wrap(variantData.getField(fieldName));
+  }
+
+  @Override
+  public Variant getVariant(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName);
+  }
+
+  /* private Object getElementValue(LogicalType elementType, Variant variant) {
+    LogicalTypeRoot root = elementType.getTypeRoot();
+
+    switch (root) {
+      case NULL:
+        return null;
+      case BOOLEAN:
+        return variant.getBoolean();
+      case TINYINT:
+        return variant.getByte();
+      case SMALLINT:
+        return variant.getShort();
+      case INTEGER:
+        return getIntValue(variant);
+      case BIGINT:
+        return getLongValue(variant);
+      case FLOAT:
+        return variant.getFloat();
+      case DOUBLE:
+        return getDoubleValue(variant);
+      case DECIMAL:
+        DecimalType decimalType = (DecimalType) elementType;
+        return DecimalData.fromBigDecimal(
+            variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
+      case CHAR:
+      case VARCHAR:
+        return StringData.fromString(variant.getString());
+      case TIMESTAMP_WITHOUT_TIME_ZONE:
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+        return getTimestamp(variant);
+      case BINARY:
+      case VARBINARY:
+        return variant.getBytes();
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported Element type in Array/Map type:" + elementType);
+    }
+  }*/
+
+  private int getIntValue(Variant variant) {
+    switch (variant.getType()) {
+      case TINYINT:
+        return variant.getByte();
+      case SMALLINT:
+        return variant.getShort();
+      case INT:
+        return variant.getInt();
+      default:
+        throw new UnsupportedOperationException(errMsg(variant, "int"));
+    }
+  }
+
+  private long getLongValue(Variant variant) {
+    switch (variant.getType()) {
+      case TINYINT:
+        return variant.getByte();
+      case SMALLINT:
+        return variant.getShort();
+      case INT:
+        return variant.getInt();
+      case BIGINT:
+        return variant.getLong();
+      default:
+        throw new UnsupportedOperationException(errMsg(variant, "long"));
+    }
+  }
+
+  private double getDoubleValue(Variant variant) {
+    switch (variant.getType()) {
+      case FLOAT:
+        return variant.getFloat();
+      case DOUBLE:
+        return variant.getDouble();
+      default:
+        throw new UnsupportedOperationException(errMsg(variant, "double"));
+    }
+  }
+
+  private TimestampData getTimestamp(Variant variant) {
+    switch (variant.getType()) {
+      case TIMESTAMP:
+        return TimestampData.fromLocalDateTime(variant.getDateTime());
+      case TIMESTAMP_LTZ:
+        return TimestampData.fromInstant(variant.getInstant());
+      case BIGINT:
+        long timeLong = variant.getLong();
+        return TimestampData.fromEpochMillis(timeLong / 1000, (int) (timeLong % 1000) * 1000);
+      default:
+        throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
+    }
+  }
+
+  private static String errMsg(Variant variant, String type) {
+    return String.format("Failed to read Variant %s as %s", variant.toJson(), type);
+  }
+
+  private String getFieldNameByIndex(int pos) {
+    return rowType.getFields().get(pos).getName();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -18,16 +18,29 @@
  */
 package org.apache.iceberg.flink.data;
 
+import java.util.List;
+import java.util.Map;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.BinaryVariantAccessorUtils;
 import org.apache.flink.types.variant.Variant;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class VariantRowDataWrapper implements RowData {
 
@@ -149,55 +162,23 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public ArrayData getArray(int pos) {
-    //    ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
-    //    LogicalType elementType = arrayType.getElementType();
-    //
-    //    String fieldName = getFieldNameByIndex(pos);
-    //    Variant arrayVariant = variantData.getField(fieldName);
-    //
-    //    if (arrayVariant != null) {
-    //        Preconditions.checkArgument(arrayVariant.getType().equals(Variant.Type.ARRAY),
-    //                "Expected Array type, but got " + arrayVariant.getType());
-    //        int arraySize = arrayVariant.getArraySize();
-    //        Object[] elements = new Object[arraySize];
-    //
-    //        for (int i=0;i< arraySize;i++) {
-    //            Variant element = arrayVariant.getElement(i);
-    //            elements[i] = element == null ? null : getElementValue(elementType, element);
-    //        }
-    //
-    //        return new GenericArrayData(elements);
-    //    }
-    //
-    //    return null;
-    throw new UnsupportedOperationException("Array Type is not supported yet.");
+    ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
+    LogicalType elementType = arrayType.getElementType();
+
+    String fieldName = getFieldNameByIndex(pos);
+    Variant arrayVariant = variantData.getField(fieldName);
+
+    return getArrayData(arrayVariant, elementType);
   }
 
   @Override
   public MapData getMap(int pos) {
-    //    MapType mapType = (MapType) rowType.getTypeAt(pos);
-    //    LogicalType keyType = mapType.getKeyType();
-    //    LogicalType valueType = mapType.getValueType();
-    //
-    //    Preconditions.checkArgument(keyType instanceof VarCharType,
-    //            "Map with STRING key types are only supported in Variant to RowData conversion");
-    //
-    //    String mapFieldName = getFieldNameByIndex(pos);
-    //    Variant mapVariant = variantData.getField(mapFieldName);
-    //
-    //    Map<Object, Object> mapData = Maps.newHashMap();
-    //    if (mapVariant != null) {
-    //        List<String> keys = mapVariant.getFieldNames();
-    //        for (String key: keys) {
-    //            mapData.put(StringData.fromString(key), getElementValue(valueType,
-    // mapVariant.getField(key)));
-    //        }
-    //
-    //        return new GenericMapData(mapData);
-    //    }
-    //
-    //    return null;
-    throw new UnsupportedOperationException("Map Type is not supported yet.");
+    MapType mapType = (MapType) rowType.getTypeAt(pos);
+
+    String mapFieldName = getFieldNameByIndex(pos);
+    Variant mapVariant = variantData.getField(mapFieldName);
+
+    return getMapData(mapVariant, mapType);
   }
 
   @Override
@@ -214,7 +195,7 @@ public class VariantRowDataWrapper implements RowData {
     return variantData.getField(fieldName);
   }
 
-  /* private Object getElementValue(LogicalType elementType, Variant variant) {
+  private Object getElementValue(LogicalType elementType, Variant variant) {
     LogicalTypeRoot root = elementType.getTypeRoot();
 
     switch (root) {
@@ -247,11 +228,59 @@ public class VariantRowDataWrapper implements RowData {
       case BINARY:
       case VARBINARY:
         return variant.getBytes();
+      case ARRAY:
+        ArrayType arrayType = (ArrayType) elementType;
+        LogicalType innerElementType = arrayType.getElementType();
+        return getArrayData(variant, innerElementType);
+      case MAP:
+        return getMapData(variant, (MapType) elementType);
+      case ROW:
+        VariantRowDataWrapper rowDataWrapper = new VariantRowDataWrapper((RowType) elementType);
+        return rowDataWrapper.wrap(variant);
       default:
         throw new UnsupportedOperationException(
             "Unsupported Element type in Array/Map type:" + elementType);
     }
-  }*/
+  }
+
+  private MapData getMapData(Variant variant, MapType mapType) {
+    LogicalType keyType = mapType.getKeyType();
+    LogicalType valueType = mapType.getValueType();
+
+    Preconditions.checkArgument(
+        keyType instanceof VarCharType,
+        "Map with STRING key types are only supported in Variant to RowData conversion");
+
+    Map<Object, Object> mapData = Maps.newHashMap();
+    if (variant != null) {
+      List<String> keys = BinaryVariantAccessorUtils.fieldNames(variant);
+      for (String key : keys) {
+        mapData.put(StringData.fromString(key), getElementValue(valueType, variant.getField(key)));
+      }
+
+      return new GenericMapData(mapData);
+    }
+
+    return null;
+  }
+
+  private ArrayData getArrayData(Variant variant, LogicalType innerElementType) {
+    if (variant != null) {
+      Preconditions.checkArgument(
+          variant.getType().equals(Variant.Type.ARRAY),
+          "Expected Array type, but got " + variant.getType());
+      int arraySize = BinaryVariantAccessorUtils.arraySize(variant);
+      Object[] elements = new Object[arraySize];
+
+      for (int i = 0; i < arraySize; i++) {
+        Variant element = variant.getElement(i);
+        elements[i] = element == null ? null : getElementValue(innerElementType, element);
+      }
+
+      return new GenericArrayData(elements);
+    }
+    return null;
+  }
 
   private int getIntValue(Variant variant) {
     switch (variant.getType()) {
@@ -307,7 +336,8 @@ public class VariantRowDataWrapper implements RowData {
   }
 
   private static String errMsg(Variant variant, String type) {
-    return String.format("Failed to read Variant %s as %s", variant.toJson(), type);
+    return String.format(
+        "Failed to read Variant %s of type %s as %s", variant.toJson(), variant.getType(), type);
   }
 
   private String getFieldNameByIndex(int pos) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -121,18 +121,13 @@ public class VariantRowDataWrapper implements RowData {
   @Override
   public StringData getString(int pos) {
     Variant value = fieldByIndex(pos);
-    return value == null
-        ? null
-        : StringData.fromString(value.getString());
+    return value == null ? null : StringData.fromString(value.getString());
   }
 
   @Override
   public DecimalData getDecimal(int pos, int precision, int scale) {
     Variant value = fieldByIndex(pos);
-    return value == null
-        ? null
-        : DecimalData.fromBigDecimal(
-            value.getDecimal(), precision, scale);
+    return value == null ? null : DecimalData.fromBigDecimal(value.getDecimal(), precision, scale);
   }
 
   @Override
@@ -181,30 +176,31 @@ public class VariantRowDataWrapper implements RowData {
   private Object element(Variant variant, LogicalType elementType) {
     LogicalTypeRoot root = elementType.getTypeRoot();
 
-      return switch (root) {
-          case NULL -> null;
-          case BOOLEAN -> variant.getBoolean();
-          case TINYINT -> variant.getByte();
-          case SMALLINT -> variant.getShort();
-          case INTEGER -> intValue(variant);
-          case BIGINT -> longValue(variant);
-          case FLOAT -> variant.getFloat();
-          case DOUBLE -> doubleValue(variant);
-          case DECIMAL -> decimalDataValue(variant, (DecimalType) elementType);
-          case CHAR, VARCHAR -> StringData.fromString(variant.getString());
-          case TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> timestampValue(variant);
-          case BINARY, VARBINARY -> variant.getBytes();
-          case ARRAY -> arrayDataValue(variant, ((ArrayType) elementType).getElementType());
-          case MAP -> mapDataValue(variant, (MapType) elementType);
-          case ROW -> new VariantRowDataWrapper((RowType) elementType).wrap(variant);
-          default -> throw new UnsupportedOperationException(
-                  "Unsupported Element type in Array/Map type:" + elementType);
-      };
+    return switch (root) {
+      case NULL -> null;
+      case BOOLEAN -> variant.getBoolean();
+      case TINYINT -> variant.getByte();
+      case SMALLINT -> variant.getShort();
+      case INTEGER -> intValue(variant);
+      case BIGINT -> longValue(variant);
+      case FLOAT -> variant.getFloat();
+      case DOUBLE -> doubleValue(variant);
+      case DECIMAL -> decimalDataValue(variant, (DecimalType) elementType);
+      case CHAR, VARCHAR -> StringData.fromString(variant.getString());
+      case TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> timestampValue(variant);
+      case BINARY, VARBINARY -> variant.getBytes();
+      case ARRAY -> arrayDataValue(variant, ((ArrayType) elementType).getElementType());
+      case MAP -> mapDataValue(variant, (MapType) elementType);
+      case ROW -> new VariantRowDataWrapper((RowType) elementType).wrap(variant);
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported Element type in Array/Map type:" + elementType);
+    };
   }
 
   private static DecimalData decimalDataValue(Variant variant, DecimalType decimalType) {
     return DecimalData.fromBigDecimal(
-            variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
+        variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
   }
 
   private MapData mapDataValue(Variant variant, MapType mapType) {
@@ -248,39 +244,39 @@ public class VariantRowDataWrapper implements RowData {
   }
 
   private int intValue(Variant variant) {
-      return switch (variant.getType()) {
-          case TINYINT -> variant.getByte();
-          case SMALLINT -> variant.getShort();
-          case INT -> variant.getInt();
-          default -> throw new UnsupportedOperationException(errMsg(variant, "int"));
-      };
+    return switch (variant.getType()) {
+      case TINYINT -> variant.getByte();
+      case SMALLINT -> variant.getShort();
+      case INT -> variant.getInt();
+      default -> throw new UnsupportedOperationException(errMsg(variant, "int"));
+    };
   }
 
   private long longValue(Variant variant) {
-      return switch (variant.getType()) {
-          case TINYINT -> variant.getByte();
-          case SMALLINT -> variant.getShort();
-          case INT -> variant.getInt();
-          case BIGINT -> variant.getLong();
-          default -> throw new UnsupportedOperationException(errMsg(variant, "long"));
-      };
+    return switch (variant.getType()) {
+      case TINYINT -> variant.getByte();
+      case SMALLINT -> variant.getShort();
+      case INT -> variant.getInt();
+      case BIGINT -> variant.getLong();
+      default -> throw new UnsupportedOperationException(errMsg(variant, "long"));
+    };
   }
 
   private double doubleValue(Variant variant) {
-      return switch (variant.getType()) {
-          case FLOAT -> variant.getFloat();
-          case DOUBLE -> variant.getDouble();
-          default -> throw new UnsupportedOperationException(errMsg(variant, "double"));
-      };
+    return switch (variant.getType()) {
+      case FLOAT -> variant.getFloat();
+      case DOUBLE -> variant.getDouble();
+      default -> throw new UnsupportedOperationException(errMsg(variant, "double"));
+    };
   }
 
   private TimestampData timestampValue(Variant variant) {
-      return switch (variant.getType()) {
-          case TIMESTAMP -> TimestampData.fromLocalDateTime(variant.getDateTime());
-          case TIMESTAMP_LTZ -> TimestampData.fromInstant(variant.getInstant());
-          case BIGINT -> timestampDataValue(variant.getLong());
-          default -> throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
-      };
+    return switch (variant.getType()) {
+      case TIMESTAMP -> TimestampData.fromLocalDateTime(variant.getDateTime());
+      case TIMESTAMP_LTZ -> TimestampData.fromInstant(variant.getInstant());
+      case BIGINT -> timestampDataValue(variant.getLong());
+      default -> throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
+    };
   }
 
   private static TimestampData timestampDataValue(long timeLong) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -79,74 +79,66 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public boolean isNullAt(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    Variant value = variantData.getField(fieldName);
+    Variant value = fieldByIndex(pos);
     return value == null || value.isNull();
   }
 
   @Override
   public boolean getBoolean(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getBoolean();
+    return fieldByIndex(pos).getBoolean();
   }
 
   @Override
   public byte getByte(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getByte();
+    return fieldByIndex(pos).getByte();
   }
 
   @Override
   public short getShort(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getShort();
+    return fieldByIndex(pos).getShort();
   }
 
   @Override
   public int getInt(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return getIntValue(variantData.getField(fieldName));
+    return intValue(fieldByIndex(pos));
   }
 
   @Override
   public long getLong(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return getLongValue(variantData.getField(fieldName));
+    return longValue(fieldByIndex(pos));
   }
 
   @Override
   public float getFloat(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getFloat();
+    return fieldByIndex(pos).getFloat();
   }
 
   @Override
   public double getDouble(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return getDoubleValue(variantData.getField(fieldName));
+    return doubleValue(fieldByIndex(pos));
   }
 
   @Override
   public StringData getString(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return isNullAt(pos)
+    Variant value = fieldByIndex(pos);
+    return value == null
         ? null
-        : StringData.fromString(variantData.getField(fieldName).getString());
+        : StringData.fromString(value.getString());
   }
 
   @Override
   public DecimalData getDecimal(int pos, int precision, int scale) {
-    String fieldName = getFieldNameByIndex(pos);
-    return isNullAt(pos)
+    Variant value = fieldByIndex(pos);
+    return value == null
         ? null
         : DecimalData.fromBigDecimal(
-            variantData.getField(fieldName).getDecimal(), precision, scale);
+            value.getDecimal(), precision, scale);
   }
 
   @Override
   public TimestampData getTimestamp(int pos, int precision) {
-    String fieldName = getFieldNameByIndex(pos);
-    return isNullAt(pos) ? null : getTimestamp(variantData.getField(fieldName));
+    Variant value = fieldByIndex(pos);
+    return value == null ? null : timestampValue(value);
   }
 
   @Override
@@ -156,94 +148,66 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public byte[] getBinary(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getBytes();
+    return fieldByIndex(pos).getBytes();
   }
 
   @Override
   public ArrayData getArray(int pos) {
     ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
     LogicalType elementType = arrayType.getElementType();
-
-    String fieldName = getFieldNameByIndex(pos);
-    Variant arrayVariant = variantData.getField(fieldName);
-
-    return getArrayData(arrayVariant, elementType);
+    Variant arrayVariant = fieldByIndex(pos);
+    return arrayDataValue(arrayVariant, elementType);
   }
 
   @Override
   public MapData getMap(int pos) {
     MapType mapType = (MapType) rowType.getTypeAt(pos);
-
-    String mapFieldName = getFieldNameByIndex(pos);
-    Variant mapVariant = variantData.getField(mapFieldName);
-
-    return getMapData(mapVariant, mapType);
+    Variant mapVariant = fieldByIndex(pos);
+    return mapDataValue(mapVariant, mapType);
   }
 
   @Override
   public RowData getRow(int pos, int numFields) {
-    String fieldName = getFieldNameByIndex(pos);
     VariantRowDataWrapper rowDataWrapper =
         new VariantRowDataWrapper((RowType) rowType.getTypeAt(pos));
-    return rowDataWrapper.wrap(variantData.getField(fieldName));
+    return rowDataWrapper.wrap(fieldByIndex(pos));
   }
 
   @Override
   public Variant getVariant(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName);
+    return fieldByIndex(pos);
   }
 
-  private Object getElementValue(LogicalType elementType, Variant variant) {
+  private Object element(Variant variant, LogicalType elementType) {
     LogicalTypeRoot root = elementType.getTypeRoot();
 
-    switch (root) {
-      case NULL:
-        return null;
-      case BOOLEAN:
-        return variant.getBoolean();
-      case TINYINT:
-        return variant.getByte();
-      case SMALLINT:
-        return variant.getShort();
-      case INTEGER:
-        return getIntValue(variant);
-      case BIGINT:
-        return getLongValue(variant);
-      case FLOAT:
-        return variant.getFloat();
-      case DOUBLE:
-        return getDoubleValue(variant);
-      case DECIMAL:
-        DecimalType decimalType = (DecimalType) elementType;
-        return DecimalData.fromBigDecimal(
-            variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
-      case CHAR:
-      case VARCHAR:
-        return StringData.fromString(variant.getString());
-      case TIMESTAMP_WITHOUT_TIME_ZONE:
-      case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-        return getTimestamp(variant);
-      case BINARY:
-      case VARBINARY:
-        return variant.getBytes();
-      case ARRAY:
-        ArrayType arrayType = (ArrayType) elementType;
-        LogicalType innerElementType = arrayType.getElementType();
-        return getArrayData(variant, innerElementType);
-      case MAP:
-        return getMapData(variant, (MapType) elementType);
-      case ROW:
-        VariantRowDataWrapper rowDataWrapper = new VariantRowDataWrapper((RowType) elementType);
-        return rowDataWrapper.wrap(variant);
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported Element type in Array/Map type:" + elementType);
-    }
+      return switch (root) {
+          case NULL -> null;
+          case BOOLEAN -> variant.getBoolean();
+          case TINYINT -> variant.getByte();
+          case SMALLINT -> variant.getShort();
+          case INTEGER -> intValue(variant);
+          case BIGINT -> longValue(variant);
+          case FLOAT -> variant.getFloat();
+          case DOUBLE -> doubleValue(variant);
+          case DECIMAL -> decimalDataValue(variant, (DecimalType) elementType);
+          case CHAR, VARCHAR -> StringData.fromString(variant.getString());
+          case TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> timestampValue(variant);
+          case BINARY, VARBINARY -> variant.getBytes();
+          case ARRAY -> arrayDataValue(variant, ((ArrayType) elementType).getElementType());
+          case MAP -> mapDataValue(variant, (MapType) elementType);
+          case ROW -> new VariantRowDataWrapper((RowType) elementType).wrap(variant);
+          default -> throw new UnsupportedOperationException(
+                  "Unsupported Element type in Array/Map type:" + elementType);
+      };
   }
 
-  private MapData getMapData(Variant variant, MapType mapType) {
+  private static DecimalData decimalDataValue(Variant variant, DecimalType decimalType) {
+    return DecimalData.fromBigDecimal(
+            variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
+  }
+
+  private MapData mapDataValue(Variant variant, MapType mapType) {
     LogicalType keyType = mapType.getKeyType();
     LogicalType valueType = mapType.getValueType();
 
@@ -255,7 +219,7 @@ public class VariantRowDataWrapper implements RowData {
     if (variant != null) {
       List<String> keys = BinaryVariantAccessorUtils.fieldNames(variant);
       for (String key : keys) {
-        mapData.put(StringData.fromString(key), getElementValue(valueType, variant.getField(key)));
+        mapData.put(StringData.fromString(key), element(variant.getField(key), valueType));
       }
 
       return new GenericMapData(mapData);
@@ -264,7 +228,7 @@ public class VariantRowDataWrapper implements RowData {
     return null;
   }
 
-  private ArrayData getArrayData(Variant variant, LogicalType innerElementType) {
+  private ArrayData arrayDataValue(Variant variant, LogicalType innerElementType) {
     if (variant != null) {
       Preconditions.checkArgument(
           variant.getType().equals(Variant.Type.ARRAY),
@@ -274,65 +238,53 @@ public class VariantRowDataWrapper implements RowData {
 
       for (int i = 0; i < arraySize; i++) {
         Variant element = variant.getElement(i);
-        elements[i] = element == null ? null : getElementValue(innerElementType, element);
+        elements[i] = element == null ? null : element(element, innerElementType);
       }
 
       return new GenericArrayData(elements);
     }
+
     return null;
   }
 
-  private int getIntValue(Variant variant) {
-    switch (variant.getType()) {
-      case TINYINT:
-        return variant.getByte();
-      case SMALLINT:
-        return variant.getShort();
-      case INT:
-        return variant.getInt();
-      default:
-        throw new UnsupportedOperationException(errMsg(variant, "int"));
-    }
+  private int intValue(Variant variant) {
+      return switch (variant.getType()) {
+          case TINYINT -> variant.getByte();
+          case SMALLINT -> variant.getShort();
+          case INT -> variant.getInt();
+          default -> throw new UnsupportedOperationException(errMsg(variant, "int"));
+      };
   }
 
-  private long getLongValue(Variant variant) {
-    switch (variant.getType()) {
-      case TINYINT:
-        return variant.getByte();
-      case SMALLINT:
-        return variant.getShort();
-      case INT:
-        return variant.getInt();
-      case BIGINT:
-        return variant.getLong();
-      default:
-        throw new UnsupportedOperationException(errMsg(variant, "long"));
-    }
+  private long longValue(Variant variant) {
+      return switch (variant.getType()) {
+          case TINYINT -> variant.getByte();
+          case SMALLINT -> variant.getShort();
+          case INT -> variant.getInt();
+          case BIGINT -> variant.getLong();
+          default -> throw new UnsupportedOperationException(errMsg(variant, "long"));
+      };
   }
 
-  private double getDoubleValue(Variant variant) {
-    switch (variant.getType()) {
-      case FLOAT:
-        return variant.getFloat();
-      case DOUBLE:
-        return variant.getDouble();
-      default:
-        throw new UnsupportedOperationException(errMsg(variant, "double"));
-    }
+  private double doubleValue(Variant variant) {
+      return switch (variant.getType()) {
+          case FLOAT -> variant.getFloat();
+          case DOUBLE -> variant.getDouble();
+          default -> throw new UnsupportedOperationException(errMsg(variant, "double"));
+      };
   }
 
-  private TimestampData getTimestamp(Variant variant) {
-    switch (variant.getType()) {
-      case TIMESTAMP:
-        return TimestampData.fromLocalDateTime(variant.getDateTime());
-      case TIMESTAMP_LTZ:
-        return TimestampData.fromInstant(variant.getInstant());
-      case BIGINT:
-        long timeLong = variant.getLong();
-        return TimestampData.fromEpochMillis(timeLong / 1000, (int) (timeLong % 1000) * 1000);
-      default:
-        throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
-    }
+  private TimestampData timestampValue(Variant variant) {
+      return switch (variant.getType()) {
+          case TIMESTAMP -> TimestampData.fromLocalDateTime(variant.getDateTime());
+          case TIMESTAMP_LTZ -> TimestampData.fromInstant(variant.getInstant());
+          case BIGINT -> timestampDataValue(variant.getLong());
+          default -> throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
+      };
+  }
+
+  private static TimestampData timestampDataValue(long timeLong) {
+    return TimestampData.fromEpochMillis(timeLong / 1000, (int) (timeLong % 1000) * 1000);
   }
 
   private static String errMsg(Variant variant, String type) {
@@ -340,7 +292,8 @@ public class VariantRowDataWrapper implements RowData {
         "Failed to read Variant %s of type %s as %s", variant.toJson(), variant.getType(), type);
   }
 
-  private String getFieldNameByIndex(int pos) {
-    return rowType.getFields().get(pos).getName();
+  private Variant fieldByIndex(int pos) {
+    String fieldName = rowType.getFields().get(pos).getName();
+    return variantData.getField(fieldName);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -18,8 +18,13 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
+import java.util.List;
+import java.util.Map;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 /**
  * Abstract base class for SQL-based dynamic record generators. Users will extend this class to
@@ -28,12 +33,44 @@ import org.apache.flink.table.types.logical.RowType;
 public abstract class DynamicTableRecordGenerator implements DynamicRecordGenerator<RowData> {
 
   private final RowType rowType;
+  private final Map<String, String> writeProps;
 
-  public DynamicTableRecordGenerator(RowType rowType) {
+  public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
     this.rowType = rowType;
+    this.writeProps = writeProps;
   }
 
-  protected RowType rowType() {
+  public RowType rowType() {
     return rowType;
+  }
+
+  public Map<String, String> writeProps() {
+    return writeProps;
+  }
+
+  protected Map<String, Integer> getFieldPositionIndex() {
+    Map<String, Integer> fieldNameToPosition = Maps.newHashMap();
+    List<RowType.RowField> fields = rowType.getFields();
+
+    for (int i = 0; i < fields.size(); i++) {
+      RowType.RowField field = fields.get(i);
+      fieldNameToPosition.put(field.getName(), i);
+    }
+
+    return fieldNameToPosition;
+  }
+
+  protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
+    int fieldIndex = rowType.getFieldIndex(columnName);
+
+    Preconditions.checkArgument(fieldIndex != -1, "Missing column %s", columnName);
+
+    LogicalType actualType = rowType.getTypeAt(fieldIndex);
+    Preconditions.checkArgument(
+        actualType.is(expectedType.getTypeRoot()),
+        "Invalid column type for %s:%s. Expected column type:%s",
+        columnName,
+        actualType,
+        expectedType);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -34,10 +34,12 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
 
   private final RowType rowType;
   private final Map<String, String> writeProperties;
+  private final Map<String, Integer> fieldNameToPosition;
 
   public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProperties) {
     this.rowType = rowType;
     this.writeProperties = writeProperties;
+    this.fieldNameToPosition = fieldNameToPositionMapping(rowType);
   }
 
   protected RowType rowType() {
@@ -48,7 +50,29 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
     return writeProperties;
   }
 
-  protected Map<String, Integer> fieldNameToPositionMapping() {
+  protected Map<String, Integer> fieldNameToPosition() {
+    return fieldNameToPosition;
+  }
+
+  protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
+    int fieldIndex = rowType.getFieldIndex(columnName);
+    Preconditions.checkArgument(
+        fieldIndex != -1,
+        "Missing column %s. Expected column %s of type %s.",
+        columnName,
+        columnName,
+        expectedType);
+
+    LogicalType actualType = rowType.getTypeAt(fieldIndex);
+    Preconditions.checkArgument(
+        actualType.is(expectedType.getTypeRoot()),
+        "Invalid column type for %s:%s. Expected column type: %s",
+        columnName,
+        actualType,
+        expectedType);
+  }
+
+  private Map<String, Integer> fieldNameToPositionMapping(RowType rowType) {
     Map<String, Integer> fieldNameToPosition = Maps.newHashMap();
     List<RowType.RowField> fields = rowType.getFields();
 
@@ -58,24 +82,5 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
     }
 
     return fieldNameToPosition;
-  }
-
-  protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
-    int fieldIndex = rowType.getFieldIndex(columnName);
-
-    Preconditions.checkArgument(
-        fieldIndex != -1,
-        "Missing column %s.Expected column %s of type %s.",
-        columnName,
-        columnName,
-        expectedType);
-
-    LogicalType actualType = rowType.getTypeAt(fieldIndex);
-    Preconditions.checkArgument(
-        actualType.is(expectedType.getTypeRoot()),
-        "Invalid column type for %s:%s. Expected column type:%s",
-        columnName,
-        actualType,
-        expectedType);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -39,7 +39,7 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
   public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProperties) {
     this.rowType = rowType;
     this.writeProperties = writeProperties;
-    this.fieldNameToPosition = fieldNameToPositionMapping(rowType);
+    this.fieldNameToPosition = fieldNameToPositionMapping();
   }
 
   protected RowType rowType() {
@@ -72,15 +72,15 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
         expectedType);
   }
 
-  private Map<String, Integer> fieldNameToPositionMapping(RowType rowType) {
-    Map<String, Integer> fieldNameToPosition = Maps.newHashMap();
-    List<RowType.RowField> fields = rowType.getFields();
+  private Map<String, Integer> fieldNameToPositionMapping() {
+    Map<String, Integer> fieldNameToPositionMap = Maps.newHashMap();
+    List<RowType.RowField> fields = this.rowType.getFields();
 
     for (int i = 0; i < fields.size(); i++) {
       RowType.RowField field = fields.get(i);
-      fieldNameToPosition.put(field.getName(), i);
+      fieldNameToPositionMap.put(field.getName(), i);
     }
 
-    return fieldNameToPosition;
+    return fieldNameToPositionMap;
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -33,22 +33,22 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 public abstract class DynamicTableRecordGenerator implements DynamicRecordGenerator<RowData> {
 
   private final RowType rowType;
-  private final Map<String, String> writeProps;
+  private final Map<String, String> writeProperties;
 
-  public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
+  public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProperties) {
     this.rowType = rowType;
-    this.writeProps = writeProps;
+    this.writeProperties = writeProperties;
   }
 
-  public RowType rowType() {
+  protected RowType rowType() {
     return rowType;
   }
 
-  public Map<String, String> writeProps() {
-    return writeProps;
+  protected Map<String, String> writeProperties() {
+    return writeProperties;
   }
 
-  protected Map<String, Integer> getFieldPositionIndex() {
+  protected Map<String, Integer> fieldNameToPositionMapping() {
     Map<String, Integer> fieldNameToPosition = Maps.newHashMap();
     List<RowType.RowField> fields = rowType.getFields();
 
@@ -63,7 +63,12 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
   protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
     int fieldIndex = rowType.getFieldIndex(columnName);
 
-    Preconditions.checkArgument(fieldIndex != -1, "Missing column %s", columnName);
+    Preconditions.checkArgument(
+        fieldIndex != -1,
+        "Missing column %s.Expected column %s of type %s.",
+        columnName,
+        columnName,
+        expectedType);
 
     LogicalType actualType = rowType.getTypeAt(fieldIndex);
     Preconditions.checkArgument(

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.Map;
+import org.apache.avro.Schema.Parser;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
+import org.apache.flink.types.variant.Variant;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.FlinkCreateTableOptions;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.flink.data.VariantRowDataWrapper;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+
+public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGenerator {
+  private transient Map<String, Integer> fieldNameToPosition;
+  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
+  private static final Parser PARSER = new Parser();
+  private static final String DEFAULT_CACHE_MAX_SIZE = "100";
+  private static final Splitter COMMA = Splitter.on(',');
+  private transient int maxCacheSize;
+
+  public VariantAvroDynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
+    super(rowType, writeProps);
+
+    String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
+    Preconditions.checkArgument(
+        rowType.getFieldIndex(catalogDatabaseColumn) != -1
+            || writeProps().containsKey(catalogDatabaseColumn),
+        "Invalid %s:null." + "Either %s column should be passed in Row or set in table options",
+        catalogDatabaseColumn,
+        catalogDatabaseColumn);
+
+    String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
+    Preconditions.checkArgument(
+        rowType.getFieldIndex(catalogTableColumn) != -1
+            || writeProps().containsKey(catalogTableColumn),
+        "Invalid %s:null." + "Either %s column should be passed in Row or set in table options",
+        catalogTableColumn,
+        catalogTableColumn);
+
+    validateRequiredFieldAndType("data", new VariantType(false));
+    validateRequiredFieldAndType("avro_schema", new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredFieldAndType("avro_schema_id", new VarCharType(false, Integer.MAX_VALUE));
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+
+    this.fieldNameToPosition = getFieldPositionIndex();
+
+    this.maxCacheSize =
+        Integer.parseInt(
+            writeProps().getOrDefault("schema-cache-max-size", DEFAULT_CACHE_MAX_SIZE));
+    this.tableCache = new LRUCache<>(maxCacheSize);
+  }
+
+  @Override
+  public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
+    String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
+    String catalogDb =
+        getStringColumnValue(
+            inputRecord, catalogDatabaseColumn, writeProps().get(catalogDatabaseColumn));
+
+    String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
+    String catalogTable =
+        getStringColumnValue(inputRecord, catalogTableColumn, writeProps().get(catalogTableColumn));
+
+    // All write options overrides should be inferred in DynamicIcebergSink
+    String branch = getStringColumnValue(inputRecord, FlinkWriteOptions.BRANCH.key());
+
+    DistributionMode distributionMode = null;
+    String distributionModeStr =
+        getStringColumnValue(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE.key());
+    if (distributionModeStr != null) {
+      distributionMode = DistributionMode.fromName(distributionModeStr);
+    }
+
+    int writeParallelism = -1;
+    Integer pos = fieldNameToPosition.get(FlinkWriteOptions.WRITE_PARALLELISM.key());
+    if (pos != null) {
+      writeParallelism = inputRecord.getInt(pos);
+    }
+
+    Variant variantData = inputRecord.getVariant(fieldNameToPosition.get("data"));
+    String avroSchema = getStringColumnValue(inputRecord, "avro_schema");
+    String avroSchemaId = getStringColumnValue(inputRecord, "avro_schema_id");
+
+    TableIdentifier tableIdentifier = TableIdentifier.of(catalogDb, catalogTable);
+    SchemaAndPartitionSpecCacheItem cacheItem =
+        tableCache.computeIfAbsent(
+            tableIdentifier, identifier -> new SchemaAndPartitionSpecCacheItem(maxCacheSize));
+
+    SchemaCacheItem schemaCacheItem = cacheItem.getOrCreateSchema(avroSchemaId, avroSchema);
+
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+    String partitionCols = getStringColumnValue(inputRecord, "partition_cols", null);
+    if (partitionCols != null) {
+      partitionSpec =
+          cacheItem.getOrCreatePartitionSpec(partitionCols, schemaCacheItem.tableSchema());
+    }
+
+    out.collect(
+        new DynamicRecord(
+            tableIdentifier,
+            branch,
+            schemaCacheItem.tableSchema(),
+            schemaCacheItem.variantRowDataWrapper().wrap(variantData),
+            partitionSpec,
+            distributionMode,
+            writeParallelism));
+  }
+
+  private String getStringColumnValue(RowData rowData, String col, String defaultValue) {
+    Integer pos = fieldNameToPosition.get(col);
+    if (pos != null) {
+      StringData value = rowData.getString(pos);
+      return value == null ? defaultValue : value.toString();
+    }
+
+    return defaultValue;
+  }
+
+  private String getStringColumnValue(RowData rowData, String col) {
+    return getStringColumnValue(rowData, col, null);
+  }
+
+  private static class SchemaAndPartitionSpecCacheItem {
+    private final Map<String, SchemaCacheItem> schemaCache;
+    private final Map<String, PartitionSpec> partitionSpecCache;
+
+    SchemaAndPartitionSpecCacheItem(int maximumSize) {
+      this.schemaCache = new LRUCache<>(maximumSize);
+      this.partitionSpecCache = new LRUCache<>(maximumSize);
+    }
+
+    SchemaCacheItem getOrCreateSchema(String avroSchemaId, String avroSchema) {
+      SchemaCacheItem schemaCacheItem = schemaCache.get(avroSchemaId);
+      if (schemaCacheItem == null) {
+        Schema icebergTableSchema = AvroSchemaUtil.toIceberg(PARSER.parse(avroSchema));
+        RowType rowType = FlinkSchemaUtil.convert(icebergTableSchema);
+        VariantRowDataWrapper variantRowDataWrapper = new VariantRowDataWrapper(rowType);
+        schemaCacheItem = new SchemaCacheItem(icebergTableSchema, variantRowDataWrapper);
+        schemaCache.put(avroSchemaId, schemaCacheItem);
+      }
+
+      return schemaCacheItem;
+    }
+
+    PartitionSpec getOrCreatePartitionSpec(String partitionCols, Schema schema) {
+      PartitionSpec partitionSpec = partitionSpecCache.get(partitionCols);
+
+      if (partitionSpec == null) {
+        PartitionSpec.Builder partitionSpecBuilder = PartitionSpec.builderFor(schema);
+        for (String col : COMMA.split(partitionCols)) {
+          partitionSpecBuilder.identity(col);
+        }
+
+        partitionSpec = partitionSpecBuilder.build();
+        partitionSpecCache.put(partitionCols, partitionSpec);
+      }
+
+      return partitionSpec;
+    }
+  }
+
+  private record SchemaCacheItem(Schema tableSchema, VariantRowDataWrapper variantRowDataWrapper) {}
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -84,20 +84,24 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
 
     String value = writeProperties().get(FlinkWriteOptions.CACHE_MAX_SIZE.key());
     this.maxCacheSize =
-            value != null ? Integer.parseInt(value) : FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
+        value != null ? Integer.parseInt(value) : FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
   @Override
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
-    String catalogDb = columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE, writeProperties());
-    String catalogTable = columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE, writeProperties());
+    String catalogDb =
+        columnValueAsString(
+            inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE, writeProperties());
+    String catalogTable =
+        columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE, writeProperties());
 
     // All write options overrides will be inferred in DynamicIcebergSink
     String branch = columnValueAsString(inputRecord, FlinkWriteOptions.BRANCH);
-    String distributionModeStr = columnValueAsString(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
+    String distributionModeStr =
+        columnValueAsString(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
     DistributionMode distributionMode =
-            distributionModeStr != null ? DistributionMode.fromName(distributionModeStr) : null;
+        distributionModeStr != null ? DistributionMode.fromName(distributionModeStr) : null;
 
     Integer pos = fieldNameToPosition().get(FlinkWriteOptions.WRITE_PARALLELISM.key());
     int writeParallelism = pos != null ? inputRecord.getInt(pos) : -1;
@@ -130,7 +134,8 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             writeParallelism));
   }
 
-  private String columnValueAsString(RowData rowData, ConfigOption<String> config, Map<String, String> writeProperties) {
+  private String columnValueAsString(
+      RowData rowData, ConfigOption<String> config, Map<String, String> writeProperties) {
     return columnValueAsString(rowData, config.key(), writeProperties.get(config.key()));
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -37,50 +37,59 @@ import org.apache.iceberg.flink.FlinkCreateTableOptions;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.FlinkWriteOptions;
 import org.apache.iceberg.flink.data.VariantRowDataWrapper;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 
 public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGenerator {
+
   private transient Map<String, Integer> fieldNameToPosition;
-  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
-  private static final Parser PARSER = new Parser();
-  private static final String DEFAULT_CACHE_MAX_SIZE = "100";
   private static final Splitter COMMA = Splitter.on(',');
   private transient int maxCacheSize;
+  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
+  @VisibleForTesting static final String DATA_COLUMN = "data";
+  @VisibleForTesting static final String AVRO_SCHEMA_COLUMN = "avro_schema";
+  @VisibleForTesting static final String AVRO_SCHEMA_ID_COLUMN = "avro_schema_id";
+  @VisibleForTesting static final String PARTITION_COLUMNS = "partition_columns";
 
-  public VariantAvroDynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
-    super(rowType, writeProps);
+  public VariantAvroDynamicTableRecordGenerator(
+      RowType rowType, Map<String, String> writeProperties) {
+    super(rowType, writeProperties);
 
     String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
     Preconditions.checkArgument(
         rowType.getFieldIndex(catalogDatabaseColumn) != -1
-            || writeProps().containsKey(catalogDatabaseColumn),
-        "Invalid %s:null." + "Either %s column should be passed in Row or set in table options",
+            || writeProperties().containsKey(catalogDatabaseColumn),
+        "Invalid %s:null.Either %s column should be passed in Row or set in table options",
         catalogDatabaseColumn,
         catalogDatabaseColumn);
 
     String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
     Preconditions.checkArgument(
         rowType.getFieldIndex(catalogTableColumn) != -1
-            || writeProps().containsKey(catalogTableColumn),
-        "Invalid %s:null." + "Either %s column should be passed in Row or set in table options",
+            || writeProperties().containsKey(catalogTableColumn),
+        "Invalid %s:null.Either %s column should be passed in Row or set in table options",
         catalogTableColumn,
         catalogTableColumn);
 
-    validateRequiredFieldAndType("data", new VariantType(false));
-    validateRequiredFieldAndType("avro_schema", new VarCharType(false, Integer.MAX_VALUE));
-    validateRequiredFieldAndType("avro_schema_id", new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredFieldAndType(DATA_COLUMN, new VariantType(false));
+    validateRequiredFieldAndType(AVRO_SCHEMA_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredFieldAndType(AVRO_SCHEMA_ID_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
   }
 
   @Override
   public void open(OpenContext openContext) throws Exception {
     super.open(openContext);
 
-    this.fieldNameToPosition = getFieldPositionIndex();
+    this.fieldNameToPosition = fieldNameToPositionMapping();
 
-    this.maxCacheSize =
-        Integer.parseInt(
-            writeProps().getOrDefault("schema-cache-max-size", DEFAULT_CACHE_MAX_SIZE));
+    String value = writeProperties().get(FlinkWriteOptions.CACHE_MAX_SIZE.key());
+    if (value != null) {
+      maxCacheSize = Integer.parseInt(value);
+    } else {
+      maxCacheSize = FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
+    }
+
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
@@ -88,19 +97,20 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
     String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
     String catalogDb =
-        getStringColumnValue(
-            inputRecord, catalogDatabaseColumn, writeProps().get(catalogDatabaseColumn));
+        stringTypedColumnValue(
+            inputRecord, catalogDatabaseColumn, writeProperties().get(catalogDatabaseColumn));
 
     String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
     String catalogTable =
-        getStringColumnValue(inputRecord, catalogTableColumn, writeProps().get(catalogTableColumn));
+        stringTypedColumnValue(
+            inputRecord, catalogTableColumn, writeProperties().get(catalogTableColumn));
 
     // All write options overrides should be inferred in DynamicIcebergSink
-    String branch = getStringColumnValue(inputRecord, FlinkWriteOptions.BRANCH.key());
+    String branch = stringTypedColumnValue(inputRecord, FlinkWriteOptions.BRANCH.key());
 
     DistributionMode distributionMode = null;
     String distributionModeStr =
-        getStringColumnValue(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE.key());
+        stringTypedColumnValue(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE.key());
     if (distributionModeStr != null) {
       distributionMode = DistributionMode.fromName(distributionModeStr);
     }
@@ -111,22 +121,21 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       writeParallelism = inputRecord.getInt(pos);
     }
 
-    Variant variantData = inputRecord.getVariant(fieldNameToPosition.get("data"));
-    String avroSchema = getStringColumnValue(inputRecord, "avro_schema");
-    String avroSchemaId = getStringColumnValue(inputRecord, "avro_schema_id");
+    Variant variantData = inputRecord.getVariant(fieldNameToPosition.get(DATA_COLUMN));
+    String avroSchema = stringTypedColumnValue(inputRecord, AVRO_SCHEMA_COLUMN);
+    String avroSchemaId = stringTypedColumnValue(inputRecord, AVRO_SCHEMA_ID_COLUMN);
 
     TableIdentifier tableIdentifier = TableIdentifier.of(catalogDb, catalogTable);
     SchemaAndPartitionSpecCacheItem cacheItem =
         tableCache.computeIfAbsent(
             tableIdentifier, identifier -> new SchemaAndPartitionSpecCacheItem(maxCacheSize));
 
-    SchemaCacheItem schemaCacheItem = cacheItem.getOrCreateSchema(avroSchemaId, avroSchema);
+    SchemaCacheItem schemaCacheItem = cacheItem.schema(avroSchemaId, avroSchema);
 
     PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
-    String partitionCols = getStringColumnValue(inputRecord, "partition_cols", null);
+    String partitionCols = stringTypedColumnValue(inputRecord, PARTITION_COLUMNS, null);
     if (partitionCols != null) {
-      partitionSpec =
-          cacheItem.getOrCreatePartitionSpec(partitionCols, schemaCacheItem.tableSchema());
+      partitionSpec = cacheItem.partitionSpec(partitionCols, schemaCacheItem.tableSchema());
     }
 
     out.collect(
@@ -140,8 +149,13 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             writeParallelism));
   }
 
-  private String getStringColumnValue(RowData rowData, String col, String defaultValue) {
-    Integer pos = fieldNameToPosition.get(col);
+  @VisibleForTesting
+  Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache() {
+    return tableCache;
+  }
+
+  private String stringTypedColumnValue(RowData rowData, String column, String defaultValue) {
+    Integer pos = fieldNameToPosition.get(column);
     if (pos != null) {
       StringData value = rowData.getString(pos);
       return value == null ? defaultValue : value.toString();
@@ -150,11 +164,12 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     return defaultValue;
   }
 
-  private String getStringColumnValue(RowData rowData, String col) {
-    return getStringColumnValue(rowData, col, null);
+  private String stringTypedColumnValue(RowData rowData, String column) {
+    return stringTypedColumnValue(rowData, column, null);
   }
 
-  private static class SchemaAndPartitionSpecCacheItem {
+  @VisibleForTesting
+  static class SchemaAndPartitionSpecCacheItem {
     private final Map<String, SchemaCacheItem> schemaCache;
     private final Map<String, PartitionSpec> partitionSpecCache;
 
@@ -163,10 +178,10 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       this.partitionSpecCache = new LRUCache<>(maximumSize);
     }
 
-    SchemaCacheItem getOrCreateSchema(String avroSchemaId, String avroSchema) {
+    SchemaCacheItem schema(String avroSchemaId, String avroSchema) {
       SchemaCacheItem schemaCacheItem = schemaCache.get(avroSchemaId);
       if (schemaCacheItem == null) {
-        Schema icebergTableSchema = AvroSchemaUtil.toIceberg(PARSER.parse(avroSchema));
+        Schema icebergTableSchema = AvroSchemaUtil.toIceberg(new Parser().parse(avroSchema));
         RowType rowType = FlinkSchemaUtil.convert(icebergTableSchema);
         VariantRowDataWrapper variantRowDataWrapper = new VariantRowDataWrapper(rowType);
         schemaCacheItem = new SchemaCacheItem(icebergTableSchema, variantRowDataWrapper);
@@ -176,7 +191,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       return schemaCacheItem;
     }
 
-    PartitionSpec getOrCreatePartitionSpec(String partitionCols, Schema schema) {
+    PartitionSpec partitionSpec(String partitionCols, Schema schema) {
       PartitionSpec partitionSpec = partitionSpecCache.get(partitionCols);
 
       if (partitionSpec == null) {
@@ -191,7 +206,18 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
 
       return partitionSpec;
     }
+
+    @VisibleForTesting
+    SchemaCacheItem schemaCacheItem(String avroSchemaId) {
+      return schemaCache.get(avroSchemaId);
+    }
+
+    @VisibleForTesting
+    PartitionSpec partitionSpec(String partitionCols) {
+      return partitionSpecCache.get(partitionCols);
+    }
   }
 
-  private record SchemaCacheItem(Schema tableSchema, VariantRowDataWrapper variantRowDataWrapper) {}
+  @VisibleForTesting
+  record SchemaCacheItem(Schema tableSchema, VariantRowDataWrapper variantRowDataWrapper) {}
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 import java.util.Map;
 import org.apache.avro.Schema.Parser;
 import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.RowType;
@@ -43,14 +44,14 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 
 public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGenerator {
 
-  private transient Map<String, Integer> fieldNameToPosition;
   private static final Splitter COMMA = Splitter.on(',');
-  private transient int maxCacheSize;
-  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
   @VisibleForTesting static final String DATA_COLUMN = "data";
   @VisibleForTesting static final String AVRO_SCHEMA_COLUMN = "avro_schema";
   @VisibleForTesting static final String AVRO_SCHEMA_ID_COLUMN = "avro_schema_id";
   @VisibleForTesting static final String PARTITION_COLUMNS = "partition_columns";
+
+  private transient int maxCacheSize;
+  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
 
   public VariantAvroDynamicTableRecordGenerator(
       RowType rowType, Map<String, String> writeProperties) {
@@ -60,7 +61,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     Preconditions.checkArgument(
         rowType.getFieldIndex(catalogDatabaseColumn) != -1
             || writeProperties().containsKey(catalogDatabaseColumn),
-        "Invalid %s:null.Either %s column should be passed in Row or set in table options",
+        "Invalid %s:null. Either %s column should be passed in Row or set in table options",
         catalogDatabaseColumn,
         catalogDatabaseColumn);
 
@@ -68,7 +69,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     Preconditions.checkArgument(
         rowType.getFieldIndex(catalogTableColumn) != -1
             || writeProperties().containsKey(catalogTableColumn),
-        "Invalid %s:null.Either %s column should be passed in Row or set in table options",
+        "Invalid %s:null. Either %s column should be passed in Row or set in table options",
         catalogTableColumn,
         catalogTableColumn);
 
@@ -81,49 +82,29 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   public void open(OpenContext openContext) throws Exception {
     super.open(openContext);
 
-    this.fieldNameToPosition = fieldNameToPositionMapping();
-
     String value = writeProperties().get(FlinkWriteOptions.CACHE_MAX_SIZE.key());
-    if (value != null) {
-      maxCacheSize = Integer.parseInt(value);
-    } else {
-      maxCacheSize = FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
-    }
-
+    this.maxCacheSize =
+            value != null ? Integer.parseInt(value) : FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
   @Override
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
-    String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
-    String catalogDb =
-        stringTypedColumnValue(
-            inputRecord, catalogDatabaseColumn, writeProperties().get(catalogDatabaseColumn));
+    String catalogDb = columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE, writeProperties());
+    String catalogTable = columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE, writeProperties());
 
-    String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
-    String catalogTable =
-        stringTypedColumnValue(
-            inputRecord, catalogTableColumn, writeProperties().get(catalogTableColumn));
+    // All write options overrides will be inferred in DynamicIcebergSink
+    String branch = columnValueAsString(inputRecord, FlinkWriteOptions.BRANCH);
+    String distributionModeStr = columnValueAsString(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
+    DistributionMode distributionMode =
+            distributionModeStr != null ? DistributionMode.fromName(distributionModeStr) : null;
 
-    // All write options overrides should be inferred in DynamicIcebergSink
-    String branch = stringTypedColumnValue(inputRecord, FlinkWriteOptions.BRANCH.key());
+    Integer pos = fieldNameToPosition().get(FlinkWriteOptions.WRITE_PARALLELISM.key());
+    int writeParallelism = pos != null ? inputRecord.getInt(pos) : -1;
 
-    DistributionMode distributionMode = null;
-    String distributionModeStr =
-        stringTypedColumnValue(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE.key());
-    if (distributionModeStr != null) {
-      distributionMode = DistributionMode.fromName(distributionModeStr);
-    }
-
-    int writeParallelism = -1;
-    Integer pos = fieldNameToPosition.get(FlinkWriteOptions.WRITE_PARALLELISM.key());
-    if (pos != null) {
-      writeParallelism = inputRecord.getInt(pos);
-    }
-
-    Variant variantData = inputRecord.getVariant(fieldNameToPosition.get(DATA_COLUMN));
-    String avroSchema = stringTypedColumnValue(inputRecord, AVRO_SCHEMA_COLUMN);
-    String avroSchemaId = stringTypedColumnValue(inputRecord, AVRO_SCHEMA_ID_COLUMN);
+    Variant variantData = inputRecord.getVariant(fieldNameToPosition().get(DATA_COLUMN));
+    String avroSchema = columnValueAsString(inputRecord, AVRO_SCHEMA_COLUMN);
+    String avroSchemaId = columnValueAsString(inputRecord, AVRO_SCHEMA_ID_COLUMN);
 
     TableIdentifier tableIdentifier = TableIdentifier.of(catalogDb, catalogTable);
     SchemaAndPartitionSpecCacheItem cacheItem =
@@ -133,7 +114,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     SchemaCacheItem schemaCacheItem = cacheItem.schema(avroSchemaId, avroSchema);
 
     PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
-    String partitionCols = stringTypedColumnValue(inputRecord, PARTITION_COLUMNS, null);
+    String partitionCols = columnValueAsString(inputRecord, PARTITION_COLUMNS, null);
     if (partitionCols != null) {
       partitionSpec = cacheItem.partitionSpec(partitionCols, schemaCacheItem.tableSchema());
     }
@@ -149,13 +130,20 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             writeParallelism));
   }
 
-  @VisibleForTesting
-  Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache() {
-    return tableCache;
+  private String columnValueAsString(RowData rowData, ConfigOption<String> config, Map<String, String> writeProperties) {
+    return columnValueAsString(rowData, config.key(), writeProperties.get(config.key()));
   }
 
-  private String stringTypedColumnValue(RowData rowData, String column, String defaultValue) {
-    Integer pos = fieldNameToPosition.get(column);
+  private String columnValueAsString(RowData rowData, ConfigOption<String> config) {
+    return columnValueAsString(rowData, config.key());
+  }
+
+  private String columnValueAsString(RowData rowData, String columnName) {
+    return columnValueAsString(rowData, columnName, null);
+  }
+
+  private String columnValueAsString(RowData rowData, String column, String defaultValue) {
+    Integer pos = fieldNameToPosition().get(column);
     if (pos != null) {
       StringData value = rowData.getString(pos);
       return value == null ? defaultValue : value.toString();
@@ -164,8 +152,9 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     return defaultValue;
   }
 
-  private String stringTypedColumnValue(RowData rowData, String column) {
-    return stringTypedColumnValue(rowData, column, null);
+  @VisibleForTesting
+  Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache() {
+    return tableCache;
   }
 
   @VisibleForTesting
@@ -178,7 +167,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       this.partitionSpecCache = new LRUCache<>(maximumSize);
     }
 
-    SchemaCacheItem schema(String avroSchemaId, String avroSchema) {
+    private SchemaCacheItem schema(String avroSchemaId, String avroSchema) {
       SchemaCacheItem schemaCacheItem = schemaCache.get(avroSchemaId);
       if (schemaCacheItem == null) {
         Schema icebergTableSchema = AvroSchemaUtil.toIceberg(new Parser().parse(avroSchema));
@@ -191,7 +180,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       return schemaCacheItem;
     }
 
-    PartitionSpec partitionSpec(String partitionCols, Schema schema) {
+    private PartitionSpec partitionSpec(String partitionCols, Schema schema) {
       PartitionSpec partitionSpec = partitionSpecCache.get(partitionCols);
 
       if (partitionSpec == null) {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerator.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.variant.Variant;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 
@@ -37,6 +38,8 @@ public interface DataGenerator {
   GenericRecord generateIcebergGenericRecord();
 
   GenericRowData generateFlinkRowData();
+
+  Variant generateFlinkVariantData();
 
   org.apache.avro.generic.GenericRecord generateAvroGenericRecord();
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -45,6 +46,8 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.variant.Variant;
+import org.apache.flink.types.variant.VariantBuilder;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.GenericRecord;
@@ -73,6 +76,8 @@ public class DataGenerators {
     private static final LocalTime JAVA_LOCAL_TIME_HOUR8 = LocalTime.of(8, 0);
     private static final OffsetDateTime JAVA_OFFSET_DATE_TIME_20220110 =
         OffsetDateTime.of(2022, 1, 10, 0, 0, 0, 0, ZoneOffset.UTC);
+    private static final Instant JAVA_INSTANT_DATE_TIME_20220110 =
+        Instant.ofEpochSecond(JAVA_OFFSET_DATE_TIME_20220110.toEpochSecond(), 0);
     private static final LocalDateTime JAVA_LOCAL_DATE_TIME_20220110 =
         LocalDateTime.of(2022, 1, 10, 0, 0, 0);
     private static final BigDecimal BIG_DECIMAL_NEGATIVE = new BigDecimal("-1.50");
@@ -224,6 +229,39 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      byte[] uuidBytes = new byte[16];
+      for (int i = 0; i < 16; ++i) {
+        uuidBytes[i] = (byte) i;
+      }
+
+      byte[] binaryBytes = new byte[7];
+      for (int i = 0; i < 7; ++i) {
+        binaryBytes[i] = (byte) i;
+      }
+
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add("boolean_field", builder.of(false))
+          .add("int_field", builder.of(Integer.MAX_VALUE))
+          .add("long_field", builder.of(Long.MAX_VALUE))
+          .add("float_field", builder.of(Float.MAX_VALUE))
+          .add("double_field", builder.of(Double.MAX_VALUE))
+          .add("string_field", builder.of("str"))
+          .add("date_field", builder.of(DAYS_BTW_EPOC_AND_20220110))
+          .add("time_field", builder.of(HOUR_8_IN_MILLI))
+          .add("ts_with_zone_field", builder.of(JAVA_INSTANT_DATE_TIME_20220110))
+          .add("ts_without_zone_field", builder.of(JAVA_LOCAL_DATE_TIME_20220110))
+          .add("uuid_field", builder.of(uuidBytes))
+          .add("binary_field", builder.of(binaryBytes))
+          .add("decimal_field", builder.of(BIG_DECIMAL_NEGATIVE))
+          .add("fixed_field", builder.of(FIXED_BYTES))
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord genericRecord = new GenericData.Record(avroSchema);
       genericRecord.put("row_id", new Utf8("row_id_value"));
@@ -316,6 +354,18 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "struct_of_primitive",
+              builder.object().add("id", builder.of(1)).add("name", builder.of("Jane")).build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.Schema structSchema = avroSchema.getField("struct_of_primitive").schema();
       org.apache.avro.generic.GenericRecord struct = new GenericData.Record(structSchema);
@@ -378,6 +428,24 @@ public class DataGenerators {
       StringData[] names = {StringData.fromString("Jane"), StringData.fromString("Joe")};
       return GenericRowData.of(
           StringData.fromString("row_id_value"), GenericRowData.of(1, new GenericArrayData(names)));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "struct_of_array",
+              builder
+                  .object()
+                  .add("id", builder.of(1))
+                  .add(
+                      "names",
+                      builder.array().add(builder.of("Jane")).add(builder.of("Joe")).build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -453,6 +521,28 @@ public class DataGenerators {
                       StringData.fromString("female"),
                       StringData.fromString("Joe"),
                       StringData.fromString("male")))));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "struct_of_map",
+              builder
+                  .object()
+                  .add("id", builder.of(1))
+                  .add(
+                      "names",
+                      builder
+                          .object()
+                          .add("Jane", builder.of("female"))
+                          .add("Joe", builder.of("male"))
+                          .build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -533,6 +623,28 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "struct_of_struct",
+              builder
+                  .object()
+                  .add("id", builder.of(1))
+                  .add(
+                      "person_struct",
+                      builder
+                          .object()
+                          .add("name", builder.of("Jane"))
+                          .add("address", builder.of("Apple Park"))
+                          .build())
+                  .build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.Schema structSchema = avroSchema.getField("struct_of_struct").schema();
       org.apache.avro.Schema personSchema = structSchema.getField("person_struct").schema();
@@ -588,6 +700,18 @@ public class DataGenerators {
     public GenericRowData generateFlinkRowData() {
       Integer[] arr = {1, 2, 3};
       return GenericRowData.of(StringData.fromString("row_id_value"), new GenericArrayData(arr));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "array_of_int",
+              builder.array().add(builder.of(1)).add(builder.of(2)).add(builder.of(3)).build())
+          .build();
     }
 
     @Override
@@ -648,6 +772,34 @@ public class DataGenerators {
       };
       return GenericRowData.of(
           StringData.fromString("row_id_value"), new GenericArrayData(arrayOfArrays));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "array_of_array",
+              builder
+                  .array()
+                  .add(
+                      builder
+                          .array()
+                          .add(builder.of(1))
+                          .add(builder.of(2))
+                          .add(builder.of(3))
+                          .build())
+                  .add(
+                      builder
+                          .array()
+                          .add(builder.of(4))
+                          .add(builder.of(5))
+                          .add(builder.of(6))
+                          .build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -712,6 +864,28 @@ public class DataGenerators {
             ImmutableMap.of(StringData.fromString("Alice"), 3, StringData.fromString("Bob"), 4))
       };
       return GenericRowData.of(StringData.fromString("row_id_value"), new GenericArrayData(array));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "array_of_map",
+              builder
+                  .array()
+                  .add(
+                      builder.object().add("Jane", builder.of(1)).add("Joe", builder.of(2)).build())
+                  .add(
+                      builder
+                          .object()
+                          .add("Alice", builder.of(3))
+                          .add("Bob", builder.of(4))
+                          .build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -786,6 +960,32 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "array_of_struct",
+              builder
+                  .array()
+                  .add(
+                      builder
+                          .object()
+                          .add("id", builder.of(1))
+                          .add("name", builder.of("Jane"))
+                          .build())
+                  .add(
+                      builder
+                          .object()
+                          .add("id", builder.of(2))
+                          .add("name", builder.of("Joe"))
+                          .build())
+                  .build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord struct1 = new GenericData.Record(structAvroSchema);
       struct1.put("id", 1);
@@ -844,6 +1044,18 @@ public class DataGenerators {
           StringData.fromString("row_id_value"),
           new GenericMapData(
               ImmutableMap.of(StringData.fromString("Jane"), 1, StringData.fromString("Joe"), 2)));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "map_of_primitives",
+              builder.object().add("Jane", builder.of(1)).add("Joe", builder.of(2)).build())
+          .build();
     }
 
     @Override
@@ -912,6 +1124,36 @@ public class DataGenerators {
                   new GenericArrayData(janeArray),
                   StringData.fromString("Joe"),
                   new GenericArrayData(joeArray))));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "map_of_array",
+              builder
+                  .object()
+                  .add(
+                      "Jane",
+                      builder
+                          .array()
+                          .add(builder.of(1))
+                          .add(builder.of(2))
+                          .add(builder.of(3))
+                          .build())
+                  .add(
+                      "Joe",
+                      builder
+                          .array()
+                          .add(builder.of(4))
+                          .add(builder.of(5))
+                          .add(builder.of(6))
+                          .build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -987,6 +1229,30 @@ public class DataGenerators {
                   new GenericMapData(
                       ImmutableMap.of(
                           StringData.fromString("Joe"), 3, StringData.fromString("Bob"), 4)))));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "map_of_map",
+              builder
+                  .object()
+                  .add(
+                      "female",
+                      builder
+                          .object()
+                          .add("Jane", builder.of(1))
+                          .add("Alice", builder.of(2))
+                          .build())
+                  .add(
+                      "male",
+                      builder.object().add("Joe", builder.of(3)).add("Bob", builder.of(4)).build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -1100,6 +1366,34 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "map_of_struct",
+              builder
+                  .object()
+                  .add(
+                      "struct1",
+                      builder
+                          .object()
+                          .add("id", builder.of(1))
+                          .add("name", builder.of("Jane"))
+                          .build())
+                  .add(
+                      "struct2",
+                      builder
+                          .object()
+                          .add("id", builder.of(2))
+                          .add("name", builder.of("Joe"))
+                          .build())
+                  .build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord struct1 = new GenericData.Record(structAvroSchema);
       struct1.put("id", 1);
@@ -1162,6 +1456,11 @@ public class DataGenerators {
               ImmutableMap.of(
                   GenericRowData.of(1L, StringData.fromString("key_data")),
                   GenericRowData.of(1L, StringData.fromString("value_data")))));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      throw new UnsupportedOperationException("Variant Map only support string key type");
     }
 
     @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.sink.dynamic.DynamicRecord;
 import org.apache.iceberg.flink.sink.dynamic.DynamicTableRecordGenerator;
+import org.apache.iceberg.flink.sink.dynamic.VariantAvroDynamicTableRecordGenerator;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -400,6 +401,74 @@ public class TestIcebergConnector extends TestBase {
   }
 
   @TestTemplate
+  public void testVariantAvroDynamicIcebergSink() throws DatabaseAlreadyExistException {
+    Map<String, String> tableProps = createTableProps();
+    Map<String, String> dynamicTableProps = Maps.newHashMap(tableProps);
+    dynamicTableProps.put("use-dynamic-iceberg-sink", "true");
+    dynamicTableProps.put(
+        "dynamic-record-generator-impl", VariantAvroDynamicTableRecordGenerator.class.getName());
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    FlinkCatalog flinkCatalog =
+        (FlinkCatalog) factory.createCatalog(catalogName, tableProps, new Configuration());
+    flinkCatalog.createDatabase(
+        databaseName(), new CatalogDatabaseImpl(Maps.newHashMap(), null), true);
+
+    String avroSchema =
+        """
+      {
+        "type": "record",
+        "name": "TestSchema",
+        "fields": [
+          {
+            "name": "id",
+            "type": "long"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ]
+      }
+      """;
+
+    String avroSchemaId = "TestSchema:1";
+    // Create table with dynamic sink enabled
+    sql(
+        "CREATE TABLE %s (data VARIANT, `catalog-database` STRING, `catalog-table` STRING, avro_schema STRING, avro_schema_id STRING, branch STRING, `write-parallelism` INT) WITH %s",
+        TABLE_NAME + "_dynamic", toWithClause(dynamicTableProps));
+
+    // Insert data with database and table information
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(PARSE_JSON('{\"id\": 1, \"name\": \"AAA\"}'), '%s', '%s', '%s', '%s', 'main', 1), "
+            + "(PARSE_JSON('{\"id\": 2, \"name\": \"BBB\"}'), '%s', '%s', '%s', '%s', 'main', 1)",
+        TABLE_NAME + "_dynamic",
+        databaseName(),
+        tableName(),
+        avroSchema,
+        avroSchemaId,
+        databaseName(),
+        tableName(),
+        avroSchema,
+        avroSchemaId);
+
+    // Verify the table and data exists
+    ObjectPath objectPath = new ObjectPath(databaseName(), tableName());
+    assertThat(flinkCatalog.tableExists(objectPath)).isTrue();
+    Table table =
+        flinkCatalog
+            .getCatalogLoader()
+            .loadCatalog()
+            .loadTable(TableIdentifier.of(databaseName(), tableName()));
+
+    tableProps.put("catalog-database", databaseName());
+    sql("CREATE TABLE %s (id BIGINT, name STRING) WITH %s", tableName(), toWithClause(tableProps));
+    assertThat(sql("SELECT * FROM %s", tableName()))
+        .containsExactlyInAnyOrder(Row.of(1L, "AAA"), Row.of(2L, "BBB"));
+  }
+
+  @TestTemplate
   public void testMissingDynamicRecordGeneratorImpl() throws DatabaseAlreadyExistException {
     Map<String, String> tableProps = createTableProps();
     tableProps.put("use-dynamic-iceberg-sink", "true");
@@ -430,8 +499,8 @@ public class TestIcebergConnector extends TestBase {
     private int databaseFieldIndex = -1;
     private int tableFieldIndex = -1;
 
-    public SimpleRowDataTableRecordGenerator(RowType rowType) {
-      super(rowType);
+    public SimpleRowDataTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
+      super(rowType, writeProps);
     }
 
     @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -407,6 +407,7 @@ public class TestIcebergConnector extends TestBase {
     dynamicTableProps.put("use-dynamic-iceberg-sink", "true");
     dynamicTableProps.put(
         "dynamic-record-generator-impl", VariantAvroDynamicTableRecordGenerator.class.getName());
+    dynamicTableProps.put("table.props.key1", "val1");
 
     FlinkCatalogFactory factory = new FlinkCatalogFactory();
     FlinkCatalog flinkCatalog =
@@ -461,6 +462,7 @@ public class TestIcebergConnector extends TestBase {
             .getCatalogLoader()
             .loadCatalog()
             .loadTable(TableIdentifier.of(databaseName(), tableName()));
+    assertThat(table.properties()).containsEntry("key1", "val1");
 
     tableProps.put("catalog-database", databaseName());
     sql("CREATE TABLE %s (id BIGINT, name STRING) WITH %s", tableName(), toWithClause(tableProps));

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
@@ -106,11 +106,11 @@ public class TestVariantRowDataWrapper {
     RowType rowType = dataGenerator.flinkRowType();
     Variant variant = dataGenerator.generateFlinkVariantData();
     RowData rowData = dataGenerator.generateFlinkRowData();
-    VariantRowDataWrapper variantRowDataWrapper = getVariantRowDataWrapper(rowType, variant);
+    VariantRowDataWrapper variantRowDataWrapper = variantRowDataWrapper(rowType, variant);
     compareData(rowType, variantRowDataWrapper, rowData);
   }
 
-  private static VariantRowDataWrapper getVariantRowDataWrapper(RowType rowType, Variant variant) {
+  private static VariantRowDataWrapper variantRowDataWrapper(RowType rowType, Variant variant) {
     VariantRowDataWrapper wrapper = new VariantRowDataWrapper(rowType);
     return wrapper.wrap(variant);
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.variant.Variant;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+import org.junit.jupiter.api.Test;
+
+public class TestVariantRowDataWrapper {
+
+  @Test
+  public void testPrimitives() {
+    testDataGenerator(new DataGenerators.Primitives());
+  }
+
+  @Test
+  public void testStructOfPrimitive() {
+    testDataGenerator(new DataGenerators.StructOfPrimitive());
+  }
+
+  @Test
+  public void testStructOfArray() {
+    testDataGenerator(new DataGenerators.StructOfArray());
+  }
+
+  @Test
+  public void testStructOfMap() {
+    testDataGenerator(new DataGenerators.StructOfMap());
+  }
+
+  @Test
+  public void testStructOfStruct() {
+    testDataGenerator(new DataGenerators.StructOfStruct());
+  }
+
+  @Test
+  public void testArrayOfPrimitive() {
+    testDataGenerator(new DataGenerators.ArrayOfPrimitive());
+  }
+
+  @Test
+  public void testArrayOfArray() {
+    testDataGenerator(new DataGenerators.ArrayOfArray());
+  }
+
+  @Test
+  public void testArrayOfMap() {
+    testDataGenerator(new DataGenerators.ArrayOfMap());
+  }
+
+  @Test
+  public void testArrayOfStruct() {
+    testDataGenerator(new DataGenerators.ArrayOfStruct());
+  }
+
+  @Test
+  public void testMapOfPrimitives() {
+    testDataGenerator(new DataGenerators.MapOfPrimitives());
+  }
+
+  @Test
+  public void testMapOfArray() {
+    testDataGenerator(new DataGenerators.MapOfArray());
+  }
+
+  @Test
+  public void testMapOfMap() {
+    testDataGenerator(new DataGenerators.MapOfMap());
+  }
+
+  @Test
+  public void testMapOfStruct() {
+    testDataGenerator(new DataGenerators.MapOfStruct());
+  }
+
+  private static void testDataGenerator(DataGenerator dataGenerator) {
+    RowType rowType = dataGenerator.flinkRowType();
+    Variant variant = dataGenerator.generateFlinkVariantData();
+    RowData rowData = dataGenerator.generateFlinkRowData();
+    VariantRowDataWrapper variantRowDataWrapper = getVariantRowDataWrapper(rowType, variant);
+    compareData(rowType, variantRowDataWrapper, rowData);
+  }
+
+  private static VariantRowDataWrapper getVariantRowDataWrapper(RowType rowType, Variant variant) {
+    VariantRowDataWrapper wrapper = new VariantRowDataWrapper(rowType);
+    return wrapper.wrap(variant);
+  }
+
+  private static void compareData(RowType rowType, Object variantRowDataWrapper, Object rowData) {
+    for (int i = 0; i < rowType.getFieldCount(); i++) {
+      LogicalType logicalType = rowType.getTypeAt(i);
+      RowData.FieldGetter fieldGetter = RowData.createFieldGetter(logicalType, i);
+
+      Object variantValue = fieldGetter.getFieldOrNull((RowData) variantRowDataWrapper);
+      Object rowDataValue = fieldGetter.getFieldOrNull((RowData) rowData);
+
+      switch (logicalType.getTypeRoot()) {
+        case ROW:
+          compareData((RowType) logicalType, variantValue, rowDataValue);
+          return;
+        case MAP:
+          MapType mapType = (MapType) logicalType;
+          LogicalType valueType = mapType.getValueType();
+
+          if (valueType.is(LogicalTypeRoot.ROW)) {
+            GenericMapData mapVariantData = (GenericMapData) variantValue;
+            GenericMapData mapRowData = (GenericMapData) rowDataValue;
+
+            ArrayData keys = mapRowData.keyArray();
+            for (int k = 0; k < keys.size(); k++) {
+              StringData key = keys.getString(k);
+              compareData((RowType) valueType, mapVariantData.get(key), mapRowData.get(key));
+            }
+          } else {
+            assertThat(variantValue).isEqualTo(rowDataValue);
+          }
+          return;
+        case ARRAY:
+          ArrayType arrayType = (ArrayType) logicalType;
+          LogicalType elementType = arrayType.getElementType();
+
+          if (elementType.is(LogicalTypeRoot.ROW)) {
+            GenericArrayData arrayVariantData = (GenericArrayData) variantValue;
+            GenericArrayData arrayRowData = (GenericArrayData) rowDataValue;
+
+            assertThat(arrayVariantData.size()).isEqualTo(arrayRowData.size());
+            for (int j = 0; j < arrayVariantData.size(); j++) {
+              ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(elementType);
+              compareData(
+                  (RowType) elementType,
+                  elementGetter.getElementOrNull(arrayVariantData, j),
+                  elementGetter.getElementOrNull(arrayRowData, j));
+            }
+          } else {
+            assertThat(variantValue).isEqualTo(rowDataValue);
+          }
+          return;
+        default:
+          assertThat(variantValue).isEqualTo(rowDataValue);
+      }
+    }
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -65,7 +65,8 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     assertThatThrownBy(() -> new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing column data. Expected column data of type VARIANT NOT NULL.");
+        .hasMessageContaining(
+            "Missing column data. Expected column data of type VARIANT NOT NULL.");
   }
 
   @Test

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -1,0 +1,444 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.flink.api.common.functions.DefaultOpenContext;
+import org.apache.flink.api.common.functions.util.ListCollector;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
+import org.apache.flink.types.variant.Variant;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+import org.apache.iceberg.flink.FlinkCreateTableOptions;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestVariantAvroDynamicTableRecordGenerator {
+
+  public static final String TEST_DB = "test_db";
+  public static final String TEST_TABLE = "test_table";
+  public static final String BRANCH = "main";
+
+  @Test
+  public void testMissingRequiredFields() {
+    List<LogicalType> types = Lists.newArrayList();
+    List<String> names = Lists.newArrayList();
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_DATABASE.key());
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_TABLE.key());
+
+    RowType rowType = RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
+
+    assertThatThrownBy(() -> new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Missing column data.Expected column data of type VARIANT NOT NULL.");
+  }
+
+  @Test
+  public void testWithWritePropertiesOverride() throws Exception {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    Schema schema = dataGenerator.avroSchema();
+    String schemaVersion = "v1";
+
+    Map<String, String> writeProperties = Maps.newHashMap();
+    writeProperties.put(FlinkCreateTableOptions.CATALOG_DATABASE.key(), "test_db_override");
+    writeProperties.put(FlinkCreateTableOptions.CATALOG_TABLE.key(), "test_table_override");
+
+    RowType rowType = createRowTypeWithRequiredFields();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, writeProperties);
+    generator.open(new DefaultOpenContext());
+
+    RowData inputRecord =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(schema.toString()),
+            StringData.fromString(schema.getName() + schemaVersion));
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+    generator.generate(inputRecord, collector);
+
+    assertThat(records).hasSize(1);
+    DynamicRecord record = records.get(0);
+    assertThat(record.tableIdentifier())
+        .isEqualTo(TableIdentifier.of("test_db_override", "test_table_override"));
+    assertThat(record.branch()).isNull();
+    assertThat(record.spec()).isEqualTo(PartitionSpec.unpartitioned());
+    assertThat(record.writeParallelism()).isEqualTo(-1);
+  }
+
+  @Test
+  public void testWithPartitionedTable() throws Exception {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    Schema schema = dataGenerator.avroSchema();
+    String schemaVersion = "v1";
+
+    RowType rowType = createRowTypeWithAllColumns();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+    generator.open(new DefaultOpenContext());
+
+    RowData inputRecord =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(schema.toString()),
+            StringData.fromString(schema.getName() + schemaVersion),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE),
+            StringData.fromString(BRANCH),
+            StringData.fromString("row_id,string_field"),
+            1);
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+    generator.generate(inputRecord, collector);
+
+    assertThat(records).hasSize(1);
+    DynamicRecord record = records.get(0);
+    assertThat(record.tableIdentifier()).isEqualTo(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(record.branch()).isEqualTo(BRANCH);
+    assertThat(record.writeParallelism()).isEqualTo(1);
+
+    PartitionSpec expectedPartitionSpec =
+        PartitionSpec.builderFor(AvroSchemaUtil.toIceberg(schema))
+            .identity("row_id")
+            .identity("string_field")
+            .build();
+    assertThat(record.spec()).isEqualTo(expectedPartitionSpec);
+  }
+
+  @Test
+  public void testSchemaCaching() throws Exception {
+    DataGenerator dataGenerator1 = new DataGenerators.Primitives();
+    DataGenerator dataGenerator2 = new DataGenerators.StructOfPrimitive();
+
+    Schema schema1 = AvroSchemaUtil.convert(dataGenerator1.icebergSchema(), "TestSchema1");
+    Schema schema2 = AvroSchemaUtil.convert(dataGenerator2.icebergSchema(), "TestSchema2");
+    String schemaId1 = schema1.getName() + ":1";
+    String schemaId2 = schema2.getName() + ":1";
+
+    RowType rowType = createRowTypeWithDbAndTable();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+    generator.open(new DefaultOpenContext());
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+
+    // Generate first record with schema1
+    RowData inputRecord1 =
+        GenericRowData.of(
+            dataGenerator1.generateFlinkVariantData(),
+            StringData.fromString(schema1.toString()),
+            StringData.fromString(schemaId1),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    generator.generate(inputRecord1, collector);
+
+    // Verify cache has been populated with first table and schema
+    VariantAvroDynamicTableRecordGenerator.SchemaAndPartitionSpecCacheItem cacheItem =
+        generator.tableCache().get(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(cacheItem).isNotNull();
+    VariantAvroDynamicTableRecordGenerator.SchemaCacheItem schemaCacheItem =
+        cacheItem.schemaCacheItem(schemaId1);
+    assertThat(schemaCacheItem).isNotNull();
+    assertThat(schemaCacheItem.tableSchema().sameSchema(dataGenerator1.icebergSchema())).isTrue();
+
+    // Generate second record with same schema1 (should use cached schema)
+    RowData inputRecord1Repeat =
+        GenericRowData.of(
+            dataGenerator1.generateFlinkVariantData(),
+            StringData.fromString(schema1.toString()),
+            StringData.fromString(schemaId1),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    generator.generate(inputRecord1Repeat, collector);
+
+    // Generate third record with different schema2 and different table
+    RowData inputRecord2 =
+        GenericRowData.of(
+            dataGenerator2.generateFlinkVariantData(),
+            StringData.fromString(schema2.toString()),
+            StringData.fromString(schemaId2),
+            StringData.fromString(TEST_DB),
+            StringData.fromString("test_table2"));
+    generator.generate(inputRecord2, collector);
+
+    // Verify we now have two table cache items
+    assertThat(generator.tableCache()).hasSize(2);
+    assertThat(generator.tableCache()).containsKey(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(generator.tableCache()).containsKey(TableIdentifier.of(TEST_DB, "test_table2"));
+
+    // Verify second table cache item has different schema
+    VariantAvroDynamicTableRecordGenerator.SchemaAndPartitionSpecCacheItem cacheItem2 =
+        generator.tableCache().get(TableIdentifier.of(TEST_DB, "test_table2"));
+    assertThat(cacheItem2).isNotNull();
+    assertThat(
+            cacheItem2
+                .schemaCacheItem(schemaId2)
+                .tableSchema()
+                .sameSchema(dataGenerator2.icebergSchema()))
+        .isTrue();
+
+    assertThat(records).hasSize(3);
+    // Should emit DynamicRecord with same tableSchema instance.
+    assertThat(records.get(1).schema() == schemaCacheItem.tableSchema()).isTrue();
+  }
+
+  @Test
+  public void testSchemaEvolution() throws Exception {
+    // Create simple schema with one field
+    org.apache.avro.Schema initialSchema =
+        org.apache.avro.SchemaBuilder.builder()
+            .record("UserRecord")
+            .namespace("test.schema")
+            .fields()
+            .requiredLong("id")
+            .endRecord();
+    String initialSchemaId = "UserRecord:v1";
+
+    // Create evolved schema with additional field
+    org.apache.avro.Schema evolvedSchema =
+        org.apache.avro.SchemaBuilder.builder()
+            .record("UserRecord")
+            .namespace("test.schema")
+            .fields()
+            .requiredLong("id")
+            .optionalString("name")
+            .endRecord();
+    String evolvedSchemaId = "UserRecord:v2";
+
+    RowType rowType = createRowTypeWithDbAndTable();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+    generator.open(new DefaultOpenContext());
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+
+    // Create variant data for initial schema (only id field)
+    Variant initialVariantData =
+        Variant.newBuilder().object().add("id", Variant.newBuilder().of(123L)).build();
+
+    // Generate record with initial schema
+    RowData inputRecord1 =
+        GenericRowData.of(
+            initialVariantData,
+            StringData.fromString(initialSchema.toString()),
+            StringData.fromString(initialSchemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    generator.generate(inputRecord1, collector);
+
+    // Create variant data for evolved schema (id and name fields)
+    Variant evolvedVariantData =
+        Variant.newBuilder()
+            .object()
+            .add("id", Variant.newBuilder().of(456L))
+            .add("name", Variant.newBuilder().of("name"))
+            .build();
+
+    // Generate record with evolved schema
+    RowData inputRecord2 =
+        GenericRowData.of(
+            evolvedVariantData,
+            StringData.fromString(evolvedSchema.toString()),
+            StringData.fromString(evolvedSchemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    generator.generate(inputRecord2, collector);
+
+    assertThat(records).hasSize(2);
+
+    // Verify all records were generated successfully
+    DynamicRecord record1 = records.get(0);
+    DynamicRecord record2 = records.get(1);
+
+    assertThat(record1.rowData().getLong(0)).isEqualTo(123L);
+    assertThat(record2.rowData().getLong(0)).isEqualTo(456L);
+    assertThat(record2.rowData().getString(1).toString()).isEqualTo("name");
+
+    VariantAvroDynamicTableRecordGenerator.SchemaAndPartitionSpecCacheItem cacheItem =
+        generator.tableCache().get(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(cacheItem).isNotNull();
+    VariantAvroDynamicTableRecordGenerator.SchemaCacheItem schemaCacheItem =
+        cacheItem.schemaCacheItem(initialSchemaId);
+    assertThat(schemaCacheItem.tableSchema().sameSchema(AvroSchemaUtil.toIceberg(initialSchema)))
+        .isTrue();
+
+    schemaCacheItem = cacheItem.schemaCacheItem(evolvedSchemaId);
+    assertThat(schemaCacheItem.tableSchema().sameSchema(AvroSchemaUtil.toIceberg(evolvedSchema)))
+        .isTrue();
+  }
+
+  @Test
+  public void testPartitionSpecCaching() throws Exception {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    String avroSchema = dataGenerator.avroSchema().toString();
+    String schemaId = "TestSchema:1";
+
+    RowType rowType = createRowTypeWithAllColumns();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+    generator.open(new DefaultOpenContext());
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+
+    // Generate first record with partition on "row_id"
+    RowData inputRecord1 =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(avroSchema),
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE),
+            StringData.fromString(BRANCH),
+            StringData.fromString("row_id"),
+            1);
+    generator.generate(inputRecord1, collector);
+
+    // Generate second record with same partition spec (should use cached partition spec)
+    RowData inputRecord2 =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(avroSchema),
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE),
+            StringData.fromString(BRANCH),
+            StringData.fromString("row_id"),
+            1);
+    generator.generate(inputRecord2, collector);
+
+    // Generate third record with different partition spec
+    RowData inputRecord3 =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(avroSchema),
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE),
+            StringData.fromString(BRANCH),
+            StringData.fromString("string_field"),
+            1);
+    generator.generate(inputRecord3, collector);
+
+    assertThat(records).hasSize(3);
+
+    DynamicRecord record1 = records.get(0);
+    DynamicRecord record2 = records.get(1);
+    DynamicRecord record3 = records.get(2);
+
+    // Verify first two records have same partition spec (partitioned on row_id)
+    assertThat(record1.spec().fields()).hasSize(1);
+    assertThat(record2.spec().fields()).hasSize(1);
+    assertThat(record1.spec().fields().get(0).name()).isEqualTo("row_id");
+    assertThat(record2.spec().fields().get(0).name()).isEqualTo("row_id");
+    assertThat(record1.spec() == record2.spec()).isTrue();
+
+    // Verify third record has different partition spec (partitioned on string_field)
+    assertThat(record3.spec().fields()).hasSize(1);
+    assertThat(record3.spec().fields().get(0).name()).isEqualTo("string_field");
+
+    VariantAvroDynamicTableRecordGenerator.SchemaAndPartitionSpecCacheItem cacheItem =
+        generator.tableCache().get(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(cacheItem.partitionSpec("row_id")).isNotNull();
+    assertThat(cacheItem.partitionSpec("string_field")).isNotNull();
+  }
+
+  private static void addRequiredFields(List<LogicalType> types, List<String> names) {
+    types.add(new VariantType(false));
+    names.add(VariantAvroDynamicTableRecordGenerator.DATA_COLUMN);
+    types.add(new VarCharType(false, Integer.MAX_VALUE));
+    names.add(VariantAvroDynamicTableRecordGenerator.AVRO_SCHEMA_COLUMN);
+    types.add(new VarCharType(false, 255));
+    names.add(VariantAvroDynamicTableRecordGenerator.AVRO_SCHEMA_ID_COLUMN);
+  }
+
+  private static RowType createRowTypeWithRequiredFields() {
+    List<LogicalType> types = Lists.newArrayList();
+    List<String> names = Lists.newArrayList();
+
+    addRequiredFields(types, names);
+
+    return RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
+  }
+
+  private static RowType createRowTypeWithDbAndTable() {
+    List<LogicalType> types = Lists.newArrayList();
+    List<String> names = Lists.newArrayList();
+
+    addRequiredFields(types, names);
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_DATABASE.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_TABLE.key());
+
+    return RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
+  }
+
+  private static RowType createRowTypeWithAllColumns() {
+    List<LogicalType> types = Lists.newArrayList();
+    List<String> names = Lists.newArrayList();
+
+    addRequiredFields(types, names);
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_DATABASE.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_TABLE.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkWriteOptions.BRANCH.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(VariantAvroDynamicTableRecordGenerator.PARTITION_COLUMNS);
+
+    types.add(new org.apache.flink.table.types.logical.IntType(false));
+    names.add(FlinkWriteOptions.WRITE_PARALLELISM.key());
+
+    return RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -65,7 +65,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     assertThatThrownBy(() -> new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing column data.Expected column data of type VARIANT NOT NULL.");
+        .hasMessageContaining("Missing column data. Expected column data of type VARIANT NOT NULL.");
   }
 
   @Test


### PR DESCRIPTION
Added,

**VariantAvroDynamicTableRecordGenerator**: Custom Dynamic table record generator designed for deserializing the Variant with the schema provided and writing to Iceberg Tables matching with avro schema passed in SQL.

**VariantRowDataWrapper**: Wrapper class for variant row data that provides type-safe conversion and handling of variant data structures as RowData.


Changes allow to ingest data in Flink SQL using dynamic iceberg sink.

```
CREATE TABLE test_dynamic (
    data VARIANT,                    -- JSON payload 
    `catalog-database` STRING,       -- Target database
    `catalog-table` STRING,          -- Target table  
    avro_schema STRING,              -- Schema definition
    avro_schema_id STRING,       -- Schema versioning ,mainly used for caching instead of relying on full schema comparison.
    branch STRING,                   -- Iceberg branch
    `write-parallelism` INT          -- Performance tuning
  ) WITH ('use-dynamic-iceberg-sink'='true', ...)
```

 ```
 INSERT INTO test_dynamic VALUES
  (PARSE_JSON('{"id": 1, "name": "AAA"}'), 'db', 'table', '<avro-schema>', 'TestSchema:1', 'main', 1)
```



**NOTE:**

Some Field accessor methods needed here are added in PR https://github.com/apache/flink/pull/27600  (Merged but not released yet).  These are required to handle AVRO map and array types. Code is being commented as it's not released yet.
Once it's released, plan is also to add **VariantDynamicTableRecordGenerator** , where Schema can also be directly inferred from Variant type itself, which can open up more use cases for dynamic iceberg ingestion. 

Will add more Test Coverage once have the consensus on approach.



**Sample Use case:**

Build generic ingestion pipelines entirely in SQL. For example with Kafka and records encoded with Avro schema stored in SchemaRegistry, we can have a KafkaDeserializationSchema deserializing records with dynamic schemas, pass the records as VARIANT in Flink SQL and route them into corresponding Iceberg tables created with schema matching the Avro schema of the records.