### PR TITLE
Docs: Improve json readability in view spec

### DIFF
--- a/format/view-spec.md
+++ b/format/view-spec.md
@@ -188,7 +188,7 @@ The path is intentionally similar to the path for Iceberg tables and uses a `met
 ```
 s3://bucket/warehouse/default.db/event_agg/metadata/00001-(uuid).metadata.json
 ```
-```
+```json
 {
   "view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
   "format-version" : 1,
@@ -257,7 +257,7 @@ Updating the view produces a new metadata file that completely replaces the old:
 ```
 s3://bucket/warehouse/default.db/event_agg/metadata/00002-(uuid).metadata.json
 ```
-```
+```json
 {
   "view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
   "format-version" : 1,


### PR DESCRIPTION
The generated page: 
<img width="872" height="524" alt="Screenshot 2026-03-04 at 16 53 12" src="https://github.com/user-attachments/assets/e700cb3c-8a37-4c3d-9e03-6d66f1521636" />

<img width="888" height="517" alt="Screenshot 2026-03-04 at 16 53 21" src="https://github.com/user-attachments/assets/55bff178-4bd9-4a93-a005-bb4043518ed3" />

The original page: https://iceberg.apache.org/view-spec/#overview