### PR TITLE
Core, Spark: add the comment table property key

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -84,7 +84,7 @@ public class TableProperties {
           DEFAULT_SORT_ORDER);
 
   /** A table property that documents the business meaning and usage context of this table. */
-  public static final String TABLE_COMMENT = "comment";
+  public static final String COMMENT = "comment";
 
   public static final String COMMIT_NUM_RETRIES = "commit.retry.num-retries";
   public static final int COMMIT_NUM_RETRIES_DEFAULT = 4;

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -272,7 +272,7 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
     assertThat(table.properties())
         .doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT)
-        .containsEntry(TableProperties.TABLE_COMMENT, "Table doc");
+        .containsEntry(TableProperties.COMMENT, "Table doc");
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -272,7 +272,7 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
     assertThat(table.properties())
         .doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT)
-        .containsEntry(TableProperties.TABLE_COMMENT, "Table doc");
+        .containsEntry(TableProperties.COMMENT, "Table doc");
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -272,7 +272,7 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
     assertThat(table.properties())
         .doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT)
-        .containsEntry(TableProperties.TABLE_COMMENT, "Table doc");
+        .containsEntry(TableProperties.COMMENT, "Table doc");
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -272,7 +272,7 @@ public class TestCreateTable extends CatalogTestBase {
     assertThat(table.spec().fields()).as("Should not be partitioned").isEmpty();
     assertThat(table.properties())
         .doesNotContainKey(TableProperties.DEFAULT_FILE_FORMAT)
-        .containsEntry(TableProperties.TABLE_COMMENT, "Table doc");
+        .containsEntry(TableProperties.COMMENT, "Table doc");
   }
 
   @TestTemplate


### PR DESCRIPTION
This is a follow up to PR #15367. 

I thought the prop key is already there. But it turns out to be false.

This change is AI assisted. 