### PR TITLE
Core: Improve HadoopFileIO performance when working with cloud storage

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.hadoop;
 
-import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -226,11 +225,10 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
 
   /**
    * This class is a simple adaptor to allow for using Hadoop's RemoteIterator as an Iterator.
-   * Implements {@code Closeable.close()}, forwarding to the delgater class if it implements it.
-   * <p>Note: current wrapping of this class in listPrefix means close() can't actually be reached.
+   *
    * @param <E> element type
    */
-  private static final class AdaptingIterator<E> implements Iterator<E>, RemoteIterator<E>, Closeable {
+  private static class AdaptingIterator<E> implements Iterator<E>, RemoteIterator<E> {
     private final RemoteIterator<E> delegate;
 
     AdaptingIterator(RemoteIterator<E> delegate) {
@@ -253,18 +251,6 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
-    }
-
-    @Override
-    public void close() throws IOException {
-      if (delegate instanceof Closeable closeable) {
-        closeable.close();
-      }
-    }
-
-    @Override
-    public String toString() {
-      return "AdaptingIterator{delegate=" + delegate + '}';
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.hadoop;
 
+import java.io.Closeable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.DelegateFileIO;
@@ -164,6 +166,8 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
                         fileStatus.getLen(),
                         fileStatus.getModificationTime()))
             .iterator();
+      } catch (FileNotFoundException e) {
+        throw new NotFoundException(e, "No prefix to list %s", prefixToList);
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
@@ -222,10 +226,11 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
 
   /**
    * This class is a simple adaptor to allow for using Hadoop's RemoteIterator as an Iterator.
-   *
+   * Implements {@code Closeable.close()}, forwarding to the delgater class if it implements it.
+   * <p>Note: current wrapping of this class in listPrefix means close() can't actually be reached.
    * @param <E> element type
    */
-  private static class AdaptingIterator<E> implements Iterator<E>, RemoteIterator<E> {
+  private static final class AdaptingIterator<E> implements Iterator<E>, RemoteIterator<E>, Closeable {
     private final RemoteIterator<E> delegate;
 
     AdaptingIterator(RemoteIterator<E> delegate) {
@@ -248,6 +253,18 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (delegate instanceof Closeable closeable) {
+        closeable.close();
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "AdaptingIterator{delegate=" + delegate + '}';
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -25,10 +25,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
@@ -193,14 +191,13 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
         builder.withFileStatus(stat);
       }
       if (length != null) {
-        // optLong() isn't in Hadoop 3.3.5, so use the string option.
+        // Use the string option for consistent interpretation across versions.
         builder.opt(Options.OpenFileOptions.FS_OPTION_OPENFILE_LENGTH, length.toString());
       }
       // read policy controls how read() calls are mapped to GET ranges.
       builder.opt(
           Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY, determineReadPolicy(path));
-      final CompletableFuture<FSDataInputStream> future = builder.build();
-      return HadoopStreams.wrap(await(future));
+      return HadoopStreams.wrap(await(builder.build()));
     } catch (FileNotFoundException e) {
       throw new NotFoundException(e, "Failed to open input stream for file: %s", path);
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -18,14 +18,21 @@
  */
 package org.apache.iceberg.hadoop;
 
+import static org.apache.iceberg.hadoop.Util.await;
+import static org.apache.iceberg.hadoop.Util.determineReadPolicy;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.encryption.NativeFileCryptoParameters;
 import org.apache.iceberg.encryption.NativelyEncryptedFile;
@@ -180,7 +187,20 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
   @Override
   public SeekableInputStream newStream() {
     try {
-      return HadoopStreams.wrap(fs.open(path));
+      final FutureDataInputStreamBuilder builder = fs.openFile(path);
+      if (stat != null) {
+        // ABFS and S3A; saves a HEAD request.
+        builder.withFileStatus(stat);
+      }
+      if (length != null) {
+        // optLong() isn't in Hadoop 3.3.5, so use the string option.
+        builder.opt(Options.OpenFileOptions.FS_OPTION_OPENFILE_LENGTH, length.toString());
+      }
+      // read policy controls how read() calls are mapped to GET ranges.
+      builder.opt(
+          Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY, determineReadPolicy(path));
+      final CompletableFuture<FSDataInputStream> future = builder.build();
+      return HadoopStreams.wrap(await(future));
     } catch (FileNotFoundException e) {
       throw new NotFoundException(e, "Failed to open input stream for file: %s", path);
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -18,9 +18,6 @@
  */
 package org.apache.iceberg.hadoop;
 
-import static org.apache.iceberg.hadoop.Util.await;
-import static org.apache.iceberg.hadoop.Util.determineReadPolicy;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
@@ -198,8 +195,8 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
       // read policy controls how read() calls are mapped to GET ranges.
       // this is potentially the most significant tuning.
       builder.opt(
-          Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY, determineReadPolicy(path));
-      return HadoopStreams.wrap(await(builder.build()));
+          Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY, Util.determineReadPolicy(path));
+      return HadoopStreams.wrap(Util.await(builder.build()));
     } catch (FileNotFoundException e) {
       throw new NotFoundException(e, "Failed to open input stream for file: %s", path);
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -191,10 +191,12 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
         builder.withFileStatus(stat);
       }
       if (length != null) {
+        // S3A is happy with this in lieu of a file status.
         // Use the string option for consistent interpretation across versions.
-        builder.opt(Options.OpenFileOptions.FS_OPTION_OPENFILE_LENGTH, length.toString());
+        builder.opt(Options.OpenFileOptions.FS_OPTION_OPENFILE_LENGTH, Long.toString(length));
       }
       // read policy controls how read() calls are mapped to GET ranges.
+      // this is potentially the most significant tuning.
       builder.opt(
           Options.OpenFileOptions.FS_OPTION_OPENFILE_READ_POLICY, determineReadPolicy(path));
       return HadoopStreams.wrap(await(builder.build()));

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -23,11 +23,14 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.ScanTaskGroup;
@@ -141,5 +144,76 @@ public class Util {
    */
   public static String uriToString(URI uri) {
     return new Path(uri).toString();
+  }
+
+  public static final String RANDOMIO_READS = "random, adaptive";
+  /**
+   * Read chain for recent parquet/orc libraries.
+   */
+  public static final String VECTOR_READS = "vector, " + RANDOMIO_READS;
+  public static final String ADAPTIVE_READS = "adaptive";
+  /** Sequential read from start of split to end. */
+  public static final String SEQUENTIAL_READS = "sequential";
+  /** Sequential read of the whole file. */
+  public static final String WHOLE_FILE_READS = "whole-file";
+  public static final String PARQUET_READS = "parquet," + VECTOR_READS;
+  public static final String ORC_READS = "orc," + VECTOR_READS;
+  public static final String JSON_READS = "json," + WHOLE_FILE_READS;
+  public static final String AVRO_READS = "avro," + SEQUENTIAL_READS;
+
+  /**
+   * Given a path, determine the read policy to use when opening the file.
+   *
+   * <p>The policy is a comma separated list of policies, the connector should use the first that it
+   * recognizes.
+   *
+   * @param path path to file being opened.
+   * @return policy to use.
+   */
+  static String determineReadPolicy(Path path) {
+    final FileFormat format = FileFormat.fromFileName(path.toString());
+    String policy;
+    if (format != null) {
+      policy =
+          switch (format) {
+            case PUFFIN -> RANDOMIO_READS;
+            case ORC -> ORC_READS;
+            case PARQUET -> PARQUET_READS;
+            case AVRO -> AVRO_READS;
+            case METADATA -> JSON_READS; // assumes metadata is JSON.
+          };
+    } else {
+      policy = ADAPTIVE_READS;
+    }
+    return policy;
+  }
+
+  /**
+   * Wait for a future to complete. RuntimeExceptions and IOExceptions are extracted and rethrown;
+   * if the wait is interrupted an RTE is generated.
+   *
+   * @param future future to await.
+   * @return the value
+   * @param <T> type of return value
+   * @throws IOException if the future raised an IOException.
+   * @throws RuntimeException any other exception raised by the future
+   */
+  static <T> T await(CompletableFuture<T> future) throws IOException {
+    try {
+      return future.get();
+    } catch (ExecutionException e) {
+      final Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException rte) {
+        // rethrow a runtime exception
+        throw rte;
+      } else if (cause instanceof IOException ioe) {
+        // expect to be handled in an outer try/catch
+        throw ioe;
+      } else {
+        throw new RuntimeException("Failed while awaiting task completion", cause);
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted while running awaiting task completion", e);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -149,7 +149,7 @@ public class Util {
   /** Random IO policy chain: {@value}. */
   public static final String RANDOM_READS = "random, adaptive";
 
-  /** Read chain for recent parquet/orc libraries: {@value}.*/
+  /** Read chain for recent parquet/orc libraries: {@value}. */
   public static final String VECTOR_READS = "vector, " + RANDOM_READS;
 
   /** Adaptive reads: inefficient compared to declaring the read strategy. */
@@ -163,6 +163,7 @@ public class Util {
 
   /** Parquet files: {@value}. */
   public static final String PARQUET_READS = "parquet," + VECTOR_READS;
+
   /** ORC files: {@value}. */
   public static final String ORC_READS = "orc," + VECTOR_READS;
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -146,19 +146,30 @@ public class Util {
     return new Path(uri).toString();
   }
 
-  public static final String RANDOMIO_READS = "random, adaptive";
-  /**
-   * Read chain for recent parquet/orc libraries.
-   */
-  public static final String VECTOR_READS = "vector, " + RANDOMIO_READS;
+  /** Random IO policy chain: {@value}. */
+  public static final String RANDOM_READS = "random, adaptive";
+
+  /** Read chain for recent parquet/orc libraries: {@value}.*/
+  public static final String VECTOR_READS = "vector, " + RANDOM_READS;
+
+  /** Adaptive reads: inefficient compared to declaring the read strategy. */
   public static final String ADAPTIVE_READS = "adaptive";
-  /** Sequential read from start of split to end. */
+
+  /** Sequential read from start of split to end: {@value}. */
   public static final String SEQUENTIAL_READS = "sequential";
-  /** Sequential read of the whole file. */
+
+  /** Sequential read of the whole file: {@value}. */
   public static final String WHOLE_FILE_READS = "whole-file";
+
+  /** Parquet files: {@value}. */
   public static final String PARQUET_READS = "parquet," + VECTOR_READS;
+  /** ORC files: {@value}. */
   public static final String ORC_READS = "orc," + VECTOR_READS;
+
+  /** JSON reads: {@value}. */
   public static final String JSON_READS = "json," + WHOLE_FILE_READS;
+
+  /** AVRO reads: {@value}. */
   public static final String AVRO_READS = "avro," + SEQUENTIAL_READS;
 
   /**
@@ -176,7 +187,7 @@ public class Util {
     if (format != null) {
       policy =
           switch (format) {
-            case PUFFIN -> RANDOMIO_READS;
+            case PUFFIN -> RANDOM_READS;
             case ORC -> ORC_READS;
             case PARQUET -> PARQUET_READS;
             case AVRO -> AVRO_READS;

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopFileIO.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.hadoop;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -35,9 +36,11 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileIOParser;
+import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.ResolvingFileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -65,7 +68,7 @@ public class TestHadoopFileIO {
   }
 
   @Test
-  public void testListPrefix() {
+  public void testListPrefix() throws IOException {
     Path parent = new Path(tempDir.toURI());
 
     List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
@@ -82,8 +85,33 @@ public class TestHadoopFileIO {
             });
 
     long totalFiles = scaleSizes.stream().mapToLong(Integer::longValue).sum();
-    assertThat(Streams.stream(hadoopFileIO.listPrefix(parent.toUri().toString())).count())
-        .isEqualTo(totalFiles);
+    final Iterable<FileInfo> listing = hadoopFileIO.listPrefix(parent.toUri().toString());
+    assertThat(Streams.stream(listing).count()).isEqualTo(totalFiles);
+    // the iterator from listPrefix is closeable, so close it.
+    // a no-op with most filesystems iterators.
+    assertThat(listing)
+        .describedAs("Listing iterator %s", listing)
+        .isInstanceOf(Closeable.class);
+    ((Closeable) listing).close();
+  }
+
+  /**
+   * Dir deletion doesn't actually surface until the iterator() call.
+   */
+  @Test
+  public void testListDirDeletedBeforeListing() {
+    tempDir.delete();
+    final Iterable<FileInfo> listing = hadoopFileIO.listPrefix(tempDir.toURI().toString());
+    assertThatThrownBy(() -> listing.iterator())
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  public void testListEmptyDir() {
+    final String prefix = tempDir.toURI().toString();
+    final Iterable<FileInfo> listing = hadoopFileIO.listPrefix(prefix);
+    assertThat(listing.iterator()).describedAs("Listing iterator %s", listing)
+        .matches(c -> !c.hasNext());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopFileIO.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.hadoop;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -85,14 +84,8 @@ public class TestHadoopFileIO {
             });
 
     long totalFiles = scaleSizes.stream().mapToLong(Integer::longValue).sum();
-    final Iterable<FileInfo> listing = hadoopFileIO.listPrefix(parent.toUri().toString());
-    assertThat(Streams.stream(listing).count()).isEqualTo(totalFiles);
-    // the iterator from listPrefix is closeable, so close it.
-    // a no-op with most filesystems iterators.
-    assertThat(listing)
-        .describedAs("Listing iterator %s", listing)
-        .isInstanceOf(Closeable.class);
-    ((Closeable) listing).close();
+    assertThat(Streams.stream(hadoopFileIO.listPrefix(parent.toUri().toString())).count())
+        .isEqualTo(totalFiles);
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopFileIO.java
@@ -88,22 +88,20 @@ public class TestHadoopFileIO {
         .isEqualTo(totalFiles);
   }
 
-  /**
-   * Dir deletion doesn't actually surface until the iterator() call.
-   */
+  /** Dir deletion doesn't actually surface until the iterator() call. */
   @Test
   public void testListDirDeletedBeforeListing() {
     tempDir.delete();
     final Iterable<FileInfo> listing = hadoopFileIO.listPrefix(tempDir.toURI().toString());
-    assertThatThrownBy(() -> listing.iterator())
-        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> listing.iterator()).isInstanceOf(NotFoundException.class);
   }
 
   @Test
   public void testListEmptyDir() {
     final String prefix = tempDir.toURI().toString();
     final Iterable<FileInfo> listing = hadoopFileIO.listPrefix(prefix);
-    assertThat(listing.iterator()).describedAs("Listing iterator %s", listing)
+    assertThat(listing.iterator())
+        .describedAs("Listing iterator %s", listing)
         .matches(c -> !c.hasNext());
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -178,7 +178,7 @@ public class TableMigrationUtil {
       if (format.contains("avro")) {
         task.run(
             index -> {
-              Metrics metrics = getAvroMetrics(fileStatus.get(index).getPath(), conf);
+              Metrics metrics = getAvroMetrics(fileStatus.get(index), conf);
               datafiles[index] =
                   buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "avro");
             });
@@ -186,15 +186,14 @@ public class TableMigrationUtil {
         task.run(
             index -> {
               Metrics metrics =
-                  getParquetMetrics(fileStatus.get(index).getPath(), conf, metricsSpec, mapping);
+                  getParquetMetrics(fileStatus.get(index), conf, metricsSpec, mapping);
               datafiles[index] =
                   buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "parquet");
             });
       } else if (format.contains("orc")) {
         task.run(
             index -> {
-              Metrics metrics =
-                  getOrcMetrics(fileStatus.get(index).getPath(), conf, metricsSpec, mapping);
+              Metrics metrics = getOrcMetrics(fileStatus.get(index), conf, metricsSpec, mapping);
               datafiles[index] =
                   buildDataFile(fileStatus.get(index), partitionValues, spec, metrics, "orc");
             });
@@ -211,32 +210,34 @@ public class TableMigrationUtil {
     }
   }
 
-  private static Metrics getAvroMetrics(Path path, Configuration conf) {
+  private static Metrics getAvroMetrics(FileStatus stat, Configuration conf) {
     try {
-      InputFile file = HadoopInputFile.fromPath(path, conf);
+      InputFile file = HadoopInputFile.fromStatus(stat, conf);
       long rowCount = Avro.rowCount(file);
       return new Metrics(rowCount, null, null, null, null);
     } catch (UncheckedIOException e) {
-      throw new RuntimeException("Unable to read Avro file: " + path, e);
+      throw new RuntimeException("Unable to read Avro file: " + stat.getPath(), e);
     }
   }
 
   private static Metrics getParquetMetrics(
-      Path path, Configuration conf, MetricsConfig metricsSpec, NameMapping mapping) {
+      FileStatus stat, Configuration conf, MetricsConfig metricsSpec, NameMapping mapping) {
     try {
-      InputFile file = HadoopInputFile.fromPath(path, conf);
+      InputFile file = HadoopInputFile.fromStatus(stat, conf);
       return ParquetUtil.fileMetrics(file, metricsSpec, mapping);
     } catch (UncheckedIOException e) {
-      throw new RuntimeException("Unable to read the metrics of the Parquet file: " + path, e);
+      throw new RuntimeException(
+          "Unable to read the metrics of the Parquet file: " + stat.getPath(), e);
     }
   }
 
   private static Metrics getOrcMetrics(
-      Path path, Configuration conf, MetricsConfig metricsSpec, NameMapping mapping) {
+      FileStatus stat, Configuration conf, MetricsConfig metricsSpec, NameMapping mapping) {
     try {
-      return OrcMetrics.fromInputFile(HadoopInputFile.fromPath(path, conf), metricsSpec, mapping);
+      return OrcMetrics.fromInputFile(HadoopInputFile.fromStatus(stat, conf), metricsSpec, mapping);
     } catch (UncheckedIOException e) {
-      throw new RuntimeException("Unable to read the metrics of the Orc file: " + path, e);
+      throw new RuntimeException(
+          "Unable to read the metrics of the Orc file: " + stat.getPath(), e);
     }
   }
 


### PR DESCRIPTION

Fixes #15353

Improve file opening and read times by
- keeping file status when known, using it in openFile() call to eliminate HEAD requests
- choosing file input policy when reading a file (`Util.determineReadPolicy()`).

ParquetIO already hands down file opening to parquet, which does the right thing.l
What matters for it is retaining any FileStatus already obtained, which is what the changes in `TableMigrationUtil` do.

It's a shame that parquet (currently) lacks a way to skip that stat() call which is does to get file length, as this adds a HEAD request to all openings of a parquet file where the length is known from a manifest. That is fixable and would save 100+mS per file opening, as well as the associated IO capacity.

However, until #12554 is fixed, that manifest file length can't be trusted, so the stat() matters. It's possibly why this issue hasn't been noticed on iceberg-java code
