### PR TITLE
Docs: Add missing CREATE DATABASE step to Spark quickstart

### DIFF
--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -146,6 +146,28 @@ You can then run any of the following commands to start a Spark session.
 To create your first Iceberg table in Spark, run a [`CREATE TABLE`](docs/latest/spark-ddl.md#create-table) command. Let's create a table
 using `demo.nyc.taxis` where `demo` is the catalog name, `nyc` is the database name, and `taxis` is the table name.
 
+First, create the database if it doesn't already exist:
+
+=== "SparkSQL"
+
+    ```sql
+    CREATE DATABASE IF NOT EXISTS demo.nyc;
+    ```
+
+=== "Spark-Shell"
+
+    ```scala
+    spark.sql("CREATE DATABASE IF NOT EXISTS demo.nyc")
+    ```
+
+=== "PySpark"
+
+    ```py
+    spark.sql("CREATE DATABASE IF NOT EXISTS demo.nyc")
+    ```
+
+Then create the table:
+
 === "SparkSQL"
 
     ```sql


### PR DESCRIPTION
## Summary
Fixes #15509

The Spark quickstart guide instructs users to create the table `demo.nyc.taxis` without first creating the `nyc` database, which causes failures for new users following the guide.

## Changes
Added a `CREATE DATABASE IF NOT EXISTS demo.nyc` step (for SparkSQL, Spark-Shell, and PySpark) before the `CREATE TABLE` command in the quickstart guide.

## Testing
- Verified the markdown renders correctly with the tabbed format
- The `CREATE DATABASE IF NOT EXISTS` command is idempotent and safe