### PR TITLE
Core, Spark: Add JMH benchmarks for Variants

### DIFF
--- a/core/src/jmh/java/org/apache/iceberg/variants/VariantSerializationBenchmark.java
+++ b/core/src/jmh/java/org/apache/iceberg/variants/VariantSerializationBenchmark.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.variants;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Microbenchmark of Variant serialization, looking at shredding and nesting.
+ *
+ * <pre>
+ * ./gradlew :iceberg-core:jmh  -PjmhIncludeRegex=VariantSerializationBenchmark
+ * </pre>
+ *
+ * <p>Benchmark query: is variant ser/deser fast and does everything scale OK?
+ *
+ * <p>In particular: does shredding or nesting create problems?
+ *
+ * <p>Benchmark design: measure time to build, serialize and deserialize a variant object where the
+ * dept of nesting and percentage shedding are parameterized.
+ *
+ * <p>Include different variant value types.
+ *
+ * <p>Within each benchmark method, repeat the operation {@link #ITERATIONS} time to compensate low
+ * clock resolution on ARM cores. Real benchmarks MUST be performed on x86 parts so that {@code
+ * rdtscp} is used to measure duration at nanosecond granularity.
+ */
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 50)
+@Measurement(iterations = 100)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Timeout(time = 10, timeUnit = TimeUnit.MINUTES)
+public class VariantSerializationBenchmark {
+
+  /** How to nest the variant. */
+  public enum Depth {
+    /** Flat structure: no nesting. */
+    Flat,
+    /** Nested values. */
+    Nested,
+    /** Deeper nesting structure. */
+    DeepNesting
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(VariantSerializationBenchmark.class);
+
+  /** Number of fields in each nested variant object. */
+  private static final int NESTED_FIELD_COUNT = 5;
+
+  /** On a deep nesting, how deep? */
+  public static final int DEEP_NEST_DEPTH = 3;
+
+  /**
+   * How many iterations of each operation within a benchmark function? This is to compensate for
+   * the lack of resolution of ARM CPUs, which only have a 50 MHz clock for measurement. Each method
+   * has to iterate internally enought that the clock resolution doesn't affect the results.
+   */
+  public static final int ITERATIONS = 100;
+
+  /** Percentage of fields that are shredded (0 = none, 100 = all). */
+  @Param({"0", "33", "67", "100"})
+  private int shreddedPercent;
+
+  /**
+   * Total number of fields in the variant object. Must be at least as big as {@link
+   * #NESTED_FIELD_COUNT}.
+   */
+  @Param({"100", "500"})
+  private int fieldCount;
+
+  /** Depth of variant.. */
+  @Param({"Flat", "Nested", "DeepNesting"})
+  private Depth depth;
+
+  /** Metadata covering every field name (shredded + unshredded). */
+  private VariantMetadata metadata;
+
+  /** Ordered list of all field names. */
+  private List<String> fieldNames;
+
+  /** Typed values for each field. Index i corresponds to {@code fieldNames.get(i)}. */
+  private VariantValue[] fieldValues;
+
+  /**
+   * Number of fields that are placed into the shredded portion of the object, derived from {@link
+   * #shreddedPercent} and {@link #fieldCount}.
+   */
+  private int shreddedFieldCount;
+
+  /**
+   * Pre-serialized object containing the unshredded fields, or {@code null} when all fields are
+   * shredded.
+   */
+  private VariantObject unshreddedObject;
+
+  /** Recycled output buffer. Must be large enough for the largest value of {@link #fieldCount}. */
+  private ByteBuffer outputBuffer;
+
+  /** For benchmarking cost of writing, ignoring creation cost. */
+  private ShreddedObject preShreddedObject;
+
+  /** Pre-shredded object marshalled to a byte buffer. */
+  private ByteBuffer marshalledVariant;
+
+  /** Drives choice of field types and more. */
+  private Random random;
+
+  /**
+   * Set up the benchmark state for the current parameter combination.
+   *
+   * <p>Builds {@link #fieldNames} and {@link #fieldValues} with a random mix of ints, doubles,
+   * strings of different sizes, and UUIDs. When nested, null values are patched with nested variant
+   * objects containing string fields. The shredded/unshredded split and pre-serialized buffers are
+   * then constructed from these values.
+   */
+  @Setup(Level.Trial)
+  public void setupTrial() {
+    LOG.info(
+        "Setting up benchmark shreddedPercent={}% fields={} depth={}",
+        shreddedPercent, fieldCount, depth);
+    // fixed random for reproducibility; other benchmarks are a mix of fixed and time-based seeds.
+    random = new Random(0x1ceb1cebL);
+
+    fieldNames = Lists.newArrayListWithCapacity(fieldCount);
+    for (int i = 0; i < fieldCount; i++) {
+      fieldNames.add("field_" + i);
+    }
+    ByteBuffer metaBuf = VariantTestUtil.createMetadata(fieldNames, true /* sorted */);
+    metadata = VariantMetadata.from(metaBuf);
+    final boolean nested = depth != Depth.Flat;
+
+    // construct the field values such that any nested variants are composed of strings
+    // with the same field names as the top-level entries.
+    List<Integer> nullFields = Lists.newArrayList();
+    List<Integer> stringFields = Lists.newArrayList();
+
+    // a factory which creates variants; by adding more string functions
+    // it is biased towards strings.
+    List<Function<Integer, VariantValue>> variantFactory = Lists.newArrayList();
+    variantFactory.add(i -> Variants.of("string-" + i));
+    variantFactory.add(i -> Variants.of("longer string-" + i));
+    variantFactory.add(
+        i -> Variants.of("a longer string assuming these will be more common #" + i));
+    variantFactory.add(i -> Variants.of('a'));
+    variantFactory.add(i -> Variants.of(random.nextInt()));
+    variantFactory.add(i -> Variants.of(random.nextDouble()));
+    variantFactory.add(i -> Variants.of(random.nextBoolean()));
+    // as an example of a byte sequence other than string.
+    variantFactory.add(i -> Variants.ofUUID(UUID.randomUUID()));
+    variantFactory.add(i -> Variants.of(new BigDecimal(new BigInteger(64, random))));
+    if (nested) {
+      // on a deep variant, this will be replaced by a nested type later
+      variantFactory.add(i -> Variants.ofNull());
+    } else {
+      // add a string on shallow to keep the distribution of other values similar.
+      // leaving the null made serialization faster.
+      variantFactory.add(i -> Variants.of(Integer.toString(i)));
+    }
+    final int factorySize = variantFactory.size();
+    fieldValues = new VariantValue[fieldCount];
+
+    // build the field values.
+    for (int i = 0; i < fieldCount; i++) {
+      final VariantValue value = variantFactory.get(random.nextInt(factorySize)).apply(i);
+      fieldValues[i] = value;
+      if (value.type() == PhysicalType.STRING) {
+        stringFields.add(i);
+      } else if (value.type() == PhysicalType.NULL) {
+        nullFields.add(i);
+      }
+    }
+
+    // now, on a nested run patch null fields with a nested variant
+    if (nested) {
+      Preconditions.checkState(!stringFields.isEmpty(), "No string fields generated");
+      nullFields.forEach(
+          index -> fieldValues[index] = buildNestedValue(index, stringFields, DEEP_NEST_DEPTH));
+    }
+
+    // set up the shredding
+    shreddedFieldCount = fieldCount * shreddedPercent / 100;
+    if (shreddedFieldCount < fieldCount) {
+      unshreddedObject = buildSerializedObject(shreddedFieldCount, fieldCount, metaBuf);
+    } else {
+      unshreddedObject = null;
+    }
+
+    // build a pre-shredded object for serialization only tests
+    preShreddedObject = buildShreddedObject();
+    // use its size for buffer allocation
+    final int size = preShreddedObject.sizeInBytes();
+    // this buffer is recycled in benchmarks to avoid memory access interference
+    outputBuffer = ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN);
+
+    // a marshalled object to measure deserialization performance
+    marshalledVariant = ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN);
+    preShreddedObject.writeTo(marshalledVariant, 0);
+
+    LOG.info("Setup complete");
+  }
+
+  /**
+   * Build a nested variant object containing {@link #NESTED_FIELD_COUNT} string fields, reusing
+   * field names from the top-level field list.
+   *
+   * @param index index of row
+   * @param stringFields list of fields which are strings
+   * @param level levels to descend.
+   */
+  private VariantValue buildNestedValue(int index, List<Integer> stringFields, int level) {
+    final ShreddedObject entry = buildSingleNestedEntry(index, stringFields);
+    if (depth == Depth.DeepNesting && level > 0) {
+      // DeepNesting: outer object whose fields are themselves nested objects (two levels deep)
+      entry.put(
+          "nested_" + (NESTED_FIELD_COUNT + 1), buildNestedValue(index, stringFields, level - 1));
+    }
+
+    return entry;
+  }
+
+  /**
+   * Build a single nested entry.
+   *
+   * @param index row index. list of fields which are strings.
+   * @param stringFields list of fields which are strings
+   * @return a nested entry.
+   */
+  private ShreddedObject buildSingleNestedEntry(int index, List<Integer> stringFields) {
+    ShreddedObject nested = Variants.object(metadata);
+    final int stringCount = stringFields.size();
+
+    for (int j = 0; j < NESTED_FIELD_COUNT; j++) {
+      nested.put(
+          fieldNames.get(stringFields.get(random.nextInt(stringCount))),
+          Variants.of("nested_" + index + "_" + j));
+    }
+    return nested;
+  }
+
+  /**
+   * Serializes a subset of fields into a {@link VariantObject} backed by a {@link ByteBuffer} so it
+   * can be used as the unshredded remainder.
+   *
+   * @param from inclusive start index into {@link #fieldNames}
+   * @param to exclusive end index into {@link #fieldNames}
+   * @param metaBuf the shared metadata buffer
+   */
+  private VariantObject buildSerializedObject(int from, int to, ByteBuffer metaBuf) {
+    LOG.info("serialize {}-{}", from, to);
+    ImmutableMap.Builder<String, VariantValue> builder = ImmutableMap.builder();
+    for (int i = from; i < to; i++) {
+      builder.put(fieldNames.get(i), fieldValues[i]);
+    }
+    Map<String, VariantValue> fields = builder.build();
+    ByteBuffer valueBuf = VariantTestUtil.createObject(metaBuf, fields);
+    return (VariantObject) Variants.value(metadata, valueBuf);
+  }
+
+  /**
+   * Build a shredded object from the benchmark's current fields.
+   *
+   * @return a new shredded object.
+   */
+  private ShreddedObject buildShreddedObject() {
+    ShreddedObject shredded = Variants.object(metadata, unshreddedObject);
+
+    for (int i = 0; i < shreddedFieldCount; i++) {
+      shredded.put(fieldNames.get(i), fieldValues[i]);
+    }
+    return shredded;
+  }
+
+  /**
+   * Serialize-only path: reuse a pre-built {@link ShreddedObject} and measure the cost of {@link
+   * ShreddedObject#sizeInBytes()} and {@link ShreddedObject#writeTo(ByteBuffer, int)}.
+   *
+   * <p>The output buffer is recycled to isolate serialization cost from memory allocation.
+   */
+  @Benchmark
+  public void serialize(Blackhole bh) {
+    for (int i = 0; i < ITERATIONS; i++) {
+      outputBuffer.clear();
+      bh.consume(preShreddedObject.sizeInBytes());
+      preShreddedObject.writeTo(outputBuffer, 0);
+      bh.consume(outputBuffer);
+    }
+  }
+
+  /**
+   * Deserialize-only path: read a pre-serialized variant from a memory buffer and access every
+   * field.
+   */
+  @Benchmark
+  public void deserialize(Blackhole bh) {
+    for (int i = 0; i < ITERATIONS; i++) {
+      marshalledVariant.rewind();
+      VariantObject parsed = (VariantObject) Variants.value(metadata, marshalledVariant);
+      for (String name : fieldNames) {
+        bh.consume(parsed.get(name));
+      }
+    }
+  }
+
+  /**
+   * Round-trip: serialize a pre-built {@link ShreddedObject} into a recycled memory buffer, then
+   * immediately deserialize from that same buffer and access every field.
+   *
+   * <p>This is the most realistic benchmark: it exercises the full serialize → write → read →
+   * deserialize path that production code follows, with the buffer reused to focus measurement on
+   * the variant logic rather than memory allocation.
+   */
+  @Benchmark
+  public void roundTrip(Blackhole bh) {
+    for (int i = 0; i < ITERATIONS; i++) {
+      outputBuffer.clear();
+      bh.consume(preShreddedObject.sizeInBytes());
+      preShreddedObject.writeTo(outputBuffer, 0);
+      VariantObject parsed = (VariantObject) Variants.value(metadata, outputBuffer);
+      for (String name : fieldNames) {
+        bh.consume(parsed.get(name));
+      }
+    }
+  }
+}

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -90,4 +90,14 @@ configure(jmhProjects) {
   }
 
   tasks.jmh.finalizedBy tasks.jmhReport
