### PR TITLE
Core: Fix all ErrorProne warnings after Java 17 upgrade

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -241,19 +241,18 @@ abstract class BaseDistributedDataScan
     }
 
     switch (mode) {
-      case LOCAL:
+      case LOCAL -> {
         return true;
-
-      case DISTRIBUTED:
+      }
+      case DISTRIBUTED -> {
         return manifests.isEmpty();
-
-      case AUTO:
+      }
+      case AUTO -> {
         return remoteParallelism() <= localParallelism
             || manifests.size() <= 2 * localParallelism
             || totalSize(manifests) <= localPlanningSizeThreshold;
-
-      default:
-        throw new IllegalArgumentException("Unknown planning mode: " + mode);
+      }
+      default -> throw new IllegalArgumentException("Unknown planning mode: " + mode);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -315,75 +315,37 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   @Override
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
-      case 0:
-        this.content = value != null ? FILE_CONTENT_VALUES[(Integer) value] : FileContent.DATA;
-        return;
-      case 1:
+      case 0 ->
+          this.content = value != null ? FILE_CONTENT_VALUES[(Integer) value] : FileContent.DATA;
+      case 1 -> {
         // always coerce to String for Serializable
         this.filePath = value.toString();
-        return;
-      case 2:
-        this.format = FileFormat.fromString(value.toString());
-        return;
-      case 3:
-        this.partitionSpecId = (value != null) ? (Integer) value : -1;
-        return;
-      case 4:
-        this.partitionData = (PartitionData) value;
-        return;
-      case 5:
-        this.recordCount = (Long) value;
-        return;
-      case 6:
-        this.fileSizeInBytes = (Long) value;
-        return;
-      case 7:
-        this.columnSizes = (Map<Integer, Long>) value;
-        return;
-      case 8:
-        this.valueCounts = (Map<Integer, Long>) value;
-        return;
-      case 9:
-        this.nullValueCounts = (Map<Integer, Long>) value;
-        return;
-      case 10:
-        this.nanValueCounts = (Map<Integer, Long>) value;
-        return;
-      case 11:
-        this.lowerBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
-        return;
-      case 12:
-        this.upperBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
-        return;
-      case 13:
-        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
-        return;
-      case 14:
-        this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
-        return;
-      case 15:
-        this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
-        return;
-      case 16:
-        this.sortOrderId = (Integer) value;
-        return;
-      case 17:
-        this.firstRowId = (Long) value;
-        return;
-      case 18:
-        this.referencedDataFile = value != null ? value.toString() : null;
-        return;
-      case 19:
-        this.contentOffset = (Long) value;
-        return;
-      case 20:
-        this.contentSizeInBytes = (Long) value;
-        return;
-      case 21:
-        this.fileOrdinal = (long) value;
-        return;
-      default:
+      }
+      case 2 -> this.format = FileFormat.fromString(value.toString());
+      case 3 -> this.partitionSpecId = (value != null) ? (Integer) value : -1;
+      case 4 -> this.partitionData = (PartitionData) value;
+      case 5 -> this.recordCount = (Long) value;
+      case 6 -> this.fileSizeInBytes = (Long) value;
+      case 7 -> this.columnSizes = (Map<Integer, Long>) value;
+      case 8 -> this.valueCounts = (Map<Integer, Long>) value;
+      case 9 -> this.nullValueCounts = (Map<Integer, Long>) value;
+      case 10 -> this.nanValueCounts = (Map<Integer, Long>) value;
+      case 11 ->
+          this.lowerBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
+      case 12 ->
+          this.upperBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
+      case 13 -> this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 14 -> this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
+      case 15 -> this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
+      case 16 -> this.sortOrderId = (Integer) value;
+      case 17 -> this.firstRowId = (Long) value;
+      case 18 -> this.referencedDataFile = value != null ? value.toString() : null;
+      case 19 -> this.contentOffset = (Long) value;
+      case 20 -> this.contentSizeInBytes = (Long) value;
+      case 21 -> this.fileOrdinal = (long) value;
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 
@@ -394,52 +356,73 @@ abstract class BaseFile<F> extends SupportsIndexProjection
 
   private Object getByPos(int basePos) {
     switch (basePos) {
-      case 0:
+      case 0 -> {
         return content.id();
-      case 1:
+      }
+      case 1 -> {
         return filePath;
-      case 2:
+      }
+      case 2 -> {
         return format != null ? format.toString() : null;
-      case 3:
+      }
+      case 3 -> {
         return partitionSpecId;
-      case 4:
+      }
+      case 4 -> {
         return partitionData;
-      case 5:
+      }
+      case 5 -> {
         return recordCount;
-      case 6:
+      }
+      case 6 -> {
         return fileSizeInBytes;
-      case 7:
+      }
+      case 7 -> {
         return columnSizes;
-      case 8:
+      }
+      case 8 -> {
         return valueCounts;
-      case 9:
+      }
+      case 9 -> {
         return nullValueCounts;
-      case 10:
+      }
+      case 10 -> {
         return nanValueCounts;
-      case 11:
+      }
+      case 11 -> {
         return lowerBounds;
-      case 12:
+      }
+      case 12 -> {
         return upperBounds;
-      case 13:
+      }
+      case 13 -> {
         return keyMetadata();
-      case 14:
+      }
+      case 14 -> {
         return splitOffsets();
-      case 15:
+      }
+      case 15 -> {
         return equalityFieldIds();
-      case 16:
+      }
+      case 16 -> {
         return sortOrderId;
-      case 17:
+      }
+      case 17 -> {
         return firstRowId;
-      case 18:
+      }
+      case 18 -> {
         return referencedDataFile;
-      case 19:
+      }
+      case 19 -> {
         return contentOffset;
-      case 20:
+      }
+      case 20 -> {
         return contentSizeInBytes;
-      case 21:
+      }
+      case 21 -> {
         return fileOrdinal;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
+      }
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
     }
   }
 
@@ -597,8 +580,8 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   private static Map<Integer, ByteBuffer> toReadableByteBufferMap(Map<Integer, ByteBuffer> map) {
     if (map == null) {
       return null;
-    } else if (map instanceof SerializableByteBufferMap) {
-      return ((SerializableByteBufferMap) map).immutableMap();
+    } else if (map instanceof SerializableByteBufferMap serializableMap) {
+      return serializableMap.immutableMap();
     } else {
       return Collections.unmodifiableMap(map);
     }

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -165,8 +165,7 @@ public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile
 
     @Override
     public boolean canMerge(ScanTask other) {
-      if (other instanceof SplitScanTask) {
-        SplitScanTask that = (SplitScanTask) other;
+      if (other instanceof SplitScanTask that) {
         return file().equals(that.file()) && offset + len == that.start();
       } else {
         return false;

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -153,30 +153,28 @@ class BaseIncrementalChangelogScan
             int changeOrdinal = snapshotOrdinals.get(commitSnapshotId);
             DataFile dataFile = entry.file().copy(context.shouldKeepStats());
 
-            switch (entry.status()) {
-              case ADDED:
-                return new BaseAddedRowsScanTask(
-                    changeOrdinal,
-                    commitSnapshotId,
-                    dataFile,
-                    NO_DELETES,
-                    context.schemaAsString(),
-                    context.specAsString(),
-                    context.residuals());
-
-              case DELETED:
-                return new BaseDeletedDataFileScanTask(
-                    changeOrdinal,
-                    commitSnapshotId,
-                    dataFile,
-                    NO_DELETES,
-                    context.schemaAsString(),
-                    context.specAsString(),
-                    context.residuals());
-
-              default:
-                throw new IllegalArgumentException("Unexpected entry status: " + entry.status());
-            }
+            return switch (entry.status()) {
+              case ADDED ->
+                  new BaseAddedRowsScanTask(
+                      changeOrdinal,
+                      commitSnapshotId,
+                      dataFile,
+                      NO_DELETES,
+                      context.schemaAsString(),
+                      context.specAsString(),
+                      context.residuals());
+              case DELETED ->
+                  new BaseDeletedDataFileScanTask(
+                      changeOrdinal,
+                      commitSnapshotId,
+                      dataFile,
+                      NO_DELETES,
+                      context.schemaAsString(),
+                      context.specAsString(),
+                      context.residuals());
+              default ->
+                  throw new IllegalArgumentException("Unexpected entry status: " + entry.status());
+            };
           });
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BasePartitionStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/BasePartitionStatistics.java
@@ -133,34 +133,46 @@ public class BasePartitionStatistics extends SupportsIndexProjection
 
   private Object getByPos(int pos) {
     switch (pos) {
-      case PARTITION_POSITION:
+      case PARTITION_POSITION -> {
         return partition;
-      case SPEC_ID_POSITION:
+      }
+      case SPEC_ID_POSITION -> {
         return specId;
-      case DATA_RECORD_COUNT_POSITION:
+      }
+      case DATA_RECORD_COUNT_POSITION -> {
         return dataRecordCount;
-      case DATA_FILE_COUNT_POSITION:
+      }
+      case DATA_FILE_COUNT_POSITION -> {
         return dataFileCount;
-      case TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION:
+      }
+      case TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION -> {
         return totalDataFileSizeInBytes;
-      case POSITION_DELETE_RECORD_COUNT_POSITION:
+      }
+      case POSITION_DELETE_RECORD_COUNT_POSITION -> {
         return positionDeleteRecordCount;
-      case POSITION_DELETE_FILE_COUNT_POSITION:
+      }
+      case POSITION_DELETE_FILE_COUNT_POSITION -> {
         return positionDeleteFileCount;
-      case EQUALITY_DELETE_RECORD_COUNT_POSITION:
+      }
+      case EQUALITY_DELETE_RECORD_COUNT_POSITION -> {
         return equalityDeleteRecordCount;
-      case EQUALITY_DELETE_FILE_COUNT_POSITION:
+      }
+      case EQUALITY_DELETE_FILE_COUNT_POSITION -> {
         return equalityDeleteFileCount;
-      case TOTAL_RECORD_COUNT_POSITION:
+      }
+      case TOTAL_RECORD_COUNT_POSITION -> {
         return totalRecordCount;
-      case LAST_UPDATED_AT_POSITION:
+      }
+      case LAST_UPDATED_AT_POSITION -> {
         return lastUpdatedAt;
-      case LAST_UPDATED_SNAPSHOT_ID_POSITION:
+      }
+      case LAST_UPDATED_SNAPSHOT_ID_POSITION -> {
         return lastUpdatedSnapshotId;
-      case DV_COUNT_POSITION:
+      }
+      case DV_COUNT_POSITION -> {
         return dvCount;
-      default:
-        throw new UnsupportedOperationException("Unknown position: " + pos);
+      }
+      default -> throw new UnsupportedOperationException("Unknown position: " + pos);
     }
   }
 
@@ -171,47 +183,20 @@ public class BasePartitionStatistics extends SupportsIndexProjection
     }
 
     switch (pos) {
-      case PARTITION_POSITION:
-        this.partition = (StructLike) value;
-        break;
-      case SPEC_ID_POSITION:
-        this.specId = (int) value;
-        break;
-      case DATA_RECORD_COUNT_POSITION:
-        this.dataRecordCount = (long) value;
-        break;
-      case DATA_FILE_COUNT_POSITION:
-        this.dataFileCount = (int) value;
-        break;
-      case TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION:
-        this.totalDataFileSizeInBytes = (long) value;
-        break;
-      case POSITION_DELETE_RECORD_COUNT_POSITION:
-        this.positionDeleteRecordCount = (long) value;
-        break;
-      case POSITION_DELETE_FILE_COUNT_POSITION:
-        this.positionDeleteFileCount = (int) value;
-        break;
-      case EQUALITY_DELETE_RECORD_COUNT_POSITION:
-        this.equalityDeleteRecordCount = (long) value;
-        break;
-      case EQUALITY_DELETE_FILE_COUNT_POSITION:
-        this.equalityDeleteFileCount = (int) value;
-        break;
-      case TOTAL_RECORD_COUNT_POSITION:
-        this.totalRecordCount = (Long) value;
-        break;
-      case LAST_UPDATED_AT_POSITION:
-        this.lastUpdatedAt = (Long) value;
-        break;
-      case LAST_UPDATED_SNAPSHOT_ID_POSITION:
-        this.lastUpdatedSnapshotId = (Long) value;
-        break;
-      case DV_COUNT_POSITION:
-        this.dvCount = (int) value;
-        break;
-      default:
-        throw new UnsupportedOperationException("Unknown position: " + pos);
+      case PARTITION_POSITION -> this.partition = (StructLike) value;
+      case SPEC_ID_POSITION -> this.specId = (int) value;
+      case DATA_RECORD_COUNT_POSITION -> this.dataRecordCount = (long) value;
+      case DATA_FILE_COUNT_POSITION -> this.dataFileCount = (int) value;
+      case TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION -> this.totalDataFileSizeInBytes = (long) value;
+      case POSITION_DELETE_RECORD_COUNT_POSITION -> this.positionDeleteRecordCount = (long) value;
+      case POSITION_DELETE_FILE_COUNT_POSITION -> this.positionDeleteFileCount = (int) value;
+      case EQUALITY_DELETE_RECORD_COUNT_POSITION -> this.equalityDeleteRecordCount = (long) value;
+      case EQUALITY_DELETE_FILE_COUNT_POSITION -> this.equalityDeleteFileCount = (int) value;
+      case TOTAL_RECORD_COUNT_POSITION -> this.totalRecordCount = (Long) value;
+      case LAST_UPDATED_AT_POSITION -> this.lastUpdatedAt = (Long) value;
+      case LAST_UPDATED_SNAPSHOT_ID_POSITION -> this.lastUpdatedSnapshotId = (Long) value;
+      case DV_COUNT_POSITION -> this.dvCount = (int) value;
+      default -> throw new UnsupportedOperationException("Unknown position: " + pos);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -310,12 +310,14 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
    */
   static List<String> scanColumns(ManifestContent content) {
     switch (content) {
-      case DATA:
+      case DATA -> {
         return BaseScan.SCAN_COLUMNS;
-      case DELETES:
+      }
+      case DELETES -> {
         return BaseScan.DELETE_SCAN_COLUMNS;
-      default:
-        throw new UnsupportedOperationException("Cannot read unknown manifest type: " + content);
+      }
+      default ->
+          throw new UnsupportedOperationException("Cannot read unknown manifest type: " + content);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -275,14 +275,11 @@ class BaseSnapshot implements Snapshot {
           ManifestFiles.readDeleteManifest(manifest, fileIO, null)) {
         for (ManifestEntry<DeleteFile> entry : reader.entries()) {
           switch (entry.status()) {
-            case ADDED:
-              adds.add(entry.file().copy());
-              break;
-            case DELETED:
-              deletes.add(entry.file().copyWithoutStats());
-              break;
-            default:
+            case ADDED -> adds.add(entry.file().copy());
+            case DELETED -> deletes.add(entry.file().copyWithoutStats());
+            default -> {
               // ignore existing
+            }
           }
         }
       } catch (IOException e) {
@@ -308,15 +305,11 @@ class BaseSnapshot implements Snapshot {
         new ManifestGroup(fileIO, changedManifests).ignoreExisting().entries()) {
       for (ManifestEntry<DataFile> entry : entries) {
         switch (entry.status()) {
-          case ADDED:
-            adds.add(entry.file().copy());
-            break;
-          case DELETED:
-            deletes.add(entry.file().copyWithoutStats());
-            break;
-          default:
-            throw new IllegalStateException(
-                "Unexpected entry status, not added or deleted: " + entry);
+          case ADDED -> adds.add(entry.file().copy());
+          case DELETED -> deletes.add(entry.file().copyWithoutStats());
+          default ->
+              throw new IllegalStateException(
+                  "Unexpected entry status, not added or deleted: " + entry);
         }
       }
     } catch (IOException e) {
@@ -333,8 +326,7 @@ class BaseSnapshot implements Snapshot {
       return true;
     }
 
-    if (o instanceof BaseSnapshot) {
-      BaseSnapshot other = (BaseSnapshot) o;
+    if (o instanceof BaseSnapshot other) {
       return this.snapshotId == other.snapshotId()
           && Objects.equal(this.parentId, other.parentId())
           && this.sequenceNumber == other.sequenceNumber()

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -127,12 +127,12 @@ public class BaseTransaction implements Transaction {
   protected final <T extends PendingUpdate> T appendUpdate(T update) {
     checkLastOperationCommitted(update.getClass());
 
-    if (update instanceof SnapshotUpdate) {
-      ((SnapshotUpdate) update).deleteWith(enqueueDelete);
+    if (update instanceof SnapshotUpdate snapshotUpdate) {
+      snapshotUpdate.deleteWith(enqueueDelete);
     }
 
-    if (update instanceof SnapshotProducer) {
-      ((SnapshotProducer) update).reportWith(reporter);
+    if (update instanceof SnapshotProducer snapshotProducer) {
+      snapshotProducer.reportWith(reporter);
     }
 
     this.updates.add(update);
@@ -256,21 +256,10 @@ public class BaseTransaction implements Transaction {
         hasLastOpCommitted, "Cannot commit transaction: last operation has not committed");
 
     switch (type) {
-      case CREATE_TABLE:
-        commitCreateTransaction();
-        break;
-
-      case REPLACE_TABLE:
-        commitReplaceTransaction(false);
-        break;
-
-      case CREATE_OR_REPLACE_TABLE:
-        commitReplaceTransaction(true);
-        break;
-
-      case SIMPLE:
-        commitSimpleTransaction();
-        break;
+      case CREATE_TABLE -> commitCreateTransaction();
+      case REPLACE_TABLE -> commitReplaceTransaction(false);
+      case CREATE_OR_REPLACE_TABLE -> commitReplaceTransaction(true);
+      case SIMPLE -> commitSimpleTransaction();
     }
   }
 
@@ -433,8 +422,8 @@ public class BaseTransaction implements Transaction {
         .suppressFailureWhenFinished()
         .run(
             update -> {
-              if (update instanceof SnapshotProducer) {
-                ((SnapshotProducer) update).cleanAll();
+              if (update instanceof SnapshotProducer snapshotProducer) {
+                snapshotProducer.cleanAll();
               }
             });
   }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -154,8 +154,8 @@ public class CachingCatalog implements Catalog {
 
       // Share TableOperations instance of origin table for all metadata tables, so that metadata
       // table instances are refreshed as well when origin table instance is refreshed.
-      if (originTable instanceof HasTableOperations) {
-        TableOperations ops = ((HasTableOperations) originTable).operations();
+      if (originTable instanceof HasTableOperations hasTableOperations) {
+        TableOperations ops = hasTableOperations.operations();
         MetadataTableType type = MetadataTableType.from(canonicalized.name());
 
         Table metadataTable =

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -211,9 +211,8 @@ public class CatalogUtil {
    */
   public static void deleteFiles(
       FileIO io, Iterable<String> files, String type, boolean concurrent) {
-    if (io instanceof SupportsBulkOperations) {
+    if (io instanceof SupportsBulkOperations bulkIO) {
       try {
-        SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
         bulkIO.deleteFiles(files);
       } catch (RuntimeException e) {
         LOG.warn("Failed to bulk delete {} files", type, e);
@@ -303,31 +302,18 @@ public class CatalogUtil {
     if (catalogImpl == null) {
       String catalogType =
           PropertyUtil.propertyAsString(options, ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
-      switch (catalogType.toLowerCase(Locale.ENGLISH)) {
-        case ICEBERG_CATALOG_TYPE_HIVE:
-          catalogImpl = ICEBERG_CATALOG_HIVE;
-          break;
-        case ICEBERG_CATALOG_TYPE_HADOOP:
-          catalogImpl = ICEBERG_CATALOG_HADOOP;
-          break;
-        case ICEBERG_CATALOG_TYPE_REST:
-          catalogImpl = ICEBERG_CATALOG_REST;
-          break;
-        case ICEBERG_CATALOG_TYPE_GLUE:
-          catalogImpl = ICEBERG_CATALOG_GLUE;
-          break;
-        case ICEBERG_CATALOG_TYPE_NESSIE:
-          catalogImpl = ICEBERG_CATALOG_NESSIE;
-          break;
-        case ICEBERG_CATALOG_TYPE_JDBC:
-          catalogImpl = ICEBERG_CATALOG_JDBC;
-          break;
-        case ICEBERG_CATALOG_TYPE_BIGQUERY:
-          catalogImpl = ICEBERG_CATALOG_BIGQUERY;
-          break;
-        default:
-          throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);
-      }
+      catalogImpl =
+          switch (catalogType.toLowerCase(Locale.ENGLISH)) {
+            case ICEBERG_CATALOG_TYPE_HIVE -> ICEBERG_CATALOG_HIVE;
+            case ICEBERG_CATALOG_TYPE_HADOOP -> ICEBERG_CATALOG_HADOOP;
+            case ICEBERG_CATALOG_TYPE_REST -> ICEBERG_CATALOG_REST;
+            case ICEBERG_CATALOG_TYPE_GLUE -> ICEBERG_CATALOG_GLUE;
+            case ICEBERG_CATALOG_TYPE_NESSIE -> ICEBERG_CATALOG_NESSIE;
+            case ICEBERG_CATALOG_TYPE_JDBC -> ICEBERG_CATALOG_JDBC;
+            case ICEBERG_CATALOG_TYPE_BIGQUERY -> ICEBERG_CATALOG_BIGQUERY;
+            default ->
+                throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);
+          };
     } else {
       String catalogType = options.get(ICEBERG_CATALOG_TYPE);
       Preconditions.checkArgument(
@@ -405,8 +391,8 @@ public class CatalogUtil {
     }
 
     configureHadoopConf(fileIO, hadoopConf);
-    if (fileIO instanceof SupportsStorageCredentials) {
-      ((SupportsStorageCredentials) fileIO).setCredentials(storageCredentials);
+    if (fileIO instanceof SupportsStorageCredentials supportsStorageCredentials) {
+      supportsStorageCredentials.setCredentials(storageCredentials);
     }
 
     fileIO.initialize(properties);
@@ -586,11 +572,10 @@ public class CatalogUtil {
       // the log, thus we don't include metadata.previousFiles() for deletion - everything else can
       // be removed
       removedPreviousMetadataFiles.removeAll(metadata.previousFiles());
-      if (io instanceof SupportsBulkOperations) {
-        ((SupportsBulkOperations) io)
-            .deleteFiles(
-                Iterables.transform(
-                    removedPreviousMetadataFiles, TableMetadata.MetadataLogEntry::file));
+      if (io instanceof SupportsBulkOperations bulkIO) {
+        bulkIO.deleteFiles(
+            Iterables.transform(
+                removedPreviousMetadataFiles, TableMetadata.MetadataLogEntry::file));
       } else {
         Tasks.foreach(removedPreviousMetadataFiles)
             .noRetry()

--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -124,9 +124,7 @@ public class ContentFileParser {
 
     JsonUtil.writeLongFieldIfPresent(FIRST_ROW_ID, contentFile.firstRowId(), generator);
 
-    if (contentFile instanceof DeleteFile) {
-      DeleteFile deleteFile = (DeleteFile) contentFile;
-
+    if (contentFile instanceof DeleteFile deleteFile) {
       if (deleteFile.referencedDataFile() != null) {
         generator.writeStringField(REFERENCED_DATA_FILE, deleteFile.referencedDataFile());
       }
@@ -355,21 +353,19 @@ public class ContentFileParser {
   }
 
   private static FileContent fileContentFromJson(String content) {
-    switch (content) {
-      case CONTENT_DATA:
-        return FileContent.DATA;
-      case CONTENT_POSITION_DELETES:
-        return FileContent.POSITION_DELETES;
-      case CONTENT_EQUALITY_DELETES:
-        return FileContent.EQUALITY_DELETES;
-      default:
+    return switch (content) {
+      case CONTENT_DATA -> FileContent.DATA;
+      case CONTENT_POSITION_DELETES -> FileContent.POSITION_DELETES;
+      case CONTENT_EQUALITY_DELETES -> FileContent.EQUALITY_DELETES;
         // In 1.10 and before, file content is serialized as the FileContent enum value
+      default -> {
         try {
-          return FileContent.valueOf(content);
+          yield FileContent.valueOf(content);
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException(
               String.format("Invalid file content value: '%s'", content), e);
         }
-    }
+      }
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -216,8 +216,8 @@ public class DataFiles {
     }
 
     public Builder withInputFile(InputFile file) {
-      if (file instanceof HadoopInputFile) {
-        return withStatus(((HadoopInputFile) file).getStat());
+      if (file instanceof HadoopInputFile hadoopInputFile) {
+        return withStatus(hadoopInputFile.getStat());
       }
 
       this.filePath = file.location();

--- a/core/src/main/java/org/apache/iceberg/Delegates.java
+++ b/core/src/main/java/org/apache/iceberg/Delegates.java
@@ -28,9 +28,9 @@ class Delegates {
 
   @SuppressWarnings("unchecked")
   static <F extends ContentFile<F>> F suppressFirstRowId(F file) {
-    if (file instanceof DataFile && null != file.firstRowId()) {
+    if (file instanceof DataFile dataFile && null != file.firstRowId()) {
       return (F)
-          new DelegatingDataFile((DataFile) file) {
+          new DelegatingDataFile(dataFile) {
             @Override
             public Long firstRowId() {
               return null;

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -501,18 +501,16 @@ class DeleteFileIndex {
 
       for (DeleteFile file : files) {
         switch (file.content()) {
-          case POSITION_DELETES:
+          case POSITION_DELETES -> {
             if (ContentFileUtil.isDV(file)) {
               add(dvByPath, file);
             } else {
               add(posDeletesByPath, posDeletesByPartition, file);
             }
-            break;
-          case EQUALITY_DELETES:
-            add(globalDeletes, eqDeletesByPartition, file, fieldLookup);
-            break;
-          default:
-            throw new UnsupportedOperationException("Unsupported content: " + file.content());
+          }
+          case EQUALITY_DELETES -> add(globalDeletes, eqDeletesByPartition, file, fieldLookup);
+          default ->
+              throw new UnsupportedOperationException("Unsupported content: " + file.content());
         }
         ScanMetricsUtil.indexedDeleteFile(scanMetrics, file);
       }

--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -100,9 +100,9 @@ abstract class FileCleanupStrategy {
   }
 
   protected void deleteFiles(Set<String> pathsToDelete, String fileType) {
-    if (deleteFunc == null && fileIO instanceof SupportsBulkOperations) {
+    if (deleteFunc == null && fileIO instanceof SupportsBulkOperations bulkOps) {
       try {
-        ((SupportsBulkOperations) fileIO).deleteFiles(pathsToDelete);
+        bulkOps.deleteFiles(pathsToDelete);
       } catch (BulkDeletionFailureException e) {
         LOG.warn(
             "Bulk deletion failed for {} of {} {} file(s)",

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -136,8 +136,8 @@ public class FileMetadata {
     }
 
     public Builder withInputFile(InputFile file) {
-      if (file instanceof HadoopInputFile) {
-        return withStatus(((HadoopInputFile) file).getStat());
+      if (file instanceof HadoopInputFile hadoopInputFile) {
+        return withStatus(hadoopInputFile.getStat());
       }
 
       this.filePath = file.location();
@@ -272,17 +272,15 @@ public class FileMetadata {
       }
 
       switch (content) {
-        case POSITION_DELETES:
-          Preconditions.checkArgument(
-              sortOrderId == null, "Position delete file should not have sort order");
-          break;
-        case EQUALITY_DELETES:
+        case POSITION_DELETES ->
+            Preconditions.checkArgument(
+                sortOrderId == null, "Position delete file should not have sort order");
+        case EQUALITY_DELETES -> {
           if (sortOrderId == null) {
             sortOrderId = SortOrder.unsorted().orderId();
           }
-          break;
-        default:
-          throw new IllegalStateException("Unknown content type " + content);
+        }
+        default -> throw new IllegalStateException("Unknown content type " + content);
       }
 
       return new GenericDeleteFile(

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -158,23 +158,14 @@ class GenericManifestEntry<F extends ContentFile<F>>
   @SuppressWarnings("unchecked")
   public void put(int i, Object v) {
     switch (i) {
-      case 0:
-        this.status = STATUS_VALUES[(Integer) v];
-        return;
-      case 1:
-        this.snapshotId = (Long) v;
-        return;
-      case 2:
-        this.dataSequenceNumber = (Long) v;
-        return;
-      case 3:
-        this.fileSequenceNumber = (Long) v;
-        return;
-      case 4:
-        this.file = (F) v;
-        return;
-      default:
+      case 0 -> this.status = STATUS_VALUES[(Integer) v];
+      case 1 -> this.snapshotId = (Long) v;
+      case 2 -> this.dataSequenceNumber = (Long) v;
+      case 3 -> this.fileSequenceNumber = (Long) v;
+      case 4 -> this.file = (F) v;
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 
@@ -185,20 +176,14 @@ class GenericManifestEntry<F extends ContentFile<F>>
 
   @Override
   public Object get(int i) {
-    switch (i) {
-      case 0:
-        return status.id();
-      case 1:
-        return snapshotId;
-      case 2:
-        return dataSequenceNumber;
-      case 3:
-        return fileSequenceNumber;
-      case 4:
-        return file;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
-    }
+    return switch (i) {
+      case 0 -> status.id();
+      case 1 -> snapshotId;
+      case 2 -> dataSequenceNumber;
+      case 3 -> fileSequenceNumber;
+      case 4 -> file;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -290,102 +290,55 @@ public class GenericManifestFile extends SupportsIndexProjection
   }
 
   private Object getByPos(int basePos) {
-    switch (basePos) {
-      case 0:
-        return manifestPath;
-      case 1:
-        return lazyLength();
-      case 2:
-        return specId;
-      case 3:
-        return content.id();
-      case 4:
-        return sequenceNumber;
-      case 5:
-        return minSequenceNumber;
-      case 6:
-        return snapshotId;
-      case 7:
-        return addedFilesCount;
-      case 8:
-        return existingFilesCount;
-      case 9:
-        return deletedFilesCount;
-      case 10:
-        return addedRowsCount;
-      case 11:
-        return existingRowsCount;
-      case 12:
-        return deletedRowsCount;
-      case 13:
-        return partitions();
-      case 14:
-        return keyMetadata();
-      case 15:
-        return firstRowId();
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
-    }
+    return switch (basePos) {
+      case 0 -> manifestPath;
+      case 1 -> lazyLength();
+      case 2 -> specId;
+      case 3 -> content.id();
+      case 4 -> sequenceNumber;
+      case 5 -> minSequenceNumber;
+      case 6 -> snapshotId;
+      case 7 -> addedFilesCount;
+      case 8 -> existingFilesCount;
+      case 9 -> deletedFilesCount;
+      case 10 -> addedRowsCount;
+      case 11 -> existingRowsCount;
+      case 12 -> deletedRowsCount;
+      case 13 -> partitions();
+      case 14 -> keyMetadata();
+      case 15 -> firstRowId();
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
+    };
   }
 
   @Override
   protected <T> void internalSet(int basePos, T value) {
     switch (basePos) {
-      case 0:
         // always coerce to String for Serializable
-        this.manifestPath = value.toString();
-        return;
-      case 1:
-        this.length = (Long) value;
-        return;
-      case 2:
-        this.specId = (Integer) value;
-        return;
-      case 3:
-        this.content =
-            value != null ? MANIFEST_CONTENT_VALUES[(Integer) value] : ManifestContent.DATA;
-        return;
-      case 4:
-        this.sequenceNumber = value != null ? (Long) value : 0;
-        return;
-      case 5:
-        this.minSequenceNumber = value != null ? (Long) value : 0;
-        return;
-      case 6:
-        this.snapshotId = (Long) value;
-        return;
-      case 7:
-        this.addedFilesCount = (Integer) value;
-        return;
-      case 8:
-        this.existingFilesCount = (Integer) value;
-        return;
-      case 9:
-        this.deletedFilesCount = (Integer) value;
-        return;
-      case 10:
-        this.addedRowsCount = (Long) value;
-        return;
-      case 11:
-        this.existingRowsCount = (Long) value;
-        return;
-      case 12:
-        this.deletedRowsCount = (Long) value;
-        return;
-      case 13:
-        this.partitions =
-            value == null
-                ? null
-                : ((List<PartitionFieldSummary>) value).toArray(new PartitionFieldSummary[0]);
-        return;
-      case 14:
-        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
-        return;
-      case 15:
-        this.firstRowId = (Long) value;
-        return;
-      default:
+      case 0 -> this.manifestPath = value.toString();
+      case 1 -> this.length = (Long) value;
+      case 2 -> this.specId = (Integer) value;
+      case 3 ->
+          this.content =
+              value != null ? MANIFEST_CONTENT_VALUES[(Integer) value] : ManifestContent.DATA;
+      case 4 -> this.sequenceNumber = value != null ? (Long) value : 0;
+      case 5 -> this.minSequenceNumber = value != null ? (Long) value : 0;
+      case 6 -> this.snapshotId = (Long) value;
+      case 7 -> this.addedFilesCount = (Integer) value;
+      case 8 -> this.existingFilesCount = (Integer) value;
+      case 9 -> this.deletedFilesCount = (Integer) value;
+      case 10 -> this.addedRowsCount = (Long) value;
+      case 11 -> this.existingRowsCount = (Long) value;
+      case 12 -> this.deletedRowsCount = (Long) value;
+      case 13 ->
+          this.partitions =
+              value == null
+                  ? null
+                  : ((List<PartitionFieldSummary>) value).toArray(new PartitionFieldSummary[0]);
+      case 14 -> this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 15 -> this.firstRowId = (Long) value;
         // ignore the object, it must be from a newer version of the format
+      default -> {}
     }
   }
 
@@ -450,8 +403,8 @@ public class GenericManifestFile extends SupportsIndexProjection
     private final GenericManifestFile manifestFile;
 
     private CopyBuilder(ManifestFile toCopy) {
-      if (toCopy instanceof GenericManifestFile) {
-        this.manifestFile = new GenericManifestFile((GenericManifestFile) toCopy);
+      if (toCopy instanceof GenericManifestFile genericManifestFile) {
+        this.manifestFile = new GenericManifestFile(genericManifestFile);
       } else {
         this.manifestFile =
             new GenericManifestFile(

--- a/core/src/main/java/org/apache/iceberg/GenericPartitionFieldSummary.java
+++ b/core/src/main/java/org/apache/iceberg/GenericPartitionFieldSummary.java
@@ -150,16 +150,19 @@ public class GenericPartitionFieldSummary
       pos = fromProjectionPos[i];
     }
     switch (pos) {
-      case 0:
+      case 0 -> {
         return containsNull;
-      case 1:
+      }
+      case 1 -> {
         return containsNaN;
-      case 2:
+      }
+      case 2 -> {
         return lowerBound();
-      case 3:
+      }
+      case 3 -> {
         return upperBound();
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      }
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
   }
 
@@ -172,20 +175,13 @@ public class GenericPartitionFieldSummary
       pos = fromProjectionPos[i];
     }
     switch (pos) {
-      case 0:
-        this.containsNull = (Boolean) value;
-        return;
-      case 1:
-        this.containsNaN = (Boolean) value;
-        return;
-      case 2:
-        this.lowerBound = ByteBuffers.toByteArray((ByteBuffer) value);
-        return;
-      case 3:
-        this.upperBound = ByteBuffers.toByteArray((ByteBuffer) value);
-        return;
-      default:
+      case 0 -> this.containsNull = (Boolean) value;
+      case 1 -> this.containsNaN = (Boolean) value;
+      case 2 -> this.lowerBound = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 3 -> this.upperBound = ByteBuffers.toByteArray((ByteBuffer) value);
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -208,17 +208,22 @@ public class ManifestFiles {
       Long snapshotId,
       Long firstRowId) {
     switch (formatVersion) {
-      case 1:
+      case 1 -> {
         return new ManifestWriter.V1Writer(spec, encryptedOutputFile, snapshotId);
-      case 2:
+      }
+      case 2 -> {
         return new ManifestWriter.V2Writer(spec, encryptedOutputFile, snapshotId);
-      case 3:
+      }
+      case 3 -> {
         return new ManifestWriter.V3Writer(spec, encryptedOutputFile, snapshotId, firstRowId);
-      case 4:
+      }
+      case 4 -> {
         return new ManifestWriter.V4Writer(spec, encryptedOutputFile, snapshotId, firstRowId);
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Cannot write manifest for table version: " + formatVersion);
     }
-    throw new UnsupportedOperationException(
-        "Cannot write manifest for table version: " + formatVersion);
   }
 
   /**
@@ -268,17 +273,20 @@ public class ManifestFiles {
   public static ManifestWriter<DeleteFile> writeDeleteManifest(
       int formatVersion, PartitionSpec spec, EncryptedOutputFile outputFile, Long snapshotId) {
     switch (formatVersion) {
-      case 1:
-        throw new IllegalArgumentException("Cannot write delete files in a v1 table");
-      case 2:
+      case 1 -> throw new IllegalArgumentException("Cannot write delete files in a v1 table");
+      case 2 -> {
         return new ManifestWriter.V2DeleteWriter(spec, outputFile, snapshotId);
-      case 3:
+      }
+      case 3 -> {
         return new ManifestWriter.V3DeleteWriter(spec, outputFile, snapshotId);
-      case 4:
+      }
+      case 4 -> {
         return new ManifestWriter.V4DeleteWriter(spec, outputFile, snapshotId);
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Cannot write manifest for table version: " + formatVersion);
     }
-    throw new UnsupportedOperationException(
-        "Cannot write manifest for table version: " + formatVersion);
   }
 
   /**
@@ -313,13 +321,16 @@ public class ManifestFiles {
   static ManifestReader<?> open(
       ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
     switch (manifest.content()) {
-      case DATA:
+      case DATA -> {
         return ManifestFiles.read(manifest, io, specsById);
-      case DELETES:
+      }
+      case DELETES -> {
         return ManifestFiles.readDeleteManifest(manifest, io, specsById);
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Cannot read unknown manifest type: " + manifest.content());
     }
-    throw new UnsupportedOperationException(
-        "Cannot read unknown manifest type: " + manifest.content());
   }
 
   static ManifestFile copyAppendManifest(
@@ -397,17 +408,15 @@ public class ManifestFiles {
             entry.status(),
             allowedEntryStatus);
         switch (entry.status()) {
-          case ADDED:
+          case ADDED -> {
             summaryBuilder.addedFile(reader.spec(), entry.file());
             writer.add(entry);
-            break;
-          case EXISTING:
-            writer.existing(entry);
-            break;
-          case DELETED:
+          }
+          case EXISTING -> writer.existing(entry);
+          case DELETED -> {
             summaryBuilder.deletedFile(reader.spec(), entry.file());
             writer.delete(entry);
-            break;
+          }
         }
       }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -39,9 +39,9 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
 
   private ManifestListWriter(
       OutputFile file, EncryptionManager encryptionManager, Map<String, String> meta) {
-    if (encryptionManager instanceof StandardEncryptionManager) {
+    if (encryptionManager instanceof StandardEncryptionManager stdEncryptionManager) {
       // ability to encrypt the manifest list key is introduced for standard encryption.
-      this.standardEncryptionManager = (StandardEncryptionManager) encryptionManager;
+      this.standardEncryptionManager = stdEncryptionManager;
       EncryptedOutputFile encryptedFile = this.standardEncryptionManager.encrypt(file);
       this.outputFile = encryptedFile.encryptingOutputFile();
       this.manifestListKeyMetadata = (NativeEncryptionKeyMetadata) encryptedFile.keyMetadata();

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -57,17 +57,19 @@ class ManifestLists {
       long sequenceNumber,
       Long firstRowId) {
     switch (formatVersion) {
-      case 1:
+      case 1 -> {
         Preconditions.checkArgument(
             sequenceNumber == TableMetadata.INITIAL_SEQUENCE_NUMBER,
             "Invalid sequence number for v1 manifest list: %s",
             sequenceNumber);
         return new ManifestListWriter.V1Writer(
             manifestListFile, encryptionManager, snapshotId, parentSnapshotId);
-      case 2:
+      }
+      case 2 -> {
         return new ManifestListWriter.V2Writer(
             manifestListFile, encryptionManager, snapshotId, parentSnapshotId, sequenceNumber);
-      case 3:
+      }
+      case 3 -> {
         return new ManifestListWriter.V3Writer(
             manifestListFile,
             encryptionManager,
@@ -75,7 +77,8 @@ class ManifestLists {
             parentSnapshotId,
             sequenceNumber,
             firstRowId);
-      case 4:
+      }
+      case 4 -> {
         return new ManifestListWriter.V4Writer(
             manifestListFile,
             encryptionManager,
@@ -83,8 +86,10 @@ class ManifestLists {
             parentSnapshotId,
             sequenceNumber,
             firstRowId);
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Cannot write manifest list for table version: " + formatVersion);
     }
-    throw new UnsupportedOperationException(
-        "Cannot write manifest list for table version: " + formatVersion);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -81,18 +81,18 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
 
   void addEntry(ManifestEntry<F> entry) {
     switch (entry.status()) {
-      case ADDED:
+      case ADDED -> {
         addedFiles += 1;
         addedRows += entry.file().recordCount();
-        break;
-      case EXISTING:
+      }
+      case EXISTING -> {
         existingFiles += 1;
         existingRows += entry.file().recordCount();
-        break;
-      case DELETED:
+      }
+      case DELETED -> {
         deletedFiles += 1;
         deletedRows += entry.file().recordCount();
-        break;
+      }
     }
 
     stats.update(entry.file().partition());
@@ -196,10 +196,9 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
     Preconditions.checkState(closed, "Cannot build ManifestFile, writer is not closed");
 
     ByteBuffer keyMetadataBuffer;
-    if (keyMetadata instanceof NativeEncryptionKeyMetadata) {
+    if (keyMetadata instanceof NativeEncryptionKeyMetadata nativeKeyMetadata) {
       // File length is required by AES GCM Stream encryption, to prevent file truncation attacks
-      keyMetadataBuffer =
-          ((NativeEncryptionKeyMetadata) keyMetadata).copyWithLength(length()).buffer();
+      keyMetadataBuffer = nativeKeyMetadata.copyWithLength(length()).buffer();
     } else if (keyMetadata != null) {
       keyMetadataBuffer = keyMetadata.buffer();
     } else {

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -288,24 +288,20 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   protected void validateNewDeleteFile(DeleteFile file) {
     Preconditions.checkNotNull(file, "Invalid delete file: null");
     switch (formatVersion()) {
-      case 1:
-        throw new IllegalArgumentException("Deletes are supported in V2 and above");
-      case 2:
-        Preconditions.checkArgument(
-            file.content() == FileContent.EQUALITY_DELETES || !ContentFileUtil.isDV(file),
-            "Must not use DVs for position deletes in V2: %s",
-            ContentFileUtil.dvDesc(file));
-        break;
-      case 3:
-      case 4:
-        Preconditions.checkArgument(
-            file.content() == FileContent.EQUALITY_DELETES || ContentFileUtil.isDV(file),
-            "Must use DVs for position deletes in V%s: %s",
-            formatVersion(),
-            file.location());
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported format version: " + formatVersion());
+      case 1 -> throw new IllegalArgumentException("Deletes are supported in V2 and above");
+      case 2 ->
+          Preconditions.checkArgument(
+              file.content() == FileContent.EQUALITY_DELETES || !ContentFileUtil.isDV(file),
+              "Must not use DVs for position deletes in V2: %s",
+              ContentFileUtil.dvDesc(file));
+      case 3, 4 ->
+          Preconditions.checkArgument(
+              file.content() == FileContent.EQUALITY_DELETES || ContentFileUtil.isDV(file),
+              "Must use DVs for position deletes in V%s: %s",
+              formatVersion(),
+              file.location());
+      default ->
+          throw new IllegalArgumentException("Unsupported format version: " + formatVersion());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -32,12 +32,9 @@ public class MetadataTableUtils {
   public static Table createMetadataTableInstance(Table table, MetadataTableType type) {
     if (table instanceof BaseTable) {
       return createMetadataTableInstance(table, metadataTableName(table.name(), type), type);
-    } else if (table instanceof HasTableOperations) {
+    } else if (table instanceof HasTableOperations hasTableOps) {
       return createMetadataTableInstance(
-          ((HasTableOperations) table).operations(),
-          table.name(),
-          metadataTableName(table.name(), type),
-          type);
+          hasTableOps.operations(), table.name(), metadataTableName(table.name(), type), type);
     } else {
       throw new IllegalArgumentException(
           String.format(
@@ -56,41 +53,57 @@ public class MetadataTableUtils {
   private static Table createMetadataTableInstance(
       Table baseTable, String metadataTableName, MetadataTableType type) {
     switch (type) {
-      case ENTRIES:
+      case ENTRIES -> {
         return new ManifestEntriesTable(baseTable, metadataTableName);
-      case FILES:
+      }
+      case FILES -> {
         return new FilesTable(baseTable, metadataTableName);
-      case DATA_FILES:
+      }
+      case DATA_FILES -> {
         return new DataFilesTable(baseTable, metadataTableName);
-      case DELETE_FILES:
+      }
+      case DELETE_FILES -> {
         return new DeleteFilesTable(baseTable, metadataTableName);
-      case HISTORY:
+      }
+      case HISTORY -> {
         return new HistoryTable(baseTable, metadataTableName);
-      case SNAPSHOTS:
+      }
+      case SNAPSHOTS -> {
         return new SnapshotsTable(baseTable, metadataTableName);
-      case METADATA_LOG_ENTRIES:
+      }
+      case METADATA_LOG_ENTRIES -> {
         return new MetadataLogEntriesTable(baseTable, metadataTableName);
-      case REFS:
+      }
+      case REFS -> {
         return new RefsTable(baseTable, metadataTableName);
-      case MANIFESTS:
+      }
+      case MANIFESTS -> {
         return new ManifestsTable(baseTable, metadataTableName);
-      case PARTITIONS:
+      }
+      case PARTITIONS -> {
         return new PartitionsTable(baseTable, metadataTableName);
-      case ALL_DATA_FILES:
+      }
+      case ALL_DATA_FILES -> {
         return new AllDataFilesTable(baseTable, metadataTableName);
-      case ALL_DELETE_FILES:
+      }
+      case ALL_DELETE_FILES -> {
         return new AllDeleteFilesTable(baseTable, metadataTableName);
-      case ALL_FILES:
+      }
+      case ALL_FILES -> {
         return new AllFilesTable(baseTable, metadataTableName);
-      case ALL_MANIFESTS:
+      }
+      case ALL_MANIFESTS -> {
         return new AllManifestsTable(baseTable, metadataTableName);
-      case ALL_ENTRIES:
+      }
+      case ALL_ENTRIES -> {
         return new AllEntriesTable(baseTable, metadataTableName);
-      case POSITION_DELETES:
+      }
+      case POSITION_DELETES -> {
         return new PositionDeletesTable(baseTable, metadataTableName);
-      default:
-        throw new NoSuchTableException(
-            "Unknown metadata table type: %s for %s", type, metadataTableName);
+      }
+      default ->
+          throw new NoSuchTableException(
+              "Unknown metadata table type: %s for %s", type, metadataTableName);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -192,89 +192,62 @@ public class MetadataUpdateParser {
     generator.writeStringField(ACTION, updateAction);
 
     switch (updateAction) {
-      case ASSIGN_UUID:
-        writeAssignUUID((MetadataUpdate.AssignUUID) metadataUpdate, generator);
-        break;
-      case UPGRADE_FORMAT_VERSION:
-        writeUpgradeFormatVersion((MetadataUpdate.UpgradeFormatVersion) metadataUpdate, generator);
-        break;
-      case ADD_SCHEMA:
-        writeAddSchema((MetadataUpdate.AddSchema) metadataUpdate, generator);
-        break;
-      case SET_CURRENT_SCHEMA:
-        writeSetCurrentSchema((MetadataUpdate.SetCurrentSchema) metadataUpdate, generator);
-        break;
-      case ADD_PARTITION_SPEC:
-        writeAddPartitionSpec((MetadataUpdate.AddPartitionSpec) metadataUpdate, generator);
-        break;
-      case SET_DEFAULT_PARTITION_SPEC:
-        writeSetDefaultPartitionSpec(
-            (MetadataUpdate.SetDefaultPartitionSpec) metadataUpdate, generator);
-        break;
-      case ADD_SORT_ORDER:
-        writeAddSortOrder((MetadataUpdate.AddSortOrder) metadataUpdate, generator);
-        break;
-      case SET_DEFAULT_SORT_ORDER:
-        writeSetDefaultSortOrder((MetadataUpdate.SetDefaultSortOrder) metadataUpdate, generator);
-        break;
-      case SET_STATISTICS:
-        writeSetStatistics((MetadataUpdate.SetStatistics) metadataUpdate, generator);
-        break;
-      case REMOVE_STATISTICS:
-        writeRemoveStatistics((MetadataUpdate.RemoveStatistics) metadataUpdate, generator);
-        break;
-      case SET_PARTITION_STATISTICS:
-        writeSetPartitionStatistics(
-            (MetadataUpdate.SetPartitionStatistics) metadataUpdate, generator);
-        break;
-      case REMOVE_PARTITION_STATISTICS:
-        writeRemovePartitionStatistics(
-            (MetadataUpdate.RemovePartitionStatistics) metadataUpdate, generator);
-        break;
-      case ADD_SNAPSHOT:
-        writeAddSnapshot((MetadataUpdate.AddSnapshot) metadataUpdate, generator);
-        break;
-      case REMOVE_SNAPSHOTS:
-        writeRemoveSnapshots((MetadataUpdate.RemoveSnapshots) metadataUpdate, generator);
-        break;
-      case REMOVE_SNAPSHOT_REF:
-        writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
-        break;
-      case SET_SNAPSHOT_REF:
-        writeSetSnapshotRef((MetadataUpdate.SetSnapshotRef) metadataUpdate, generator);
-        break;
-      case SET_PROPERTIES:
-        writeSetProperties((MetadataUpdate.SetProperties) metadataUpdate, generator);
-        break;
-      case REMOVE_PROPERTIES:
-        writeRemoveProperties((MetadataUpdate.RemoveProperties) metadataUpdate, generator);
-        break;
-      case SET_LOCATION:
-        writeSetLocation((MetadataUpdate.SetLocation) metadataUpdate, generator);
-        break;
-      case ADD_VIEW_VERSION:
-        writeAddViewVersion((MetadataUpdate.AddViewVersion) metadataUpdate, generator);
-        break;
-      case SET_CURRENT_VIEW_VERSION:
-        writeSetCurrentViewVersionId(
-            (MetadataUpdate.SetCurrentViewVersion) metadataUpdate, generator);
-        break;
-      case REMOVE_PARTITION_SPECS:
-        writeRemovePartitionSpecs((MetadataUpdate.RemovePartitionSpecs) metadataUpdate, generator);
-        break;
-      case REMOVE_SCHEMAS:
-        writeRemoveSchemas((MetadataUpdate.RemoveSchemas) metadataUpdate, generator);
-        break;
-      case ADD_ENCRYPTION_KEY:
-        writeAddEncryptionKey((MetadataUpdate.AddEncryptionKey) metadataUpdate, generator);
-        break;
-      case REMOVE_ENCRYPTION_KEY:
-        writeRemoveEncryptionKey((MetadataUpdate.RemoveEncryptionKey) metadataUpdate, generator);
-        break;
-      default:
-        throw new IllegalArgumentException(
-            String.format(
-                "Cannot convert metadata update to json. Unrecognized action: %s", updateAction));
+      case ASSIGN_UUID -> writeAssignUUID((MetadataUpdate.AssignUUID) metadataUpdate, generator);
+      case UPGRADE_FORMAT_VERSION ->
+          writeUpgradeFormatVersion(
+              (MetadataUpdate.UpgradeFormatVersion) metadataUpdate, generator);
+      case ADD_SCHEMA -> writeAddSchema((MetadataUpdate.AddSchema) metadataUpdate, generator);
+      case SET_CURRENT_SCHEMA ->
+          writeSetCurrentSchema((MetadataUpdate.SetCurrentSchema) metadataUpdate, generator);
+      case ADD_PARTITION_SPEC ->
+          writeAddPartitionSpec((MetadataUpdate.AddPartitionSpec) metadataUpdate, generator);
+      case SET_DEFAULT_PARTITION_SPEC ->
+          writeSetDefaultPartitionSpec(
+              (MetadataUpdate.SetDefaultPartitionSpec) metadataUpdate, generator);
+      case ADD_SORT_ORDER ->
+          writeAddSortOrder((MetadataUpdate.AddSortOrder) metadataUpdate, generator);
+      case SET_DEFAULT_SORT_ORDER ->
+          writeSetDefaultSortOrder((MetadataUpdate.SetDefaultSortOrder) metadataUpdate, generator);
+      case SET_STATISTICS ->
+          writeSetStatistics((MetadataUpdate.SetStatistics) metadataUpdate, generator);
+      case REMOVE_STATISTICS ->
+          writeRemoveStatistics((MetadataUpdate.RemoveStatistics) metadataUpdate, generator);
+      case SET_PARTITION_STATISTICS ->
+          writeSetPartitionStatistics(
+              (MetadataUpdate.SetPartitionStatistics) metadataUpdate, generator);
+      case REMOVE_PARTITION_STATISTICS ->
+          writeRemovePartitionStatistics(
+              (MetadataUpdate.RemovePartitionStatistics) metadataUpdate, generator);
+      case ADD_SNAPSHOT -> writeAddSnapshot((MetadataUpdate.AddSnapshot) metadataUpdate, generator);
+      case REMOVE_SNAPSHOTS ->
+          writeRemoveSnapshots((MetadataUpdate.RemoveSnapshots) metadataUpdate, generator);
+      case REMOVE_SNAPSHOT_REF ->
+          writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
+      case SET_SNAPSHOT_REF ->
+          writeSetSnapshotRef((MetadataUpdate.SetSnapshotRef) metadataUpdate, generator);
+      case SET_PROPERTIES ->
+          writeSetProperties((MetadataUpdate.SetProperties) metadataUpdate, generator);
+      case REMOVE_PROPERTIES ->
+          writeRemoveProperties((MetadataUpdate.RemoveProperties) metadataUpdate, generator);
+      case SET_LOCATION -> writeSetLocation((MetadataUpdate.SetLocation) metadataUpdate, generator);
+      case ADD_VIEW_VERSION ->
+          writeAddViewVersion((MetadataUpdate.AddViewVersion) metadataUpdate, generator);
+      case SET_CURRENT_VIEW_VERSION ->
+          writeSetCurrentViewVersionId(
+              (MetadataUpdate.SetCurrentViewVersion) metadataUpdate, generator);
+      case REMOVE_PARTITION_SPECS ->
+          writeRemovePartitionSpecs(
+              (MetadataUpdate.RemovePartitionSpecs) metadataUpdate, generator);
+      case REMOVE_SCHEMAS ->
+          writeRemoveSchemas((MetadataUpdate.RemoveSchemas) metadataUpdate, generator);
+      case ADD_ENCRYPTION_KEY ->
+          writeAddEncryptionKey((MetadataUpdate.AddEncryptionKey) metadataUpdate, generator);
+      case REMOVE_ENCRYPTION_KEY ->
+          writeRemoveEncryptionKey((MetadataUpdate.RemoveEncryptionKey) metadataUpdate, generator);
+      default ->
+          throw new IllegalArgumentException(
+              String.format(
+                  "Cannot convert metadata update to json. Unrecognized action: %s", updateAction));
     }
 
     generator.writeEndObject();
@@ -300,59 +273,84 @@ public class MetadataUpdateParser {
     String action = JsonUtil.getString(ACTION, jsonNode).toLowerCase(Locale.ROOT);
 
     switch (action) {
-      case ASSIGN_UUID:
+      case ASSIGN_UUID -> {
         return readAssignUUID(jsonNode);
-      case UPGRADE_FORMAT_VERSION:
+      }
+      case UPGRADE_FORMAT_VERSION -> {
         return readUpgradeFormatVersion(jsonNode);
-      case ADD_SCHEMA:
+      }
+      case ADD_SCHEMA -> {
         return readAddSchema(jsonNode);
-      case SET_CURRENT_SCHEMA:
+      }
+      case SET_CURRENT_SCHEMA -> {
         return readSetCurrentSchema(jsonNode);
-      case ADD_PARTITION_SPEC:
+      }
+      case ADD_PARTITION_SPEC -> {
         return readAddPartitionSpec(jsonNode);
-      case SET_DEFAULT_PARTITION_SPEC:
+      }
+      case SET_DEFAULT_PARTITION_SPEC -> {
         return readSetDefaultPartitionSpec(jsonNode);
-      case ADD_SORT_ORDER:
+      }
+      case ADD_SORT_ORDER -> {
         return readAddSortOrder(jsonNode);
-      case SET_DEFAULT_SORT_ORDER:
+      }
+      case SET_DEFAULT_SORT_ORDER -> {
         return readSetDefaultSortOrder(jsonNode);
-      case SET_STATISTICS:
+      }
+      case SET_STATISTICS -> {
         return readSetStatistics(jsonNode);
-      case REMOVE_STATISTICS:
+      }
+      case REMOVE_STATISTICS -> {
         return readRemoveStatistics(jsonNode);
-      case SET_PARTITION_STATISTICS:
+      }
+      case SET_PARTITION_STATISTICS -> {
         return readSetPartitionStatistics(jsonNode);
-      case REMOVE_PARTITION_STATISTICS:
+      }
+      case REMOVE_PARTITION_STATISTICS -> {
         return readRemovePartitionStatistics(jsonNode);
-      case ADD_SNAPSHOT:
+      }
+      case ADD_SNAPSHOT -> {
         return readAddSnapshot(jsonNode);
-      case REMOVE_SNAPSHOTS:
+      }
+      case REMOVE_SNAPSHOTS -> {
         return readRemoveSnapshots(jsonNode);
-      case REMOVE_SNAPSHOT_REF:
+      }
+      case REMOVE_SNAPSHOT_REF -> {
         return readRemoveSnapshotRef(jsonNode);
-      case SET_SNAPSHOT_REF:
+      }
+      case SET_SNAPSHOT_REF -> {
         return readSetSnapshotRef(jsonNode);
-      case SET_PROPERTIES:
+      }
+      case SET_PROPERTIES -> {
         return readSetProperties(jsonNode);
-      case REMOVE_PROPERTIES:
+      }
+      case REMOVE_PROPERTIES -> {
         return readRemoveProperties(jsonNode);
-      case SET_LOCATION:
+      }
+      case SET_LOCATION -> {
         return readSetLocation(jsonNode);
-      case ADD_VIEW_VERSION:
+      }
+      case ADD_VIEW_VERSION -> {
         return readAddViewVersion(jsonNode);
-      case SET_CURRENT_VIEW_VERSION:
+      }
+      case SET_CURRENT_VIEW_VERSION -> {
         return readCurrentViewVersionId(jsonNode);
-      case REMOVE_PARTITION_SPECS:
+      }
+      case REMOVE_PARTITION_SPECS -> {
         return readRemovePartitionSpecs(jsonNode);
-      case REMOVE_SCHEMAS:
+      }
+      case REMOVE_SCHEMAS -> {
         return readRemoveSchemas(jsonNode);
-      case ADD_ENCRYPTION_KEY:
+      }
+      case ADD_ENCRYPTION_KEY -> {
         return readAddEncryptionKey(jsonNode);
-      case REMOVE_ENCRYPTION_KEY:
+      }
+      case REMOVE_ENCRYPTION_KEY -> {
         return readRemoveEncryptionKey(jsonNode);
-      default:
-        throw new UnsupportedOperationException(
-            String.format("Cannot convert metadata update action to json: %s", action));
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("Cannot convert metadata update action to json: %s", action));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -203,21 +203,15 @@ public class PartitionData
       } else {
         Types.NestedField field = fields.get(i);
         switch (field.type().typeId()) {
-          case STRUCT:
-          case LIST:
-          case MAP:
-            throw new IllegalArgumentException("Unsupported type in partition data: " + type);
-          case BINARY:
-          case FIXED:
+          case STRUCT, LIST, MAP ->
+              throw new IllegalArgumentException("Unsupported type in partition data: " + type);
+          case BINARY, FIXED -> {
             byte[] buffer = (byte[]) data[i];
             copy[i] = Arrays.copyOf(buffer, buffer.length);
-            break;
-          case STRING:
-            copy[i] = data[i].toString();
-            break;
-          default:
+          }
+          case STRING -> copy[i] = data[i].toString();
             // no need to copy the object
-            copy[i] = data[i];
+          default -> copy[i] = data[i];
         }
       }
     }
@@ -242,9 +236,8 @@ public class PartitionData
     if (value instanceof Utf8) {
       // Utf8 is not Serializable
       return value.toString();
-    } else if (value instanceof ByteBuffer) {
+    } else if (value instanceof ByteBuffer buffer) {
       // ByteBuffer is not Serializable
-      ByteBuffer buffer = (ByteBuffer) value;
       byte[] bytes = new byte[buffer.remaining()];
       buffer.duplicate().get(bytes);
       return bytes;

--- a/core/src/main/java/org/apache/iceberg/PartitionStats.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStats.java
@@ -111,26 +111,26 @@ public class PartitionStats implements StructLike {
     Preconditions.checkArgument(specId == file.specId(), "Spec IDs must match");
 
     switch (file.content()) {
-      case DATA:
+      case DATA -> {
         this.dataRecordCount += file.recordCount();
         this.dataFileCount += 1;
         this.totalDataFileSizeInBytes += file.fileSizeInBytes();
-        break;
-      case POSITION_DELETES:
+      }
+      case POSITION_DELETES -> {
         this.positionDeleteRecordCount += file.recordCount();
         if (file.format() == FileFormat.PUFFIN) {
           this.dvCount += 1;
         } else {
           this.positionDeleteFileCount += 1;
         }
-
-        break;
-      case EQUALITY_DELETES:
+      }
+      case EQUALITY_DELETES -> {
         this.equalityDeleteRecordCount += file.recordCount();
         this.equalityDeleteFileCount += 1;
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported file content type: " + file.content());
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported file content type: " + file.content());
     }
 
     if (snapshot != null) {
@@ -161,26 +161,26 @@ public class PartitionStats implements StructLike {
     Preconditions.checkArgument(specId == file.specId(), "Spec IDs must match");
 
     switch (file.content()) {
-      case DATA:
+      case DATA -> {
         this.dataRecordCount -= file.recordCount();
         this.dataFileCount -= 1;
         this.totalDataFileSizeInBytes -= file.fileSizeInBytes();
-        break;
-      case POSITION_DELETES:
+      }
+      case POSITION_DELETES -> {
         this.positionDeleteRecordCount -= file.recordCount();
         if (file.format() == FileFormat.PUFFIN) {
           this.dvCount -= 1;
         } else {
           this.positionDeleteFileCount -= 1;
         }
-
-        break;
-      case EQUALITY_DELETES:
+      }
+      case EQUALITY_DELETES -> {
         this.equalityDeleteRecordCount -= file.recordCount();
         this.equalityDeleteFileCount -= 1;
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported file content type: " + file.content());
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported file content type: " + file.content());
     }
 
     if (snapshot != null) {
@@ -233,85 +233,77 @@ public class PartitionStats implements StructLike {
   @Override
   public <T> T get(int pos, Class<T> javaClass) {
     switch (pos) {
-      case 0:
+      case 0 -> {
         return javaClass.cast(partition);
-      case 1:
+      }
+      case 1 -> {
         return javaClass.cast(specId);
-      case 2:
+      }
+      case 2 -> {
         return javaClass.cast(dataRecordCount);
-      case 3:
+      }
+      case 3 -> {
         return javaClass.cast(dataFileCount);
-      case 4:
+      }
+      case 4 -> {
         return javaClass.cast(totalDataFileSizeInBytes);
-      case 5:
+      }
+      case 5 -> {
         return javaClass.cast(positionDeleteRecordCount);
-      case 6:
+      }
+      case 6 -> {
         return javaClass.cast(positionDeleteFileCount);
-      case 7:
+      }
+      case 7 -> {
         return javaClass.cast(equalityDeleteRecordCount);
-      case 8:
+      }
+      case 8 -> {
         return javaClass.cast(equalityDeleteFileCount);
-      case 9:
+      }
+      case 9 -> {
         return javaClass.cast(totalRecordCount);
-      case 10:
+      }
+      case 10 -> {
         return javaClass.cast(lastUpdatedAt);
-      case 11:
+      }
+      case 11 -> {
         return javaClass.cast(lastUpdatedSnapshotId);
-      case 12:
+      }
+      case 12 -> {
         return javaClass.cast(dvCount);
-      default:
-        throw new UnsupportedOperationException("Unknown position: " + pos);
+      }
+      default -> throw new UnsupportedOperationException("Unknown position: " + pos);
     }
   }
 
   @Override
   public <T> void set(int pos, T value) {
     switch (pos) {
-      case 0:
-        this.partition = (StructLike) value;
-        break;
-      case 1:
-        this.specId = (int) value;
-        break;
-      case 2:
-        this.dataRecordCount = (long) value;
-        break;
-      case 3:
-        this.dataFileCount = (int) value;
-        break;
-      case 4:
-        this.totalDataFileSizeInBytes = (long) value;
-        break;
-      case 5:
-        // optional field as per spec, implementation initialize to 0 for counters
-        this.positionDeleteRecordCount = value == null ? 0L : (long) value;
-        break;
-      case 6:
-        // optional field as per spec, implementation initialize to 0 for counters
-        this.positionDeleteFileCount = value == null ? 0 : (int) value;
-        break;
-      case 7:
-        // optional field as per spec, implementation initialize to 0 for counters
-        this.equalityDeleteRecordCount = value == null ? 0L : (long) value;
-        break;
-      case 8:
-        // optional field as per spec, implementation initialize to 0 for counters
-        this.equalityDeleteFileCount = value == null ? 0 : (int) value;
-        break;
-      case 9:
-        this.totalRecordCount = (Long) value;
-        break;
-      case 10:
-        this.lastUpdatedAt = (Long) value;
-        break;
-      case 11:
-        this.lastUpdatedSnapshotId = (Long) value;
-        break;
-      case 12:
-        this.dvCount = value == null ? 0 : (int) value;
-        break;
-      default:
-        throw new UnsupportedOperationException("Unknown position: " + pos);
+      case 0 -> this.partition = (StructLike) value;
+      case 1 -> this.specId = (int) value;
+      case 2 -> this.dataRecordCount = (long) value;
+      case 3 -> this.dataFileCount = (int) value;
+      case 4 -> this.totalDataFileSizeInBytes = (long) value;
+      case 5 ->
+          // optional field as per spec, implementation initialize to 0 for counters
+          this.positionDeleteRecordCount = value == null ? 0L : (long) value;
+      case 6 ->
+          // optional field as per spec, implementation initialize to 0 for counters
+          this.positionDeleteFileCount = value == null ? 0 : (int) value;
+
+      case 7 ->
+          // optional field as per spec, implementation initialize to 0 for counters
+          this.equalityDeleteRecordCount = value == null ? 0L : (long) value;
+
+      case 8 ->
+          // optional field as per spec, implementation initialize to 0 for counters
+          this.equalityDeleteFileCount = value == null ? 0 : (int) value;
+
+      case 9 -> this.totalRecordCount = (Long) value;
+      case 10 -> this.lastUpdatedAt = (Long) value;
+      case 11 -> this.lastUpdatedSnapshotId = (Long) value;
+      case 12 -> this.dvCount = value == null ? 0 : (int) value;
+      default -> throw new UnsupportedOperationException("Unknown position: " + pos);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
@@ -569,7 +569,7 @@ public class PartitionStatsHandler {
     Preconditions.checkArgument(stats.specId() == file.specId(), "Spec IDs must match");
 
     switch (file.content()) {
-      case DATA:
+      case DATA -> {
         stats.set(
             PartitionStatistics.DATA_RECORD_COUNT_POSITION,
             stats.dataRecordCount() + file.recordCount());
@@ -577,8 +577,8 @@ public class PartitionStatsHandler {
         stats.set(
             PartitionStatistics.TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION,
             stats.totalDataFileSizeInBytes() + file.fileSizeInBytes());
-        break;
-      case POSITION_DELETES:
+      }
+      case POSITION_DELETES -> {
         stats.set(
             PartitionStatistics.POSITION_DELETE_RECORD_COUNT_POSITION,
             stats.positionDeleteRecordCount() + file.recordCount());
@@ -589,18 +589,18 @@ public class PartitionStatsHandler {
               PartitionStatistics.POSITION_DELETE_FILE_COUNT_POSITION,
               stats.positionDeleteFileCount() + 1);
         }
-
-        break;
-      case EQUALITY_DELETES:
+      }
+      case EQUALITY_DELETES -> {
         stats.set(
             PartitionStatistics.EQUALITY_DELETE_RECORD_COUNT_POSITION,
             stats.equalityDeleteRecordCount() + file.recordCount());
         stats.set(
             PartitionStatistics.EQUALITY_DELETE_FILE_COUNT_POSITION,
             stats.equalityDeleteFileCount() + 1);
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported file content type: " + file.content());
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported file content type: " + file.content());
     }
 
     if (snapshot != null) {
@@ -634,7 +634,7 @@ public class PartitionStatsHandler {
     Preconditions.checkArgument(stats.specId() == file.specId(), "Spec IDs must match");
 
     switch (file.content()) {
-      case DATA:
+      case DATA -> {
         stats.set(
             PartitionStatistics.DATA_RECORD_COUNT_POSITION,
             stats.dataRecordCount() - file.recordCount());
@@ -642,8 +642,8 @@ public class PartitionStatsHandler {
         stats.set(
             PartitionStatistics.TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION,
             stats.totalDataFileSizeInBytes() - file.fileSizeInBytes());
-        break;
-      case POSITION_DELETES:
+      }
+      case POSITION_DELETES -> {
         stats.set(
             PartitionStatistics.POSITION_DELETE_RECORD_COUNT_POSITION,
             stats.positionDeleteRecordCount() - file.recordCount());
@@ -654,18 +654,18 @@ public class PartitionStatsHandler {
               PartitionStatistics.POSITION_DELETE_FILE_COUNT_POSITION,
               stats.positionDeleteFileCount() - 1);
         }
-
-        break;
-      case EQUALITY_DELETES:
+      }
+      case EQUALITY_DELETES -> {
         stats.set(
             PartitionStatistics.EQUALITY_DELETE_RECORD_COUNT_POSITION,
             stats.equalityDeleteRecordCount() - file.recordCount());
         stats.set(
             PartitionStatistics.EQUALITY_DELETE_FILE_COUNT_POSITION,
             stats.equalityDeleteFileCount() - 1);
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported file content type: " + file.content());
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported file content type: " + file.content());
     }
 
     if (snapshot != null) {

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -255,11 +255,8 @@ public class PartitionsTable extends BaseMetadataTable {
 
     @Override
     public int compare(StructLike o1, StructLike o2) {
-      if (o1 instanceof StructProjection && o2 instanceof StructProjection) {
-        int cmp =
-            Integer.compare(
-                ((StructProjection) o1).projectedFields(),
-                ((StructProjection) o2).projectedFields());
+      if (o1 instanceof StructProjection sp1 && o2 instanceof StructProjection sp2) {
+        int cmp = Integer.compare(sp1.projectedFields(), sp2.projectedFields());
         if (cmp != 0) {
           return cmp;
         }
@@ -306,22 +303,22 @@ public class PartitionsTable extends BaseMetadataTable {
       }
 
       switch (file.content()) {
-        case DATA:
+        case DATA -> {
           this.dataRecordCount += file.recordCount();
           this.dataFileCount += 1;
           this.dataFileSizeInBytes += file.fileSizeInBytes();
-          break;
-        case POSITION_DELETES:
+        }
+        case POSITION_DELETES -> {
           this.posDeleteRecordCount += file.recordCount();
           this.posDeleteFileCount += 1;
-          break;
-        case EQUALITY_DELETES:
+        }
+        case EQUALITY_DELETES -> {
           this.eqDeleteRecordCount += file.recordCount();
           this.eqDeleteFileCount += 1;
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Unsupported file content type: " + file.content());
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Unsupported file content type: " + file.content());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -283,8 +283,8 @@ public class RewriteTablePathUtil {
                 sourcePrefix));
 
     EncryptionManager encryptionManager =
-        (io instanceof EncryptingFileIO)
-            ? ((EncryptingFileIO) io).encryptionManager()
+        (io instanceof EncryptingFileIO encryptingFileIO)
+            ? encryptingFileIO.encryptionManager()
             : PlaintextEncryptionManager.instance();
 
     try (FileAppender<ManifestFile> writer =
@@ -451,7 +451,7 @@ public class RewriteTablePathUtil {
     RewriteResult<DeleteFile> result = new RewriteResult<>();
 
     switch (file.content()) {
-      case POSITION_DELETES:
+      case POSITION_DELETES -> {
         DeleteFile posDeleteFile = newPositionDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, posDeleteFile);
         // keep the following entries in metadata but exclude them from copyPlan
@@ -467,7 +467,8 @@ public class RewriteTablePathUtil {
         }
         result.toRewrite().add(file);
         return result;
-      case EQUALITY_DELETES:
+      }
+      case EQUALITY_DELETES -> {
         DeleteFile eqDeleteFile = newEqualityDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, eqDeleteFile);
         // keep the following entries in metadata but exclude them from copyPlan
@@ -478,9 +479,11 @@ public class RewriteTablePathUtil {
           result.copyPlan().add(Pair.of(file.location(), eqDeleteFile.location()));
         }
         return result;
+      }
 
-      default:
-        throw new UnsupportedOperationException("Unsupported delete file type: " + file.content());
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported delete file type: " + file.content());
     }
   }
 
@@ -488,16 +491,11 @@ public class RewriteTablePathUtil {
       ManifestEntry<F> entry, ManifestWriter<F> writer, F file) {
 
     switch (entry.status()) {
-      case ADDED:
-        writer.add(file);
-        break;
-      case EXISTING:
-        writer.existing(
-            file, entry.snapshotId(), entry.dataSequenceNumber(), entry.fileSequenceNumber());
-        break;
-      case DELETED:
-        writer.delete(file, entry.dataSequenceNumber(), entry.fileSequenceNumber());
-        break;
+      case ADDED -> writer.add(file);
+      case EXISTING ->
+          writer.existing(
+              file, entry.snapshotId(), entry.dataSequenceNumber(), entry.fileSequenceNumber());
+      case DELETED -> writer.delete(file, entry.dataSequenceNumber(), entry.fileSequenceNumber());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ScanSummary.java
+++ b/core/src/main/java/org/apache/iceberg/ScanSummary.java
@@ -129,10 +129,8 @@ public class ScanSummary {
         removeTimeFilters(expressions, and.right());
         return;
 
-      } else if (expression instanceof UnboundPredicate) {
-        UnboundPredicate pred = (UnboundPredicate) expression;
-        if (pred.term() instanceof NamedReference) {
-          NamedReference<?> ref = (NamedReference<?>) pred.term();
+      } else if (expression instanceof UnboundPredicate pred) {
+        if (pred.term() instanceof NamedReference<?> ref) {
           Literal<?> lit = pred.literal();
           if (TIMESTAMP_NAMES.contains(ref.name())) {
             Literal<Long> tsLiteral = lit.to(Types.TimestampType.withoutZone());
@@ -388,37 +386,37 @@ public class ScanSummary {
     for (UnboundPredicate<Long> pred : timeFilters) {
       long value = pred.literal().value();
       switch (pred.op()) {
-        case LT:
+        case LT -> {
           if (value - 1 < maxTimestamp) {
             maxTimestamp = value - 1;
           }
-          break;
-        case LT_EQ:
+        }
+        case LT_EQ -> {
           if (value < maxTimestamp) {
             maxTimestamp = value;
           }
-          break;
-        case GT:
+        }
+        case GT -> {
           if (value + 1 > minTimestamp) {
             minTimestamp = value + 1;
           }
-          break;
-        case GT_EQ:
+        }
+        case GT_EQ -> {
           if (value > minTimestamp) {
             minTimestamp = value;
           }
-          break;
-        case EQ:
+        }
+        case EQ -> {
           if (value < maxTimestamp) {
             maxTimestamp = value;
           }
           if (value > minTimestamp) {
             minTimestamp = value;
           }
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Cannot filter timestamps using predicate: " + pred);
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Cannot filter timestamps using predicate: " + pred);
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/ScanTaskParser.java
+++ b/core/src/main/java/org/apache/iceberg/ScanTaskParser.java
@@ -80,20 +80,19 @@ public class ScanTaskParser {
       throws IOException {
     generator.writeStartObject();
 
-    if (fileScanTask instanceof StaticDataTask) {
+    if (fileScanTask instanceof StaticDataTask staticDataTask) {
       generator.writeStringField(TASK_TYPE, TaskType.DATA_TASK.typeName());
-      DataTaskParser.toJson((StaticDataTask) fileScanTask, generator);
-    } else if (fileScanTask instanceof BaseFilesTable.ManifestReadTask) {
+      DataTaskParser.toJson(staticDataTask, generator);
+    } else if (fileScanTask instanceof BaseFilesTable.ManifestReadTask manifestReadTask) {
       generator.writeStringField(TASK_TYPE, TaskType.FILES_TABLE_TASK.typeName());
-      FilesTableTaskParser.toJson((BaseFilesTable.ManifestReadTask) fileScanTask, generator);
-    } else if (fileScanTask instanceof AllManifestsTable.ManifestListReadTask) {
+      FilesTableTaskParser.toJson(manifestReadTask, generator);
+    } else if (fileScanTask
+        instanceof AllManifestsTable.ManifestListReadTask manifestListReadTask) {
       generator.writeStringField(TASK_TYPE, TaskType.ALL_MANIFESTS_TABLE_TASK.typeName());
-      AllManifestsTableTaskParser.toJson(
-          (AllManifestsTable.ManifestListReadTask) fileScanTask, generator);
-    } else if (fileScanTask instanceof BaseEntriesTable.ManifestReadTask) {
+      AllManifestsTableTaskParser.toJson(manifestListReadTask, generator);
+    } else if (fileScanTask instanceof BaseEntriesTable.ManifestReadTask entriesReadTask) {
       generator.writeStringField(TASK_TYPE, TaskType.MANIFEST_ENTRIES_TABLE_TASK.typeName());
-      ManifestEntriesTableTaskParser.toJson(
-          (BaseEntriesTable.ManifestReadTask) fileScanTask, generator);
+      ManifestEntriesTableTaskParser.toJson(entriesReadTask, generator);
     } else if (fileScanTask instanceof BaseFileScanTask
         || fileScanTask instanceof BaseFileScanTask.SplitScanTask) {
       generator.writeStringField(TASK_TYPE, TaskType.FILE_SCAN_TASK.typeName());
@@ -114,18 +113,23 @@ public class ScanTaskParser {
     }
 
     switch (taskType) {
-      case FILE_SCAN_TASK:
+      case FILE_SCAN_TASK -> {
         return FileScanTaskParser.fromJson(jsonNode, caseSensitive);
-      case DATA_TASK:
+      }
+      case DATA_TASK -> {
         return DataTaskParser.fromJson(jsonNode);
-      case FILES_TABLE_TASK:
+      }
+      case FILES_TABLE_TASK -> {
         return FilesTableTaskParser.fromJson(jsonNode);
-      case ALL_MANIFESTS_TABLE_TASK:
+      }
+      case ALL_MANIFESTS_TABLE_TASK -> {
         return AllManifestsTableTaskParser.fromJson(jsonNode);
-      case MANIFEST_ENTRIES_TABLE_TASK:
+      }
+      case MANIFEST_ENTRIES_TABLE_TASK -> {
         return ManifestEntriesTableTaskParser.fromJson(jsonNode);
-      default:
-        throw new UnsupportedOperationException("Unsupported task type: " + taskType.typeName());
+      }
+      default ->
+          throw new UnsupportedOperationException("Unsupported task type: " + taskType.typeName());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -146,17 +146,10 @@ public class SchemaParser {
     } else {
       Type.NestedType nested = type.asNestedType();
       switch (type.typeId()) {
-        case STRUCT:
-          toJson(nested.asStructType(), generator);
-          break;
-        case LIST:
-          toJson(nested.asListType(), generator);
-          break;
-        case MAP:
-          toJson(nested.asMapType(), generator);
-          break;
-        default:
-          throw new IllegalArgumentException("Cannot write unknown type: " + type);
+        case STRUCT -> toJson(nested.asStructType(), generator);
+        case LIST -> toJson(nested.asListType(), generator);
+        case MAP -> toJson(nested.asMapType(), generator);
+        default -> throw new IllegalArgumentException("Cannot write unknown type: " + type);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -789,27 +789,21 @@ class SchemaUpdate implements UpdateSchema {
       reordered.remove(toMove);
 
       switch (move.type()) {
-        case FIRST:
-          reordered.addFirst(toMove);
-          break;
-
-        case BEFORE:
+        case FIRST -> reordered.addFirst(toMove);
+        case BEFORE -> {
           Types.NestedField before =
               Iterables.find(reordered, field -> field.fieldId() == move.referenceFieldId());
           int beforeIndex = reordered.indexOf(before);
           // insert the new node at the index of the existing node
           reordered.add(beforeIndex, toMove);
-          break;
-
-        case AFTER:
+        }
+        case AFTER -> {
           Types.NestedField after =
               Iterables.find(reordered, field -> field.fieldId() == move.referenceFieldId());
           int afterIndex = reordered.indexOf(after);
           reordered.add(afterIndex + 1, toMove);
-          break;
-
-        default:
-          throw new UnsupportedOperationException("Unknown move type: " + move.type());
+        }
+        default -> throw new UnsupportedOperationException("Unknown move type: " + move.type());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -98,8 +98,8 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
    * @return a read-only serializable table reflecting the current state of the original table
    */
   public static Table copyOf(Table table) {
-    if (table instanceof BaseMetadataTable) {
-      return new SerializableMetadataTable((BaseMetadataTable) table);
+    if (table instanceof BaseMetadataTable baseMetadataTable) {
+      return new SerializableMetadataTable(baseMetadataTable);
     } else {
       return new SerializableTable(table);
     }
@@ -114,11 +114,11 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
   }
 
   private String metadataFileLocation(Table table) {
-    if (table instanceof HasTableOperations) {
-      TableOperations ops = ((HasTableOperations) table).operations();
+    if (table instanceof HasTableOperations hasTableOps) {
+      TableOperations ops = hasTableOps.operations();
       return ops.current().metadataFileLocation();
-    } else if (table instanceof BaseMetadataTable) {
-      return ((BaseMetadataTable) table).table().operations().current().metadataFileLocation();
+    } else if (table instanceof BaseMetadataTable baseMetadataTable) {
+      return baseMetadataTable.table().operations().current().metadataFileLocation();
     } else {
       return null;
     }

--- a/core/src/main/java/org/apache/iceberg/SingleValueParser.java
+++ b/core/src/main/java/org/apache/iceberg/SingleValueParser.java
@@ -46,45 +46,51 @@ public class SingleValueParser {
   private static final String KEYS = "keys";
   private static final String VALUES = "values";
 
+  @SuppressWarnings("MethodLength")
   public static Object fromJson(Type type, JsonNode defaultValue) {
     if (defaultValue == null || defaultValue.isNull()) {
       return null;
     }
 
     switch (type.typeId()) {
-      case BOOLEAN:
+      case BOOLEAN -> {
         Preconditions.checkArgument(
             defaultValue.isBoolean(), "Cannot parse default as a %s value: %s", type, defaultValue);
         return defaultValue.booleanValue();
-      case INTEGER:
+      }
+      case INTEGER -> {
         Preconditions.checkArgument(
             defaultValue.isIntegralNumber() && defaultValue.canConvertToInt(),
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
         return defaultValue.intValue();
-      case LONG:
+      }
+      case LONG -> {
         Preconditions.checkArgument(
             defaultValue.isIntegralNumber() && defaultValue.canConvertToLong(),
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
         return defaultValue.longValue();
-      case FLOAT:
+      }
+      case FLOAT -> {
         Preconditions.checkArgument(
             defaultValue.isFloatingPointNumber(),
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
         return defaultValue.floatValue();
-      case DOUBLE:
+      }
+      case DOUBLE -> {
         Preconditions.checkArgument(
             defaultValue.isFloatingPointNumber(),
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
         return defaultValue.doubleValue();
-      case DECIMAL:
+      }
+      case DECIMAL -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         BigDecimal retDecimal;
@@ -100,11 +106,13 @@ public class SingleValueParser {
             type,
             defaultValue);
         return retDecimal;
-      case STRING:
+      }
+      case STRING -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         return defaultValue.textValue();
-      case UUID:
+      }
+      case UUID -> {
         Preconditions.checkArgument(
             defaultValue.isTextual() && defaultValue.textValue().length() == 36,
             "Cannot parse default as a %s value: %s",
@@ -118,15 +126,18 @@ public class SingleValueParser {
               String.format("Cannot parse default as a %s value: %s", type, defaultValue), e);
         }
         return uuid;
-      case DATE:
+      }
+      case DATE -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         return DateTimeUtil.isoDateToDays(defaultValue.textValue());
-      case TIME:
+      }
+      case TIME -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         return DateTimeUtil.isoTimeToMicros(defaultValue.textValue());
-      case TIMESTAMP:
+      }
+      case TIMESTAMP -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
@@ -140,7 +151,8 @@ public class SingleValueParser {
         } else {
           return DateTimeUtil.isoTimestampToMicros(defaultValue.textValue());
         }
-      case TIMESTAMP_NANO:
+      }
+      case TIMESTAMP_NANO -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
@@ -154,7 +166,8 @@ public class SingleValueParser {
         } else {
           return DateTimeUtil.isoTimestampToNanos(defaultValue.textValue());
         }
-      case FIXED:
+      }
+      case FIXED -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         int defaultLength = defaultValue.textValue().length();
@@ -168,20 +181,25 @@ public class SingleValueParser {
         byte[] fixedBytes =
             BaseEncoding.base16().decode(defaultValue.textValue().toUpperCase(Locale.ROOT));
         return ByteBuffer.wrap(fixedBytes);
-      case BINARY:
+      }
+      case BINARY -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         byte[] binaryBytes =
             BaseEncoding.base16().decode(defaultValue.textValue().toUpperCase(Locale.ROOT));
         return ByteBuffer.wrap(binaryBytes);
-      case LIST:
+      }
+      case LIST -> {
         return listFromJson(type, defaultValue);
-      case MAP:
+      }
+      case MAP -> {
         return mapFromJson(type, defaultValue);
-      case STRUCT:
+      }
+      case STRUCT -> {
         return structFromJson(type, defaultValue);
-      default:
-        throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
+      }
+      default ->
+          throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
     }
   }
 
@@ -259,42 +277,42 @@ public class SingleValueParser {
     }
 
     switch (type.typeId()) {
-      case BOOLEAN:
+      case BOOLEAN -> {
         Preconditions.checkArgument(
             defaultValue instanceof Boolean, "Invalid default %s value: %s", type, defaultValue);
         generator.writeBoolean((Boolean) defaultValue);
-        break;
-      case INTEGER:
+      }
+      case INTEGER -> {
         Preconditions.checkArgument(
             defaultValue instanceof Integer, "Invalid default %s value: %s", type, defaultValue);
         generator.writeNumber((Integer) defaultValue);
-        break;
-      case LONG:
+      }
+      case LONG -> {
         Preconditions.checkArgument(
             defaultValue instanceof Long, "Invalid default %s value: %s", type, defaultValue);
         generator.writeNumber((Long) defaultValue);
-        break;
-      case FLOAT:
+      }
+      case FLOAT -> {
         Preconditions.checkArgument(
             defaultValue instanceof Float, "Invalid default %s value: %s", type, defaultValue);
         generator.writeNumber((Float) defaultValue);
-        break;
-      case DOUBLE:
+      }
+      case DOUBLE -> {
         Preconditions.checkArgument(
             defaultValue instanceof Double, "Invalid default %s value: %s", type, defaultValue);
         generator.writeNumber((Double) defaultValue);
-        break;
-      case DATE:
+      }
+      case DATE -> {
         Preconditions.checkArgument(
             defaultValue instanceof Integer, "Invalid default %s value: %s", type, defaultValue);
         generator.writeString(DateTimeUtil.daysToIsoDate((Integer) defaultValue));
-        break;
-      case TIME:
+      }
+      case TIME -> {
         Preconditions.checkArgument(
             defaultValue instanceof Long, "Invalid default %s value: %s", type, defaultValue);
         generator.writeString(DateTimeUtil.microsToIsoTime((Long) defaultValue));
-        break;
-      case TIMESTAMP:
+      }
+      case TIMESTAMP -> {
         Preconditions.checkArgument(
             defaultValue instanceof Long, "Invalid default %s value: %s", type, defaultValue);
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
@@ -302,8 +320,8 @@ public class SingleValueParser {
         } else {
           generator.writeString(DateTimeUtil.microsToIsoTimestamp((Long) defaultValue));
         }
-        break;
-      case TIMESTAMP_NANO:
+      }
+      case TIMESTAMP_NANO -> {
         Preconditions.checkArgument(
             defaultValue instanceof Long, "Invalid default %s value: %s", type, defaultValue);
         if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
@@ -311,21 +329,21 @@ public class SingleValueParser {
         } else {
           generator.writeString(DateTimeUtil.nanosToIsoTimestamp((Long) defaultValue));
         }
-        break;
-      case STRING:
+      }
+      case STRING -> {
         Preconditions.checkArgument(
             defaultValue instanceof CharSequence,
             "Invalid default %s value: %s",
             type,
             defaultValue);
         generator.writeString(((CharSequence) defaultValue).toString());
-        break;
-      case UUID:
+      }
+      case UUID -> {
         Preconditions.checkArgument(
             defaultValue instanceof UUID, "Invalid default %s value: %s", type, defaultValue);
         generator.writeString(defaultValue.toString());
-        break;
-      case FIXED:
+      }
+      case FIXED -> {
         Preconditions.checkArgument(
             defaultValue instanceof ByteBuffer, "Invalid default %s value: %s", type, defaultValue);
         ByteBuffer byteBufferValue = (ByteBuffer) defaultValue;
@@ -337,28 +355,29 @@ public class SingleValueParser {
             byteBufferValue.remaining());
         generator.writeString(
             BaseEncoding.base16().encode(ByteBuffers.toByteArray(byteBufferValue)));
-        break;
-      case BINARY:
+      }
+      case BINARY -> {
         Preconditions.checkArgument(
             defaultValue instanceof ByteBuffer, "Invalid default %s value: %s", type, defaultValue);
         generator.writeString(
             BaseEncoding.base16().encode(ByteBuffers.toByteArray((ByteBuffer) defaultValue)));
-        break;
-      case DECIMAL:
+      }
+      case DECIMAL -> {
         Preconditions.checkArgument(
-            defaultValue instanceof BigDecimal
-                && ((BigDecimal) defaultValue).scale() == ((Types.DecimalType) type).scale(),
+            defaultValue instanceof BigDecimal, "Invalid default %s value: %s", type, defaultValue);
+        BigDecimal decimalValue = (BigDecimal) defaultValue;
+        Preconditions.checkArgument(
+            decimalValue.scale() == ((Types.DecimalType) type).scale(),
             "Invalid default %s value: %s",
             type,
             defaultValue);
-        BigDecimal decimalValue = (BigDecimal) defaultValue;
         if (decimalValue.scale() >= 0) {
           generator.writeString(decimalValue.toPlainString());
         } else {
           generator.writeString(decimalValue.toString());
         }
-        break;
-      case LIST:
+      }
+      case LIST -> {
         Preconditions.checkArgument(
             defaultValue instanceof List, "Invalid default %s value: %s", type, defaultValue);
         List<Object> defaultList = (List<Object>) defaultValue;
@@ -368,8 +387,8 @@ public class SingleValueParser {
           toJson(elementType, element, generator);
         }
         generator.writeEndArray();
-        break;
-      case MAP:
+      }
+      case MAP -> {
         Preconditions.checkArgument(
             defaultValue instanceof Map, "Invalid default %s value: %s", type, defaultValue);
         Map<Object, Object> defaultMap = (Map<Object, Object>) defaultValue;
@@ -390,8 +409,8 @@ public class SingleValueParser {
         }
         generator.writeEndArray();
         generator.writeEndObject();
-        break;
-      case STRUCT:
+      }
+      case STRUCT -> {
         Preconditions.checkArgument(
             defaultValue instanceof StructLike, "Invalid default %s value: %s", type, defaultValue);
         Types.StructType structType = type.asStructType();
@@ -409,9 +428,9 @@ public class SingleValueParser {
           }
         }
         generator.writeEndObject();
-        break;
-      default:
-        throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
+      }
+      default ->
+          throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -546,9 +546,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       if (event != null) {
         Listeners.notifyAll(event);
 
-        if (event instanceof CreateSnapshotEvent) {
-          CreateSnapshotEvent createSnapshotEvent = (CreateSnapshotEvent) event;
-
+        if (event instanceof CreateSnapshotEvent createSnapshotEvent) {
           reporter.report(
               ImmutableCommitReport.builder()
                   .tableName(createSnapshotEvent.tableName())
@@ -811,24 +809,24 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         }
 
         switch (entry.status()) {
-          case ADDED:
+          case ADDED -> {
             addedFiles += 1;
             addedRows += entry.file().recordCount();
             if (snapshotId == null) {
               snapshotId = entry.snapshotId();
             }
-            break;
-          case EXISTING:
+          }
+          case EXISTING -> {
             existingFiles += 1;
             existingRows += entry.file().recordCount();
-            break;
-          case DELETED:
+          }
+          case DELETED -> {
             deletedFiles += 1;
             deletedRows += entry.file().recordCount();
             if (snapshotId == null) {
               snapshotId = entry.snapshotId();
             }
-            break;
+          }
         }
 
         stats.update(entry.file().partition());

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -126,10 +126,10 @@ public class SnapshotSummary {
     }
 
     public void deletedFile(PartitionSpec spec, ContentFile<?> file) {
-      if (file instanceof DataFile) {
-        deletedFile(spec, (DataFile) file);
-      } else if (file instanceof DeleteFile) {
-        deletedFile(spec, (DeleteFile) file);
+      if (file instanceof DataFile dataFile) {
+        deletedFile(spec, dataFile);
+      } else if (file instanceof DeleteFile deleteFile) {
+        deletedFile(spec, deleteFile);
       } else {
         throw new IllegalArgumentException(
             "Unsupported file type: " + file.getClass().getSimpleName());
@@ -291,72 +291,74 @@ public class SnapshotSummary {
     void addedFile(ContentFile<?> file) {
       this.addedSize += ScanTaskUtil.contentSizeInBytes(file);
       switch (file.content()) {
-        case DATA:
+        case DATA -> {
           this.addedFiles += 1;
           this.addedRecords += file.recordCount();
-          break;
-        case POSITION_DELETES:
+        }
+        case POSITION_DELETES -> {
           DeleteFile deleteFile = (DeleteFile) file;
           if (ContentFileUtil.isDV(deleteFile)) {
             this.addedDVs += 1;
           } else {
             this.addedPosDeleteFiles += 1;
           }
+
           this.addedDeleteFiles += 1;
           this.addedPosDeletes += file.recordCount();
-          break;
-        case EQUALITY_DELETES:
+        }
+        case EQUALITY_DELETES -> {
           this.addedDeleteFiles += 1;
           this.addedEqDeleteFiles += 1;
           this.addedEqDeletes += file.recordCount();
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Unsupported file content type: " + file.content());
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Unsupported file content type: " + file.content());
       }
     }
 
     void removedFile(ContentFile<?> file) {
       this.removedSize += ScanTaskUtil.contentSizeInBytes(file);
       switch (file.content()) {
-        case DATA:
+        case DATA -> {
           this.removedFiles += 1;
           this.deletedRecords += file.recordCount();
-          break;
-        case POSITION_DELETES:
+        }
+        case POSITION_DELETES -> {
           DeleteFile deleteFile = (DeleteFile) file;
           if (ContentFileUtil.isDV(deleteFile)) {
             this.removedDVs += 1;
           } else {
             this.removedPosDeleteFiles += 1;
           }
+
           this.removedDeleteFiles += 1;
           this.removedPosDeletes += file.recordCount();
-          break;
-        case EQUALITY_DELETES:
+        }
+        case EQUALITY_DELETES -> {
           this.removedDeleteFiles += 1;
           this.removedEqDeleteFiles += 1;
           this.removedEqDeletes += file.recordCount();
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Unsupported file content type: " + file.content());
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Unsupported file content type: " + file.content());
       }
     }
 
     void addedManifest(ManifestFile manifest) {
       switch (manifest.content()) {
-        case DATA:
+        case DATA -> {
           this.addedFiles += manifest.addedFilesCount();
           this.addedRecords += manifest.addedRowsCount();
           this.removedFiles += manifest.deletedFilesCount();
           this.deletedRecords += manifest.deletedRowsCount();
-          break;
-        case DELETES:
+        }
+        case DELETES -> {
           this.addedDeleteFiles += manifest.addedFilesCount();
           this.removedDeleteFiles += manifest.deletedFilesCount();
           this.trustSizeAndDeleteCounts = false;
-          break;
+        }
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -165,12 +165,14 @@ public class SortOrderParser {
 
   private static NullOrder toNullOrder(String nullOrderingAsString) {
     switch (nullOrderingAsString.toLowerCase(Locale.ROOT)) {
-      case "nulls-first":
+      case "nulls-first" -> {
         return NULLS_FIRST;
-      case "nulls-last":
+      }
+      case "nulls-last" -> {
         return NULLS_LAST;
-      default:
-        throw new IllegalArgumentException("Unexpected null order: " + nullOrderingAsString);
+      }
+      default ->
+          throw new IllegalArgumentException("Unexpected null order: " + nullOrderingAsString);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SplitPositionDeletesScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/SplitPositionDeletesScanTask.java
@@ -63,8 +63,7 @@ class SplitPositionDeletesScanTask
 
   @Override
   public boolean canMerge(org.apache.iceberg.ScanTask other) {
-    if (other instanceof SplitPositionDeletesScanTask) {
-      SplitPositionDeletesScanTask that = (SplitPositionDeletesScanTask) other;
+    if (other instanceof SplitPositionDeletesScanTask that) {
       return file().equals(that.file()) && offset + length == that.start();
     } else {
       return false;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1826,12 +1826,10 @@ public class TableMetadata implements Serializable {
       Set<Long> addedSnapshotIds = Sets.newHashSet();
       Set<Long> intermediateSnapshotIds = Sets.newHashSet();
       for (MetadataUpdate update : changes) {
-        if (update instanceof MetadataUpdate.AddSnapshot) {
+        if (update instanceof MetadataUpdate.AddSnapshot addSnapshot) {
           // adds must always come before set current snapshot
-          MetadataUpdate.AddSnapshot addSnapshot = (MetadataUpdate.AddSnapshot) update;
           addedSnapshotIds.add(addSnapshot.snapshot().snapshotId());
-        } else if (update instanceof MetadataUpdate.SetSnapshotRef) {
-          MetadataUpdate.SetSnapshotRef setRef = (MetadataUpdate.SetSnapshotRef) update;
+        } else if (update instanceof MetadataUpdate.SetSnapshotRef setRef) {
           long snapshotId = setRef.snapshotId();
           if (addedSnapshotIds.contains(snapshotId)
               && SnapshotRef.MAIN_BRANCH.equals(setRef.name())

--- a/core/src/main/java/org/apache/iceberg/TableUtil.java
+++ b/core/src/main/java/org/apache/iceberg/TableUtil.java
@@ -27,14 +27,11 @@ public class TableUtil {
   public static int formatVersion(Table table) {
     Preconditions.checkArgument(null != table, "Invalid table: null");
 
-    if (table instanceof SerializableTable) {
-      SerializableTable serializableTable = (SerializableTable) table;
+    if (table instanceof SerializableTable serializableTable) {
       return serializableTable.formatVersion();
-    } else if (table instanceof HasTableOperations) {
-      HasTableOperations ops = (HasTableOperations) table;
+    } else if (table instanceof HasTableOperations ops) {
       return ops.operations().current().formatVersion();
-    } else if (table instanceof BaseMetadataTable) {
-      BaseMetadataTable metadataTable = (BaseMetadataTable) table;
+    } else if (table instanceof BaseMetadataTable metadataTable) {
       return metadataTable.table().operations().current().formatVersion();
     } else {
       throw new IllegalArgumentException(
@@ -46,14 +43,12 @@ public class TableUtil {
   public static String metadataFileLocation(Table table) {
     Preconditions.checkArgument(null != table, "Invalid table: null");
 
-    if (table instanceof SerializableTable) {
-      SerializableTable serializableTable = (SerializableTable) table;
+    if (table instanceof SerializableTable serializableTable) {
       return serializableTable.metadataFileLocation();
-    } else if (table instanceof HasTableOperations) {
-      HasTableOperations ops = (HasTableOperations) table;
+    } else if (table instanceof HasTableOperations ops) {
       return ops.operations().current().metadataFileLocation();
-    } else if (table instanceof BaseMetadataTable) {
-      return ((BaseMetadataTable) table).table().operations().current().metadataFileLocation();
+    } else if (table instanceof BaseMetadataTable metadataTable) {
+      return metadataTable.table().operations().current().metadataFileLocation();
     } else {
       throw new IllegalArgumentException(
           String.format(

--- a/core/src/main/java/org/apache/iceberg/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/UpdateRequirementParser.java
@@ -97,44 +97,35 @@ public class UpdateRequirementParser {
     generator.writeStringField(TYPE, requirementType);
 
     switch (requirementType) {
-      case ASSERT_TABLE_DOES_NOT_EXIST:
         // No fields beyond the requirement itself
-        break;
-      case ASSERT_TABLE_UUID:
-        writeAssertTableUUID((UpdateRequirement.AssertTableUUID) updateRequirement, generator);
-        break;
-      case ASSERT_VIEW_UUID:
-        writeAssertViewUUID((UpdateRequirement.AssertViewUUID) updateRequirement, generator);
-        break;
-      case ASSERT_REF_SNAPSHOT_ID:
-        writeAssertRefSnapshotId(
-            (UpdateRequirement.AssertRefSnapshotID) updateRequirement, generator);
-        break;
-      case ASSERT_LAST_ASSIGNED_FIELD_ID:
-        writeAssertLastAssignedFieldId(
-            (UpdateRequirement.AssertLastAssignedFieldId) updateRequirement, generator);
-        break;
-      case ASSERT_LAST_ASSIGNED_PARTITION_ID:
-        writeAssertLastAssignedPartitionId(
-            (UpdateRequirement.AssertLastAssignedPartitionId) updateRequirement, generator);
-        break;
-      case ASSERT_CURRENT_SCHEMA_ID:
-        writeAssertCurrentSchemaId(
-            (UpdateRequirement.AssertCurrentSchemaID) updateRequirement, generator);
-        break;
-      case ASSERT_DEFAULT_SPEC_ID:
-        writeAssertDefaultSpecId(
-            (UpdateRequirement.AssertDefaultSpecID) updateRequirement, generator);
-        break;
-      case ASSERT_DEFAULT_SORT_ORDER_ID:
-        writeAssertDefaultSortOrderId(
-            (UpdateRequirement.AssertDefaultSortOrderID) updateRequirement, generator);
-        break;
-      default:
-        throw new IllegalArgumentException(
-            String.format(
-                "Cannot convert update requirement to json. Unrecognized type: %s",
-                requirementType));
+      case ASSERT_TABLE_DOES_NOT_EXIST -> {}
+      case ASSERT_TABLE_UUID ->
+          writeAssertTableUUID((UpdateRequirement.AssertTableUUID) updateRequirement, generator);
+      case ASSERT_VIEW_UUID ->
+          writeAssertViewUUID((UpdateRequirement.AssertViewUUID) updateRequirement, generator);
+      case ASSERT_REF_SNAPSHOT_ID ->
+          writeAssertRefSnapshotId(
+              (UpdateRequirement.AssertRefSnapshotID) updateRequirement, generator);
+      case ASSERT_LAST_ASSIGNED_FIELD_ID ->
+          writeAssertLastAssignedFieldId(
+              (UpdateRequirement.AssertLastAssignedFieldId) updateRequirement, generator);
+      case ASSERT_LAST_ASSIGNED_PARTITION_ID ->
+          writeAssertLastAssignedPartitionId(
+              (UpdateRequirement.AssertLastAssignedPartitionId) updateRequirement, generator);
+      case ASSERT_CURRENT_SCHEMA_ID ->
+          writeAssertCurrentSchemaId(
+              (UpdateRequirement.AssertCurrentSchemaID) updateRequirement, generator);
+      case ASSERT_DEFAULT_SPEC_ID ->
+          writeAssertDefaultSpecId(
+              (UpdateRequirement.AssertDefaultSpecID) updateRequirement, generator);
+      case ASSERT_DEFAULT_SORT_ORDER_ID ->
+          writeAssertDefaultSortOrderId(
+              (UpdateRequirement.AssertDefaultSortOrderID) updateRequirement, generator);
+      default ->
+          throw new IllegalArgumentException(
+              String.format(
+                  "Cannot convert update requirement to json. Unrecognized type: %s",
+                  requirementType));
     }
 
     generator.writeEndObject();
@@ -159,29 +150,20 @@ public class UpdateRequirementParser {
         jsonNode.hasNonNull(TYPE), "Cannot parse update requirement. Missing field: type");
     String type = JsonUtil.getString(TYPE, jsonNode).toLowerCase(Locale.ROOT);
 
-    switch (type) {
-      case ASSERT_TABLE_DOES_NOT_EXIST:
-        return readAssertTableDoesNotExist(jsonNode);
-      case ASSERT_TABLE_UUID:
-        return readAssertTableUUID(jsonNode);
-      case ASSERT_VIEW_UUID:
-        return readAssertViewUUID(jsonNode);
-      case ASSERT_REF_SNAPSHOT_ID:
-        return readAssertRefSnapshotId(jsonNode);
-      case ASSERT_LAST_ASSIGNED_FIELD_ID:
-        return readAssertLastAssignedFieldId(jsonNode);
-      case ASSERT_LAST_ASSIGNED_PARTITION_ID:
-        return readAssertLastAssignedPartitionId(jsonNode);
-      case ASSERT_CURRENT_SCHEMA_ID:
-        return readAssertCurrentSchemaId(jsonNode);
-      case ASSERT_DEFAULT_SPEC_ID:
-        return readAssertDefaultSpecId(jsonNode);
-      case ASSERT_DEFAULT_SORT_ORDER_ID:
-        return readAssertDefaultSortOrderId(jsonNode);
-      default:
-        throw new UnsupportedOperationException(
-            String.format("Unrecognized update requirement. Cannot convert to json: %s", type));
-    }
+    return switch (type) {
+      case ASSERT_TABLE_DOES_NOT_EXIST -> readAssertTableDoesNotExist(jsonNode);
+      case ASSERT_TABLE_UUID -> readAssertTableUUID(jsonNode);
+      case ASSERT_VIEW_UUID -> readAssertViewUUID(jsonNode);
+      case ASSERT_REF_SNAPSHOT_ID -> readAssertRefSnapshotId(jsonNode);
+      case ASSERT_LAST_ASSIGNED_FIELD_ID -> readAssertLastAssignedFieldId(jsonNode);
+      case ASSERT_LAST_ASSIGNED_PARTITION_ID -> readAssertLastAssignedPartitionId(jsonNode);
+      case ASSERT_CURRENT_SCHEMA_ID -> readAssertCurrentSchemaId(jsonNode);
+      case ASSERT_DEFAULT_SPEC_ID -> readAssertDefaultSpecId(jsonNode);
+      case ASSERT_DEFAULT_SORT_ORDER_ID -> readAssertDefaultSortOrderId(jsonNode);
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("Unrecognized update requirement. Cannot convert to json: %s", type));
+    };
   }
 
   private static void writeAssertTableUUID(

--- a/core/src/main/java/org/apache/iceberg/UpdateRequirements.java
+++ b/core/src/main/java/org/apache/iceberg/UpdateRequirements.java
@@ -93,22 +93,22 @@ public class UpdateRequirements {
       Preconditions.checkArgument(update != null, "Invalid update: null");
 
       // add requirements based on the change
-      if (update instanceof MetadataUpdate.SetSnapshotRef) {
-        update((MetadataUpdate.SetSnapshotRef) update);
-      } else if (update instanceof MetadataUpdate.AddSchema) {
-        update((MetadataUpdate.AddSchema) update);
-      } else if (update instanceof MetadataUpdate.SetCurrentSchema) {
-        update((MetadataUpdate.SetCurrentSchema) update);
-      } else if (update instanceof MetadataUpdate.AddPartitionSpec) {
-        update((MetadataUpdate.AddPartitionSpec) update);
-      } else if (update instanceof MetadataUpdate.SetDefaultPartitionSpec) {
-        update((MetadataUpdate.SetDefaultPartitionSpec) update);
-      } else if (update instanceof MetadataUpdate.SetDefaultSortOrder) {
-        update((MetadataUpdate.SetDefaultSortOrder) update);
-      } else if (update instanceof MetadataUpdate.RemovePartitionSpecs) {
-        update((MetadataUpdate.RemovePartitionSpecs) update);
-      } else if (update instanceof MetadataUpdate.RemoveSchemas) {
-        update((MetadataUpdate.RemoveSchemas) update);
+      if (update instanceof MetadataUpdate.SetSnapshotRef setSnapshotRef) {
+        update(setSnapshotRef);
+      } else if (update instanceof MetadataUpdate.AddSchema addSchema) {
+        update(addSchema);
+      } else if (update instanceof MetadataUpdate.SetCurrentSchema setCurrentSchema) {
+        update(setCurrentSchema);
+      } else if (update instanceof MetadataUpdate.AddPartitionSpec addPartitionSpec) {
+        update(addPartitionSpec);
+      } else if (update instanceof MetadataUpdate.SetDefaultPartitionSpec setDefaultPartitionSpec) {
+        update(setDefaultPartitionSpec);
+      } else if (update instanceof MetadataUpdate.SetDefaultSortOrder setDefaultSortOrder) {
+        update(setDefaultSortOrder);
+      } else if (update instanceof MetadataUpdate.RemovePartitionSpecs removePartitionSpecs) {
+        update(removePartitionSpecs);
+      } else if (update instanceof MetadataUpdate.RemoveSchemas removeSchemas) {
+        update(removeSchemas);
       }
 
       return this;

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -75,32 +75,43 @@ class V1Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return path();
-        case 1:
+        }
+        case 1 -> {
           return length();
-        case 2:
+        }
+        case 2 -> {
           return partitionSpecId();
-        case 3:
+        }
+        case 3 -> {
           return snapshotId();
-        case 4:
+        }
+        case 4 -> {
           return addedFilesCount();
-        case 5:
+        }
+        case 5 -> {
           return existingFilesCount();
-        case 6:
+        }
+        case 6 -> {
           return deletedFilesCount();
-        case 7:
+        }
+        case 7 -> {
           return partitions();
-        case 8:
+        }
+        case 8 -> {
           return addedRowsCount();
-        case 9:
+        }
+        case 9 -> {
           return existingRowsCount();
-        case 10:
+        }
+        case 10 -> {
           return deletedRowsCount();
-        case 11:
+        }
+        case 11 -> {
           return keyMetadata();
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -267,18 +278,20 @@ class V1Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.status().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.snapshotId();
-        case 2:
+        }
+        case 2 -> {
           DataFile file = wrapped.file();
           if (file != null) {
             return fileWrapper.wrap(file);
           }
           return null;
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -365,38 +378,53 @@ class V1Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.location();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.format() != null ? wrapped.format().toString() : null;
-        case 2:
+        }
+        case 2 -> {
           return wrapped.partition();
-        case 3:
+        }
+        case 3 -> {
           return wrapped.recordCount();
-        case 4:
+        }
+        case 4 -> {
           return wrapped.fileSizeInBytes();
-        case 5:
+        }
+        case 5 -> {
           return DEFAULT_BLOCK_SIZE;
-        case 6:
+        }
+        case 6 -> {
           return wrapped.columnSizes();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.valueCounts();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.nullValueCounts();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.nanValueCounts();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.lowerBounds();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.upperBounds();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.keyMetadata();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.splitOffsets();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.sortOrderId();
+        }
+        default -> throw new IllegalArgumentException("Unknown field ordinal: " + pos);
       }
-      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -86,15 +86,19 @@ class V2Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.path();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.length();
-        case 2:
+        }
+        case 2 -> {
           return wrapped.partitionSpecId();
-        case 3:
+        }
+        case 3 -> {
           return wrapped.content().id();
-        case 4:
+        }
+        case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // if the sequence number is being assigned here, then the manifest must be created by
             // the current
@@ -107,7 +111,8 @@ class V2Metadata {
           } else {
             return wrapped.sequenceNumber();
           }
-        case 5:
+        }
+        case 5 -> {
           if (wrapped.minSequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // same sanity check as above
             Preconditions.checkState(
@@ -122,26 +127,35 @@ class V2Metadata {
           } else {
             return wrapped.minSequenceNumber();
           }
-        case 6:
+        }
+        case 6 -> {
           return wrapped.snapshotId();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.addedFilesCount();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.existingFilesCount();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.deletedFilesCount();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.addedRowsCount();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.existingRowsCount();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.deletedRowsCount();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.partitions();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.keyMetadata();
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -312,11 +326,13 @@ class V2Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.status().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.snapshotId();
-        case 2:
+        }
+        case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
             // then it will inherit the sequence number of the current commit.
@@ -335,12 +351,14 @@ class V2Metadata {
             return null;
           }
           return wrapped.dataSequenceNumber();
-        case 3:
+        }
+        case 3 -> {
           return wrapped.fileSequenceNumber();
-        case 4:
+        }
+        case 4 -> {
           return fileWrapper.wrap(wrapped.file());
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -427,46 +445,63 @@ class V2Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.content().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.location();
-        case 2:
+        }
+        case 2 -> {
           return wrapped.format() != null ? wrapped.format().toString() : null;
-        case 3:
+        }
+        case 3 -> {
           return wrapped.partition();
-        case 4:
+        }
+        case 4 -> {
           return wrapped.recordCount();
-        case 5:
+        }
+        case 5 -> {
           return wrapped.fileSizeInBytes();
-        case 6:
+        }
+        case 6 -> {
           return wrapped.columnSizes();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.valueCounts();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.nullValueCounts();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.nanValueCounts();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.lowerBounds();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.upperBounds();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.keyMetadata();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.splitOffsets();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.equalityFieldIds();
-        case 15:
+        }
+        case 15 -> {
           return wrapped.sortOrderId();
-        case 16:
-          if (wrapped instanceof DeleteFile) {
-            return ((DeleteFile) wrapped).referencedDataFile();
+        }
+        case 16 -> {
+          if (wrapped instanceof DeleteFile deleteFile) {
+            return deleteFile.referencedDataFile();
           } else {
             return null;
           }
+        }
+        default -> throw new IllegalArgumentException("Unknown field ordinal: " + pos);
       }
-      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V3Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V3Metadata.java
@@ -86,16 +86,12 @@ class V3Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0:
-          return wrapped.path();
-        case 1:
-          return wrapped.length();
-        case 2:
-          return wrapped.partitionSpecId();
-        case 3:
-          return wrapped.content().id();
-        case 4:
+      return switch (pos) {
+        case 0 -> wrapped.path();
+        case 1 -> wrapped.length();
+        case 2 -> wrapped.partitionSpecId();
+        case 3 -> wrapped.content().id();
+        case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // if the sequence number is being assigned here, then the manifest must be created by
             // the current
@@ -104,11 +100,12 @@ class V3Metadata {
                 commitSnapshotId == wrapped.snapshotId(),
                 "Found unassigned sequence number for a manifest from snapshot: %s",
                 wrapped.snapshotId());
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.sequenceNumber();
+            yield wrapped.sequenceNumber();
           }
-        case 5:
+        }
+        case 5 -> {
           if (wrapped.minSequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // same sanity check as above
             Preconditions.checkState(
@@ -119,47 +116,39 @@ class V3Metadata {
             // number for any file
             // written to the wrapped manifest. replace the unassigned sequence number with the one
             // for this commit
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.minSequenceNumber();
+            yield wrapped.minSequenceNumber();
           }
-        case 6:
-          return wrapped.snapshotId();
-        case 7:
-          return wrapped.addedFilesCount();
-        case 8:
-          return wrapped.existingFilesCount();
-        case 9:
-          return wrapped.deletedFilesCount();
-        case 10:
-          return wrapped.addedRowsCount();
-        case 11:
-          return wrapped.existingRowsCount();
-        case 12:
-          return wrapped.deletedRowsCount();
-        case 13:
-          return wrapped.partitions();
-        case 14:
-          return wrapped.keyMetadata();
-        case 15:
+        }
+        case 6 -> wrapped.snapshotId();
+        case 7 -> wrapped.addedFilesCount();
+        case 8 -> wrapped.existingFilesCount();
+        case 9 -> wrapped.deletedFilesCount();
+        case 10 -> wrapped.addedRowsCount();
+        case 11 -> wrapped.existingRowsCount();
+        case 12 -> wrapped.deletedRowsCount();
+        case 13 -> wrapped.partitions();
+        case 14 -> wrapped.keyMetadata();
+        case 15 -> {
           if (wrappedFirstRowId != null) {
             // if first-row-id is assigned, ensure that it is valid
             Preconditions.checkState(
                 wrapped.content() == ManifestContent.DATA && wrapped.firstRowId() == null,
                 "Found invalid first-row-id assignment: %s",
                 wrapped);
-            return wrappedFirstRowId;
+            yield wrappedFirstRowId;
           } else if (wrapped.content() != ManifestContent.DATA) {
-            return null;
+            yield null;
           } else {
             Preconditions.checkState(
                 wrapped.firstRowId() != null,
                 "Found unassigned first-row-id for file: " + wrapped.path());
-            return wrapped.firstRowId();
+            yield wrapped.firstRowId();
           }
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override
@@ -336,12 +325,10 @@ class V3Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0:
-          return wrapped.status().id();
-        case 1:
-          return wrapped.snapshotId();
-        case 2:
+      return switch (pos) {
+        case 0 -> wrapped.status().id();
+        case 1 -> wrapped.snapshotId();
+        case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
             // then it will inherit the sequence number of the current commit.
@@ -357,16 +344,15 @@ class V3Metadata {
                 wrapped.status() == Status.ADDED,
                 "Only entries with status ADDED can have null sequence number");
 
-            return null;
+            yield null;
           }
-          return wrapped.dataSequenceNumber();
-        case 3:
-          return wrapped.fileSequenceNumber();
-        case 4:
-          return fileWrapper.wrap(wrapped.file());
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+
+          yield wrapped.dataSequenceNumber();
+        }
+        case 3 -> wrapped.fileSequenceNumber();
+        case 4 -> fileWrapper.wrap(wrapped.file());
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override
@@ -452,65 +438,53 @@ class V3Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0:
-          return wrapped.content().id();
-        case 1:
-          return wrapped.location();
-        case 2:
-          return wrapped.format() != null ? wrapped.format().toString() : null;
-        case 3:
-          return wrapped.partition();
-        case 4:
-          return wrapped.recordCount();
-        case 5:
-          return wrapped.fileSizeInBytes();
-        case 6:
-          return wrapped.columnSizes();
-        case 7:
-          return wrapped.valueCounts();
-        case 8:
-          return wrapped.nullValueCounts();
-        case 9:
-          return wrapped.nanValueCounts();
-        case 10:
-          return wrapped.lowerBounds();
-        case 11:
-          return wrapped.upperBounds();
-        case 12:
-          return wrapped.keyMetadata();
-        case 13:
-          return wrapped.splitOffsets();
-        case 14:
-          return wrapped.equalityFieldIds();
-        case 15:
-          return wrapped.sortOrderId();
-        case 16:
+      return switch (pos) {
+        case 0 -> wrapped.content().id();
+        case 1 -> wrapped.location();
+        case 2 -> wrapped.format() != null ? wrapped.format().toString() : null;
+        case 3 -> wrapped.partition();
+        case 4 -> wrapped.recordCount();
+        case 5 -> wrapped.fileSizeInBytes();
+        case 6 -> wrapped.columnSizes();
+        case 7 -> wrapped.valueCounts();
+        case 8 -> wrapped.nullValueCounts();
+        case 9 -> wrapped.nanValueCounts();
+        case 10 -> wrapped.lowerBounds();
+        case 11 -> wrapped.upperBounds();
+        case 12 -> wrapped.keyMetadata();
+        case 13 -> wrapped.splitOffsets();
+        case 14 -> wrapped.equalityFieldIds();
+        case 15 -> wrapped.sortOrderId();
+        case 16 -> {
           if (wrapped.content() == FileContent.DATA) {
-            return wrapped.firstRowId();
+            yield wrapped.firstRowId();
           } else {
-            return null;
+            yield null;
           }
-        case 17:
+        }
+        case 17 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).referencedDataFile();
+            yield ((DeleteFile) wrapped).referencedDataFile();
           } else {
-            return null;
+            yield null;
           }
-        case 18:
+        }
+        case 18 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentOffset();
+            yield ((DeleteFile) wrapped).contentOffset();
           } else {
-            return null;
+            yield null;
           }
-        case 19:
+        }
+        case 19 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentSizeInBytes();
+            yield ((DeleteFile) wrapped).contentSizeInBytes();
           } else {
-            return null;
+            yield null;
           }
-      }
-      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V4Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V4Metadata.java
@@ -86,16 +86,12 @@ class V4Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0:
-          return wrapped.path();
-        case 1:
-          return wrapped.length();
-        case 2:
-          return wrapped.partitionSpecId();
-        case 3:
-          return wrapped.content().id();
-        case 4:
+      return switch (pos) {
+        case 0 -> wrapped.path();
+        case 1 -> wrapped.length();
+        case 2 -> wrapped.partitionSpecId();
+        case 3 -> wrapped.content().id();
+        case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // if the sequence number is being assigned here, then the manifest must be created by
             // the current
@@ -104,11 +100,12 @@ class V4Metadata {
                 commitSnapshotId == wrapped.snapshotId(),
                 "Found unassigned sequence number for a manifest from snapshot: %s",
                 wrapped.snapshotId());
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.sequenceNumber();
+            yield wrapped.sequenceNumber();
           }
-        case 5:
+        }
+        case 5 -> {
           if (wrapped.minSequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // same sanity check as above
             Preconditions.checkState(
@@ -119,47 +116,39 @@ class V4Metadata {
             // number for any file
             // written to the wrapped manifest. replace the unassigned sequence number with the one
             // for this commit
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.minSequenceNumber();
+            yield wrapped.minSequenceNumber();
           }
-        case 6:
-          return wrapped.snapshotId();
-        case 7:
-          return wrapped.addedFilesCount();
-        case 8:
-          return wrapped.existingFilesCount();
-        case 9:
-          return wrapped.deletedFilesCount();
-        case 10:
-          return wrapped.addedRowsCount();
-        case 11:
-          return wrapped.existingRowsCount();
-        case 12:
-          return wrapped.deletedRowsCount();
-        case 13:
-          return wrapped.partitions();
-        case 14:
-          return wrapped.keyMetadata();
-        case 15:
+        }
+        case 6 -> wrapped.snapshotId();
+        case 7 -> wrapped.addedFilesCount();
+        case 8 -> wrapped.existingFilesCount();
+        case 9 -> wrapped.deletedFilesCount();
+        case 10 -> wrapped.addedRowsCount();
+        case 11 -> wrapped.existingRowsCount();
+        case 12 -> wrapped.deletedRowsCount();
+        case 13 -> wrapped.partitions();
+        case 14 -> wrapped.keyMetadata();
+        case 15 -> {
           if (wrappedFirstRowId != null) {
             // if first-row-id is assigned, ensure that it is valid
             Preconditions.checkState(
                 wrapped.content() == ManifestContent.DATA && wrapped.firstRowId() == null,
                 "Found invalid first-row-id assignment: %s",
                 wrapped);
-            return wrappedFirstRowId;
+            yield wrappedFirstRowId;
           } else if (wrapped.content() != ManifestContent.DATA) {
-            return null;
+            yield null;
           } else {
             Preconditions.checkState(
                 wrapped.firstRowId() != null,
                 "Found unassigned first-row-id for file: " + wrapped.path());
-            return wrapped.firstRowId();
+            yield wrapped.firstRowId();
           }
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override
@@ -336,12 +325,10 @@ class V4Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0:
-          return wrapped.status().id();
-        case 1:
-          return wrapped.snapshotId();
-        case 2:
+      return switch (pos) {
+        case 0 -> wrapped.status().id();
+        case 1 -> wrapped.snapshotId();
+        case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
             // then it will inherit the sequence number of the current commit.
@@ -357,16 +344,15 @@ class V4Metadata {
                 wrapped.status() == Status.ADDED,
                 "Only entries with status ADDED can have null sequence number");
 
-            return null;
+            yield null;
           }
-          return wrapped.dataSequenceNumber();
-        case 3:
-          return wrapped.fileSequenceNumber();
-        case 4:
-          return fileWrapper.wrap(wrapped.file());
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+
+          yield wrapped.dataSequenceNumber();
+        }
+        case 3 -> wrapped.fileSequenceNumber();
+        case 4 -> fileWrapper.wrap(wrapped.file());
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override
@@ -452,65 +438,53 @@ class V4Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0:
-          return wrapped.content().id();
-        case 1:
-          return wrapped.location();
-        case 2:
-          return wrapped.format() != null ? wrapped.format().toString() : null;
-        case 3:
-          return wrapped.partition();
-        case 4:
-          return wrapped.recordCount();
-        case 5:
-          return wrapped.fileSizeInBytes();
-        case 6:
-          return wrapped.columnSizes();
-        case 7:
-          return wrapped.valueCounts();
-        case 8:
-          return wrapped.nullValueCounts();
-        case 9:
-          return wrapped.nanValueCounts();
-        case 10:
-          return wrapped.lowerBounds();
-        case 11:
-          return wrapped.upperBounds();
-        case 12:
-          return wrapped.keyMetadata();
-        case 13:
-          return wrapped.splitOffsets();
-        case 14:
-          return wrapped.equalityFieldIds();
-        case 15:
-          return wrapped.sortOrderId();
-        case 16:
+      return switch (pos) {
+        case 0 -> wrapped.content().id();
+        case 1 -> wrapped.location();
+        case 2 -> wrapped.format() != null ? wrapped.format().toString() : null;
+        case 3 -> wrapped.partition();
+        case 4 -> wrapped.recordCount();
+        case 5 -> wrapped.fileSizeInBytes();
+        case 6 -> wrapped.columnSizes();
+        case 7 -> wrapped.valueCounts();
+        case 8 -> wrapped.nullValueCounts();
+        case 9 -> wrapped.nanValueCounts();
+        case 10 -> wrapped.lowerBounds();
+        case 11 -> wrapped.upperBounds();
+        case 12 -> wrapped.keyMetadata();
+        case 13 -> wrapped.splitOffsets();
+        case 14 -> wrapped.equalityFieldIds();
+        case 15 -> wrapped.sortOrderId();
+        case 16 -> {
           if (wrapped.content() == FileContent.DATA) {
-            return wrapped.firstRowId();
+            yield wrapped.firstRowId();
           } else {
-            return null;
+            yield null;
           }
-        case 17:
+        }
+        case 17 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).referencedDataFile();
+            yield ((DeleteFile) wrapped).referencedDataFile();
           } else {
-            return null;
+            yield null;
           }
-        case 18:
+        }
+        case 18 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentOffset();
+            yield ((DeleteFile) wrapped).contentOffset();
           } else {
-            return null;
+            yield null;
           }
-        case 19:
+        }
+        case 19 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentSizeInBytes();
+            yield ((DeleteFile) wrapped).contentSizeInBytes();
           } else {
-            return null;
+            yield null;
           }
-      }
-      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -104,18 +104,14 @@ public class RewriteFileGroup extends RewriteGroupBase<FileGroupInfo, FileScanTa
   }
 
   public static Comparator<RewriteFileGroup> comparator(RewriteJobOrder rewriteJobOrder) {
-    switch (rewriteJobOrder) {
-      case BYTES_ASC:
-        return Comparator.comparing(RewriteFileGroup::inputFilesSizeInBytes);
-      case BYTES_DESC:
-        return Comparator.comparing(
-            RewriteFileGroup::inputFilesSizeInBytes, Comparator.reverseOrder());
-      case FILES_ASC:
-        return Comparator.comparing(RewriteFileGroup::inputFileNum);
-      case FILES_DESC:
-        return Comparator.comparing(RewriteFileGroup::inputFileNum, Comparator.reverseOrder());
-      default:
-        return (unused, unused2) -> 0;
-    }
+    return switch (rewriteJobOrder) {
+      case BYTES_ASC -> Comparator.comparing(RewriteFileGroup::inputFilesSizeInBytes);
+      case BYTES_DESC ->
+          Comparator.comparing(RewriteFileGroup::inputFilesSizeInBytes, Comparator.reverseOrder());
+      case FILES_ASC -> Comparator.comparing(RewriteFileGroup::inputFileNum);
+      case FILES_DESC ->
+          Comparator.comparing(RewriteFileGroup::inputFileNum, Comparator.reverseOrder());
+      default -> (unused, unused2) -> 0;
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesGroup.java
@@ -108,19 +108,16 @@ public class RewritePositionDeletesGroup
   }
 
   public static Comparator<RewritePositionDeletesGroup> comparator(RewriteJobOrder order) {
-    switch (order) {
-      case BYTES_ASC:
-        return Comparator.comparing(RewritePositionDeletesGroup::inputFilesSizeInBytes);
-      case BYTES_DESC:
-        return Comparator.comparing(
-            RewritePositionDeletesGroup::inputFilesSizeInBytes, Comparator.reverseOrder());
-      case FILES_ASC:
-        return Comparator.comparing(RewritePositionDeletesGroup::inputFileNum);
-      case FILES_DESC:
-        return Comparator.comparing(
-            RewritePositionDeletesGroup::inputFileNum, Comparator.reverseOrder());
-      default:
-        return (unused, unused2) -> 0;
-    }
+    return switch (order) {
+      case BYTES_ASC -> Comparator.comparing(RewritePositionDeletesGroup::inputFilesSizeInBytes);
+      case BYTES_DESC ->
+          Comparator.comparing(
+              RewritePositionDeletesGroup::inputFilesSizeInBytes, Comparator.reverseOrder());
+      case FILES_ASC -> Comparator.comparing(RewritePositionDeletesGroup::inputFileNum);
+      case FILES_DESC ->
+          Comparator.comparing(
+              RewritePositionDeletesGroup::inputFileNum, Comparator.reverseOrder());
+      default -> (unused, unused2) -> 0;
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -93,8 +93,8 @@ public class Avro {
   }
 
   public static WriteBuilder write(OutputFile file) {
-    if (file instanceof EncryptedOutputFile) {
-      return write((EncryptedOutputFile) file);
+    if (file instanceof EncryptedOutputFile encryptedOutputFile) {
+      return write(encryptedOutputFile);
     }
 
     return new WriteBuilder(file);
@@ -249,24 +249,19 @@ public class Avro {
         CodecFactory codecFactory;
         try {
           switch (Codec.valueOf(codecAsString.toUpperCase(Locale.ENGLISH))) {
-            case UNCOMPRESSED:
-              codecFactory = CodecFactory.nullCodec();
-              break;
-            case SNAPPY:
-              codecFactory = CodecFactory.snappyCodec();
-              break;
-            case ZSTD:
-              codecFactory =
-                  CodecFactory.zstandardCodec(
-                      compressionLevelAsInt(compressionLevel, ZSTD_COMPRESSION_LEVEL_DEFAULT));
-              break;
-            case GZIP:
-              codecFactory =
-                  CodecFactory.deflateCodec(
-                      compressionLevelAsInt(compressionLevel, GZIP_COMPRESSION_LEVEL_DEFAULT));
-              break;
-            default:
-              throw new IllegalArgumentException("Unsupported compression codec: " + codecAsString);
+            case UNCOMPRESSED -> codecFactory = CodecFactory.nullCodec();
+            case SNAPPY -> codecFactory = CodecFactory.snappyCodec();
+            case ZSTD ->
+                codecFactory =
+                    CodecFactory.zstandardCodec(
+                        compressionLevelAsInt(compressionLevel, ZSTD_COMPRESSION_LEVEL_DEFAULT));
+            case GZIP ->
+                codecFactory =
+                    CodecFactory.deflateCodec(
+                        compressionLevelAsInt(compressionLevel, GZIP_COMPRESSION_LEVEL_DEFAULT));
+            default ->
+                throw new IllegalArgumentException(
+                    "Unsupported compression codec: " + codecAsString);
           }
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException("Unsupported compression codec: " + codecAsString);
@@ -764,13 +759,13 @@ public class Avro {
         reader = (DatumReader<D>) defaultCreateReaderFunc.apply(schema);
       }
 
-      if (reader instanceof SupportsCustomRecords) {
-        ((SupportsCustomRecords) reader).setClassLoader(loader);
-        ((SupportsCustomRecords) reader).setRenames(renames);
+      if (reader instanceof SupportsCustomRecords supportsCustomRecords) {
+        supportsCustomRecords.setClassLoader(loader);
+        supportsCustomRecords.setRenames(renames);
       }
 
-      if (reader instanceof SupportsCustomTypes) {
-        ((SupportsCustomTypes) reader).setCustomTypes(rootType, typeMap);
+      if (reader instanceof SupportsCustomTypes supportsCustomTypes) {
+        supportsCustomTypes.setCustomTypes(rootType, typeMap);
       }
 
       return new AvroIterable<>(

--- a/core/src/main/java/org/apache/iceberg/avro/AvroCustomOrderSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroCustomOrderSchemaVisitor.java
@@ -32,7 +32,7 @@ abstract class AvroCustomOrderSchemaVisitor<T, F> {
 
   public static <T, F> T visit(Schema schema, AvroCustomOrderSchemaVisitor<T, F> visitor) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         // check to make sure this hasn't been visited before
         String name = schema.getFullName();
         Preconditions.checkState(
@@ -60,23 +60,29 @@ abstract class AvroCustomOrderSchemaVisitor<T, F> {
           visitor.recordLevels.pop();
           return visitor.record(schema, names, Iterables.transform(results, Supplier::get));
         }
+      }
 
-      case UNION:
+      case UNION -> {
         List<Schema> types = schema.getTypes();
         List<Supplier<T>> options = Lists.newArrayListWithExpectedSize(types.size());
         for (Schema type : types) {
           options.add(new VisitFuture<>(type, visitor));
         }
+
         return visitor.union(schema, Iterables.transform(options, Supplier::get));
+      }
 
-      case ARRAY:
+      case ARRAY -> {
         return visitor.array(schema, new VisitFuture<>(schema.getElementType(), visitor));
+      }
 
-      case MAP:
+      case MAP -> {
         return visitor.map(schema, new VisitFuture<>(schema.getValueType(), visitor));
+      }
 
-      default:
+      default -> {
         return visitor.primitive(schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFormatModel.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFormatModel.java
@@ -159,17 +159,19 @@ public class AvroFormatModel<D, S>
     @Override
     public FileAppender<D> build() throws IOException {
       switch (content) {
-        case DATA:
+        case DATA -> {
           internal.createContextFunc(Avro.WriteBuilder.Context::dataContext);
           internal.createWriterFunc(
               avroSchema -> writerFunction.write(schema, avroSchema, engineSchema));
-          break;
-        case EQUALITY_DELETES:
+        }
+
+        case EQUALITY_DELETES -> {
           internal.createContextFunc(Avro.WriteBuilder.Context::deleteContext);
           internal.createWriterFunc(
               avroSchema -> writerFunction.write(schema, avroSchema, engineSchema));
-          break;
-        case POSITION_DELETES:
+        }
+
+        case POSITION_DELETES -> {
           Preconditions.checkState(
               schema == null,
               "Invalid schema: %s. Position deletes with schema are not supported by the API.",
@@ -182,9 +184,9 @@ public class AvroFormatModel<D, S>
           internal.createContextFunc(Avro.WriteBuilder.Context::deleteContext);
           internal.createWriterFunc(unused -> new Avro.PositionDatumWriter());
           internal.schema(DeleteSchemaUtil.pathPosSchema());
-          break;
-        default:
-          throw new IllegalArgumentException("Unknown file content: " + content);
+        }
+
+        default -> throw new IllegalArgumentException("Unknown file content: " + content);
       }
 
       return internal.build();

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIO.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIO.java
@@ -57,8 +57,8 @@ class AvroIO {
           : null;
 
   static SeekableInput stream(SeekableInputStream stream, long length) {
-    if (stream instanceof DelegatingInputStream) {
-      InputStream wrapped = ((DelegatingInputStream) stream).getDelegate();
+    if (stream instanceof DelegatingInputStream delegatingInputStream) {
+      InputStream wrapped = delegatingInputStream.getDelegate();
       if (AVRO_FS_INPUT_CTOR != null
           && FS_DATA_INPUT_STREAM_CLASS != null
           && FS_DATA_INPUT_STREAM_CLASS.isInstance(wrapped)) {

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -78,14 +78,13 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
     FileReader<D> fileReader = initMetadata(newFileReader());
 
     if (start != null) {
-      if (reader instanceof SupportsRowPosition) {
-        ((SupportsRowPosition) reader)
-            .setRowPositionSupplier(
-                Suppliers.memoize(() -> AvroIO.findStartingRowPos(file::newStream, start)));
+      if (reader instanceof SupportsRowPosition supportsRowPosition) {
+        supportsRowPosition.setRowPositionSupplier(
+            Suppliers.memoize(() -> AvroIO.findStartingRowPos(file::newStream, start)));
       }
       fileReader = new AvroRangeIterator<>(fileReader, start, end);
-    } else if (reader instanceof SupportsRowPosition) {
-      ((SupportsRowPosition) reader).setRowPositionSupplier(() -> 0L);
+    } else if (reader instanceof SupportsRowPosition supportsRowPosition) {
+      supportsRowPosition.setRowPositionSupplier(() -> 0L);
     }
 
     addCloseable(fileReader);

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -163,10 +163,10 @@ public class AvroSchemaUtil {
         // not all avro timestamp logical types will have the adjust_to_utc prop, default to
         // timestamp without timezone
         return false;
-      } else if (value instanceof Boolean) {
-        return (Boolean) value;
-      } else if (value instanceof String) {
-        return Boolean.parseBoolean((String) value);
+      } else if (value instanceof Boolean boolValue) {
+        return boolValue;
+      } else if (value instanceof String stringValue) {
+        return Boolean.parseBoolean(stringValue);
       }
     }
 
@@ -190,14 +190,19 @@ public class AvroSchemaUtil {
 
   static Schema toOption(Schema schema) {
     switch (schema.getType()) {
-      case UNION:
+      case UNION -> {
         Preconditions.checkArgument(
             isOptionSchema(schema), "Union schemas are not supported: %s", schema);
         return schema;
-      case NULL:
+      }
+
+      case NULL -> {
         return schema;
-      default:
+      }
+
+      default -> {
         return Schema.createUnion(NULL, schema);
+      }
     }
   }
 
@@ -433,10 +438,10 @@ public class AvroSchemaUtil {
   }
 
   private static int toInt(Object value) {
-    if (value instanceof Number) {
-      return ((Number) value).intValue();
-    } else if (value instanceof String) {
-      return Integer.parseInt((String) value);
+    if (value instanceof Number number) {
+      return number.intValue();
+    } else if (value instanceof String stringValue) {
+      return Integer.parseInt(stringValue);
     }
 
     throw new UnsupportedOperationException("Cannot coerce value to int: " + value);

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
@@ -30,7 +30,7 @@ public abstract class AvroSchemaVisitor<T> {
 
   public static <T> T visit(Schema schema, AvroSchemaVisitor<T> visitor) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         // check to make sure this hasn't been visited before
         String name = schema.getFullName();
         Preconditions.checkState(
@@ -59,27 +59,33 @@ public abstract class AvroSchemaVisitor<T> {
           visitor.recordLevels.pop();
           return visitor.record(schema, names, results);
         }
+      }
 
-      case UNION:
+      case UNION -> {
         List<Schema> types = schema.getTypes();
         List<T> options = Lists.newArrayListWithExpectedSize(types.size());
         for (Schema type : types) {
           options.add(visit(type, visitor));
         }
-        return visitor.union(schema, options);
 
-      case ARRAY:
+        return visitor.union(schema, options);
+      }
+
+      case ARRAY -> {
         if (schema.getLogicalType() instanceof LogicalMap) {
           return visitor.array(schema, visit(schema.getElementType(), visitor));
         } else {
           return visitor.array(schema, visitWithName("element", schema.getElementType(), visitor));
         }
+      }
 
-      case MAP:
+      case MAP -> {
         return visitor.map(schema, visitWithName("value", schema.getValueType(), visitor));
+      }
 
-      default:
+      default -> {
         return visitor.primitive(schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -34,24 +34,29 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
 
   public static <T> T visit(Type iType, Schema schema, AvroSchemaWithTypeVisitor<T> visitor) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         return visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
+      }
 
-      case UNION:
+      case UNION -> {
         return visitUnion(iType, schema, visitor);
+      }
 
-      case ARRAY:
+      case ARRAY -> {
         return visitArray(iType, schema, visitor);
+      }
 
-      case MAP:
+      case MAP -> {
         Types.MapType map = iType != null ? iType.asMapType() : null;
         return visitor.map(
             map,
             schema,
             visit(map != null ? map.valueType() : null, schema.getValueType(), visitor));
+      }
 
-      default:
+      default -> {
         return visitor.primitive(iType != null ? iType.asPrimitiveType() : null, schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerByStructureVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerByStructureVisitor.java
@@ -38,29 +38,34 @@ public abstract class AvroWithPartnerByStructureVisitor<P, T> {
   public static <P, T> T visit(
       P partner, Schema schema, AvroWithPartnerByStructureVisitor<P, T> visitor) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         if (schema.getLogicalType() instanceof VariantLogicalType
             || visitor.isVariantType(partner)) {
           return visitVariant(partner, schema, visitor);
         } else {
           return visitRecord(partner, schema, visitor);
         }
+      }
 
-      case UNION:
+      case UNION -> {
         return visitUnion(partner, schema, visitor);
+      }
 
-      case ARRAY:
+      case ARRAY -> {
         return visitArray(partner, schema, visitor);
+      }
 
-      case MAP:
+      case MAP -> {
         P keyType = visitor.mapKeyType(partner);
         Preconditions.checkArgument(
             visitor.isStringType(keyType), "Invalid map: %s is not a string", keyType);
         return visitor.map(
             partner, schema, visit(visitor.mapValueType(partner), schema.getValueType(), visitor));
+      }
 
-      default:
+      default -> {
         return visitor.primitive(partner, schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerVisitor.java
@@ -103,20 +103,23 @@ public class AvroWithPartnerVisitor<P, R> {
       AvroWithPartnerVisitor<P, R> visitor,
       PartnerAccessors<P> accessors) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         if (schema.getLogicalType() instanceof VariantLogicalType) {
           return visitVariant(partner, schema, visitor, accessors);
         } else {
           return visitRecord(partner, schema, visitor, accessors);
         }
+      }
 
-      case UNION:
+      case UNION -> {
         return visitUnion(partner, schema, visitor, accessors);
+      }
 
-      case ARRAY:
+      case ARRAY -> {
         return visitArray(partner, schema, visitor, accessors);
+      }
 
-      case MAP:
+      case MAP -> {
         return visitor.map(
             partner,
             schema,
@@ -125,9 +128,11 @@ public class AvroWithPartnerVisitor<P, R> {
                 schema.getValueType(),
                 visitor,
                 accessors));
+      }
 
-      default:
+      default -> {
         return visitor.primitive(partner, schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
@@ -75,51 +75,73 @@ abstract class BaseWriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {
     LogicalType logicalType = primitive.getLogicalType();
     if (logicalType != null) {
       switch (logicalType.getName()) {
-        case "date":
+        case "date" -> {
           return ValueWriters.ints();
+        }
 
-        case "time-micros":
+        case "time-micros" -> {
           return ValueWriters.longs();
+        }
 
-        case "timestamp-micros":
+        case "timestamp-micros" -> {
           return ValueWriters.longs();
+        }
 
-        case "timestamp-nanos":
+        case "timestamp-nanos" -> {
           return ValueWriters.longs();
+        }
 
-        case "decimal":
+        case "decimal" -> {
           LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
           return ValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
+        }
 
-        case "uuid":
+        case "uuid" -> {
           return ValueWriters.uuids();
+        }
 
-        default:
-          throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
+        default -> throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
       }
     }
 
     switch (primitive.getType()) {
-      case NULL:
+      case NULL -> {
         return ValueWriters.nulls();
-      case BOOLEAN:
+      }
+
+      case BOOLEAN -> {
         return ValueWriters.booleans();
-      case INT:
+      }
+
+      case INT -> {
         return ValueWriters.ints();
-      case LONG:
+      }
+
+      case LONG -> {
         return ValueWriters.longs();
-      case FLOAT:
+      }
+
+      case FLOAT -> {
         return ValueWriters.floats();
-      case DOUBLE:
+      }
+
+      case DOUBLE -> {
         return ValueWriters.doubles();
-      case STRING:
+      }
+
+      case STRING -> {
         return ValueWriters.strings();
-      case FIXED:
+      }
+
+      case FIXED -> {
         return fixedWriter(primitive.getFixedSize());
-      case BYTES:
+      }
+
+      case BYTES -> {
         return ValueWriters.byteBuffers();
-      default:
-        throw new IllegalArgumentException("Unsupported type: " + primitive);
+      }
+
+      default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -274,20 +274,25 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
   public Schema primitive(Schema primitive) {
     // check for type promotion
     switch (primitive.getType()) {
-      case INT:
+      case INT -> {
         if (current.typeId() == Type.TypeID.LONG) {
           return Schema.create(Schema.Type.LONG);
         }
-        return primitive;
 
-      case FLOAT:
+        return primitive;
+      }
+
+      case FLOAT -> {
         if (current.typeId() == Type.TypeID.DOUBLE) {
           return Schema.create(Schema.Type.DOUBLE);
         }
-        return primitive;
 
-      default:
         return primitive;
+      }
+
+      default -> {
+        return primitive;
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -174,65 +174,90 @@ public class GenericAvroReader<T>
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
             // Spark uses the same representation
+          case "date" -> {
             return ValueReaders.ints();
+          }
 
-          case "time-micros":
+          case "time-micros" -> {
             return ValueReaders.longs();
+          }
 
-          case "timestamp-millis":
+          case "timestamp-millis" -> {
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
+          }
 
-          case "timestamp-micros":
-          case "timestamp-nanos":
             // both are handled in memory as long values, using the type to track units
+          case "timestamp-micros", "timestamp-nanos" -> {
             return ValueReaders.longs();
+          }
 
-          case "decimal":
+          case "decimal" -> {
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),
                 ((LogicalTypes.Decimal) logicalType).getScale());
+          }
 
-          case "uuid":
+          case "uuid" -> {
             return ValueReaders.uuids();
+          }
 
-          default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+          default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
         }
       }
 
       switch (primitive.getType()) {
-        case NULL:
+        case NULL -> {
           return ValueReaders.nulls();
-        case BOOLEAN:
+        }
+
+        case BOOLEAN -> {
           return ValueReaders.booleans();
-        case INT:
+        }
+
+        case INT -> {
           if (partner != null && partner.typeId() == Type.TypeID.LONG) {
             return ValueReaders.intsAsLongs();
           }
+
           return ValueReaders.ints();
-        case LONG:
+        }
+
+        case LONG -> {
           return ValueReaders.longs();
-        case FLOAT:
+        }
+
+        case FLOAT -> {
           if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
             return ValueReaders.floatsAsDoubles();
           }
+
           return ValueReaders.floats();
-        case DOUBLE:
+        }
+
+        case DOUBLE -> {
           return ValueReaders.doubles();
-        case STRING:
+        }
+
+        case STRING -> {
           return ValueReaders.utf8s();
-        case FIXED:
+        }
+
+        case FIXED -> {
           return ValueReaders.fixed(primitive);
-        case BYTES:
+        }
+
+        case BYTES -> {
           return ValueReaders.byteBuffers();
-        case ENUM:
+        }
+
+        case ENUM -> {
           return ValueReaders.enums(primitive.getEnumSymbols());
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
+        }
+
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -171,63 +171,85 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             return ValueReaders.ints();
+          }
 
-          case "time-micros":
+          case "time-micros" -> {
             return ValueReaders.longs();
+          }
 
-          case "timestamp-millis":
+          case "timestamp-millis" -> {
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
+          }
 
-          case "timestamp-micros":
-          case "timestamp-nanos":
             // both are handled in memory as long values, using the type to track units
+          case "timestamp-micros", "timestamp-nanos" -> {
             return ValueReaders.longs();
+          }
 
-          case "decimal":
+          case "decimal" -> {
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),
                 ((LogicalTypes.Decimal) logicalType).getScale());
+          }
 
-          case "uuid":
+          case "uuid" -> {
             return ValueReaders.uuids();
+          }
 
-          default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+          default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
         }
       }
 
       switch (primitive.getType()) {
-        case NULL:
+        case NULL -> {
           return ValueReaders.nulls();
-        case BOOLEAN:
+        }
+
+        case BOOLEAN -> {
           return ValueReaders.booleans();
-        case INT:
+        }
+
+        case INT -> {
           if (partner != null && partner.second().typeId() == Type.TypeID.LONG) {
             return ValueReaders.intsAsLongs();
           }
+
           return ValueReaders.ints();
-        case LONG:
+        }
+
+        case LONG -> {
           return ValueReaders.longs();
-        case FLOAT:
+        }
+
+        case FLOAT -> {
           if (partner != null && partner.second().typeId() == Type.TypeID.DOUBLE) {
             return ValueReaders.floatsAsDoubles();
           }
+
           return ValueReaders.floats();
-        case DOUBLE:
+        }
+
+        case DOUBLE -> {
           return ValueReaders.doubles();
-        case STRING:
+        }
+
+        case STRING -> {
           return ValueReaders.strings();
-        case FIXED:
-        case BYTES:
+        }
+
+        case FIXED, BYTES -> {
           return ValueReaders.byteBuffers();
-        case ENUM:
+        }
+
+        case ENUM -> {
           return ValueReaders.enums(primitive.getEnumSymbols());
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
+        }
+
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReaders.java
@@ -90,8 +90,8 @@ class InternalReaders {
 
     @Override
     protected GenericRecord reuseOrCreate(Object reuse) {
-      if (reuse instanceof GenericRecord) {
-        return (GenericRecord) reuse;
+      if (reuse instanceof GenericRecord genericRecord) {
+        return genericRecord;
       } else {
         return GenericRecord.create(structType);
       }

--- a/core/src/main/java/org/apache/iceberg/avro/NameMappingDatumReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/NameMappingDatumReader.java
@@ -59,8 +59,8 @@ public class NameMappingDatumReader<D> implements DatumReader<D>, SupportsRowPos
 
   @Override
   public void setRowPositionSupplier(Supplier<Long> posSupplier) {
-    if (wrapped instanceof SupportsRowPosition) {
-      ((SupportsRowPosition) wrapped).setRowPositionSupplier(posSupplier);
+    if (wrapped instanceof SupportsRowPosition supportsRowPosition) {
+      supportsRowPosition.setRowPositionSupplier(posSupplier);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -179,10 +179,8 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
 
   public Type logicalType(Schema primitive, LogicalType logical) {
     String name = logical.getName();
-    if (logical instanceof LogicalTypes.Decimal) {
-      return Types.DecimalType.of(
-          ((LogicalTypes.Decimal) logical).getPrecision(),
-          ((LogicalTypes.Decimal) logical).getScale());
+    if (logical instanceof LogicalTypes.Decimal decimal) {
+      return Types.DecimalType.of(decimal.getPrecision(), decimal.getScale());
 
     } else if (logical instanceof LogicalTypes.Date) {
       return Types.DateType.get();
@@ -225,25 +223,41 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
     }
 
     switch (primitive.getType()) {
-      case BOOLEAN:
+      case BOOLEAN -> {
         return Types.BooleanType.get();
-      case INT:
+      }
+
+      case INT -> {
         return Types.IntegerType.get();
-      case LONG:
+      }
+
+      case LONG -> {
         return Types.LongType.get();
-      case FLOAT:
+      }
+
+      case FLOAT -> {
         return Types.FloatType.get();
-      case DOUBLE:
+      }
+
+      case DOUBLE -> {
         return Types.DoubleType.get();
-      case STRING:
-      case ENUM:
+      }
+
+      case STRING, ENUM -> {
         return Types.StringType.get();
-      case FIXED:
+      }
+
+      case FIXED -> {
         return Types.FixedType.ofLength(primitive.getFixedSize());
-      case BYTES:
+      }
+
+      case BYTES -> {
         return Types.BinaryType.get();
-      case NULL:
+      }
+
+      case NULL -> {
         return Types.UnknownType.get();
+      }
     }
 
     throw new UnsupportedOperationException("Unsupported primitive type: " + primitive);

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -211,73 +211,54 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
 
   @Override
   public Schema primitive(Type.PrimitiveType primitive) {
-    Schema primitiveSchema;
-    switch (primitive.typeId()) {
-      case UNKNOWN:
-        primitiveSchema = NULL_SCHEMA;
-        break;
-      case BOOLEAN:
-        primitiveSchema = BOOLEAN_SCHEMA;
-        break;
-      case INTEGER:
-        primitiveSchema = INTEGER_SCHEMA;
-        break;
-      case LONG:
-        primitiveSchema = LONG_SCHEMA;
-        break;
-      case FLOAT:
-        primitiveSchema = FLOAT_SCHEMA;
-        break;
-      case DOUBLE:
-        primitiveSchema = DOUBLE_SCHEMA;
-        break;
-      case DATE:
-        primitiveSchema = DATE_SCHEMA;
-        break;
-      case TIME:
-        primitiveSchema = TIME_SCHEMA;
-        break;
-      case TIMESTAMP:
-        if (((Types.TimestampType) primitive).shouldAdjustToUTC()) {
-          primitiveSchema = TIMESTAMPTZ_SCHEMA;
-        } else {
-          primitiveSchema = TIMESTAMP_SCHEMA;
-        }
-        break;
-      case TIMESTAMP_NANO:
-        if (((Types.TimestampNanoType) primitive).shouldAdjustToUTC()) {
-          primitiveSchema = TIMESTAMPTZ_NANO_SCHEMA;
-        } else {
-          primitiveSchema = TIMESTAMP_NANO_SCHEMA;
-        }
-        break;
-      case STRING:
-        primitiveSchema = STRING_SCHEMA;
-        break;
-      case UUID:
-        primitiveSchema = UUID_SCHEMA;
-        break;
-      case FIXED:
-        Types.FixedType fixed = (Types.FixedType) primitive;
-        primitiveSchema = Schema.createFixed("fixed_" + fixed.length(), null, null, fixed.length());
-        break;
-      case BINARY:
-        primitiveSchema = BINARY_SCHEMA;
-        break;
-      case DECIMAL:
-        Types.DecimalType decimal = (Types.DecimalType) primitive;
-        primitiveSchema =
-            LogicalTypes.decimal(decimal.precision(), decimal.scale())
+    Schema primitiveSchema =
+        switch (primitive.typeId()) {
+          case UNKNOWN -> NULL_SCHEMA;
+          case BOOLEAN -> BOOLEAN_SCHEMA;
+          case INTEGER -> INTEGER_SCHEMA;
+          case LONG -> LONG_SCHEMA;
+          case FLOAT -> FLOAT_SCHEMA;
+          case DOUBLE -> DOUBLE_SCHEMA;
+          case DATE -> DATE_SCHEMA;
+          case TIME -> TIME_SCHEMA;
+          case TIMESTAMP -> {
+            if (((Types.TimestampType) primitive).shouldAdjustToUTC()) {
+              yield TIMESTAMPTZ_SCHEMA;
+            } else {
+              yield TIMESTAMP_SCHEMA;
+            }
+          }
+
+          case TIMESTAMP_NANO -> {
+            if (((Types.TimestampNanoType) primitive).shouldAdjustToUTC()) {
+              yield TIMESTAMPTZ_NANO_SCHEMA;
+            } else {
+              yield TIMESTAMP_NANO_SCHEMA;
+            }
+          }
+
+          case STRING -> STRING_SCHEMA;
+          case UUID -> UUID_SCHEMA;
+          case FIXED -> {
+            Types.FixedType fixed = (Types.FixedType) primitive;
+            yield Schema.createFixed("fixed_" + fixed.length(), null, null, fixed.length());
+          }
+
+          case BINARY -> BINARY_SCHEMA;
+          case DECIMAL -> {
+            Types.DecimalType decimal = (Types.DecimalType) primitive;
+            yield LogicalTypes.decimal(decimal.precision(), decimal.scale())
                 .addToSchema(
                     Schema.createFixed(
                         "decimal_" + decimal.precision() + "_" + decimal.scale(),
                         null,
                         null,
                         TypeUtil.decimalRequiredBytes(decimal.precision())));
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported type ID: " + primitive.typeId());
-    }
+          }
+
+          default ->
+              throw new UnsupportedOperationException("Unsupported type ID: " + primitive.typeId());
+        };
 
     cacheSchema(primitive, primitiveSchema);
 

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -134,13 +134,17 @@ public class ValueReaders {
 
   public static ValueReader<byte[]> decimalBytesReader(Schema schema) {
     switch (schema.getType()) {
-      case FIXED:
+      case FIXED -> {
         return ValueReaders.fixed(schema.getFixedSize());
-      case BYTES:
+      }
+
+      case BYTES -> {
         return ValueReaders.bytes();
-      default:
-        throw new IllegalArgumentException(
-            "Invalid primitive type for decimal: " + schema.getType());
+      }
+
+      default ->
+          throw new IllegalArgumentException(
+              "Invalid primitive type for decimal: " + schema.getType());
     }
   }
 
@@ -548,8 +552,8 @@ public class ValueReaders {
     @Override
     public Utf8 read(Decoder decoder, Object reuse) throws IOException {
       // use the decoder's readString(Utf8) method because it may be a resolving decoder
-      if (reuse instanceof Utf8) {
-        return decoder.readString((Utf8) reuse);
+      if (reuse instanceof Utf8 utf8) {
+        return decoder.readString(utf8);
       } else {
         return decoder.readString(null);
       }
@@ -603,8 +607,7 @@ public class ValueReaders {
 
     @Override
     public byte[] read(Decoder decoder, Object reuse) throws IOException {
-      if (reuse instanceof byte[]) {
-        byte[] reusedBytes = (byte[]) reuse;
+      if (reuse instanceof byte[] reusedBytes) {
         if (reusedBytes.length == length) {
           decoder.readFixed(reusedBytes, 0, length);
           return reusedBytes;
@@ -633,8 +636,7 @@ public class ValueReaders {
 
     @Override
     public GenericData.Fixed read(Decoder decoder, Object reuse) throws IOException {
-      if (reuse instanceof GenericData.Fixed) {
-        GenericData.Fixed reusedFixed = (GenericData.Fixed) reuse;
+      if (reuse instanceof GenericData.Fixed reusedFixed) {
         if (reusedFixed.bytes().length == length) {
           decoder.readFixed(reusedFixed.bytes(), 0, length);
           return reusedFixed;
@@ -686,8 +688,8 @@ public class ValueReaders {
     @Override
     public ByteBuffer read(Decoder decoder, Object reuse) throws IOException {
       // use the decoder's readBytes method because it may be a resolving decoder
-      if (reuse instanceof ByteBuffer) {
-        return decoder.readBytes((ByteBuffer) reuse);
+      if (reuse instanceof ByteBuffer byteBuffer) {
+        return decoder.readBytes(byteBuffer);
       } else {
         return decoder.readBytes(null);
       }
@@ -1011,8 +1013,8 @@ public class ValueReaders {
     @Override
     public void setRowPositionSupplier(Supplier<Long> posSupplier) {
       for (ValueReader<?> reader : readers) {
-        if (reader instanceof SupportsRowPosition) {
-          ((SupportsRowPosition) reader).setRowPositionSupplier(posSupplier);
+        if (reader instanceof SupportsRowPosition supportsRowPosition) {
+          supportsRowPosition.setRowPositionSupplier(posSupplier);
         }
       }
     }
@@ -1058,8 +1060,8 @@ public class ValueReaders {
 
     @Override
     protected GenericData.Record reuseOrCreate(Object reuse) {
-      if (reuse instanceof GenericData.Record) {
-        return (GenericData.Record) reuse;
+      if (reuse instanceof GenericData.Record record) {
+        return record;
       } else {
         return new GenericData.Record(recordSchema);
       }
@@ -1177,8 +1179,8 @@ public class ValueReaders {
       }
 
       for (ValueReader<?> reader : readers) {
-        if (reader instanceof SupportsRowPosition) {
-          ((SupportsRowPosition) reader).setRowPositionSupplier(posSupplier);
+        if (reader instanceof SupportsRowPosition supportsRowPosition) {
+          supportsRowPosition.setRowPositionSupplier(posSupplier);
         }
       }
     }
@@ -1197,9 +1199,9 @@ public class ValueReaders {
     public S read(Decoder decoder, Object reuse) throws IOException {
       S struct = reuseOrCreate(reuse);
 
-      if (decoder instanceof ResolvingDecoder) {
+      if (decoder instanceof ResolvingDecoder resolvingDecoder) {
         // this may not set all of the fields. nulls are set by default.
-        for (Schema.Field field : ((ResolvingDecoder) decoder).readFieldOrder()) {
+        for (Schema.Field field : resolvingDecoder.readFieldOrder()) {
           Object reusedValue = get(struct, field.pos());
           set(struct, field.pos(), readers[field.pos()].read(decoder, reusedValue));
         }
@@ -1229,8 +1231,8 @@ public class ValueReaders {
 
     @Override
     protected GenericData.Record reuseOrCreate(Object reuse) {
-      if (reuse instanceof GenericData.Record) {
-        return (GenericData.Record) reuse;
+      if (reuse instanceof GenericData.Record record) {
+        return record;
       } else {
         return new GenericData.Record(recordSchema);
       }

--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -243,10 +243,10 @@ public class ValueWriters {
       // use getBytes because it may return the backing byte array if available.
       // otherwise, it copies to a new byte array, which is still cheaper than Avro
       // calling toString, which incurs encoding costs
-      if (s instanceof Utf8) {
-        encoder.writeString((Utf8) s);
-      } else if (s instanceof String) {
-        encoder.writeString(new Utf8((String) s));
+      if (s instanceof Utf8 utf8) {
+        encoder.writeString(utf8);
+      } else if (s instanceof String str) {
+        encoder.writeString(new Utf8(str));
       } else if (s == null) {
         throw new IllegalArgumentException("Cannot write null to required string column");
       } else {
@@ -392,8 +392,8 @@ public class ValueWriters {
 
     @Override
     public void write(T datum, Encoder encoder) throws IOException {
-      if (datum instanceof Serialized) {
-        encoder.writeBytes(((Serialized) datum).buffer());
+      if (datum instanceof Serialized serialized) {
+        encoder.writeBytes(serialized.buffer());
       } else {
         encoder.writeBytes(serialize(datum));
       }

--- a/core/src/main/java/org/apache/iceberg/data/GenericDataUtil.java
+++ b/core/src/main/java/org/apache/iceberg/data/GenericDataUtil.java
@@ -41,24 +41,29 @@ public class GenericDataUtil {
     }
 
     switch (type.typeId()) {
-      case DATE:
+      case DATE -> {
         return DateTimeUtil.dateFromDays((Integer) value);
-      case TIME:
+      }
+      case TIME -> {
         return DateTimeUtil.timeFromMicros((Long) value);
-      case TIMESTAMP:
+      }
+      case TIMESTAMP -> {
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
           return DateTimeUtil.timestamptzFromMicros((Long) value);
         } else {
           return DateTimeUtil.timestampFromMicros((Long) value);
         }
-      case TIMESTAMP_NANO:
+      }
+      case TIMESTAMP_NANO -> {
         if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
           return DateTimeUtil.timestamptzFromNanos((Long) value);
         } else {
           return DateTimeUtil.timestampFromNanos((Long) value);
         }
-      case FIXED:
+      }
+      case FIXED -> {
         return ByteBuffers.toByteArray((ByteBuffer) value);
+      }
     }
 
     return value;

--- a/core/src/main/java/org/apache/iceberg/data/GenericRecord.java
+++ b/core/src/main/java/org/apache/iceberg/data/GenericRecord.java
@@ -78,10 +78,10 @@ public class GenericRecord implements Record, StructLike {
   }
 
   private Object deepCopyValue(Object value) {
-    if (value instanceof ByteBuffer) {
-      return ByteBuffers.copy((ByteBuffer) value);
-    } else if (value instanceof GenericRecord) {
-      return ((GenericRecord) value).copy();
+    if (value instanceof ByteBuffer byteBuffer) {
+      return ByteBuffers.copy(byteBuffer);
+    } else if (value instanceof GenericRecord genericRecord) {
+      return genericRecord.copy();
     } else {
       return value;
     }

--- a/core/src/main/java/org/apache/iceberg/data/IdentityPartitionConverters.java
+++ b/core/src/main/java/org/apache/iceberg/data/IdentityPartitionConverters.java
@@ -33,24 +33,29 @@ public class IdentityPartitionConverters {
     }
 
     switch (type.typeId()) {
-      case STRING:
+      case STRING -> {
         return value.toString();
-      case TIME:
+      }
+      case TIME -> {
         return DateTimeUtil.timeFromMicros((Long) value);
-      case DATE:
+      }
+      case DATE -> {
         return DateTimeUtil.dateFromDays((Integer) value);
-      case TIMESTAMP:
+      }
+      case TIMESTAMP -> {
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
           return DateTimeUtil.timestamptzFromMicros((Long) value);
         } else {
           return DateTimeUtil.timestampFromMicros((Long) value);
         }
-      case FIXED:
-        if (value instanceof GenericData.Fixed) {
-          return ((GenericData.Fixed) value).bytes();
+      }
+      case FIXED -> {
+        if (value instanceof GenericData.Fixed fixed) {
+          return fixed.bytes();
         }
         return value;
-      default:
+      }
+      default -> {}
     }
     return value;
   }

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
@@ -78,8 +78,8 @@ public class DataReader<T> implements DatumReader<T>, SupportsRowPosition {
 
   @Override
   public void setRowPositionSupplier(Supplier<Long> posSupplier) {
-    if (reader instanceof SupportsRowPosition) {
-      ((SupportsRowPosition) reader).setRowPositionSupplier(posSupplier);
+    if (reader instanceof SupportsRowPosition supportsRowPosition) {
+      supportsRowPosition.setRowPositionSupplier(posSupplier);
     }
   }
 
@@ -128,65 +128,79 @@ public class DataReader<T> implements DatumReader<T>, SupportsRowPosition {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             return GenericReaders.dates();
+          }
 
-          case "time-micros":
+          case "time-micros" -> {
             return GenericReaders.times();
+          }
 
-          case "timestamp-micros":
+          case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptz();
             }
             return GenericReaders.timestamps();
+          }
 
-          case "timestamp-nanos":
+          case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzNanos();
             }
             return GenericReaders.timestampNanos();
+          }
 
-          case "timestamp-millis":
+          case "timestamp-millis" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzMillis();
             }
             return GenericReaders.timestampMillis();
+          }
 
-          case "decimal":
+          case "decimal" -> {
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),
                 ((LogicalTypes.Decimal) logicalType).getScale());
+          }
 
-          case "uuid":
+          case "uuid" -> {
             return ValueReaders.uuids();
+          }
 
-          default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+          default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
         }
       }
 
       switch (primitive.getType()) {
-        case NULL:
+        case NULL -> {
           return ValueReaders.nulls();
-        case BOOLEAN:
+        }
+        case BOOLEAN -> {
           return ValueReaders.booleans();
-        case INT:
+        }
+        case INT -> {
           return ValueReaders.ints();
-        case LONG:
+        }
+        case LONG -> {
           return ValueReaders.longs();
-        case FLOAT:
+        }
+        case FLOAT -> {
           return ValueReaders.floats();
-        case DOUBLE:
+        }
+        case DOUBLE -> {
           return ValueReaders.doubles();
-        case STRING:
+        }
           // might want to use a binary-backed container like Utf8
+        case STRING -> {
           return ValueReaders.strings();
-        case FIXED:
+        }
+        case FIXED -> {
           return ValueReaders.fixed(primitive.getFixedSize());
-        case BYTES:
+        }
+        case BYTES -> {
           return ValueReaders.byteBuffers();
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
+        }
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -112,57 +112,70 @@ public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             return GenericWriters.dates();
+          }
 
-          case "time-micros":
+          case "time-micros" -> {
             return GenericWriters.times();
+          }
 
-          case "timestamp-micros":
+          case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericWriters.timestamptz();
             }
             return GenericWriters.timestamps();
+          }
 
-          case "timestamp-nanos":
+          case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericWriters.timestamptzNanos();
             }
             return GenericWriters.timestampNanos();
+          }
 
-          case "decimal":
+          case "decimal" -> {
             LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
             return ValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
+          }
 
-          case "uuid":
+          case "uuid" -> {
             return ValueWriters.uuids();
+          }
 
-          default:
-            throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
+          default -> throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
         }
       }
 
       switch (primitive.getType()) {
-        case NULL:
+        case NULL -> {
           return ValueWriters.nulls();
-        case BOOLEAN:
+        }
+        case BOOLEAN -> {
           return ValueWriters.booleans();
-        case INT:
+        }
+        case INT -> {
           return ValueWriters.ints();
-        case LONG:
+        }
+        case LONG -> {
           return ValueWriters.longs();
-        case FLOAT:
+        }
+        case FLOAT -> {
           return ValueWriters.floats();
-        case DOUBLE:
+        }
+        case DOUBLE -> {
           return ValueWriters.doubles();
-        case STRING:
+        }
+        case STRING -> {
           return ValueWriters.strings();
-        case FIXED:
+        }
+        case FIXED -> {
           return ValueWriters.fixed(primitive.getFixedSize());
-        case BYTES:
+        }
+        case BYTES -> {
           return ValueWriters.byteBuffers();
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
+        }
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/data/avro/GenericReaders.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/GenericReaders.java
@@ -177,8 +177,8 @@ class GenericReaders {
 
     @Override
     protected Record reuseOrCreate(Object reuse) {
-      if (reuse instanceof Record) {
-        return (Record) reuse;
+      if (reuse instanceof Record record) {
+        return record;
       } else {
         return GenericRecord.create(structType);
       }
@@ -206,8 +206,8 @@ class GenericReaders {
 
     @Override
     protected Record reuseOrCreate(Object reuse) {
-      if (reuse instanceof Record) {
-        return (Record) reuse;
+      if (reuse instanceof Record record) {
+        return record;
       } else {
         return GenericRecord.create(structType);
       }

--- a/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
@@ -136,71 +136,85 @@ public class PlannedDataReader<T> implements DatumReader<T>, SupportsRowPosition
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             return GenericReaders.dates();
+          }
 
-          case "time-micros":
+          case "time-micros" -> {
             return GenericReaders.times();
+          }
 
-          case "timestamp-micros":
+          case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptz();
             }
             return GenericReaders.timestamps();
+          }
 
-          case "timestamp-nanos":
+          case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzNanos();
             }
             return GenericReaders.timestampNanos();
+          }
 
-          case "timestamp-millis":
+          case "timestamp-millis" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzMillis();
             }
             return GenericReaders.timestampMillis();
+          }
 
-          case "decimal":
+          case "decimal" -> {
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),
                 ((LogicalTypes.Decimal) logicalType).getScale());
+          }
 
-          case "uuid":
+          case "uuid" -> {
             return ValueReaders.uuids();
+          }
 
-          default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+          default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
         }
       }
 
       switch (primitive.getType()) {
-        case NULL:
+        case NULL -> {
           return ValueReaders.nulls();
-        case BOOLEAN:
+        }
+        case BOOLEAN -> {
           return ValueReaders.booleans();
-        case INT:
+        }
+        case INT -> {
           if (partner != null && partner.typeId() == Type.TypeID.LONG) {
             return ValueReaders.intsAsLongs();
           }
           return ValueReaders.ints();
-        case LONG:
+        }
+        case LONG -> {
           return ValueReaders.longs();
-        case FLOAT:
+        }
+        case FLOAT -> {
           if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
             return ValueReaders.floatsAsDoubles();
           }
           return ValueReaders.floats();
-        case DOUBLE:
+        }
+        case DOUBLE -> {
           return ValueReaders.doubles();
-        case STRING:
+        }
           // might want to use a binary-backed container like Utf8
+        case STRING -> {
           return ValueReaders.strings();
-        case FIXED:
+        }
+        case FIXED -> {
           return ValueReaders.fixed(primitive.getFixedSize());
-        case BYTES:
+        }
+        case BYTES -> {
           return ValueReaders.byteBuffers();
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
+        }
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -75,8 +75,8 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
 
   @Override
   public void merge(PositionDeleteIndex that) {
-    if (that instanceof BitmapPositionDeleteIndex) {
-      merge((BitmapPositionDeleteIndex) that);
+    if (that instanceof BitmapPositionDeleteIndex bitmapIndex) {
+      merge(bitmapIndex);
     } else {
       that.forEach(this::delete);
       deleteFiles.addAll(that.deleteFiles());

--- a/core/src/main/java/org/apache/iceberg/deletes/DeleteGranularity.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/DeleteGranularity.java
@@ -48,14 +48,10 @@ public enum DeleteGranularity {
 
   @Override
   public String toString() {
-    switch (this) {
-      case FILE:
-        return "file";
-      case PARTITION:
-        return "partition";
-      default:
-        throw new IllegalArgumentException("Unknown delete granularity: " + this);
-    }
+    return switch (this) {
+      case FILE -> "file";
+      case PARTITION -> "partition";
+    };
   }
 
   public static DeleteGranularity fromString(String valueAsString) {

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDelete.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDelete.java
@@ -81,32 +81,21 @@ public class PositionDelete<R> implements StructLike {
   @Override
   @SuppressWarnings("unchecked")
   public <T> T get(int colPos, Class<T> javaClass) {
-    switch (colPos) {
-      case 0:
-        return (T) path;
-      case 1:
-        return (T) (Long) pos;
-      case 2:
-        return (T) row;
-      default:
-        throw new IllegalArgumentException("No column at position " + colPos);
-    }
+    return switch (colPos) {
+      case 0 -> (T) path;
+      case 1 -> (T) (Long) pos;
+      case 2 -> (T) row;
+      default -> throw new IllegalArgumentException("No column at position " + colPos);
+    };
   }
 
   @Override
   public <T> void set(int colPos, T value) {
     switch (colPos) {
-      case 0:
-        this.path = (CharSequence) value;
-        break;
-      case 1:
-        this.pos = (Long) value;
-        break;
-      case 2:
-        this.row = (R) value;
-        break;
-      default:
-        throw new IllegalArgumentException("No column at position " + colPos);
+      case 0 -> this.path = (CharSequence) value;
+      case 1 -> this.pos = (Long) value;
+      case 2 -> this.row = (R) value;
+      default -> throw new IllegalArgumentException("No column at position " + colPos);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
@@ -101,14 +101,11 @@ public class SortingPositionOnlyDeleteWriter<T>
   public void close() throws IOException {
     if (result == null) {
       switch (granularity) {
-        case FILE:
-          this.result = writeFileDeletes();
-          return;
-        case PARTITION:
-          this.result = writePartitionDeletes();
-          return;
-        default:
-          throw new UnsupportedOperationException("Unsupported delete granularity: " + granularity);
+        case FILE -> this.result = writeFileDeletes();
+        case PARTITION -> this.result = writePartitionDeletes();
+        default ->
+            throw new UnsupportedOperationException(
+                "Unsupported delete granularity: " + granularity);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -103,8 +103,8 @@ public class StandardEncryptionManager implements EncryptionManager {
   @Override
   public NativeEncryptionInputFile decrypt(EncryptedInputFile encrypted) {
     // this input file will lazily parse key metadata in case the file is not an AES GCM stream.
-    if (encrypted instanceof NativeEncryptionInputFile) {
-      return (NativeEncryptionInputFile) encrypted;
+    if (encrypted instanceof NativeEncryptionInputFile nativeEncryptionInputFile) {
+      return nativeEncryptionInputFile;
     }
 
     return new StandardDecryptedInputFile(encrypted);

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
@@ -101,8 +101,8 @@ class StandardKeyMetadata implements NativeEncryptionKeyMetadata, IndexedRecord 
   }
 
   static StandardKeyMetadata castOrParse(EncryptionKeyMetadata keyMetadata) {
-    if (keyMetadata instanceof StandardKeyMetadata) {
-      return (StandardKeyMetadata) keyMetadata;
+    if (keyMetadata instanceof StandardKeyMetadata standardKeyMetadata) {
+      return standardKeyMetadata;
     }
 
     ByteBuffer kmBuffer = keyMetadata.buffer();
@@ -144,32 +144,23 @@ class StandardKeyMetadata implements NativeEncryptionKeyMetadata, IndexedRecord 
   @Override
   public void put(int i, Object v) {
     switch (i) {
-      case 0:
-        this.encryptionKey = (ByteBuffer) v;
-        return;
-      case 1:
-        this.aadPrefix = (ByteBuffer) v;
-        return;
-      case 2:
-        this.fileLength = (Long) v;
-        return;
-      default:
+      case 0 -> this.encryptionKey = (ByteBuffer) v;
+      case 1 -> this.aadPrefix = (ByteBuffer) v;
+      case 2 -> this.fileLength = (Long) v;
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 
   @Override
   public Object get(int i) {
-    switch (i) {
-      case 0:
-        return encryptionKey;
-      case 1:
-        return aadPrefix;
-      case 2:
-        return fileLength;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
-    }
+    return switch (i) {
+      case 0 -> encryptionKey;
+      case 1 -> aadPrefix;
+      case 2 -> fileLength;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -218,12 +218,11 @@ public class ExpressionParser {
         SingleValueParser.toJson(Types.BooleanType.get(), object, gen);
       } else if (object instanceof ByteBuffer) {
         SingleValueParser.toJson(Types.BinaryType.get(), object, gen);
-      } else if (object instanceof byte[]) {
-        SingleValueParser.toJson(Types.BinaryType.get(), ByteBuffer.wrap((byte[]) object), gen);
+      } else if (object instanceof byte[] bytes) {
+        SingleValueParser.toJson(Types.BinaryType.get(), ByteBuffer.wrap(bytes), gen);
       } else if (object instanceof UUID) {
         SingleValueParser.toJson(Types.UUIDType.get(), object, gen);
-      } else if (object instanceof BigDecimal) {
-        BigDecimal decimal = (BigDecimal) object;
+      } else if (object instanceof BigDecimal decimal) {
         SingleValueParser.toJson(
             Types.DecimalType.of(decimal.precision(), decimal.scale()), decimal, gen);
       }
@@ -296,16 +295,20 @@ public class ExpressionParser {
 
     Expression.Operation op = fromType(type);
     switch (op) {
-      case NOT:
+      case NOT -> {
         return Expressions.not(fromJson(JsonUtil.get(CHILD, json), schema));
-      case AND:
+      }
+      case AND -> {
         return Expressions.and(
             fromJson(JsonUtil.get(LEFT, json), schema),
             fromJson(JsonUtil.get(RIGHT, json), schema));
-      case OR:
+      }
+      case OR -> {
         return Expressions.or(
             fromJson(JsonUtil.get(LEFT, json), schema),
             fromJson(JsonUtil.get(RIGHT, json), schema));
+      }
+      default -> {}
     }
 
     return predicateFromJson(op, json, schema);
@@ -329,34 +332,25 @@ public class ExpressionParser {
     }
 
     switch (op) {
-      case IS_NULL:
-      case NOT_NULL:
-      case IS_NAN:
-      case NOT_NAN:
         // unary predicates
+      case IS_NULL, NOT_NULL, IS_NAN, NOT_NAN -> {
         Preconditions.checkArgument(
             !node.has(VALUE), "Cannot parse %s predicate: has invalid value field", op);
         Preconditions.checkArgument(
             !node.has(VALUES), "Cannot parse %s predicate: has invalid values field", op);
         return Expressions.predicate(op, term);
-      case LT:
-      case LT_EQ:
-      case GT:
-      case GT_EQ:
-      case EQ:
-      case NOT_EQ:
-      case STARTS_WITH:
-      case NOT_STARTS_WITH:
+      }
         // literal predicates
+      case LT, LT_EQ, GT, GT_EQ, EQ, NOT_EQ, STARTS_WITH, NOT_STARTS_WITH -> {
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);
         Preconditions.checkArgument(
             !node.has(VALUES), "Cannot parse %s predicate: has invalid values field", op);
         T value = literal(JsonUtil.get(VALUE, node), convertValue);
         return Expressions.predicate(op, term, ImmutableList.of(value));
-      case IN:
-      case NOT_IN:
+      }
         // literal set predicates
+      case IN, NOT_IN -> {
         Preconditions.checkArgument(
             node.has(VALUES), "Cannot parse %s predicate: missing values", op);
         Preconditions.checkArgument(
@@ -369,8 +363,8 @@ public class ExpressionParser {
             term,
             Iterables.transform(
                 ((ArrayNode) valuesNode)::elements, valueNode -> literal(valueNode, convertValue)));
-      default:
-        throw new UnsupportedOperationException("Unsupported operation: " + op);
+      }
+      default -> throw new UnsupportedOperationException("Unsupported operation: " + op);
     }
   }
 
@@ -407,15 +401,16 @@ public class ExpressionParser {
     } else if (node.isObject()) {
       String type = JsonUtil.getString(TYPE, node);
       switch (type) {
-        case REFERENCE:
+        case REFERENCE -> {
           return Expressions.ref(JsonUtil.getString(TERM, node));
-        case TRANSFORM:
+        }
+        case TRANSFORM -> {
           UnboundTerm<T> child = term(JsonUtil.get(TERM, node));
           String transform = JsonUtil.getString(TRANSFORM, node);
           return (UnboundTerm<T>)
               Expressions.transform(child.ref().name(), Transforms.fromString(transform));
-        default:
-          throw new IllegalArgumentException("Cannot parse type as a reference: " + type);
+        }
+        default -> throw new IllegalArgumentException("Cannot parse type as a reference: " + type);
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -67,22 +67,26 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   @SuppressWarnings("unchecked")
   public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
     switch (name) {
-      case READ_BYTES:
+      case READ_BYTES -> {
         ValidationException.check(type == Long.class, "'%s' requires Long type", READ_BYTES);
         return (Counter<T>) longCounter(statistics()::incrementBytesRead);
-      case READ_OPERATIONS:
+      }
+      case READ_OPERATIONS -> {
         ValidationException.check(
             type == Integer.class, "'%s' requires Integer type", READ_OPERATIONS);
         return (Counter<T>) integerCounter(statistics()::incrementReadOps);
-      case WRITE_BYTES:
+      }
+      case WRITE_BYTES -> {
         ValidationException.check(type == Long.class, "'%s' requires Long type", WRITE_BYTES);
         return (Counter<T>) longCounter(statistics()::incrementBytesWritten);
-      case WRITE_OPERATIONS:
+      }
+      case WRITE_OPERATIONS -> {
         ValidationException.check(
             type == Integer.class, "'%s' requires Integer type", WRITE_OPERATIONS);
         return (Counter<T>) integerCounter(statistics()::incrementWriteOps);
-      default:
-        throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
+      }
+      default ->
+          throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
     }
   }
 
@@ -126,17 +130,21 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   @Override
   public org.apache.iceberg.metrics.Counter counter(String name, Unit unit) {
     switch (name) {
-      case READ_BYTES:
+      case READ_BYTES -> {
         return counter(statistics()::incrementBytesRead, statistics()::getBytesRead);
-      case READ_OPERATIONS:
+      }
+      case READ_OPERATIONS -> {
         return counter((long x) -> statistics.incrementReadOps((int) x), statistics()::getReadOps);
-      case WRITE_BYTES:
+      }
+      case WRITE_BYTES -> {
         return counter(statistics()::incrementBytesWritten, statistics()::getBytesWritten);
-      case WRITE_OPERATIONS:
+      }
+      case WRITE_OPERATIONS -> {
         return counter(
             (long x) -> statistics.incrementWriteOps((int) x), statistics()::getWriteOps);
-      default:
-        throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
+      }
+      default ->
+          throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -90,8 +90,8 @@ public class Util {
   public static boolean mayHaveBlockLocations(FileIO io, String location) {
     if (usesHadoopFileIO(io, location)) {
       InputFile inputFile = io.newInputFile(location);
-      if (inputFile instanceof HadoopInputFile) {
-        String scheme = ((HadoopInputFile) inputFile).getFileSystem().getScheme();
+      if (inputFile instanceof HadoopInputFile hadoopInputFile) {
+        String scheme = hadoopInputFile.getFileSystem().getScheme();
         return LOCALITY_WHITELIST_FS.contains(scheme);
 
       } else {
@@ -106,8 +106,8 @@ public class Util {
     String location = task.file().location();
     if (usesHadoopFileIO(io, location)) {
       InputFile inputFile = io.newInputFile(location);
-      if (inputFile instanceof HadoopInputFile) {
-        return ((HadoopInputFile) inputFile).getBlockLocations(task.start(), task.length());
+      if (inputFile instanceof HadoopInputFile hadoopInputFile) {
+        return hadoopInputFile.getBlockLocations(task.start(), task.length());
 
       } else {
         return HadoopInputFile.NO_LOCATION_PREFERENCE;
@@ -121,8 +121,7 @@ public class Util {
     if (io instanceof HadoopFileIO) {
       return true;
 
-    } else if (io instanceof ResolvingFileIO) {
-      ResolvingFileIO resolvingFileIO = (ResolvingFileIO) io;
+    } else if (io instanceof ResolvingFileIO resolvingFileIO) {
       return HadoopFileIO.class.isAssignableFrom(resolvingFileIO.ioClass(location));
 
     } else {

--- a/core/src/main/java/org/apache/iceberg/io/ClusteredPositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/ClusteredPositionDeleteWriter.java
@@ -70,14 +70,12 @@ public class ClusteredPositionDeleteWriter<T>
   @Override
   protected FileWriter<PositionDelete<T>, DeleteWriteResult> newWriter(
       PartitionSpec spec, StructLike partition) {
-    switch (granularity) {
-      case FILE:
-        return new FileScopedPositionDeleteWriter<>(() -> newRollingWriter(spec, partition));
-      case PARTITION:
-        return newRollingWriter(spec, partition);
-      default:
-        throw new UnsupportedOperationException("Unsupported delete granularity: " + granularity);
-    }
+    return switch (granularity) {
+      case FILE -> new FileScopedPositionDeleteWriter<>(() -> newRollingWriter(spec, partition));
+      case PARTITION -> newRollingWriter(spec, partition);
+      default ->
+          throw new UnsupportedOperationException("Unsupported delete granularity: " + granularity);
+    };
   }
 
   private RollingPositionDeleteWriter<T> newRollingWriter(

--- a/core/src/main/java/org/apache/iceberg/io/IOUtil.java
+++ b/core/src/main/java/org/apache/iceberg/io/IOUtil.java
@@ -65,8 +65,8 @@ public class IOUtil {
       InputFile inputFile, long fileOffset, byte[] bytes, int offset, int length)
       throws IOException {
     try (SeekableInputStream stream = inputFile.newStream()) {
-      if (stream instanceof RangeReadable) {
-        ((RangeReadable) stream).readFully(fileOffset, bytes, offset, length);
+      if (stream instanceof RangeReadable rangeReadable) {
+        rangeReadable.readFully(fileOffset, bytes, offset, length);
       } else {
         stream.seek(fileOffset);
         readFully(stream, bytes, offset, length);

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -167,18 +167,19 @@ public class ResolvingFileIO
     String impl = implFromLocation(location);
     DelegateFileIO io = ioInstances.get(impl);
     if (io != null) {
-      if (io instanceof HadoopConfigurable && ((HadoopConfigurable) io).getConf() == null) {
+      if (io instanceof HadoopConfigurable hadoopConfigurable
+          && hadoopConfigurable.getConf() == null) {
         synchronized (io) {
-          if (((HadoopConfigurable) io).getConf() == null) {
+          if (hadoopConfigurable.getConf() == null) {
             // re-apply the config in case it's null after Kryo serialization
-            ((HadoopConfigurable) io).setConf(getConf());
+            hadoopConfigurable.setConf(getConf());
           }
         }
       }
 
-      if (io instanceof SupportsStorageCredentials
-          && !((SupportsStorageCredentials) io).credentials().equals(storageCredentials)) {
-        ((SupportsStorageCredentials) io).setCredentials(storageCredentials);
+      if (io instanceof SupportsStorageCredentials supportsStorageCredentials
+          && !supportsStorageCredentials.credentials().equals(storageCredentials)) {
+        supportsStorageCredentials.setCredentials(storageCredentials);
       }
 
       return io;

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
@@ -109,7 +109,7 @@ public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
   @Override
   protected boolean isConnectionException(Exception e) {
     return super.isConnectionException(e)
-        || (e instanceof SQLException
-            && retryableStatusCodes.contains(((SQLException) e).getSQLState()));
+        || (e instanceof SQLException sqlException
+            && retryableStatusCodes.contains(sqlException.getSQLState()));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/metrics/MetricsReporters.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/MetricsReporters.java
@@ -40,14 +40,14 @@ public class MetricsReporters {
 
     Set<MetricsReporter> reporters = Sets.newIdentityHashSet();
 
-    if (first instanceof CompositeMetricsReporter) {
-      reporters.addAll(((CompositeMetricsReporter) first).reporters());
+    if (first instanceof CompositeMetricsReporter compositeFirst) {
+      reporters.addAll(compositeFirst.reporters());
     } else {
       reporters.add(first);
     }
 
-    if (second instanceof CompositeMetricsReporter) {
-      reporters.addAll(((CompositeMetricsReporter) second).reporters());
+    if (second instanceof CompositeMetricsReporter compositeSecond) {
+      reporters.addAll(compositeSecond.reporters());
     } else {
       reporters.add(second);
     }

--- a/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
@@ -119,23 +119,17 @@ class TimerResultParser {
   }
 
   private static ChronoUnit toChronoUnit(TimeUnit unit) {
-    switch (unit) {
-      case NANOSECONDS:
-        return ChronoUnit.NANOS;
-      case MICROSECONDS:
-        return ChronoUnit.MICROS;
-      case MILLISECONDS:
-        return ChronoUnit.MILLIS;
-      case SECONDS:
-        return ChronoUnit.SECONDS;
-      case MINUTES:
-        return ChronoUnit.MINUTES;
-      case HOURS:
-        return ChronoUnit.HOURS;
-      case DAYS:
-        return ChronoUnit.DAYS;
-      default:
-        throw new IllegalArgumentException("Cannot determine chrono unit from time unit: " + unit);
-    }
+    return switch (unit) {
+      case NANOSECONDS -> ChronoUnit.NANOS;
+      case MICROSECONDS -> ChronoUnit.MICROS;
+      case MILLISECONDS -> ChronoUnit.MILLIS;
+      case SECONDS -> ChronoUnit.SECONDS;
+      case MINUTES -> ChronoUnit.MINUTES;
+      case HOURS -> ChronoUnit.HOURS;
+      case DAYS -> ChronoUnit.DAYS;
+      default ->
+          throw new IllegalArgumentException(
+              "Cannot determine chrono unit from time unit: " + unit);
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinFormat.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinFormat.java
@@ -105,15 +105,18 @@ final class PuffinFormat {
 
   static ByteBuffer compress(PuffinCompressionCodec codec, ByteBuffer input) {
     switch (codec) {
-      case NONE:
+      case NONE -> {
         return input.duplicate();
-      case LZ4:
+      }
+      case LZ4 -> {
         // TODO requires LZ4 frame compressor, e.g.
         // https://github.com/airlift/aircompressor/pull/142
-        break;
-      case ZSTD:
+      }
+      case ZSTD -> {
         return compress(new ZstdCompressor(), input);
+      }
     }
+
     throw new UnsupportedOperationException("Unsupported codec: " + codec);
   }
 
@@ -126,16 +129,16 @@ final class PuffinFormat {
 
   static ByteBuffer decompress(PuffinCompressionCodec codec, ByteBuffer input) {
     switch (codec) {
-      case NONE:
+      case NONE -> {
         return input.duplicate();
-
-      case LZ4:
+      }
+      case LZ4 -> {
         // TODO requires LZ4 frame decompressor, e.g.
         // https://github.com/airlift/aircompressor/pull/142
-        break;
-
-      case ZSTD:
+      }
+      case ZSTD -> {
         return decompressZstd(input);
+      }
     }
 
     throw new UnsupportedOperationException("Unsupported codec: " + codec);

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -72,11 +72,9 @@ public class PuffinReader implements Closeable {
       PuffinCompressionCodec footerCompression = PuffinCompressionCodec.NONE;
       for (Flag flag : decodeFlags(footer, footerStructOffset)) {
         switch (flag) {
-          case FOOTER_PAYLOAD_COMPRESSED:
-            footerCompression = PuffinFormat.FOOTER_COMPRESSION_CODEC;
-            break;
-          default:
-            throw new IllegalStateException("Unsupported flag: " + flag);
+          case FOOTER_PAYLOAD_COMPRESSED ->
+              footerCompression = PuffinFormat.FOOTER_COMPRESSION_CODEC;
+          default -> throw new IllegalStateException("Unsupported flag: " + flag);
         }
       }
 
@@ -183,8 +181,8 @@ public class PuffinReader implements Closeable {
 
   private byte[] readInput(long offset, int length) throws IOException {
     byte[] data = new byte[length];
-    if (input instanceof RangeReadable) {
-      ((RangeReadable) input).readFully(offset, data);
+    if (input instanceof RangeReadable rangeReadable) {
+      rangeReadable.readFully(offset, data);
     } else {
       input.seek(offset);
       ByteStreams.readFully(input, data);

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -455,9 +455,9 @@ public class CatalogHandlers {
             .withProperties(request.properties())
             .create();
 
-    if (table instanceof BaseTable) {
+    if (table instanceof BaseTable baseTable) {
       return LoadTableResponse.builder()
-          .withTableMetadata(((BaseTable) table).operations().current())
+          .withTableMetadata(baseTable.operations().current())
           .build();
     }
 
@@ -470,9 +470,9 @@ public class CatalogHandlers {
 
     TableIdentifier identifier = TableIdentifier.of(namespace, request.name());
     Table table = catalog.registerTable(identifier, request.metadataLocation());
-    if (table instanceof BaseTable) {
+    if (table instanceof BaseTable baseTable) {
       return LoadTableResponse.builder()
-          .withTableMetadata(((BaseTable) table).operations().current())
+          .withTableMetadata(baseTable.operations().current())
           .build();
     }
 
@@ -513,23 +513,20 @@ public class CatalogHandlers {
       Catalog catalog, TableIdentifier ident, SnapshotMode mode) {
     Table table = catalog.loadTable(ident);
 
-    if (table instanceof BaseTable) {
-      TableMetadata loadedMetadata = ((BaseTable) table).operations().current();
+    if (table instanceof BaseTable baseTable) {
+      TableMetadata loadedMetadata = baseTable.operations().current();
 
       TableMetadata metadata;
       switch (mode) {
-        case ALL:
-          metadata = loadedMetadata;
-          break;
-        case REFS:
-          metadata =
-              TableMetadata.buildFrom(loadedMetadata)
-                  .withMetadataLocation(loadedMetadata.metadataFileLocation())
-                  .suppressHistoricalSnapshots()
-                  .build();
-          break;
-        default:
-          throw new IllegalArgumentException(String.format("Invalid snapshot mode: %s", mode));
+        case ALL -> metadata = loadedMetadata;
+        case REFS ->
+            metadata =
+                TableMetadata.buildFrom(loadedMetadata)
+                    .withMetadataLocation(loadedMetadata.metadataFileLocation())
+                    .suppressHistoricalSnapshots()
+                    .build();
+        default ->
+            throw new IllegalArgumentException(String.format("Invalid snapshot mode: %s", mode));
       }
 
       return LoadTableResponse.builder().withTableMetadata(metadata).build();
@@ -548,8 +545,7 @@ public class CatalogHandlers {
       // this is a hacky way to get TableOperations for an uncommitted table
       Transaction transaction =
           catalog.buildTable(ident, EMPTY_SCHEMA).createOrReplaceTransaction();
-      if (transaction instanceof BaseTransaction) {
-        BaseTransaction baseTransaction = (BaseTransaction) transaction;
+      if (transaction instanceof BaseTransaction baseTransaction) {
         finalMetadata = create(baseTransaction.underlyingOps(), request);
       } else {
         throw new IllegalStateException(
@@ -558,8 +554,8 @@ public class CatalogHandlers {
 
     } else {
       Table table = catalog.loadTable(ident);
-      if (table instanceof BaseTable) {
-        TableOperations ops = ((BaseTable) table).operations();
+      if (table instanceof BaseTable baseTable) {
+        TableOperations ops = baseTable.operations();
         finalMetadata = commit(ops, request);
       } else {
         throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");

--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -164,11 +164,10 @@ public class Endpoint {
       return true;
     }
 
-    if (!(o instanceof Endpoint)) {
+    if (!(o instanceof Endpoint endpoint)) {
       return false;
     }
 
-    Endpoint endpoint = (Endpoint) o;
     return Objects.equals(httpMethod, endpoint.httpMethod) && Objects.equals(path, endpoint.path);
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -117,16 +117,13 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
-          throw new NoSuchTableException("%s", error.message());
-        case 409:
-          throw new CommitFailedException("Commit failed: %s", error.message());
-        case 500:
-        case 502:
-        case 503:
-        case 504:
-          throw new CommitStateUnknownException(
-              new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));
+        case 404 -> throw new NoSuchTableException("%s", error.message());
+        case 409 -> throw new CommitFailedException("Commit failed: %s", error.message());
+        case 500, 502, 503, 504 ->
+            throw new CommitStateUnknownException(
+                new ServiceFailureException(
+                    "Service failed: %s: %s", error.code(), error.message()));
+        default -> {}
       }
 
       super.accept(error);
@@ -140,7 +137,7 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
+        case 404 -> {
           if (NoSuchNamespaceException.class.getSimpleName().equals(error.type())) {
             throw new NoSuchNamespaceException("%s", error.message());
           } else if (NotFoundException.class.getSimpleName().equals(error.type())) {
@@ -148,8 +145,9 @@ public class ErrorHandlers {
           } else {
             throw new NoSuchTableException("%s", error.message());
           }
-        case 409:
-          throw new AlreadyExistsException("%s", error.message());
+        }
+        case 409 -> throw new AlreadyExistsException("%s", error.message());
+        default -> {}
       }
 
       super.accept(error);
@@ -163,10 +161,9 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
-          throw new NoSuchNamespaceException("%s", error.message());
-        case 409:
-          throw new AlreadyExistsException("%s", error.message());
+        case 404 -> throw new NoSuchNamespaceException("%s", error.message());
+        case 409 -> throw new AlreadyExistsException("%s", error.message());
+        default -> {}
       }
 
       super.accept(error);
@@ -220,16 +217,13 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
-          throw new NoSuchViewException("%s", error.message());
-        case 409:
-          throw new CommitFailedException("Commit failed: %s", error.message());
-        case 500:
-        case 502:
-        case 503:
-        case 504:
-          throw new CommitStateUnknownException(
-              new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));
+        case 404 -> throw new NoSuchViewException("%s", error.message());
+        case 409 -> throw new CommitFailedException("Commit failed: %s", error.message());
+        case 500, 502, 503, 504 ->
+            throw new CommitStateUnknownException(
+                new ServiceFailureException(
+                    "Service failed: %s: %s", error.code(), error.message()));
+        default -> {}
       }
 
       super.accept(error);
@@ -243,14 +237,15 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
+        case 404 -> {
           if (NoSuchNamespaceException.class.getSimpleName().equals(error.type())) {
             throw new NoSuchNamespaceException("%s", error.message());
           } else {
             throw new NoSuchViewException("%s", error.message());
           }
-        case 409:
-          throw new AlreadyExistsException("%s", error.message());
+        }
+        case 409 -> throw new AlreadyExistsException("%s", error.message());
+        default -> {}
       }
 
       super.accept(error);
@@ -264,17 +259,16 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 400:
+        case 400 -> {
           if (NamespaceNotEmptyException.class.getSimpleName().equals(error.type())) {
             throw new NamespaceNotEmptyException("%s", error.message());
           }
           throw new BadRequestException("Malformed request: %s", error.message());
-        case 404:
-          throw new NoSuchNamespaceException("%s", error.message());
-        case 409:
-          throw new AlreadyExistsException("%s", error.message());
-        case 422:
-          throw createRESTException(error);
+        }
+        case 404 -> throw new NoSuchNamespaceException("%s", error.message());
+        case 409 -> throw new AlreadyExistsException("%s", error.message());
+        case 422 -> throw createRESTException(error);
+        default -> {}
       }
 
       super.accept(error);
@@ -315,24 +309,22 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 400:
+        case 400 -> {
           if (IllegalArgumentException.class.getSimpleName().equals(error.type())) {
             throw new IllegalArgumentException(error.message());
           }
           throw new BadRequestException("Malformed request: %s", error.message());
-        case 401:
-          throw new NotAuthorizedException("Not authorized: %s", error.message());
-        case 403:
-          throw new ForbiddenException("Forbidden: %s", error.message());
-        case 405:
-        case 406:
-          break;
-        case 500:
-          throw new ServiceFailureException("Server error: %s: %s", error.type(), error.message());
-        case 501:
-          throw new UnsupportedOperationException(error.message());
-        case 503:
-          throw new ServiceUnavailableException("Service unavailable: %s", error.message());
+        }
+        case 401 -> throw new NotAuthorizedException("Not authorized: %s", error.message());
+        case 403 -> throw new ForbiddenException("Forbidden: %s", error.message());
+        case 405, 406 -> {}
+        case 500 ->
+            throw new ServiceFailureException(
+                "Server error: %s: %s", error.type(), error.message());
+        case 501 -> throw new UnsupportedOperationException(error.message());
+        case 503 ->
+            throw new ServiceUnavailableException("Service unavailable: %s", error.message());
+        default -> {}
       }
 
       throw createRESTException(error);
@@ -356,16 +348,17 @@ public class ErrorHandlers {
     public void accept(ErrorResponse error) {
       if (error.type() != null) {
         switch (error.type()) {
-          case OAuth2Properties.INVALID_CLIENT_ERROR:
-            throw new NotAuthorizedException(
-                "Not authorized: %s: %s", error.type(), error.message());
-          case OAuth2Properties.INVALID_REQUEST_ERROR:
-          case OAuth2Properties.INVALID_GRANT_ERROR:
-          case OAuth2Properties.UNAUTHORIZED_CLIENT_ERROR:
-          case OAuth2Properties.UNSUPPORTED_GRANT_TYPE_ERROR:
-          case OAuth2Properties.INVALID_SCOPE_ERROR:
-            throw new BadRequestException(
-                "Malformed request: %s: %s", error.type(), error.message());
+          case OAuth2Properties.INVALID_CLIENT_ERROR ->
+              throw new NotAuthorizedException(
+                  "Not authorized: %s: %s", error.type(), error.message());
+          case OAuth2Properties.INVALID_REQUEST_ERROR,
+                  OAuth2Properties.INVALID_GRANT_ERROR,
+                  OAuth2Properties.UNAUTHORIZED_CLIENT_ERROR,
+                  OAuth2Properties.UNSUPPORTED_GRANT_TYPE_ERROR,
+                  OAuth2Properties.INVALID_SCOPE_ERROR ->
+              throw new BadRequestException(
+                  "Malformed request: %s: %s", error.type(), error.message());
+          default -> {}
         }
       }
       throw createRESTException(error);

--- a/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ExponentialHttpRequestRetryStrategy.java
@@ -125,8 +125,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
       }
     }
 
-    if (request instanceof CancellableDependency
-        && ((CancellableDependency) request).isCancelled()) {
+    if (request instanceof CancellableDependency cancellable && cancellable.isCancelled()) {
       return false;
     }
 
@@ -137,7 +136,7 @@ class ExponentialHttpRequestRetryStrategy implements HttpRequestRetryStrategy {
   @Override
   public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
     HttpRequest request =
-        context instanceof HttpCoreContext ? ((HttpCoreContext) context).getRequest() : null;
+        context instanceof HttpCoreContext httpCoreContext ? httpCoreContext.getRequest() : null;
 
     boolean is503Retryable =
         response.getCode() == HttpStatus.SC_SERVICE_UNAVAILABLE

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -206,9 +206,8 @@ public class HTTPClient extends BaseHTTPClient {
 
     if (responseBody != null) {
       try {
-        if (errorHandler instanceof ErrorHandler) {
-          errorResponse =
-              ((ErrorHandler) errorHandler).parseResponse(response.getCode(), responseBody);
+        if (errorHandler instanceof ErrorHandler handler) {
+          errorResponse = handler.parseResponse(response.getCode(), responseBody);
         } else {
           LOG.warn(
               "Unknown error handler {}, response body won't be parsed",

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -160,7 +160,7 @@ class RESTTableOperations implements TableOperations {
     List<UpdateRequirement> requirements;
     List<MetadataUpdate> updates;
     switch (updateType) {
-      case CREATE:
+      case CREATE -> {
         Preconditions.checkState(
             base == null, "Invalid base metadata for create transaction, expected null: %s", base);
         updates =
@@ -170,9 +170,9 @@ class RESTTableOperations implements TableOperations {
                 .build();
         requirements = UpdateRequirements.forCreateTable(updates);
         errorHandler = ErrorHandlers.createTableErrorHandler();
-        break;
+      }
 
-      case REPLACE:
+      case REPLACE -> {
         Preconditions.checkState(base != null, "Invalid base metadata: null");
         updates =
             ImmutableList.<MetadataUpdate>builder()
@@ -182,18 +182,18 @@ class RESTTableOperations implements TableOperations {
         // use the original replace base metadata because the transaction will refresh
         requirements = UpdateRequirements.forReplaceTable(replaceBase, updates);
         errorHandler = ErrorHandlers.tableCommitHandler();
-        break;
+      }
 
-      case SIMPLE:
+      case SIMPLE -> {
         Preconditions.checkState(base != null, "Invalid base metadata: null");
         updates = metadata.changes();
         requirements = UpdateRequirements.forUpdateTable(base, updates);
         errorHandler = ErrorHandlers.tableCommitHandler();
-        break;
+      }
 
-      default:
-        throw new UnsupportedOperationException(
-            String.format("Update type %s is not supported", updateType));
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("Update type %s is not supported", updateType));
     }
 
     UpdateTableRequest request = new UpdateTableRequest(requirements, updates);
@@ -253,13 +253,12 @@ class RESTTableOperations implements TableOperations {
     Long mainRefSnapshotId = null;
 
     for (MetadataUpdate update : updates) {
-      if (update instanceof MetadataUpdate.AddSnapshot) {
+      if (update instanceof MetadataUpdate.AddSnapshot addSnapshot) {
         if (addedSnapshotId != null) {
           return null; // multiple snapshot adds -> not safe
         }
-        addedSnapshotId = ((MetadataUpdate.AddSnapshot) update).snapshot().snapshotId();
-      } else if (update instanceof MetadataUpdate.SetSnapshotRef) {
-        MetadataUpdate.SetSnapshotRef setRef = (MetadataUpdate.SetSnapshotRef) update;
+        addedSnapshotId = addSnapshot.snapshot().snapshotId();
+      } else if (update instanceof MetadataUpdate.SetSnapshotRef setRef) {
         if (!SnapshotRef.MAIN_BRANCH.equals(setRef.name())) {
           return null; // only allow main ref update
         }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -181,20 +181,22 @@ class RESTTableScan extends DataTableScan {
     }
 
     switch (planStatus) {
-      case COMPLETED:
+      case COMPLETED -> {
         return scanTasksIterable(response.planTasks(), response.fileScanTasks());
-      case SUBMITTED:
+      }
+      case SUBMITTED -> {
         Endpoint.check(supportedEndpoints, Endpoint.V1_FETCH_TABLE_SCAN_PLAN);
         return fetchPlanningResult();
-      case FAILED:
-        throw new IllegalStateException(
-            String.format("Received status: %s for planId: %s", PlanStatus.FAILED, planId));
-      case CANCELLED:
-        throw new IllegalStateException(
-            String.format("Received status: %s for planId: %s", PlanStatus.CANCELLED, planId));
-      default:
-        throw new IllegalStateException(
-            String.format("Invalid planStatus: %s for planId: %s", planStatus, planId));
+      }
+      case FAILED ->
+          throw new IllegalStateException(
+              String.format("Received status: %s for planId: %s", PlanStatus.FAILED, planId));
+      case CANCELLED ->
+          throw new IllegalStateException(
+              String.format("Received status: %s for planId: %s", PlanStatus.CANCELLED, planId));
+      default ->
+          throw new IllegalStateException(
+              String.format("Invalid planStatus: %s for planId: %s", planStatus, planId));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthManagers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthManagers.java
@@ -86,23 +86,12 @@ public class AuthManagers {
 
     String impl;
     switch (authType.toLowerCase(Locale.ROOT)) {
-      case AuthProperties.AUTH_TYPE_NONE:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_NONE;
-        break;
-      case AuthProperties.AUTH_TYPE_BASIC:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_BASIC;
-        break;
-      case AuthProperties.AUTH_TYPE_SIGV4:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_SIGV4;
-        break;
-      case AuthProperties.AUTH_TYPE_GOOGLE:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_GOOGLE;
-        break;
-      case AuthProperties.AUTH_TYPE_OAUTH2:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_OAUTH2;
-        break;
-      default:
-        impl = authType;
+      case AuthProperties.AUTH_TYPE_NONE -> impl = AuthProperties.AUTH_MANAGER_IMPL_NONE;
+      case AuthProperties.AUTH_TYPE_BASIC -> impl = AuthProperties.AUTH_MANAGER_IMPL_BASIC;
+      case AuthProperties.AUTH_TYPE_SIGV4 -> impl = AuthProperties.AUTH_MANAGER_IMPL_SIGV4;
+      case AuthProperties.AUTH_TYPE_GOOGLE -> impl = AuthProperties.AUTH_MANAGER_IMPL_GOOGLE;
+      case AuthProperties.AUTH_TYPE_OAUTH2 -> impl = AuthProperties.AUTH_MANAGER_IMPL_OAUTH2;
+      default -> impl = authType;
     }
 
     LOG.info("Loading AuthManager implementation: {}", impl);

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthSessionCache.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthSessionCache.java
@@ -98,8 +98,7 @@ public class AuthSessionCache implements AutoCloseable {
         cache.cleanUp();
       }
     } finally {
-      if (executor instanceof ExecutorService) {
-        ExecutorService service = (ExecutorService) executor;
+      if (executor instanceof ExecutorService service) {
         service.shutdown();
         if (!Uninterruptibles.awaitTerminationUninterruptibly(service, 10, TimeUnit.SECONDS)) {
           LOG.warn("Timed out waiting for eviction executor to terminate");

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -291,15 +291,19 @@ public class OAuth2Util {
     Preconditions.checkNotNull(credential, "Invalid credential: null");
     List<String> parts = CREDENTIAL_SPLITTER.splitToList(credential);
     switch (parts.size()) {
-      case 2:
-        // client ID and client secret
+      case 2 ->
+      // client ID and client secret
+      {
         return Pair.of(parts.get(0), parts.get(1));
-      case 1:
-        // client secret
+      }
+      case 1 ->
+      // client secret
+      {
         return Pair.of(null, parts.get(0));
-      default:
-        // this should never happen because the credential splitter is limited to 2
-        throw new IllegalArgumentException("Invalid credential: " + credential);
+      }
+      default ->
+          // this should never happen because the credential splitter is limited to 2
+          throw new IllegalArgumentException("Invalid credential: " + credential);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/schema/SchemaWithPartnerVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/schema/SchemaWithPartnerVisitor.java
@@ -48,7 +48,7 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
   public static <P, T> T visit(
       Type type, P partner, SchemaWithPartnerVisitor<P, T> visitor, PartnerAccessors<P> accessors) {
     switch (type.typeId()) {
-      case STRUCT:
+      case STRUCT -> {
         Types.StructType struct = type.asNestedType().asStructType();
         List<T> results = Lists.newArrayListWithExpectedSize(struct.fields().size());
         for (Types.NestedField field : struct.fields()) {
@@ -66,8 +66,9 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
           results.add(visitor.field(field, fieldPartner, result));
         }
         return visitor.struct(struct, partner, results);
+      }
 
-      case LIST:
+      case LIST -> {
         Types.ListType list = type.asNestedType().asListType();
         T elementResult;
 
@@ -81,8 +82,9 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
         }
 
         return visitor.list(list, partner, elementResult);
+      }
 
-      case MAP:
+      case MAP -> {
         Types.MapType map = type.asNestedType().asMapType();
         T keyResult;
         T valueResult;
@@ -106,12 +108,15 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
         }
 
         return visitor.map(map, partner, keyResult, valueResult);
+      }
 
-      case VARIANT:
+      case VARIANT -> {
         return visitor.variant(type.asVariantType(), partner);
+      }
 
-      default:
+      default -> {
         return visitor.primitive(type.asPrimitiveType(), partner);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/stats/BaseContentStats.java
+++ b/core/src/main/java/org/apache/iceberg/stats/BaseContentStats.java
@@ -181,11 +181,10 @@ public class BaseContentStats implements ContentStats, Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof BaseContentStats)) {
+    if (!(o instanceof BaseContentStats that)) {
       return false;
     }
 
-    BaseContentStats that = (BaseContentStats) o;
     return Objects.equals(fieldStats, that.fieldStats)
         && Objects.equals(statsStruct, that.statsStruct);
   }

--- a/core/src/main/java/org/apache/iceberg/stats/BaseFieldStats.java
+++ b/core/src/main/java/org/apache/iceberg/stats/BaseFieldStats.java
@@ -102,9 +102,9 @@ public class BaseFieldStats<T> implements FieldStats<T>, Serializable {
     if (bound instanceof CharBuffer) {
       // CharBuffer is not serializable, use String instead
       return (T) bound.toString();
-    } else if (bound instanceof ByteBuffer) {
+    } else if (bound instanceof ByteBuffer byteBuffer) {
       // ByteBuffer is not serializable, use byte[] instead
-      return (T) ByteBuffers.toByteArray((ByteBuffer) bound);
+      return (T) ByteBuffers.toByteArray(byteBuffer);
     }
 
     return bound;
@@ -115,10 +115,10 @@ public class BaseFieldStats<T> implements FieldStats<T>, Serializable {
   public T lowerBound() {
     if (null != type
         && type.typeId().javaClass().equals(ByteBuffer.class)
-        && lowerBound instanceof byte[]) {
+        && lowerBound instanceof byte[] lowerBytes) {
       // for serializability we store binary types as byte[] and must convert back to
       // ByteBuffer
-      return (T) ByteBuffer.wrap((byte[]) lowerBound);
+      return (T) ByteBuffer.wrap(lowerBytes);
     } else {
       return lowerBound;
     }
@@ -129,10 +129,10 @@ public class BaseFieldStats<T> implements FieldStats<T>, Serializable {
   public T upperBound() {
     if (null != type
         && type.typeId().javaClass().equals(ByteBuffer.class)
-        && upperBound instanceof byte[]) {
+        && upperBound instanceof byte[] upperBytes) {
       // for serializability we store binary types as byte[] and must convert back to
       // ByteBuffer
-      return (T) ByteBuffer.wrap((byte[]) upperBound);
+      return (T) ByteBuffer.wrap(upperBytes);
     } else {
       return upperBound;
     }

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -316,8 +316,8 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
     @Override
     public void close() throws IOException {
       iterator = null;
-      if (input instanceof Closeable) {
-        ((Closeable) input).close();
+      if (input instanceof Closeable closeable) {
+        closeable.close();
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/PartitionMap.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionMap.java
@@ -200,11 +200,11 @@ public class PartitionMap<V> extends AbstractMap<Pair<Integer, StructLike>, V> {
   }
 
   private <R> R execute(Object key, BiFunction<Integer, StructLike, R> action, R defaultValue) {
-    if (key instanceof Pair) {
-      Object first = ((Pair<?, ?>) key).first();
-      Object second = ((Pair<?, ?>) key).second();
-      if (first instanceof Integer && (second == null || second instanceof StructLike)) {
-        return action.apply((Integer) first, (StructLike) second);
+    if (key instanceof Pair<?, ?> pair) {
+      Object first = pair.first();
+      Object second = pair.second();
+      if (first instanceof Integer specId && (second == null || second instanceof StructLike)) {
+        return action.apply(specId, (StructLike) second);
       }
     } else if (key == null) {
       throw new NullPointerException(getClass().getName() + " does not support null keys");

--- a/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
@@ -60,11 +60,11 @@ public class PartitionSet extends AbstractSet<Pair<Integer, StructLike>> {
 
   @Override
   public boolean contains(Object o) {
-    if (o instanceof Pair) {
-      Object first = ((Pair<?, ?>) o).first();
-      Object second = ((Pair<?, ?>) o).second();
-      if (first instanceof Integer && (second == null || second instanceof StructLike)) {
-        return contains((Integer) first, (StructLike) second);
+    if (o instanceof Pair<?, ?> pair) {
+      Object first = pair.first();
+      Object second = pair.second();
+      if (first instanceof Integer specId && (second == null || second instanceof StructLike)) {
+        return contains(specId, (StructLike) second);
       }
     }
 
@@ -95,11 +95,11 @@ public class PartitionSet extends AbstractSet<Pair<Integer, StructLike>> {
 
   @Override
   public boolean remove(Object o) {
-    if (o instanceof Pair) {
-      Object first = ((Pair<?, ?>) o).first();
-      Object second = ((Pair<?, ?>) o).second();
-      if (first instanceof Integer && (second == null || second instanceof StructLike)) {
-        return remove((Integer) first, (StructLike) second);
+    if (o instanceof Pair<?, ?> pair) {
+      Object first = pair.first();
+      Object second = pair.second();
+      if (first instanceof Integer specId && (second == null || second instanceof StructLike)) {
+        return remove(specId, (StructLike) second);
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
@@ -56,8 +56,8 @@ public class SerializationUtil {
    */
   public static byte[] serializeToBytes(
       Object obj, Function<Configuration, SerializableSupplier<Configuration>> confSerializer) {
-    if (obj instanceof HadoopConfigurable) {
-      ((HadoopConfigurable) obj).serializeConfWith(confSerializer);
+    if (obj instanceof HadoopConfigurable hadoopConfigurable) {
+      hadoopConfigurable.serializeConfWith(confSerializer);
     }
 
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/core/src/main/java/org/apache/iceberg/util/SortedMerge.java
+++ b/core/src/main/java/org/apache/iceberg/util/SortedMerge.java
@@ -126,9 +126,9 @@ public class SortedMerge<T> extends CloseableGroup implements CloseableIterable<
     }
 
     private void close(Iterator<?> iter) {
-      if (iter instanceof Closeable) {
+      if (iter instanceof Closeable closeable) {
         try {
-          ((Closeable) iter).close();
+          closeable.close();
         } catch (IOException e) {
           throw new UncheckedIOException(e);
         }

--- a/core/src/main/java/org/apache/iceberg/util/StructLikeUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeUtil.java
@@ -41,8 +41,8 @@ public class StructLikeUtil {
       for (int i = 0; i < values.length; i += 1) {
         Object value = toCopy.get(i, Object.class);
 
-        if (value instanceof StructLike) {
-          values[i] = copy((StructLike) value);
+        if (value instanceof StructLike structLike) {
+          values[i] = copy(structLike);
         } else {
           values[i] = value;
         }

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -500,11 +500,11 @@ public class Tasks {
 
           } catch (ExecutionException e) {
             Throwable cause = e.getCause();
-            if (cause instanceof Error) {
+            if (cause instanceof Error error) {
               for (Throwable t : uncaught) {
                 cause.addSuppressed(t);
               }
-              throw (Error) cause;
+              throw error;
             }
 
             if (cause != null) {

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -60,10 +60,10 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
   private ByteBuffer buffer = null;
 
   PrimitiveWrapper(PhysicalType type, T value) {
-    if (value instanceof Boolean
+    if (value instanceof Boolean boolValue
         && (type == PhysicalType.BOOLEAN_TRUE || type == PhysicalType.BOOLEAN_FALSE)) {
       // set the boolean type from the value so that callers can use BOOLEAN_* interchangeably
-      this.type = ((Boolean) value) ? PhysicalType.BOOLEAN_TRUE : PhysicalType.BOOLEAN_FALSE;
+      this.type = boolValue ? PhysicalType.BOOLEAN_TRUE : PhysicalType.BOOLEAN_FALSE;
     } else {
       this.type = type;
     }
@@ -82,113 +82,110 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
 
   @Override
   public int sizeInBytes() {
-    switch (type()) {
-      case NULL:
-      case BOOLEAN_TRUE:
-      case BOOLEAN_FALSE:
-        return 1; // 1 header only
-      case INT8:
-        return 2; // 1 header + 1 value
-      case INT16:
-        return 3; // 1 header + 2 value
-      case INT32:
-      case DATE:
-      case FLOAT:
-        return 5; // 1 header + 4 value
-      case INT64:
-      case DOUBLE:
-      case TIMESTAMPTZ:
-      case TIMESTAMPNTZ:
-      case TIMESTAMPTZ_NANOS:
-      case TIMESTAMPNTZ_NANOS:
-      case TIME:
-        return 9; // 1 header + 8 value
-      case DECIMAL4:
-        return 6; // 1 header + 1 scale + 4 unscaled value
-      case DECIMAL8:
-        return 10; // 1 header + 1 scale + 8 unscaled value
-      case DECIMAL16:
-        return 18; // 1 header + 1 scale + 16 unscaled value
-      case BINARY:
-        return 5 + ((ByteBuffer) value).remaining(); // 1 header + 4 length + value length
-      case STRING:
+    return switch (type()) {
+      case NULL, BOOLEAN_TRUE, BOOLEAN_FALSE -> 1; // 1 header only
+      case INT8 -> 2; // 1 header + 1 value
+      case INT16 -> 3; // 1 header + 2 value
+      case INT32, DATE, FLOAT -> 5; // 1 header + 4 value
+      case INT64, DOUBLE, TIMESTAMPTZ, TIMESTAMPNTZ, TIMESTAMPTZ_NANOS, TIMESTAMPNTZ_NANOS, TIME ->
+          9; // 1 header + 8 value
+      case DECIMAL4 -> 6; // 1 header + 1 scale + 4 unscaled value
+      case DECIMAL8 -> 10; // 1 header + 1 scale + 8 unscaled value
+      case DECIMAL16 -> 18; // 1 header + 1 scale + 16 unscaled value
+      case BINARY -> 5 + ((ByteBuffer) value).remaining(); // 1 header + 4 length + value length
+      case STRING -> {
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
-        if (buffer.remaining() <= MAX_SHORT_STRING_LENGTH) {
-          return 1 + buffer.remaining(); // 1 header + value length
-        }
-        return 5 + buffer.remaining(); // 1 header + 4 length + value length
-      case UUID:
-        return 1 + 16; // 1 header + 16 length
-    }
 
-    throw new UnsupportedOperationException("Unsupported primitive type: " + type());
+        if (buffer.remaining() <= MAX_SHORT_STRING_LENGTH) {
+          yield 1 + buffer.remaining(); // 1 header + value length
+        }
+
+        yield 5 + buffer.remaining(); // 1 header + 4 length + value length
+      }
+      case UUID -> 1 + 16; // 1 header + 16 length
+      default -> throw new UnsupportedOperationException("Unsupported primitive type: " + type());
+    };
   }
 
   @Override
   public int writeTo(ByteBuffer outBuffer, int offset) {
     Preconditions.checkArgument(
         outBuffer.order() == ByteOrder.LITTLE_ENDIAN, "Invalid byte order: big endian");
-    switch (type()) {
-      case NULL:
+    return switch (type()) {
+      case NULL -> {
         outBuffer.put(offset, NULL_HEADER);
-        return 1;
-      case BOOLEAN_TRUE:
+        yield 1;
+      }
+      case BOOLEAN_TRUE -> {
         outBuffer.put(offset, TRUE_HEADER);
-        return 1;
-      case BOOLEAN_FALSE:
+        yield 1;
+      }
+      case BOOLEAN_FALSE -> {
         outBuffer.put(offset, FALSE_HEADER);
-        return 1;
-      case INT8:
+        yield 1;
+      }
+      case INT8 -> {
         outBuffer.put(offset, INT8_HEADER);
         outBuffer.put(offset + 1, (Byte) value);
-        return 2;
-      case INT16:
+        yield 2;
+      }
+      case INT16 -> {
         outBuffer.put(offset, INT16_HEADER);
         outBuffer.putShort(offset + 1, (Short) value);
-        return 3;
-      case INT32:
+        yield 3;
+      }
+      case INT32 -> {
         outBuffer.put(offset, INT32_HEADER);
         outBuffer.putInt(offset + 1, (Integer) value);
-        return 5;
-      case INT64:
+        yield 5;
+      }
+      case INT64 -> {
         outBuffer.put(offset, INT64_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
-      case FLOAT:
+        yield 9;
+      }
+      case FLOAT -> {
         outBuffer.put(offset, FLOAT_HEADER);
         outBuffer.putFloat(offset + 1, (Float) value);
-        return 5;
-      case DOUBLE:
+        yield 5;
+      }
+      case DOUBLE -> {
         outBuffer.put(offset, DOUBLE_HEADER);
         outBuffer.putDouble(offset + 1, (Double) value);
-        return 9;
-      case DATE:
+        yield 9;
+      }
+      case DATE -> {
         outBuffer.put(offset, DATE_HEADER);
         outBuffer.putInt(offset + 1, (Integer) value);
-        return 5;
-      case TIMESTAMPTZ:
+        yield 5;
+      }
+      case TIMESTAMPTZ -> {
         outBuffer.put(offset, TIMESTAMPTZ_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
-      case TIMESTAMPNTZ:
+        yield 9;
+      }
+      case TIMESTAMPNTZ -> {
         outBuffer.put(offset, TIMESTAMPNTZ_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
-      case DECIMAL4:
+        yield 9;
+      }
+      case DECIMAL4 -> {
         BigDecimal decimal4 = (BigDecimal) value;
         outBuffer.put(offset, DECIMAL4_HEADER);
         outBuffer.put(offset + 1, (byte) decimal4.scale());
         outBuffer.putInt(offset + 2, decimal4.unscaledValue().intValueExact());
-        return 6;
-      case DECIMAL8:
+        yield 6;
+      }
+      case DECIMAL8 -> {
         BigDecimal decimal8 = (BigDecimal) value;
         outBuffer.put(offset, DECIMAL8_HEADER);
         outBuffer.put(offset + 1, (byte) decimal8.scale());
         outBuffer.putLong(offset + 2, decimal8.unscaledValue().longValueExact());
-        return 10;
-      case DECIMAL16:
+        yield 10;
+      }
+      case DECIMAL16 -> {
         BigDecimal decimal16 = (BigDecimal) value;
         byte padding = (byte) (decimal16.signum() < 0 ? 0xFF : 0x00);
         byte[] bytes = decimal16.unscaledValue().toByteArray();
@@ -203,47 +200,55 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
             outBuffer.put(offset + 2 + i, padding);
           }
         }
-        return 18;
-      case BINARY:
+
+        yield 18;
+      }
+      case BINARY -> {
         ByteBuffer binary = (ByteBuffer) value;
         outBuffer.put(offset, BINARY_HEADER);
         outBuffer.putInt(offset + 1, binary.remaining());
         VariantUtil.writeBufferAbsolute(outBuffer, offset + 5, binary);
-        return 5 + binary.remaining();
-      case STRING:
+        yield 5 + binary.remaining();
+      }
+      case STRING -> {
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
+
         if (buffer.remaining() <= MAX_SHORT_STRING_LENGTH) {
           outBuffer.put(offset, VariantUtil.shortStringHeader(buffer.remaining()));
           VariantUtil.writeBufferAbsolute(outBuffer, offset + 1, buffer);
-          return 1 + buffer.remaining();
+          yield 1 + buffer.remaining();
         } else {
           outBuffer.put(offset, STRING_HEADER);
           outBuffer.putInt(offset + 1, buffer.remaining());
           VariantUtil.writeBufferAbsolute(outBuffer, offset + 5, buffer);
-          return 5 + buffer.remaining();
+          yield 5 + buffer.remaining();
         }
-      case TIME:
+      }
+      case TIME -> {
         outBuffer.put(offset, TIME_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
-      case TIMESTAMPTZ_NANOS:
+        yield 9;
+      }
+      case TIMESTAMPTZ_NANOS -> {
         outBuffer.put(offset, TIMESTAMPTZ_NANOS_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
-      case TIMESTAMPNTZ_NANOS:
+        yield 9;
+      }
+      case TIMESTAMPNTZ_NANOS -> {
         outBuffer.put(offset, TIMESTAMPNTZ_NANOS_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
-      case UUID:
+        yield 9;
+      }
+      case UUID -> {
         outBuffer.put(offset, UUID_HEADER);
         VariantUtil.writeBufferAbsolute(
             outBuffer, offset + 1, UUIDUtil.convertToByteBuffer((UUID) value));
-        return 17;
-    }
-
-    throw new UnsupportedOperationException("Unsupported primitive type: " + type());
+        yield 17;
+      }
+      default -> throw new UnsupportedOperationException("Unsupported primitive type: " + type());
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
@@ -164,9 +164,7 @@ public class ShreddedObject implements VariantObject {
       int totalDataSize = 0;
       // get the unshredded field names and values as byte buffers
       ImmutableMap.Builder<String, ByteBuffer> unshreddedBuilder = ImmutableMap.builder();
-      if (unshredded instanceof SerializedObject) {
-        // for serialized objects, use existing buffers instead of materializing values
-        SerializedObject serialized = (SerializedObject) unshredded;
+      if (unshredded instanceof SerializedObject serialized) {
         for (Map.Entry<String, Integer> field : serialized.fields()) {
           // if the value is replaced by an unshredded field, don't include it
           String name = field.getKey();

--- a/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
@@ -47,8 +47,8 @@ public class VariantVisitor<R> {
   }
 
   public static <R> R visit(VariantValue value, VariantVisitor<R> visitor) {
-    switch (value.type()) {
-      case ARRAY:
+    return switch (value.type()) {
+      case ARRAY -> {
         VariantArray array = value.asArray();
         List<R> elementResults = Lists.newArrayList();
         for (int index = 0; index < array.numElements(); index += 1) {
@@ -60,9 +60,9 @@ public class VariantVisitor<R> {
           }
         }
 
-        return visitor.array(array, elementResults);
-
-      case OBJECT:
+        yield visitor.array(array, elementResults);
+      }
+      case OBJECT -> {
         VariantObject object = value.asObject();
         List<String> fieldNames = Lists.newArrayList();
         List<R> fieldResults = Lists.newArrayList();
@@ -76,10 +76,9 @@ public class VariantVisitor<R> {
           }
         }
 
-        return visitor.object(object, fieldNames, fieldResults);
-
-      default:
-        return visitor.primitive(value.asPrimitive());
-    }
+        yield visitor.object(object, fieldNames, fieldResults);
+      }
+      default -> visitor.primitive(value.asPrimitive());
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/Variants.java
+++ b/core/src/main/java/org/apache/iceberg/variants/Variants.java
@@ -108,10 +108,10 @@ public class Variants {
   }
 
   public static ShreddedObject object(VariantObject object) {
-    if (object instanceof ShreddedObject) {
-      return new ShreddedObject(((ShreddedObject) object).metadata(), object);
-    } else if (object instanceof SerializedObject) {
-      return new ShreddedObject(((SerializedObject) object).metadata(), object);
+    if (object instanceof ShreddedObject shreddedObject) {
+      return new ShreddedObject(shreddedObject.metadata(), object);
+    } else if (object instanceof SerializedObject serializedObject) {
+      return new ShreddedObject(serializedObject.metadata(), object);
     }
 
     throw new UnsupportedOperationException("Metadata is required for object: " + object);

--- a/core/src/main/java/org/apache/iceberg/view/BaseView.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseView.java
@@ -116,8 +116,7 @@ public class BaseView implements View, Serializable {
     Preconditions.checkArgument(!dialect.isEmpty(), "Invalid dialect: (empty string)");
     SQLViewRepresentation closest = null;
     for (ViewRepresentation representation : currentVersion().representations()) {
-      if (representation instanceof SQLViewRepresentation) {
-        SQLViewRepresentation sqlViewRepresentation = (SQLViewRepresentation) representation;
+      if (representation instanceof SQLViewRepresentation sqlViewRepresentation) {
         if (sqlViewRepresentation.dialect().equalsIgnoreCase(dialect)) {
           return sqlViewRepresentation;
         } else if (closest == null) {

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
@@ -306,8 +306,7 @@ public interface ViewMetadata extends Serializable {
 
       Set<String> dialects = Sets.newHashSet();
       for (ViewRepresentation repr : version.representations()) {
-        if (repr instanceof SQLViewRepresentation) {
-          SQLViewRepresentation sql = (SQLViewRepresentation) repr;
+        if (repr instanceof SQLViewRepresentation sql) {
           Preconditions.checkArgument(
               dialects.add(sql.dialect().toLowerCase(Locale.ROOT)),
               "Invalid view version: Cannot add multiple queries for dialect %s",
@@ -568,8 +567,7 @@ public interface ViewMetadata extends Serializable {
     private Set<String> sqlDialectsFor(ViewVersion viewVersion) {
       Set<String> dialects = Sets.newHashSet();
       for (ViewRepresentation repr : viewVersion.representations()) {
-        if (repr instanceof SQLViewRepresentation) {
-          SQLViewRepresentation sql = (SQLViewRepresentation) repr;
+        if (repr instanceof SQLViewRepresentation sql) {
           dialects.add(sql.dialect().toLowerCase(Locale.ROOT));
         }
       }

--- a/core/src/main/java/org/apache/iceberg/view/ViewRepresentationParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewRepresentationParser.java
@@ -34,14 +34,12 @@ class ViewRepresentationParser {
       throws IOException {
     Preconditions.checkArgument(representation != null, "Invalid view representation: null");
     switch (representation.type().toLowerCase(Locale.ENGLISH)) {
-      case ViewRepresentation.Type.SQL:
-        SQLViewRepresentationParser.toJson((SQLViewRepresentation) representation, generator);
-        break;
-
-      default:
-        throw new UnsupportedOperationException(
-            String.format(
-                "Cannot serialize unsupported view representation: %s", representation.type()));
+      case ViewRepresentation.Type.SQL ->
+          SQLViewRepresentationParser.toJson((SQLViewRepresentation) representation, generator);
+      default ->
+          throw new UnsupportedOperationException(
+              String.format(
+                  "Cannot serialize unsupported view representation: %s", representation.type()));
     }
   }
 
@@ -58,12 +56,9 @@ class ViewRepresentationParser {
     Preconditions.checkArgument(
         node.isObject(), "Cannot parse view representation from non-object: %s", node);
     String type = JsonUtil.getString(TYPE, node).toLowerCase(Locale.ENGLISH);
-    switch (type) {
-      case ViewRepresentation.Type.SQL:
-        return SQLViewRepresentationParser.fromJson(node);
-
-      default:
-        return ImmutableUnknownViewRepresentation.builder().type(type).build();
-    }
+    return switch (type) {
+      case ViewRepresentation.Type.SQL -> SQLViewRepresentationParser.fromJson(node);
+      default -> ImmutableUnknownViewRepresentation.builder().type(type).build();
+    };
   }
 }


### PR DESCRIPTION
This gets rid of 257 warnings in the build of iceberg-core, all of them caused by these two ErrorProne rules:

- StatementSwitchToExpressionSwitch: https://errorprone.info/bugpattern/StatementSwitchToExpressionSwitch
- PatternMatchingInstanceof: https://errorprone.info/bugpattern/PatternMatchingInstanceof

After these changes, there are no warnings left in iceberg-core. 

Overall, these changes make the code more readable and less error-prone, e.g. no more casts after `instanceof`, no more forgetting `break` statements in switch statements, switch expressions are exhaustive by default.