### PR TITLE
Spark: Delegate temp file deletion to JUnit in TestParquetVectorizedReads

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -213,7 +213,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       Map<Integer, Object> idToConstant)
       throws IOException {
     // write a test parquet file using iceberg writer
-    File testFile = temp.resolve("junit.parquet").toFile();
+    File testFile = temp.resolve("data.parquet").toFile();
 
     try (FileAppender<Record> writer = getParquetWriter(writeSchema, testFile)) {
       writer.addAll(expected);
@@ -389,7 +389,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             optional(102, "float_data", Types.FloatType.get()),
             optional(103, "decimal_data", Types.DecimalType.of(10, 5)));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(writeSchema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetWriter(writeSchema, dataFile)) {
@@ -421,7 +421,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             optional(107, "string_data", Types.StringType.get()),
             optional(108, "binary_data", Types.BinaryType.get()));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
@@ -434,7 +434,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
   public void testUnsupportedReadsForParquetV2() throws Exception {
     // Some types use delta encoding and which are not supported for vectorized reads
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
@@ -452,7 +452,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
     int numRows = 1;
     Schema schema = new Schema(optional(100, "uuid", Types.UUIDType.get()));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data = generateData(schema, numRows, 0L, 0, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -213,7 +213,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       Map<Integer, Object> idToConstant)
       throws IOException {
     // write a test parquet file using iceberg writer
-    File testFile = temp.resolve("junit.parquet").toFile();
+    File testFile = temp.resolve("data.parquet").toFile();
 
     try (FileAppender<Record> writer = getParquetWriter(writeSchema, testFile)) {
       writer.addAll(expected);
@@ -389,7 +389,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             optional(102, "float_data", Types.FloatType.get()),
             optional(103, "decimal_data", Types.DecimalType.of(10, 5)));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(writeSchema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetWriter(writeSchema, dataFile)) {
@@ -421,7 +421,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             optional(107, "string_data", Types.StringType.get()),
             optional(108, "binary_data", Types.BinaryType.get()));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
@@ -434,7 +434,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
   public void testUnsupportedReadsForParquetV2() throws Exception {
     // Some types use delta encoding and which are not supported for vectorized reads
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
@@ -452,7 +452,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
     int numRows = 1;
     Schema schema = new Schema(optional(100, "uuid", Types.UUIDType.get()));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data = generateData(schema, numRows, 0L, 0, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -213,7 +213,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       Map<Integer, Object> idToConstant)
       throws IOException {
     // write a test parquet file using iceberg writer
-    File testFile = temp.resolve("junit.parquet").toFile();
+    File testFile = temp.resolve("data.parquet").toFile();
 
     try (FileAppender<Record> writer = getParquetWriter(writeSchema, testFile)) {
       writer.addAll(expected);
@@ -389,7 +389,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             optional(102, "float_data", Types.FloatType.get()),
             optional(103, "decimal_data", Types.DecimalType.of(10, 5)));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(writeSchema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetWriter(writeSchema, dataFile)) {
@@ -421,7 +421,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             optional(107, "string_data", Types.StringType.get()),
             optional(108, "binary_data", Types.BinaryType.get()));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
@@ -434,7 +434,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
   public void testUnsupportedReadsForParquetV2() throws Exception {
     // Some types use delta encoding and which are not supported for vectorized reads
     Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data =
         generateData(schema, 30000, 0L, RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
@@ -452,7 +452,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
     int numRows = 1;
     Schema schema = new Schema(optional(100, "uuid", Types.UUIDType.get()));
 
-    File dataFile = temp.resolve("junit.parquet").toFile();
+    File dataFile = temp.resolve("data.parquet").toFile();
     Iterable<Record> data = generateData(schema, numRows, 0L, 0, IDENTITY);
     try (FileAppender<Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);


### PR DESCRIPTION
## Description

Related to #13506

Replace the manual `File.createTempFile + delete` pattern with `temp.resolve(...).toFile()` in `TestParquetVectorizedReads`, delegating temp file cleanup to JUnit's `@TempDir` (already inherited from `AvroDataTestBase`).

**Before:**
```java
File testFile = File.createTempFile("junit", null, temp.toFile());
assertThat(testFile.delete()).as("Delete should succeed").isTrue();
```

**After:**
```java
File testFile = temp.resolve("data.parquet").toFile();
```

Applied to Spark v3.5, v4.0, and v4.1 modules (5 occurrences each).

Note: A broader cleanup across all Spark test files was previously attempted in #14095 but went stale. This PR intentionally limits scope to just `TestParquetVectorizedReads` as originally described in the issue, to keep it small and reviewable. Follow-up PRs can address the remaining files.

## Type of Change

- [ ] Bug fix
- [x] Improvement (non-breaking change)
- [ ] New feature
- [ ] Test improvement

## Checklist

- [x] Code follows the project's style guidelines
- [x] No new production code changed (test-only)