### PR TITLE
Core: Use Stream overload for reading response in HTTPClient

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -340,14 +340,13 @@ public class HTTPClient extends BaseHTTPClient {
         return null;
       }
 
-      String responseBody = extractResponseBodyAsString(response);
-
       if (!isSuccessful(response)) {
         // The provided error handler is expected to throw, but a RESTException is thrown if not.
+        String responseBody = extractResponseBodyAsString(response);
         throwFailure(response, responseBody, errorHandler);
       }
 
-      if (responseBody == null) {
+      if (response.getEntity() == null) {
         throw new RESTException(
             "Invalid (null) response body for request (expected %s): method=%s, path=%s, status=%d",
             responseType.getSimpleName(), req.method(), req.path(), response.getCode());
@@ -358,7 +357,7 @@ public class HTTPClient extends BaseHTTPClient {
         if (parserContext != null && !parserContext.isEmpty()) {
           reader = reader.with(parserContext.toInjectableValues());
         }
-        return reader.readValue(responseBody);
+        return reader.readValue(response.getEntity().getContent());
       } catch (JsonProcessingException e) {
         throw new RESTException(
             e,

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -352,19 +352,11 @@ public class HTTPClient extends BaseHTTPClient {
             responseType.getSimpleName(), req.method(), req.path(), response.getCode());
       }
 
-      try {
-        ObjectReader reader = objectReaderCache.computeIfAbsent(responseType, mapper::readerFor);
-        if (parserContext != null && !parserContext.isEmpty()) {
+      ObjectReader reader = objectReaderCache.computeIfAbsent(responseType, mapper::readerFor);
+      if (parserContext != null && !parserContext.isEmpty()) {
           reader = reader.with(parserContext.toInjectableValues());
-        }
-        return reader.readValue(response.getEntity().getContent());
-      } catch (JsonProcessingException e) {
-        throw new RESTException(
-            e,
-            "Received a success response code of %d, but failed to parse response body into %s",
-            response.getCode(),
-            responseType.getSimpleName());
       }
+      return reader.readValue(response.getEntity().getContent());
     } catch (IOException e) {
       throw new RESTException(e, "Error occurred while processing %s request", req.method());
     }

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.rest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
@@ -354,7 +353,7 @@ public class HTTPClient extends BaseHTTPClient {
 
       ObjectReader reader = objectReaderCache.computeIfAbsent(responseType, mapper::readerFor);
       if (parserContext != null && !parserContext.isEmpty()) {
-          reader = reader.with(parserContext.toInjectableValues());
+        reader = reader.with(parserContext.toInjectableValues());
       }
       return reader.readValue(response.getEntity().getContent());
     } catch (IOException e) {


### PR DESCRIPTION
For tables with big metadata files `loadTable` was allocating a lot of `char[]`

<img width="1285" height="309" alt="image" src="https://github.com/user-attachments/assets/7fee49c8-9dcf-49a7-93b1-61a153dc81db" />
<img width="1552" height="305" alt="image" src="https://github.com/user-attachments/assets/02410bce-75e1-4c69-b289-8e0d55e13065" />