+
+  // iceberg-open-api has no main jar (jar task is disabled); exclude it from the JMH fat jar
+  // to prevent failures when the task tries to expand a file that was never produced.
+  // Benchmark sources do not use iceberg-open-api directly; test fixtures from that module
+  // are pulled in transitively via the Spark test classpath but are not needed at benchmark runtime.
+  afterEvaluate {
+    configurations.jmhRuntimeClasspath {
+      exclude group: 'org.apache.iceberg', module: 'iceberg-open-api'
+    }
+  }
 }

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
@@ -52,6 +53,11 @@ import org.apache.iceberg.variants.ValueArray;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -117,17 +123,21 @@ import org.slf4j.LoggerFactory;
  *       -PjmhOutputPath=build/reports/benchmark/iceberg-source-variant-io-benchmark-result.txt
  * </code>
  */
-@Fork(0)
-@Warmup(iterations = 1)
-@Measurement(iterations = 1)
+@Fork(1)
+@Warmup(iterations = 20)
+@Measurement(iterations = 20)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Timeout(time = 10, timeUnit = TimeUnit.MINUTES)
+@Timeout(time = 60, timeUnit = TimeUnit.MINUTES)
 public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
 
   private static final Logger LOG = LoggerFactory.getLogger(IcebergSourceVariantIOBenchmark.class);
 
+  /** Table to use in benchmark. */
+  @Param({"Avro", "Unshredded", "Shredded"})
+  private TableType tableType;
+
   private static final int NUM_FILES = 1;
-  private static final int NUM_ROWS_PER_FILE = 10_000_000;
+  private static final int NUM_ROWS_PER_FILE = 100_000;
 
   /** Size of a compressed rowgroup. */
   private static final int ROW_GROUP_SIZE = 1 * 1024 * 1024;
@@ -214,10 +224,6 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     }
   }
 
-  /** Table to use in benchmark. */
-  @Param({"Avro", "Unshredded", "Shredded"})
-  private TableType tableType;
-
   /** Size must be 20 as the choice of string is derived from category. */
   private String[] repeatedStrings;
 
@@ -258,10 +264,9 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     properties.put(TableProperties.SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
     // large split size keeps the single data file as one Spark task.
     properties.put(TableProperties.SPLIT_SIZE, Integer.toString(512 * 1024 * 1024));
-    // turn off compression to remove it as a factor.
-    properties.put(TableProperties.METADATA_COMPRESSION, "none");
-    properties.put(TableProperties.PARQUET_COMPRESSION, "none");
-    properties.put(TableProperties.AVRO_COMPRESSION, "none");
+    /*    properties.put(TableProperties.METADATA_COMPRESSION, "zstd");
+    properties.put(TableProperties.PARQUET_COMPRESSION, "zstd");
+    properties.put(TableProperties.AVRO_COMPRESSION, "zstd");*/
     // small row group size ensures multiple row groups per file for row-group skipping benchmarks.
     properties.put(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(ROW_GROUP_SIZE));
     // variant projection pushdown not supported with the vectorized reader.
@@ -435,7 +440,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    */
   @Benchmark
   public void filterCatProjectVarID(Blackhole blackhole) {
-    select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_CATEGORY, true);
+    select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_CATEGORY, false);
   }
 
   /** Project on ID. */
@@ -476,7 +481,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
 
   @Benchmark
   public void filterVarCatSetMembership(Blackhole blackhole) {
-    select(blackhole, COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (5)", true);
+    select(blackhole, COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (1)", true);
   }
 
   @Benchmark
@@ -629,13 +634,16 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
                     .locationProvider()
                     .newDataLocation(String.format(Locale.ROOT, "data-%05d.parquet", fileIndex)));
 
+    // forTable(table()) propagates the table properties (including
+    // PARQUET_ROW_GROUP_SIZE_BYTES set in initTable()) into the writer. Without this,
+    // the writer falls back to the Parquet default row-group size and emits a single
+    // row group for the whole file, defeating row-group skipping.
     DataWriter<Record> writer =
         Parquet.writeData(outputFile)
-            .schema(SCHEMA)
+            .forTable(table())
             .createWriterFunc(GenericParquetWriter::create)
             .variantShreddingFunc(shredder)
             .overwrite()
-            .withSpec(PartitionSpec.unpartitioned())
             .build();
 
     writeOneFile(writer, variantMetadata, fileIndex);
@@ -645,7 +653,125 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
         fileIndex,
         dataFile.fileSizeInBytes(),
         Math.max(1, dataFile.fileSizeInBytes() / ROW_GROUP_SIZE));
+    dumpRowGroupDiagnostics(outputFile);
     return dataFile;
