### PR TITLE
Flink: Fix INSERT OVERWRITE on empty table

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -217,8 +217,19 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       String newFlinkJobId,
       String operatorId) {
     long checkpointId = pendingResults.lastKey();
-    Preconditions.checkState(
-        summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
+    if (summary.deleteFilesCount() > 0) {
+      LOG.warn(
+          "Dropping {} delete files during dynamic partition overwrite. "
+              + "Delete files are not applicable in overwrite mode as the partitions are replaced.",
+          summary.deleteFilesCount());
+    }
+
+    if (summary.dataFilesCount() == 0) {
+      LOG.info(
+          "Skipping replace partitions commit with no data files for checkpoint {}.", checkpointId);
+      return;
+    }
+
     // Commit the overwrite transaction.
     ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
     for (WriteResult result : pendingResults.values()) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -307,8 +307,19 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String newFlinkJobId,
       String operatorId,
       long checkpointId) {
-    Preconditions.checkState(
-        summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
+    if (summary.deleteFilesCount() > 0) {
+      LOG.warn(
+          "Dropping {} delete files during dynamic partition overwrite. "
+              + "Delete files are not applicable in overwrite mode as the partitions are replaced.",
+          summary.deleteFilesCount());
+    }
+
+    if (summary.dataFilesCount() == 0) {
+      LOG.info(
+          "Skipping replace partitions commit with no data files for checkpoint {}.", checkpointId);
+      return;
+    }
+
     // Commit the overwrite transaction.
     ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
     for (WriteResult result : pendingResults.values()) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -1164,6 +1164,83 @@ class TestIcebergCommitter extends TestBase {
     }
   }
 
+  @TestTemplate
+  public void testReplacePartitionsWithDeleteFiles() throws Exception {
+    assumeThat(formatVersion).as("Only support delete in format v2").isGreaterThanOrEqualTo(2);
+
+    FileWriterFactory<RowData> writerFactory = createFileWriterFactory();
+
+    // Create a committer with replacePartitions=true
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            tableLoader,
+            branch,
+            Collections.singletonMap("flink.test", TestIcebergCommitter.class.getName()),
+            true,
+            10,
+            "sinkId",
+            metric,
+            false);
+
+    // Build a WriteResult that contains both data files and delete files
+    RowData row1 = SimpleDataUtil.createInsert(1, "aaa");
+    DataFile dataFile1 = writeDataFile("data-file-overwrite-1", ImmutableList.of(row1));
+
+    RowData delete1 = SimpleDataUtil.createDelete(1, "aaa");
+    DeleteFile deleteFile1 =
+        writeEqDeleteFile(
+            writerFactory, "delete-file-overwrite-1", ImmutableList.of(delete1), table.spec());
+
+    WriteResult withDeleteFiles =
+        WriteResult.builder().addDataFiles(dataFile1).addDeleteFiles(deleteFile1).build();
+
+    // This should succeed without throwing "Cannot overwrite partitions with delete files"
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1L, ImmutableList.of(withDeleteFiles));
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    // Verify the commit succeeded - only data files should be committed, delete files dropped
+    assertSnapshotSize(1);
+  }
+
+  @TestTemplate
+  public void testReplacePartitionsOnEmptyTableWithDeleteFiles() throws Exception {
+    assumeThat(formatVersion).as("Only support delete in format v2").isGreaterThanOrEqualTo(2);
+
+    FileWriterFactory<RowData> writerFactory = createFileWriterFactory();
+
+    // Create a committer with replacePartitions=true
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            tableLoader,
+            branch,
+            Collections.singletonMap("flink.test", TestIcebergCommitter.class.getName()),
+            true,
+            10,
+            "sinkId",
+            metric,
+            false);
+
+    // Build a WriteResult with only delete files and no data files (empty table scenario)
+    RowData delete1 = SimpleDataUtil.createDelete(1, "aaa");
+    DeleteFile deleteFile1 =
+        writeEqDeleteFile(
+            writerFactory, "delete-file-empty-1", ImmutableList.of(delete1), table.spec());
+
+    WriteResult onlyDeleteFiles = WriteResult.builder().addDeleteFiles(deleteFile1).build();
+
+    // This should succeed without throwing "Cannot overwrite partitions with delete files"
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1L, ImmutableList.of(onlyDeleteFiles));
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    // Verify the operation completed - delete files dropped and no data files means no commit
+    // needed
+    assertSnapshotSize(0);
+  }
+
   private ManifestFile createTestingManifestFile(Path manifestPath, DataFile dataFile)
       throws IOException {
     ManifestWriter<DataFile> writer =

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -217,8 +217,19 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       String newFlinkJobId,
       String operatorId) {
     long checkpointId = pendingResults.lastKey();
-    Preconditions.checkState(
-        summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
+    if (summary.deleteFilesCount() > 0) {
+      LOG.warn(
+          "Dropping {} delete files during dynamic partition overwrite. "
+              + "Delete files are not applicable in overwrite mode as the partitions are replaced.",
+          summary.deleteFilesCount());
+    }
+
+    if (summary.dataFilesCount() == 0) {
+      LOG.info(
+          "Skipping replace partitions commit with no data files for checkpoint {}.", checkpointId);
+      return;
+    }
+
     // Commit the overwrite transaction.
     ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
     for (WriteResult result : pendingResults.values()) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -310,8 +310,19 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String newFlinkJobId,
       String operatorId,
       long checkpointId) {
-    Preconditions.checkState(
-        summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
+    if (summary.deleteFilesCount() > 0) {
+      LOG.warn(
+          "Dropping {} delete files during dynamic partition overwrite. "
+              + "Delete files are not applicable in overwrite mode as the partitions are replaced.",
+          summary.deleteFilesCount());
+    }
+
+    if (summary.dataFilesCount() == 0) {
+      LOG.info(
+          "Skipping replace partitions commit with no data files for checkpoint {}.", checkpointId);
+      return;
+    }
+
     // Commit the overwrite transaction.
     ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
     for (WriteResult result : pendingResults.values()) {

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -1154,6 +1154,83 @@ class TestIcebergCommitter extends TestBase {
     }
   }
 
+  @TestTemplate
+  public void testReplacePartitionsWithDeleteFiles() throws Exception {
+    assumeThat(formatVersion).as("Only support delete in format v2").isGreaterThanOrEqualTo(2);
+
+    FileWriterFactory<RowData> writerFactory = createFileWriterFactory();
+
+    // Create a committer with replacePartitions=true
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            tableLoader,
+            branch,
+            Collections.singletonMap("flink.test", TestIcebergCommitter.class.getName()),
+            true,
+            10,
+            "sinkId",
+            metric,
+            false);
+
+    // Build a WriteResult that contains both data files and delete files
+    RowData row1 = SimpleDataUtil.createInsert(1, "aaa");
+    DataFile dataFile1 = writeDataFile("data-file-overwrite-1", ImmutableList.of(row1));
+
+    RowData delete1 = SimpleDataUtil.createDelete(1, "aaa");
+    DeleteFile deleteFile1 =
+        writeEqDeleteFile(
+            writerFactory, "delete-file-overwrite-1", ImmutableList.of(delete1), table.spec());
+
+    WriteResult withDeleteFiles =
+        WriteResult.builder().addDataFiles(dataFile1).addDeleteFiles(deleteFile1).build();
+
+    // This should succeed without throwing "Cannot overwrite partitions with delete files"
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1L, ImmutableList.of(withDeleteFiles));
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    // Verify the commit succeeded - only data files should be committed, delete files dropped
+    assertSnapshotSize(1);
+  }
+
+  @TestTemplate
+  public void testReplacePartitionsOnEmptyTableWithDeleteFiles() throws Exception {
+    assumeThat(formatVersion).as("Only support delete in format v2").isGreaterThanOrEqualTo(2);
+
+    FileWriterFactory<RowData> writerFactory = createFileWriterFactory();
+
+    // Create a committer with replacePartitions=true
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            tableLoader,
+            branch,
+            Collections.singletonMap("flink.test", TestIcebergCommitter.class.getName()),
+            true,
+            10,
+            "sinkId",
+            metric,
+            false);
+
+    // Build a WriteResult with only delete files and no data files (empty table scenario)
+    RowData delete1 = SimpleDataUtil.createDelete(1, "aaa");
+    DeleteFile deleteFile1 =
+        writeEqDeleteFile(
+            writerFactory, "delete-file-empty-1", ImmutableList.of(delete1), table.spec());
+
+    WriteResult onlyDeleteFiles = WriteResult.builder().addDeleteFiles(deleteFile1).build();
+
+    // This should succeed without throwing "Cannot overwrite partitions with delete files"
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1L, ImmutableList.of(onlyDeleteFiles));
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    // Verify the operation completed - delete files dropped and no data files means no commit
+    // needed
+    assertSnapshotSize(0);
+  }
+
   private ManifestFile createTestingManifestFile(Path manifestPath, DataFile dataFile)
       throws IOException {
     ManifestWriter<DataFile> writer =

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -217,8 +217,19 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       String newFlinkJobId,
       String operatorId) {
     long checkpointId = pendingResults.lastKey();
-    Preconditions.checkState(
-        summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
+    if (summary.deleteFilesCount() > 0) {
+      LOG.warn(
+          "Dropping {} delete files during dynamic partition overwrite. "
+              + "Delete files are not applicable in overwrite mode as the partitions are replaced.",
+          summary.deleteFilesCount());
+    }
+
+    if (summary.dataFilesCount() == 0) {
+      LOG.info(
+          "Skipping replace partitions commit with no data files for checkpoint {}.", checkpointId);
+      return;
+    }
+
     // Commit the overwrite transaction.
     ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
     for (WriteResult result : pendingResults.values()) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -310,8 +310,19 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String newFlinkJobId,
       String operatorId,
       long checkpointId) {
-    Preconditions.checkState(
-        summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
+    if (summary.deleteFilesCount() > 0) {
+      LOG.warn(
+          "Dropping {} delete files during dynamic partition overwrite. "
+              + "Delete files are not applicable in overwrite mode as the partitions are replaced.",
+          summary.deleteFilesCount());
+    }
+
+    if (summary.dataFilesCount() == 0) {
+      LOG.info(
+          "Skipping replace partitions commit with no data files for checkpoint {}.", checkpointId);
+      return;
+    }
+
     // Commit the overwrite transaction.
     ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
     for (WriteResult result : pendingResults.values()) {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -1154,6 +1154,83 @@ class TestIcebergCommitter extends TestBase {
     }
   }
 
+  @TestTemplate
+  public void testReplacePartitionsWithDeleteFiles() throws Exception {
+    assumeThat(formatVersion).as("Only support delete in format v2").isGreaterThanOrEqualTo(2);
+
+    FileWriterFactory<RowData> writerFactory = createFileWriterFactory();
+
+    // Create a committer with replacePartitions=true
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            tableLoader,
+            branch,
+            Collections.singletonMap("flink.test", TestIcebergCommitter.class.getName()),
+            true,
+            10,
+            "sinkId",
+            metric,
+            false);
+
+    // Build a WriteResult that contains both data files and delete files
+    RowData row1 = SimpleDataUtil.createInsert(1, "aaa");
+    DataFile dataFile1 = writeDataFile("data-file-overwrite-1", ImmutableList.of(row1));
+
+    RowData delete1 = SimpleDataUtil.createDelete(1, "aaa");
+    DeleteFile deleteFile1 =
+        writeEqDeleteFile(
+            writerFactory, "delete-file-overwrite-1", ImmutableList.of(delete1), table.spec());
+
+    WriteResult withDeleteFiles =
+        WriteResult.builder().addDataFiles(dataFile1).addDeleteFiles(deleteFile1).build();
+
+    // This should succeed without throwing "Cannot overwrite partitions with delete files"
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1L, ImmutableList.of(withDeleteFiles));
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    // Verify the commit succeeded - only data files should be committed, delete files dropped
+    assertSnapshotSize(1);
+  }
+
+  @TestTemplate
+  public void testReplacePartitionsOnEmptyTableWithDeleteFiles() throws Exception {
+    assumeThat(formatVersion).as("Only support delete in format v2").isGreaterThanOrEqualTo(2);
+
+    FileWriterFactory<RowData> writerFactory = createFileWriterFactory();
+
+    // Create a committer with replacePartitions=true
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            tableLoader,
+            branch,
+            Collections.singletonMap("flink.test", TestIcebergCommitter.class.getName()),
+            true,
+            10,
+            "sinkId",
+            metric,
+            false);
+
+    // Build a WriteResult with only delete files and no data files (empty table scenario)
+    RowData delete1 = SimpleDataUtil.createDelete(1, "aaa");
+    DeleteFile deleteFile1 =
+        writeEqDeleteFile(
+            writerFactory, "delete-file-empty-1", ImmutableList.of(delete1), table.spec());
+
+    WriteResult onlyDeleteFiles = WriteResult.builder().addDeleteFiles(deleteFile1).build();
+
+    // This should succeed without throwing "Cannot overwrite partitions with delete files"
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1L, ImmutableList.of(onlyDeleteFiles));
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    // Verify the operation completed - delete files dropped and no data files means no commit
+    // needed
+    assertSnapshotSize(0);
+  }
+
   private ManifestFile createTestingManifestFile(Path manifestPath, DataFile dataFile)
       throws IOException {
     ManifestWriter<DataFile> writer =


### PR DESCRIPTION
Fixes #14699

## Summary

When `replacePartitions` mode is enabled and the write result contains delete files (e.g., from equality delete writers mixed with overwrite mode), the Flink committer throws `IllegalStateException: Cannot overwrite partitions with delete files`. This is overly aggressive because delete files are not applicable during a dynamic partition overwrite -- the entire partition is being replaced.

This change:
- Replaces the hard `Preconditions.checkState` with a warning log when delete files are present (they are safely dropped since partition replacement makes them unnecessary)
- Adds an early return when there are no data files to commit (empty table or delete-only scenario), avoiding `Cannot determine partition specs: no data files have been added`
- Applies the fix to `IcebergCommitter` and `IcebergFilesCommitter` across all Flink versions (v1.20, v2.0, v2.1)

## Test plan

- Added `testReplacePartitionsWithDeleteFiles` -- verifies overwrite succeeds when both data files and delete files are present (delete files are dropped)
- Added `testReplacePartitionsOnEmptyTableWithDeleteFiles` -- verifies overwrite succeeds when only delete files are present with no data files (the commit is skipped)
- All 288 existing `TestIcebergCommitter` tests continue to pass