### PR TITLE
Improve benchmark docs page coverage and formatting

### DIFF
--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -20,111 +20,198 @@ title: "Benchmarks"
 
 ## Available Benchmarks and how to run them
 
-Benchmarks are located under `<project-name>/jmh`. It is generally favorable to only run the tests of interest rather than running all available benchmarks.
-Also note that JMH benchmarks run within the same JVM as the system-under-test, so results might vary between runs.
+Benchmarks are located under `<module>/src/jmh`. It is generally better to run only the benchmarks you are investigating instead of the full suite.
+Also note that JMH benchmarks run in the same JVM as the system under test, so results may vary between runs.
 
 ## Running Benchmarks on GitHub
 
-It is possible to run one or more Benchmarks via the **JMH Benchmarks** GH action on your own fork of the Iceberg repo. This GH action takes the following inputs:
-* The repository name where those benchmarks should be run against, such as `apache/iceberg` or `<user>/iceberg`
-* The branch name to run benchmarks against, such as `main` or `my-cool-feature-branch`
-* A list of comma-separated double-quoted Benchmark names, such as `"IcebergSourceFlatParquetDataReadBenchmark", "IcebergSourceFlatParquetDataFilterBenchmark", "IcebergSourceNestedListParquetDataWriteBenchmark"`
+It is possible to run one or more benchmarks via the **JMH Benchmarks** GitHub Actions workflow on your own fork of the Iceberg repository. This workflow takes the following inputs:
+
+* The repository name to run against, such as `apache/iceberg` or `<user>/iceberg`
+* The branch name to benchmark, such as `main` or `my-feature-branch`
+* A comma-separated list of double-quoted benchmark names, such as `"IcebergSourceFlatParquetDataReadBenchmark", "IcebergSourceFlatParquetDataFilterBenchmark", "IcebergSourceNestedListParquetDataWriteBenchmark"`
 
 Benchmark results will be uploaded once **all** benchmarks are done.
 
-It is worth noting that the GH runners have limited resources so the benchmark results should rather be seen as an indicator to guide developers in understanding code changes.
-It is likely that there is variability in results across different runs, therefore the benchmark results shouldn't be used to form assumptions around production choices.
+GitHub-hosted runners have limited and shared resources, so treat these results as directional signals for understanding code changes rather than as production-grade measurements.
 
 ## Running Benchmarks locally
 
-Below are the existing benchmarks shown with the actual commands on how to run them locally.
+JMH writes human-readable output to `build/reports/jmh/human-readable-output.txt` and JSON output to `build/reports/jmh/results.json` by default. Override them with `-PjmhOutputPath=<path>` and `-PjmhJsonOutputPath=<path>` if needed.
 
-### IcebergSourceNestedListParquetDataWriteBenchmark
-A benchmark that evaluates the performance of writing nested Parquet data using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+The default versions in this repository are:
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceNestedListParquetDataWriteBenchmark -PjmhOutputPath=benchmark/iceberg-source-nested-list-parquet-data-write-benchmark-result.txt`
+* Spark `4.1`
+* Flink `2.1`
+* Scala `2.12`
 
-### SparkParquetReadersNestedDataBenchmark
-A benchmark that evaluates the performance of reading nested Parquet data using Iceberg and Spark Parquet readers. To run this benchmark for either spark-2 or spark-3:
+Core and data benchmarks can be run directly. Spark and Flink benchmarks use versioned Gradle modules.
+Spark `4.1` benchmarks use `2.13` module names, while older Spark modules follow the configured `scalaVersion`.
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=SparkParquetReadersNestedDataBenchmark -PjmhOutputPath=benchmark/spark-parquet-readers-nested-data-benchmark-result.txt`
+### Command templates
 