+  }
+
+  /**
+   * Per-row-group statistics dump. Confirms that:
+   *
+   * <ul>
+   *   <li>multiple row groups were actually written (not just one)
+   *   <li>category and shredded {@code varcategory} columns have populated min/max stats
+   *   <li>clustering produced tight ranges per row group (most groups have {@code min == max})
+   *   <li>a filter like {@code varcategory = 1} can theoretically skip groups
+   * </ul>
+   *
+   * <p>Only the shredded path looks at {@code nested.typed_value.varcategory.typed_value}; on
+   * unshredded runs that path doesn't exist and is silently absent in the per-block dump.
+   */
+  private void dumpRowGroupDiagnostics(OutputFile outputFile) throws IOException {
+    ColumnPath categoryPath = ColumnPath.get("category");
+    ColumnPath shreddedVarcategoryPath =
+        ColumnPath.get("nested", "typed_value", "varcategory", "typed_value");
+    int expectedSkipForVarcatEq1 = 0;
+    int blocksMissingShreddedVarcategory = 0;
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(ParquetIO.file(outputFile.toInputFile()))) {
+      List<BlockMetaData> blocks = reader.getFooter().getBlocks();
+      LOG.info("Parquet diagnostics: {} row groups", blocks.size());
+      for (int i = 0; i < blocks.size(); i++) {
+        BlockMetaData block = blocks.get(i);
+        ColumnChunkMetaData categoryChunk = findChunk(block, categoryPath);
+        ColumnChunkMetaData varcategoryChunk = findChunk(block, shreddedVarcategoryPath);
+        String categorySummary = summarizeStats(categoryChunk);
+        String varcategorySummary =
+            varcategoryChunk == null ? "<absent>" : summarizeStats(varcategoryChunk);
+        LOG.info(
+            "  block[{}]: rows={} bytes={} category={} shreddedVarcategory={}",
+            i,
+            block.getRowCount(),
+            block.getTotalByteSize(),
+            categorySummary,
+            varcategorySummary);
+        if (isShredded()) {
+          if (varcategoryChunk == null) {
+            blocksMissingShreddedVarcategory++;
+          } else if (rangeExcludesIntLiteral(varcategoryChunk.getStatistics(), 1)) {
+            expectedSkipForVarcatEq1++;
+          }
+        }
+      }
+      if (isShredded()) {
+        if (blocksMissingShreddedVarcategory > 0) {
+          LOG.warn(
+              "Shredded run is missing the varcategory typed_value column in {} of {} blocks "
+                  + "- shredding did not produce the expected layout",
+              blocksMissingShreddedVarcategory,
+              blocks.size());
+        }
+        LOG.info(
+            "Parquet diagnostics summary: rowGroups={} expectedSkipForVarcatEq1={}",
+            blocks.size(),
+            expectedSkipForVarcatEq1);
+      }
+    }
+  }
+
+  /**
+   * Find the column chunk for a given column path
+   *
+   * @param block metadata
+   * @param path column path
+   * @return chunk metadata or null if not found.
+   */
+  private static ColumnChunkMetaData findChunk(BlockMetaData block, ColumnPath path) {
+    return block.getColumns().stream()
+        .filter(chunk -> chunk.getPath().equals(path))
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Generate a simple summary of the column chunk stats, or &lt;absent&gt; if the supplied metadata
+   * is null, &lt;no-stats&gt; if there were no statistics found.
+   *
+   * @param chunk chunk metadata
+   * @return summary.
+   */
+  private static String summarizeStats(ColumnChunkMetaData chunk) {
+    if (chunk == null) {
+      return "<absent>";
+    }
+    Statistics<?> stats = chunk.getStatistics();
+    if (stats == null || stats.isEmpty()) {
+      return "<no-stats>";
+    }
+    return String.format(
+        Locale.ROOT,
+        "min=%s max=%s nulls=%s values=%d",
+        stats.hasNonNullValue() ? stats.genericGetMin() : "<unset>",
+        stats.hasNonNullValue() ? stats.genericGetMax() : "<unset>",
+        stats.isNumNullsSet() ? Long.toString(stats.getNumNulls()) : "<unset>",
+        chunk.getValueCount());
+  }
+
+  /**
+   * True if the chunk's statistics prove the integer literal cannot appear in the group — i.e. the
+   * row group is skippable for an equality predicate on that literal. Returns false if stats are
+   * absent, empty, or span the literal.
+   */
+  private static boolean rangeExcludesIntLiteral(Statistics<?> stats, int literal) {
+    if (stats == null || stats.isEmpty() || !stats.hasNonNullValue()) {
+      return false;
+    }
+    if (!(stats.genericGetMin() instanceof Number minNum)
+        || !(stats.genericGetMax() instanceof Number maxNum)) {
+      return false;
+    }
+    long min = minNum.longValue();
+    long max = maxNum.longValue();
+    return literal < min || literal > max;
   }
 
   /**
@@ -684,6 +810,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
 
     DataWriter<Record> writer =
         Avro.writeData(outputFile)
+            .forTable(table())
             .schema(SCHEMA)
             .createWriterFunc(org.apache.iceberg.data.avro.DataWriter::create)
             .overwrite()

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
@@ -1,0 +1,731 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.source.IcebergSourceBenchmark;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.ValueArray;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.schema.Type;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A benchmark that evaluates the performance of reading and filtering variant data through
+ * Iceberg's Spark data source.
+ *
+ * <p>Three tables are created with identical data:
+ *
+ * <ol>
+ *   <li>avro records containing the bytes
+ *   <li>unshredded variant object
+ *   <li>fully shredded variant object
+ * </ol>
+ *
+ * <p>The table structure is:
+ *
+ * <pre>
+ *   id: int64 :- unique per row
+ *   category: int32 :- in range 0-19; written in clustered order so each Parquet row group covers
+ *                      only a narrow category range (~1–2 row groups per category).
+ *   nested: variant (object)
+ *       .idstr: string :- unique string per row
+ *       .varid: int64  :- id
+ *       .varcategory: int32  :- category (0-19)
+ *       .col4: string :- non-unique string per row (picked from 20 values based on category)
+ *   arr: variant (array, always unshredded)
+ *       [0]: int32 :- category (0-19)
+ *       [1]: int32 :- id % 20
+ *       [2]: int32 :- id % 100
+ *       [3]: int32 :- id % 50
+ *       [4]: int32 :- id % 1000
+ * </pre>
+ *
+ * <p>Arrays don't shred because they are anonymous.
+ *
+ * <p>All data is written into a single file to keep the Spark task count to 1. Combined with a
+ * {@code local[1]} Spark master, all benchmark iterations execute on a single thread, which
+ * eliminates inter-task scheduling noise and makes measurements reproducible.
+ *
+ * <p>The structure and repetition helps highlight the space-saving benefits of parquet and shredded
+ * parquet, irrespective of performance — look in the output logs for "Size of Table" to see the
+ * values.
+ *
+ * <p>To run this benchmark for spark-4.1: <code>
+ *   ./gradlew -DsparkVersions=4.1 :iceberg-spark:iceberg-spark-4.1_2.13:jmh \
+ *       -PjmhIncludeRegex=IcebergSourceVariantIOBenchmark \
+ *       -PjmhOutputPath=build/reports/benchmark/iceberg-source-variant-io-benchmark-result.txt
+ * </code>
+ */
+@Fork(1)
+@Warmup(iterations = 4)
+@Measurement(iterations = 4)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Timeout(time = 10, timeUnit = TimeUnit.MINUTES)
+public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergSourceVariantIOBenchmark.class);
+
+  private static final int NUM_FILES = 1;
+  private static final int NUM_ROWS_PER_FILE = 1_000_000;
+
+  /**
+   * At ~140 bytes/row (uncompressed), 4MB ≈ 29k rows/group. With 1M rows in one file clustered by
+   * 20 categories (50k rows each), this gives ~1–2 row groups per category. Filter={@code category
+   * IN (5)} skips ~32/34 row groups (95% skip rate).
+   */
+  private static final int ROW_GROUP_SIZE = 4 * 1024 * 1024; // 4 MB
+
+  /** Number of distinct category values. */
+  private static final int NUM_CATEGORIES = 20;
+
+  public static final String COL_ID = "id";
+  private static final String COL_NESTED = "nested";
+  private static final String COL_ARR = "arr";
+
+  /** Name of the Spark temp view registered in {@link #setupBenchmark()}. */
+  private static final String TEMP_VIEW = "variant_table";
+
+  /**
+   * Name of the second Spark temp view for the self-join benchmark. Both views read the same
+   * underlying table; registering two aliases avoids any Spark self-join restrictions.
+   */
+  private static final String TEMP_VIEW2 = "variant_table2";
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, COL_ID, Types.LongType.get()),
+          required(2, "category", Types.IntegerType.get()),
+          required(3, COL_NESTED, Types.VariantType.get()), /* The variant object. */
+          required(4, COL_ARR, Types.VariantType.get())); /* The variant array. */
+
+  /** Filter to use when filtering on category column: {@value}. */
+  private static final String FILTER_ON_CATEGORY = "category = 5";
+
+  /** Get the category column from the variant: {@value}. */
+  private static final String VARIANT_GET_NESTED_CATEGORY =
+      "variant_get(nested, '$.varcategory', 'int')";
+
+  /** Get the ID field from inside the variant: {@value}. */
+  private static final String VARIANT_GET_NESTED_ID = "variant_get(nested, '$.varid', 'int')";
+
+  /**
+   * Equality check.
+   */
+  public static final String EQUALITY_CHECK_5 = " = 5";
+
+  /** Equivalent of {@link #FILTER_ON_CATEGORY} using the field within the variant: {@value}. */
+  private static final String FILTER_ON_NESTED_CATEGORY =
+      VARIANT_GET_NESTED_CATEGORY + EQUALITY_CHECK_5;
+
+  /**
+   * Get element 0 of the array variant; element 0 = category (range 0-19): {@value}.
+   *
+   * <p>Note: {@code variant_get} with a JSONPath {@code $[n]} expression accesses array elements.
+   */
+  private static final String VARIANT_GET_ARR_ELT0 = "variant_get(arr, '$[0]', 'int')";
+
+  /**
+   * Filter on element 0 of the array variant — same ~5% selectivity as {@link #FILTER_ON_CATEGORY}:
+   * {@value}.
+   */
+  private static final String FILTER_ON_ARR_ELT0 = VARIANT_GET_ARR_ELT0 + EQUALITY_CHECK_5;
+
+  /** Table to use in benchmark. */
+  public enum TableType {
+    /** Parquet, no shedding. */
+    Unshredded("parquet", FileFormat.PARQUET, false),
+    /** Parquet, shedded. */
+    Shredded("parquet", FileFormat.PARQUET, true),
+    /** Avro. */
+    Avro("avro", FileFormat.AVRO, false);
+    private final String name;
+    private final FileFormat format;
+    private final boolean shredded;
+
+    TableType(String name, FileFormat format, boolean shredded) {
+      this.name = name;
+      this.format = format;
+      this.shredded = shredded;
+    }
+
+    @Override
+    public String toString() {
+      return "TableType{"
+          + "name='"
+          + name
+          + '\''
+          + ", format="
+          + format
+          + ",  shredded="
+          + shredded
+          + '}';
+    }
+  }
+
+  /** Table to use in benchmark. */
+  @Param({"Avro", "Unshredded", "Shredded"})
+  private TableType tableType;
+
+  /** Size must be 20 as the choice of string is derived from category. */
+  private String[] repeatedStrings;
+
+  /** Variant metadata. */
+  private VariantMetadata variantMetadata;
+
+  /** Function to shred variants; will be different for shredded vs unshredded tables. */
+  private VariantShreddingFunction shredder;
+
+  @Override
+  protected Configuration initHadoopConf() {
+    final Configuration conf = new Configuration();
+    conf.setBoolean("fs.file.checksum.verify", false);
+    return conf;
+  }
+
+  /**
+   * Use a single-threaded Spark master to eliminate inter-task scheduling noise.
+   *
+   * <p>With one file and {@code local[1]}, every scan benchmark runs as a single serial task.
+   */
+  @Override
+  protected String sparkMaster() {
+    return "local[1]";
+  }
+
+  /**
+   * This gets invoked in the superclass constructor, at which time the table type is unknown. This
+   * is why the default table type cannot be set.
+   *
+   * @return a table
+   */
+  @Override
+  protected Table initTable() {
+    HadoopTables tables = new HadoopTables(hadoopConf());
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.FORMAT_VERSION, "3");
+    properties.put(TableProperties.SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    // large split size keeps the single data file as one Spark task.
+    properties.put(TableProperties.SPLIT_SIZE, Integer.toString(512 * 1024 * 1024));
+    // turn off compression to remove it as a factor.
+    properties.put(TableProperties.METADATA_COMPRESSION, "none");
+    properties.put(TableProperties.PARQUET_COMPRESSION, "none");
+    properties.put(TableProperties.AVRO_COMPRESSION, "none");
+    // small row group size ensures multiple row groups per file for row-group skipping benchmarks.
+    properties.put(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(ROW_GROUP_SIZE));
+    // variant projection pushdown not supported with the vectorized reader.
+    properties.put(TableProperties.PARQUET_VECTORIZATION_ENABLED, "false");
+
+    return tables.create(SCHEMA, PartitionSpec.unpartitioned(), properties, newTableLocation());
+  }
+
+  @Setup
+  public void setupBenchmark() throws IOException {
+    setupSpark();
+    // one shuffle partition keeps the join benchmark on a single task.
+    spark().conf().set("spark.sql.shuffle.partitions", "1");
+
+    // build the parquet schema of the shredded type by creating one variant instance
+    // and type converting it.
+    variantMetadata = Variants.metadata("idstr", "varid", "varcategory", "col4");
+    Type shreddedType =
+        ParquetVariantUtil.toParquetSchema(buildVariant(variantMetadata, 0, 0, "").value());
+    shredder =
+        tableType.shredded
+            ? (fieldId, fieldName) -> COL_NESTED.equals(fieldName) ? shreddedType : null
+            : (fieldId, fieldName) -> null;
+
+    // algorithm for category produces a value 0..19
+    final int categoryCount = 20;
+    repeatedStrings = new String[categoryCount];
+    IntStream.range(0, categoryCount)
+        .forEach(i -> repeatedStrings[i] = "Longer repeated string " + i);
+    // only one table is populated, to keep setup times down
+    LOG.info("building table {}", tableType);
+    long size =
+        switch (tableType) {
+          case Unshredded, Shredded -> appendVariantData();
+          case Avro -> appendAvroVariantData();
+        };
+    tableDataset().createOrReplaceTempView(TEMP_VIEW);
+    tableDataset().createOrReplaceTempView(TEMP_VIEW2);
+    final String summary = String.format(Locale.ROOT, "Size of Table %s : %,3d", tableType, size);
+    LOG.info("{}", summary);
+    tableDataset().printSchema();
+  }
+
+  @TearDown
+  public void tearDownBenchmark() throws IOException {
+    tearDownSpark();
+    cleanupFiles();
+  }
+
+  @Override
+  protected FileFormat fileFormat() {
+    return tableType.format;
+  }
+
+  /**
+   * Create a Spark dataset for the table being benchmarked.
+   *
+   * @return a dataset reading the appropriate table.
+   */
+  private Dataset<Row> tableDataset() {
+    return spark().read().format("iceberg").load(table().location());
+  }
+
+  /** Read the entire table. */
+  @Benchmark
+  public void count() {
+    project("*");
+  }
+
+  /**
+   * Read the rows, filtering on the category field, which is outside the variant, then filter on
+   * ID.
+   *
+   * <p>This measures classic query performance where columnar formats have an advantage over
+   * row-structured ones, especially as the tables grow in size or row width.
+   */
+  @Benchmark
+  public void filterCatProjectID() {
+    select(COL_ID, FILTER_ON_CATEGORY);
+  }
+
+  /**
+   * Perform a sql select operation.
+   *
+   * @param projection columns to project.
+   * @param where optional WHERE clause
+   * @return the result.
+   */
+  private long select(String projection, String where) {
+    final String text =
+        "SELECT " + projection + " FROM " + TEMP_VIEW + (where != null ? " WHERE " + where : "");
+    return sql(text);
+  }
+
+  /**
+   * Issue any Spark SQL command.
+   *
+   * @param command command to execute
+   * @return count of result.
+   */
+  private long sql(String command) {
+    LOG.info("{}", command);
+    return materializeNonEmpty(command, spark().sql(command));
+  }
+
+  /**
+   * Perform a sql projection operation.
+   *
+   * @param projection columns to project.
+   * @return the result.
+   */
+  private long project(String projection) {
+    return select(projection, null);
+  }
+
+  /**
+   * Read the rows, filtering on the category field, which is outside the variant, then filter on
+   * the variant ID.
+   */
+  @Benchmark
+  public void filterCatProjectVarID() {
+    select(VARIANT_GET_NESTED_ID, FILTER_ON_CATEGORY);
+  }
+
+  /** Project on ID. */
+  @Benchmark
+  public void projectID() {
+    project(COL_ID);
+  }
+
+  /** Extract the varid field only. */
+  @Benchmark
+  public void projectVarID() {
+    project(VARIANT_GET_NESTED_ID);
+  }
+
+  /**
+   * Read filtering on an element within the variant through {@code variant_get()} then project on
+   * ID.
+   *
+   * <p>Filtering on a column within the variant assesses predicate pushdown: is the whole variant
+   * reconstructed before filtering? or does the {@code variant_get()} get used early.
+   */
+  @Benchmark
+  public void filterVarcatProjectID() {
+    select(COL_ID, FILTER_ON_NESTED_CATEGORY);
+  }
+
+  /** Filter to the category match; no projection. */
+  @Benchmark
+  public void filterCat() {
+    select("*", FILTER_ON_CATEGORY);
+  }
+
+  /** Filter to the varcat match; no projection. */
+  @Benchmark
+  public void filterVarCat() {
+    select("*", FILTER_ON_NESTED_CATEGORY);
+  }
+
+  @Benchmark
+  public void filterVarCatSetMembership() {
+    select(COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (5)");
+  }
+
+  @Benchmark
+  public void filterVarCatSetNotInMembership() {
+    select(COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (100, 400)");
+  }
+
+  @Benchmark
+  public void filterVarCatSetNotInRange() {
+    select(COL_ID, VARIANT_GET_NESTED_CATEGORY + " < 0");
+  }
+
+  /** Project on the category field within the variant; no filtering. */
+  @Benchmark
+  public void projectVarCat() {
+    project(VARIANT_GET_NESTED_CATEGORY);
+  }
+
+  /** Filter on nested category field then project on the nested ID field. */
+  @Benchmark
+  public void filterVarcatProjectVarID() {
+    select(VARIANT_GET_NESTED_ID, FILTER_ON_NESTED_CATEGORY);
+  }
+
+  /**
+   * Materialize a dataset by counting its elements; raise an exception if the set is empty, as that
+   * is interpreted a sign the query is somehow broken.
+   *
+   * @param operation operation (for logging)
+   * @param ds dataset
+   * @return count of records returned.
+   */
+  private long materializeNonEmpty(String operation, Dataset<?> ds) {
+    LOG.info("{} table={}", operation, tableType);
+    final long count = ds.count();
+    Preconditions.checkState(
+        count > 0, "Operation %s on %s table returned no results", operation, tableType);
+    LOG.info("Materialization of Dataset returned {} records", count);
+    return count;
+  }
+
+  /**
+   * Generate files in the target subdir, sorted by timestamp and with their format included in the
+   * path.
+   *
+   * @return the location for the new table
+   */
+  @Override
+  protected String newTableLocation() {
+    Path tablePath =
+        new Path(
+            String.format(
+                Locale.ROOT,
+                "build/tables/spark-iceberg-table-%d-%s",
+                System.currentTimeMillis(),
+                UUID.randomUUID()));
+    return tablePath.toString();
+  }
+
+  /**
+   * Build the parquet dataset.
+   *
+   * @throws IOException creation failure.
+   */
+  private long appendVariantData() throws IOException {
+    long size = 0;
+    final AppendFiles append = table().newAppend();
+
+    for (int fileNum = 0; fileNum < NUM_FILES; fileNum++) {
+      final DataFile dataFile = createOneParquetFile(fileNum);
+      append.appendFile(dataFile);
+      size += dataFile.fileSizeInBytes();
+    }
+    append.commit();
+    return size;
+  }
+
+  /**
+   * Create a single parquet file as part of the append operation.
+   *
+   * @param fileIndex file index to use in generation of name and category derivation.
+   * @return the data file.
+   * @throws IOException write failure.
+   */
+  private DataFile createOneParquetFile(int fileIndex) throws IOException {
+    OutputFile outputFile =
+        table()
+            .io()
+            .newOutputFile(
+                table()
+                    .locationProvider()
+                    .newDataLocation(String.format(Locale.ROOT, "data-%05d.parquet", fileIndex)));
+
+    DataWriter<Record> writer =
+        Parquet.writeData(outputFile)
+            .schema(SCHEMA)
+            .createWriterFunc(GenericParquetWriter::create)
+            .variantShreddingFunc(shredder)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+
+    writeOneFile(writer, variantMetadata, fileIndex);
+    DataFile dataFile = writer.toDataFile();
+    LOG.info(
+        "File {}: {} bytes, ~{} row groups",
+        fileIndex,
+        dataFile.fileSizeInBytes(),
+        Math.max(1, dataFile.fileSizeInBytes() / ROW_GROUP_SIZE));
+    return dataFile;
+  }
+
+  /**
+   * Build the Avro table.
+   *
+   * @return the file size.
+   * @throws IOException creation failure.
+   */
+  private long appendAvroVariantData() throws IOException {
+    long size = 0;
+    final AppendFiles append = table().newAppend();
+    for (int fileNum = 0; fileNum < NUM_FILES; fileNum++) {
+      final DataFile dataFile = createOneAvroFile(fileNum);
+      append.appendFile(dataFile);
+      size += dataFile.fileSizeInBytes();
+    }
+    append.commit();
+    return size;
+  }
+
+  /**
+   * Create a single Avro file as part of the append operation.
+   *
+   * @param fileIndex file index to use in generation of name and category derivation.
+   * @return the data file.
+   * @throws IOException write failure.
+   */
+  private DataFile createOneAvroFile(int fileIndex) throws IOException {
+    OutputFile outputFile =
+        table()
+            .io()
+            .newOutputFile(
+                table()
+                    .locationProvider()
+                    .newDataLocation(String.format(Locale.ROOT, "data-%05d.avro", fileIndex)));
+
+    DataWriter<Record> writer =
+        Avro.writeData(outputFile)
+            .schema(SCHEMA)
+            .createWriterFunc(org.apache.iceberg.data.avro.DataWriter::create)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+
+    writeOneFile(writer, variantMetadata, fileIndex);
+    return writer.toDataFile();
+  }
+
+  /**
+   * Build the contents of a Parquet or Avro file, close the writer when done.
+   *
+   * <p>Rows are written in category-clustered order (all rows for category 0, then category 1,
+   * etc.) so that each Parquet row group covers only a narrow range of category values. This
+   * enables row-group skipping: a filter such as {@code category IN (5)} skips ~95% of row groups
+   * (those whose min/max range excludes 5) across the ~34 row groups in the file.
+   *
+   * @param writer record writer (will be closed when the method returns)
+   * @param metadata variant metadata
+   * @param fileNum file number in sequence (unused; retained for call-site consistency)
+   * @throws IOException write failure
+   */
+  private void writeOneFile(DataWriter<Record> writer, VariantMetadata metadata, int fileNum)
+      throws IOException {
+    try (writer) {
+      // large base value from filenum
+      long id = fileNum * 10_000_000_000L;
+      GenericRecord record = GenericRecord.create(SCHEMA);
+      int rowsPerCategory = NUM_ROWS_PER_FILE / NUM_CATEGORIES;
+      for (int category = 0; category < NUM_CATEGORIES; category++) {
+        for (int j = 0; j < rowsPerCategory; j++) {
+          id++;
+          Variant variant = buildVariant(metadata, id, category, repeatedStrings[category]);
+          record.setField(COL_ID, id);
+          record.setField("category", category);
+          record.setField(COL_NESTED, variant);
+          record.setField(COL_ARR, buildArrayVariant(id, category));
+          writer.write(record);
+        }
+      }
+    }
+  }
+
+  /**
+   * Build the nested variant structure.
+   *
+   * @param metadata variant metadata
+   * @param id row ID
+   * @param category category
+   * @param col4 string for column 4
+   * @return a variant
+   */
+  private static Variant buildVariant(
+      VariantMetadata metadata, long id, int category, String col4) {
+    ShreddedObject obj = Variants.object(metadata);
+    obj.put("idstr", Variants.of("item_" + id));
+    obj.put("varid", Variants.of(id));
+    obj.put("varcategory", Variants.of(category));
+    obj.put("col4", Variants.of(col4));
+    return Variant.of(metadata, obj);
+  }
+
+  /**
+   * Build a 5-element integer array variant.
+   *
+   * <p>Arrays have no field-name metadata, so {@link Variants#emptyMetadata()} is used.
+   *
+   * @param id row ID
+   * @param category category value (0-19)
+   * @return a variant holding an array
+   */
+  private static Variant buildArrayVariant(long id, int category) {
+    ValueArray arr = Variants.array();
+    arr.add(Variants.of(category));
+    arr.add(Variants.of((int) (id % 20)));
+    arr.add(Variants.of((int) (id % 100)));
+    arr.add(Variants.of((int) (id % 50)));
+    arr.add(Variants.of((int) (id % 1000)));
+    return Variant.of(Variants.emptyMetadata(), arr);
+  }
+
+  /**
+   * Project element 0 of the array variant.
+   *
+   * <p>Note: the {@code arr} column is stored unshredded in all table types (array shredding is out
+   * of scope). This benchmark compares unshredded Parquet vs Avro array element access.
+   */
+  @Benchmark
+  public void projectArrayCategory() {
+    project(VARIANT_GET_ARR_ELT0);
+  }
+
+  /**
+   * Filter on element 0 of the array variant then project on ID.
+   *
+   * <p>Element 0 equals {@code category} (0-19), so this has the same ~5% selectivity as {@link
+   * #filterCatProjectID()}, enabling direct comparison.
+   */
+  @Benchmark
+  public void filterArraryCategoryProjectID() {
+    select(COL_ID, FILTER_ON_ARR_ELT0);
+  }
+
+  /**
+   * Filter on element 0 of the array variant then project element 0.
+   *
+   * <p>Both the filter and projection touch the same array element; this measures the cost of
+   * evaluating {@code variant_get} on an array twice per row (once for filter, once for output).
+   */
+  @Benchmark
+  public void filterArray0ProjectArray0() {
+    select(VARIANT_GET_ARR_ELT0, FILTER_ON_ARR_ELT0);
+  }
+
+  /**
+   * Explode the array variant into one row per element.
+   *
+   * <p>With 5 elements per row and 1M rows the result set is 5M rows. Uses Spark's TVF syntax:
+   * {@code LATERAL variant_explode(arr) AS t}, which returns {@code (pos, key, value)} — {@code
+   * key} is null for arrays.
+   */
+  @Benchmark
+  public void explodeArraryColumns() {
+    sql("select t.* from " + TEMP_VIEW + " as table, lateral variant_explode(arr) as t");
+  }
+
+  /**
+   * Self-join the table on {@code arr[4]} (= {@code id % 1000}, range 0-999) against {@code
+   * varcategory} (range 0-19) from the nested variant.
+   *
+   * <p>Because arr[4] spans 0-999 and varcategory spans 0-19, only ~2% of probe rows match, giving
+   * a small result set. This benchmark measures the cost of extracting variant values on both sides
+   * of a join condition.
+   */
+  @Benchmark
+  public void joinArrElt4OnVarcat() {
+    final String text =
+        "SELECT t1."
+            + COL_ID
+            + ", t2."
+            + COL_ID
+            + " FROM "
+            + TEMP_VIEW
+            + " t1 JOIN "
+            + TEMP_VIEW2
+            + " t2 ON "
+            + "variant_get(t1.arr, '$[4]', 'int') = variant_get(t2.nested, '$.varcategory', 'int')";
+    sql(text);
+  }
+}

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
@@ -123,9 +123,9 @@ import org.slf4j.LoggerFactory;
  *       -PjmhOutputPath=build/reports/benchmark/iceberg-source-variant-io-benchmark-result.txt
  * </code>
  */
-@Fork(1)
-@Warmup(iterations = 20)
-@Measurement(iterations = 20)
+@Fork(0)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Timeout(time = 60, timeUnit = TimeUnit.MINUTES)
 public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
@@ -143,7 +143,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   private static final int ROW_GROUP_SIZE = 1 * 1024 * 1024;
 
   /** Number of distinct category values. */
-  private static final int NUM_CATEGORIES = 5;
+  private static final int NUM_CATEGORIES = 10;
 
   public static final String COL_ID = "id";
   private static final String COL_NESTED = "nested";
@@ -264,9 +264,6 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     properties.put(TableProperties.SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
     // large split size keeps the single data file as one Spark task.
     properties.put(TableProperties.SPLIT_SIZE, Integer.toString(512 * 1024 * 1024));
-    /*    properties.put(TableProperties.METADATA_COMPRESSION, "zstd");
-    properties.put(TableProperties.PARQUET_COMPRESSION, "zstd");
-    properties.put(TableProperties.AVRO_COMPRESSION, "zstd");*/
     // small row group size ensures multiple row groups per file for row-group skipping benchmarks.
     properties.put(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(ROW_GROUP_SIZE));
     // variant projection pushdown not supported with the vectorized reader.
@@ -314,6 +311,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   public void tearDownBenchmark() throws IOException {
     tearDownSpark();
     cleanupFiles();
+    logRowGroupFiltering();
   }
 
   @Override
@@ -504,6 +502,13 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   @Benchmark
   public void filterVarcatProjectVarID(Blackhole blackhole) {
     select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_NESTED_CATEGORY, true);
+  }
+
+  /** selecting on 1, but using a pair of ranges to locate. Two scans needed */
+  @Benchmark
+  public void filterVarcatProjectVarIDRanged(Blackhole blackhole) {
+    select(blackhole, VARIANT_GET_NESTED_ID,
+        VARIANT_GET_NESTED_CATEGORY + " > 0 and " + VARIANT_GET_NESTED_CATEGORY + " < 2", true);
   }
 
   /**
@@ -891,6 +896,13 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     arr.add(Variants.of((int) (id % 50)));
     arr.add(Variants.of((int) (id % 1000)));
     return Variant.of(Variants.emptyMetadata(), arr);
+  }
+
+  /** Log the parquet metrics invocations. */
+  private void logRowGroupFiltering() {
+    final long scans = ParquetMetricsRowGroupFilter.variantPredicatesShreddedMetricsEvaluated();
+    final long skipped = ParquetMetricsRowGroupFilter.variantPredicatesShreddedSkipped();
+    LOG.info("Scanned {} shredded metrics, skipped {} row groups", scans, skipped);
   }
 
   /** Reset the metrics counter. */

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
@@ -123,7 +123,7 @@ import org.slf4j.LoggerFactory;
  *       -PjmhOutputPath=build/reports/benchmark/iceberg-source-variant-io-benchmark-result.txt
  * </code>
  */
-@Fork(0)
+@Fork(1)
 @Warmup(iterations = 5)
 @Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -170,7 +170,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
       "variant_get(nested, '$.varcategory', 'int')";
 
   /** Get the ID field from inside the variant: {@value}. */
-  private static final String VARIANT_GET_NESTED_ID = "variant_get(nested, '$.varid', 'int')";
+  private static final String VARIANT_GET_NESTED_ID = "variant_get(nested, '$.varid', 'bigint')";
 
   /** Equality check. Pulled out to allow experimentation with set membershop vs. equals. */
   public static final String EQUALITY_CHECK = " = 1";
@@ -507,8 +507,11 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   /** selecting on 1, but using a pair of ranges to locate. Two scans needed */
   @Benchmark
   public void filterVarcatProjectVarIDRanged(Blackhole blackhole) {
-    select(blackhole, VARIANT_GET_NESTED_ID,
-        VARIANT_GET_NESTED_CATEGORY + " > 0 and " + VARIANT_GET_NESTED_CATEGORY + " < 2", true);
+    select(
+        blackhole,
+        VARIANT_GET_NESTED_ID,
+        VARIANT_GET_NESTED_CATEGORY + " > 0 and " + VARIANT_GET_NESTED_CATEGORY + " < 2",
+        true);
   }
 
   /**
@@ -899,34 +902,14 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   }
 
   /** Log the parquet metrics invocations. */
-  private void logRowGroupFiltering() {
-    final long scans = ParquetMetricsRowGroupFilter.variantPredicatesShreddedMetricsEvaluated();
-    final long skipped = ParquetMetricsRowGroupFilter.variantPredicatesShreddedSkipped();
-    LOG.info("Scanned {} shredded metrics, skipped {} row groups", scans, skipped);
-  }
+  private void logRowGroupFiltering() {}
 
   /** Reset the metrics counter. */
-  private void resetMetricsCounter() {
-    /*
-    ParquetMetricsRowGroupFilter.resetShreddedMetricsCounters();
-    */
-  }
+  private void resetMetricsCounter() {}
 
   /**
    * On shredded tables, assert that shredded field were scanned for filtering operations. Log the
    * count at info.
    */
-  private void expectFilteringOfShreddedFields() {
-    /*
-      if (isShredded()) {
-        final long scans = ParquetMetricsRowGroupFilter.variantPredicatesShreddedMetricsEvaluated();
-        final long skipped = ParquetMetricsRowGroupFilter.variantPredicatesShreddedSkipped();
-        LOG.info("Scanned {} shredded metrics, skipped {} row groups", scans, skipped);
-        assertThat(scans)
-            .describedAs("Number of times rowgroup metrics of shredded fields were scanned")
-            .isGreaterThan(0);
-        assertThat(skipped).describedAs("rowgroups skipped").isGreaterThan(0);
-      }
-    */
-  }
+  private void expectFilteringOfShreddedFields() {}
 }

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.parquet;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -54,8 +55,10 @@ import org.apache.iceberg.variants.Variants;
 import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RuntimeConfig;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
