### PR TITLE
API: Fix javadoc of ManageSnapshots.setMaxRefAgeMs

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
@@ -207,9 +207,9 @@ public interface ManageSnapshots extends PendingUpdate<Snapshot> {
   ManageSnapshots setMaxSnapshotAgeMs(String branchName, long maxSnapshotAgeMs);
 
   /**
-   * Updates the retention policy for a reference.
+   * Updates the retention policy for a reference. The reference can be a branch or a tag.
    *
-   * @param name reference name
+   * @param name branch or tag name
    * @param maxRefAgeMs retention age in milliseconds of the reference itself
    * @return this for method chaining
    * @throws IllegalArgumentException if the reference does not exist


### PR DESCRIPTION
The method accepts both branches and tags: 

https://github.com/apache/iceberg/blob/11dbe2f091edd4ac492f210c878d22386ec9d605/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java#L545-L579