### PR TITLE
Spark: Fix ThreadLocal capacity leak in CommitMetadata

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
@@ -56,7 +56,7 @@ public class CommitMetadata {
       ExceptionUtil.castAndThrow(e, exClass);
       return null;
     } finally {
-      COMMIT_PROPERTIES.set(ImmutableMap.of());
+      COMMIT_PROPERTIES.remove();
     }
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
@@ -56,7 +56,7 @@ public class CommitMetadata {
       ExceptionUtil.castAndThrow(e, exClass);
       return null;
     } finally {
-      COMMIT_PROPERTIES.set(ImmutableMap.of());
+      COMMIT_PROPERTIES.remove();
     }
   }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
@@ -56,7 +56,7 @@ public class CommitMetadata {
       ExceptionUtil.castAndThrow(e, exClass);
       return null;
     } finally {
-      COMMIT_PROPERTIES.set(ImmutableMap.of());
+      COMMIT_PROPERTIES.remove();
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
@@ -56,7 +56,7 @@ public class CommitMetadata {
       ExceptionUtil.castAndThrow(e, exClass);
       return null;
     } finally {
-      COMMIT_PROPERTIES.set(ImmutableMap.of());
+      COMMIT_PROPERTIES.remove();
     }
   }
 


### PR DESCRIPTION
## Summary
Fix ThreadLocal memory leak in `CommitMetadata` by replacing `COMMIT_PROPERTIES.set(ImmutableMap.of())` with `COMMIT_PROPERTIES.remove()` in the finally block.

Using `set()` with an empty map keeps the entry in the ThreadLocal map, causing a capacity leak over time. `remove()` properly cleans up the entry from the thread's ThreadLocalMap.

Fixes #15284