### PR TITLE
Hive: Replace View should rewrite sql text in HMS if HMS catalog is used

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -115,7 +115,7 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
     refreshFromMetadataLocation(metadataLocation);
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  @SuppressWarnings({"checkstyle:CyclomaticComplexity", "MethodLength"})
   @Override
   public void doCommit(ViewMetadata base, ViewMetadata metadata) {
     boolean newView = base == null;
@@ -147,6 +147,9 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
         }
 
         updateHiveView = true;
+        String sqlQuery = sqlFor(metadata);
+        tbl.setViewOriginalText(sqlQuery);
+        tbl.setViewExpandedText(sqlQuery);
         LOG.debug("Committing existing view: {}", fullName);
       } else {
         tbl = newHMSView(metadata);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCatalog.java
@@ -262,6 +262,38 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
   }
 
   @Test
+  public void testReplaceViewUpdatesHiveViewText() throws TException, IOException {
+    String dbName = "hivedb";
+    Namespace ns = Namespace.of(dbName);
+    TableIdentifier identifier = TableIdentifier.of(ns, "test_iceberg_replace_view_hive_text");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(identifier.namespace());
+    }
+
+    String initialQuery = "select * from hivedb.tbl";
+    String updatedQuery = "select count(*) from hivedb.tbl";
+
+    catalog
+        .buildView(identifier)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(ns)
+        .withQuery("hive", initialQuery)
+        .create();
+
+    catalog
+        .buildView(identifier)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(ns)
+        .withQuery("hive", updatedQuery)
+        .replace();
+
+    Table hiveTable =
+        HIVE_METASTORE_EXTENSION.metastoreClient().getTable(dbName, identifier.name());
+    assertThat(hiveTable.getViewOriginalText()).isEqualTo(updatedQuery);
+    assertThat(hiveTable.getViewExpandedText()).isEqualTo(updatedQuery);
+  }
+
+  @Test
   public void testInvalidIdentifiersWithRename() {
     TableIdentifier invalidFrom = TableIdentifier.of(Namespace.of("l1", "l2"), "view");
     TableIdentifier validTo = TableIdentifier.of(Namespace.of("l1"), "renamedView");


### PR DESCRIPTION
We are using HMS catalog, replacing iceberg view currently does not update sql text in HMS. When we query the view, SparkSessionCatalog.loadTable would use HiveExternalCatalog.loadTable to retrieve the view and get the wrong sql text. The pr would update sql text in HMS for replacing.