### PR TITLE
Core: Use ArrayList for manifest list materialization

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -40,7 +40,7 @@ class ManifestLists {
             .project(ManifestFile.schema())
             .build()) {
 
-      return Lists.newLinkedList(files);
+      return Lists.newArrayList(files);
 
     } catch (IOException e) {
       throw new RuntimeIOException(

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -318,7 +318,7 @@ public class RewriteTablePathUtil {
 
   private static List<ManifestFile> manifestFilesInSnapshot(FileIO io, Snapshot snapshot) {
     String path = snapshot.manifestListLocation();
-    List<ManifestFile> manifestFiles = Lists.newLinkedList();
+    List<ManifestFile> manifestFiles = Lists.newArrayList();
     try {
       manifestFiles = ManifestLists.read(io.newInputFile(path));
     } catch (RuntimeIOException e) {


### PR DESCRIPTION
For lower memory overhead and better locality. It's used for `allManifests` in `BaseSnapshot`.