-### SparkParquetWritersFlatDataBenchmark
-A benchmark that evaluates the performance of writing Parquet data with a flat schema using Iceberg and Spark Parquet writers. To run this benchmark for either spark-2 or spark-3:
+#### Core and data modules
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=SparkParquetWritersFlatDataBenchmark -PjmhOutputPath=benchmark/spark-parquet-writers-flat-data-benchmark-result.txt`
+```bash
+./gradlew :iceberg-core:jmh -PjmhIncludeRegex=<BenchmarkName>
+./gradlew :iceberg-data:jmh -PjmhIncludeRegex=<BenchmarkName>
+```
 
-### IcebergSourceFlatORCDataReadBenchmark
-A benchmark that evaluates the performance of reading ORC data with a flat schema using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+#### Spark modules
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceFlatORCDataReadBenchmark -PjmhOutputPath=benchmark/iceberg-source-flat-orc-data-read-benchmark-result.txt`
+Run benchmarks in the default Spark module:
 
-### SparkParquetReadersFlatDataBenchmark
-A benchmark that evaluates the performance of reading Parquet data with a flat schema using Iceberg and Spark Parquet readers. To run this benchmark for either spark-2 or spark-3:
+```bash
+./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:jmh \
+  -PjmhIncludeRegex=<BenchmarkName>
+```
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=SparkParquetReadersFlatDataBenchmark -PjmhOutputPath=benchmark/spark-parquet-readers-flat-data-benchmark-result.txt`
+Run benchmarks in the default Spark extensions module:
 
-### VectorizedReadDictionaryEncodedFlatParquetDataBenchmark
-A benchmark to compare performance of reading Parquet dictionary encoded data with a flat schema using vectorized Iceberg read path and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+```bash
+./gradlew :iceberg-spark:iceberg-spark-extensions-4.1_2.13:jmh \
+  -PjmhIncludeRegex=<BenchmarkName>
+```
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=VectorizedReadDictionaryEncodedFlatParquetDataBenchmark -PjmhOutputPath=benchmark/vectorized-read-dict-encoded-flat-parquet-data-result.txt`
+To use another supported Spark version, set the version properties and update the module name accordingly. For example:
 
-### IcebergSourceNestedListORCDataWriteBenchmark
-A benchmark that evaluates the performance of writing nested Parquet data using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+```bash
+./gradlew -DsparkVersions=3.5 -DscalaVersion=2.12 \
+  :iceberg-spark:iceberg-spark-3.5_2.12:jmh \
+  -PjmhIncludeRegex=IcebergSourceFlatParquetDataReadBenchmark
+```
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceNestedListORCDataWriteBenchmark -PjmhOutputPath=benchmark/iceberg-source-nested-list-orc-data-write-benchmark-result.txt`
+#### Flink modules
 
-### VectorizedReadFlatParquetDataBenchmark
-A benchmark to compare performance of reading Parquet data with a flat schema using vectorized Iceberg read path and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+Run benchmarks in the default Flink module:
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=VectorizedReadFlatParquetDataBenchmark -PjmhOutputPath=benchmark/vectorized-read-flat-parquet-data-result.txt`
+```bash
+./gradlew :iceberg-flink:iceberg-flink-2.1:jmh \
+  -PjmhIncludeRegex=<BenchmarkName>
+```
 
-### IcebergSourceFlatParquetDataWriteBenchmark
-A benchmark that evaluates the performance of writing Parquet data with a flat schema using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+To use another supported Flink version, set the version property and update the module name. For example:
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceFlatParquetDataWriteBenchmark -PjmhOutputPath=benchmark/iceberg-source-flat-parquet-data-write-benchmark-result.txt`
+```bash
+./gradlew -DflinkVersions=2.0 \
+  :iceberg-flink:iceberg-flink-2.0:jmh \
+  -PjmhIncludeRegex=MapRangePartitionerBenchmark
+```
 
-### IcebergSourceNestedAvroDataReadBenchmark
-A benchmark that evaluates the performance of reading Avro data with a flat schema using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+### Core benchmarks
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceNestedAvroDataReadBenchmark -PjmhOutputPath=benchmark/iceberg-source-nested-avro-data-read-benchmark-result.txt`
+Run benchmarks in this group with:
 
