### PR TITLE
Spark: Apply custom snapshot properties for DELETE operations

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
+import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.TimeTravel;
 import org.apache.iceberg.spark.TimeTravel.AsOfTimestamp;
 import org.apache.iceberg.spark.TimeTravel.AsOfVersion;
@@ -277,6 +278,12 @@ public class SparkTable extends BaseSparkTable
 
     if (branch != null) {
       deleteFiles.toBranch(branch);
+    }
+
+    SparkWriteConf writeConf = new SparkWriteConf(spark(), table());
+    Map<String, String> extraSnapshotMetadata = writeConf.extraSnapshotMetadata();
+    if (!extraSnapshotMetadata.isEmpty()) {
+      extraSnapshotMetadata.forEach(deleteFiles::set);
     }
 
     if (!CommitMetadata.commitProperties().isEmpty()) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -451,6 +451,26 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
   }
 
   @TestTemplate
+  public void testExtraSnapshotMetadataPersistedOnDelete() {
+    String propertyKey = "test-key";
+    String propertyValue = "session-value";
+
+    // insert data first so that DELETE has rows to remove
+    spark.sql(
+        String.format(
+            "INSERT INTO %s VALUES (1, 'a', DATE '2021-01-01', TIMESTAMP '2021-01-01 00:00:00')",
+            tableName));
+
+    withSQLConf(
+        ImmutableMap.of("spark.sql.iceberg.snapshot-property." + propertyKey, propertyValue),
+        () -> {
+          spark.sql(String.format("DELETE FROM %s WHERE id = 1", tableName));
+          Table table = validationCatalog.loadTable(tableIdent);
+          assertThat(table.currentSnapshot().summary()).containsEntry(propertyKey, propertyValue);
+        });
+  }
+
+  @TestTemplate
   public void testDataPropsDefaultsAsDeleteProps() {
     List<List<Map<String, String>>> propertiesSuites =
         Lists.newArrayList(


### PR DESCRIPTION
## Summary
Apply custom snapshot properties from session configuration to DELETE operations, matching the existing behavior for INSERT and UPDATE operations.

Previously, snapshot properties set via `spark.sql.iceberg.commit.properties.*` were not applied when executing DELETE statements.

Fixes #15060