### PR TITLE
docs: document preserved whitespace behavior in string partition values

### DIFF
--- a/docs/docs/partitioning.md
+++ b/docs/docs/partitioning.md
@@ -116,4 +116,3 @@ If a query unexpectedly returns no results:
 - Inspect the table’s partition values using metadata tables or engine‑specific commands.
 - Check for leading or trailing whitespace in string partition columns.
 - Ensure ingestion pipelines produce canonicalized partition values.
-- 


### PR DESCRIPTION
### Overview
This PR adds a new section to the partitioning documentation that explains how Iceberg preserves string partition values exactly as written by the engine, including any leading or trailing whitespace. Because engines rely on strict string equality for partition pruning, whitespace differences can cause partitions to be skipped unexpectedly. This behavior is correct but previously undocumented.

### What’s Included

The new section covers:
- How Iceberg stores string partition values without trimming or normalization
- How strict equality impacts pruning when whitespace differs
- Examples illustrating mismatches between query filters and stored values
- Implications for ingestion pipelines and query behavior
- Best practices for avoiding unintended whitespace
- Troubleshooting steps for diagnosing unexpected empty results

The section is added immediately after “Iceberg’s hidden partitioning” in `docs/docs/partitioning.md`.

### Motivation
Users occasionally encounter unexpected query results due to trailing or leading whitespace in partition values. While this behavior aligns with Iceberg’s design principles, it is not currently documented. Adding this section improves clarity, helps users avoid subtle ingestion issues, and provides guidance for debugging.

### Documentation Impact
This change updates the nightly documentation and will appear under:
```
User Experience → Partitioning
```
No navigation updates are required.

Closes #15427