-### IcebergSourceFlatAvroDataReadBenchmark
-A benchmark that evaluates the performance of reading Avro data with a flat schema using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+```bash
+./gradlew :iceberg-core:jmh -PjmhIncludeRegex=<BenchmarkName>
+```
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceFlatAvroDataReadBenchmark -PjmhOutputPath=benchmark/iceberg-source-flat-avro-data-read-benchmark-result.txt`
+* `AppendBenchmark`: Append data files to a table.
+* `ManifestReadBenchmark`: Read table manifests.
+* `ManifestWriteBenchmark`: Write table manifests.
+* `MetricsConfigBenchmark`: Evaluate metrics configuration lookups.
+* `ReplaceDeleteFilesBenchmark`: Replace delete files during a commit.
+* `RewriteDataFilesBenchmark`: Rewrite data files in table maintenance flows.
+* `RoaringPositionBitmapBenchmark`: Measure roaring bitmap operations used for position deletes.
+* `CountersBenchmark`: Measure metrics counter updates.
+* `ZOrderByteUtilsBenchmark`: Measure Z-order byte utility operations.
 
-### IcebergSourceNestedParquetDataWriteBenchmark
-A benchmark that evaluates the performance of writing nested Parquet data using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+### Data benchmarks
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceNestedParquetDataWriteBenchmark -PjmhOutputPath=benchmark/iceberg-source-nested-parquet-data-write-benchmark-result.txt`
+Run benchmarks in this group with:
 
-### IcebergSourceNestedParquetDataReadBenchmark
-* A benchmark that evaluates the performance of reading nested Parquet data using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+```bash
+./gradlew :iceberg-data:jmh -PjmhIncludeRegex=<BenchmarkName>
+```
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceNestedParquetDataReadBenchmark -PjmhOutputPath=benchmark/iceberg-source-nested-parquet-data-read-benchmark-result.txt`
+* `GenericOrcReaderBenchmark`: Read ORC data through the generic Iceberg reader.
+* `GenericParquetReaderBenchmark`: Read Parquet data through the generic Iceberg reader.
+* `PartitionStatsHandlerBenchmark`: Read and write partition statistics metadata.
 
-### IcebergSourceNestedORCDataReadBenchmark
-A benchmark that evaluates the performance of reading ORC data with a flat schema using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+### Spark action benchmarks
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceNestedORCDataReadBenchmark -PjmhOutputPath=benchmark/iceberg-source-nested-orc-data-read-benchmark-result.txt`
+Run benchmarks in this group with:
 
-### IcebergSourceFlatParquetDataReadBenchmark
-A benchmark that evaluates the performance of reading Parquet data with a flat schema using Iceberg and the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+```bash
+./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:jmh \
+  -PjmhIncludeRegex=<BenchmarkName>
+```
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceFlatParquetDataReadBenchmark -PjmhOutputPath=benchmark/iceberg-source-flat-parquet-data-read-benchmark-result.txt`
+* `DeleteOrphanFilesBenchmark`: Execute the delete-orphan-files action.
+* `IcebergSortCompactionBenchmark`: Execute sort-based compaction.
 
-### IcebergSourceFlatParquetDataFilterBenchmark
-A benchmark that evaluates the file skipping capabilities in the Spark data source for Iceberg. This class uses a dataset with a flat schema, where the records are clustered according to the
-column used in the filter predicate. The performance is compared to the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
+### Spark Parquet reader and writer benchmarks
 
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceFlatParquetDataFilterBenchmark -PjmhOutputPath=benchmark/iceberg-source-flat-parquet-data-filter-benchmark-result.txt`
+Run benchmarks in this group with:
 
-### IcebergSourceNestedParquetDataFilterBenchmark
-A benchmark that evaluates the file skipping capabilities in the Spark data source for Iceberg. This class uses a dataset with nested data, where the records are clustered according to the
-column used in the filter predicate. The performance is compared to the built-in file source in Spark. To run this benchmark for either spark-2 or spark-3:
-`./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=IcebergSourceNestedParquetDataFilterBenchmark -PjmhOutputPath=benchmark/iceberg-source-nested-parquet-data-filter-benchmark-result.txt`
+```bash
+./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:jmh \
+  -PjmhIncludeRegex=<BenchmarkName>
+```
 
