### PR TITLE
Core: Fix thread pool shutdown hook leak in ThreadPools

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -53,8 +54,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Predicates;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.io.CountingOutputStream;
-import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.iceberg.util.ManagedThreadPools;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,15 +112,16 @@ class S3OutputStream extends PositionOutputStream {
     if (executorService == null) {
       synchronized (S3OutputStream.class) {
         if (executorService == null) {
-          executorService =
-              MoreExecutors.getExitingExecutorService(
-                  (ThreadPoolExecutor)
-                      Executors.newFixedThreadPool(
-                          s3FileIOProperties.multipartUploadThreads(),
-                          new ThreadFactoryBuilder()
-                              .setDaemon(true)
-                              .setNameFormat("iceberg-s3fileio-upload-%d")
-                              .build()));
+          ThreadPoolExecutor pool =
+              (ThreadPoolExecutor)
+                  Executors.newFixedThreadPool(
+                      s3FileIOProperties.multipartUploadThreads(),
+                      new ThreadFactoryBuilder()
+                          .setDaemon(true)
+                          .setNameFormat("iceberg-s3fileio-upload-%d")
+                          .build());
+          ManagedThreadPools.add(pool, Duration.ofSeconds(10));
+          executorService = pool;
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -61,6 +61,19 @@ public class SystemConfigs {
           1,
           Integer::parseUnsignedInt);
 
+  /**
+   * Controls whether a JVM shutdown hook is automatically registered to shut down all thread pools
+   * managed by {@link org.apache.iceberg.util.ManagedThreadPools}. Set to {@code false} to opt out
+   * of the automatic hook and invoke {@code ManagedThreadPools.shutdownAll()} manually from your
+   * own application lifecycle (e.g., a Flink operator {@code close()} method).
+   */
+  public static final ConfigEntry<Boolean> THREAD_POOLS_AUTO_SHUTDOWN =
+      new ConfigEntry<>(
+          "iceberg.thread-pools.auto-shutdown",
+          "ICEBERG_THREAD_POOLS_AUTO_SHUTDOWN",
+          true,
+          Boolean::parseBoolean);
+
   /** Whether to use the shared worker pool when planning table scans. */
   public static final ConfigEntry<Boolean> SCAN_THREAD_POOL_ENABLED =
       new ConfigEntry<>(

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthSessionCache.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthSessionCache.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.iceberg.util.ManagedThreadPools;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,6 +101,7 @@ public class AuthSessionCache implements AutoCloseable {
     } finally {
       if (executor instanceof ExecutorService) {
         ExecutorService service = (ExecutorService) executor;
+        ManagedThreadPools.remove(service);
         service.shutdown();
         if (!Uninterruptibles.awaitTerminationUninterruptibly(service, 10, TimeUnit.SECONDS)) {
           LOG.warn("Timed out waiting for eviction executor to terminate");

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthSessionCache.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthSessionCache.java
@@ -101,12 +101,12 @@ public class AuthSessionCache implements AutoCloseable {
     } finally {
       if (executor instanceof ExecutorService) {
         ExecutorService service = (ExecutorService) executor;
-        ManagedThreadPools.remove(service);
         service.shutdown();
         if (!Uninterruptibles.awaitTerminationUninterruptibly(service, 10, TimeUnit.SECONDS)) {
           LOG.warn("Timed out waiting for eviction executor to terminate");
         }
         service.shutdownNow();
+        ManagedThreadPools.remove(service);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/ManagedThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ManagedThreadPools.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.Uninterruptibles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("ShutdownHook")
+public class ManagedThreadPools {
+  private static final Logger LOG = LoggerFactory.getLogger(ManagedThreadPools.class);
+  private static final List<PoolEntry> POOLS = Lists.newArrayList();
+
+  private ManagedThreadPools() {}
+
+  private static class PoolEntry {
+    private final ExecutorService executor;
+    private final long terminationTimeoutMs;
+
+    PoolEntry(ExecutorService executor, long terminationTimeoutMs) {
+      this.executor = executor;
+      this.terminationTimeoutMs = terminationTimeoutMs;
+    }
+  }
+
+  public static void add(ExecutorService executor, Duration terminationTimeout) {
+    synchronized (POOLS) {
+      POOLS.add(new PoolEntry(executor, terminationTimeout.toMillis()));
+    }
+  }
+
+  public static void remove(ExecutorService executor) {
+    synchronized (POOLS) {
+      POOLS.removeIf(entry -> entry.executor == executor);
+    }
+  }
+
+  public static void shutdownAll() {
+    synchronized (POOLS) {
+      for (PoolEntry entry : POOLS) {
+        entry.executor.shutdown();
+        if (entry.terminationTimeoutMs > 0
+            && !Uninterruptibles.awaitTerminationUninterruptibly(
+                entry.executor, entry.terminationTimeoutMs, TimeUnit.MILLISECONDS)) {
+          LOG.warn("Timed out waiting for thread pool to terminate");
+        }
+        entry.executor.shutdownNow();
+      }
+    }
+  }
+
+  static {
+    Runtime.getRuntime().addShutdownHook(new Thread(ManagedThreadPools::shutdownAll));
+  }
+
+  @VisibleForTesting
+  static List<ExecutorService> getPools() {
+    synchronized (POOLS) {
+      List<ExecutorService> executors = Lists.newArrayList();
+      for (PoolEntry entry : POOLS) {
+        executors.add(entry.executor);
+      }
+      return ImmutableList.copyOf(executors);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/ManagedThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ManagedThreadPools.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.SystemConfigs;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -59,21 +60,36 @@ public class ManagedThreadPools {
   }
 
   public static void shutdownAll() {
+    List<PoolEntry> snapshot;
     synchronized (POOLS) {
-      for (PoolEntry entry : POOLS) {
-        entry.executor.shutdown();
-        if (entry.terminationTimeoutMs > 0
-            && !Uninterruptibles.awaitTerminationUninterruptibly(
-                entry.executor, entry.terminationTimeoutMs, TimeUnit.MILLISECONDS)) {
-          LOG.warn("Timed out waiting for thread pool to terminate");
-        }
-        entry.executor.shutdownNow();
+      snapshot = ImmutableList.copyOf(POOLS);
+      POOLS.clear();
+    }
+
+    // Phase 1: signal all pools to stop accepting new work so they drain concurrently
+    for (PoolEntry entry : snapshot) {
+      entry.executor.shutdown();
+    }
+
+    // Phase 2: wait for each pool with its own timeout
+    for (PoolEntry entry : snapshot) {
+      if (entry.terminationTimeoutMs > 0
+          && !Uninterruptibles.awaitTerminationUninterruptibly(
+              entry.executor, entry.terminationTimeoutMs, TimeUnit.MILLISECONDS)) {
+        LOG.warn("Timed out waiting for thread pool to terminate");
       }
+    }
+
+    // Phase 3: force-stop any pool that did not drain in time
+    for (PoolEntry entry : snapshot) {
+      entry.executor.shutdownNow();
     }
   }
 
   static {
-    Runtime.getRuntime().addShutdownHook(new Thread(ManagedThreadPools::shutdownAll));
+    if (SystemConfigs.THREAD_POOLS_AUTO_SHUTDOWN.value()) {
+      Runtime.getRuntime().addShutdownHook(new Thread(ManagedThreadPools::shutdownAll));
+    }
   }
 
   @VisibleForTesting

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -25,9 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.SystemConfigs;
-import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class ThreadPools {
@@ -98,7 +96,7 @@ public class ThreadPools {
   private static class AuthRefreshPoolHolder {
     private static final ScheduledExecutorService INSTANCE =
         ThreadPools.newExitingScheduledPool(
-            "auth-session-refresh", AUTH_REFRESH_THREAD_POOL_SIZE, Duration.ZERO);
+            "auth-session-refresh", AUTH_REFRESH_THREAD_POOL_SIZE, Duration.ofSeconds(10));
   }
 
   /**
@@ -149,8 +147,9 @@ public class ThreadPools {
    * that should be automatically cleaned up on JVM shutdown.
    */
   public static ExecutorService newExitingWorkerPool(String namePrefix, int poolSize) {
-    return MoreExecutors.getExitingExecutorService(
-        (ThreadPoolExecutor) newFixedThreadPool(namePrefix, poolSize));
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) newFixedThreadPool(namePrefix, poolSize);
+    ManagedThreadPools.add(executor, Duration.ofSeconds(10));
+    return executor;
   }
 
   /** Creates a fixed-size thread pool that uses daemon threads. */
@@ -182,10 +181,10 @@ public class ThreadPools {
    */
   public static ScheduledExecutorService newExitingScheduledPool(
       String namePrefix, int poolSize, Duration terminationTimeout) {
-    return MoreExecutors.getExitingScheduledExecutorService(
-        (ScheduledThreadPoolExecutor) newScheduledPool(namePrefix, poolSize),
-        terminationTimeout.toMillis(),
-        TimeUnit.MILLISECONDS);
+    ScheduledThreadPoolExecutor executor =
+        (ScheduledThreadPoolExecutor) newScheduledPool(namePrefix, poolSize);
+    ManagedThreadPools.add(executor, terminationTimeout);
+    return executor;
   }
 
   private static ThreadFactory newDaemonThreadFactory(String namePrefix) {

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestAuthSessionCache.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestAuthSessionCache.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import java.time.Duration;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -87,5 +88,13 @@ class TestAuthSessionCache {
     Mockito.verify(session1).close();
 
     cache.close();
+  }
+
+  @Test
+  void testClose() {
+    ExecutorService executor = Mockito.mock(ExecutorService.class);
+    AuthSessionCache cache = new AuthSessionCache(Duration.ofHours(1), executor, System::nanoTime);
+    cache.close();
+    Mockito.verify(executor).shutdown();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ExecutorService;
+import org.junit.jupiter.api.Test;
+
+public class TestThreadPools {
+
+  @Test
+  public void testNewExitingWorkerPool() {
+    ExecutorService executor = ThreadPools.newExitingWorkerPool("test-shutdown-hook", 1);
+    try {
+      assertThat(ManagedThreadPools.getPools()).contains(executor);
+      assertThat(executor.isShutdown()).as("Executor should be running").isFalse();
+    } finally {
+      ManagedThreadPools.remove(executor);
+      executor.shutdown();
+      assertThat(executor.isShutdown()).as("Executor should be shut down").isTrue();
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestThreadPools.java
@@ -37,4 +37,30 @@ public class TestThreadPools {
       assertThat(executor.isShutdown()).as("Executor should be shut down").isTrue();
     }
   }
+
+  @Test
+  public void testShutdownAllClosesAndClearsPools() {
+    ExecutorService e1 = ThreadPools.newExitingWorkerPool("test-shutdown-all-1", 1);
+    ExecutorService e2 = ThreadPools.newExitingWorkerPool("test-shutdown-all-2", 1);
+    assertThat(ManagedThreadPools.getPools()).contains(e1, e2);
+
+    ManagedThreadPools.shutdownAll();
+
+    assertThat(e1.isShutdown()).as("First pool should be shut down").isTrue();
+    assertThat(e2.isShutdown()).as("Second pool should be shut down").isTrue();
+    assertThat(ManagedThreadPools.getPools()).isEmpty();
+  }
+
+  @Test
+  public void testShutdownAllIsIdempotent() {
+    ThreadPools.newExitingWorkerPool("test-idempotent", 1);
+
+    ManagedThreadPools.shutdownAll();
+    assertThat(ManagedThreadPools.getPools()).isEmpty();
+
+    // second call on empty registry must not throw
+    ManagedThreadPools.shutdownAll();
+    assertThat(ManagedThreadPools.getPools()).isEmpty();
+  }
 }
+


### PR DESCRIPTION
  ## Problem                                                                                                                                                                               
                                                                                                                                                                                           
  ThreadPools.newExitingWorkerPool and newExitingScheduledPool use Guava's                                                                                                                 
  MoreExecutors.getExitingExecutorService() which registers a new JVM shutdown                                                                                                             
  hook on every call. These hooks are never removed, even when the pool is                                                                                                                 
  explicitly shut down. In long-running services like Spark, Trino, and Flink,
  where REST catalogs and AuthSessionCache instances are created and closed
  repeatedly, this causes unbounded accumulation of shutdown hooks.

  Fixes #15031

  ## Solution

  Introduce ManagedThreadPools to centralize thread pool lifecycle management:
  - Single shutdown hook registered once, replacing per-pool Guava hooks
  - Per-pool terminationTimeout preserved for graceful shutdown
  - AuthSessionCache.close() calls ManagedThreadPools.remove() to deregister
    explicitly closed pools
  - Static WORKER_POOL and DELETE_WORKER_POOL structurally untouched