@@ -63,6 +66,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Timeout;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,15 +86,15 @@ import org.slf4j.LoggerFactory;
  *
  * <pre>
  *   id: int64 :- unique per row
- *   category: int32 :- in range 0-19; written in clustered order so each Parquet row group covers
- *                      only a narrow category range (~1–2 row groups per category).
+ *   category: int32 :- in a very small range; written in clustered order so each Parquet row group should
+ *     contain very few entries from different ranges.
  *   nested: variant (object)
  *       .idstr: string :- unique string per row
  *       .varid: int64  :- id
- *       .varcategory: int32  :- category (0-19)
- *       .col4: string :- non-unique string per row (picked from 20 values based on category)
+ *       .varcategory: int32
+ *       .col4: string :- non-unique string per row (same number as category count)
  *   arr: variant (array, always unshredded)
- *       [0]: int32 :- category (0-19)
+ *       [0]: int32 :- category
  *       [1]: int32 :- id % 20
  *       [2]: int32 :- id % 100
  *       [3]: int32 :- id % 50
@@ -113,9 +117,9 @@ import org.slf4j.LoggerFactory;
  *       -PjmhOutputPath=build/reports/benchmark/iceberg-source-variant-io-benchmark-result.txt
  * </code>
  */
-@Fork(1)
-@Warmup(iterations = 4)
-@Measurement(iterations = 4)
+@Fork(0)
+@Warmup(iterations = 1)
+@Measurement(iterations = 1)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Timeout(time = 10, timeUnit = TimeUnit.MINUTES)
 public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
