### PR TITLE
Core: Replace View Support Multiple Dialects

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1713,7 +1713,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               .max(Integer::compareTo)
               .orElseGet(metadata::currentVersionId);
 
-      if (PropertyUtil.propertyAsBoolean(
+      if (!PropertyUtil.propertyAsBoolean(
           properties,
           ViewProperties.REPLACE_DROP_DIALECT_ALLOWED,
           ViewProperties.REPLACE_DROP_DIALECT_ALLOWED_DEFAULT)) {

--- a/core/src/main/java/org/apache/iceberg/view/BaseMetastoreViewCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseMetastoreViewCatalog.java
@@ -241,7 +241,7 @@ public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog impl
               .max(Integer::compareTo)
               .orElseGet(metadata::currentVersionId);
 
-      if (PropertyUtil.propertyAsBoolean(
+      if (!PropertyUtil.propertyAsBoolean(
           properties,
           ViewProperties.REPLACE_DROP_DIALECT_ALLOWED,
           ViewProperties.REPLACE_DROP_DIALECT_ALLOWED_DEFAULT)) {

--- a/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
@@ -905,7 +905,6 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
         .withSchema(SCHEMA)
         .withDefaultNamespace(tableIdentifier.namespace())
         .withQuery("trino", "select * from ns.tbl limit 10")
-        .withProperty(ViewProperties.REPLACE_DROP_DIALECT_ALLOWED, "true")
         .replace();
 
     assertThat(catalog().viewExists(tableIdentifier)).as("View should exist").isTrue();
@@ -1134,14 +1133,10 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
     assertThat(replacedViewVersion.schemaId()).isEqualTo(1);
     assertThat(replacedViewVersion.operation()).isEqualTo("replace");
     assertThat(replacedViewVersion.representations())
-        .containsExactlyInAnyOrder(
+        .containsExactly(
             ImmutableSQLViewRepresentation.builder()
                 .sql("select count(*) from ns.tbl")
                 .dialect("trino")
-                .build(),
-            ImmutableSQLViewRepresentation.builder()
-                .sql("select * from ns.tbl")
-                .dialect("spark")
                 .build());
 
     assertThat(catalog().dropView(identifier)).isTrue();

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1911,7 +1911,7 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
-  public void replacingTrinoViewShouldFail() {
+  public void replacingTrinoView() {
     String viewName = viewName("trinoView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
@@ -1925,16 +1925,21 @@ public class TestViews extends ExtensionsTestBase {
         .withSchema(schema(sql))
         .create();
 
-    assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot replace view due to loss of view dialects (replace.drop-dialect.allowed=false):\n"
-                + "Previous dialects: [trino]\n"
-                + "New dialects: [spark]");
+    sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql + " limit 10");
+
+    View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build(),
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql(sql + " limit 10")
+                .build());
   }
 
   @TestTemplate
-  public void replacingTrinoAndSparkViewShouldFail() {
+  public void replacingTrinoAndSparkView() {
     String viewName = viewName("trinoAndSparkView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
@@ -1949,12 +1954,17 @@ public class TestViews extends ExtensionsTestBase {
         .withSchema(schema(sql))
         .create();
 
-    assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot replace view due to loss of view dialects (replace.drop-dialect.allowed=false):\n"
-                + "Previous dialects: [trino, spark]\n"
-                + "New dialects: [spark]");
+    sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql + " limit 10");
+
+    View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql(sql + " limit 10")
+                .build(),
+            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
   }
 
   @TestTemplate
@@ -1978,6 +1988,11 @@ public class TestViews extends ExtensionsTestBase {
         viewName, ViewProperties.REPLACE_DROP_DIALECT_ALLOWED, tableName);
 
     View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(1)
+        .first()
+        .asInstanceOf(InstanceOfAssertFactories.type(SQLViewRepresentation.class))
+        .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
 
     // trino view should show up in the view versions & history
     assertThat(view.history()).hasSize(2);
@@ -1995,10 +2010,10 @@ public class TestViews extends ExtensionsTestBase {
         .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
 
     assertThat(Lists.newArrayList(view.versions()).get(1).representations())
-        .hasSize(2)
-        .containsExactlyInAnyOrder(
-            ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build(),
-            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
+        .hasSize(1)
+        .first()
+        .asInstanceOf(InstanceOfAssertFactories.type(SQLViewRepresentation.class))
+        .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
   }
 
   @TestTemplate

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1907,7 +1907,7 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
-  public void replacingTrinoViewShouldFail() {
+  public void replacingTrinoView() {
     String viewName = viewName("trinoView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
@@ -1921,16 +1921,21 @@ public class TestViews extends ExtensionsTestBase {
         .withSchema(schema(sql))
         .create();
 
-    assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot replace view due to loss of view dialects (replace.drop-dialect.allowed=false):\n"
-                + "Previous dialects: [trino]\n"
-                + "New dialects: [spark]");
+    sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql + " limit 10");
+
+    View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build(),
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql(sql + " limit 10")
+                .build());
   }
 
   @TestTemplate
-  public void replacingTrinoAndSparkViewShouldFail() {
+  public void replacingTrinoAndSparkView() {
     String viewName = viewName("trinoAndSparkView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
@@ -1945,12 +1950,17 @@ public class TestViews extends ExtensionsTestBase {
         .withSchema(schema(sql))
         .create();
 
-    assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot replace view due to loss of view dialects (replace.drop-dialect.allowed=false):\n"
-                + "Previous dialects: [trino, spark]\n"
-                + "New dialects: [spark]");
+    sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql + " limit 10");
+
+    View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql(sql + " limit 10")
+                .build(),
+            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
   }
 
   @TestTemplate
@@ -1974,6 +1984,11 @@ public class TestViews extends ExtensionsTestBase {
         viewName, ViewProperties.REPLACE_DROP_DIALECT_ALLOWED, tableName);
 
     View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(1)
+        .first()
+        .asInstanceOf(InstanceOfAssertFactories.type(SQLViewRepresentation.class))
+        .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
 
     // trino view should show up in the view versions & history
     assertThat(view.history()).hasSize(2);
@@ -1991,10 +2006,10 @@ public class TestViews extends ExtensionsTestBase {
         .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
 
     assertThat(Lists.newArrayList(view.versions()).get(1).representations())
-        .hasSize(2)
-        .containsExactlyInAnyOrder(
-            ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build(),
-            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
+        .hasSize(1)
+        .first()
+        .asInstanceOf(InstanceOfAssertFactories.type(SQLViewRepresentation.class))
+        .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
   }
 
   @TestTemplate

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1905,7 +1905,7 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
-  public void replacingTrinoViewShouldFail() {
+  public void replacingTrinoView() {
     String viewName = viewName("trinoView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
@@ -1919,16 +1919,21 @@ public class TestViews extends ExtensionsTestBase {
         .withSchema(schema(sql))
         .create();
 
-    assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot replace view due to loss of view dialects (replace.drop-dialect.allowed=false):\n"
-                + "Previous dialects: [trino]\n"
-                + "New dialects: [spark]");
+    sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql + " limit 10");
+
+    View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build(),
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql(sql + " limit 10")
+                .build());
   }
 
   @TestTemplate
-  public void replacingTrinoAndSparkViewShouldFail() {
+  public void replacingTrinoAndSparkView() {
     String viewName = viewName("trinoAndSparkView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
@@ -1943,12 +1948,17 @@ public class TestViews extends ExtensionsTestBase {
         .withSchema(schema(sql))
         .create();
 
-    assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot replace view due to loss of view dialects (replace.drop-dialect.allowed=false):\n"
-                + "Previous dialects: [trino, spark]\n"
-                + "New dialects: [spark]");
+    sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql + " limit 10");
+
+    View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql(sql + " limit 10")
+                .build(),
+            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
   }
 
   @TestTemplate
@@ -1972,6 +1982,11 @@ public class TestViews extends ExtensionsTestBase {
         viewName, ViewProperties.REPLACE_DROP_DIALECT_ALLOWED, tableName);
 
     View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(1)
+        .first()
+        .asInstanceOf(InstanceOfAssertFactories.type(SQLViewRepresentation.class))
+        .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
 
     // trino view should show up in the view versions & history
     assertThat(view.history()).hasSize(2);
@@ -1989,10 +2004,10 @@ public class TestViews extends ExtensionsTestBase {
         .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
 
     assertThat(Lists.newArrayList(view.versions()).get(1).representations())
-        .hasSize(2)
-        .containsExactlyInAnyOrder(
-            ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build(),
-            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
+        .hasSize(1)
+        .first()
+        .asInstanceOf(InstanceOfAssertFactories.type(SQLViewRepresentation.class))
+        .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
   }
 
   @TestTemplate

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -1905,7 +1905,7 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
-  public void replacingTrinoViewShouldFail() {
+  public void replacingTrinoView() {
     String viewName = viewName("trinoView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
@@ -1919,16 +1919,21 @@ public class TestViews extends ExtensionsTestBase {
         .withSchema(schema(sql))
         .create();
 
-    assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot replace view due to loss of view dialects (replace.drop-dialect.allowed=false):\n"
-                + "Previous dialects: [trino]\n"
-                + "New dialects: [spark]");
+    sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql + " limit 10");
+
+    View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build(),
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql(sql + " limit 10")
+                .build());
   }
 
   @TestTemplate
-  public void replacingTrinoAndSparkViewShouldFail() {
+  public void replacingTrinoAndSparkView() {
     String viewName = viewName("trinoAndSparkView");
     String sql = String.format("SELECT id FROM %s", tableName);
 
@@ -1943,12 +1948,17 @@ public class TestViews extends ExtensionsTestBase {
         .withSchema(schema(sql))
         .create();
 
-    assertThatThrownBy(() -> sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot replace view due to loss of view dialects (replace.drop-dialect.allowed=false):\n"
-                + "Previous dialects: [trino, spark]\n"
-                + "New dialects: [spark]");
+    sql("CREATE OR REPLACE VIEW %s AS %s", viewName, sql + " limit 10");
+
+    View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql(sql + " limit 10")
+                .build(),
+            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
   }
 
   @TestTemplate
@@ -1972,6 +1982,11 @@ public class TestViews extends ExtensionsTestBase {
         viewName, ViewProperties.REPLACE_DROP_DIALECT_ALLOWED, tableName);
 
     View view = viewCatalog.loadView(TableIdentifier.of(NAMESPACE, viewName));
+    assertThat(view.currentVersion().representations())
+        .hasSize(1)
+        .first()
+        .asInstanceOf(InstanceOfAssertFactories.type(SQLViewRepresentation.class))
+        .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
 
     // trino view should show up in the view versions & history
     assertThat(view.history()).hasSize(2);
@@ -1989,10 +2004,10 @@ public class TestViews extends ExtensionsTestBase {
         .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build());
 
     assertThat(view.currentVersion().representations())
-        .hasSize(2)
-        .containsExactlyInAnyOrder(
-            ImmutableSQLViewRepresentation.builder().dialect("trino").sql(sql).build(),
-            ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
+        .hasSize(1)
+        .first()
+        .asInstanceOf(InstanceOfAssertFactories.type(SQLViewRepresentation.class))
+        .isEqualTo(ImmutableSQLViewRepresentation.builder().dialect("spark").sql(sql).build());
   }
 
   @TestTemplate


### PR DESCRIPTION
Iceberg views support multiple engines, but when running `REPLACE VIEW` today it simply replaces the entire existing view. As a result, if view A contains multiple dialects, they get removed. Currently, the only workaround is to maintain separate views per engine.  

This PR changes that behavior: ~~When enable  replace.drop-dialect.allowed , during `REPLACE`, it only replaces the entries for the same dialect and preserves the other dialects, enabling true multi-engine support for views.~~
if replace.drop-dialect.allowed is set to true, we keep the existing behavior and drop the other dialects; if it’s set to false, we preserve the other dialects and only update our own, enabling true multi-engine support for views.

Close https://github.com/apache/iceberg/issues/15296