### PR TITLE
Kafka Connect: include hadoop-auth and commons-configuration2 in runtime distro

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -111,8 +111,6 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
       exclude group: 'org.apache.curator'
       exclude group: 'org.apache.zookeeper'
       exclude group: 'org.apache.kerby'
-      exclude group: 'org.apache.hadoop', module: 'hadoop-auth'
-      exclude group: 'org.apache.commons', module: 'commons-configuration2'
       exclude group: 'org.apache.hadoop.thirdparty', module: 'hadoop-shaded-protobuf_3_7'
       exclude group: 'org.eclipse.jetty'
     }


### PR DESCRIPTION
Fixes #13691

## Summary
This draft removes two runtime dependency excludes in `kafka-connect/build.gradle` for `iceberg-kafka-connect-runtime`:
- `org.apache.hadoop:hadoop-auth`
- `org.apache.commons:commons-configuration2`

## Why
Local repro showed Hadoop catalog mode fails under Kafka Connect plugin isolation with:
- `NoClassDefFoundError: org/apache/commons/configuration2/Configuration`
- then `NoClassDefFoundError: org/apache/hadoop/util/PlatformName`

Including these two jars in the runtime distribution resolves the reproduced startup/classloading failure.

## Notes
There are tradeoffs (bundle size/transitive surface/classpath conflict risk), so opening as draft for maintainer direction.