### PR TITLE
Infra: Remove legacy github.del_branch_on_merge flag

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,9 +33,6 @@ github:
     squash: true
     rebase: true
 
-  # deprecated but still set for backward compatibility
-  del_branch_on_merge: true
-
   pull_requests:
     # auto-delete head branches after being merged
     del_branch_on_merge: true


### PR DESCRIPTION
This is to avoid the mails that come from ASF Infra
```
An error occurred while processing the github feature in .asf.yaml:

found legacy setting 'github.del_branch_on_merge' while 'github.pull_requests' is present. Move setting to 'github.pull_requests'
```