### PR TITLE
docs: reformat mailing list

### DIFF
--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -34,20 +34,20 @@ Apache Iceberg mailing lists:
     - [Archive](https://lists.apache.org/list.html?dev@iceberg.apache.org)
     - [Subscribe](mailto:dev-subscribe@iceberg.apache.org)
     - [Unsubscribe](mailto:dev-unsubscribe@iceberg.apache.org)
-* **Commits**: `commits@iceberg.apache.org` -- Github commit notifications
+* **Commits**: `commits@iceberg.apache.org` -- GitHub commit notifications
     - [Archive](https://lists.apache.org/list.html?commits@iceberg.apache.org)
     - [Subscribe](mailto:commits-subscribe@iceberg.apache.org)
     - [Unsubscribe](mailto:commits-unsubscribe@iceberg.apache.org)
-* **Issues**: `issues@iceberg.apache.org` -- Github issue tracking
+* **Issues**: `issues@iceberg.apache.org` -- GitHub issue tracking
     - [Archive](https://lists.apache.org/list.html?issues@iceberg.apache.org)
     - [Subscribe](mailto:issues-subscribe@iceberg.apache.org)
     - [Unsubscribe](mailto:issues-unsubscribe@iceberg.apache.org)
-* **CI Jobs**: `ci-jobs@iceberg.apache.org` -- GitHub actions notifications
+* **CI Jobs**: `ci-jobs@iceberg.apache.org` -- GitHub Actions notifications
     - [Archive](https://lists.apache.org/list.html?ci-jobs@iceberg.apache.org)
     - [Subscribe](mailto:ci-jobs-subscribe@iceberg.apache.org)
     - [Unsubscribe](mailto:ci-jobs-unsubscribe@iceberg.apache.org)
 * **Private**: `private@iceberg.apache.org` -- private mailing list for the PMC to discuss sensitive issues related to the health of the project
-    - [Archive](https://lists.apache.org/list.html?private@iceberg.apache.org)
+    - [Archive](https://lists.apache.org/list.html?private@iceberg.apache.org) (PMC-only access)
 
 ### Slack
 


### PR DESCRIPTION
Reformatting https://iceberg.apache.org/community/#mailing-lists

When I want to go to the apache mailing list archive (https://lists.apache.org/list?dev@iceberg.apache.org), I would click on `dev@iceberg.apache.org` on this page and my email app will pop up (annoying!) 
This PR changes the email url so it is no longer rendered as `mailto:dev@iceberg.apache.org`. 
 I also reordered the bullet points so `Archive` shows up first for easier access

Local render:
<img width="1178" height="818" alt="Screenshot 2026-03-06 at 7 46 12 PM" src="https://github.com/user-attachments/assets/d32a53f3-b831-4ce2-8e56-713d5be1ec9f" />
