### PR TITLE
Core: Allow SchemaUpdate to drop a map field

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -563,7 +563,8 @@ class SchemaUpdate implements UpdateSchema {
 
     // apply schema changes
     Types.StructType struct =
-        TypeUtil.visit(schema, new ApplyChanges(deletes, updates, parentToAddedIds, moves, idToParent))
+        TypeUtil.visit(
+                schema, new ApplyChanges(deletes, updates, parentToAddedIds, moves, idToParent))
             .asNestedType()
             .asStructType();
 
@@ -716,7 +717,10 @@ class SchemaUpdate implements UpdateSchema {
     public Type map(Types.MapType map, Type kResult, Type valueResult) {
       // if any updates are intended for the key, throw an exception
       int keyId = map.fields().get(0).fieldId();
-      if (deletes.contains(keyId) && !deletes.contains(idToParent.get(keyId))) {
+      if (deletes.contains(idToParent.get(keyId))) {
+        return null;
+      }
+      if (deletes.contains(keyId)) {
         throw new IllegalArgumentException("Cannot delete map keys: " + map);
       } else if (updates.containsKey(keyId)) {
         throw new IllegalArgumentException("Cannot update map keys: " + map);

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -563,7 +563,7 @@ class SchemaUpdate implements UpdateSchema {
 
     // apply schema changes
     Types.StructType struct =
-        TypeUtil.visit(schema, new ApplyChanges(deletes, updates, parentToAddedIds, moves))
+        TypeUtil.visit(schema, new ApplyChanges(deletes, updates, parentToAddedIds, moves, idToParent))
             .asNestedType()
             .asStructType();
 
@@ -588,6 +588,7 @@ class SchemaUpdate implements UpdateSchema {
 
   private static class ApplyChanges extends TypeUtil.SchemaVisitor<Type> {
     private final List<Integer> deletes;
+    private final Map<Integer, Integer> idToParent;
     private final Map<Integer, Types.NestedField> updates;
     private final Multimap<Integer, Integer> parentToAddedIds;
     private final Multimap<Integer, Move> moves;
@@ -596,11 +597,13 @@ class SchemaUpdate implements UpdateSchema {
         List<Integer> deletes,
         Map<Integer, Types.NestedField> updates,
         Multimap<Integer, Integer> parentToAddedIds,
-        Multimap<Integer, Move> moves) {
+        Multimap<Integer, Move> moves,
+        Map<Integer, Integer> idToParent) {
       this.deletes = deletes;
       this.updates = updates;
       this.parentToAddedIds = parentToAddedIds;
       this.moves = moves;
+      this.idToParent = idToParent;
     }
 
     @Override
@@ -713,7 +716,7 @@ class SchemaUpdate implements UpdateSchema {
     public Type map(Types.MapType map, Type kResult, Type valueResult) {
       // if any updates are intended for the key, throw an exception
       int keyId = map.fields().get(0).fieldId();
-      if (deletes.contains(keyId)) {
+      if (deletes.contains(keyId) && !deletes.contains(idToParent.get(keyId))) {
         throw new IllegalArgumentException("Cannot delete map keys: " + map);
       } else if (updates.containsKey(keyId)) {
         throw new IllegalArgumentException("Cannot update map keys: " + map);

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -1171,6 +1171,39 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testDeleteMapField() {
+    Schema expectedNested =
+            new Schema(
+                    required(1, "id", Types.IntegerType.get()),
+                    optional(2, "data", Types.StringType.get()),
+                    optional(
+                            3,
+                            "preferences",
+                            Types.StructType.of(
+                                    required(8, "feature1", Types.BooleanType.get()),
+                                    optional(9, "feature2", Types.BooleanType.get())),
+                            "struct of named boolean options"),
+                    optional(
+                            5,
+                            "points",
+                            Types.ListType.ofOptional(
+                                    14,
+                                    Types.StructType.of(
+                                            required(15, "x", Types.LongType.get()),
+                                            required(16, "y", Types.LongType.get()))),
+                            "2-D cartesian points"),
+                    required(6, "doubles", Types.ListType.ofRequired(17, Types.DoubleType.get())));
+
+    Schema updatedNested =
+            new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+                    .deleteColumn("locations")
+                    .deleteColumn("properties")
+                    .apply();
+
+    assertThat(updatedNested.asStruct()).isEqualTo(expectedNested.asStruct());
+  }
+
+  @Test
   public void testDeleteMapKey() {
     assertThatThrownBy(
             () ->

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -1173,32 +1173,34 @@ public class TestSchemaUpdate {
   @Test
   public void testDeleteMapField() {
     Schema expectedNested =
-            new Schema(
-                    required(1, "id", Types.IntegerType.get()),
-                    optional(2, "data", Types.StringType.get()),
-                    optional(
-                            3,
-                            "preferences",
-                            Types.StructType.of(
-                                    required(8, "feature1", Types.BooleanType.get()),
-                                    optional(9, "feature2", Types.BooleanType.get())),
-                            "struct of named boolean options"),
-                    optional(
-                            5,
-                            "points",
-                            Types.ListType.ofOptional(
-                                    14,
-                                    Types.StructType.of(
-                                            required(15, "x", Types.LongType.get()),
-                                            required(16, "y", Types.LongType.get()))),
-                            "2-D cartesian points"),
-                    required(6, "doubles", Types.ListType.ofRequired(17, Types.DoubleType.get())));
+        new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(
+                3,
+                "preferences",
+                Types.StructType.of(
+                    required(8, "feature1", Types.BooleanType.get()),
+                    optional(9, "feature2", Types.BooleanType.get())),
+                "struct of named boolean options"),
+            optional(
+                5,
+                "points",
+                Types.ListType.ofOptional(
+                    14,
+                    Types.StructType.of(
+                        required(15, "x", Types.LongType.get()),
+                        required(16, "y", Types.LongType.get()))),
+                "2-D cartesian points"),
+            required(6, "doubles", Types.ListType.ofRequired(17, Types.DoubleType.get())));
 
     Schema updatedNested =
-            new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
-                    .deleteColumn("locations")
-                    .deleteColumn("properties")
-                    .apply();
+        new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+            .deleteColumn("locations")
+            .deleteColumn("properties")
+            .deleteColumn("properties.key")
+            .deleteColumn("properties.value")
+            .apply();
 
     assertThat(updatedNested.asStruct()).isEqualTo(expectedNested.asStruct());
   }


### PR DESCRIPTION
Previously a check prevents us from dropping map key field, which in fact prevents dropping map field at all. Dropping map key should be allowd when map field itself is dropped.

Fixes #15313