@@ -123,17 +127,13 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   private static final Logger LOG = LoggerFactory.getLogger(IcebergSourceVariantIOBenchmark.class);
 
   private static final int NUM_FILES = 1;
-  private static final int NUM_ROWS_PER_FILE = 1_000_000;
+  private static final int NUM_ROWS_PER_FILE = 10_000_000;
 
-  /**
-   * At ~140 bytes/row (uncompressed), 4MB ≈ 29k rows/group. With 1M rows in one file clustered by
-   * 20 categories (50k rows each), this gives ~1–2 row groups per category. Filter={@code category
-   * IN (5)} skips ~32/34 row groups (95% skip rate).
-   */
-  private static final int ROW_GROUP_SIZE = 4 * 1024 * 1024; // 4 MB
+  /** Size of a compressed rowgroup. */
+  private static final int ROW_GROUP_SIZE = 1 * 1024 * 1024;
 
   /** Number of distinct category values. */
-  private static final int NUM_CATEGORIES = 20;
+  private static final int NUM_CATEGORIES = 5;
 
   public static final String COL_ID = "id";
   private static final String COL_NESTED = "nested";
@@ -155,9 +155,6 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
           required(3, COL_NESTED, Types.VariantType.get()), /* The variant object. */
           required(4, COL_ARR, Types.VariantType.get())); /* The variant array. */
 
