### PR TITLE
Glue: Check commit status on non-deterministic AWS errors

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -46,6 +46,7 @@ import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.glue.model.ConcurrentModificationException;
 import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
 import software.amazon.awssdk.services.glue.model.GlueException;
+import software.amazon.awssdk.services.glue.model.OperationTimeoutException;
 import software.amazon.awssdk.services.glue.model.ValidationException;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
@@ -129,6 +130,32 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     assertThat(metadataFileCount(ops.current()))
         .as("No new metadata files should exist")
         .isEqualTo(2);
+  }
+
+  @Test
+  public void testOperationTimeoutExceptionAfterSuccessfulCommitPreservesMetadata() {
+    Table table = setupTable();
+    GlueTableOperations ops = (GlueTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+    TableMetadata metadataV2 = updateTable(table, ops);
+
+    GlueTableOperations spyOps = Mockito.spy(ops);
+
+    // Simulate an OperationTimeoutException after a successful commit
+    commitAndThrowException(ops, spyOps, OperationTimeoutException.builder().build());
+
+    // Shouldn't throw because the commit actually succeeds even though persistTable throws an
+    // OperationTimeoutException
+    spyOps.commit(metadataV2, metadataV1);
+    Mockito.verify(spyOps, Mockito.times(1)).refresh();
+
+    ops.refresh();
+    assertThat(ops.current()).as("Current metadata should have changed").isNotEqualTo(metadataV2);
+    assertThat(metadataFileExists(ops.current())).isTrue();
+    assertThat(metadataFileCount(ops.current()))
+        .as("Commit should have been successful and new metadata file should be made")
+        .isEqualTo(3);
   }
 
   @Test
@@ -490,6 +517,12 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
   @SuppressWarnings("unchecked")
   private void commitAndThrowException(GlueTableOperations realOps, GlueTableOperations spyOps) {
+    commitAndThrowException(realOps, spyOps, new RuntimeException("Datacenter on fire"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void commitAndThrowException(
+      GlueTableOperations realOps, GlueTableOperations spyOps, RuntimeException exceptionToThrow) {
     Mockito.doAnswer(
             i -> {
               realOps.persistGlueTable(
@@ -497,7 +530,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
                   i.getArgument(1, Map.class),
                   i.getArgument(2, TableMetadata.class),
                   i.getArgument(3, RetryDetector.class));
-              throw new RuntimeException("Datacenter on fire");
+              throw exceptionToThrow;
             })
         .when(spyOps)
         .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any(), Mockito.any());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -163,10 +163,11 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       throw e;
     } catch (RuntimeException persistFailure) {
       boolean isAwsServiceException = persistFailure instanceof AwsServiceException;
+      boolean isKnownCommitFailure = isKnownGlueCommitFailure(persistFailure);
 
-      // If we got an exception we weren't expecting, or we got an AWS service exception
-      // but retries were performed, attempt to reconcile the actual commit status.
-      if (!isAwsServiceException || retryDetector.retried()) {
+      // If we got an exception we weren't expecting, or we got a deterministic AWS service
+      // exception but retries were performed, attempt to reconcile the actual commit status.
+      if (!isKnownCommitFailure || retryDetector.retried()) {
         LOG.warn(
             "Received unexpected failure when committing to {}, validating if commit ended up succeeding.",
             fullTableName,
@@ -348,6 +349,28 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                       .build())
               .build());
     }
+  }
+
+  /**
+   * Returns true if the exception is a known Glue exception that indicates the commit did not
+   * happen, so commit status check can be skipped:
+   *
+   * <ul>
+   *   <li>{@link ConcurrentModificationException}: another writer committed first
+   *   <li>{@link software.amazon.awssdk.services.glue.model.AlreadyExistsException}: table already
+   *       exists, create was rejected before any update
+   *   <li>{@link EntityNotFoundException}: table or database does not exist
+   *   <li>{@link AccessDeniedException}: request was rejected due to missing permissions
+   *   <li>{@link software.amazon.awssdk.services.glue.model.ValidationException}: request was
+   *       rejected due to invalid input
+   * </ul>
+   */
+  private static boolean isKnownGlueCommitFailure(RuntimeException exception) {
+    return exception instanceof ConcurrentModificationException
+        || exception instanceof software.amazon.awssdk.services.glue.model.AlreadyExistsException
+        || exception instanceof EntityNotFoundException
+        || exception instanceof AccessDeniedException
+        || exception instanceof software.amazon.awssdk.services.glue.model.ValidationException;
   }
 
   private void handleAWSExceptions(AwsServiceException persistFailure) {


### PR DESCRIPTION
When `doCommit` catches a non-deterministic `AwsServiceException` like `OperationTimeoutException`, the old guard assumed `FAILURE` and deleted the new metadata file. If Glue had actually committed before the timeout, the table now points to a metadata file that no longer exists, corrupting it.

Narrow the skip-check guard to only the five deterministic Glue exception types (`ConcurrentModificationException`, `AlreadyExistsException`, `EntityNotFoundException`, `AccessDeniedException`, `ValidationException`). All other `AwsServiceException` subtypes now go through `checkCommitStatus`.