-### SparkParquetWritersNestedDataBenchmark
-* A benchmark that evaluates the performance of writing nested Parquet data using Iceberg and Spark Parquet writers. To run this benchmark for either spark-2 or spark-3:
-  `./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:jmh -PjmhIncludeRegex=SparkParquetWritersNestedDataBenchmark -PjmhOutputPath=benchmark/spark-parquet-writers-nested-data-benchmark-result.txt`
+* `SparkParquetReadersFlatDataBenchmark`: Read flat Parquet data with Spark Parquet readers.
+* `SparkParquetReadersNestedDataBenchmark`: Read nested Parquet data with Spark Parquet readers.
+* `SparkParquetWritersFlatDataBenchmark`: Write flat Parquet data with Spark Parquet writers.
+* `SparkParquetWritersNestedDataBenchmark`: Write nested Parquet data with Spark Parquet writers.
+
+### Spark source benchmarks
+
+Run benchmarks in this group with:
+
+```bash
+./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:jmh \
+  -PjmhIncludeRegex=<BenchmarkName>
+```
+
+* `AvroWritersBenchmark`: Write Avro data through Iceberg writer implementations.
+* `DVReaderBenchmark`: Read data with deletion vectors.
+* `DVWriterBenchmark`: Write deletion vectors.
+* `IcebergSourceFlatAvroDataReadBenchmark`: Read flat Avro data through the Spark Iceberg source.
+* `IcebergSourceFlatORCDataReadBenchmark`: Read flat ORC data through the Spark Iceberg source.
+* `IcebergSourceFlatParquetDataFilterBenchmark`: Evaluate file skipping for clustered flat Parquet data.
+* `IcebergSourceFlatParquetDataReadBenchmark`: Read flat Parquet data through the Spark Iceberg source.
+* `IcebergSourceFlatParquetDataWriteBenchmark`: Write flat Parquet data through the Spark Iceberg source.
+* `IcebergSourceNestedAvroDataReadBenchmark`: Read nested Avro data through the Spark Iceberg source.
+* `IcebergSourceNestedListORCDataWriteBenchmark`: Write nested-list ORC data through the Spark Iceberg source.
+* `IcebergSourceNestedListParquetDataWriteBenchmark`: Write nested-list Parquet data through the Spark Iceberg source.
+* `IcebergSourceNestedORCDataReadBenchmark`: Read nested ORC data through the Spark Iceberg source.
+* `IcebergSourceNestedParquetDataFilterBenchmark`: Evaluate file skipping for clustered nested Parquet data.
+* `IcebergSourceNestedParquetDataReadBenchmark`: Read nested Parquet data through the Spark Iceberg source.
+* `IcebergSourceNestedParquetDataWriteBenchmark`: Write nested Parquet data through the Spark Iceberg source.
+* `IcebergSourceParquetEqDeleteBenchmark`: Read Parquet data with equality deletes applied.
+* `IcebergSourceParquetMultiDeleteFileBenchmark`: Read Parquet data with many delete files applied.
+* `IcebergSourceParquetPosDeleteBenchmark`: Read Parquet data with position deletes applied.
+* `IcebergSourceParquetWithUnrelatedDeleteBenchmark`: Read Parquet data when unrelated delete files are present.
+* `ParquetWritersBenchmark`: Write Parquet data through Iceberg writer implementations.
+* `VectorizedReadDictionaryEncodedFlatParquetDataBenchmark`: Vectorized reads of dictionary-encoded flat Parquet data.
+* `VectorizedReadFlatParquetDataBenchmark`: Vectorized reads of flat Parquet data.
+* `VectorizedReadParquetDecimalBenchmark`: Vectorized reads of Parquet decimal columns.
+
+### Spark extensions benchmarks
+
+Run benchmarks in this group with:
+
+```bash
+./gradlew :iceberg-spark:iceberg-spark-extensions-4.1_2.13:jmh \
+  -PjmhIncludeRegex=<BenchmarkName>
+```
+
+* `DeleteFileIndexBenchmark`: Build and query delete file indexes.
+* `MergeCardinalityCheckBenchmark`: Perform merge cardinality checks.
+* `PlanningBenchmark`: Plan Spark scans over Iceberg tables.
+* `TaskGroupPlanningBenchmark`: Plan Spark task groups for distributed execution.
+* `UpdateProjectionBenchmark`: Apply projection logic for Spark update operations.
+
+### Flink benchmarks
+
+Run benchmarks in this group with:
+
+```bash
+./gradlew :iceberg-flink:iceberg-flink-2.1:jmh \
+  -PjmhIncludeRegex=<BenchmarkName>
+```
+
+* `DynamicRecordSerializerDeserializerBenchmark`: Serialize and deserialize dynamic Flink records.
+* `MapRangePartitionerBenchmark`: Partition Flink shuffle data with the map-based range partitioner.
+* `SketchRangePartitionerBenchmark`: Partition Flink shuffle data with the sketch-based range partitioner.
+* `StatisticsRecordSerializerBenchmark`: Serialize shuffle statistics records in Flink.

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -106,15 +106,17 @@ Run benchmarks in this group with:
 ./gradlew :iceberg-core:jmh -PjmhIncludeRegex=<BenchmarkName>
 ```
 
-* `AppendBenchmark`: Append data files to a table.
-* `ManifestReadBenchmark`: Read table manifests.
-* `ManifestWriteBenchmark`: Write table manifests.
-* `MetricsConfigBenchmark`: Evaluate metrics configuration lookups.
-* `ReplaceDeleteFilesBenchmark`: Replace delete files during a commit.
-* `RewriteDataFilesBenchmark`: Rewrite data files in table maintenance flows.
-* `RoaringPositionBitmapBenchmark`: Measure roaring bitmap operations used for position deletes.
-* `CountersBenchmark`: Measure metrics counter updates.
-* `ZOrderByteUtilsBenchmark`: Measure Z-order byte utility operations.
+| Benchmark | Description |
+| --- | --- |
+| `AppendBenchmark` | Append data files to a table. |
+| `ManifestReadBenchmark` | Read table manifests. |
+| `ManifestWriteBenchmark` | Write table manifests. |
+| `MetricsConfigBenchmark` | Evaluate metrics configuration lookups. |
+| `ReplaceDeleteFilesBenchmark` | Replace delete files during a commit. |
+| `RewriteDataFilesBenchmark` | Rewrite data files in table maintenance flows. |
+| `RoaringPositionBitmapBenchmark` | Measure roaring bitmap operations used for position deletes. |
+| `CountersBenchmark` | Measure metrics counter updates. |
+| `ZOrderByteUtilsBenchmark` | Measure Z-order byte utility operations. |
 
 ### Data benchmarks
 
@@ -124,9 +126,11 @@ Run benchmarks in this group with:
 ./gradlew :iceberg-data:jmh -PjmhIncludeRegex=<BenchmarkName>
 ```
 
