### PR TITLE
Build: Cap the number of workers in Flink CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,8 @@ subprojects {
   if (testParallelism != null) {
     def numTestWorkers
     if (testParallelism.equalsIgnoreCase('auto')) {
-      numTestWorkers = Math.ceil(Runtime.getRuntime().availableProcessors() / 2.0) as int
+      // Cap at 4 to avoid memory pressure on CI runners (each fork uses up to 1500m heap)
+      numTestWorkers = Math.min(Math.ceil(Runtime.getRuntime().availableProcessors() / 2.0) as int, 4)
     } else {
       numTestWorkers = testParallelism as int
     }


### PR DESCRIPTION
I have observed intermittent timeout on CI for the Flink jobs.

Usually, the CI Flink jobs take around 30mn, but sometime, they are running forever, and timing out after 6 hours.

This change is to timeout after 60 minutes (no need to wait 6 hours), and cap the number of workers for parallelism test to reduce the memory pressure on CI runners.