### PR TITLE
Spark: fix delete from branch for canDeleteWhere where it does not resolve to the correct branch

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -1425,6 +1425,62 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
   }
 
   @TestTemplate
+  public void testDeleteToWapBranchCanDeleteWhereScansWapBranch() throws NoSuchTableException {
+    assumeThat(branch).as("WAP branch only works for table identifier without branch").isNull();
+
+    createAndInitPartitionedTable();
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
+        tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
+
+    append(tableName, new Employee(1, "hr"));
+
+    spark.conf().set(SparkSQLProperties.WAP_BRANCH, "wap");
+    try {
+      append(tableName, new Employee(0, "hr"), new Employee(1, "hr"), new Employee(2, "hr"));
+
+      sql("DELETE FROM %s WHERE id = 1", tableName);
+
+      assertThat(sql("SELECT id, dep FROM %s.branch_wap ORDER BY id", tableName))
+          .as("DELETE should remove the matching rows from the WAP branch")
+          .containsExactly(row(0, "hr"), row(2, "hr"));
+      assertThat(sql("SELECT id, dep FROM %s.branch_main", tableName))
+          .as("Main branch must not be modified by a WAP-targeted DELETE")
+          .containsExactly(row(1, "hr"));
+    } finally {
+      spark.conf().unset(SparkSQLProperties.WAP_BRANCH);
+    }
+  }
+
+  @TestTemplate
+  public void testMetadataDeleteToWapBranchCommitsToWapBranch() throws NoSuchTableException {
+    assumeThat(branch).as("WAP branch only works for table identifier without branch").isNull();
+
+    createAndInitPartitionedTable();
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'true')",
+        tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
+
+    append(tableName, new Employee(1, "hr"), new Employee(5, "eng"));
+
+    spark.conf().set(SparkSQLProperties.WAP_BRANCH, "wap");
+    try {
+      append(tableName, new Employee(0, "hr"), new Employee(2, "eng"));
+
+      sql("DELETE FROM %s WHERE dep = 'hr'", tableName);
+
+      assertThat(sql("SELECT id, dep FROM %s.branch_wap ORDER BY id", tableName))
+          .as("Metadata delete should remove the hr partition on the WAP branch")
+          .containsExactly(row(2, "eng"), row(5, "eng"));
+      assertThat(sql("SELECT id, dep FROM %s.branch_main ORDER BY id", tableName))
+          .as("Metadata delete must not commit to main when WAP is set")
+          .containsExactly(row(1, "hr"), row(5, "eng"));
+    } finally {
+      spark.conf().unset(SparkSQLProperties.WAP_BRANCH);
+    }
+  }
+
+  @TestTemplate
   public void testDeleteWithFilterOnNestedColumn() {
     createAndInitNestedColumnsTable();
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -197,6 +197,10 @@ public class SparkTable extends BaseSparkTable
   public boolean canDeleteWhere(Predicate[] predicates) {
     Preconditions.checkArgument(timeTravel == null, "Cannot delete from table with time travel");
 
+    if (SparkTableUtil.wapEnabled(table())) {
+      branch = SparkTableUtil.determineWriteBranch(sparkSession(), icebergTable, branch);
+    }
+
     Expression deleteExpr = Expressions.alwaysTrue();
 
     for (Predicate predicate : predicates) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -197,10 +197,6 @@ public class SparkTable extends BaseSparkTable
   public boolean canDeleteWhere(Predicate[] predicates) {
     Preconditions.checkArgument(timeTravel == null, "Cannot delete from table with time travel");
 
-    if (SparkTableUtil.wapEnabled(table())) {
-      branch = SparkTableUtil.determineWriteBranch(sparkSession(), icebergTable, branch);
-    }
-
     Expression deleteExpr = Expressions.alwaysTrue();
 
     for (Predicate predicate : predicates) {
@@ -212,7 +208,10 @@ public class SparkTable extends BaseSparkTable
       }
     }
 
-    return canDeleteUsingMetadata(deleteExpr);
+    String scanBranch =
+        SparkTableUtil.determineReadBranch(
+            sparkSession(), icebergTable, branch, CaseInsensitiveStringMap.empty());
+    return canDeleteUsingMetadata(deleteExpr, scanBranch);
   }
 
   // a metadata delete is possible iff matching files can be deleted entirely

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
 import org.apache.iceberg.spark.TimeTravel;
@@ -210,12 +211,12 @@ public class SparkTable extends BaseSparkTable
 
     String scanBranch =
         SparkTableUtil.determineReadBranch(
-            sparkSession(), icebergTable, branch, CaseInsensitiveStringMap.empty());
+            spark(), table(), branch, CaseInsensitiveStringMap.empty());
     return canDeleteUsingMetadata(deleteExpr, scanBranch);
   }
 
   // a metadata delete is possible iff matching files can be deleted entirely
