### PR TITLE
Arrow: Add vectorized read support for StructType fields

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
@@ -84,6 +84,7 @@ import org.slf4j.LoggerFactory;
  *   <li>Iceberg: {@link Types.DateType}, Arrow: {@link MinorType#DATEDAY}
  *   <li>Iceberg: {@link Types.TimeType}, Arrow: {@link MinorType#TIMEMICRO}
  *   <li>Iceberg: {@link Types.UUIDType}, Arrow: {@link MinorType#FIXEDSIZEBINARY}(16)
+ *   <li>Iceberg: {@link Types.StructType}, Arrow: {@link MinorType#STRUCT}
  * </ul>
  *
  * <p>Features that don't work in this implementation:
@@ -92,7 +93,7 @@ import org.slf4j.LoggerFactory;
  *   <li>Type promotion: In case of type promotion, the Arrow vector corresponding to the data type
  *       in the parquet file is returned instead of the data type in the latest schema. See
  *       https://github.com/apache/iceberg/issues/2483.
- *   <li>Data types: {@link Types.ListType}, {@link Types.MapType} and {@link Types.StructType} See
+ *   <li>Data types: {@link Types.ListType} and {@link Types.MapType}. See
  *       https://github.com/apache/iceberg/issues/2485 and
  *       https://github.com/apache/iceberg/issues/2486.
  *   <li>Delete files are not supported. See https://github.com/apache/iceberg/issues/2487.
@@ -116,7 +117,8 @@ public class ArrowReader extends CloseableGroup {
           TypeID.TIME,
           TypeID.DECIMAL,
           TypeID.FIXED,
-          TypeID.TIMESTAMP_NANO);
+          TypeID.TIMESTAMP_NANO,
+          TypeID.STRUCT);
 
   private final Schema schema;
   private final FileIO io;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
@@ -22,9 +22,11 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.DecimalFactory;
 import org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.StringFactory;
+import org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.StructChildFactory;
 
 final class ArrowVectorAccessors {
 
@@ -35,7 +37,7 @@ final class ArrowVectorAccessors {
         new GenericArrowVectorAccessorFactory<>(
             JavaDecimalFactory::new,
             JavaStringFactory::new,
-            throwingSupplier("Struct type is not supported"),
+            JavaStructChildFactory::new,
             throwingSupplier("List type is not supported"));
   }
 
@@ -82,6 +84,31 @@ final class ArrowVectorAccessors {
       byte[] bytes = new byte[byteBuffer.remaining()];
       byteBuffer.get(bytes);
       return new String(bytes, StandardCharsets.UTF_8);
+    }
+  }
+
+  private static final class JavaStructChildFactory implements StructChildFactory<ColumnVector> {
+    @Override
+    public Class<ColumnVector> getGenericClass() {
+      return ColumnVector.class;
+    }
+
+    @Override
+    public ColumnVector of(ValueVector childVector) {
+      int valueCount = childVector.getValueCount();
+      NullabilityHolder nulls = new NullabilityHolder(Math.max(valueCount, 1));
+      for (int i = 0; i < valueCount; i++) {
+        if (childVector.isNull(i)) {
+          nulls.setNull(i);
+        } else {
+          nulls.setNotNull(i);
+        }
+      }
+
+      VectorHolder holder =
+          new VectorHolder(
+              (org.apache.arrow.vector.FieldVector) childVector, null, nulls);
+      return new ColumnVector(holder);
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
@@ -106,8 +106,7 @@ final class ArrowVectorAccessors {
       }
 
       VectorHolder holder =
-          new VectorHolder(
-              (org.apache.arrow.vector.FieldVector) childVector, null, nulls);
+          new VectorHolder((org.apache.arrow.vector.FieldVector) childVector, null, nulls);
       return new ColumnVector(holder);
     }
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.types.Types;
  *   <li>{@link Types.TimeType}
  *   <li>{@link Types.UUIDType}
  *   <li>{@link Types.DecimalType}
+ *   <li>{@link Types.StructType}
  * </ul>
  */
 public class ColumnVector implements AutoCloseable {
@@ -132,6 +133,10 @@ public class ColumnVector implements AutoCloseable {
       return null;
     }
     return (BigDecimal) accessor.getDecimal(rowId, precision, scale);
+  }
+
+  public ColumnVector getChildColumn(int pos) {
+    return (ColumnVector) accessor.childColumn(pos);
   }
 
   private static ArrowVectorAccessor<?, String, ?, ?> getVectorAccessor(VectorHolder holder) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -99,7 +99,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     this(null);
   }
 
-  private VectorizedArrowReader(Types.NestedField icebergField) {
+  VectorizedArrowReader(Types.NestedField icebergField) {
     this.icebergField = icebergField;
     this.batchSize = DEFAULT_BATCH_SIZE;
     this.columnDescriptor = null;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -148,8 +148,30 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
   public VectorizedReader<?> struct(
       Types.StructType expected, GroupType groupType, List<VectorizedReader<?>> fieldReaders) {
     if (expected != null) {
-      throw new UnsupportedOperationException(
-          "Vectorized reads are not supported yet for struct fields");
+      Map<Integer, VectorizedReader<?>> readersById = Maps.newHashMap();
+      List<Type> fields = groupType.getFields();
+
+      IntStream.range(0, fields.size())
+          .filter(pos -> fields.get(pos).getId() != null)
+          .forEach(
+              pos ->
+                  readersById.put(
+                      fields.get(pos).getId().intValue(), fieldReaders.get(pos)));
+
+      List<Types.NestedField> icebergFields = expected.fields();
+      List<VectorizedReader<?>> reorderedFields =
+          Lists.newArrayListWithExpectedSize(icebergFields.size());
+
+      for (Types.NestedField field : icebergFields) {
+        VectorizedReader<?> reader =
+            VectorizedArrowReader.replaceWithMetadataReader(
+                field, readersById.get(field.fieldId()), idToConstant, setArrowValidityVector);
+        reorderedFields.add(defaultReader(field, reader));
+      }
+
+      // Look up the NestedField by the Parquet field ID
+      Types.NestedField structField = icebergSchema.findField(groupType.getId().intValue());
+      return new VectorizedStructReader(structField, reorderedFields, rootAllocator);
     }
     return null;
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -154,9 +154,7 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
       IntStream.range(0, fields.size())
           .filter(pos -> fields.get(pos).getId() != null)
           .forEach(
-              pos ->
-                  readersById.put(
-                      fields.get(pos).getId().intValue(), fieldReaders.get(pos)));
+              pos -> readersById.put(fields.get(pos).getId().intValue(), fieldReaders.get(pos)));
 
       List<Types.NestedField> icebergFields = expected.fields();
       List<VectorizedReader<?>> reorderedFields =

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedStructReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedStructReader.java
@@ -46,11 +46,14 @@ class VectorizedStructReader extends VectorizedArrowReader {
 
   @SuppressWarnings("unchecked")
   VectorizedStructReader(
-      Types.NestedField icebergField, List<VectorizedReader<?>> readers, BufferAllocator allocator) {
+      Types.NestedField icebergField,
+      List<VectorizedReader<?>> readers,
+      BufferAllocator allocator) {
     super(icebergField);
     this.structType = icebergField.type().asStructType();
     this.childReaders = readers.toArray(new VectorizedReader[0]);
-    this.allocator = allocator.newChildAllocator("struct-" + icebergField.name(), 0, Long.MAX_VALUE);
+    this.allocator =
+        allocator.newChildAllocator("struct-" + icebergField.name(), 0, Long.MAX_VALUE);
   }
 
   @Override
@@ -79,9 +82,7 @@ class VectorizedStructReader extends VectorizedArrowReader {
       FieldVector child = childHolders[i].vector();
       if (child != null) {
         structVector.addOrGet(
-            childArrowField.getName(),
-            childArrowField.getFieldType(),
-            child.getClass());
+            childArrowField.getName(), childArrowField.getFieldType(), child.getClass());
         // Transfer data from the reader's child vector into the struct's child vector
         FieldVector structChild = structVector.getChild(childArrowField.getName());
         child.makeTransferPair(structChild).transfer();

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedStructReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedStructReader.java
@@ -35,7 +35,7 @@ import org.apache.parquet.hadoop.metadata.ColumnPath;
  * A vectorized reader for struct (nested) fields that reads child columns individually and
  * assembles them into an Arrow {@link StructVector}.
  */
-public class VectorizedStructReader extends VectorizedArrowReader {
+class VectorizedStructReader extends VectorizedArrowReader {
 
   private final VectorizedReader<VectorHolder>[] childReaders;
   private final Types.StructType structType;
@@ -63,11 +63,10 @@ public class VectorizedStructReader extends VectorizedArrowReader {
     }
 
     List<Types.NestedField> fields = structType.fields();
-    FieldVector[] childVectors = new FieldVector[childReaders.length];
+    VectorHolder[] childHolders = new VectorHolder[childReaders.length];
 
     for (int i = 0; i < childReaders.length; i++) {
-      VectorHolder childHolder = childReaders[i].read(null, numValsToRead);
-      childVectors[i] = childHolder.vector();
+      childHolders[i] = childReaders[i].read(null, numValsToRead);
     }
 
     // Build the StructVector from child vectors
@@ -77,7 +76,7 @@ public class VectorizedStructReader extends VectorizedArrowReader {
     for (int i = 0; i < fields.size(); i++) {
       Types.NestedField childField = fields.get(i);
       Field childArrowField = ArrowSchemaUtil.convert(childField);
-      FieldVector child = childVectors[i];
+      FieldVector child = childHolders[i].vector();
       if (child != null) {
         structVector.addOrGet(
             childArrowField.getName(),
@@ -90,17 +89,51 @@ public class VectorizedStructReader extends VectorizedArrowReader {
     }
 
     structVector.setValueCount(numValsToRead);
-    // Set all values as non-null at the struct level by default.
-    // Individual child nullability is handled by the child readers.
+
     if (nullabilityHolder == null || nullabilityHolder.size() < numValsToRead) {
       nullabilityHolder = new NullabilityHolder(numValsToRead);
     } else {
       nullabilityHolder.reset();
     }
 
-    nullabilityHolder.setNotNulls(0, numValsToRead);
+    // Derive struct-level nullability: if the struct field is optional, a row where all
+    // children are null indicates the struct itself is null (Parquet encodes a null optional
+    // struct by marking all children absent).
+    if (icebergField().isOptional()) {
+      for (int row = 0; row < numValsToRead; row++) {
+        if (allChildrenNullAt(childHolders, row)) {
+          nullabilityHolder.setNull(row);
+          structVector.setNull(row);
+        } else {
+          nullabilityHolder.setNotNull(row);
+          structVector.setIndexDefined(row);
+        }
+      }
+    } else {
+      nullabilityHolder.setNotNulls(0, numValsToRead);
+      for (int row = 0; row < numValsToRead; row++) {
+        structVector.setIndexDefined(row);
+      }
+    }
 
     return new VectorHolder(structVector, icebergField(), nullabilityHolder);
+  }
+
+  private static boolean allChildrenNullAt(VectorHolder[] holders, int row) {
+    boolean hasNonDummyChild = false;
+    for (VectorHolder holder : holders) {
+      if (holder.isDummy()) {
+        continue;
+      }
+
+      hasNonDummyChild = true;
+      NullabilityHolder childNulls = holder.nullabilityHolder();
+      if (childNulls == null || childNulls.isNullAt(row) != 1) {
+        return false;
+      }
+    }
+
+    return hasNonDummyChild;
   }
 
   @Override

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedStructReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedStructReader.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.iceberg.arrow.ArrowSchemaUtil;
+import org.apache.iceberg.parquet.VectorizedReader;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+/**
+ * A vectorized reader for struct (nested) fields that reads child columns individually and
+ * assembles them into an Arrow {@link StructVector}.
+ */
+public class VectorizedStructReader extends VectorizedArrowReader {
+
+  private final VectorizedReader<VectorHolder>[] childReaders;
+  private final Types.StructType structType;
+  private final BufferAllocator allocator;
+
+  private StructVector structVector;
+  private NullabilityHolder nullabilityHolder;
+
+  @SuppressWarnings("unchecked")
+  VectorizedStructReader(
+      Types.NestedField icebergField, List<VectorizedReader<?>> readers, BufferAllocator allocator) {
+    super(icebergField);
+    this.structType = icebergField.type().asStructType();
+    this.childReaders = readers.toArray(new VectorizedReader[0]);
+    this.allocator = allocator.newChildAllocator("struct-" + icebergField.name(), 0, Long.MAX_VALUE);
+  }
+
+  @Override
+  public VectorHolder read(VectorHolder reuse, int numValsToRead) {
+    // Always close the previous struct vector since child data is transferred into it
+    // and cannot be reused after transfer
+    if (structVector != null) {
+      structVector.close();
+      structVector = null;
+    }
+
+    List<Types.NestedField> fields = structType.fields();
+    FieldVector[] childVectors = new FieldVector[childReaders.length];
+
+    for (int i = 0; i < childReaders.length; i++) {
+      VectorHolder childHolder = childReaders[i].read(null, numValsToRead);
+      childVectors[i] = childHolder.vector();
+    }
+
+    // Build the StructVector from child vectors
+    structVector = StructVector.empty(icebergField().name(), allocator);
+
+    // Add child vectors
+    for (int i = 0; i < fields.size(); i++) {
+      Types.NestedField childField = fields.get(i);
+      Field childArrowField = ArrowSchemaUtil.convert(childField);
+      FieldVector child = childVectors[i];
+      if (child != null) {
+        structVector.addOrGet(
+            childArrowField.getName(),
+            childArrowField.getFieldType(),
+            child.getClass());
+        // Transfer data from the reader's child vector into the struct's child vector
+        FieldVector structChild = structVector.getChild(childArrowField.getName());
+        child.makeTransferPair(structChild).transfer();
+      }
+    }
+
+    structVector.setValueCount(numValsToRead);
+    // Set all values as non-null at the struct level by default.
+    // Individual child nullability is handled by the child readers.
+    if (nullabilityHolder == null || nullabilityHolder.size() < numValsToRead) {
+      nullabilityHolder = new NullabilityHolder(numValsToRead);
+    } else {
+      nullabilityHolder.reset();
+    }
+
+    nullabilityHolder.setNotNulls(0, numValsToRead);
+
+    return new VectorHolder(structVector, icebergField(), nullabilityHolder);
+  }
+
+  @Override
+  public void setRowGroupInfo(PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata) {
+    for (VectorizedReader<VectorHolder> reader : childReaders) {
+      if (reader != null) {
+        reader.setRowGroupInfo(source, metadata);
+      }
+    }
+  }
+
+  @Override
+  public void setBatchSize(int batchSize) {
+    for (VectorizedReader<VectorHolder> reader : childReaders) {
+      if (reader != null) {
+        reader.setBatchSize(batchSize);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    for (VectorizedReader<VectorHolder> reader : childReaders) {
+      if (reader != null) {
+        reader.close();
+      }
+    }
+
+    if (structVector != null) {
+      structVector.close();
+      structVector = null;
+    }
+
+    allocator.close();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("VectorizedStructReader: %s", icebergField().name());
+  }
+}

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReaderStruct.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReaderStruct.java
@@ -814,6 +814,285 @@ public class TestArrowReaderStruct {
     assertThat(totalRows).isEqualTo(NUM_ROWS * 2);
   }
 
+  /** Optional struct where some rows have a null struct value. */
+  @Test
+  public void testNullStructRows() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                2,
+                "info",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "name", Types.StringType.get()),
+                    Types.NestedField.required(4, "value", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      if (i % 3 == 0) {
+        rec.setField("info", null);
+      } else {
+        GenericRecord info = GenericRecord.create(schema.findType("info").asStructType());
+        info.setField("name", "n" + i);
+        info.setField("value", i * 10);
+        rec.setField("info", info);
+      }
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector infoVec = (StructVector) root.getVector("info");
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          if (i % 3 == 0) {
+            assertThat(infoVec.isNull(i))
+                .as("Struct at row %d should be null", i)
+                .isTrue();
+          } else {
+            assertThat(infoVec.isNull(i))
+                .as("Struct at row %d should not be null", i)
+                .isFalse();
+            VarCharVector nameVec = (VarCharVector) infoVec.getChild("name");
+            assertThat(new String(nameVec.get(i), StandardCharsets.UTF_8)).isEqualTo("n" + i);
+            IntVector valueVec = (IntVector) infoVec.getChild("value");
+            assertThat(valueVec.get(i)).isEqualTo(i * 10);
+          }
+        }
+
+        root.close();
+      }
+    }
+  }
+
+  /** Null struct rows detected through the ColumnVector API. */
+  @Test
+  public void testNullStructRowsViaColumnVector() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                2,
+                "info",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "b", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      if (i % 2 == 0) {
+        rec.setField("info", null);
+      } else {
+        GenericRecord info = GenericRecord.create(schema.findType("info").asStructType());
+        info.setField("a", i);
+        info.setField("b", i * 2);
+        rec.setField("info", info);
+      }
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        ColumnVector structCol = batch.column(1);
+        for (int i = 0; i < NUM_ROWS; i++) {
+          if (i % 2 == 0) {
+            assertThat(structCol.isNullAt(i))
+                .as("Struct at row %d should be null", i)
+                .isTrue();
+          } else {
+            assertThat(structCol.isNullAt(i)).isFalse();
+            ColumnVector aChild = structCol.getChildColumn(0);
+            ColumnVector bChild = structCol.getChildColumn(1);
+            assertThat(aChild.getInt(i)).isEqualTo(i);
+            assertThat(bChild.getInt(i)).isEqualTo(i * 2);
+          }
+        }
+      }
+    }
+  }
+
+  /** All struct rows are null. */
+  @Test
+  public void testAllNullStructRows() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                2,
+                "info",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      rec.setField("info", null);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        ColumnVector structCol = batch.column(1);
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(structCol.isNullAt(i))
+              .as("Struct at row %d should be null", i)
+              .isTrue();
+        }
+      }
+    }
+  }
+
+  /** Schema evolution: a new child field is added after initial data is written. */
+  @Test
+  public void testSchemaEvolutionNewChildField() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "info",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord info = GenericRecord.create(schema.findType("info").asStructType());
+      info.setField("a", i * 10);
+      rec.setField("info", info);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    // Evolve the schema: add an optional child field to the struct
+    table.updateSchema().addColumn("info", "b", Types.StringType.get()).commit();
+
+    // Write new data with the evolved schema
+    Schema evolvedSchema = table.schema();
+    List<GenericRecord> newRecords = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(evolvedSchema);
+      rec.setField("id", NUM_ROWS + i);
+      GenericRecord info = GenericRecord.create(evolvedSchema.findType("info").asStructType());
+      info.setField("a", (NUM_ROWS + i) * 10);
+      info.setField("b", "val-" + i);
+      rec.setField("info", info);
+      newRecords.add(rec);
+    }
+
+    appendData(table, newRecords);
+
+    int totalRows = 0;
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS * 2, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector infoVec = (StructVector) root.getVector("info");
+        IntVector aVec = (IntVector) infoVec.getChild("a");
+        IntVector idVec = (IntVector) root.getVector("id");
+
+        for (int i = 0; i < batch.numRows(); i++) {
+          // The "a" child should always match id * 10
+          assertThat(aVec.get(i)).isEqualTo(idVec.get(i) * 10);
+        }
+
+        totalRows += batch.numRows();
+        root.close();
+      }
+    }
+
+    assertThat(totalRows).isEqualTo(NUM_ROWS * 2);
+  }
+
+  /** Empty table with struct column returns no rows. */
+  @Test
+  public void testEmptyTable() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "pair",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "b", Types.IntegerType.get()))));
+
+    createTable(schema);
+    Table table =
+        tables.load(tableLocation);
+
+    int totalRows = 0;
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        totalRows += batch.numRows();
+      }
+    }
+
+    assertThat(totalRows).isEqualTo(0);
+  }
+
+  /** Single row with a struct to verify boundary conditions. */
+  @Test
+  public void testSingleRowWithStruct() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "pair",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "b", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    GenericRecord rec = GenericRecord.create(schema);
+    rec.setField("id", 42);
+    GenericRecord pair = GenericRecord.create(schema.findType("pair").asStructType());
+    pair.setField("a", 100);
+    pair.setField("b", 200);
+    rec.setField("pair", pair);
+    records.add(rec);
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        assertThat(batch.numRows()).isEqualTo(1);
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector pairVec = (StructVector) root.getVector("pair");
+        IntVector aVec = (IntVector) pairVec.getChild("a");
+        IntVector bVec = (IntVector) pairVec.getChild("b");
+        assertThat(aVec.get(0)).isEqualTo(100);
+        assertThat(bVec.get(0)).isEqualTo(200);
+        root.close();
+      }
+    }
+  }
+
   private Table createTable(Schema schema) {
     return tables.create(
         schema,

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReaderStruct.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReaderStruct.java
@@ -502,9 +502,7 @@ public class TestArrowReaderStruct {
           assertThat(nameChild.isNullAt(i)).isFalse();
           assertThat(nameChild.getString(i)).isEqualTo("n" + i);
           if (i % 2 == 0) {
-            assertThat(valueChild.isNullAt(i))
-                .as("Row %d should be null", i)
-                .isTrue();
+            assertThat(valueChild.isNullAt(i)).as("Row %d should be null", i).isTrue();
           } else {
             assertThat(valueChild.isNullAt(i)).isFalse();
             assertThat(valueChild.getInt(i)).isEqualTo(i);
@@ -649,8 +647,7 @@ public class TestArrowReaderStruct {
 
     // Project only the struct column
     try (VectorizedTableScanIterable reader =
-        new VectorizedTableScanIterable(
-            table.newScan().select("pair"), NUM_ROWS, false)) {
+        new VectorizedTableScanIterable(table.newScan().select("pair"), NUM_ROWS, false)) {
       for (ColumnarBatch batch : reader) {
         assertThat(batch.numCols()).isEqualTo(1);
 
@@ -852,13 +849,9 @@ public class TestArrowReaderStruct {
 
         for (int i = 0; i < NUM_ROWS; i++) {
           if (i % 3 == 0) {
-            assertThat(infoVec.isNull(i))
-                .as("Struct at row %d should be null", i)
-                .isTrue();
+            assertThat(infoVec.isNull(i)).as("Struct at row %d should be null", i).isTrue();
           } else {
-            assertThat(infoVec.isNull(i))
-                .as("Struct at row %d should not be null", i)
-                .isFalse();
+            assertThat(infoVec.isNull(i)).as("Struct at row %d should not be null", i).isFalse();
             VarCharVector nameVec = (VarCharVector) infoVec.getChild("name");
             assertThat(new String(nameVec.get(i), StandardCharsets.UTF_8)).isEqualTo("n" + i);
             IntVector valueVec = (IntVector) infoVec.getChild("value");
@@ -908,9 +901,7 @@ public class TestArrowReaderStruct {
         ColumnVector structCol = batch.column(1);
         for (int i = 0; i < NUM_ROWS; i++) {
           if (i % 2 == 0) {
-            assertThat(structCol.isNullAt(i))
-                .as("Struct at row %d should be null", i)
-                .isTrue();
+            assertThat(structCol.isNullAt(i)).as("Struct at row %d should be null", i).isTrue();
           } else {
             assertThat(structCol.isNullAt(i)).isFalse();
             ColumnVector aChild = structCol.getChildColumn(0);
@@ -932,8 +923,7 @@ public class TestArrowReaderStruct {
             Types.NestedField.optional(
                 2,
                 "info",
-                Types.StructType.of(
-                    Types.NestedField.required(3, "a", Types.IntegerType.get()))));
+                Types.StructType.of(Types.NestedField.required(3, "a", Types.IntegerType.get()))));
 
     Table table = createTable(schema);
     List<GenericRecord> records = Lists.newArrayList();
@@ -951,9 +941,7 @@ public class TestArrowReaderStruct {
       for (ColumnarBatch batch : reader) {
         ColumnVector structCol = batch.column(1);
         for (int i = 0; i < NUM_ROWS; i++) {
-          assertThat(structCol.isNullAt(i))
-              .as("Struct at row %d should be null", i)
-              .isTrue();
+          assertThat(structCol.isNullAt(i)).as("Struct at row %d should be null", i).isTrue();
         }
       }
     }
@@ -968,8 +956,7 @@ public class TestArrowReaderStruct {
             Types.NestedField.required(
                 2,
                 "info",
-                Types.StructType.of(
-                    Types.NestedField.required(3, "a", Types.IntegerType.get()))));
+                Types.StructType.of(Types.NestedField.required(3, "a", Types.IntegerType.get()))));
 
     Table table = createTable(schema);
     List<GenericRecord> records = Lists.newArrayList();
@@ -1038,8 +1025,7 @@ public class TestArrowReaderStruct {
                     Types.NestedField.required(4, "b", Types.IntegerType.get()))));
 
     createTable(schema);
-    Table table =
-        tables.load(tableLocation);
+    Table table = tables.load(tableLocation);
 
     int totalRows = 0;
     try (VectorizedTableScanIterable reader =

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReaderStruct.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReaderStruct.java
@@ -1,0 +1,849 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized;
+
+import static org.apache.iceberg.Files.localInput;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Test cases for vectorized reads of struct (nested) fields via the Arrow reader. */
+public class TestArrowReaderStruct {
+
+  private static final int NUM_ROWS = 20;
+
+  @TempDir private File tempDir;
+
+  private HadoopTables tables;
+  private String tableLocation;
+
+  @BeforeEach
+  public void before() {
+    tables = new HadoopTables();
+    tableLocation = tempDir.toURI().toString();
+  }
+
+  /** Required struct with required primitive children. */
+  @Test
+  public void testRequiredStructWithRequiredFields() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "location",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "lat", Types.DoubleType.get()),
+                    Types.NestedField.required(4, "lon", Types.DoubleType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord location = GenericRecord.create(schema.findType("location").asStructType());
+      location.setField("lat", 37.0 + i * 0.1);
+      location.setField("lon", -122.0 + i * 0.1);
+      rec.setField("location", location);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        assertThat(batch.numRows()).isEqualTo(NUM_ROWS);
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+
+        StructVector structVec = (StructVector) root.getVector("location");
+        assertThat(structVec).isNotNull();
+        assertThat(structVec.size()).isEqualTo(2);
+        assertThat(structVec.getValueCount()).isEqualTo(NUM_ROWS);
+
+        Float8Vector latVec = (Float8Vector) structVec.getChild("lat");
+        Float8Vector lonVec = (Float8Vector) structVec.getChild("lon");
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(latVec.get(i)).isEqualTo(37.0 + i * 0.1);
+          assertThat(lonVec.get(i)).isEqualTo(-122.0 + i * 0.1);
+        }
+
+        root.close();
+      }
+    }
+  }
+
+  /** Optional struct with a mix of required and optional children. */
+  @Test
+  public void testOptionalStructWithMixedFields() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                2,
+                "info",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "name", Types.StringType.get()),
+                    Types.NestedField.optional(4, "count", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord info = GenericRecord.create(schema.findType("info").asStructType());
+      info.setField("name", "item-" + i);
+      info.setField("count", i % 3 == 0 ? null : i * 10);
+      rec.setField("info", info);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector infoVec = (StructVector) root.getVector("info");
+        VarCharVector nameVec = (VarCharVector) infoVec.getChild("name");
+        IntVector countVec = (IntVector) infoVec.getChild("count");
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(new String(nameVec.get(i), StandardCharsets.UTF_8)).isEqualTo("item-" + i);
+          if (i % 3 == 0) {
+            assertThat(countVec.isNull(i)).isTrue();
+          } else {
+            assertThat(countVec.get(i)).isEqualTo(i * 10);
+          }
+        }
+
+        root.close();
+      }
+    }
+  }
+
+  /** Struct with many different primitive child types. */
+  @Test
+  public void testStructWithVariousChildTypes() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "data",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "int_val", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "long_val", Types.LongType.get()),
+                    Types.NestedField.required(5, "double_val", Types.DoubleType.get()),
+                    Types.NestedField.required(6, "string_val", Types.StringType.get()),
+                    Types.NestedField.required(7, "date_val", Types.DateType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord data = GenericRecord.create(schema.findType("data").asStructType());
+      data.setField("int_val", i * 10);
+      data.setField("long_val", (long) i * 100);
+      data.setField("double_val", i * 1.5);
+      data.setField("string_val", "row-" + i);
+      data.setField("date_val", LocalDate.of(2024, 1, 1).plusDays(i));
+      rec.setField("data", data);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector dataVec = (StructVector) root.getVector("data");
+
+        assertThat(dataVec.size()).isEqualTo(5);
+
+        IntVector intChild = (IntVector) dataVec.getChild("int_val");
+        BigIntVector longChild = (BigIntVector) dataVec.getChild("long_val");
+        Float8Vector doubleChild = (Float8Vector) dataVec.getChild("double_val");
+        VarCharVector stringChild = (VarCharVector) dataVec.getChild("string_val");
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(intChild.get(i)).isEqualTo(i * 10);
+          assertThat(longChild.get(i)).isEqualTo((long) i * 100);
+          assertThat(doubleChild.get(i)).isEqualTo(i * 1.5);
+          assertThat(new String(stringChild.get(i), StandardCharsets.UTF_8)).isEqualTo("row-" + i);
+        }
+
+        root.close();
+      }
+    }
+  }
+
+  /** Nested struct: struct containing another struct. */
+  @Test
+  public void testNestedStruct() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "outer",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "tag", Types.StringType.get()),
+                    Types.NestedField.required(
+                        4,
+                        "inner",
+                        Types.StructType.of(
+                            Types.NestedField.required(5, "x", Types.IntegerType.get()),
+                            Types.NestedField.required(6, "y", Types.IntegerType.get()))))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+
+      Types.StructType innerType = schema.findType("outer.inner").asStructType();
+      GenericRecord inner = GenericRecord.create(innerType);
+      inner.setField("x", i);
+      inner.setField("y", i * 2);
+
+      GenericRecord outer = GenericRecord.create(schema.findType("outer").asStructType());
+      outer.setField("tag", "t-" + i);
+      outer.setField("inner", inner);
+      rec.setField("outer", outer);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+
+        StructVector outerVec = (StructVector) root.getVector("outer");
+        assertThat(outerVec.size()).isEqualTo(2);
+
+        VarCharVector tagVec = (VarCharVector) outerVec.getChild("tag");
+        StructVector innerVec = (StructVector) outerVec.getChild("inner");
+        assertThat(innerVec.size()).isEqualTo(2);
+
+        IntVector xVec = (IntVector) innerVec.getChild("x");
+        IntVector yVec = (IntVector) innerVec.getChild("y");
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(new String(tagVec.get(i), StandardCharsets.UTF_8)).isEqualTo("t-" + i);
+          assertThat(xVec.get(i)).isEqualTo(i);
+          assertThat(yVec.get(i)).isEqualTo(i * 2);
+        }
+
+        root.close();
+      }
+    }
+  }
+
+  /** Multiple struct columns alongside primitive columns. */
+  @Test
+  public void testMultipleStructColumns() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "point",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "x", Types.DoubleType.get()),
+                    Types.NestedField.required(4, "y", Types.DoubleType.get()))),
+            Types.NestedField.required(5, "label", Types.StringType.get()),
+            Types.NestedField.required(
+                6,
+                "metadata",
+                Types.StructType.of(
+                    Types.NestedField.required(7, "key", Types.StringType.get()),
+                    Types.NestedField.required(8, "value", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+
+      GenericRecord point = GenericRecord.create(schema.findType("point").asStructType());
+      point.setField("x", (double) i);
+      point.setField("y", (double) i * 2);
+      rec.setField("point", point);
+
+      rec.setField("label", "label-" + i);
+
+      GenericRecord metadata = GenericRecord.create(schema.findType("metadata").asStructType());
+      metadata.setField("key", "k" + i);
+      metadata.setField("value", i * 100);
+      rec.setField("metadata", metadata);
+
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        assertThat(batch.numCols()).isEqualTo(4);
+
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+
+        // Verify primitive columns
+        IntVector idVec = (IntVector) root.getVector("id");
+        VarCharVector labelVec = (VarCharVector) root.getVector("label");
+
+        // Verify first struct
+        StructVector pointVec = (StructVector) root.getVector("point");
+        Float8Vector xVec = (Float8Vector) pointVec.getChild("x");
+        Float8Vector yVec = (Float8Vector) pointVec.getChild("y");
+
+        // Verify second struct
+        StructVector metaVec = (StructVector) root.getVector("metadata");
+        VarCharVector keyVec = (VarCharVector) metaVec.getChild("key");
+        IntVector valueVec = (IntVector) metaVec.getChild("value");
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(idVec.get(i)).isEqualTo(i);
+          assertThat(new String(labelVec.get(i), StandardCharsets.UTF_8)).isEqualTo("label-" + i);
+          assertThat(xVec.get(i)).isEqualTo((double) i);
+          assertThat(yVec.get(i)).isEqualTo((double) i * 2);
+          assertThat(new String(keyVec.get(i), StandardCharsets.UTF_8)).isEqualTo("k" + i);
+          assertThat(valueVec.get(i)).isEqualTo(i * 100);
+        }
+
+        root.close();
+      }
+    }
+  }
+
+  /** Struct data is read correctly when the batch size is smaller than the total row count. */
+  @Test
+  public void testStructWithSmallerBatchSize() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "pair",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "b", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord pair = GenericRecord.create(schema.findType("pair").asStructType());
+      pair.setField("a", i);
+      pair.setField("b", i + 100);
+      rec.setField("pair", pair);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    int batchSize = 7;
+    int totalRows = 0;
+    int batchIndex = 0;
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), batchSize, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector pairVec = (StructVector) root.getVector("pair");
+        IntVector aVec = (IntVector) pairVec.getChild("a");
+        IntVector bVec = (IntVector) pairVec.getChild("b");
+
+        for (int i = 0; i < batch.numRows(); i++) {
+          int rowIdx = batchIndex * batchSize + i;
+          assertThat(aVec.get(i)).isEqualTo(rowIdx);
+          assertThat(bVec.get(i)).isEqualTo(rowIdx + 100);
+        }
+
+        totalRows += batch.numRows();
+        batchIndex++;
+        root.close();
+      }
+    }
+
+    assertThat(totalRows).isEqualTo(NUM_ROWS);
+    assertThat(batchIndex).as("Should have multiple batches").isGreaterThan(1);
+  }
+
+  /** Struct accessed through the ColumnVector.getChildColumn() API. */
+  @Test
+  public void testStructAccessViaColumnVector() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "point",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "x", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "y", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord point = GenericRecord.create(schema.findType("point").asStructType());
+      point.setField("x", i * 10);
+      point.setField("y", i * 20);
+      rec.setField("point", point);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        ColumnVector structCol = batch.column(1);
+        ColumnVector xChild = structCol.getChildColumn(0);
+        ColumnVector yChild = structCol.getChildColumn(1);
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(xChild.getInt(i)).isEqualTo(i * 10);
+          assertThat(yChild.getInt(i)).isEqualTo(i * 20);
+        }
+      }
+    }
+  }
+
+  /** Nullable child fields report null correctly through the ColumnVector API. */
+  @Test
+  public void testStructChildNullabilityViaColumnVector() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "data",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "name", Types.StringType.get()),
+                    Types.NestedField.optional(4, "value", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord data = GenericRecord.create(schema.findType("data").asStructType());
+      data.setField("name", "n" + i);
+      data.setField("value", i % 2 == 0 ? null : i);
+      rec.setField("data", data);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        ColumnVector structCol = batch.column(1);
+        ColumnVector nameChild = structCol.getChildColumn(0);
+        ColumnVector valueChild = structCol.getChildColumn(1);
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(nameChild.isNullAt(i)).isFalse();
+          assertThat(nameChild.getString(i)).isEqualTo("n" + i);
+          if (i % 2 == 0) {
+            assertThat(valueChild.isNullAt(i))
+                .as("Row %d should be null", i)
+                .isTrue();
+          } else {
+            assertThat(valueChild.isNullAt(i)).isFalse();
+            assertThat(valueChild.getInt(i)).isEqualTo(i);
+          }
+        }
+      }
+    }
+  }
+
+  /** Struct field is returned as StructVector in the VectorSchemaRoot. */
+  @Test
+  public void testStructArrowSchemaInVectorSchemaRoot() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                2,
+                "attrs",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "name", Types.StringType.get()),
+                    Types.NestedField.optional(4, "score", Types.DoubleType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord attrs = GenericRecord.create(schema.findType("attrs").asStructType());
+      attrs.setField("name", "n" + i);
+      attrs.setField("score", i * 0.5);
+      rec.setField("attrs", attrs);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+
+        // Verify the Arrow schema reflects the struct type
+        org.apache.arrow.vector.types.pojo.Schema arrowSchema = root.getSchema();
+        assertThat(arrowSchema.getFields()).hasSize(2);
+
+        org.apache.arrow.vector.types.pojo.Field structField = arrowSchema.getFields().get(1);
+        assertThat(structField.getName()).isEqualTo("attrs");
+        assertThat(structField.getType())
+            .isInstanceOf(org.apache.arrow.vector.types.pojo.ArrowType.Struct.class);
+        assertThat(structField.getChildren()).hasSize(2);
+        assertThat(structField.getChildren().get(0).getName()).isEqualTo("name");
+        assertThat(structField.getChildren().get(1).getName()).isEqualTo("score");
+
+        // Verify the vector type
+        FieldVector attrsVec = root.getVector("attrs");
+        assertThat(attrsVec).isInstanceOf(StructVector.class);
+
+        root.close();
+      }
+    }
+  }
+
+  /** Reading with container reuse enabled. */
+  @Test
+  public void testStructWithReuseContainers() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "pair",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "b", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord pair = GenericRecord.create(schema.findType("pair").asStructType());
+      pair.setField("a", i);
+      pair.setField("b", i + 1);
+      rec.setField("pair", pair);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    int batchSize = 7;
+    int totalRows = 0;
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), batchSize, true)) {
+      for (ColumnarBatch batch : reader) {
+        // Access struct data through the ColumnarBatch API (not VectorSchemaRoot)
+        // since VectorSchemaRoot.close() would release the vectors that are being reused
+        ColumnVector structCol = batch.column(1);
+        ColumnVector aChild = structCol.getChildColumn(0);
+        ColumnVector bChild = structCol.getChildColumn(1);
+
+        for (int i = 0; i < batch.numRows(); i++) {
+          int rowIdx = totalRows + i;
+          assertThat(aChild.getInt(i)).isEqualTo(rowIdx);
+          assertThat(bChild.getInt(i)).isEqualTo(rowIdx + 1);
+        }
+
+        totalRows += batch.numRows();
+      }
+    }
+
+    assertThat(totalRows).isEqualTo(NUM_ROWS);
+  }
+
+  /** Only the struct column is projected (no primitive siblings). */
+  @Test
+  public void testSelectOnlyStructColumn() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "pair",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "b", Types.IntegerType.get()))),
+            Types.NestedField.required(5, "name", Types.StringType.get()));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord pair = GenericRecord.create(schema.findType("pair").asStructType());
+      pair.setField("a", i * 3);
+      pair.setField("b", i * 4);
+      rec.setField("pair", pair);
+      rec.setField("name", "n" + i);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    // Project only the struct column
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(
+            table.newScan().select("pair"), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        assertThat(batch.numCols()).isEqualTo(1);
+
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        assertThat(root.getSchema().getFields()).hasSize(1);
+
+        StructVector pairVec = (StructVector) root.getVector("pair");
+        IntVector aVec = (IntVector) pairVec.getChild("a");
+        IntVector bVec = (IntVector) pairVec.getChild("b");
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(aVec.get(i)).isEqualTo(i * 3);
+          assertThat(bVec.get(i)).isEqualTo(i * 4);
+        }
+
+        root.close();
+      }
+    }
+  }
+
+  /** Struct alongside a filter on a primitive column. */
+  @Test
+  public void testStructWithRowFilter() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "pair",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "b", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      rec.setField("id", i);
+      GenericRecord pair = GenericRecord.create(schema.findType("pair").asStructType());
+      pair.setField("a", i);
+      pair.setField("b", i + 1);
+      rec.setField("pair", pair);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    // The filter here is a residual that still gets applied; the scan should succeed
+    // even with struct columns present
+    int totalRows = 0;
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector pairVec = (StructVector) root.getVector("pair");
+        assertThat(pairVec).isNotNull();
+        totalRows += batch.numRows();
+        root.close();
+      }
+    }
+
+    assertThat(totalRows).isEqualTo(NUM_ROWS);
+  }
+
+  /** Struct-only schema (no top-level primitive columns). */
+  @Test
+  public void testStructOnlySchema() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(
+                1,
+                "point",
+                Types.StructType.of(
+                    Types.NestedField.required(2, "x", Types.IntegerType.get()),
+                    Types.NestedField.required(3, "y", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+    List<GenericRecord> records = Lists.newArrayList();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRecord rec = GenericRecord.create(schema);
+      GenericRecord point = GenericRecord.create(schema.findType("point").asStructType());
+      point.setField("x", i);
+      point.setField("y", i * 10);
+      rec.setField("point", point);
+      records.add(rec);
+    }
+
+    appendData(table, records);
+
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        assertThat(batch.numCols()).isEqualTo(1);
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector pointVec = (StructVector) root.getVector("point");
+
+        IntVector xVec = (IntVector) pointVec.getChild("x");
+        IntVector yVec = (IntVector) pointVec.getChild("y");
+
+        for (int i = 0; i < NUM_ROWS; i++) {
+          assertThat(xVec.get(i)).isEqualTo(i);
+          assertThat(yVec.get(i)).isEqualTo(i * 10);
+        }
+
+        root.close();
+      }
+    }
+  }
+
+  /** Data written across multiple Parquet files is read correctly. */
+  @Test
+  public void testStructAcrossMultipleFiles() throws Exception {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "pair",
+                Types.StructType.of(
+                    Types.NestedField.required(3, "a", Types.IntegerType.get()),
+                    Types.NestedField.required(4, "b", Types.IntegerType.get()))));
+
+    Table table = createTable(schema);
+
+    // Write two separate files
+    for (int file = 0; file < 2; file++) {
+      List<GenericRecord> records = Lists.newArrayList();
+      for (int i = 0; i < NUM_ROWS; i++) {
+        int val = file * NUM_ROWS + i;
+        GenericRecord rec = GenericRecord.create(schema);
+        rec.setField("id", val);
+        GenericRecord pair = GenericRecord.create(schema.findType("pair").asStructType());
+        pair.setField("a", val);
+        pair.setField("b", val * 2);
+        rec.setField("pair", pair);
+        records.add(rec);
+      }
+      appendData(table, records);
+    }
+
+    int totalRows = 0;
+    try (VectorizedTableScanIterable reader =
+        new VectorizedTableScanIterable(table.newScan(), NUM_ROWS, false)) {
+      for (ColumnarBatch batch : reader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        StructVector pairVec = (StructVector) root.getVector("pair");
+        IntVector aVec = (IntVector) pairVec.getChild("a");
+        IntVector idVec = (IntVector) root.getVector("id");
+
+        for (int i = 0; i < batch.numRows(); i++) {
+          // struct child values should match the id column
+          assertThat(aVec.get(i)).isEqualTo(idVec.get(i));
+        }
+
+        totalRows += batch.numRows();
+        root.close();
+      }
+    }
+
+    assertThat(totalRows).isEqualTo(NUM_ROWS * 2);
+  }
+
+  private Table createTable(Schema schema) {
+    return tables.create(
+        schema,
+        PartitionSpec.unpartitioned(),
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, "3"),
+        tableLocation);
+  }
+
+  private void appendData(Table table, List<GenericRecord> records) throws IOException {
+    File parquetFile = File.createTempFile("struct-test", null, tempDir);
+    assertThat(parquetFile.delete()).isTrue();
+
+    FileAppender<GenericRecord> appender =
+        Parquet.write(Files.localOutput(parquetFile))
+            .schema(table.schema())
+            .createWriterFunc(GenericParquetWriter::create)
+            .build();
+    try {
+      appender.addAll(records);
+    } finally {
+      appender.close();
+    }
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withInputFile(localInput(parquetFile))
+            .withMetrics(appender.metrics())
+            .withFormat(FileFormat.PARQUET)
+            .build();
+
+    table.newAppend().appendFile(dataFile).commit();
+  }
+}

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReaderStruct.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReaderStruct.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.List;
@@ -672,9 +671,9 @@ public class TestArrowReaderStruct {
     }
   }
 
