### PR TITLE
Core: Expose HostnameVerificationPolicy in TLSConfigurer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -399,6 +399,7 @@ project(':iceberg-core') {
       exclude group: 'junit'
     }
     testImplementation libs.awaitility
+    testImplementation libs.bouncycastle.bcpkix
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -399,6 +399,10 @@ project(':iceberg-core') {
       exclude group: 'junit'
     }
     testImplementation libs.awaitility
+
+    // Lock BouncyCastle versions to avoid version mismatches
+    // when these dependencies are added transitively.
+    // Required for TLS tests with MockServer.
     testImplementation libs.bouncycastle.bcpkix
     testImplementation libs.bouncycastle.bcutil
     testImplementation libs.bouncycastle.bcprov

--- a/build.gradle
+++ b/build.gradle
@@ -400,6 +400,8 @@ project(':iceberg-core') {
     }
     testImplementation libs.awaitility
     testImplementation libs.bouncycastle.bcpkix
+    testImplementation libs.bouncycastle.bcutil
+    testImplementation libs.bouncycastle.bcprov
   }
 }
 

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -416,6 +416,7 @@ public class HTTPClient extends BaseHTTPClient {
               tlsConfigurer.supportedProtocols(),
               tlsConfigurer.supportedCipherSuites(),
               SSLBufferMode.STATIC,
+              tlsConfigurer.hostnameVerificationPolicy(),
               tlsConfigurer.hostnameVerifier()));
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import javax.net.ssl.HostnameVerifier;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -43,6 +44,7 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuil
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
@@ -410,14 +412,19 @@ public class HTTPClient extends BaseHTTPClient {
 
     TLSConfigurer tlsConfigurer = loadTlsConfigurer(properties);
     if (tlsConfigurer != null) {
+      HostnameVerifier customVerifier = tlsConfigurer.hostnameVerifier();
+      HostnameVerificationPolicy verificationPolicy =
+          customVerifier != null
+              ? HostnameVerificationPolicy.CLIENT
+              : HostnameVerificationPolicy.BUILTIN;
       connectionManagerBuilder.setTlsSocketStrategy(
           new DefaultClientTlsStrategy(
               tlsConfigurer.sslContext(),
               tlsConfigurer.supportedProtocols(),
               tlsConfigurer.supportedCipherSuites(),
               SSLBufferMode.STATIC,
-              tlsConfigurer.hostnameVerificationPolicy(),
-              tlsConfigurer.hostnameVerifier()));
+              verificationPolicy,
+              customVerifier));
     }
 
     return connectionManagerBuilder.build();

--- a/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.rest.auth;
 import java.util.Map;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.HttpsSupport;
 import org.apache.hc.core5.ssl.SSLContexts;
 
