### PR TITLE
docs: document iceberg.tables.hadoop prefix used by HadoopTables for lock configuration

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -236,9 +236,12 @@ The HMS table locking is a 2-step process:
 | iceberg.hive.table-level-lock-evict-ms    | 600000 (10 min) | The timeout for the JVM table lock is                                        |
 | iceberg.engine.hive.lock-enabled          | true            | Use HMS locks to ensure atomicity of commits                                 |
 
-Note: `iceberg.hive.lock-check-max-wait-ms` and `iceberg.hive.lock-heartbeat-interval-ms` should be less than the [transaction timeout](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.txn.timeout)
+Notes:
+
+- `iceberg.hive.lock-check-max-wait-ms` and `iceberg.hive.lock-heartbeat-interval-ms` should be less than the [transaction timeout](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.txn.timeout)
 of the Hive Metastore (`hive.txn.timeout` or `metastore.txn.timeout` in the newer versions). Otherwise, the heartbeats on the lock (which happens during the lock checks) would end up expiring in the
 Hive Metastore before the lock is retried from Iceberg.
+- Iceberg reads all Hadoop configuration entries whose keys begin with the prefix `iceberg.tables.hadoop.` and includes them verbatim in the property map passed to the `LockManager` used by `HadoopTables`. The lock‑manager implementation is responsible for interpreting these keys according to its own configuration semantics.
 
 Warn: Setting `iceberg.engine.hive.lock-enabled`=`false` will cause HiveCatalog to commit to tables without using Hive locks.
 This should only be set to `false` if all following conditions are met:


### PR DESCRIPTION
**Summary**
This PR adds documentation for the `iceberg.tables.hadoop.` configuration prefix used by `HadoopTables` to forward lock‑related properties to the `LockManager`. This prefix is currently used in the code but not documented in the Hadoop configuration section.

**What this PR changes**

- Adds a new subsection under `Hadoop Configuration` documenting the `iceberg.tables.hadoop.` prefix.
- Explains that keys beginning with this prefix are forwarded unchanged to the LockManager.
- Notes that supported keys depend on the lock‑manager implementation.

**Testing**

- Documentation‑only change; no tests required.
 - Site deployed locally
<img width="1462" height="931" alt="docs-add-hadoop-tables-lock-prefix" src="https://github.com/user-attachments/assets/927e7bd6-f910-4fda-9ed8-14fbb9cbca41" />

Closes https://github.com/apache/iceberg/issues/15493
