### PR TITLE
GCS: Add ability to configure http max connections and timeouts for gcs client. 

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -73,6 +73,15 @@ public class GCPProperties implements Serializable {
   /** Controls whether analytics core library is enabled or not. Defaults to false. */
   public static final String GCS_ANALYTICS_CORE_ENABLED = "gcs.analytics-core.enabled";
 
+  /** Optional configuration for connection timeout in milliseconds for GCS client. */
+  public static final String GCS_CONNECTION_TIMEOUT_MILLIS = "gcs.connection.timeout-millis";
+
+  /** Optional configuration for read timeout in milliseconds for GCS client. */
+  public static final String GCS_READ_TIMEOUT_MILLIS = "gcs.read.timeout-millis";
+
+  /** Optional configuration for max connections for GCS client. */
+  public static final String GCS_MAX_CONNECTIONS = "gcs.connection.max-connections";
+
   /**
    * Max possible batch size for deletion. Currently, a max of 100 keys is advised, so we default to
    * a number below that. https://cloud.google.com/storage/docs/batch
@@ -103,6 +112,12 @@ public class GCPProperties implements Serializable {
   private int gcsImpersonateLifetimeSeconds;
   private List<String> gcsImpersonateDelegates;
   private List<String> gcsImpersonateScopes;
+
+  private Integer connectionTimeoutMillis;
+
+  private Integer readTimeoutMillis;
+
+  private Integer maxConnections;
 
   private int gcsDeleteBatchSize = GCS_DELETE_BATCH_SIZE_DEFAULT;
 
@@ -197,6 +212,17 @@ public class GCPProperties implements Serializable {
 
     gcsAnalyticsCoreEnabled =
         PropertyUtil.propertyAsBoolean(properties, GCS_ANALYTICS_CORE_ENABLED, false);
+    if (properties.containsKey(GCS_CONNECTION_TIMEOUT_MILLIS)) {
+      connectionTimeoutMillis = Integer.parseInt(properties.get("gcs.connection.timeout-millis"));
+    }
+
+    if (properties.containsKey(GCS_MAX_CONNECTIONS)) {
+      maxConnections = Integer.parseInt(properties.get("gcs.connection.max-connections"));
+    }
+
+    if (properties.containsKey(GCS_READ_TIMEOUT_MILLIS)) {
+      readTimeoutMillis = Integer.parseInt(properties.get("gcs.read.timeout-millis"));
+    }
   }
 
   public Optional<Integer> channelReadChunkSize() {
@@ -277,5 +303,17 @@ public class GCPProperties implements Serializable {
 
   public boolean isGcsAnalyticsCoreEnabled() {
     return gcsAnalyticsCoreEnabled;
+  }
+
+  public Optional<Integer> getReadTimeoutMillis() {
+    return Optional.ofNullable(readTimeoutMillis);
+  }
+
+  public Optional<Integer> getMaxConnections() {
+    return Optional.ofNullable(maxConnections);
+  }
+
+  public Optional<Integer> getConnectionTimeoutMillis() {
+    return Optional.ofNullable(connectionTimeoutMillis);
   }
 }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.gcp.gcs;
 
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -27,11 +28,15 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemImpl;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.core.GcsAnalyticsCoreOptions;
+import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.gcp.GCPAuthUtils;
 import org.apache.iceberg.gcp.GCPProperties;
@@ -72,7 +77,7 @@ class PrefixedStorage implements AutoCloseable {
             gcpProperties.projectId().ifPresent(builder::setProjectId);
             gcpProperties.clientLibToken().ifPresent(builder::setClientLibToken);
             gcpProperties.serviceHost().ifPresent(builder::setHost);
-
+            updateHttpTransportOptions(builder, gcpProperties);
             Credentials credentials = credentials(gcpProperties);
             if (credentials != null) {
               builder.setCredentials(credentials);
@@ -83,6 +88,48 @@ class PrefixedStorage implements AutoCloseable {
     }
 
     this.gcsFileSystemSupplier = gcsFileSystemSupplier(properties);
+  }
+
+  /**
+   * Update the StorageOptions builder with HTTP transport options from GCP properties, if
+   * specified.
+   */
+  private void updateHttpTransportOptions(
+      StorageOptions.Builder builder, GCPProperties properties) {
+    HttpTransportOptions.Builder httpBuilder = HttpTransportOptions.newBuilder();
+    properties.getConnectionTimeoutMillis().ifPresent(httpBuilder::setConnectTimeout);
+    properties.getReadTimeoutMillis().ifPresent(httpBuilder::setReadTimeout);
+    properties
+        .getMaxConnections()
+        .ifPresent(
+            maxConnections -> {
+              updateConnectionManagerSettings(properties, maxConnections, httpBuilder);
+            });
+    builder.setTransportOptions(httpBuilder.build());
+  }
+
+  /**
+   * Update the HTTP transport settings to use a connection manager with the specified max
+   * connections, and apply any connection/request timeout settings from GCP properties.
+   */
+  private void updateConnectionManagerSettings(
+      GCPProperties properties, Integer maxConnections, HttpTransportOptions.Builder httpBuilder) {
+    RequestConfig.Builder requestConfig = RequestConfig.custom();
+    properties.getConnectionTimeoutMillis().ifPresent(requestConfig::setConnectionRequestTimeout);
+    properties.getReadTimeoutMillis().ifPresent(requestConfig::setSocketTimeout);
+    PoolingHttpClientConnectionManager poolingHttpClientConnectionManager =
+        new PoolingHttpClientConnectionManager();
+    poolingHttpClientConnectionManager.setMaxTotal(maxConnections);
+    // Do we have to set this?
+    poolingHttpClientConnectionManager.setDefaultMaxPerRoute(maxConnections);
+    httpBuilder.setHttpTransportFactory(
+        () ->
+            new ApacheHttpTransport(
+                HttpClients.custom()
+                    .setConnectionManager(poolingHttpClientConnectionManager)
+                    .setDefaultRequestConfig(requestConfig.build())
+                    .build()));
+    this.closeableGroup.addCloseable(poolingHttpClientConnectionManager);
   }
 
   public String storagePrefix() {

--- a/gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java
@@ -77,4 +77,31 @@ public class TestGCPProperties {
         .get()
         .isEqualTo("/v1/credentials");
   }
+
+  @Test
+  public void testHttpTransportOptionsUnset() {
+    GCPProperties emptyProps = new GCPProperties();
+    assertThat(emptyProps.getConnectionTimeoutMillis())
+        .describedAs("Connection timeout should not be set when the property is not provided")
+        .isNotPresent();
+    assertThat(emptyProps.getReadTimeoutMillis())
+        .describedAs("Read timeout should not be set when the property is not provided")
+        .isNotPresent();
+    assertThat(emptyProps.getConnectionTimeoutMillis())
+        .describedAs("Connection timeout should not be set when the property is not provided")
+        .isNotPresent();
+  }
+
+  @Test
+  public void testHttpTransportOptionsSet() {
+    GCPProperties gcpProperties =
+        new GCPProperties(
+            ImmutableMap.of(
+                GCPProperties.GCS_CONNECTION_TIMEOUT_MILLIS, "1000",
+                GCPProperties.GCS_READ_TIMEOUT_MILLIS, "2000",
+                GCPProperties.GCS_MAX_CONNECTIONS, "100"));
+    assertThat(gcpProperties.getConnectionTimeoutMillis()).isPresent().get().isEqualTo(1000);
+    assertThat(gcpProperties.getReadTimeoutMillis()).isPresent().get().isEqualTo(2000);
+    assertThat(gcpProperties.getMaxConnections()).isPresent().get().isEqualTo(100);
+  }
 }

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
@@ -21,10 +21,14 @@ package org.apache.iceberg.gcp.gcs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.cloud.gcs.analyticscore.client.GcsClientOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsReadOptions;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.StorageOptions;
 import java.util.Map;
 import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.gcp.GCPProperties;
@@ -78,12 +82,16 @@ public class TestPrefixedStorage {
   public void impersonationPropertiesAreRead() {
     Map<String, String> properties =
         ImmutableMap.of(
-            GCPProperties.GCS_PROJECT_ID, "myProject",
+            GCPProperties.GCS_PROJECT_ID,
+            "myProject",
             GCPProperties.GCS_IMPERSONATE_SERVICE_ACCOUNT,
-                "test-sa@project.iam.gserviceaccount.com",
-            GCPProperties.GCS_IMPERSONATE_DELEGATES, "delegate-sa@project.iam.gserviceaccount.com",
-            GCPProperties.GCS_IMPERSONATE_LIFETIME_SECONDS, "1800",
-            GCPProperties.GCS_IMPERSONATE_SCOPES, "bigquery,devstorage.read_only");
+            "test-sa@project.iam.gserviceaccount.com",
+            GCPProperties.GCS_IMPERSONATE_DELEGATES,
+            "delegate-sa@project.iam.gserviceaccount.com",
+            GCPProperties.GCS_IMPERSONATE_LIFETIME_SECONDS,
+            "1800",
+            GCPProperties.GCS_IMPERSONATE_SCOPES,
+            "bigquery,devstorage.read_only");
 
     GCPProperties gcpProperties = new GCPProperties(properties);
 
@@ -102,9 +110,10 @@ public class TestPrefixedStorage {
   public void impersonationPropertiesWithDefaults() {
     Map<String, String> properties =
         ImmutableMap.of(
-            GCPProperties.GCS_PROJECT_ID, "myProject",
+            GCPProperties.GCS_PROJECT_ID,
+            "myProject",
             GCPProperties.GCS_IMPERSONATE_SERVICE_ACCOUNT,
-                "test-sa@project.iam.gserviceaccount.com");
+            "test-sa@project.iam.gserviceaccount.com");
 
     GCPProperties gcpProperties = new GCPProperties(properties);
 
@@ -149,5 +158,57 @@ public class TestPrefixedStorage {
     assertThat(fileSystem).isNotNull();
     assertThat(fileSystem.getGcsClient()).isNotNull();
     assertThat(fileSystem.getFileSystemOptions()).isEqualTo(expectedOptions);
+  }
+
+  @Test
+  public void testDefaultHttpTransportClass() {
+    Map<String, String> properties = ImmutableMap.of(GCPProperties.GCS_PROJECT_ID, "myProject");
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+    StorageOptions options = storage.storage().getOptions();
+    HttpTransportOptions httpOptions = (HttpTransportOptions) options.getTransportOptions();
+    assertThat(httpOptions.getHttpTransportFactory().create())
+        .describedAs("Default HTTP transport should be NetHttpTransport")
+        .isInstanceOf(NetHttpTransport.class);
+  }
+
+  @Test
+  public void testHttpTransportOptions() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID, "myProject",
+            GCPProperties.GCS_CONNECTION_TIMEOUT_MILLIS, "1000",
+            GCPProperties.GCS_READ_TIMEOUT_MILLIS, "2000");
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+    StorageOptions options = storage.storage().getOptions();
+    assertThat(options.getTransportOptions()).isInstanceOf(HttpTransportOptions.class);
+    HttpTransportOptions httpOptions = (HttpTransportOptions) options.getTransportOptions();
+    assertThat(httpOptions.getHttpTransportFactory().create())
+        .describedAs(
+            "HTTP transport should be NetHttpTransport when connection or read timeout is set")
+        .isInstanceOf(NetHttpTransport.class);
+    assertThat(httpOptions.getConnectTimeout())
+        .describedAs("Connection timeout should be set from properties")
+        .isEqualTo(1000);
+    assertThat(httpOptions.getReadTimeout())
+        .describedAs("Read timeout should be set from properties")
+        .isEqualTo(2000);
+  }
+
+  @Test
+  public void testMaxConnections() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID, "myProject",
+            GCPProperties.GCS_CONNECTION_TIMEOUT_MILLIS, "10000",
+            GCPProperties.GCS_READ_TIMEOUT_MILLIS, "30000",
+            GCPProperties.GCS_MAX_CONNECTIONS, "10");
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+    StorageOptions options = storage.storage().getOptions();
+    assertThat(options.getTransportOptions()).isInstanceOf(HttpTransportOptions.class);
+    HttpTransportOptions httpOptions = (HttpTransportOptions) options.getTransportOptions();
+    assertThat(httpOptions.getHttpTransportFactory().create())
+        .describedAs("HTTP transport should be ApacheHttpTransport when max connections is set")
+        .isInstanceOf(ApacheHttpTransport.class);
+    // Figuring out if we can match the value max connection.
   }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/15587 
Initially I was only implementing above issue.
But later I found a way for https://github.com/apache/iceberg/issues/15411

This adds new configs to tune http connection parameters while while working with google cloud storage. 

Please refer to gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java files for the added configurations. 

### Test Plan 

Added new tests in gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
and gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java 

and reran full iceberg-gcp module tests