### PR TITLE
Core: Coalesce contiguous blob reads in PuffinReader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -36,6 +35,7 @@ import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.puffin.PuffinFormat.Flag;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.apache.iceberg.util.Pair;
 
@@ -126,7 +126,7 @@ public class PuffinReader implements Closeable {
       return ImmutableList.of();
     }
 
-    List<BlobMetadata> sortedBlobs = new ArrayList<>(blobs);
+    List<BlobMetadata> sortedBlobs = Lists.newArrayList(blobs);
     sortedBlobs.sort(Comparator.comparingLong(BlobMetadata::offset));
 
     // Coalesce adjacent blob reads to reduce I/O operations. Blobs that are contiguous
@@ -165,8 +165,8 @@ public class PuffinReader implements Closeable {
    * exactly where the previous one ends) are grouped together to be read in a single I/O request.
    */
   static List<List<BlobMetadata>> coalesceRanges(List<BlobMetadata> sortedBlobs) {
-    List<List<BlobMetadata>> ranges = new ArrayList<>();
-    List<BlobMetadata> currentRange = new ArrayList<>();
+    List<List<BlobMetadata>> ranges = Lists.newArrayList();
+    List<BlobMetadata> currentRange = Lists.newArrayList();
     currentRange.add(sortedBlobs.get(0));
 
     for (int i = 1; i < sortedBlobs.size(); i++) {
@@ -180,7 +180,7 @@ public class PuffinReader implements Closeable {
       } else {
         // Gap between blobs — start a new range
         ranges.add(currentRange);
-        currentRange = new ArrayList<>();
+        currentRange = Lists.newArrayList();
         currentRange.add(curr);
       }
     }

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -125,27 +126,67 @@ public class PuffinReader implements Closeable {
       return ImmutableList.of();
     }
 
-    // TODO inspect blob offsets and coalesce read regions close to each other
+    List<BlobMetadata> sortedBlobs = new ArrayList<>(blobs);
+    sortedBlobs.sort(Comparator.comparingLong(BlobMetadata::offset));
 
-    return () ->
-        blobs.stream()
-            .sorted(Comparator.comparingLong(BlobMetadata::offset))
-            .map(
-                (BlobMetadata blobMetadata) -> {
-                  try {
-                    input.seek(blobMetadata.offset());
-                    byte[] bytes = new byte[Math.toIntExact(blobMetadata.length())];
-                    ByteStreams.readFully(input, bytes);
-                    ByteBuffer rawData = ByteBuffer.wrap(bytes);
-                    PuffinCompressionCodec codec =
-                        PuffinCompressionCodec.forName(blobMetadata.compressionCodec());
-                    ByteBuffer data = PuffinFormat.decompress(codec, rawData);
-                    return Pair.of(blobMetadata, data);
-                  } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                  }
-                })
-            .iterator();
+    // Coalesce adjacent blob reads to reduce I/O operations. Blobs that are contiguous
+    // (no gap between them) are read together in a single I/O request.
+    List<List<BlobMetadata>> readRanges = coalesceRanges(sortedBlobs);
+
+    ImmutableList.Builder<Pair<BlobMetadata, ByteBuffer>> result = ImmutableList.builder();
+    try {
+      for (List<BlobMetadata> range : readRanges) {
+        long rangeStart = range.get(0).offset();
+        BlobMetadata lastBlob = range.get(range.size() - 1);
+        long rangeEnd = lastBlob.offset() + lastBlob.length();
+        int rangeLength = Math.toIntExact(rangeEnd - rangeStart);
+
+        byte[] rangeData = readInput(rangeStart, rangeLength);
+
+        for (BlobMetadata blobMetadata : range) {
+          int blobOffset = Math.toIntExact(blobMetadata.offset() - rangeStart);
+          int blobLength = Math.toIntExact(blobMetadata.length());
+          ByteBuffer rawData = ByteBuffer.wrap(rangeData, blobOffset, blobLength).slice();
+          PuffinCompressionCodec codec =
+              PuffinCompressionCodec.forName(blobMetadata.compressionCodec());
+          ByteBuffer data = PuffinFormat.decompress(codec, rawData);
+          result.add(Pair.of(blobMetadata, data));
+        }
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    return result.build();
+  }
+
+  /**
+   * Groups blobs into coalesced read ranges. Blobs that are contiguous (the next blob starts
+   * exactly where the previous one ends) are grouped together to be read in a single I/O request.
+   */
+  static List<List<BlobMetadata>> coalesceRanges(List<BlobMetadata> sortedBlobs) {
+    List<List<BlobMetadata>> ranges = new ArrayList<>();
+    List<BlobMetadata> currentRange = new ArrayList<>();
+    currentRange.add(sortedBlobs.get(0));
+
+    for (int i = 1; i < sortedBlobs.size(); i++) {
+      BlobMetadata prev = sortedBlobs.get(i - 1);
+      BlobMetadata curr = sortedBlobs.get(i);
+      long prevEnd = prev.offset() + prev.length();
+
+      if (curr.offset() <= prevEnd) {
+        // Contiguous or overlapping — coalesce into the same range
+        currentRange.add(curr);
+      } else {
+        // Gap between blobs — start a new range
+        ranges.add(currentRange);
+        currentRange = new ArrayList<>();
+        currentRange.add(curr);
+      }
+    }
+
+    ranges.add(currentRange);
+    return ranges;
   }
 
   private static void checkMagic(byte[] data, int offset) {

--- a/core/src/test/java/org/apache/iceberg/puffin/TestPuffinReader.java
+++ b/core/src/test/java/org/apache/iceberg/puffin/TestPuffinReader.java
@@ -28,9 +28,12 @@ import static org.apache.iceberg.relocated.com.google.common.collect.ImmutableMa
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.iceberg.inmemory.InMemoryInputFile;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
@@ -153,5 +156,169 @@ public class TestPuffinReader {
       assertThat(reader.fileMetadata().properties())
           .isEqualTo(ImmutableMap.of("created-by", "Test 1234"));
     }
+  }
+
+  @Test
+  public void testCoalesceRangesContiguousBlobs() {
+    // Two contiguous blobs (second starts right after the first ends) should be coalesced
+    BlobMetadata blob1 = testBlobMetadata(100, 50);
+    BlobMetadata blob2 = testBlobMetadata(150, 60);
+
+    List<List<BlobMetadata>> ranges = PuffinReader.coalesceRanges(ImmutableList.of(blob1, blob2));
+
+    assertThat(ranges).as("contiguous blobs should be in one range").hasSize(1);
+    assertThat(ranges.get(0)).containsExactly(blob1, blob2);
+  }
+
+  @Test
+  public void testCoalesceRangesNonContiguousBlobs() {
+    // Two blobs with a gap should NOT be coalesced
+    BlobMetadata blob1 = testBlobMetadata(100, 50);
+    BlobMetadata blob2 = testBlobMetadata(200, 60);
+
+    List<List<BlobMetadata>> ranges = PuffinReader.coalesceRanges(ImmutableList.of(blob1, blob2));
+
+    assertThat(ranges).as("non-contiguous blobs should be in separate ranges").hasSize(2);
+    assertThat(ranges.get(0)).containsExactly(blob1);
+    assertThat(ranges.get(1)).containsExactly(blob2);
+  }
+
+  @Test
+  public void testCoalesceRangesSingleBlob() {
+    BlobMetadata blob1 = testBlobMetadata(100, 50);
+
+    List<List<BlobMetadata>> ranges = PuffinReader.coalesceRanges(ImmutableList.of(blob1));
+
+    assertThat(ranges).as("single blob should produce one range").hasSize(1);
+    assertThat(ranges.get(0)).containsExactly(blob1);
+  }
+
+  @Test
+  public void testCoalesceRangesMultipleContiguousGroups() {
+    // Group 1: blobs at [100, 150) and [150, 210) — contiguous
+    // Group 2: blobs at [300, 350) and [350, 400) — contiguous
+    BlobMetadata blob1 = testBlobMetadata(100, 50);
+    BlobMetadata blob2 = testBlobMetadata(150, 60);
+    BlobMetadata blob3 = testBlobMetadata(300, 50);
+    BlobMetadata blob4 = testBlobMetadata(350, 50);
+
+    List<List<BlobMetadata>> ranges =
+        PuffinReader.coalesceRanges(ImmutableList.of(blob1, blob2, blob3, blob4));
+
+    assertThat(ranges).as("should have two separate groups").hasSize(2);
+    assertThat(ranges.get(0)).containsExactly(blob1, blob2);
+    assertThat(ranges.get(1)).containsExactly(blob3, blob4);
+  }
+
+  @Test
+  public void testCoalesceRangesAllNonContiguous() {
+    BlobMetadata blob1 = testBlobMetadata(100, 10);
+    BlobMetadata blob2 = testBlobMetadata(200, 10);
+    BlobMetadata blob3 = testBlobMetadata(300, 10);
+
+    List<List<BlobMetadata>> ranges =
+        PuffinReader.coalesceRanges(ImmutableList.of(blob1, blob2, blob3));
+
+    assertThat(ranges).as("all non-contiguous blobs should produce separate ranges").hasSize(3);
+  }
+
+  @Test
+  public void testCoalescedReadAllWithMultipleBlobs() throws Exception {
+    // Write multiple blobs and verify readAll correctly reads them with coalescing
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (PuffinWriter writer = Puffin.write(outputFile).build()) {
+      writer.add(
+          new Blob(
+              "blob-type-a",
+              ImmutableList.of(1),
+              1,
+              1,
+              ByteBuffer.wrap("first-blob-data".getBytes(UTF_8)),
+              NONE,
+              ImmutableMap.of()));
+      writer.add(
+          new Blob(
+              "blob-type-b",
+              ImmutableList.of(2),
+              1,
+              1,
+              ByteBuffer.wrap("second-blob-data".getBytes(UTF_8)),
+              NONE,
+              ImmutableMap.of()));
+      writer.add(
+          new Blob(
+              "blob-type-c",
+              ImmutableList.of(3),
+              1,
+              1,
+              ByteBuffer.wrap("third-blob-data".getBytes(UTF_8)),
+              NONE,
+              ImmutableMap.of()));
+    }
+
+    InMemoryInputFile inputFile = new InMemoryInputFile(outputFile.toByteArray());
+    try (PuffinReader reader = Puffin.read(inputFile).build()) {
+      FileMetadata fileMetadata = reader.fileMetadata();
+      assertThat(fileMetadata.blobs()).hasSize(3);
+
+      // Read all blobs — these should be contiguous and coalesced into a single read
+      Map<BlobMetadata, byte[]> read =
+          Streams.stream(reader.readAll(fileMetadata.blobs()))
+              .collect(toImmutableMap(Pair::first, pair -> ByteBuffers.toByteArray(pair.second())));
+
+      assertThat(read).hasSize(3);
+      assertThat(read.get(fileMetadata.blobs().get(0)))
+          .isEqualTo("first-blob-data".getBytes(UTF_8));
+      assertThat(read.get(fileMetadata.blobs().get(1)))
+          .isEqualTo("second-blob-data".getBytes(UTF_8));
+      assertThat(read.get(fileMetadata.blobs().get(2)))
+          .isEqualTo("third-blob-data".getBytes(UTF_8));
+    }
+  }
+
+  @Test
+  public void testCoalescedReadAllReversedOrder() throws Exception {
+    // Verify readAll works when blobs are requested in reverse order
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (PuffinWriter writer = Puffin.write(outputFile).build()) {
+      writer.add(
+          new Blob(
+              "blob-a",
+              ImmutableList.of(1),
+              1,
+              1,
+              ByteBuffer.wrap("aaa".getBytes(UTF_8)),
+              NONE,
+              ImmutableMap.of()));
+      writer.add(
+          new Blob(
+              "blob-b",
+              ImmutableList.of(2),
+              1,
+              1,
+              ByteBuffer.wrap("bbb".getBytes(UTF_8)),
+              NONE,
+              ImmutableMap.of()));
+    }
+
+    InMemoryInputFile inputFile = new InMemoryInputFile(outputFile.toByteArray());
+    try (PuffinReader reader = Puffin.read(inputFile).build()) {
+      FileMetadata fileMetadata = reader.fileMetadata();
+      BlobMetadata firstBlob = fileMetadata.blobs().get(0);
+      BlobMetadata secondBlob = fileMetadata.blobs().get(1);
+
+      // Request in reverse order
+      Map<BlobMetadata, byte[]> read =
+          Streams.stream(reader.readAll(ImmutableList.of(secondBlob, firstBlob)))
+              .collect(toImmutableMap(Pair::first, pair -> ByteBuffers.toByteArray(pair.second())));
+
+      assertThat(read.get(firstBlob)).isEqualTo("aaa".getBytes(UTF_8));
+      assertThat(read.get(secondBlob)).isEqualTo("bbb".getBytes(UTF_8));
+    }
+  }
+
+  private static BlobMetadata testBlobMetadata(long offset, long length) {
+    return new BlobMetadata(
+        "test-type", ImmutableList.of(1), 1, 1, offset, length, null, ImmutableMap.of());
   }
 }


### PR DESCRIPTION
PuffinReader.readAll() currently issues a separate seek+read for each blob. Since blobs are written back-to-back in a Puffin file, this results in unnecessary I/O overhead. This PR coalesces contiguous blobs into a single read. Blobs are sorted by offset, grouped into ranges where adjacent blobs touch, and each range is read in one I/O call.