-  private boolean canDeleteUsingMetadata(Expression deleteExpr) {
+  private boolean canDeleteUsingMetadata(Expression deleteExpr, String scanBranch) {
     boolean caseSensitive = SparkUtil.caseSensitive(spark());
 
     if (ExpressionUtil.selectsPartitions(deleteExpr, table(), caseSensitive)) {
@@ -230,7 +231,9 @@ public class SparkTable extends BaseSparkTable
             .includeColumnStats()
             .ignoreResiduals();
 
-    if (snapshot != null) {
+    if (scanBranch != null) {
+      scan = scan.useRef(scanBranch);
+    } else if (snapshot != null) {
       scan = scan.useSnapshot(snapshot.snapshotId());
     }
 
@@ -272,8 +275,12 @@ public class SparkTable extends BaseSparkTable
             .set("spark.app.id", spark().sparkContext().applicationId())
             .deleteFromRowFilter(deleteExpr);
 
-    if (branch != null) {
-      deleteFiles.toBranch(branch);
+    String writeBranch =
+        SparkTableUtil.determineWriteBranch(
+            spark(), table(), branch, CaseInsensitiveStringMap.empty());
+
+    if (writeBranch != null) {
+      deleteFiles.toBranch(writeBranch);
     }
 
     if (!CommitMetadata.commitProperties().isEmpty()) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -24,9 +24,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CatalogTestBase;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -184,5 +186,33 @@ public class TestDeleteFrom extends CatalogTestBase {
         "Should have expected rows",
         ImmutableList.of(row(1L, new byte[] {-29, -68, -47})),
         sql("SELECT * FROM %s where data = X'e3bcd1'", tableName));
+  }
+
+  @TestTemplate
+  public void testDeleteWithWapBranch() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES ('%s' = 'true')",
+        tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
+
+    spark.conf().set(SparkSQLProperties.WAP_BRANCH, "dev1");
+    try {
+      // all rows go into one file on the WAP branch; main stays empty
+      List<SimpleRecord> records =
+          Lists.newArrayList(
+              new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+      Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+      df.coalesce(1).writeTo(tableName).append();
+
+      // delete a subset of rows - canDeleteWhere and deleteWhere must both
+      // resolve the WAP branch so they scan and commit to the same branch
+      sql("DELETE FROM %s WHERE id = 1", tableName);
+
+      assertEquals(
+          "Should have deleted only the matching row on the WAP branch",
+          ImmutableList.of(row(2L, "b"), row(3L, "c")),
+          sql("SELECT * FROM %s VERSION AS OF 'dev1' ORDER BY id", tableName));
+    } finally {
+      spark.conf().unset(SparkSQLProperties.WAP_BRANCH);
+    }
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -24,11 +24,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CatalogTestBase;
-import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -186,33 +184,5 @@ public class TestDeleteFrom extends CatalogTestBase {
         "Should have expected rows",
         ImmutableList.of(row(1L, new byte[] {-29, -68, -47})),
         sql("SELECT * FROM %s where data = X'e3bcd1'", tableName));
-  }
-
-  @TestTemplate
-  public void testDeleteWithWapBranch() throws NoSuchTableException {
-    sql(
-        "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES ('%s' = 'true')",
-        tableName, TableProperties.WRITE_AUDIT_PUBLISH_ENABLED);
-
-    spark.conf().set(SparkSQLProperties.WAP_BRANCH, "dev1");
-    try {
-      // all rows go into one file on the WAP branch; main stays empty
-      List<SimpleRecord> records =
-          Lists.newArrayList(
-              new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
-      Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
-      df.coalesce(1).writeTo(tableName).append();
-
-      // delete a subset of rows - canDeleteWhere and deleteWhere must both
-      // resolve the WAP branch so they scan and commit to the same branch
-      sql("DELETE FROM %s WHERE id = 1", tableName);
-
-      assertEquals(
-          "Should have deleted only the matching row on the WAP branch",
-          ImmutableList.of(row(2L, "b"), row(3L, "c")),
-          sql("SELECT * FROM %s VERSION AS OF 'dev1' ORDER BY id", tableName));
-    } finally {
-      spark.conf().unset(SparkSQLProperties.WAP_BRANCH);
-    }
   }
 }


### PR DESCRIPTION
---                                                                                                                                                
  Problem
                                                                                                                                                     
  When WAP (Write-Audit-Publish) is enabled via spark.wap.branch, canDeleteWhere() and deleteWhere() scan different branches:

  - canDeleteWhere() scans using this.branch (null → main) because the WAP branch is only a session config, not part of the table identifier
  - deleteWhere() resolves the WAP branch before committing

  This causes canDeleteWhere() to incorrectly return true (metadata-only delete is possible) based on main's data, while deleteWhere() commits to the
   WAP branch where the file has partial matches, resulting in:

  ValidationException: Cannot delete file where some, but not all, rows match filter

  Example

  -- WAP enabled, spark.wap.branch = dev1
  INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c');  -- goes to dev1, main is empty
  DELETE FROM t WHERE id = 1;
  -- canDeleteWhere scans main (empty) → true → metadata delete
  -- deleteWhere commits to dev1 → partial match → ValidationException

  Fix

  - canDeleteWhere() now resolves the WAP branch via determineReadBranch before scanning. This uses determineReadBranch (not determineWriteBranch)
  because the scan is a read operation, and determineReadBranch correctly handles the case where the WAP branch doesn't exist yet by falling back to
  main.
  - Both canDeleteWhere() and deleteWhere() now use local variables for the resolved branch instead of mutating this.branch, avoiding side effects on
   reads and other operations that share the field.

  Will work on the backport to other Spark versions once there is consensus from the community.