### PR TITLE
AWS: Add proxy system property and environment variable configuration for HTTP clients

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/ApacheHttpClientConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/ApacheHttpClientConfigurations.java
@@ -41,6 +41,8 @@ class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
   private Boolean tcpKeepAliveEnabled;
   private Boolean useIdleConnectionReaperEnabled;
   private String proxyEndpoint;
+  private Boolean proxyUseSystemPropertyValues;
+  private Boolean proxyUseEnvironmentVariableValues;
 
   private ApacheHttpClientConfigurations() {}
 
@@ -82,6 +84,12 @@ class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
     this.proxyEndpoint =
         PropertyUtil.propertyAsString(
             httpClientProperties, HttpClientProperties.PROXY_ENDPOINT, null);
+    this.proxyUseSystemPropertyValues =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpClientProperties, HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES);
+    this.proxyUseEnvironmentVariableValues =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpClientProperties, HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES);
   }
 
   @VisibleForTesting
@@ -113,9 +121,26 @@ class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
     if (useIdleConnectionReaperEnabled != null) {
       apacheHttpClientBuilder.useIdleConnectionReaper(useIdleConnectionReaperEnabled);
     }
-    if (proxyEndpoint != null) {
-      apacheHttpClientBuilder.proxyConfiguration(
-          ProxyConfiguration.builder().endpoint(URI.create(proxyEndpoint)).build());
+    configureProxy(apacheHttpClientBuilder);
+  }
+
+  private void configureProxy(ApacheHttpClient.Builder apacheHttpClientBuilder) {
+    if (proxyEndpoint != null
+        || proxyUseSystemPropertyValues != null
+        || proxyUseEnvironmentVariableValues != null) {
+      ProxyConfiguration.Builder proxyBuilder = ProxyConfiguration.builder();
+
+      if (proxyEndpoint != null) {
+        proxyBuilder.endpoint(URI.create(proxyEndpoint));
+      }
+      if (proxyUseSystemPropertyValues != null) {
+        proxyBuilder.useSystemPropertyValues(proxyUseSystemPropertyValues);
+      }
+      if (proxyUseEnvironmentVariableValues != null) {
+        proxyBuilder.useEnvironmentVariableValues(proxyUseEnvironmentVariableValues);
+      }
+
+      apacheHttpClientBuilder.proxyConfiguration(proxyBuilder.build());
     }
   }
 
@@ -138,6 +163,8 @@ class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
     keyComponents.put("tcpKeepAliveEnabled", tcpKeepAliveEnabled);
     keyComponents.put("useIdleConnectionReaperEnabled", useIdleConnectionReaperEnabled);
     keyComponents.put("proxyEndpoint", proxyEndpoint);
+    keyComponents.put("proxyUseSystemPropertyValues", proxyUseSystemPropertyValues);
+    keyComponents.put("proxyUseEnvironmentVariableValues", proxyUseEnvironmentVariableValues);
 
     return keyComponents.entrySet().stream()
         .map(entry -> entry.getKey() + "=" + Objects.toString(entry.getValue(), "null"))