@@ -30,6 +31,10 @@ public interface TLSConfigurer {
 
   default SSLContext sslContext() {
     return SSLContexts.createDefault();
+  }
+
+  default HostnameVerificationPolicy hostnameVerificationPolicy() {
+    return HostnameVerificationPolicy.BOTH;
   }
 
   default HostnameVerifier hostnameVerifier() {

--- a/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
@@ -19,10 +19,9 @@
 package org.apache.iceberg.rest.auth;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
-import org.apache.hc.client5.http.ssl.HttpsSupport;
 import org.apache.hc.core5.ssl.SSLContexts;
 
 public interface TLSConfigurer {
@@ -33,12 +32,16 @@ public interface TLSConfigurer {
     return SSLContexts.createDefault();
   }
 
-  default HostnameVerificationPolicy hostnameVerificationPolicy() {
-    return HostnameVerificationPolicy.CLIENT;
-  }
-
+  /**
+   * Returns a custom {@link HostnameVerifier} to use for hostname verification, or {@code null} to
+   * use the default JSSE built-in hostname verifier.
+   *
+   * <p>If a non-null verifier is returned, only the custom verifier is executed and the JSSE
+   * built-in hostname verifier won't be executed.
+   */
+  @Nullable
   default HostnameVerifier hostnameVerifier() {
-    return HttpsSupport.getDefaultHostnameVerifier();
+    return null;
   }
 
   default String[] supportedProtocols() {

--- a/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/TLSConfigurer.java
@@ -34,7 +34,7 @@ public interface TLSConfigurer {
   }
 
   default HostnameVerificationPolicy hostnameVerificationPolicy() {
-    return HostnameVerificationPolicy.BOTH;
+    return HostnameVerificationPolicy.CLIENT;
   }
 
   default HostnameVerifier hostnameVerifier() {

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -35,22 +35,31 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.TLSConfigurer;
 import org.apache.iceberg.rest.responses.ErrorResponse;
@@ -58,14 +67,17 @@ import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockserver.configuration.Configuration;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.logging.MockServerLogger;
 import org.mockserver.matchers.Times;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
+import org.mockserver.socket.tls.KeyStoreFactory;
 import org.mockserver.verify.VerificationTimes;
 
 /**
@@ -393,6 +405,99 @@ public class TestHTTPClient {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Cannot initialize TLSConfigurer")
         .hasMessageContaining("does not implement TLSConfigurer");
+  }
+
+  public static class LaxTLSConfigurer implements TLSConfigurer {
+
+    private static HostnameVerificationPolicy policy = HostnameVerificationPolicy.BUILTIN;
+
+    static void setPolicy(HostnameVerificationPolicy policy) {
+      LaxTLSConfigurer.policy = policy;
+    }
+
+    @Override
+    public SSLContext sslContext() {
+      // Create an SSLContext that trusts MockServer's CA certificate but still performs hostname
+      // verification during SSL handshake
+      try {
+        KeyStore keyStore =
+            new KeyStoreFactory(Configuration.configuration(), new MockServerLogger())
+                .loadOrCreateKeyStore();
+        TrustManagerFactory tmf =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(keyStore);
+        SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+        sslContext.init(null, tmf.getTrustManagers(), null);
+        return sslContext;
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to create SSLContext", e);
+      }
+    }
+
+    @Override
+    public HostnameVerificationPolicy hostnameVerificationPolicy() {
+      return policy;
+    }
+
+    @Override
+    public HostnameVerifier hostnameVerifier() {
+      // Disable hostname verification at HttpClient level (post SSL handshake)
+      return NoopHostnameVerifier.INSTANCE;
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(HostnameVerificationPolicy.class)
+  public void testTLSConfigurerHostnameVerificationPolicy(
+      HostnameVerificationPolicy policy, @TempDir Path temp) throws IOException {
+
+    // Start a dedicated MockServer with a certificate that does NOT include 127.0.0.1 or localhost
+    // in its SANs. Hostname verification must be disabled for this test to pass.
+    Configuration tlsConfig = Configuration.configuration();
+    tlsConfig.proactivelyInitialiseTLS(true);
+    tlsConfig.preventCertificateDynamicUpdate(true);
+    tlsConfig.sslCertificateDomainName("example.com");
+    tlsConfig.sslSubjectAlternativeNameIps(Sets.newHashSet("1.2.3.4"));
+    tlsConfig.sslSubjectAlternativeNameDomains(Sets.newHashSet("example.com"));
+    tlsConfig.directoryToSaveDynamicSSLCertificate(temp.toFile().getAbsolutePath());
+
+    int tlsPort = PORT + 1;
+    try (ClientAndServer server = startClientAndServer(tlsConfig, tlsPort)) {
+
+      String path = "tls/path";
+      HttpRequest mockRequest =
+          request()
+              .withPath("/" + path)
+              .withMethod(HttpMethod.HEAD.name().toUpperCase(Locale.ROOT));
+      HttpResponse mockResponse = response().withStatusCode(200).withBody("TLS response");
+      server.when(mockRequest).respond(mockResponse);
+
+      LaxTLSConfigurer.setPolicy(policy);
+
+      Map<String, String> properties =
+          Map.of(HTTPClient.REST_TLS_CONFIGURER, LaxTLSConfigurer.class.getName());
+
+      try (HTTPClient client =
+          HTTPClient.builder(properties)
+              .uri(String.format("https://127.0.0.1:%d", tlsPort))
+              .withAuthSession(AuthSession.EMPTY)
+              .build()) {
+
+        if (policy == HostnameVerificationPolicy.CLIENT) {
+          // With hostname verification performed by the HttpClient *only*,
+          // the request should succeed
+          assertThatCode(() -> client.head(path, Map.of(), (unused) -> {}))
+              .doesNotThrowAnyException();
+        } else {
+          // With hostname verification performed by the JSSE provider,
+          // the request should fail with a CertificateException
+          assertThatThrownBy(() -> client.head(path, Map.of(), (unused) -> {}))
+              .rootCause()
+              .isInstanceOf(CertificateException.class)
+              .hasMessage("No subject alternative names matching IP address 127.0.0.1 found");
+        }
+      }
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -500,6 +500,79 @@ public class TestHTTPClient {
     }
   }
 
+  /**
+   * A TLSConfigurer that overrides sslContext() and hostnameVerifier() but does NOT override
+   * hostnameVerificationPolicy(), relying on the default (CLIENT). This directly tests that the
+   * default hostname verification policy allows the NoopHostnameVerifier to take effect.
+   */
+  public static class ClientPolicyTLSConfigurer implements TLSConfigurer {
+
+    @Override
+    public SSLContext sslContext() {
+      try {
+        KeyStore keyStore =
+            new KeyStoreFactory(Configuration.configuration(), new MockServerLogger())
+                .loadOrCreateKeyStore();
+        TrustManagerFactory tmf =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(keyStore);
+        SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+        sslContext.init(null, tmf.getTrustManagers(), null);
+        return sslContext;
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to create SSLContext", e);
+      }
+    }
+
+    @Override
+    public HostnameVerifier hostnameVerifier() {
+      return NoopHostnameVerifier.INSTANCE;
+    }
+  }
+
+  @Test
+  public void testTLSConfigurerDefaultHostnameVerificationPolicy(@TempDir Path temp)
+      throws IOException {
+
+    // Start a dedicated MockServer with a certificate that does NOT include 127.0.0.1 or localhost
+    // in its SANs. The default hostname verification policy (CLIENT) should allow the
+    // NoopHostnameVerifier to bypass hostname verification, so the request should succeed.
+    Configuration tlsConfig = Configuration.configuration();
+    tlsConfig.proactivelyInitialiseTLS(true);
+    tlsConfig.preventCertificateDynamicUpdate(true);
+    tlsConfig.sslCertificateDomainName("example.com");
+    tlsConfig.sslSubjectAlternativeNameIps(Sets.newHashSet("1.2.3.4"));
+    tlsConfig.sslSubjectAlternativeNameDomains(Sets.newHashSet("example.com"));
+    tlsConfig.directoryToSaveDynamicSSLCertificate(temp.toFile().getAbsolutePath());
+
+    int tlsPort = PORT + 1;
+    try (ClientAndServer server = startClientAndServer(tlsConfig, tlsPort)) {
+
+      String path = "tls/default-policy/path";
+      HttpRequest mockRequest =
+          request()
+              .withPath("/" + path)
+              .withMethod(HttpMethod.HEAD.name().toUpperCase(Locale.ROOT));
+      HttpResponse mockResponse = response().withStatusCode(200).withBody("TLS response");
+      server.when(mockRequest).respond(mockResponse);
+
+      Map<String, String> properties =
+          Map.of(HTTPClient.REST_TLS_CONFIGURER, ClientPolicyTLSConfigurer.class.getName());
+
+      try (HTTPClient client =
+          HTTPClient.builder(properties)
+              .uri(String.format("https://127.0.0.1:%d", tlsPort))
+              .withAuthSession(AuthSession.EMPTY)
+              .build()) {
+
+        // With the default hostname verification policy (CLIENT) and NoopHostnameVerifier,
+        // the request should succeed even though the certificate SANs don't match 127.0.0.1
+        assertThatCode(() -> client.head(path, Map.of(), (unused) -> {}))
+            .doesNotThrowAnyException();
+      }
+    }
+  }
+
   @Test
   public void testSocketTimeout() throws IOException {
     long socketTimeoutMs = 2000L;

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -98,6 +98,7 @@ public class TestHTTPClient {
   private static RESTClient restClient;
 
   public static class DefaultTLSConfigurer implements TLSConfigurer {
+
     public static int count = 0;
 
     public DefaultTLSConfigurer() {
@@ -106,6 +107,7 @@ public class TestHTTPClient {
   }
 
   public static class TLSConfigurerMissingNoArgCtor implements TLSConfigurer {
+
     TLSConfigurerMissingNoArgCtor(String str) {}
   }
 
@@ -469,32 +471,32 @@ public class TestHTTPClient {
       HttpResponse mockResponse = response().withStatusCode(200).withBody("TLS response");
       server.when(mockRequest).respond(mockResponse);
 
+      // With no custom hostnameVerifier (null), the BUILTIN policy is used automatically,
+      // so the JSSE built-in verifier rejects the connection because the SANs don't match
       try (HTTPClient builtInVerifierClient =
-              HTTPClient.builder(
-                      Map.of(
-                          HTTPClient.REST_TLS_CONFIGURER,
-                          BuiltInHostnameVerifierTLSConfigurer.class.getName()))
-                  .uri(String.format("https://127.0.0.1:%d", tlsPort))
-                  .withAuthSession(AuthSession.EMPTY)
-                  .build();
-          HTTPClient customVerifierClient =
-              HTTPClient.builder(
-                      Map.of(
-                          HTTPClient.REST_TLS_CONFIGURER,
-                          CustomHostnameVerifierTLSConfigurer.class.getName()))
-                  .uri(String.format("https://127.0.0.1:%d", tlsPort))
-                  .withAuthSession(AuthSession.EMPTY)
-                  .build()) {
-
-        // With no custom hostnameVerifier (null), the BUILTIN policy is used automatically,
-        // so the JSSE built-in verifier rejects the connection because the SANs don't match
+          HTTPClient.builder(
+                  Map.of(
+                      HTTPClient.REST_TLS_CONFIGURER,
+                      BuiltInHostnameVerifierTLSConfigurer.class.getName()))
+              .uri(String.format("https://127.0.0.1:%d", tlsPort))
+              .withAuthSession(AuthSession.EMPTY)
+              .build()) {
         assertThatThrownBy(() -> builtInVerifierClient.head(path, Map.of(), (unused) -> {}))
             .rootCause()
             .isInstanceOf(CertificateException.class)
             .hasMessage("No subject alternative names matching IP address 127.0.0.1 found");
+      }
 
-        // With a custom hostnameVerifier (NoopHostnameVerifier), the CLIENT policy is used
-        // automatically, so hostname verification is bypassed and the request succeeds
+      // With a custom hostnameVerifier (NoopHostnameVerifier), the CLIENT policy is used
+      // automatically, so hostname verification is bypassed and the request succeeds
+      try (HTTPClient customVerifierClient =
+          HTTPClient.builder(
+                  Map.of(
+                      HTTPClient.REST_TLS_CONFIGURER,
+                      CustomHostnameVerifierTLSConfigurer.class.getName()))
+              .uri(String.format("https://127.0.0.1:%d", tlsPort))
+              .withAuthSession(AuthSession.EMPTY)
+              .build()) {
         assertThatCode(() -> customVerifierClient.head(path, Map.of(), (unused) -> {}))
             .doesNotThrowAnyException();
       }
@@ -719,6 +721,7 @@ public class TestHTTPClient {
   }
 
   public static class Item implements RESTRequest, RESTResponse {
+
     private Long id;
     private String data;
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -52,7 +52,6 @@ import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
-import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
@@ -407,136 +406,50 @@ public class TestHTTPClient {
         .hasMessageContaining("does not implement TLSConfigurer");
   }
 
-  public static class LaxTLSConfigurer implements TLSConfigurer {
-
-    private static HostnameVerificationPolicy policy = HostnameVerificationPolicy.BUILTIN;
-
-    static void setPolicy(HostnameVerificationPolicy policy) {
-      LaxTLSConfigurer.policy = policy;
-    }
+  /** A TLSConfigurer that relies on the default (built-in) JSSE verifier. */
+  public static class BuiltInHostnameVerifierTLSConfigurer implements TLSConfigurer {
 
     @Override
     public SSLContext sslContext() {
-      // Create an SSLContext that trusts MockServer's CA certificate but still performs hostname
-      // verification during SSL handshake
-      try {
-        KeyStore keyStore =
-            new KeyStoreFactory(Configuration.configuration(), new MockServerLogger())
-                .loadOrCreateKeyStore();
-        TrustManagerFactory tmf =
-            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        tmf.init(keyStore);
-        SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
-        sslContext.init(null, tmf.getTrustManagers(), null);
-        return sslContext;
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to create SSLContext", e);
-      }
-    }
-
-    @Override
-    public HostnameVerificationPolicy hostnameVerificationPolicy() {
-      return policy;
-    }
-
-    @Override
-    public HostnameVerifier hostnameVerifier() {
-      // Disable hostname verification at HttpClient level (post SSL handshake)
-      return NoopHostnameVerifier.INSTANCE;
+      return mockServerSSLContext();
     }
   }
 
-  @ParameterizedTest
-  @EnumSource(HostnameVerificationPolicy.class)
-  public void testTLSConfigurerHostnameVerificationPolicy(
-      HostnameVerificationPolicy policy, @TempDir Path temp) throws IOException {
-
-    // Start a dedicated MockServer with a certificate that does NOT include 127.0.0.1 or localhost
-    // in its SANs. Hostname verification must be disabled for this test to pass.
-    Configuration tlsConfig = Configuration.configuration();
-    tlsConfig.proactivelyInitialiseTLS(true);
-    tlsConfig.preventCertificateDynamicUpdate(true);
-    tlsConfig.sslCertificateDomainName("example.com");
-    tlsConfig.sslSubjectAlternativeNameIps(Sets.newHashSet("1.2.3.4"));
-    tlsConfig.sslSubjectAlternativeNameDomains(Sets.newHashSet("example.com"));
-    tlsConfig.directoryToSaveDynamicSSLCertificate(temp.toFile().getAbsolutePath());
-
-    int tlsPort = PORT + 1;
-    try (ClientAndServer server = startClientAndServer(tlsConfig, tlsPort)) {
-
-      String path = "tls/path";
-      HttpRequest mockRequest =
-          request()
-              .withPath("/" + path)
-              .withMethod(HttpMethod.HEAD.name().toUpperCase(Locale.ROOT));
-      HttpResponse mockResponse = response().withStatusCode(200).withBody("TLS response");
-      server.when(mockRequest).respond(mockResponse);
-
-      LaxTLSConfigurer.setPolicy(policy);
-
-      Map<String, String> properties =
-          Map.of(HTTPClient.REST_TLS_CONFIGURER, LaxTLSConfigurer.class.getName());
-
-      try (HTTPClient client =
-          HTTPClient.builder(properties)
-              .uri(String.format("https://127.0.0.1:%d", tlsPort))
-              .withAuthSession(AuthSession.EMPTY)
-              .build()) {
-
-        if (policy == HostnameVerificationPolicy.CLIENT) {
-          // With hostname verification performed by the HttpClient *only*,
-          // the request should succeed
-          assertThatCode(() -> client.head(path, Map.of(), (unused) -> {}))
-              .doesNotThrowAnyException();
-        } else {
-          // With hostname verification performed by the JSSE provider,
-          // the request should fail with a CertificateException
-          assertThatThrownBy(() -> client.head(path, Map.of(), (unused) -> {}))
-              .rootCause()
-              .isInstanceOf(CertificateException.class)
-              .hasMessage("No subject alternative names matching IP address 127.0.0.1 found");
-        }
-      }
-    }
-  }
-
-  /**
-   * A TLSConfigurer that overrides sslContext() and hostnameVerifier() but does NOT override
-   * hostnameVerificationPolicy(), relying on the default (CLIENT). This directly tests that the
-   * default hostname verification policy allows the NoopHostnameVerifier to take effect.
-   */
-  public static class ClientPolicyTLSConfigurer implements TLSConfigurer {
+  /** A TLSConfigurer that overrides hostnameVerifier() to return a custom verifier. */
+  public static class CustomHostnameVerifierTLSConfigurer implements TLSConfigurer {
 
     @Override
     public SSLContext sslContext() {
-      try {
-        KeyStore keyStore =
-            new KeyStoreFactory(Configuration.configuration(), new MockServerLogger())
-                .loadOrCreateKeyStore();
-        TrustManagerFactory tmf =
-            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        tmf.init(keyStore);
-        SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
-        sslContext.init(null, tmf.getTrustManagers(), null);
-        return sslContext;
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to create SSLContext", e);
-      }
+      return mockServerSSLContext();
     }
 
     @Override
     public HostnameVerifier hostnameVerifier() {
       return NoopHostnameVerifier.INSTANCE;
+    }
+  }
+
+  private static SSLContext mockServerSSLContext() {
+    try {
+      KeyStore keyStore =
+          new KeyStoreFactory(Configuration.configuration(), new MockServerLogger())
+              .loadOrCreateKeyStore();
+      TrustManagerFactory tmf =
+          TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      tmf.init(keyStore);
+      SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+      sslContext.init(null, tmf.getTrustManagers(), null);
+      return sslContext;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create SSLContext", e);
     }
   }
 
   @Test
-  public void testTLSConfigurerDefaultHostnameVerificationPolicy(@TempDir Path temp)
-      throws IOException {
+  public void testTLSConfigurerHostnameVerifier(@TempDir Path temp) throws IOException {
 
-    // Start a dedicated MockServer with a certificate that does NOT include 127.0.0.1 or localhost
-    // in its SANs. The default hostname verification policy (CLIENT) should allow the
-    // NoopHostnameVerifier to bypass hostname verification, so the request should succeed.
+    // Start a dedicated MockServer with a certificate that does NOT include
+    // 127.0.0.1 or localhost in its SANs.
     Configuration tlsConfig = Configuration.configuration();
     tlsConfig.proactivelyInitialiseTLS(true);
     tlsConfig.preventCertificateDynamicUpdate(true);
@@ -548,7 +461,7 @@ public class TestHTTPClient {
     int tlsPort = PORT + 1;
     try (ClientAndServer server = startClientAndServer(tlsConfig, tlsPort)) {
 
-      String path = "tls/default-policy/path";
+      String path = "tls/hostname-verifier/path";
       HttpRequest mockRequest =
           request()
               .withPath("/" + path)
@@ -556,18 +469,33 @@ public class TestHTTPClient {
       HttpResponse mockResponse = response().withStatusCode(200).withBody("TLS response");
       server.when(mockRequest).respond(mockResponse);
 
-      Map<String, String> properties =
-          Map.of(HTTPClient.REST_TLS_CONFIGURER, ClientPolicyTLSConfigurer.class.getName());
+      try (HTTPClient builtInVerifierClient =
+              HTTPClient.builder(
+                      Map.of(
+                          HTTPClient.REST_TLS_CONFIGURER,
+                          BuiltInHostnameVerifierTLSConfigurer.class.getName()))
+                  .uri(String.format("https://127.0.0.1:%d", tlsPort))
+                  .withAuthSession(AuthSession.EMPTY)
+                  .build();
+          HTTPClient customVerifierClient =
+              HTTPClient.builder(
+                      Map.of(
+                          HTTPClient.REST_TLS_CONFIGURER,
+                          CustomHostnameVerifierTLSConfigurer.class.getName()))
+                  .uri(String.format("https://127.0.0.1:%d", tlsPort))
+                  .withAuthSession(AuthSession.EMPTY)
+                  .build()) {
 
-      try (HTTPClient client =
-          HTTPClient.builder(properties)
-              .uri(String.format("https://127.0.0.1:%d", tlsPort))
-              .withAuthSession(AuthSession.EMPTY)
-              .build()) {
+        // With no custom hostnameVerifier (null), the BUILTIN policy is used automatically,
+        // so the JSSE built-in verifier rejects the connection because the SANs don't match
+        assertThatThrownBy(() -> builtInVerifierClient.head(path, Map.of(), (unused) -> {}))
+            .rootCause()
+            .isInstanceOf(CertificateException.class)
+            .hasMessage("No subject alternative names matching IP address 127.0.0.1 found");
 
-        // With the default hostname verification policy (CLIENT) and NoopHostnameVerifier,
-        // the request should succeed even though the certificate SANs don't match 127.0.0.1
-        assertThatCode(() -> client.head(path, Map.of(), (unused) -> {}))
+        // With a custom hostnameVerifier (NoopHostnameVerifier), the CLIENT policy is used
+        // automatically, so hostname verification is bypassed and the request succeeds
+        assertThatCode(() -> customVerifierClient.head(path, Map.of(), (unused) -> {}))
             .doesNotThrowAnyException();
       }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ awaitility = "4.3.0"
 awssdk-bom = "2.42.8"
 azuresdk-bom = "1.3.5"
 awssdk-s3accessgrants = "2.4.1"
+bouncycastle = "1.83"
 bson-ver = "4.11.5"
 caffeine = "2.9.3"
 calcite = "1.41.0"
@@ -111,6 +112,7 @@ awssdk-bom = { module = "software.amazon.awssdk:bom", version.ref = "awssdk-bom"
 awssdk-s3accessgrants = { module = "software.amazon.s3.accessgrants:aws-s3-accessgrants-java-plugin", version.ref = "awssdk-s3accessgrants" }
 azuresdk-bom = { module = "com.azure:azure-sdk-bom", version.ref = "azuresdk-bom" }
 bson = { module = "org.mongodb:bson", version.ref = "bson-ver"}
+bouncycastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }
 calcite-druid = { module = "org.apache.calcite:calcite-druid", version.ref = "calcite" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ awaitility = "4.3.0"
 awssdk-bom = "2.42.8"
 azuresdk-bom = "1.3.5"
 awssdk-s3accessgrants = "2.4.1"
-bouncycastle = "1.83"
+bouncycastle = "1.82"
 bson-ver = "4.11.5"
 caffeine = "2.9.3"
 calcite = "1.41.0"
@@ -113,6 +113,8 @@ awssdk-s3accessgrants = { module = "software.amazon.s3.accessgrants:aws-s3-acces
 azuresdk-bom = { module = "com.azure:azure-sdk-bom", version.ref = "azuresdk-bom" }
 bson = { module = "org.mongodb:bson", version.ref = "bson-ver"}
 bouncycastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcutil = { module = "org.bouncycastle:bcutil-jdk18on", version.ref = "bouncycastle" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }
 calcite-druid = { module = "org.apache.calcite:calcite-druid", version.ref = "calcite" }


### PR DESCRIPTION
Fixes #15598.

This change exposes `HostnameVerificationPolicy` in `TLSConfigurer`. The default policy is set to `CLIENT`.

I also added a unit test that intentionally uses a custom hostname verifier that is incompatible with JSSE hostname verification strategies. Thus, the test cannot pass unless the verification policy is set to `CLIENT`.