-* `GenericOrcReaderBenchmark`: Read ORC data through the generic Iceberg reader.
-* `GenericParquetReaderBenchmark`: Read Parquet data through the generic Iceberg reader.
-* `PartitionStatsHandlerBenchmark`: Read and write partition statistics metadata.
+| Benchmark | Description |
+| --- | --- |
+| `GenericOrcReaderBenchmark` | Read ORC data through the generic Iceberg reader. |
+| `GenericParquetReaderBenchmark` | Read Parquet data through the generic Iceberg reader. |
+| `PartitionStatsHandlerBenchmark` | Read and write partition statistics metadata. |
 
 ### Spark action benchmarks
 
@@ -137,8 +141,10 @@ Run benchmarks in this group with:
   -PjmhIncludeRegex=<BenchmarkName>
 ```
 
-* `DeleteOrphanFilesBenchmark`: Execute the delete-orphan-files action.
-* `IcebergSortCompactionBenchmark`: Execute sort-based compaction.
+| Benchmark | Description |
+| --- | --- |
+| `DeleteOrphanFilesBenchmark` | Execute the delete-orphan-files action. |
+| `IcebergSortCompactionBenchmark` | Execute sort-based compaction. |
 
 ### Spark Parquet reader and writer benchmarks
 
@@ -149,10 +155,12 @@ Run benchmarks in this group with:
   -PjmhIncludeRegex=<BenchmarkName>
 ```
 
