### PR TITLE
infra: restore github.del_branch_on_merge in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,7 @@
 #
 
 # The format of this file is documented at
-# https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+# https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
 
 github:
   description: "Apache Iceberg"


### PR DESCRIPTION
Follow up to #14710, I noticed that my branches are not auto-deleted after merging... 
Adding the [deprecated `github.del_branch_on_merge`](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#delete-branch-on-merge) in case some tools are still using it

Now we set both `github.del_branch_on_merge` (old/deprecated) and `github.pull_requests.del_branch_on_merge` (new) 

Also update docs to point to https://github.com/apache/infrastructure-asfyaml/blob/main/README.md, https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features is deprecated according to its content