### PR TITLE
Core, Spark: Unify bulk deletion

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -39,10 +39,8 @@ import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
-import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.metrics.LoggingMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -52,7 +50,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -440,22 +437,7 @@ public class BaseTransaction implements Transaction {
   }
 
   private void deleteUncommittedFiles(Iterable<String> paths) {
-    if (ops.io() instanceof SupportsBulkOperations) {
-      try {
-        ((SupportsBulkOperations) ops.io()).deleteFiles(paths);
-      } catch (BulkDeletionFailureException e) {
-        LOG.warn(
-            "Failed to delete {} uncommitted files using bulk deletes", e.numberFailedObjects(), e);
-      } catch (RuntimeException e) {
-        LOG.warn("Failed to delete uncommitted files using bulk deletes", e);
-      }
-    } else {
-      Tasks.foreach(paths)
-          .executeWith(ThreadPools.getWorkerPool())
-          .suppressFailureWhenFinished()
-          .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
-          .run(ops.io()::deleteFile);
-    }
+    CatalogUtil.deleteFiles(ops.io(), paths, "uncommitted");
   }
 
   private void applyUpdates(TableOperations underlyingOps) {

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.Configurable;
+import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.io.SupportsBulkOperations;
@@ -129,23 +130,18 @@ public class CatalogUtil {
       deleteFiles(io, manifestsToDelete);
     }
 
-    deleteFiles(io, Iterables.transform(manifestsToDelete, ManifestFile::path), "manifest", true);
-    deleteFiles(io, manifestListsToDelete, "manifest list", true);
+    deleteFiles(io, Iterables.transform(manifestsToDelete, ManifestFile::path), "manifest");
+    deleteFiles(io, manifestListsToDelete, "manifest list");
     deleteFiles(
         io,
         Iterables.transform(metadata.previousFiles(), TableMetadata.MetadataLogEntry::file),
-        "previous metadata",
-        true);
+        "previous metadata");
     deleteFiles(
-        io,
-        Iterables.transform(metadata.statisticsFiles(), StatisticsFile::path),
-        "statistics",
-        true);
+        io, Iterables.transform(metadata.statisticsFiles(), StatisticsFile::path), "statistics");
     deleteFiles(
         io,
         Iterables.transform(metadata.partitionStatisticsFiles(), PartitionStatisticsFile::path),
-        "partition statistics",
-        true);
+        "partition statistics");
     deleteFile(io, metadata.metadataFileLocation(), "metadata");
   }
 