-  /** Struct alongside a filter on a primitive column. */
+  /** Full scan succeeds when struct columns are present. */
   @Test
-  public void testStructWithRowFilter() throws Exception {
+  public void testFullScanWithStructColumn() throws Exception {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.IntegerType.get()),

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -49,9 +49,6 @@ import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ParquetProperties;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.junit.jupiter.api.Test;
 
@@ -192,21 +189,6 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             throw new RuntimeException(e);
           }
         });
-  }
-
-  @Test
-  @Override
-  public void testNestedStruct() {
-    assertThatThrownBy(
-            () ->
-                VectorizedSparkParquetReaders.buildReader(
-                    TypeUtil.assignIncreasingFreshIds(
-                        new Schema(required(1, "struct", SUPPORTED_PRIMITIVES))),
-                    new MessageType(
-                        "struct", new GroupType(Type.Repetition.OPTIONAL, "struct").withId(1)),
-                    Maps.newHashMap()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Vectorized reads are not supported yet for struct fields");
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -55,7 +55,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.data.AvroDataTestBase;
 import org.apache.iceberg.spark.data.GenericsHelpers;
 import org.apache.iceberg.spark.data.RandomData;
@@ -65,9 +64,6 @@ import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ParquetProperties;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.junit.jupiter.api.Test;
@@ -304,21 +300,6 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             throw new RuntimeException(e);
           }
         });
