### PR TITLE
Spark: Fix changelog ordinals for initial MERGE INTO write

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
@@ -647,8 +647,8 @@ public class TestCreateChangelogViewProcedure extends ExtensionsTestBase {
         "Rows should match",
         ImmutableList.of(
             row(1, "a", 12, INSERT, 0, snap1.snapshotId()),
-            row(3, "c", 15, INSERT, 2, snap3.snapshotId()),
-            row(2, "e", 12, INSERT, 2, snap3.snapshotId())),
+            row(2, "e", 12, INSERT, 0, snap1.snapshotId()),
+            row(3, "c", 15, INSERT, 2, snap3.snapshotId())),
         sql("select * from %s order by _change_ordinal, data", viewName));
 
     // test with snap2 and snap3
@@ -676,6 +676,53 @@ public class TestCreateChangelogViewProcedure extends ExtensionsTestBase {
                     catalogName, tableName))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Not support net changes with update images");
+  }
+
+  @TestTemplate
+  public void testNetChangesWithInitialMergeInto() {
+    // use an unpartitioned table to ensure COW carries over all rows in the same file
+    sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
+
+    // initial MERGE INTO (first write into an empty table)
+    sql(
+        "MERGE INTO %s t USING (SELECT * FROM VALUES (1, 'a'), (2, 'b'), (3, 'c') AS t(id, data)) s "
+            + "ON t.id = s.id "
+            + "WHEN NOT MATCHED THEN INSERT *",
+        tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    // second MERGE INTO: update id=1, insert id=4
+    // COW rewrites the file, carrying over rows (2, 'b') and (3, 'c')
+    sql(
+        "MERGE INTO %s t USING (SELECT * FROM VALUES (1, 'aa'), (4, 'd') AS t(id, data)) s "
+            + "ON t.id = s.id "
+            + "WHEN MATCHED THEN UPDATE SET * "
+            + "WHEN NOT MATCHED THEN INSERT *",
+        tableName);
+
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // query changelog with net_changes
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view(table => '%s', net_changes => true)",
+            catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+
+    // rows (2, 'b') and (3, 'c') were inserted in snap1 and carried over in snap2;
+    // they should have ordinal 0 (from snap1), not ordinal 1 (from snap2)
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(2, "b", INSERT, 0, snap1.snapshotId()),
+            row(3, "c", INSERT, 0, snap1.snapshotId()),
+            row(1, "aa", INSERT, 1, snap2.snapshotId()),
+            row(4, "d", INSERT, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id", viewName));
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
@@ -302,7 +302,7 @@ public class CreateChangelogViewProcedure extends BaseProcedure {
     Column changeType = df.col(MetadataColumns.CHANGE_TYPE.name());
     Column changeOrdinal = df.col(MetadataColumns.CHANGE_ORDINAL.name());
     Column[] extraColumns =
-        netChanges ? new Column[] {changeOrdinal, changeType} : new Column[] {changeType};
+        netChanges ? new Column[] {changeOrdinal, changeType.desc()} : new Column[] {changeType};
 
     Column[] sortSpec = new Column[repartitionSpec.length + extraColumns.length];
 


### PR DESCRIPTION
## Summary

Fixes #14851

When querying a changelog view with `net_changes => true`, rows carried over by copy-on-write operations (e.g., MERGE INTO) show incorrect ordinals. A row inserted in snapshot 0 and carried over in snapshot 1 would incorrectly show ordinal 1 instead of 0.

### Root Cause

In `CreateChangelogViewProcedure`, the sort spec for net changes processing sorts `_change_type` in ascending order within each `_change_ordinal`. This puts DELETE before INSERT within the same ordinal. When `RemoveNetCarryoverIterator` processes rows sequentially, it greedily pairs a cross-ordinal INSERT (from an earlier snapshot) with a same-ordinal DELETE (carry-over), instead of first cancelling the same-ordinal DELETE/INSERT carry-over pair.

Example with a row carried over from ordinal 0 to ordinal 1:
\`\`\`
Row(data, INSERT, ordinal=0)   -- original insert
Row(data, DELETE, ordinal=1)   -- carry-over delete (sorted first within ordinal 1)
Row(data, INSERT, ordinal=1)   -- carry-over insert
\`\`\`
The iterator pairs INSERT@0 with DELETE@1, cancelling both, leaving only INSERT@1 (wrong).

### Fix

Change the sort order for \`_change_type\` to **descending** when computing net changes. This puts INSERT before DELETE within the same ordinal:
\`\`\`
Row(data, INSERT, ordinal=0)   -- original insert
Row(data, INSERT, ordinal=1)   -- carry-over insert (now sorted first)
Row(data, DELETE, ordinal=1)   -- carry-over delete
\`\`\`
The iterator now sees INSERT@0, then INSERT@1 (same type, count=2), then DELETE@1 (opposite, count=1). Result: INSERT@0 (correct).

### Testing

- Added \`testNetChangesWithInitialMergeInto\`: creates an unpartitioned table, writes initial data with MERGE INTO, performs a second MERGE INTO that triggers COW carry-overs, and verifies that carried-over rows retain their original ordinal.
- Updated \`testNetChangesWithRemoveCarryOvers\` to reflect the corrected ordinal for carried-over rows.