### PR TITLE
Build, Kafka-Connect: Disable publishing for empty grouping project

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-// duplicate artifact coordinates with the nested subproject, disable publishing...
+// disable publishing from empty grouping project
 afterEvaluate {
   tasks.matching { it.group == 'publishing' }.each { it.enabled = false }
 }


### PR DESCRIPTION
Running into publish issue with `org.apache.iceberg:iceberg-kafka-connect` as I realized there's name collision in top level and nested project. Disabled top level one here to allow a happy publish 

- top level: https://github.com/apache/iceberg/blob/main/settings.gradle#L192
- nested: https://github.com/apache/iceberg/blob/main/settings.gradle#L200


CC @bryanck @amogh-jahagirdar @huaxingao 


Local test to verify the new behavior
```sh
$ ./gradlew :iceberg-kafka-connect:publishToMavenLocal :iceberg-kafka-connect:iceberg-kafka-connect:publishToMavenLocal 2>&1 | grep -E "(publishApache|publishTo|SKIPPED|disabled)" 

> Task :iceberg-kafka-connect:generatePomFileForApachePublication SKIPPED
> Task :iceberg-kafka-connect:generateMetadataFileForApachePublication SKIPPED
> Task :iceberg-kafka-connect:publishApachePublicationToMavenLocal SKIPPED
> Task :iceberg-kafka-connect:publishToMavenLocal SKIPPED
> Task :iceberg-kafka-connect:iceberg-kafka-connect:publishApachePublicationToMavenLocal
> Task :iceberg-kafka-connect:iceberg-kafka-connect:publishToMavenLocal
```