### PR TITLE
Flink: Fix typo in FlinkCatalogFactory comment

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -103,7 +103,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
       case ICEBERG_CATALOG_TYPE_HIVE:
         // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
         // that case it will
-        // fallback to parse those values from hadoop configuration which is loaded from classpath.
+        // fall back to parse those values from hadoop configuration which is loaded from classpath.
         String hiveConfDir = properties.get(HIVE_CONF_DIR);
         String hadoopConfDir = properties.get(HADOOP_CONF_DIR);
         Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir, hadoopConfDir);


### PR DESCRIPTION
### Description
This PR fixes a minor grammatical typo in `FlinkCatalogFactory`.
It changes "fallback" (noun) to "fall back" (verb) in a comment to correctly describe the action of parsing values from the Hadoop configuration.

### why this change is necessary?
To improve code comments quality and maintain grammatical correctness within the codebase.