-  /** Filter to use when filtering on category column: {@value}. */
-  private static final String FILTER_ON_CATEGORY = "category = 5";
-
   /** Get the category column from the variant: {@value}. */
   private static final String VARIANT_GET_NESTED_CATEGORY =
       "variant_get(nested, '$.varcategory', 'int')";
@@ -165,27 +162,25 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   /** Get the ID field from inside the variant: {@value}. */
   private static final String VARIANT_GET_NESTED_ID = "variant_get(nested, '$.varid', 'int')";
 
-  /**
-   * Equality check.
-   */
-  public static final String EQUALITY_CHECK_5 = " = 5";
+  /** Equality check. Pulled out to allow experimentation with set membershop vs. equals. */
+  public static final String EQUALITY_CHECK = " = 1";
+
+  /** Filter to use when filtering on category column: {@value}. */
+  private static final String FILTER_ON_CATEGORY = "category " + EQUALITY_CHECK;
 
   /** Equivalent of {@link #FILTER_ON_CATEGORY} using the field within the variant: {@value}. */
   private static final String FILTER_ON_NESTED_CATEGORY =
-      VARIANT_GET_NESTED_CATEGORY + EQUALITY_CHECK_5;
+      VARIANT_GET_NESTED_CATEGORY + EQUALITY_CHECK;
 
   /**
-   * Get element 0 of the array variant; element 0 = category (range 0-19): {@value}.
+   * Get element 0 of the array variant: {@value}.
    *
    * <p>Note: {@code variant_get} with a JSONPath {@code $[n]} expression accesses array elements.
    */
   private static final String VARIANT_GET_ARR_ELT0 = "variant_get(arr, '$[0]', 'int')";
 
-  /**
-   * Filter on element 0 of the array variant — same ~5% selectivity as {@link #FILTER_ON_CATEGORY}:
-   * {@value}.
-   */
-  private static final String FILTER_ON_ARR_ELT0 = VARIANT_GET_ARR_ELT0 + EQUALITY_CHECK_5;
+  /** Filter on element 0 of the array variant: {@value}. */
+  private static final String FILTER_ON_ARR_ELT0 = VARIANT_GET_ARR_ELT0 + EQUALITY_CHECK;
 
   /** Table to use in benchmark. */
   public enum TableType {
@@ -275,11 +270,12 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     return tables.create(SCHEMA, PartitionSpec.unpartitioned(), properties, newTableLocation());
   }
 
-  @Setup
+  @Setup(Level.Trial)
   public void setupBenchmark() throws IOException {
     setupSpark();
+    final RuntimeConfig sc = spark().conf();
     // one shuffle partition keeps the join benchmark on a single task.
-    spark().conf().set("spark.sql.shuffle.partitions", "1");
+    sc.set("spark.sql.shuffle.partitions", "1");
 
     // build the parquet schema of the shredded type by creating one variant instance
     // and type converting it.
@@ -287,12 +283,11 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     Type shreddedType =
         ParquetVariantUtil.toParquetSchema(buildVariant(variantMetadata, 0, 0, "").value());
     shredder =
-        tableType.shredded
+        isShredded()
             ? (fieldId, fieldName) -> COL_NESTED.equals(fieldName) ? shreddedType : null
             : (fieldId, fieldName) -> null;
 
-    // algorithm for category produces a value 0..19
-    final int categoryCount = 20;
+    final int categoryCount = NUM_CATEGORIES;
     repeatedStrings = new String[categoryCount];
     IntStream.range(0, categoryCount)
         .forEach(i -> repeatedStrings[i] = "Longer repeated string " + i);
@@ -330,10 +325,19 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     return spark().read().format("iceberg").load(table().location());
   }
 
+  /**
+   * Is the table shredded?
+   *
+   * @return true if the table is shredded.
+   */
+  private boolean isShredded() {
+    return tableType.shredded;
+  }
+
   /** Read the entire table. */
   @Benchmark