--- a/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
@@ -62,6 +62,30 @@ public class HttpClientProperties implements Serializable {
   public static final String PROXY_ENDPOINT = "http-client.proxy-endpoint";
 
   /**
+   * Used to enable reading proxy configuration from Java system properties (http.proxyHost,
+   * http.proxyPort, http.nonProxyHosts, etc.). Default is true.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.html
+   * and
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ProxyConfiguration.html
+   */
+  public static final String PROXY_USE_SYSTEM_PROPERTY_VALUES =
+      "http-client.proxy-use-system-property-values";
+
+  /**
+   * Used to enable reading proxy configuration from environment variables (HTTP_PROXY, HTTPS_PROXY,
+   * NO_PROXY, etc.). Default is true.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.html
+   * and
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ProxyConfiguration.html
+   */
+  public static final String PROXY_USE_ENVIRONMENT_VARIABLE_VALUES =
+      "http-client.proxy-use-environment-variable-values";
+
+  /**
    * Used to configure the connection timeout in milliseconds for {@link
    * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder}. This flag only
    * works when {@link #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_URLCONNECTION}

--- a/aws/src/main/java/org/apache/iceberg/aws/UrlConnectionHttpClientConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/UrlConnectionHttpClientConfigurations.java
@@ -35,6 +35,8 @@ class UrlConnectionHttpClientConfigurations extends BaseHttpClientConfigurations
   private Long httpClientUrlConnectionConnectionTimeoutMs;
   private Long httpClientUrlConnectionSocketTimeoutMs;
   private String proxyEndpoint;
+  private Boolean proxyUseSystemPropertyValues;
+  private Boolean proxyUseEnvironmentVariableValues;
 
   private UrlConnectionHttpClientConfigurations() {}
 
@@ -56,6 +58,12 @@ class UrlConnectionHttpClientConfigurations extends BaseHttpClientConfigurations
     this.proxyEndpoint =
         PropertyUtil.propertyAsString(
             httpClientProperties, HttpClientProperties.PROXY_ENDPOINT, null);
+    this.proxyUseSystemPropertyValues =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpClientProperties, HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES);
+    this.proxyUseEnvironmentVariableValues =
+        PropertyUtil.propertyAsNullableBoolean(
+            httpClientProperties, HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES);
   }
 
   @VisibleForTesting
@@ -69,9 +77,26 @@ class UrlConnectionHttpClientConfigurations extends BaseHttpClientConfigurations
       urlConnectionHttpClientBuilder.socketTimeout(
           Duration.ofMillis(httpClientUrlConnectionSocketTimeoutMs));
     }
-    if (proxyEndpoint != null) {
-      urlConnectionHttpClientBuilder.proxyConfiguration(
-          ProxyConfiguration.builder().endpoint(URI.create(proxyEndpoint)).build());
+    configureProxy(urlConnectionHttpClientBuilder);
+  }
+
+  private void configureProxy(UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder) {
+    if (proxyEndpoint != null
+        || proxyUseSystemPropertyValues != null
+        || proxyUseEnvironmentVariableValues != null) {
+      ProxyConfiguration.Builder proxyBuilder = ProxyConfiguration.builder();
+
+      if (proxyEndpoint != null) {
+        proxyBuilder.endpoint(URI.create(proxyEndpoint));
+      }
+      if (proxyUseSystemPropertyValues != null) {
+        proxyBuilder.useSystemPropertyValues(proxyUseSystemPropertyValues);
+      }
+      if (proxyUseEnvironmentVariableValues != null) {
+        proxyBuilder.useEnvironmentVariablesValues(proxyUseEnvironmentVariableValues);
+      }
+
+      urlConnectionHttpClientBuilder.proxyConfiguration(proxyBuilder.build());
     }
   }
 
@@ -87,6 +112,8 @@ class UrlConnectionHttpClientConfigurations extends BaseHttpClientConfigurations
     keyComponents.put("connectionTimeoutMs", httpClientUrlConnectionConnectionTimeoutMs);
     keyComponents.put("socketTimeoutMs", httpClientUrlConnectionSocketTimeoutMs);
     keyComponents.put("proxyEndpoint", proxyEndpoint);
+    keyComponents.put("proxyUseSystemPropertyValues", proxyUseSystemPropertyValues);
+    keyComponents.put("proxyUseEnvironmentVariableValues", proxyUseEnvironmentVariableValues);
 
     return keyComponents.entrySet().stream()
         .map(entry -> entry.getKey() + "=" + Objects.toString(entry.getValue(), "null"))

--- a/aws/src/test/java/org/apache/iceberg/aws/TestHttpClientConfigurations.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestHttpClientConfigurations.java
@@ -137,4 +137,140 @@ public class TestHttpClientConfigurations {
     Mockito.verify(spyApacheHttpClientBuilder, Mockito.never())
         .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
   }
+
+  @Test
+  public void testApacheProxySystemPropertyValues() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES, "false");
+    ApacheHttpClientConfigurations apacheHttpClientConfigurations =
+        ApacheHttpClientConfigurations.create(properties);
+    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
+    ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
+
+    apacheHttpClientConfigurations.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
+
+    Mockito.verify(spyApacheHttpClientBuilder)
+        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testApacheProxyEnvironmentVariableValues() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES, "false");
+    ApacheHttpClientConfigurations apacheHttpClientConfigurations =
+        ApacheHttpClientConfigurations.create(properties);
+    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
+    ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
+
+    apacheHttpClientConfigurations.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
+
+    Mockito.verify(spyApacheHttpClientBuilder)
+        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testUrlConnectionProxySystemPropertyValues() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES, "false");
+    UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
+        UrlConnectionHttpClientConfigurations.create(properties);
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
+        Mockito.spy(urlConnectionHttpClientBuilder);
+
+    urlConnectionHttpClientConfigurations.configureUrlConnectionHttpClientBuilder(
+        spyUrlConnectionHttpClientBuilder);
+
+    Mockito.verify(spyUrlConnectionHttpClientBuilder)
+        .proxyConfiguration(
+            Mockito.any(software.amazon.awssdk.http.urlconnection.ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testUrlConnectionProxyEnvironmentVariableValues() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES, "false");
+    UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
+        UrlConnectionHttpClientConfigurations.create(properties);
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
+        Mockito.spy(urlConnectionHttpClientBuilder);
+
+    urlConnectionHttpClientConfigurations.configureUrlConnectionHttpClientBuilder(
+        spyUrlConnectionHttpClientBuilder);
+
+    Mockito.verify(spyUrlConnectionHttpClientBuilder)
+        .proxyConfiguration(
+            Mockito.any(software.amazon.awssdk.http.urlconnection.ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testApacheProxySystemPropertyValuesExplicitTrue() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES, "true");
+    ApacheHttpClientConfigurations apacheHttpClientConfigurations =
+        ApacheHttpClientConfigurations.create(properties);
+    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
+    ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
+
+    apacheHttpClientConfigurations.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
+
+    Mockito.verify(spyApacheHttpClientBuilder)
+        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testApacheProxyEnvironmentVariableValuesExplicitTrue() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES, "true");
+    ApacheHttpClientConfigurations apacheHttpClientConfigurations =
+        ApacheHttpClientConfigurations.create(properties);
+    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
+    ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
+
+    apacheHttpClientConfigurations.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
+
+    Mockito.verify(spyApacheHttpClientBuilder)
+        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testUrlConnectionProxySystemPropertyValuesExplicitTrue() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES, "true");
+    UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
+        UrlConnectionHttpClientConfigurations.create(properties);
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
+        Mockito.spy(urlConnectionHttpClientBuilder);
+
+    urlConnectionHttpClientConfigurations.configureUrlConnectionHttpClientBuilder(
+        spyUrlConnectionHttpClientBuilder);
+
+    Mockito.verify(spyUrlConnectionHttpClientBuilder)
+        .proxyConfiguration(
+            Mockito.any(software.amazon.awssdk.http.urlconnection.ProxyConfiguration.class));
+  }
+
+  @Test
+  public void testUrlConnectionProxyEnvironmentVariableValuesExplicitTrue() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES, "true");
+    UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
+        UrlConnectionHttpClientConfigurations.create(properties);
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
+        Mockito.spy(urlConnectionHttpClientBuilder);
+
+    urlConnectionHttpClientConfigurations.configureUrlConnectionHttpClientBuilder(
+        spyUrlConnectionHttpClientBuilder);
+
+    Mockito.verify(spyUrlConnectionHttpClientBuilder)
+        .proxyConfiguration(
+            Mockito.any(software.amazon.awssdk.http.urlconnection.ProxyConfiguration.class));
+  }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/TestHttpClientConfigurations.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestHttpClientConfigurations.java
@@ -22,6 +22,8 @@ import java.time.Duration;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
@@ -138,138 +140,37 @@ public class TestHttpClientConfigurations {
         .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
   }
 
-  @Test
-  public void testApacheProxySystemPropertyValues() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES,
+        HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES
+      })
+  public void testApacheProxyFlagTriggersProxyConfig(String propertyKey) {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES, "false");
-    ApacheHttpClientConfigurations apacheHttpClientConfigurations =
-        ApacheHttpClientConfigurations.create(properties);
-    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
-    ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
+    properties.put(propertyKey, "false");
+    ApacheHttpClient.Builder spy = Mockito.spy(ApacheHttpClient.builder());
 
-    apacheHttpClientConfigurations.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
+    ApacheHttpClientConfigurations.create(properties).configureApacheHttpClientBuilder(spy);
 
-    Mockito.verify(spyApacheHttpClientBuilder)
-        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
+    Mockito.verify(spy).proxyConfiguration(Mockito.any(ProxyConfiguration.class));
   }
 
-  @Test
-  public void testApacheProxyEnvironmentVariableValues() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES,
+        HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES
+      })
+  public void testUrlConnectionProxyFlagTriggersProxyConfig(String propertyKey) {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES, "false");
-    ApacheHttpClientConfigurations apacheHttpClientConfigurations =
-        ApacheHttpClientConfigurations.create(properties);
-    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
-    ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
+    properties.put(propertyKey, "false");
+    UrlConnectionHttpClient.Builder spy = Mockito.spy(UrlConnectionHttpClient.builder());
 
-    apacheHttpClientConfigurations.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
+    UrlConnectionHttpClientConfigurations.create(properties)
+        .configureUrlConnectionHttpClientBuilder(spy);
 
-    Mockito.verify(spyApacheHttpClientBuilder)
-        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
-  }
-
-  @Test
-  public void testUrlConnectionProxySystemPropertyValues() {
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES, "false");
-    UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
-        UrlConnectionHttpClientConfigurations.create(properties);
-    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
-        UrlConnectionHttpClient.builder();
-    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
-        Mockito.spy(urlConnectionHttpClientBuilder);
-
-    urlConnectionHttpClientConfigurations.configureUrlConnectionHttpClientBuilder(
-        spyUrlConnectionHttpClientBuilder);
-
-    Mockito.verify(spyUrlConnectionHttpClientBuilder)
-        .proxyConfiguration(
-            Mockito.any(software.amazon.awssdk.http.urlconnection.ProxyConfiguration.class));
-  }
-
-  @Test
-  public void testUrlConnectionProxyEnvironmentVariableValues() {
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES, "false");
-    UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
-        UrlConnectionHttpClientConfigurations.create(properties);
-    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
-        UrlConnectionHttpClient.builder();
-    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
-        Mockito.spy(urlConnectionHttpClientBuilder);
-
-    urlConnectionHttpClientConfigurations.configureUrlConnectionHttpClientBuilder(
-        spyUrlConnectionHttpClientBuilder);
-
-    Mockito.verify(spyUrlConnectionHttpClientBuilder)
-        .proxyConfiguration(
-            Mockito.any(software.amazon.awssdk.http.urlconnection.ProxyConfiguration.class));
-  }
-
-  @Test
-  public void testApacheProxySystemPropertyValuesExplicitTrue() {
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES, "true");
-    ApacheHttpClientConfigurations apacheHttpClientConfigurations =
-        ApacheHttpClientConfigurations.create(properties);
-    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
-    ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
-
-    apacheHttpClientConfigurations.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
-
-    Mockito.verify(spyApacheHttpClientBuilder)
-        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
-  }
-
-  @Test
-  public void testApacheProxyEnvironmentVariableValuesExplicitTrue() {
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES, "true");
-    ApacheHttpClientConfigurations apacheHttpClientConfigurations =
-        ApacheHttpClientConfigurations.create(properties);
-    ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
-    ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
-
-    apacheHttpClientConfigurations.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
-
-    Mockito.verify(spyApacheHttpClientBuilder)
-        .proxyConfiguration(Mockito.any(ProxyConfiguration.class));
-  }
-
-  @Test
-  public void testUrlConnectionProxySystemPropertyValuesExplicitTrue() {
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES, "true");
-    UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
-        UrlConnectionHttpClientConfigurations.create(properties);
-    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
-        UrlConnectionHttpClient.builder();
-    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
-        Mockito.spy(urlConnectionHttpClientBuilder);
-
-    urlConnectionHttpClientConfigurations.configureUrlConnectionHttpClientBuilder(
-        spyUrlConnectionHttpClientBuilder);
-
-    Mockito.verify(spyUrlConnectionHttpClientBuilder)
-        .proxyConfiguration(
-            Mockito.any(software.amazon.awssdk.http.urlconnection.ProxyConfiguration.class));
-  }
-
-  @Test
-  public void testUrlConnectionProxyEnvironmentVariableValuesExplicitTrue() {
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES, "true");
-    UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
-        UrlConnectionHttpClientConfigurations.create(properties);
-    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
-        UrlConnectionHttpClient.builder();
-    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
-        Mockito.spy(urlConnectionHttpClientBuilder);
-
-    urlConnectionHttpClientConfigurations.configureUrlConnectionHttpClientBuilder(
-        spyUrlConnectionHttpClientBuilder);
-
-    Mockito.verify(spyUrlConnectionHttpClientBuilder)
+    Mockito.verify(spy)
         .proxyConfiguration(
             Mockito.any(software.amazon.awssdk.http.urlconnection.ProxyConfiguration.class));
   }

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -705,10 +705,12 @@ For more details of configuration, see sections [URL Connection HTTP Client Conf
 
 Configurations for the HTTP client can be set via catalog properties. Below is an overview of available configurations:
 
-| Property                   | Default | Description                                                                                                |
-|----------------------------|---------|------------------------------------------------------------------------------------------------------------|
-| http-client.type           | apache  | Types of HTTP Client. <br/> `urlconnection`: URL Connection HTTP Client <br/> `apache`: Apache HTTP Client |
-| http-client.proxy-endpoint | null    | An optional proxy endpoint to use for the HTTP client.                                                     |
+| Property                                          | Default | Description                                                                                                                                                                                                                                                          |
+|---------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| http-client.type                                  | apache  | Types of HTTP Client. <br/> `urlconnection`: URL Connection HTTP Client <br/> `apache`: Apache HTTP Client                                                                                                                                                          |
+| http-client.proxy-endpoint                        | null    | An optional proxy endpoint to use for the HTTP client.                                                                                                                                                                                                               |
+| http-client.proxy-use-system-property-values      | null, enabled by default | An optional `true/false` setting that controls whether proxy configuration is read from Java system properties (`http.proxyHost`, `http.proxyPort`, `http.nonProxyHosts`, etc.).                                                               |
+| http-client.proxy-use-environment-variable-values | null, enabled by default | An optional `true/false` setting that controls whether proxy configuration is read from environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, etc.).                                                                                |
 
 #### URL Connection HTTP Client Configurations
 


### PR DESCRIPTION
### Summary                                                                                                                                                                                                                                                                
Add `http-client.proxy-use-system-property-values` and `http-client.proxy-use-environment-variable-values` properties to control whether AWS SDK reads proxy settings from Java system properties and environment variables.

Both default to `true` (AWS SDK default). Applied to both `ApacheHttpClient` and `UrlConnectionHttpClient`.

These map directly to the AWS SDK's `ProxyConfiguration` builder:
- https://github.com/aws/aws-sdk-java-v2/pull/4467
- https://github.com/aws/aws-sdk-java-v2/pull/4735

### Motivation
In environments where proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`) are set globally but should not apply to AWS/S3 traffic, there is currently no way to disable them without unsetting the variables system-wide.

### Test plan
- Added unit tests in `TestHttpClientConfigurations` covering both HTTP client types with `true` and `false` values for each property
- Default behavior (not set) covered by existing tests
- Documentation updated in `docs/docs/aws.md`

Closes #15504