-* `SparkParquetReadersFlatDataBenchmark`: Read flat Parquet data with Spark Parquet readers.
-* `SparkParquetReadersNestedDataBenchmark`: Read nested Parquet data with Spark Parquet readers.
-* `SparkParquetWritersFlatDataBenchmark`: Write flat Parquet data with Spark Parquet writers.
-* `SparkParquetWritersNestedDataBenchmark`: Write nested Parquet data with Spark Parquet writers.
+| Benchmark | Description |
+| --- | --- |
+| `SparkParquetReadersFlatDataBenchmark` | Read flat Parquet data with Spark Parquet readers. |
+| `SparkParquetReadersNestedDataBenchmark` | Read nested Parquet data with Spark Parquet readers. |
+| `SparkParquetWritersFlatDataBenchmark` | Write flat Parquet data with Spark Parquet writers. |
+| `SparkParquetWritersNestedDataBenchmark` | Write nested Parquet data with Spark Parquet writers. |
 
 ### Spark source benchmarks
 
@@ -163,29 +171,31 @@ Run benchmarks in this group with:
   -PjmhIncludeRegex=<BenchmarkName>
 ```
 
-* `AvroWritersBenchmark`: Write Avro data through Iceberg writer implementations.
-* `DVReaderBenchmark`: Read data with deletion vectors.
-* `DVWriterBenchmark`: Write deletion vectors.
-* `IcebergSourceFlatAvroDataReadBenchmark`: Read flat Avro data through the Spark Iceberg source.
-* `IcebergSourceFlatORCDataReadBenchmark`: Read flat ORC data through the Spark Iceberg source.
-* `IcebergSourceFlatParquetDataFilterBenchmark`: Evaluate file skipping for clustered flat Parquet data.
-* `IcebergSourceFlatParquetDataReadBenchmark`: Read flat Parquet data through the Spark Iceberg source.
-* `IcebergSourceFlatParquetDataWriteBenchmark`: Write flat Parquet data through the Spark Iceberg source.
-* `IcebergSourceNestedAvroDataReadBenchmark`: Read nested Avro data through the Spark Iceberg source.
-* `IcebergSourceNestedListORCDataWriteBenchmark`: Write nested-list ORC data through the Spark Iceberg source.
-* `IcebergSourceNestedListParquetDataWriteBenchmark`: Write nested-list Parquet data through the Spark Iceberg source.
-* `IcebergSourceNestedORCDataReadBenchmark`: Read nested ORC data through the Spark Iceberg source.
-* `IcebergSourceNestedParquetDataFilterBenchmark`: Evaluate file skipping for clustered nested Parquet data.
-* `IcebergSourceNestedParquetDataReadBenchmark`: Read nested Parquet data through the Spark Iceberg source.
-* `IcebergSourceNestedParquetDataWriteBenchmark`: Write nested Parquet data through the Spark Iceberg source.
-* `IcebergSourceParquetEqDeleteBenchmark`: Read Parquet data with equality deletes applied.
-* `IcebergSourceParquetMultiDeleteFileBenchmark`: Read Parquet data with many delete files applied.
-* `IcebergSourceParquetPosDeleteBenchmark`: Read Parquet data with position deletes applied.
-* `IcebergSourceParquetWithUnrelatedDeleteBenchmark`: Read Parquet data when unrelated delete files are present.
-* `ParquetWritersBenchmark`: Write Parquet data through Iceberg writer implementations.
-* `VectorizedReadDictionaryEncodedFlatParquetDataBenchmark`: Vectorized reads of dictionary-encoded flat Parquet data.
-* `VectorizedReadFlatParquetDataBenchmark`: Vectorized reads of flat Parquet data.
-* `VectorizedReadParquetDecimalBenchmark`: Vectorized reads of Parquet decimal columns.
+| Benchmark | Description |
+| --- | --- |
+| `AvroWritersBenchmark` | Write Avro data through Iceberg writer implementations. |
+| `DVReaderBenchmark` | Read data with deletion vectors. |
+| `DVWriterBenchmark` | Write deletion vectors. |
+| `IcebergSourceFlatAvroDataReadBenchmark` | Read flat Avro data through the Spark Iceberg source. |
+| `IcebergSourceFlatORCDataReadBenchmark` | Read flat ORC data through the Spark Iceberg source. |
+| `IcebergSourceFlatParquetDataFilterBenchmark` | Evaluate file skipping for clustered flat Parquet data. |
+| `IcebergSourceFlatParquetDataReadBenchmark` | Read flat Parquet data through the Spark Iceberg source. |
+| `IcebergSourceFlatParquetDataWriteBenchmark` | Write flat Parquet data through the Spark Iceberg source. |
+| `IcebergSourceNestedAvroDataReadBenchmark` | Read nested Avro data through the Spark Iceberg source. |
+| `IcebergSourceNestedListORCDataWriteBenchmark` | Write nested-list ORC data through the Spark Iceberg source. |
+| `IcebergSourceNestedListParquetDataWriteBenchmark` | Write nested-list Parquet data through the Spark Iceberg source. |
+| `IcebergSourceNestedORCDataReadBenchmark` | Read nested ORC data through the Spark Iceberg source. |
+| `IcebergSourceNestedParquetDataFilterBenchmark` | Evaluate file skipping for clustered nested Parquet data. |
+| `IcebergSourceNestedParquetDataReadBenchmark` | Read nested Parquet data through the Spark Iceberg source. |
+| `IcebergSourceNestedParquetDataWriteBenchmark` | Write nested Parquet data through the Spark Iceberg source. |
+| `IcebergSourceParquetEqDeleteBenchmark` | Read Parquet data with equality deletes applied. |
+| `IcebergSourceParquetMultiDeleteFileBenchmark` | Read Parquet data with many delete files applied. |
+| `IcebergSourceParquetPosDeleteBenchmark` | Read Parquet data with position deletes applied. |
+| `IcebergSourceParquetWithUnrelatedDeleteBenchmark` | Read Parquet data when unrelated delete files are present. |
+| `ParquetWritersBenchmark` | Write Parquet data through Iceberg writer implementations. |
+| `VectorizedReadDictionaryEncodedFlatParquetDataBenchmark` | Vectorized reads of dictionary-encoded flat Parquet data. |
+| `VectorizedReadFlatParquetDataBenchmark` | Vectorized reads of flat Parquet data. |
+| `VectorizedReadParquetDecimalBenchmark` | Vectorized reads of Parquet decimal columns. |
 
 ### Spark extensions benchmarks
 
@@ -196,11 +206,13 @@ Run benchmarks in this group with:
   -PjmhIncludeRegex=<BenchmarkName>
 ```
 