-  public void count() {
-    project("*");
+  public void count(Blackhole blackhole) {
+    project(blackhole, "*");
   }
 
   /**
@@ -344,32 +348,75 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    * row-structured ones, especially as the tables grow in size or row width.
    */
   @Benchmark
-  public void filterCatProjectID() {
-    select(COL_ID, FILTER_ON_CATEGORY);
+  public void filterCatProjectID(Blackhole blackhole) {
+    select(blackhole, COL_ID, FILTER_ON_CATEGORY, false);
   }
 
   /**
-   * Perform a sql select operation.
+   * Perform a sql select operation to non-zero count of rows.
+   *
+   * @param blackhole consumer of all data
+   * @param projection columns to project.
+   * @param where optional WHERE clause
+   * @param expectPushdownWhenShredded on a shredded table, should the rowgroup filter report
+   *     invocation?
+   * @return the result.
+   */
+  private long select(
+      final Blackhole blackhole,
+      String projection,
+      String where,
+      boolean expectPushdownWhenShredded) {
+    final long result = sql(blackhole, toSql(projection, where));
+    if (expectPushdownWhenShredded) {
+      expectFilteringOfShreddedFields();
+    }
+    return result;
+  }
+
+  /**
+   * Perform a sql select operation where the result is an empty set.
    *
    * @param projection columns to project.
    * @param where optional WHERE clause
-   * @return the result.
+   * @param expectPushdownWhenShredded on a shredded table, should the rowgroup filter report
+   *     invocation?
    */
-  private long select(String projection, String where) {
-    final String text =
-        "SELECT " + projection + " FROM " + TEMP_VIEW + (where != null ? " WHERE " + where : "");
-    return sql(text);
+  private void selectEmptyResults(
+      final String projection, final String where, boolean expectPushdownWhenShredded) {
+    String command = toSql(projection, where);
+    resetMetricsCounter();
+    final Dataset<Row> ds = spark().sql(command);
+    assertThat(ds.collectAsList()).describedAs("Result of command %s", command).isEmpty();
+    if (expectPushdownWhenShredded) {
+      expectFilteringOfShreddedFields();
+    }
   }
 
   /**
-   * Issue any Spark SQL command.
+   * Create a SQL select statement.
    *
+   * @param projection projection clause
+   * @param where filter, may be null
+   * @return the string for evaluation.
+   */
+  private static String toSql(final String projection, final String where) {
+    final String text =
+        "SELECT " + projection + " FROM " + TEMP_VIEW + (where != null ? " WHERE " + where : "");
+    return text;
+  }
+
+  /**
+   * Issue any Spark SQL command that returns a non-zero count of rows.
+   *
+   * @param blackhole consumer of all data
    * @param command command to execute
    * @return count of result.
    */
-  private long sql(String command) {
+  private long sql(final Blackhole blackhole, String command) {
     LOG.info("{}", command);
-    return materializeNonEmpty(command, spark().sql(command));
+    resetMetricsCounter();
+    return materializeNonEmpty(blackhole, command, spark().sql(command));
   }
 
   /**
@@ -378,8 +425,8 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    * @param projection columns to project.
    * @return the result.
    */
-  private long project(String projection) {
-    return select(projection, null);
+  private long project(final Blackhole blackhole, String projection) {
+    return select(blackhole, projection, null, false);
   }
 
   /**
@@ -387,20 +434,20 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    * the variant ID.
    */
   @Benchmark
-  public void filterCatProjectVarID() {
-    select(VARIANT_GET_NESTED_ID, FILTER_ON_CATEGORY);
+  public void filterCatProjectVarID(Blackhole blackhole) {
+    select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_CATEGORY, true);
   }
 
   /** Project on ID. */
   @Benchmark
-  public void projectID() {
-    project(COL_ID);
+  public void projectID(Blackhole blackhole) {
+    project(blackhole, COL_ID);
   }
 
   /** Extract the varid field only. */
   @Benchmark
-  public void projectVarID() {
-    project(VARIANT_GET_NESTED_ID);
+  public void projectVarID(Blackhole blackhole) {
+    project(blackhole, VARIANT_GET_NESTED_ID);
   }
 
   /**
@@ -411,60 +458,119 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    * reconstructed before filtering? or does the {@code variant_get()} get used early.
    */
   @Benchmark
-  public void filterVarcatProjectID() {
-    select(COL_ID, FILTER_ON_NESTED_CATEGORY);
+  public void filterVarcatProjectID(Blackhole blackhole) {
+    select(blackhole, COL_ID, FILTER_ON_NESTED_CATEGORY, true);
   }
 
   /** Filter to the category match; no projection. */
   @Benchmark
-  public void filterCat() {
-    select("*", FILTER_ON_CATEGORY);
+  public void filterCat(Blackhole blackhole) {
+    select(blackhole, "*", FILTER_ON_CATEGORY, false);
   }
 
   /** Filter to the varcat match; no projection. */
   @Benchmark
-  public void filterVarCat() {
-    select("*", FILTER_ON_NESTED_CATEGORY);
+  public void filterVarCat(Blackhole blackhole) {
+    select(blackhole, "*", FILTER_ON_NESTED_CATEGORY, true);
   }
 
   @Benchmark
-  public void filterVarCatSetMembership() {
-    select(COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (5)");
+  public void filterVarCatSetMembership(Blackhole blackhole) {
+    select(blackhole, COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (5)", true);
   }
 
   @Benchmark
-  public void filterVarCatSetNotInMembership() {
-    select(COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (100, 400)");
+  public void filterVarCatSetNotInMembership(Blackhole blackhole) {
+    selectEmptyResults(COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (100, 400)", false);
   }
 
   @Benchmark
-  public void filterVarCatSetNotInRange() {
-    select(COL_ID, VARIANT_GET_NESTED_CATEGORY + " < 0");
+  public void filterVarCatSetNotInRange(Blackhole blackhole) {
+    selectEmptyResults(COL_ID, VARIANT_GET_NESTED_CATEGORY + " < 0", false);
   }
 
   /** Project on the category field within the variant; no filtering. */
   @Benchmark
-  public void projectVarCat() {
-    project(VARIANT_GET_NESTED_CATEGORY);
+  public void projectVarCat(Blackhole blackhole) {
+    project(blackhole, VARIANT_GET_NESTED_CATEGORY);
   }
 
   /** Filter on nested category field then project on the nested ID field. */
   @Benchmark
-  public void filterVarcatProjectVarID() {
-    select(VARIANT_GET_NESTED_ID, FILTER_ON_NESTED_CATEGORY);
+  public void filterVarcatProjectVarID(Blackhole blackhole) {
+    select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_NESTED_CATEGORY, true);
+  }
+
+  /**
+   * Project element 0 of the array variant.
+   *
+   * <p>Note: the {@code arr} column is stored unshredded in all table types (array shredding is out
+   * of scope). This benchmark compares unshredded Parquet vs Avro array element access.
+   */
+  @Benchmark
+  public void projectArrayCategory(Blackhole blackhole) {
+    project(blackhole, VARIANT_GET_ARR_ELT0);
+  }
+
+  /** Filter on element 0 of the array variant then project on ID. */
+  @Benchmark
+  public void filterArrayCategoryProjectID(Blackhole blackhole) {
+    select(blackhole, COL_ID, FILTER_ON_ARR_ELT0, false);
+  }
+
+  /**
+   * Filter on element 0 of the array variant then project element 0.
+   *
+   * <p>Both the filter and projection touch the same array element; this measures the cost of
+   * evaluating {@code variant_get} on an array twice per row (once for filter, once for output).
+   */
+  @Benchmark
+  public void filterArray0ProjectArray0(Blackhole blackhole) {
+    select(blackhole, VARIANT_GET_ARR_ELT0, FILTER_ON_ARR_ELT0, false);
+  }
+
+  /** Explode the array variant into one row per element. */
+  @Benchmark
+  public void explodeArraryColumns(Blackhole blackhole) {
+    sql(blackhole, "select t.* from " + TEMP_VIEW + " as table, lateral variant_explode(arr) as t");
+  }
+
+  /**
+   * Self-join the table on {@code arr[4]} (= {@code id % 1000}, range 0-999) against {@code
+   * varcategory} from the nested variant.
+   *
+   * <p>TODO: failing in spark. Needs investigation.
+   */
+  // @Benchmark
+  public void joinArrElt4OnVarcat(Blackhole blackhole) {
+    final String text =
+        "SELECT t1."
+            + COL_ID
+            + ", t2."
+            + COL_ID
+            + " FROM "
+            + TEMP_VIEW
+            + " t1 JOIN "
+            + TEMP_VIEW2
+            + " t2 ON "
+            + "variant_get(t1.arr, '$[4]', 'int') = variant_get(t2.nested, '$.varcategory', 'int')";
+    sql(blackhole, text);
+    expectFilteringOfShreddedFields();
   }
 
   /**
    * Materialize a dataset by counting its elements; raise an exception if the set is empty, as that
    * is interpreted a sign the query is somehow broken.
    *
+   * @param blackhole consumer of all data
    * @param operation operation (for logging)
    * @param ds dataset
    * @return count of records returned.
    */
-  private long materializeNonEmpty(String operation, Dataset<?> ds) {
+  private long materializeNonEmpty(final Blackhole blackhole, String operation, Dataset<?> ds) {
     LOG.info("{} table={}", operation, tableType);
-    final long count = ds.count();
+    final long count = ds.queryExecution().toRdd().toJavaRDD().count();
+    blackhole.consume(count);
     Preconditions.checkState(
         count > 0, "Operation %s on %s table returned no results", operation, tableType);
     LOG.info("Materialization of Dataset returned {} records", count);
@@ -647,7 +753,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    * <p>Arrays have no field-name metadata, so {@link Variants#emptyMetadata()} is used.
    *
    * @param id row ID
-   * @param category category value (0-19)
+   * @param category category value
    * @return a variant holding an array
    */
   private static Variant buildArrayVariant(long id, int category) {
@@ -660,72 +766,12 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     return Variant.of(Variants.emptyMetadata(), arr);
   }
 
-  /**
-   * Project element 0 of the array variant.
-   *
-   * <p>Note: the {@code arr} column is stored unshredded in all table types (array shredding is out
-   * of scope). This benchmark compares unshredded Parquet vs Avro array element access.
-   */
-  @Benchmark
-  public void projectArrayCategory() {
-    project(VARIANT_GET_ARR_ELT0);
-  }
+  /** Reset the metrics counter. */
+  private void resetMetricsCounter() {}
 
   /**
-   * Filter on element 0 of the array variant then project on ID.
-   *
-   * <p>Element 0 equals {@code category} (0-19), so this has the same ~5% selectivity as {@link
-   * #filterCatProjectID()}, enabling direct comparison.
+   * On shredded tables, assert that shredded field were scanned for filtering operations. Log the
+   * count at info.
    */
-  @Benchmark
-  public void filterArraryCategoryProjectID() {
-    select(COL_ID, FILTER_ON_ARR_ELT0);
-  }
-
-  /**
-   * Filter on element 0 of the array variant then project element 0.
-   *
-   * <p>Both the filter and projection touch the same array element; this measures the cost of
-   * evaluating {@code variant_get} on an array twice per row (once for filter, once for output).
-   */
-  @Benchmark
-  public void filterArray0ProjectArray0() {
-    select(VARIANT_GET_ARR_ELT0, FILTER_ON_ARR_ELT0);
-  }
-
-  /**
-   * Explode the array variant into one row per element.
-   *
-   * <p>With 5 elements per row and 1M rows the result set is 5M rows. Uses Spark's TVF syntax:
-   * {@code LATERAL variant_explode(arr) AS t}, which returns {@code (pos, key, value)} — {@code
-   * key} is null for arrays.
-   */
-  @Benchmark
-  public void explodeArraryColumns() {
-    sql("select t.* from " + TEMP_VIEW + " as table, lateral variant_explode(arr) as t");
-  }
-
-  /**
-   * Self-join the table on {@code arr[4]} (= {@code id % 1000}, range 0-999) against {@code
-   * varcategory} (range 0-19) from the nested variant.
-   *
-   * <p>Because arr[4] spans 0-999 and varcategory spans 0-19, only ~2% of probe rows match, giving
-   * a small result set. This benchmark measures the cost of extracting variant values on both sides
-   * of a join condition.
-   */
-  @Benchmark
-  public void joinArrElt4OnVarcat() {
-    final String text =
-        "SELECT t1."
-            + COL_ID
-            + ", t2."
-            + COL_ID
-            + " FROM "
-            + TEMP_VIEW
-            + " t1 JOIN "
-            + TEMP_VIEW2
-            + " t2 ON "
-            + "variant_get(t1.arr, '$[4]', 'int') = variant_get(t2.nested, '$.varcategory', 'int')";
-    sql(text);
-  }
+  private void expectFilteringOfShreddedFields() {}
 }

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
@@ -145,7 +145,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   /** Number of distinct category values. */
   private static final int NUM_CATEGORIES = 10;
 
-  public static final String COL_ID = "id";
+  private static final String COL_ID = "id";
   private static final String COL_NESTED = "nested";
   private static final String COL_ARR = "arr";
 
@@ -173,7 +173,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   private static final String VARIANT_GET_NESTED_ID = "variant_get(nested, '$.varid', 'bigint')";
 
   /** Equality check. Pulled out to allow experimentation with set membershop vs. equals. */
-  public static final String EQUALITY_CHECK = " = 1";
+  private static final String EQUALITY_CHECK = " = 1";
 
   /** Filter to use when filtering on category column: {@value}. */
   private static final String FILTER_ON_CATEGORY = "category " + EQUALITY_CHECK;
@@ -300,8 +300,9 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
           case Unshredded, Shredded -> appendVariantData();
           case Avro -> appendAvroVariantData();
         };
-    tableDataset().createOrReplaceTempView(TEMP_VIEW);
-    tableDataset().createOrReplaceTempView(TEMP_VIEW2);
+    Dataset<Row> ds = tableDataset();
+    ds.createOrReplaceTempView(TEMP_VIEW);
+    ds.createOrReplaceTempView(TEMP_VIEW2);
     final String summary = String.format(Locale.ROOT, "Size of Table %s : %,3d", tableType, size);
     LOG.info("{}", summary);
     tableDataset().printSchema();
@@ -311,7 +312,6 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   public void tearDownBenchmark() throws IOException {
     tearDownSpark();
     cleanupFiles();
-    logRowGroupFiltering();
   }
 
   @Override
@@ -352,7 +352,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    */
   @Benchmark
   public void filterCatProjectID(Blackhole blackhole) {
-    select(blackhole, COL_ID, FILTER_ON_CATEGORY, false);
+    select(blackhole, COL_ID, FILTER_ON_CATEGORY);
   }
 
   /**
@@ -361,19 +361,10 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    * @param blackhole consumer of all data
    * @param projection columns to project.
    * @param where optional WHERE clause
-   * @param expectPushdownWhenShredded on a shredded table, should the rowgroup filter report
-   *     invocation?
    * @return the result.
    */
-  private long select(
-      final Blackhole blackhole,
-      String projection,
-      String where,
-      boolean expectPushdownWhenShredded) {
+  private long select(final Blackhole blackhole, String projection, String where) {
     final long result = sql(blackhole, toSql(projection, where));
-    if (expectPushdownWhenShredded) {
-      expectFilteringOfShreddedFields();
-    }
     return result;
   }
 
@@ -382,18 +373,11 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    *
    * @param projection columns to project.
    * @param where optional WHERE clause
-   * @param expectPushdownWhenShredded on a shredded table, should the rowgroup filter report
-   *     invocation?
    */
-  private void selectEmptyResults(
-      final String projection, final String where, boolean expectPushdownWhenShredded) {
+  private void selectEmptyResults(final String projection, final String where) {
     String command = toSql(projection, where);
-    resetMetricsCounter();
     final Dataset<Row> ds = spark().sql(command);
     assertThat(ds.collectAsList()).describedAs("Result of command %s", command).isEmpty();
-    if (expectPushdownWhenShredded) {
-      expectFilteringOfShreddedFields();
-    }
   }
 
   /**
@@ -418,7 +402,6 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    */
   private long sql(final Blackhole blackhole, String command) {
     LOG.info("{}", command);
-    resetMetricsCounter();
     return materializeNonEmpty(blackhole, command, spark().sql(command));
   }
 
@@ -429,7 +412,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    * @return the result.
    */
   private long project(final Blackhole blackhole, String projection) {
-    return select(blackhole, projection, null, false);
+    return select(blackhole, projection, null);
   }
 
   /**
@@ -438,7 +421,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    */
   @Benchmark
   public void filterCatProjectVarID(Blackhole blackhole) {
-    select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_CATEGORY, false);
+    select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_CATEGORY);
   }
 
   /** Project on ID. */
@@ -462,34 +445,34 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    */
   @Benchmark
   public void filterVarcatProjectID(Blackhole blackhole) {
-    select(blackhole, COL_ID, FILTER_ON_NESTED_CATEGORY, true);
+    select(blackhole, COL_ID, FILTER_ON_NESTED_CATEGORY);
   }
 
   /** Filter to the category match; no projection. */
   @Benchmark
   public void filterCat(Blackhole blackhole) {
-    select(blackhole, "*", FILTER_ON_CATEGORY, false);
+    select(blackhole, "*", FILTER_ON_CATEGORY);
   }
 
   /** Filter to the varcat match; no projection. */
   @Benchmark
   public void filterVarCat(Blackhole blackhole) {
-    select(blackhole, "*", FILTER_ON_NESTED_CATEGORY, true);
+    select(blackhole, "*", FILTER_ON_NESTED_CATEGORY);
   }
 
   @Benchmark
   public void filterVarCatSetMembership(Blackhole blackhole) {
-    select(blackhole, COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (1)", true);
+    select(blackhole, COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (1)");
   }
 
   @Benchmark
   public void filterVarCatSetNotInMembership(Blackhole blackhole) {
-    selectEmptyResults(COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (100, 400)", false);
+    selectEmptyResults(COL_ID, VARIANT_GET_NESTED_CATEGORY + " IN (100, 400)");
   }
 
   @Benchmark
   public void filterVarCatSetNotInRange(Blackhole blackhole) {
-    selectEmptyResults(COL_ID, VARIANT_GET_NESTED_CATEGORY + " < 0", false);
+    selectEmptyResults(COL_ID, VARIANT_GET_NESTED_CATEGORY + " < 0");
   }
 
   /** Project on the category field within the variant; no filtering. */
@@ -501,7 +484,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   /** Filter on nested category field then project on the nested ID field. */
   @Benchmark
   public void filterVarcatProjectVarID(Blackhole blackhole) {
-    select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_NESTED_CATEGORY, true);
+    select(blackhole, VARIANT_GET_NESTED_ID, FILTER_ON_NESTED_CATEGORY);
   }
 
   /** selecting on 1, but using a pair of ranges to locate. Two scans needed */
@@ -510,8 +493,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     select(
         blackhole,
         VARIANT_GET_NESTED_ID,
-        VARIANT_GET_NESTED_CATEGORY + " > 0 and " + VARIANT_GET_NESTED_CATEGORY + " < 2",
-        true);
+        VARIANT_GET_NESTED_CATEGORY + " > 0 and " + VARIANT_GET_NESTED_CATEGORY + " < 2");
   }
 
   /**
@@ -528,7 +510,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   /** Filter on element 0 of the array variant then project on ID. */
   @Benchmark
   public void filterArrayCategoryProjectID(Blackhole blackhole) {
-    select(blackhole, COL_ID, FILTER_ON_ARR_ELT0, false);
+    select(blackhole, COL_ID, FILTER_ON_ARR_ELT0);
   }
 
   /**
@@ -539,7 +521,7 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
    */
   @Benchmark
   public void filterArray0ProjectArray0(Blackhole blackhole) {
-    select(blackhole, VARIANT_GET_ARR_ELT0, FILTER_ON_ARR_ELT0, false);
+    select(blackhole, VARIANT_GET_ARR_ELT0, FILTER_ON_ARR_ELT0);
   }
 
   /** Explode the array variant into one row per element. */
@@ -551,10 +533,8 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   /**
    * Self-join the table on {@code arr[4]} (= {@code id % 1000}, range 0-999) against {@code
    * varcategory} from the nested variant.
-   *
-   * <p>TODO: failing in spark. Needs investigation.
    */
-  // @Benchmark
+  @Benchmark
   public void joinArrElt4OnVarcat(Blackhole blackhole) {
     final String text =
         "SELECT t1."
@@ -568,7 +548,6 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
             + " t2 ON "
             + "variant_get(t1.arr, '$[4]', 'int') = variant_get(t2.nested, '$.varcategory', 'int')";
     sql(blackhole, text);
-    expectFilteringOfShreddedFields();
   }
 
   /**
@@ -900,16 +879,4 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
     arr.add(Variants.of((int) (id % 1000)));
     return Variant.of(Variants.emptyMetadata(), arr);
   }
-
-  /** Log the parquet metrics invocations. */
-  private void logRowGroupFiltering() {}
-
-  /** Reset the metrics counter. */
-  private void resetMetricsCounter() {}
-
-  /**
-   * On shredded tables, assert that shredded field were scanned for filtering operations. Log the
-   * count at info.
-   */
-  private void expectFilteringOfShreddedFields() {}
 }

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/parquet/IcebergSourceVariantIOBenchmark.java
@@ -894,11 +894,27 @@ public class IcebergSourceVariantIOBenchmark extends IcebergSourceBenchmark {
   }
 
   /** Reset the metrics counter. */
-  private void resetMetricsCounter() {}
+  private void resetMetricsCounter() {
+    /*
+    ParquetMetricsRowGroupFilter.resetShreddedMetricsCounters();
+    */
+  }
 
   /**
    * On shredded tables, assert that shredded field were scanned for filtering operations. Log the
    * count at info.
    */
-  private void expectFilteringOfShreddedFields() {}
+  private void expectFilteringOfShreddedFields() {
+    /*
+      if (isShredded()) {
+        final long scans = ParquetMetricsRowGroupFilter.variantPredicatesShreddedMetricsEvaluated();
+        final long skipped = ParquetMetricsRowGroupFilter.variantPredicatesShreddedSkipped();
+        LOG.info("Scanned {} shredded metrics, skipped {} row groups", scans, skipped);
+        assertThat(scans)
+            .describedAs("Number of times rowgroup metrics of shredded fields were scanned")
+            .isGreaterThan(0);
+        assertThat(skipped).describedAs("rowgroups skipped").isGreaterThan(0);
+      }
+    */
+  }
 }

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
@@ -94,6 +94,16 @@ public abstract class IcebergSourceBenchmark {
     }
   }
 
+  /**
+   * Returns the Spark master URL used when creating the session.
+   *
+   * <p>Override in subclasses to customize parallelism, e.g. {@code "local[1]"} to force serial
+   * task execution and eliminate inter-task scheduling noise.
+   */
+  protected String sparkMaster() {
+    return "local";
+  }
+
   protected void setupSpark(boolean enableDictionaryEncoding) {
     SparkSession.Builder builder = SparkSession.builder().config(TestBase.DISABLE_UI);
     if (!enableDictionaryEncoding) {
@@ -102,10 +112,10 @@ public abstract class IcebergSourceBenchmark {
           .config("parquet.enable.dictionary", false)
           .config(TableProperties.PARQUET_DICT_SIZE_BYTES, "1");
     }
-    builder.master("local");
+    // propagate the hadoop conf entries as spark.hadoop. entries.
+    hadoopConf.forEach(entry -> builder.config("spark.hadoop." + entry.getKey(), entry.getValue()));
+    builder.master(sparkMaster());
     spark = builder.getOrCreate();
-    Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
-    hadoopConf.forEach(entry -> sparkHadoopConf.set(entry.getKey(), entry.getValue()));
   }
 
   protected void setupSpark() {


### PR DESCRIPTION

Fixes #15628

## core:VariantSerializationBenchmark

Separate benchmarks for
* serializing a prebuilt object
* deserializing

Variables are:
 - depth: [shallow, nested, deep-nested]
 - percentage of fields shed [0, 33, 67, 100]


## spark-4.1:IcebergSourceVariantReadBenchmark

Generate Avro, unshedded Parquet and shedded Parquet tables with the same variant data and then compare performance for basic filter and project operations against the normal columns and the variant fields.

Key findings:
* although it has the smallest file size, parquet files with shredded variants have significantly worse performance when working with the variant structs than unshredded.
* Avro is best for the variant data, though all operations will have to read the entire file, operations on other columns are (as expected) slower.
* Filtering is the operation which is slow. Projecting on an variant column, shredded or unshredded, is as fast as projecting normal parquet column.

I'm not reaching any conclusion why this is the case. I am looking at improving the performance of reconstructing string fields in parquet-java as those benchmark show needless byte-string-byte conversion. For the iceberg benchmark and layers below, I think knowing where issues like is enough of a change.

# Writeup

See https://steveloughran.github.io/benchmarking-variants/ for the writeup and the interactive benchmark results of Iceberg and Parquet benchmarks.