### PR TITLE
Flink: Set forkEvery=1 on integration test to prevent worker JVM hang

### DIFF
--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -255,6 +255,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   task integrationTest(type: Test) {
     description = "Test Flink Runtime Jar against Flink ${flinkMajorVersion}"
     group = "verification"
+    forkEvery = 1
     jvmArgs += project.property('extraJvmArgs')
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -255,6 +255,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   task integrationTest(type: Test) {
     description = "Test Flink Runtime Jar against Flink ${flinkMajorVersion}"
     group = "verification"
+    forkEvery = 1
     jvmArgs += project.property('extraJvmArgs')
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -255,6 +255,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   task integrationTest(type: Test) {
     description = "Test Flink Runtime Jar against Flink ${flinkMajorVersion}"
     group = "verification"
+    forkEvery = 1
     jvmArgs += project.property('extraJvmArgs')
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)


### PR DESCRIPTION
Flink 2.0/2.1 mini-cluster shutdown leaves non-daemon threads (TaskExecutorFileMergingManager) alive, preventing the Gradle test worker JVM from exiting. This causes the integration test task to hang indefinitely until the CI timeout kills it.

Setting forkEvery=1 forces Gradle to terminate the worker process after each test class, avoiding the hang.

This is the tentative to fix the flakiness timeout on the Flink CI.