-* `DeleteFileIndexBenchmark`: Build and query delete file indexes.
-* `MergeCardinalityCheckBenchmark`: Perform merge cardinality checks.
-* `PlanningBenchmark`: Plan Spark scans over Iceberg tables.
-* `TaskGroupPlanningBenchmark`: Plan Spark task groups for distributed execution.
-* `UpdateProjectionBenchmark`: Apply projection logic for Spark update operations.
+| Benchmark | Description |
+| --- | --- |
+| `DeleteFileIndexBenchmark` | Build and query delete file indexes. |
+| `MergeCardinalityCheckBenchmark` | Perform merge cardinality checks. |
+| `PlanningBenchmark` | Plan Spark scans over Iceberg tables. |
+| `TaskGroupPlanningBenchmark` | Plan Spark task groups for distributed execution. |
+| `UpdateProjectionBenchmark` | Apply projection logic for Spark update operations. |
 
 ### Flink benchmarks
 
@@ -211,7 +223,9 @@ Run benchmarks in this group with:
   -PjmhIncludeRegex=<BenchmarkName>
 ```
 
-* `DynamicRecordSerializerDeserializerBenchmark`: Serialize and deserialize dynamic Flink records.
-* `MapRangePartitionerBenchmark`: Partition Flink shuffle data with the map-based range partitioner.
-* `SketchRangePartitionerBenchmark`: Partition Flink shuffle data with the sketch-based range partitioner.
-* `StatisticsRecordSerializerBenchmark`: Serialize shuffle statistics records in Flink.
+| Benchmark | Description |
+| --- | --- |
+| `DynamicRecordSerializerDeserializerBenchmark` | Serialize and deserialize dynamic Flink records. |
+| `MapRangePartitionerBenchmark` | Partition Flink shuffle data with the map-based range partitioner. |
+| `SketchRangePartitionerBenchmark` | Partition Flink shuffle data with the sketch-based range partitioner. |
+| `StatisticsRecordSerializerBenchmark` | Serialize shuffle statistics records in Flink. |

--- a/site/docs/benchmarks.md
+++ b/site/docs/benchmarks.md
@@ -37,7 +37,7 @@ GitHub-hosted runners have limited and shared resources, so treat these results 
 
 ## Running Benchmarks locally
 
-JMH writes human-readable output to `build/reports/jmh/human-readable-output.txt` and JSON output to `build/reports/jmh/results.json` by default. Override them with `-PjmhOutputPath=<path>` and `-PjmhJsonOutputPath=<path>` if needed.
+JMH writes human-readable output to `build/reports/jmh/human-readable-output.txt` and JSON output to `build/reports/jmh/results.json` by default. Override them with `-PjmhOutputPath=<path>` and `-PjmhJsonOutputPath=<path>` if needed. You can share the JSON output with others and view it in the [JMH Visualizer](https://jmh.morethan.io/).
 
 The default versions in this repository are:
 


### PR DESCRIPTION
## Why this change
The benchmarks page had a few separate problems that were all tied together:

- the markdown had rendering issues from inconsistent list and code-block formatting
- the page still described the Spark benchmarks as if they were generic "spark-2 or spark-3" commands, while the current build uses versioned Gradle modules
- the page only documented a small subset of the JMH benchmarks that exist in the repository today

Because of that, a narrow formatting-only edit would still have left the page inaccurate and incomplete. The page needed to be cleaned up structurally and rewritten around the current benchmark layout so the commands and benchmark inventory stayed aligned with the repository.

## What changed
- fixed the markdown formatting so the page renders consistently
- replaced the repeated per-benchmark command blocks with grouped command templates for core, data, Spark, Spark extensions, and Flink benchmarks
- documented the current default benchmark modules and version properties used by the build
- removed stale wording that implied the documented commands applied to older Spark generations without module/version differences
- added the missing benchmark groups and benchmark names from the current default JMH modules in the repository

## How this was validated
- compared the page content against the current JMH benchmark sources under `core`, `data`, `spark/v4.1/spark`, `spark/v4.1/spark-extensions`, and `flink/v2.1/flink`
- verified the documented Gradle task paths with:

```bash
./gradlew :iceberg-core:help --task jmh
```

That command resolved successfully and confirmed the task paths referenced by the updated page, including:
- `:iceberg-core:jmh`
- `:iceberg-data:jmh`
- `:iceberg-flink:iceberg-flink-2.1:jmh`
- `:iceberg-spark:iceberg-spark-4.1_2.13:jmh`
- `:iceberg-spark:iceberg-spark-extensions-4.1_2.13:jmh`

Closes #15556