@@ -203,6 +199,18 @@ public class CatalogUtil {
   }
 
   /**
+   * Helper to delete files. Bulk deletion is used if possible, otherwise deletions are done
+   * concurrently for non-bulk FileIO.
+   *
+   * @param io FileIO for deletes
+   * @param files files to delete
+   * @param type type of files being deleted
+   */
+  public static void deleteFiles(FileIO io, Iterable<String> files, String type) {
+    deleteFiles(io, files, type, true);
+  }
+
+  /**
    * Helper to delete files. Bulk deletion is used if possible.
    *
    * @param io FileIO for deletes
@@ -212,28 +220,29 @@ public class CatalogUtil {
    */
   public static void deleteFiles(
       FileIO io, Iterable<String> files, String type, boolean concurrent) {
-    if (io instanceof SupportsBulkOperations) {
+    if (io instanceof SupportsBulkOperations bulkIO) {
       try {
-        SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
         bulkIO.deleteFiles(files);
+      } catch (BulkDeletionFailureException e) {
+        LOG.warn("Failed to bulk delete {} {} files", e.numberFailedObjects(), type, e);
       } catch (RuntimeException e) {
         LOG.warn("Failed to bulk delete {} files", type, e);
       }
     } else {
       if (concurrent) {
-        deleteFiles(io, files, type);
+        concurrentlyDeleteFiles(io, files, type);
       } else {
         files.forEach(file -> deleteFile(io, file, type));
       }
     }
   }
 
-  private static void deleteFiles(FileIO io, Iterable<String> files, String type) {
+  private static void concurrentlyDeleteFiles(FileIO io, Iterable<String> files, String type) {
     Tasks.foreach(files)
         .executeWith(ThreadPools.getWorkerPool())
         .noRetry()
         .suppressFailureWhenFinished()
-        .onFailure((file, exc) -> LOG.warn("Failed to delete {} file {}", type, file, exc))
+        .onFailure((file, exc) -> LOG.warn("Failed to delete {} file: {}", type, file, exc))
         .run(io::deleteFile);
   }
 
@@ -592,8 +601,7 @@ public class CatalogUtil {
           removedPreviousMetadataFiles.stream()
               .map(TableMetadata.MetadataLogEntry::file)
               .collect(Collectors.toSet()),
-          "metadata",
-          true);
+          "metadata");
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -91,7 +91,7 @@ public class RewritePositionDeletesCommitManager {
 
     Iterable<String> filePaths =
         Iterables.transform(fileGroup.addedDeleteFiles(), ContentFile::location);
-    CatalogUtil.deleteFiles(table.io(), filePaths, "position delete", true);
+    CatalogUtil.deleteFiles(table.io(), filePaths, "position delete");
   }
 
   public void commitOrClean(Set<RewritePositionDeletesGroup> rewriteGroups) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -66,7 +67,6 @@ import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -80,8 +80,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -951,15 +949,7 @@ public class SparkTableUtil {
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {
-    if (io instanceof SupportsBulkOperations) {
-      ((SupportsBulkOperations) io).deleteFiles(Lists.transform(manifests, ManifestFile::path));
-    } else {
-      Tasks.foreach(manifests)
-          .executeWith(ThreadPools.getWorkerPool())
-          .noRetry()
-          .suppressFailureWhenFinished()
-          .run(item -> io.deleteFile(item.path()));
-    }
+    CatalogUtil.deleteFiles(io, Lists.transform(manifests, ManifestFile::path), "manifests");
   }
 
   public static Dataset<Row> loadTable(SparkSession spark, Table table, long snapshotId) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.spark.source;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.exceptions.NotFoundException;
-import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -84,31 +84,10 @@ class SparkCleanupUtil {
    */
   public static void deleteFiles(String context, FileIO io, List<? extends ContentFile<?>> files) {
     List<String> paths = Lists.transform(files, ContentFile::location);
-    deletePaths(context, io, paths);
-  }
-
-  private static void deletePaths(String context, FileIO io, List<String> paths) {
     if (io instanceof SupportsBulkOperations) {
-      SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
-      bulkDelete(context, bulkIO, paths);
+      CatalogUtil.deleteFiles(io, paths, "");
     } else {
       delete(context, io, paths);
-    }
-  }
-
-  private static void bulkDelete(String context, SupportsBulkOperations io, List<String> paths) {
-    try {
-      io.deleteFiles(paths);
-      LOG.info("Deleted {} file(s) using bulk deletes ({})", paths.size(), context);
-
-    } catch (BulkDeletionFailureException e) {
-      int deletedFilesCount = paths.size() - e.numberFailedObjects();
-      LOG.warn(
-          "Deleted only {} of {} file(s) using bulk deletes ({})",
-          deletedFilesCount,
-          paths.size(),
-          context,
-          e);
     }
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -66,7 +67,6 @@ import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -80,8 +80,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -951,15 +949,7 @@ public class SparkTableUtil {
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {
-    if (io instanceof SupportsBulkOperations) {
-      ((SupportsBulkOperations) io).deleteFiles(Lists.transform(manifests, ManifestFile::path));
-    } else {
-      Tasks.foreach(manifests)
-          .executeWith(ThreadPools.getWorkerPool())
-          .noRetry()
-          .suppressFailureWhenFinished()
-          .run(item -> io.deleteFile(item.path()));
-    }
+    CatalogUtil.deleteFiles(io, Lists.transform(manifests, ManifestFile::path), "manifests");
   }
 
   public static Dataset<Row> loadTable(SparkSession spark, Table table, long snapshotId) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.spark.source;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.exceptions.NotFoundException;
-import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -84,31 +84,10 @@ class SparkCleanupUtil {
    */
   public static void deleteFiles(String context, FileIO io, List<? extends ContentFile<?>> files) {
     List<String> paths = Lists.transform(files, ContentFile::location);
-    deletePaths(context, io, paths);
-  }
-
-  private static void deletePaths(String context, FileIO io, List<String> paths) {
     if (io instanceof SupportsBulkOperations) {
-      SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
-      bulkDelete(context, bulkIO, paths);
+      CatalogUtil.deleteFiles(io, paths, "");
     } else {
       delete(context, io, paths);
-    }
-  }
-
-  private static void bulkDelete(String context, SupportsBulkOperations io, List<String> paths) {
-    try {
-      io.deleteFiles(paths);
-      LOG.info("Deleted {} file(s) using bulk deletes ({})", paths.size(), context);
-
-    } catch (BulkDeletionFailureException e) {
-      int deletedFilesCount = paths.size() - e.numberFailedObjects();
-      LOG.warn(
-          "Deleted only {} of {} file(s) using bulk deletes ({})",
-          deletedFilesCount,
-          paths.size(),
-          context,
-          e);
     }
   }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -66,7 +67,6 @@ import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -80,8 +80,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -976,15 +974,7 @@ public class SparkTableUtil {
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {
-    if (io instanceof SupportsBulkOperations) {
-      ((SupportsBulkOperations) io).deleteFiles(Lists.transform(manifests, ManifestFile::path));
-    } else {
-      Tasks.foreach(manifests)
-          .executeWith(ThreadPools.getWorkerPool())
-          .noRetry()
-          .suppressFailureWhenFinished()
-          .run(item -> io.deleteFile(item.path()));
-    }
+    CatalogUtil.deleteFiles(io, Lists.transform(manifests, ManifestFile::path), "manifests");
   }
 
   public static Dataset<Row> loadTable(SparkSession spark, Table table, long snapshotId) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.spark.source;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.exceptions.NotFoundException;
-import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -84,31 +84,10 @@ class SparkCleanupUtil {
    */
   public static void deleteFiles(String context, FileIO io, List<? extends ContentFile<?>> files) {
     List<String> paths = Lists.transform(files, ContentFile::location);
-    deletePaths(context, io, paths);
-  }
-
-  private static void deletePaths(String context, FileIO io, List<String> paths) {
     if (io instanceof SupportsBulkOperations) {
-      SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
-      bulkDelete(context, bulkIO, paths);
+      CatalogUtil.deleteFiles(io, paths, "");
     } else {
       delete(context, io, paths);
-    }
-  }
-
-  private static void bulkDelete(String context, SupportsBulkOperations io, List<String> paths) {
-    try {
-      io.deleteFiles(paths);
-      LOG.info("Deleted {} file(s) using bulk deletes ({})", paths.size(), context);
-
-    } catch (BulkDeletionFailureException e) {
-      int deletedFilesCount = paths.size() - e.numberFailedObjects();
-      LOG.warn(
-          "Deleted only {} of {} file(s) using bulk deletes ({})",
-          deletedFilesCount,
-          paths.size(),
-          context,
-          e);
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -65,7 +66,6 @@ import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -79,8 +79,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -975,15 +973,7 @@ public class SparkTableUtil {
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {
-    if (io instanceof SupportsBulkOperations) {
-      ((SupportsBulkOperations) io).deleteFiles(Lists.transform(manifests, ManifestFile::path));
-    } else {
-      Tasks.foreach(manifests)
-          .executeWith(ThreadPools.getWorkerPool())
-          .noRetry()
-          .suppressFailureWhenFinished()
-          .run(item -> io.deleteFile(item.path()));
-    }
+    CatalogUtil.deleteFiles(io, Lists.transform(manifests, ManifestFile::path), "manifests");
   }
 
   public static Dataset<Row> loadTable(SparkSession spark, Table table, long snapshotId) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.spark.source;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.exceptions.NotFoundException;
-import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -84,31 +84,10 @@ class SparkCleanupUtil {
    */
   public static void deleteFiles(String context, FileIO io, List<? extends ContentFile<?>> files) {
     List<String> paths = Lists.transform(files, ContentFile::location);
-    deletePaths(context, io, paths);
-  }
-
-  private static void deletePaths(String context, FileIO io, List<String> paths) {
     if (io instanceof SupportsBulkOperations) {
-      SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
-      bulkDelete(context, bulkIO, paths);
+      CatalogUtil.deleteFiles(io, paths, "");
     } else {
       delete(context, io, paths);
-    }
-  }
-
-  private static void bulkDelete(String context, SupportsBulkOperations io, List<String> paths) {
-    try {
-      io.deleteFiles(paths);
-      LOG.info("Deleted {} file(s) using bulk deletes ({})", paths.size(), context);
-
-    } catch (BulkDeletionFailureException e) {
-      int deletedFilesCount = paths.size() - e.numberFailedObjects();
-      LOG.warn(
-          "Deleted only {} of {} file(s) using bulk deletes ({})",
-          deletedFilesCount,
-          paths.size(),
-          context,
-          e);
     }
   }
 


### PR DESCRIPTION
Noticed that there are a few places that do the same pattern of deletes:
1) check if IO supports `SupportsBulkOperations` and use its deletion functionality
2) fall back to concurrent deletes using worker thread pool

We already have defined the same functionality in `CatalogUtil`, so figured we can unify some of those places into calling the same functionality