-  }
-
-  @Test
-  @Override
-  public void testNestedStruct() {
-    assertThatThrownBy(
-            () ->
-                VectorizedSparkParquetReaders.buildReader(
-                    TypeUtil.assignIncreasingFreshIds(
-                        new Schema(required(1, "struct", SUPPORTED_PRIMITIVES))),
-                    new MessageType(
-                        "struct", new GroupType(Type.Repetition.OPTIONAL, "struct").withId(1)),
-                    Maps.newHashMap()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Vectorized reads are not supported yet for struct fields");
   }
 
   @Test

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -55,7 +55,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.data.AvroDataTestBase;
 import org.apache.iceberg.spark.data.GenericsHelpers;
 import org.apache.iceberg.spark.data.RandomData;
@@ -65,9 +64,6 @@ import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ParquetProperties;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.junit.jupiter.api.Test;
@@ -304,21 +300,6 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             throw new RuntimeException(e);
           }
         });
-  }
-
-  @Test
-  @Override
-  public void testNestedStruct() {
-    assertThatThrownBy(
-            () ->
-                VectorizedSparkParquetReaders.buildReader(
-                    TypeUtil.assignIncreasingFreshIds(
-                        new Schema(required(1, "struct", SUPPORTED_PRIMITIVES))),
-                    new MessageType(
-                        "struct", new GroupType(Type.Repetition.OPTIONAL, "struct").withId(1)),
-                    Maps.newHashMap()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Vectorized reads are not supported yet for struct fields");
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -55,7 +55,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.data.AvroDataTestBase;
 import org.apache.iceberg.spark.data.GenericsHelpers;
 import org.apache.iceberg.spark.data.RandomData;
@@ -65,9 +64,6 @@ import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ParquetProperties;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.junit.jupiter.api.Test;
@@ -304,21 +300,6 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
             throw new RuntimeException(e);
           }
         });
-  }
-
-  @Test
-  @Override
-  public void testNestedStruct() {
-    assertThatThrownBy(
-            () ->
-                VectorizedSparkParquetReaders.buildReader(
-                    TypeUtil.assignIncreasingFreshIds(
-                        new Schema(required(1, "struct", SUPPORTED_PRIMITIVES))),
-                    new MessageType(
-                        "struct", new GroupType(Type.Repetition.OPTIONAL, "struct").withId(1)),
-                    Maps.newHashMap()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Vectorized reads are not supported yet for struct fields");
   }
 
   @Test


### PR DESCRIPTION
The Arrow vectorized reader previously threw UnsupportedOperationException for struct fields. This adds full support for reading nested struct columns into Arrow StructVectors.

- Add VectorizedStructReader that reads child columns and assembles them into Arrow StructVector via transfer pairs
- Update VectorizedReaderBuilder.struct() to create VectorizedStructReader with properly reordered child readers
- Add StructChildFactory in ArrowVectorAccessors for struct vector access
- Add ColumnVector.getChildColumn() for programmatic struct child access
- Add TypeID.STRUCT to ArrowReader.SUPPORTED_TYPES
- Widen VectorizedArrowReader(NestedField) constructor to package-private