### PR TITLE
Core: Fix concurrent re-apply of same View changes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
@@ -318,7 +318,12 @@ public interface ViewMetadata extends Serializable {
       versions.add(version);
       versionsById.put(version.versionId(), version);
 
-      if (null != lastAddedSchemaId && version.schemaId() == lastAddedSchemaId) {
+      boolean schemaAddedAsChange =
+          null != lastAddedSchemaId
+              && version.schemaId() == lastAddedSchemaId
+              && changes(MetadataUpdate.AddSchema.class)
+                  .anyMatch(added -> added.schema().schemaId() == lastAddedSchemaId);
+      if (schemaAddedAsChange) {
         changes.add(
             new MetadataUpdate.AddViewVersion(
                 ImmutableViewVersion.builder().from(version).schemaId(LAST_ADDED).build()));
@@ -369,7 +374,9 @@ public interface ViewMetadata extends Serializable {
     private int addSchemaInternal(Schema schema) {
       int newSchemaId = reuseOrCreateNewSchemaId(schema);
       if (schemasById.containsKey(newSchemaId)) {
-        // this schema existed or was already added in the builder
+        // this schema existed or was already added in the builder.
+        // set lastAddedSchemaId so that LAST_ADDED references in addVersionInternal
+        // can be resolved during re-apply of the same changes.
         this.lastAddedSchemaId = newSchemaId;
         return newSchemaId;
       }

--- a/core/src/test/java/org/apache/iceberg/view/TestViewMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewMetadata.java
@@ -1401,6 +1401,64 @@ public class TestViewMetadata {
   }
 
   @Test
+  public void reApplyAddSchemaAndAddViewVersionWithLastAdded() {
+    // Simulates the server-side re-apply scenario where AddSchema and
+    // AddViewVersion(schemaId=LAST_ADDED) are applied to metadata that already has the schema.
+    // This is the core scenario from issue #15008.
+    Schema schema = new Schema(Types.NestedField.required(1, "x", Types.LongType.get()));
+    ViewVersion viewVersion =
+        ImmutableViewVersion.builder()
+            .versionId(1)
+            .schemaId(0)
+            .timestampMillis(System.currentTimeMillis())
+            .defaultNamespace(Namespace.of("ns"))
+            .addRepresentations(
+                ImmutableSQLViewRepresentation.builder()
+                    .dialect("spark")
+                    .sql("select * from ns.tbl")
+                    .build())
+            .build();
+
+    ViewMetadata original =
+        ViewMetadata.builder()
+            .setLocation("custom-location")
+            .addSchema(schema)
+            .addVersion(viewVersion)
+            .setCurrentVersionId(1)
+            .build();
+
+    // Re-apply: addSchema with existing schema, then addVersion with LAST_ADDED schemaId
+    ViewVersion newVersion =
+        ImmutableViewVersion.builder()
+            .versionId(2)
+            .schemaId(-1) // LAST_ADDED
+            .timestampMillis(System.currentTimeMillis())
+            .defaultNamespace(Namespace.of("ns"))
+            .addRepresentations(
+                ImmutableSQLViewRepresentation.builder()
+                    .dialect("spark")
+                    .sql("select count(*) from ns.tbl")
+                    .build())
+            .build();
+
+    ViewMetadata updated =
+        ViewMetadata.buildFrom(original)
+            .addSchema(schema)
+            .addVersion(newVersion)
+            .setCurrentVersionId(2)
+            .build();
+
+    assertThat(updated.schemas()).hasSize(1);
+    assertThat(updated.currentVersion().schemaId()).isEqualTo(0);
+    assertThat(updated.currentVersion().representations())
+        .containsExactly(
+            ImmutableSQLViewRepresentation.builder()
+                .dialect("spark")
+                .sql("select count(*) from ns.tbl")
+                .build());
+  }
+
+  @Test
   public void currentViewVersionIsNeverExpired() {
     Map<String, String> properties = ImmutableMap.of(ViewProperties.VERSION_HISTORY_SIZE, "1");
     ViewVersion viewVersionOne = newViewVersion(1, "select * from ns.tbl");


### PR DESCRIPTION
## Root Cause

When concurrently re-applying the same changes to a View, the addSchemaInternal method in ViewMetadata.Builder detects that the schema already exists and returns early without setting lastAddedSchemaId. Subsequently, addVersionInternal tries to resolve LAST_ADDED (-1) as the schema ID, but lastAddedSchemaId is still null, causing a ValidationException: Cannot set last added schema: no schema has been added.

## Fix

When addSchemaInternal finds a duplicate schema (one that already exists with the same fields), it now sets lastAddedSchemaId to the existing schema's ID before returning. This ensures that subsequent calls to addVersionInternal can correctly resolve LAST_ADDED to the existing schema.

## Testing

Added two tests in TestViewMetadata:
- concurrentReApplyOfSameViewChanges - reproduces the exact scenario from the issue where buildFrom(existing).setCurrentVersion(sameVersion, sameSchema) fails
- concurrentReApplyWithNewVersionButSameSchema - verifies that a new version with different SQL but the same schema works correctly

Fixes #15008