### PR TITLE
Rely - Rename read.identifier-fields.rely to identifier-fields.rely

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -252,9 +252,9 @@ public class TableProperties {
    * query engines for optimization purposes (e.g. eliminating redundant joins or distinct). This is
    * not enforced at write time and does not validate existing data.
    */
-  public static final String READ_IDENTIFIER_FIELDS_RELY = "read.identifier-fields.rely";
+  public static final String IDENTIFIER_FIELDS_RELY = "identifier-fields.rely";
 
-  public static final boolean READ_IDENTIFIER_FIELDS_RELY_DEFAULT = false;
+  public static final boolean IDENTIFIER_FIELDS_RELY_DEFAULT = false;
 
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -361,8 +361,8 @@ public class SparkReadConf {
     return confParser
         .booleanConf()
         .sessionConf(SparkSQLProperties.IDENTIFIER_FIELDS_RELY)
-        .tableProperty(TableProperties.READ_IDENTIFIER_FIELDS_RELY)
-        .defaultValue(TableProperties.READ_IDENTIFIER_FIELDS_RELY_DEFAULT)
+        .tableProperty(TableProperties.IDENTIFIER_FIELDS_RELY)
+        .defaultValue(TableProperties.IDENTIFIER_FIELDS_RELY_DEFAULT)
         .parse();
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -74,7 +74,7 @@ public class TestSparkTable extends CatalogTestBase {
     // enabling rely without identifier fields still produces no primary key
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
-        tableName, TableProperties.READ_IDENTIFIER_FIELDS_RELY);
+        tableName, TableProperties.IDENTIFIER_FIELDS_RELY);
     sparkTable = loadSparkTable();
     assertThat(primaryKeys(sparkTable)).isEmpty();
   }
@@ -91,7 +91,7 @@ public class TestSparkTable extends CatalogTestBase {
 
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
-        tableName, TableProperties.READ_IDENTIFIER_FIELDS_RELY);
+        tableName, TableProperties.IDENTIFIER_FIELDS_RELY);
 
     sparkTable = loadSparkTable();
     List<PrimaryKey> pks = primaryKeys(sparkTable);
@@ -110,7 +110,7 @@ public class TestSparkTable extends CatalogTestBase {
     // disabling rely removes the primary key
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'false')",
-        tableName, TableProperties.READ_IDENTIFIER_FIELDS_RELY);
+        tableName, TableProperties.IDENTIFIER_FIELDS_RELY);
     sparkTable = loadSparkTable();
     assertThat(primaryKeys(sparkTable)).isEmpty();
   }
@@ -137,7 +137,7 @@ public class TestSparkTable extends CatalogTestBase {
     // session conf rely=false overrides table property rely=true
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
-        tableName, TableProperties.READ_IDENTIFIER_FIELDS_RELY);
+        tableName, TableProperties.IDENTIFIER_FIELDS_RELY);
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.IDENTIFIER_FIELDS_RELY, "false"),
         () -> assertThat(primaryKeys(loadSparkTable())).isEmpty());


### PR DESCRIPTION
This is a follow-up to https://github.com/apache/iceberg/pull/15372. It addresses @aokolnychyi's [last suggestion](https://github.com/apache/iceberg/pull/15372/files#r1975826459) to drop the read. prefix from the table property, renaming read.identifier-fields.rely to identifier-fields.rely.

As Anton pointed out, the property is exposed on Table#constraints where we don't know whether the table will be used for reads or writes, so the read. prefix is unnecessarily restrictive.