### PR TITLE
docs: define `Trusted Iceberg Client` In Iceberg Rest Catalog Spec docs

### DIFF
--- a/site/docs/rest-catalog-spec.md
+++ b/site/docs/rest-catalog-spec.md
@@ -43,9 +43,6 @@ You can use the REST catalog protocol with any built-in catalog using translatio
 
 ### Trusted Iceberg Client
 
-A **Trusted Iceberg Client** is a client implementation that a catalog operator trusts to correctly enforce
-restrictions and instructions returned by the REST Catalog server.
+A **Trusted Iceberg Client** is a client implementation that a catalog operator trusts to correctly enforce restrictions and instructions returned by the REST Catalog server.
 
-In this model, the trusted client is entrusted to interpret server responses correctly and apply
-the required client-side behavior when reading or presenting data, so it does not expose data
-the user is not authorized to access.
+In this model, the trusted client is entrusted to interpret server responses correctly and apply the required client-side behavior when reading or presenting data, so it does not expose data the user is not authorized to access.


### PR DESCRIPTION
This PR adds a docs-only clarification to https://iceberg.apache.org/rest-catalog-spec/ by introducing the term `Trusted Iceberg Client` as a subsection under `REST Catalog Protocol`

The intent is to establish shared terminology for an assumption that already appears across current Iceberg design discussions across UDF, DEFINER/INVOKER views, and read restrictions: some catalog-driven restrictions only have security meaning when enforced by a trusted client. 

In many deployments today, the lowest consistently enforceable authorization boundary at the catalog/storage layer is table-level access, because effective enforcement depends on storage permissions. As a result, more granular data-permission enforcement needs a trusted boundary above that layer, and this is the role captured by `Trusted Iceberg Client`.

By naming that trust boundary as `Trusted Iceberg Client`, future proposals can reference a consistent term instead of re-defining the same concept in each discussion.

This PR uses `Trusted Iceberg Client` instead of the frequently used `Trusted Engine` because, in REST Catalog interactions, the enforcement point is the **client** component that consumes catalog responses and applies restrictions. Trusted `Engine` can be interpreted to be broader or narrower depending on which context you are thinking of the word **engine**.