### PR TITLE
Per-commitId group separation for stale DataWritten recovery

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -81,6 +81,9 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
 | iceberg.control.commit.threads             | Number of threads to use for commits, default is (`cores * 2`)                                                     |
+| iceberg.control.commit.stale-ttl-ms                | Time-to-live for stale commit events in the buffer (msec), default is 3,600,000 (1 hr). Set 0 to disable. |
+| iceberg.control.commit.stale-max-blocking-retries  | Number of retries before a stale group transitions to the configured failure policy, default is 3.         |
+| iceberg.control.commit.stale-failure-policy        | Policy after max retries: `fail` (default, stop connector) or `non-blocking` (proceed, may duplicate).    |
 | iceberg.coordinator.transactional.prefix   | Prefix for the transactional id to use for the coordinator producer, default is to use no/empty prefix           |
 | iceberg.catalog                            | Name of the catalog, default is `iceberg`                                                                        |
 | iceberg.catalog.*                          | Properties passed through to Iceberg catalog initialization                                                      |
@@ -363,6 +366,46 @@ See above for creating two tables.
   }
 }
 ```
+
+## Commit behavior
+
+The coordinator commits data to Iceberg tables in cycles. Each cycle, the coordinator
+sends a `StartCommit` to the control topic, waits for worker responses (`DataWritten`
+and `DataComplete`), and then commits the collected data files to Iceberg.
+
+### Partial commits and stale events
+
+When a commit times out (a worker hasn't responded within `commit.timeout-ms`), the
+coordinator performs a **partial commit** with the data files received so far. Workers
+that finish after the timeout send their `DataWritten` events to the control topic,
+which are consumed in the next commit cycle.
+
+These late-arriving ("stale") events carry the previous cycle's `commitId`. The
+coordinator separates them from current-cycle events and commits each group in a
+separate `RowDelta` with its own Iceberg sequence number. This ensures equality
+deletes from the current cycle correctly apply to stale data files (because
+`data_sequence_number < delete_sequence_number` is required).
+
+### Stale event error handling
+
+If a stale group fails to commit, the coordinator uses a three-stage escalation:
+
+1. **Blocking retries** (`stale-max-blocking-retries`, default 3): The stale group
+   blocks the current group for the same table to preserve sequence number ordering.
+2. **Failure policy** (`stale-failure-policy`):
+   * `fail` (default): Throws a `ConnectException`, moving the connector to `FAILED` state.
+   * `non-blocking`: Proceeds with the current group, accepting ordering inversion risk.
+3. **TTL eviction** (`stale-ttl-ms`, default 1 hour): Stale events older than the TTL
+   are evicted with an `ERROR` log containing the orphaned file paths for manual recovery.
+
+### JMX monitoring
+
+The coordinator registers a `CommitStateMXBean` under
+`org.apache.iceberg.connect:type=CommitState,connector=<name>` exposing:
+
+- `EvictedStaleEventCount`: Cumulative count of stale events evicted by TTL.
+- `StaleGroupCount`: Number of distinct stale commitId groups in the buffer.
+- `BufferSize`: Total number of envelopes in the commit buffer.
 
 ## SMTs for the Apache Iceberg Sink Connector
 

--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -81,9 +81,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
 | iceberg.control.commit.threads             | Number of threads to use for commits, default is (`cores * 2`)                                                     |
-| iceberg.control.commit.stale-ttl-ms                | Time-to-live for stale commit events in the buffer (msec), default is 3,600,000 (1 hr). Set 0 to disable. |
-| iceberg.control.commit.stale-max-blocking-retries  | Number of retries before a stale group transitions to the configured failure policy, default is 3.         |
-| iceberg.control.commit.stale-failure-policy        | Policy after max retries: `fail` (default, stop connector) or `non-blocking` (proceed, may duplicate).    |
+| iceberg.control.commit.stale-max-blocking-retries  | Number of retries before a stale group fails the connector, default is 3. Set 0 to fail immediately.       |
 | iceberg.coordinator.transactional.prefix   | Prefix for the transactional id to use for the coordinator producer, default is to use no/empty prefix           |
 | iceberg.catalog                            | Name of the catalog, default is `iceberg`                                                                        |
 | iceberg.catalog.*                          | Properties passed through to Iceberg catalog initialization                                                      |
@@ -388,22 +386,17 @@ deletes from the current cycle correctly apply to stale data files (because
 
 ### Stale event error handling
 
-If a stale group fails to commit, the coordinator uses a three-stage escalation:
-
-1. **Blocking retries** (`stale-max-blocking-retries`, default 3): The stale group
-   blocks the current group for the same table to preserve sequence number ordering.
-2. **Failure policy** (`stale-failure-policy`):
-   * `fail` (default): Throws a `ConnectException`, moving the connector to `FAILED` state.
-   * `non-blocking`: Proceeds with the current group, accepting ordering inversion risk.
-3. **TTL eviction** (`stale-ttl-ms`, default 1 hour): Stale events older than the TTL
-   are evicted with an `ERROR` log containing the orphaned file paths for manual recovery.
+If a stale group fails to commit, the coordinator retries it up to
+`stale-max-blocking-retries` times (default 3). During retries, the stale group blocks
+subsequent groups for the same table to preserve sequence number ordering. After max
+retries are exhausted, the coordinator throws a `ConnectException`, moving the connector
+to `FAILED` state for operator intervention.
 
 ### JMX monitoring
 
 The coordinator registers a `CommitStateMXBean` under
 `org.apache.iceberg.connect:type=CommitState,connector=<name>` exposing:
 
-- `EvictedStaleEventCount`: Cumulative count of stale events evicted by TTL.
 - `StaleGroupCount`: Number of distinct stale commitId groups in the buffer.
 - `BufferSize`: Total number of envelopes in the commit buffer.
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -86,6 +86,14 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String COMMIT_TIMEOUT_MS_PROP = "iceberg.control.commit.timeout-ms";
   private static final int COMMIT_TIMEOUT_MS_DEFAULT = 30_000;
   private static final String COMMIT_THREADS_PROP = "iceberg.control.commit.threads";
+  private static final String COMMIT_STALE_TTL_MS_PROP = "iceberg.control.commit.stale-ttl-ms";
+  private static final int COMMIT_STALE_TTL_MS_DEFAULT = 3_600_000;
+  private static final String COMMIT_STALE_MAX_BLOCKING_RETRIES_PROP =
+      "iceberg.control.commit.stale-max-blocking-retries";
+  private static final int COMMIT_STALE_MAX_BLOCKING_RETRIES_DEFAULT = 3;
+  private static final String COMMIT_STALE_FAILURE_POLICY_PROP =
+      "iceberg.control.commit.stale-failure-policy";
+  private static final String COMMIT_STALE_FAILURE_POLICY_DEFAULT = "fail";
   private static final String CONNECT_GROUP_ID_PROP = "iceberg.connect.group-id";
   private static final String TRANSACTIONAL_PREFIX_PROP =
       "iceberg.coordinator.transactional.prefix";
@@ -217,6 +225,29 @@ public class IcebergSinkConfig extends AbstractConfig {
         Runtime.getRuntime().availableProcessors() * 2,
         Importance.MEDIUM,
         "Coordinator threads to use for table commits, default is (cores * 2)");
+    configDef.define(
+        COMMIT_STALE_TTL_MS_PROP,
+        ConfigDef.Type.INT,
+        COMMIT_STALE_TTL_MS_DEFAULT,
+        Importance.LOW,
+        "Time-to-live for stale commit events in the buffer, in millis. "
+            + "Stale events older than this are evicted with an ERROR log containing orphaned file paths. "
+            + "Set to 0 to disable TTL eviction.");
+    configDef.define(
+        COMMIT_STALE_MAX_BLOCKING_RETRIES_PROP,
+        ConfigDef.Type.INT,
+        COMMIT_STALE_MAX_BLOCKING_RETRIES_DEFAULT,
+        Importance.LOW,
+        "Number of times a stale commit group will block subsequent groups before "
+            + "transitioning to the configured failure policy.");
+    configDef.define(
+        COMMIT_STALE_FAILURE_POLICY_PROP,
+        ConfigDef.Type.STRING,
+        COMMIT_STALE_FAILURE_POLICY_DEFAULT,
+        Importance.LOW,
+        "Policy when a stale commit group exceeds max blocking retries. "
+            + "'non-blocking': proceed with current group (may produce duplicates for overlapping keys). "
+            + "'fail': throw an error and move the connector to FAILED state.");
     configDef.define(
         TRANSACTIONAL_PREFIX_PROP,
         ConfigDef.Type.STRING,
@@ -417,6 +448,18 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public int commitThreads() {
     return getInt(COMMIT_THREADS_PROP);
+  }
+
+  public int commitStaleTtlMs() {
+    return getInt(COMMIT_STALE_TTL_MS_PROP);
+  }
+
+  public int commitStaleMaxBlockingRetries() {
+    return getInt(COMMIT_STALE_MAX_BLOCKING_RETRIES_PROP);
+  }
+
+  public String commitStaleFailurePolicy() {
+    return getString(COMMIT_STALE_FAILURE_POLICY_PROP);
   }
 
   public String transactionalPrefix() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -86,14 +86,9 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String COMMIT_TIMEOUT_MS_PROP = "iceberg.control.commit.timeout-ms";
   private static final int COMMIT_TIMEOUT_MS_DEFAULT = 30_000;
   private static final String COMMIT_THREADS_PROP = "iceberg.control.commit.threads";
-  private static final String COMMIT_STALE_TTL_MS_PROP = "iceberg.control.commit.stale-ttl-ms";
-  private static final int COMMIT_STALE_TTL_MS_DEFAULT = 3_600_000;
   private static final String COMMIT_STALE_MAX_BLOCKING_RETRIES_PROP =
       "iceberg.control.commit.stale-max-blocking-retries";
   private static final int COMMIT_STALE_MAX_BLOCKING_RETRIES_DEFAULT = 3;
-  private static final String COMMIT_STALE_FAILURE_POLICY_PROP =
-      "iceberg.control.commit.stale-failure-policy";
-  private static final String COMMIT_STALE_FAILURE_POLICY_DEFAULT = "fail";
   private static final String CONNECT_GROUP_ID_PROP = "iceberg.connect.group-id";
   private static final String TRANSACTIONAL_PREFIX_PROP =
       "iceberg.coordinator.transactional.prefix";
@@ -226,28 +221,13 @@ public class IcebergSinkConfig extends AbstractConfig {
         Importance.MEDIUM,
         "Coordinator threads to use for table commits, default is (cores * 2)");
     configDef.define(
-        COMMIT_STALE_TTL_MS_PROP,
-        ConfigDef.Type.INT,
-        COMMIT_STALE_TTL_MS_DEFAULT,
-        Importance.LOW,
-        "Time-to-live for stale commit events in the buffer, in millis. "
-            + "Stale events older than this are evicted with an ERROR log containing orphaned file paths. "
-            + "Set to 0 to disable TTL eviction.");
-    configDef.define(
         COMMIT_STALE_MAX_BLOCKING_RETRIES_PROP,
         ConfigDef.Type.INT,
         COMMIT_STALE_MAX_BLOCKING_RETRIES_DEFAULT,
+        ConfigDef.Range.atLeast(0),
         Importance.LOW,
         "Number of times a stale commit group will block subsequent groups before "
-            + "transitioning to the configured failure policy.");
-    configDef.define(
-        COMMIT_STALE_FAILURE_POLICY_PROP,
-        ConfigDef.Type.STRING,
-        COMMIT_STALE_FAILURE_POLICY_DEFAULT,
-        Importance.LOW,
-        "Policy when a stale commit group exceeds max blocking retries. "
-            + "'non-blocking': proceed with current group (may produce duplicates for overlapping keys). "
-            + "'fail': throw an error and move the connector to FAILED state.");
+            + "failing the connector. Set to 0 to fail immediately.");
     configDef.define(
         TRANSACTIONAL_PREFIX_PROP,
         ConfigDef.Type.STRING,
@@ -450,16 +430,8 @@ public class IcebergSinkConfig extends AbstractConfig {
     return getInt(COMMIT_THREADS_PROP);
   }
 
-  public int commitStaleTtlMs() {
-    return getInt(COMMIT_STALE_TTL_MS_PROP);
-  }
-
   public int commitStaleMaxBlockingRetries() {
     return getInt(COMMIT_STALE_MAX_BLOCKING_RETRIES_PROP);
-  }
-
-  public String commitStaleFailurePolicy() {
-    return getString(COMMIT_STALE_FAILURE_POLICY_PROP);
   }
 
   public String transactionalPrefix() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -143,11 +143,14 @@ abstract class Channel {
   }
 
   protected void commitConsumerOffsets() {
+    commitConsumerOffsetsTo(controlTopicOffsets());
+  }
+
+  protected void commitConsumerOffsetsTo(Map<Integer, Long> specificOffsets) {
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();
-    controlTopicOffsets()
-        .forEach(
-            (k, v) ->
-                offsetsToCommit.put(new TopicPartition(controlTopic, k), new OffsetAndMetadata(v)));
+    specificOffsets.forEach(
+        (k, v) ->
+            offsetsToCommit.put(new TopicPartition(controlTopic, k), new OffsetAndMetadata(v)));
     consumer.commitSync(offsetsToCommit);
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.events.DataComplete;
@@ -47,8 +48,7 @@ class CommitState implements CommitStateMXBean {
   private final List<DataComplete> readyBuffer = Lists.newArrayList();
   private int receivedPartitionCount = 0;
   private final Map<UUID, AtomicInteger> groupRetryCount = new ConcurrentHashMap<>();
-  private final Map<UUID, Long> groupFirstSeenMs = new ConcurrentHashMap<>();
-  private long evictedStaleEventCount;
+  private final AtomicReference<RuntimeException> fatalFailure = new AtomicReference<>();
   private long startTime;
   private UUID currentCommitId;
   private final IcebergSinkConfig config;
@@ -108,6 +108,7 @@ class CommitState implements CommitStateMXBean {
     readyBuffer.clear();
     receivedPartitionCount = 0;
     currentCommitId = null;
+    fatalFailure.set(null);
   }
 
   void clearResponses() {
@@ -154,6 +155,20 @@ class CommitState implements CommitStateMXBean {
 
   int getRetryCount(UUID commitId) {
     return groupRetryCount.getOrDefault(commitId, new AtomicInteger(0)).get();
+  }
+
+  /**
+   * Records the original exception from a group whose retry budget is exhausted. The coordinator
+   * rethrows it after the commit cycle finishes, stopping the connector with the true root cause.
+   * The first fatal failure in a cycle wins. Written from parallel table-commit threads, hence the
+   * atomic holder; cleared each cycle by {@link #endCurrentCommit}.
+   */
+  void recordFatalFailure(RuntimeException exception) {
+    fatalFailure.compareAndSet(null, exception);
+  }
+
+  RuntimeException fatalFailure() {
+    return fatalFailure.get();
   }
 
   boolean isBufferEmpty() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.connect.channel;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -19,11 +19,17 @@
 package org.apache.iceberg.connect.channel;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
@@ -35,12 +41,18 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class CommitState {
+class CommitState implements CommitStateMXBean {
   private static final Logger LOG = LoggerFactory.getLogger(CommitState.class);
+
+  static final String STALE_FAILURE_POLICY_FAIL = "fail";
+  static final String STALE_FAILURE_POLICY_NON_BLOCKING = "non-blocking";
 
   private final List<Envelope> commitBuffer = Lists.newArrayList();
   private final List<DataComplete> readyBuffer = Lists.newArrayList();
   private int receivedPartitionCount = 0;
+  private final Map<UUID, Integer> groupRetryCount = new HashMap<>();
+  private final Map<UUID, Long> groupFirstSeenMs = new HashMap<>();
+  private long evictedStaleEventCount;
   private long startTime;
   private UUID currentCommitId;
   private final IcebergSinkConfig config;
@@ -51,8 +63,9 @@ class CommitState {
 
   void addResponse(Envelope envelope) {
     commitBuffer.add(envelope);
+    DataWritten dataWritten = (DataWritten) envelope.event().payload();
+    groupFirstSeenMs.putIfAbsent(dataWritten.commitId(), System.currentTimeMillis());
     if (!isCommitInProgress()) {
-      DataWritten dataWritten = (DataWritten) envelope.event().payload();
       LOG.warn(
           "Received commit response when no commit in progress, this can happen during recovery. Commit ID: {}",
           dataWritten.commitId());
@@ -89,6 +102,9 @@ class CommitState {
   }
 
   void startNewCommit() {
+    // Do NOT clear commitBuffer. Stale events from prior failed or timed-out cycles are
+    // retained for retry. Successfully committed groups are removed selectively by
+    // removeEnvelopes() after each group's RowDelta commit succeeds.
     currentCommitId = UUID.randomUUID();
     startTime = System.currentTimeMillis();
   }
@@ -101,6 +117,47 @@ class CommitState {
 
   void clearResponses() {
     commitBuffer.clear();
+  }
+
+  /**
+   * Removes only the specified envelopes from the commit buffer. Used after per-group RowDelta
+   * commits to selectively drain successfully committed events while retaining events from failed
+   * or skipped groups for retry next cycle.
+   */
+  void removeEnvelopes(Collection<Envelope> committed) {
+    commitBuffer.removeAll(new HashSet<>(committed));
+
+    // Clean up tracking maps for commitIds no longer in the buffer.
+    Set<UUID> remainingIds =
+        commitBuffer.stream()
+            .map(env -> ((DataWritten) env.event().payload()).commitId())
+            .collect(Collectors.toSet());
+    groupRetryCount.keySet().retainAll(remainingIds);
+    groupFirstSeenMs.keySet().retainAll(remainingIds);
+  }
+
+  void recordGroupFailure(UUID commitId) {
+    groupRetryCount.merge(commitId, 1, Integer::sum);
+  }
+
+  void recordGroupSuccess(UUID commitId) {
+    groupRetryCount.remove(commitId);
+  }
+
+  boolean isGroupBlocking(UUID commitId) {
+    return groupRetryCount.getOrDefault(commitId, 0) < config.commitStaleMaxBlockingRetries();
+  }
+
+  boolean isStaleFailurePolicyFail() {
+    return STALE_FAILURE_POLICY_FAIL.equalsIgnoreCase(config.commitStaleFailurePolicy());
+  }
+
+  int getRetryCount(UUID commitId) {
+    return groupRetryCount.getOrDefault(commitId, 0);
+  }
+
+  boolean isBufferEmpty() {
+    return commitBuffer.isEmpty();
   }
 
   boolean isCommitTimedOut() {
@@ -137,6 +194,121 @@ class CommitState {
     return false;
   }
 
+  // ── MXBean interface methods ──
+
+  @Override
+  public long getEvictedStaleEventCount() {
+    return evictedStaleEventCount;
+  }
+
+  @Override
+  public int getStaleGroupCount() {
+    return staleGroupCount();
+  }
+
+  @Override
+  public int getBufferSize() {
+    return bufferSize();
+  }
+
+  // ── Internal accessors ──
+
+  long evictedStaleEventCount() {
+    return evictedStaleEventCount;
+  }
+
+  int staleGroupCount() {
+    if (currentCommitId == null) {
+      return 0;
+    }
+    return (int)
+        commitBuffer.stream()
+            .map(env -> ((DataWritten) env.event().payload()).commitId())
+            .filter(cid -> !cid.equals(currentCommitId))
+            .distinct()
+            .count();
+  }
+
+  int bufferSize() {
+    return commitBuffer.size();
+  }
+
+  /**
+   * Returns the minimum control topic offset per partition among uncommitted envelopes remaining in
+   * the buffer. Used for partial consumer offset advancement: advancing to these offsets ensures
+   * uncommitted events survive a restart while already-committed events are not re-consumed.
+   */
+  Map<Integer, Long> remainingEnvelopeMinOffsets() {
+    Map<Integer, Long> minOffsets = new HashMap<>();
+    for (Envelope env : commitBuffer) {
+      minOffsets.merge(env.partition(), env.offset(), Long::min);
+    }
+    return minOffsets;
+  }
+
+  private void evictExpiredStaleEvents() {
+    long ttlMs = config.commitStaleTtlMs();
+    if (ttlMs <= 0) {
+      return;
+    }
+
+    long now = System.currentTimeMillis();
+    // Collect stale commitIds that have exceeded the TTL.
+    Set<UUID> expiredIds = new HashSet<>();
+    groupFirstSeenMs.forEach(
+        (commitId, firstSeenMs) -> {
+          boolean isStale = currentCommitId == null || !commitId.equals(currentCommitId);
+          if (isStale && (now - firstSeenMs) > ttlMs) {
+            expiredIds.add(commitId);
+          }
+        });
+
+    if (expiredIds.isEmpty()) {
+      return;
+    }
+
+    // Log orphaned file paths at ERROR level for each evicted event.
+    commitBuffer.stream()
+        .filter(
+            env -> {
+              DataWritten dw = (DataWritten) env.event().payload();
+              return expiredIds.contains(dw.commitId());
+            })
+        .forEach(
+            env -> {
+              DataWritten dw = (DataWritten) env.event().payload();
+              long age = now - groupFirstSeenMs.getOrDefault(dw.commitId(), now);
+              List<String> dataFilePaths =
+                  dw.dataFiles() != null
+                      ? dw.dataFiles().stream()
+                          .map(f -> f.path().toString())
+                          .collect(Collectors.toList())
+                      : Collections.emptyList();
+              List<String> deleteFilePaths =
+                  dw.deleteFiles() != null
+                      ? dw.deleteFiles().stream()
+                          .map(f -> f.path().toString())
+                          .collect(Collectors.toList())
+                      : Collections.emptyList();
+              LOG.error(
+                  "Evicting stale DataWritten past TTL ({}ms): commitId={}, table={}, age={}ms. "
+                      + "Orphaned data files: {}. Orphaned delete files: {}. "
+                      + "These files exist on storage but are not registered in the Iceberg table.",
+                  ttlMs,
+                  dw.commitId(),
+                  dw.tableReference().identifier(),
+                  age,
+                  dataFilePaths,
+                  deleteFilePaths);
+              evictedStaleEventCount++;
+            });
+
+    commitBuffer.removeIf(
+        env -> expiredIds.contains(((DataWritten) env.event().payload()).commitId()));
+    expiredIds.forEach(groupRetryCount::remove);
+    expiredIds.forEach(groupFirstSeenMs::remove);
+  }
+
   /**
    * Returns commit buffer entries grouped by table, separated by commitId.
    *
@@ -150,6 +322,8 @@ class CommitState {
    * list should be committed in a separate RowDelta to preserve sequence number ordering.
    */
   List<Map<TableReference, List<Envelope>>> tableCommitMaps() {
+    evictExpiredStaleEvents();
+
     // LinkedHashMap preserves insertion order from control topic consumption
     Map<UUID, List<Envelope>> byCommitId = new LinkedHashMap<>();
     for (Envelope envelope : commitBuffer) {
@@ -176,13 +350,66 @@ class CommitState {
 
     // Current commitId last — ensures highest sequence number
     if (currentCommitId != null) {
-      List<Envelope> currentEnvelopes = byCommitId.getOrDefault(currentCommitId, Lists.newArrayList());
+      List<Envelope> currentEnvelopes =
+          byCommitId.getOrDefault(currentCommitId, Lists.newArrayList());
       if (!currentEnvelopes.isEmpty()) {
         result.add(toTableMap(currentEnvelopes));
       }
     }
 
     return result;
+  }
+
+  /**
+   * Groups commit buffer entries by table, then by commitId within each table. CommitId groups are
+   * ordered by first appearance in the buffer (insertion order), which matches control topic
+   * consumption order. This ensures stale groups from prior failed or timed-out cycles sort before
+   * the current cycle's group.
+   *
+   * <p>Each group becomes a separate RowDelta commit with its own Iceberg sequence number, allowing
+   * equality deletes from newer groups to apply to data files from older groups.
+   */
+  Map<TableReference, List<CommitGroup>> tableCommitGroups() {
+    evictExpiredStaleEvents();
+
+    Map<TableReference, List<Envelope>> byTable =
+        commitBuffer.stream()
+            .collect(
+                Collectors.groupingBy(
+                    envelope -> ((DataWritten) envelope.event().payload()).tableReference()));
+
+    Map<TableReference, List<CommitGroup>> result = new LinkedHashMap<>();
+    for (Map.Entry<TableReference, List<Envelope>> entry : byTable.entrySet()) {
+      LinkedHashMap<UUID, List<Envelope>> byCommitId = new LinkedHashMap<>();
+      for (Envelope env : entry.getValue()) {
+        UUID cid = ((DataWritten) env.event().payload()).commitId();
+        byCommitId.computeIfAbsent(cid, k -> new ArrayList<>()).add(env);
+      }
+      List<CommitGroup> groups =
+          byCommitId.entrySet().stream()
+              .map(e -> new CommitGroup(e.getKey(), e.getValue()))
+              .collect(Collectors.toList());
+      result.put(entry.getKey(), groups);
+    }
+    return result;
+  }
+
+  static class CommitGroup {
+    private final UUID commitId;
+    private final List<Envelope> envelopes;
+
+    CommitGroup(UUID commitId, List<Envelope> envelopes) {
+      this.commitId = commitId;
+      this.envelopes = envelopes;
+    }
+
+    UUID commitId() {
+      return commitId;
+    }
+
+    List<Envelope> envelopes() {
+      return envelopes;
+    }
   }
 
   private Map<TableReference, List<Envelope>> toTableMap(List<Envelope> envelopes) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.connect.channel;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.connect.channel;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -155,10 +154,10 @@ class CommitState {
     Map<UUID, List<Envelope>> byCommitId = new LinkedHashMap<>();
     for (Envelope envelope : commitBuffer) {
       UUID commitId = ((DataWritten) envelope.event().payload()).commitId();
-      byCommitId.computeIfAbsent(commitId, k -> new ArrayList<>()).add(envelope);
+      byCommitId.computeIfAbsent(commitId, k -> Lists.newArrayList()).add(envelope);
     }
 
-    List<Map<TableReference, List<Envelope>>> result = new ArrayList<>();
+    List<Map<TableReference, List<Envelope>>> result = Lists.newArrayList();
 
     // Stale commitIds first (in control topic consumption order)
     for (Map.Entry<UUID, List<Envelope>> entry : byCommitId.entrySet()) {
@@ -177,7 +176,7 @@ class CommitState {
 
     // Current commitId last — ensures highest sequence number
     if (currentCommitId != null) {
-      List<Envelope> currentEnvelopes = byCommitId.getOrDefault(currentCommitId, new ArrayList<>());
+      List<Envelope> currentEnvelopes = byCommitId.getOrDefault(currentCommitId, Lists.newArrayList());
       if (!currentEnvelopes.isEmpty()) {
         result.add(toTableMap(currentEnvelopes));
       }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -131,14 +131,16 @@ class CommitState implements CommitStateMXBean {
   }
 
   void recordGroupFailure(UUID commitId) {
-    groupRetryCount.compute(commitId, (id, count) -> {
-      if (count == null) {
-        return new AtomicInteger(1);
-      } else {
-        count.incrementAndGet();
-        return count;
-      }
-    });
+    groupRetryCount.compute(
+        commitId,
+        (id, count) -> {
+          if (count == null) {
+            return new AtomicInteger(1);
+          } else {
+            count.incrementAndGet();
+            return count;
+          }
+        });
   }
 
   void recordGroupSuccess(UUID commitId) {
@@ -146,7 +148,8 @@ class CommitState implements CommitStateMXBean {
   }
 
   boolean isRetryAllowed(UUID commitId) {
-    return groupRetryCount.getOrDefault(commitId, new AtomicInteger(0)).get() <= config.commitStaleMaxBlockingRetries();
+    return groupRetryCount.getOrDefault(commitId, new AtomicInteger(0)).get()
+        <= config.commitStaleMaxBlockingRetries();
   }
 
   int getRetryCount(UUID commitId) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -19,9 +19,9 @@
 package org.apache.iceberg.connect.channel;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -177,8 +177,7 @@ class CommitState {
 
     // Current commitId last — ensures highest sequence number
     if (currentCommitId != null) {
-      List<Envelope> currentEnvelopes =
-          byCommitId.getOrDefault(currentCommitId, new ArrayList<>());
+      List<Envelope> currentEnvelopes = byCommitId.getOrDefault(currentCommitId, new ArrayList<>());
       if (!currentEnvelopes.isEmpty()) {
         result.add(toTableMap(currentEnvelopes));
       }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -19,12 +19,8 @@
 package org.apache.iceberg.connect.channel;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +35,8 @@ import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +120,7 @@ class CommitState implements CommitStateMXBean {
    * or skipped groups for retry next cycle.
    */
   void removeEnvelopes(Collection<Envelope> committed) {
-    commitBuffer.removeAll(new HashSet<>(committed));
+    commitBuffer.removeAll(Sets.newHashSet(committed));
 
     // Clean up tracking maps for commitIds no longer in the buffer.
     Set<UUID> remainingIds =
@@ -229,7 +227,7 @@ class CommitState implements CommitStateMXBean {
    * uncommitted events survive a restart while already-committed events are not re-consumed.
    */
   Map<Integer, Long> remainingEnvelopeMinOffsets() {
-    Map<Integer, Long> minOffsets = new HashMap<>();
+    Map<Integer, Long> minOffsets = Maps.newHashMap();
     for (Envelope env : commitBuffer) {
       minOffsets.merge(env.partition(), env.offset(), Long::min);
     }
@@ -250,7 +248,7 @@ class CommitState implements CommitStateMXBean {
    */
   List<Map<TableReference, List<Envelope>>> tableCommitMaps() {
     // LinkedHashMap preserves insertion order from control topic consumption
-    Map<UUID, List<Envelope>> byCommitId = new LinkedHashMap<>();
+    Map<UUID, List<Envelope>> byCommitId = Maps.newLinkedHashMap();
     for (Envelope envelope : commitBuffer) {
       UUID commitId = ((DataWritten) envelope.event().payload()).commitId();
       byCommitId.computeIfAbsent(commitId, k -> Lists.newArrayList()).add(envelope);
@@ -301,12 +299,12 @@ class CommitState implements CommitStateMXBean {
                 Collectors.groupingBy(
                     envelope -> ((DataWritten) envelope.event().payload()).tableReference()));
 
-    Map<TableReference, List<CommitGroup>> result = new LinkedHashMap<>();
+    Map<TableReference, List<CommitGroup>> result = Maps.newLinkedHashMap();
     for (Map.Entry<TableReference, List<Envelope>> entry : byTable.entrySet()) {
-      LinkedHashMap<UUID, List<Envelope>> byCommitId = new LinkedHashMap<>();
+      Map<UUID, List<Envelope>> byCommitId = Maps.newLinkedHashMap();
       for (Envelope env : entry.getValue()) {
         UUID cid = ((DataWritten) env.event().payload()).commitId();
-        byCommitId.computeIfAbsent(cid, k -> new ArrayList<>()).add(env);
+        byCommitId.computeIfAbsent(cid, k -> Lists.newArrayList()).add(env);
       }
       List<CommitGroup> groups =
           byCommitId.entrySet().stream()

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.connect.channel;
 
 import java.time.OffsetDateTime;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -136,8 +138,57 @@ class CommitState {
     return false;
   }
 
-  Map<TableReference, List<Envelope>> tableCommitMap() {
-    return commitBuffer.stream()
+  /**
+   * Returns commit buffer entries grouped by table, separated by commitId.
+   *
+   * <p>After a partial commit (timeout), late-arriving DataWritten events from the previous cycle
+   * may be present in the buffer alongside current cycle events. Merging them into a single
+   * RowDelta would assign the same sequence number to both, breaking equality delete semantics
+   * (which require {@code data_sequence_number < delete_sequence_number}).
+   *
+   * <p>This method separates entries by commitId and returns them as an ordered list: stale
+   * commitIds first (in control topic consumption order), current commitId last. Each map in the
+   * list should be committed in a separate RowDelta to preserve sequence number ordering.
+   */
+  List<Map<TableReference, List<Envelope>>> tableCommitMaps() {
+    // LinkedHashMap preserves insertion order from control topic consumption
+    Map<UUID, List<Envelope>> byCommitId = new LinkedHashMap<>();
+    for (Envelope envelope : commitBuffer) {
+      UUID commitId = ((DataWritten) envelope.event().payload()).commitId();
+      byCommitId.computeIfAbsent(commitId, k -> new ArrayList<>()).add(envelope);
+    }
+
+    List<Map<TableReference, List<Envelope>>> result = new ArrayList<>();
+
+    // Stale commitIds first (in control topic consumption order)
+    for (Map.Entry<UUID, List<Envelope>> entry : byCommitId.entrySet()) {
+      UUID commitId = entry.getKey();
+      if (currentCommitId != null && commitId.equals(currentCommitId)) {
+        continue;
+      }
+      LOG.warn(
+          "Stale DataWritten detected: commitId={} (current={}), envelopes={}, "
+              + "will commit in separate RowDelta to preserve sequence number ordering",
+          commitId,
+          currentCommitId,
+          entry.getValue().size());
+      result.add(toTableMap(entry.getValue()));
+    }
+
+    // Current commitId last — ensures highest sequence number
+    if (currentCommitId != null) {
+      List<Envelope> currentEnvelopes =
+          byCommitId.getOrDefault(currentCommitId, new ArrayList<>());
+      if (!currentEnvelopes.isEmpty()) {
+        result.add(toTableMap(currentEnvelopes));
+      }
+    }
+
+    return result;
+  }
+
+  private Map<TableReference, List<Envelope>> toTableMap(List<Envelope> envelopes) {
+    return envelopes.stream()
         .collect(
             Collectors.groupingBy(
                 envelope -> ((DataWritten) envelope.event().payload()).tableReference()));

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.connect.channel;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,6 +30,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.events.DataComplete;
@@ -44,14 +45,11 @@ import org.slf4j.LoggerFactory;
 class CommitState implements CommitStateMXBean {
   private static final Logger LOG = LoggerFactory.getLogger(CommitState.class);
 
-  static final String STALE_FAILURE_POLICY_FAIL = "fail";
-  static final String STALE_FAILURE_POLICY_NON_BLOCKING = "non-blocking";
-
   private final List<Envelope> commitBuffer = Lists.newArrayList();
   private final List<DataComplete> readyBuffer = Lists.newArrayList();
   private int receivedPartitionCount = 0;
-  private final Map<UUID, Integer> groupRetryCount = new HashMap<>();
-  private final Map<UUID, Long> groupFirstSeenMs = new HashMap<>();
+  private final Map<UUID, AtomicInteger> groupRetryCount = new ConcurrentHashMap<>();
+  private final Map<UUID, Long> groupFirstSeenMs = new ConcurrentHashMap<>();
   private long evictedStaleEventCount;
   private long startTime;
   private UUID currentCommitId;
@@ -64,7 +62,6 @@ class CommitState implements CommitStateMXBean {
   void addResponse(Envelope envelope) {
     commitBuffer.add(envelope);
     DataWritten dataWritten = (DataWritten) envelope.event().payload();
-    groupFirstSeenMs.putIfAbsent(dataWritten.commitId(), System.currentTimeMillis());
     if (!isCommitInProgress()) {
       LOG.warn(
           "Received commit response when no commit in progress, this can happen during recovery. Commit ID: {}",
@@ -133,27 +130,29 @@ class CommitState implements CommitStateMXBean {
             .map(env -> ((DataWritten) env.event().payload()).commitId())
             .collect(Collectors.toSet());
     groupRetryCount.keySet().retainAll(remainingIds);
-    groupFirstSeenMs.keySet().retainAll(remainingIds);
   }
 
   void recordGroupFailure(UUID commitId) {
-    groupRetryCount.merge(commitId, 1, Integer::sum);
+    groupRetryCount.compute(commitId, (id, count) -> {
+      if (count == null) {
+        return new AtomicInteger(1);
+      } else {
+        count.incrementAndGet();
+        return count;
+      }
+    });
   }
 
   void recordGroupSuccess(UUID commitId) {
     groupRetryCount.remove(commitId);
   }
 
-  boolean isGroupBlocking(UUID commitId) {
-    return groupRetryCount.getOrDefault(commitId, 0) < config.commitStaleMaxBlockingRetries();
-  }
-
-  boolean isStaleFailurePolicyFail() {
-    return STALE_FAILURE_POLICY_FAIL.equalsIgnoreCase(config.commitStaleFailurePolicy());
+  boolean isRetryAllowed(UUID commitId) {
+    return groupRetryCount.getOrDefault(commitId, new AtomicInteger(0)).get() <= config.commitStaleMaxBlockingRetries();
   }
 
   int getRetryCount(UUID commitId) {
-    return groupRetryCount.getOrDefault(commitId, 0);
+    return groupRetryCount.getOrDefault(commitId, new AtomicInteger(0)).get();
   }
 
   boolean isBufferEmpty() {
@@ -197,11 +196,6 @@ class CommitState implements CommitStateMXBean {
   // ── MXBean interface methods ──
 
   @Override
-  public long getEvictedStaleEventCount() {
-    return evictedStaleEventCount;
-  }
-
-  @Override
   public int getStaleGroupCount() {
     return staleGroupCount();
   }
@@ -212,10 +206,6 @@ class CommitState implements CommitStateMXBean {
   }
 
   // ── Internal accessors ──
-
-  long evictedStaleEventCount() {
-    return evictedStaleEventCount;
-  }
 
   int staleGroupCount() {
     if (currentCommitId == null) {
@@ -246,69 +236,6 @@ class CommitState implements CommitStateMXBean {
     return minOffsets;
   }
 
-  private void evictExpiredStaleEvents() {
-    long ttlMs = config.commitStaleTtlMs();
-    if (ttlMs <= 0) {
-      return;
-    }
-
-    long now = System.currentTimeMillis();
-    // Collect stale commitIds that have exceeded the TTL.
-    Set<UUID> expiredIds = new HashSet<>();
-    groupFirstSeenMs.forEach(
-        (commitId, firstSeenMs) -> {
-          boolean isStale = currentCommitId == null || !commitId.equals(currentCommitId);
-          if (isStale && (now - firstSeenMs) > ttlMs) {
-            expiredIds.add(commitId);
-          }
-        });
-
-    if (expiredIds.isEmpty()) {
-      return;
-    }
-
-    // Log orphaned file paths at ERROR level for each evicted event.
-    commitBuffer.stream()
-        .filter(
-            env -> {
-              DataWritten dw = (DataWritten) env.event().payload();
-              return expiredIds.contains(dw.commitId());
-            })
-        .forEach(
-            env -> {
-              DataWritten dw = (DataWritten) env.event().payload();
-              long age = now - groupFirstSeenMs.getOrDefault(dw.commitId(), now);
-              List<String> dataFilePaths =
-                  dw.dataFiles() != null
-                      ? dw.dataFiles().stream()
-                          .map(f -> f.path().toString())
-                          .collect(Collectors.toList())
-                      : Collections.emptyList();
-              List<String> deleteFilePaths =
-                  dw.deleteFiles() != null
-                      ? dw.deleteFiles().stream()
-                          .map(f -> f.path().toString())
-                          .collect(Collectors.toList())
-                      : Collections.emptyList();
-              LOG.error(
-                  "Evicting stale DataWritten past TTL ({}ms): commitId={}, table={}, age={}ms. "
-                      + "Orphaned data files: {}. Orphaned delete files: {}. "
-                      + "These files exist on storage but are not registered in the Iceberg table.",
-                  ttlMs,
-                  dw.commitId(),
-                  dw.tableReference().identifier(),
-                  age,
-                  dataFilePaths,
-                  deleteFilePaths);
-              evictedStaleEventCount++;
-            });
-
-    commitBuffer.removeIf(
-        env -> expiredIds.contains(((DataWritten) env.event().payload()).commitId()));
-    expiredIds.forEach(groupRetryCount::remove);
-    expiredIds.forEach(groupFirstSeenMs::remove);
-  }
-
   /**
    * Returns commit buffer entries grouped by table, separated by commitId.
    *
@@ -322,8 +249,6 @@ class CommitState implements CommitStateMXBean {
    * list should be committed in a separate RowDelta to preserve sequence number ordering.
    */
   List<Map<TableReference, List<Envelope>>> tableCommitMaps() {
-    evictExpiredStaleEvents();
-
     // LinkedHashMap preserves insertion order from control topic consumption
     Map<UUID, List<Envelope>> byCommitId = new LinkedHashMap<>();
     for (Envelope envelope : commitBuffer) {
@@ -370,8 +295,6 @@ class CommitState implements CommitStateMXBean {
    * equality deletes from newer groups to apply to data files from older groups.
    */
   Map<TableReference, List<CommitGroup>> tableCommitGroups() {
-    evictExpiredStaleEvents();
-
     Map<TableReference, List<Envelope>> byTable =
         commitBuffer.stream()
             .collect(

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitStateMXBean.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitStateMXBean.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+/**
+ * JMX MXBean interface for monitoring the commit buffer state. Exposes metrics for stale event
+ * eviction, buffer size, and stale group count. Registered under {@code
+ * org.apache.iceberg.connect:type=CommitState,connector=<name>}.
+ */
+public interface CommitStateMXBean {
+  /** Cumulative count of stale events evicted by TTL. */
+  long getEvictedStaleEventCount();
+
+  /** Number of distinct stale commitId groups currently in the buffer. */
+  int getStaleGroupCount();
+
+  /** Total number of envelopes currently in the commit buffer. */
+  int getBufferSize();
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitStateMXBean.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitStateMXBean.java
@@ -19,14 +19,11 @@
 package org.apache.iceberg.connect.channel;
 
 /**
- * JMX MXBean interface for monitoring the commit buffer state. Exposes metrics for stale event
- * eviction, buffer size, and stale group count. Registered under {@code
+ * JMX MXBean interface for monitoring the commit buffer state. Exposes metrics for buffer size and
+ * stale group count. Registered under {@code
  * org.apache.iceberg.connect:type=CommitState,connector=<name>}.
  */
 public interface CommitStateMXBean {
-  /** Cumulative count of stale events evicted by TTL. */
-  long getEvictedStaleEventCount();
-
   /** Number of distinct stale commitId groups currently in the buffer. */
   int getStaleGroupCount();
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -174,16 +174,17 @@ class Coordinator extends Channel {
   private void commit(boolean partialCommit) {
     try {
       doCommit(partialCommit);
-    } catch (ConnectException e) {
-      // Deliberate failure (e.g., stale group retries exhausted) — must propagate
-      // to stop the connector. CoordinatorThread catches this and terminates.
-      throw e;
     } catch (RuntimeException e) {
       if (partialCommit) {
-        partialCommitFailures.incrementAndGet();
         LOG.warn("Partial commit {} failed for task {}", commitState.currentCommitId(), taskId, e);
       } else {
         LOG.warn("Commit {} failed for task {}", commitState.currentCommitId(), taskId, e);
+      }
+
+      // Deliberate failure (e.g., stale group retries exhausted) — must propagate
+      // to stop the connector. CoordinatorThread catches this and terminates.
+      if (commitState.fatalFailure() != null) {
+        throw e;
       }
     } catch (Exception e) {
       LOG.warn("Commit failed, will try again next cycle", e);
@@ -203,7 +204,8 @@ class Coordinator extends Channel {
     }
 
     Map<Integer, Long> ctlOffsets = controlTopicOffsets();
-    CommitCycleResult result = runTableCommits(commitGroups, ctlOffsets, validThroughTs);
+    CommitCycleResult result =
+        runTableCommits(commitGroups, ctlOffsets, validThroughTs, partialCommit);
     finalizeCommitCycle(commitGroups, result, validThroughTs);
   }
 
@@ -227,7 +229,8 @@ class Coordinator extends Channel {
   private CommitCycleResult runTableCommits(
       Map<TableReference, List<CommitState.CommitGroup>> commitGroups,
       Map<Integer, Long> ctlOffsets,
-      OffsetDateTime validThroughTs) {
+      OffsetDateTime validThroughTs,
+      boolean partialCommit) {
     // Track successfully committed envelopes for selective removal.
     // Synchronized because table commits run in parallel via the exec thread pool.
     List<Envelope> committedEnvelopes = Collections.synchronizedList(Lists.newArrayList());
@@ -237,7 +240,7 @@ class Coordinator extends Channel {
     // If a group fails for a table, remaining groups for that table are skipped
     // to preserve sequence number ordering. Other tables are unaffected.
     // Capture exception from parallel table commits so cleanup always runs.
-    // Without this, a ConnectException from one table's exhausted retries would
+    // Without this, an exception from one table's exhausted retries would
     // skip removeEnvelopes(), leaving successfully committed envelopes in the buffer
     // indefinitely (memory leak + wasted retry work on subsequent cycles).
     RuntimeException taskException = null;
@@ -276,33 +279,32 @@ class Coordinator extends Channel {
                         isCurrentGroup ? validThroughTs : null);
                     committedEnvelopes.addAll(group.envelopes());
                     commitState.recordGroupSuccess(group.commitId());
-                  } catch (Exception e) {
+                  } catch (RuntimeException e) {
                     commitState.recordGroupFailure(group.commitId());
+                    // A failure during a partial (timeout-driven) commit counts toward the
+                    // observability metric. It also counts toward the per-group retry budget
+                    if (partialCommit) {
+                      partialCommitFailures.incrementAndGet();
+                    }
                     int remaining = groups.size() - i - 1;
 
-                    if (!isCurrentGroup && !commitState.isRetryAllowed(group.commitId())) {
-                      // Stale group exceeded max blocking retries - fail the connector.
-                      throw new ConnectException(
-                          "Stale group "
-                              + group.commitId()
-                              + " for table "
-                              + tableRef.identifier()
-                              + " failed after "
-                              + commitState.getRetryCount(group.commitId())
-                              + " retries. Connector stopping.",
+                    if (commitState.isRetryAllowed(group.commitId())) {
+                      // Within budget: skip this table's remaining groups to preserve sequence
+                      // number ordering, then retry next cycle.
+                      LOG.warn(
+                          "Commit failed for table {} group {} ({}, attempt {}), "
+                              + "skipping {} remaining group(s) for this table",
+                          tableRef.identifier(),
+                          group.commitId(),
+                          isCurrentGroup ? "current" : "stale",
+                          commitState.getRetryCount(group.commitId()),
+                          remaining,
                           e);
+                    } else {
+                      // Retry budget exhausted: record fatal failure to propagate the original
+                      // exception to stop the connector.
+                      commitState.recordFatalFailure(e);
                     }
-
-                    // Blocking: skip remaining groups to preserve ordering.
-                    LOG.warn(
-                        "Commit failed for table {} group {} ({}, attempt {}), "
-                            + "skipping {} remaining group(s) for this table",
-                        tableRef.identifier(),
-                        group.commitId(),
-                        isCurrentGroup ? "current" : "stale",
-                        commitState.getRetryCount(group.commitId()),
-                        remaining,
-                        e);
                     break;
                   }
                 }
@@ -344,11 +346,11 @@ class Coordinator extends Channel {
       send(event);
 
       LOG.info(
-          "Coordinator {} completed commit {} complete, committed to {} table(s) in {} batch(es), valid-through {}",
+          "Coordinator {} completed commit {}, committed to {} table(s) in {} batch(es), valid-through {}",
           taskId,
           commitState.currentCommitId(),
-          tableCount,
-          commitMaps.size(),
+          commitGroups.size(),
+          commitGroups.values().stream().mapToInt(List::size).sum(),
           validThroughTs);
 
     } else {
@@ -369,6 +371,10 @@ class Coordinator extends Channel {
     }
 
     // Re-throw after cleanup so the commit() wrapper can log it.
+    RuntimeException fatal = commitState.fatalFailure();
+    if (fatal != null) {
+      throw fatal;
+    }
     if (result.taskException() != null) {
       throw result.taskException();
     }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -25,7 +25,6 @@ import java.io.UncheckedIOException;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +59,7 @@ import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -221,7 +221,7 @@ class Coordinator extends Channel {
 
     // Track successfully committed envelopes for selective removal.
     // Synchronized because table commits run in parallel via the exec thread pool.
-    List<Envelope> committedEnvelopes = Collections.synchronizedList(new ArrayList<>());
+    List<Envelope> committedEnvelopes = Collections.synchronizedList(Lists.newArrayList());
 
     // Outer: tables in parallel (via exec thread pool).
     // Inner: commitId groups sequentially per table, oldest first.

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -200,25 +200,42 @@ class Coordinator extends Channel {
     }
   }
 
-  @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})
   private void doCommit(boolean partialCommit) {
     Map<TableReference, List<CommitState.CommitGroup>> commitGroups =
         commitState.tableCommitGroups();
     OffsetDateTime validThroughTs = commitState.validThroughTs(partialCommit);
-    Map<Integer, Long> ctlOffsets = controlTopicOffsets();
 
     if (commitGroups.isEmpty()) {
-      LOG.info("Nothing to commit");
-      commitConsumerOffsets();
-      commitState.clearResponses();
-      Event event =
-          new Event(
-              config.connectGroupId(),
-              new CommitComplete(commitState.currentCommitId(), validThroughTs));
-      send(event);
+      handleEmptyCommit(validThroughTs);
       return;
     }
 
+    Map<Integer, Long> ctlOffsets = controlTopicOffsets();
+    CommitCycleResult result = runTableCommits(commitGroups, ctlOffsets, validThroughTs);
+    finalizeCommitCycle(commitGroups, result, validThroughTs);
+  }
+
+  private void handleEmptyCommit(OffsetDateTime validThroughTs) {
+    LOG.info(
+        "Coordinator {} found nothing to commit for commit {}",
+        taskId,
+        commitState.currentCommitId());
+    commitConsumerOffsets();
+    commitState.clearResponses();
+    Event event =
+        new Event(
+            config.connectGroupId(),
+            new CommitComplete(commitState.currentCommitId(), validThroughTs));
+    send(event);
+  }
+
+  private record CommitCycleResult(
+      List<Envelope> committedEnvelopes, RuntimeException taskException) {}
+
+  private CommitCycleResult runTableCommits(
+      Map<TableReference, List<CommitState.CommitGroup>> commitGroups,
+      Map<Integer, Long> ctlOffsets,
+      OffsetDateTime validThroughTs) {
     // Track successfully committed envelopes for selective removal.
     // Synchronized because table commits run in parallel via the exec thread pool.
     List<Envelope> committedEnvelopes = Collections.synchronizedList(Lists.newArrayList());
@@ -301,6 +318,14 @@ class Coordinator extends Channel {
     } catch (RuntimeException e) {
       taskException = e;
     }
+    return new CommitCycleResult(committedEnvelopes, taskException);
+  }
+
+  private void finalizeCommitCycle(
+      Map<TableReference, List<CommitState.CommitGroup>> commitGroups,
+      CommitCycleResult result,
+      OffsetDateTime validThroughTs) {
+    List<Envelope> committedEnvelopes = result.committedEnvelopes();
 
     // Remove only the envelopes whose groups committed successfully.
     if (!committedEnvelopes.isEmpty()) {
@@ -352,8 +377,8 @@ class Coordinator extends Channel {
     }
 
     // Re-throw after cleanup so the commit() wrapper can log it.
-    if (taskException != null) {
-      throw taskException;
+    if (result.taskException() != null) {
+      throw result.taskException();
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -181,17 +181,9 @@ class Coordinator extends Channel {
     } catch (RuntimeException e) {
       if (partialCommit) {
         partialCommitFailures.incrementAndGet();
-        LOG.warn(
-            "Partial commit {} failed for task {}",
-            commitState.currentCommitId(),
-            taskId,
-            e);
+        LOG.warn("Partial commit {} failed for task {}", commitState.currentCommitId(), taskId, e);
       } else {
-        LOG.warn(
-            "Commit {} failed for task {}",
-            commitState.currentCommitId(),
-            taskId,
-            e);
+        LOG.warn("Commit {} failed for task {}", commitState.currentCommitId(), taskId, e);
       }
     } catch (Exception e) {
       LOG.warn("Commit failed, will try again next cycle", e);
@@ -352,12 +344,12 @@ class Coordinator extends Channel {
       send(event);
 
       LOG.info(
-        "Coordinator {} completed commit {} complete, committed to {} table(s) in {} batch(es), valid-through {}",
-        taskId,
-        commitState.currentCommitId(),
-        tableCount,
-        commitMaps.size(),
-        validThroughTs);
+          "Coordinator {} completed commit {} complete, committed to {} table(s) in {} batch(es), valid-through {}",
+          taskId,
+          commitState.currentCommitId(),
+          tableCount,
+          commitMaps.size(),
+          validThroughTs);
 
     } else {
       // Advance consumer offsets to the minimum uncommitted envelope offset per partition.

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -174,18 +174,27 @@ class Coordinator extends Channel {
   private void commit(boolean partialCommit) {
     try {
       doCommit(partialCommit);
+    } catch (ConnectException e) {
+      // Deliberate failure (e.g., stale group retries exhausted) — must propagate
+      // to stop the connector. CoordinatorThread catches this and terminates.
+      throw e;
     } catch (RuntimeException e) {
       if (partialCommit) {
         partialCommitFailures.incrementAndGet();
         LOG.warn(
-            "Partial commit {} failed for task {}, will retry",
+            "Partial commit {} failed for task {}",
             commitState.currentCommitId(),
             taskId,
             e);
       } else {
-        LOG.error("Commit {} failed for task {}", commitState.currentCommitId(), taskId, e);
-        throw e;
+        LOG.warn(
+            "Commit {} failed for task {}",
+            commitState.currentCommitId(),
+            taskId,
+            e);
       }
+    } catch (Exception e) {
+      LOG.warn("Commit failed, will try again next cycle", e);
     } finally {
       commitState.endCurrentCommit();
     }
@@ -218,47 +227,52 @@ class Coordinator extends Channel {
     // Inner: commitId groups sequentially per table, oldest first.
     // If a group fails for a table, remaining groups for that table are skipped
     // to preserve sequence number ordering. Other tables are unaffected.
-    Tasks.foreach(commitGroups.entrySet())
-        .executeWith(exec)
-        .run(
-            entry -> {
-              TableReference tableRef = entry.getKey();
-              List<CommitState.CommitGroup> groups = entry.getValue();
+    // Capture exception from parallel table commits so cleanup always runs.
+    // Without this, a ConnectException from one table's exhausted retries would
+    // skip removeEnvelopes(), leaving successfully committed envelopes in the buffer
+    // indefinitely (memory leak + wasted retry work on subsequent cycles).
+    RuntimeException taskException = null;
+    try {
+      Tasks.foreach(commitGroups.entrySet())
+          .executeWith(exec)
+          .run(
+              entry -> {
+                TableReference tableRef = entry.getKey();
+                List<CommitState.CommitGroup> groups = entry.getValue();
 
-              for (int i = 0; i < groups.size(); i++) {
-                CommitState.CommitGroup group = groups.get(i);
-                boolean isCurrentGroup = group.commitId().equals(commitState.currentCommitId());
+                for (int i = 0; i < groups.size(); i++) {
+                  CommitState.CommitGroup group = groups.get(i);
+                  boolean isCurrentGroup = group.commitId().equals(commitState.currentCommitId());
 
-                // Stale groups must only write their own envelope offsets to the snapshot,
-                // not the global consumer position. Otherwise the global offsets "poison"
-                // subsequent groups: their envelopes appear already-committed and get
-                // filtered out. The current (last) group writes the global offsets.
-                Map<Integer, Long> groupOffsets;
-                if (isCurrentGroup) {
-                  groupOffsets = ctlOffsets;
-                } else {
-                  groupOffsets = Maps.newHashMap();
-                  for (Envelope env : group.envelopes()) {
-                    groupOffsets.merge(env.partition(), env.offset() + 1, Long::max);
+                  // Stale groups must only write their own envelope offsets to the snapshot,
+                  // not the global consumer position. Otherwise the global offsets "poison"
+                  // subsequent groups: their envelopes appear already-committed and get
+                  // filtered out. The current (last) group writes the global offsets.
+                  Map<Integer, Long> groupOffsets;
+                  if (isCurrentGroup) {
+                    groupOffsets = ctlOffsets;
+                  } else {
+                    groupOffsets = Maps.newHashMap();
+                    for (Envelope env : group.envelopes()) {
+                      groupOffsets.merge(env.partition(), env.offset() + 1, Long::max);
+                    }
                   }
-                }
 
-                try {
-                  commitToTable(
-                      tableRef,
-                      group.envelopes(),
-                      group.commitId(),
-                      groupOffsets,
-                      isCurrentGroup ? validThroughTs : null);
-                  committedEnvelopes.addAll(group.envelopes());
-                  commitState.recordGroupSuccess(group.commitId());
-                } catch (Exception e) {
-                  commitState.recordGroupFailure(group.commitId());
-                  int remaining = groups.size() - i - 1;
+                  try {
+                    commitToTable(
+                        tableRef,
+                        group.envelopes(),
+                        group.commitId(),
+                        groupOffsets,
+                        isCurrentGroup ? validThroughTs : null);
+                    committedEnvelopes.addAll(group.envelopes());
+                    commitState.recordGroupSuccess(group.commitId());
+                  } catch (Exception e) {
+                    commitState.recordGroupFailure(group.commitId());
+                    int remaining = groups.size() - i - 1;
 
-                  if (!isCurrentGroup && !commitState.isGroupBlocking(group.commitId())) {
-                    if (commitState.isStaleFailurePolicyFail()) {
-                      // Fail policy: throw to move the connector to FAILED state.
+                    if (!isCurrentGroup && !commitState.isRetryAllowed(group.commitId())) {
+                      // Stale group exceeded max blocking retries - fail the connector.
                       throw new ConnectException(
                           "Stale group "
                               + group.commitId()
@@ -266,25 +280,11 @@ class Coordinator extends Channel {
                               + tableRef.identifier()
                               + " failed after "
                               + commitState.getRetryCount(group.commitId())
-                              + " retries (policy=fail). Connector stopping.",
+                              + " retries. Connector stopping.",
                           e);
                     }
-                    // Non-blocking policy: proceed with remaining groups.
-                    // Accepting ordering inversion risk to unblock current data.
-                    LOG.warn(
-                        "Stale group {} for table {} failed (attempt {}, exceeded {} "
-                            + "blocking retries, policy=non-blocking), proceeding with "
-                            + "remaining {} group(s). Ordering inversion may produce "
-                            + "duplicates for overlapping keys.",
-                        group.commitId(),
-                        tableRef.identifier(),
-                        commitState.getRetryCount(group.commitId()),
-                        config.commitStaleMaxBlockingRetries(),
-                        remaining,
-                        e);
-                    // Don't break — continue with next group
-                  } else {
-                    // Blocking mode: skip remaining groups to preserve ordering.
+
+                    // Blocking: skip remaining groups to preserve ordering.
                     LOG.warn(
                         "Commit failed for table {} group {} ({}, attempt {}), "
                             + "skipping {} remaining group(s) for this table",
@@ -297,8 +297,10 @@ class Coordinator extends Channel {
                     break;
                   }
                 }
-              }
-            });
+              });
+    } catch (RuntimeException e) {
+      taskException = e;
+    }
 
     // Remove only the envelopes whose groups committed successfully.
     if (!committedEnvelopes.isEmpty()) {
@@ -347,6 +349,11 @@ class Coordinator extends Channel {
           commitState.currentCommitId(),
           commitState.bufferSize(),
           minUncommitted);
+    }
+
+    // Re-throw after cleanup so the commit() wrapper can log it.
+    if (taskException != null) {
+      throw taskException;
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -194,8 +194,7 @@ class Coordinator extends Channel {
           .stopOnFailure()
           .run(
               entry -> {
-                commitToTable(
-                    entry.getKey(), entry.getValue(), batchOffsets, batchVtts);
+                commitToTable(entry.getKey(), entry.getValue(), batchOffsets, batchVtts);
               });
 
       tableCount += commitMap.size();

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -170,17 +170,37 @@ class Coordinator extends Channel {
   }
 
   private void doCommit(boolean partialCommit) {
-    Map<TableReference, List<Envelope>> commitMap = commitState.tableCommitMap();
+    List<Map<TableReference, List<Envelope>>> commitMaps = commitState.tableCommitMaps();
     OffsetDateTime validThroughTs = commitState.validThroughTs(partialCommit);
 
-    Tasks.foreach(commitMap.entrySet())
-        .executeWith(exec)
-        .stopOnFailure()
-        .run(
-            entry ->
-                commitToTable(
-                    entry.getKey(), entry.getValue(), controlTopicOffsets(), validThroughTs));
+    Map<Integer, Long> offsets = controlTopicOffsets();
+    int tableCount = 0;
 
+    // Commit each batch in a separate RowDelta to preserve sequence number ordering.
+    // Stale batches (from previous partial commit cycles) are committed first with lower
+    // sequence numbers, ensuring equality deletes from the current cycle apply correctly.
+    for (int i = 0; i < commitMaps.size(); i++) {
+      Map<TableReference, List<Envelope>> commitMap = commitMaps.get(i);
+      boolean isLastBatch = (i == commitMaps.size() - 1);
+
+      // Only store offsets and vtts on the last batch (current commitId).
+      // Storing on intermediate batches would cause the next batch's
+      // lastCommittedOffsetsForTable() to filter out its own envelopes.
+      final Map<Integer, Long> batchOffsets = isLastBatch ? offsets : null;
+      final OffsetDateTime batchVtts = isLastBatch ? validThroughTs : null;
+
+      Tasks.foreach(commitMap.entrySet())
+          .executeWith(exec)
+          .stopOnFailure()
+          .run(
+              entry -> {
+                commitToTable(
+                    entry.getKey(), entry.getValue(), batchOffsets, batchVtts);
+              });
+
+      tableCount += commitMap.size();
+    }
+    
     // we should only get here if all tables committed successfully...
     commitConsumerOffsets();
     commitState.clearResponses();
@@ -192,10 +212,11 @@ class Coordinator extends Channel {
     send(event);
 
     LOG.info(
-        "Coordinator {} completed commit {}, committed to {} table(s), valid-through {}",
+        "Coordinator {} completed commit {} complete, committed to {} table(s) in {} batch(es), valid-through {}",
         taskId,
         commitState.currentCommitId(),
-        commitMap.size(),
+        tableCount,
+        commitMaps.size(),
         validThroughTs);
   }
 
@@ -233,15 +254,18 @@ class Coordinator extends Channel {
 
     String branch = config.tableConfig(tableIdentifier.toString()).commitBranch();
 
-    // Control topic partition offsets may include a subset of partition ids if there were no
-    // records for other partitions.  Merge the updated topic partitions with the last committed
-    // offsets.
     Map<Integer, Long> committedOffsets = lastCommittedOffsetsForTable(table, branch);
-    Map<Integer, Long> mergedOffsets =
-        Stream.of(committedOffsets, controlTopicOffsets)
-            .flatMap(map -> map.entrySet().stream())
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Long::max));
-    String offsetsJson = offsetsToJson(mergedOffsets);
+
+    // controlTopicOffsets is null for intermediate (stale) batches — offsets and vtts
+    // are only stored on the last batch to avoid interfering with subsequent batches.
+    String offsetsJson = null;
+    if (controlTopicOffsets != null) {
+      Map<Integer, Long> mergedOffsets =
+          Stream.of(committedOffsets, controlTopicOffsets)
+              .flatMap(map -> map.entrySet().stream())
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Long::max));
+      offsetsJson = offsetsToJson(mergedOffsets);
+    }
 
     List<DataWritten> payloads =
         envelopeList.stream()
@@ -284,7 +308,9 @@ class Coordinator extends Channel {
         if (branch != null) {
           appendOp.toBranch(branch);
         }
-        appendOp.set(snapshotOffsetsProp, offsetsJson);
+        if (offsetsJson != null) {
+          appendOp.set(snapshotOffsetsProp, offsetsJson);
+        }
         appendOp.set(COMMIT_ID_SNAPSHOT_PROP, commitState.currentCommitId().toString());
         appendOp.set(TASK_ID_SNAPSHOT_PROP, taskId);
         if (validThroughTs != null) {
@@ -298,7 +324,9 @@ class Coordinator extends Channel {
         if (branch != null) {
           deltaOp.toBranch(branch);
         }
-        deltaOp.set(snapshotOffsetsProp, offsetsJson);
+        if (offsetsJson != null) {
+          deltaOp.set(snapshotOffsetsProp, offsetsJson);
+        }
         deltaOp.set(COMMIT_ID_SNAPSHOT_PROP, commitState.currentCommitId().toString());
         deltaOp.set(TASK_ID_SNAPSHOT_PROP, taskId);
         if (validThroughTs != null) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -22,12 +22,16 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -37,6 +41,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.management.ObjectName;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -82,6 +87,7 @@ class Coordinator extends Channel {
   private final ExecutorService exec;
   private final CommitState commitState;
   private final AtomicLong partialCommitFailures = new AtomicLong();
+  private final ObjectName commitStateMBeanName;
   private volatile boolean terminated;
   private final String taskId;
 
@@ -114,6 +120,22 @@ class Coordinator extends Channel {
                 .build());
     this.commitState = new CommitState(config);
     this.taskId = config.connectorName() + "-" + config.taskId();
+    this.commitStateMBeanName = registerCommitStateMBean(taskId);
+  }
+
+  private ObjectName registerCommitStateMBean(String connectorName) {
+    try {
+      ObjectName name =
+          new ObjectName(
+              String.format(
+                  "org.apache.iceberg.connect:type=CommitState,connector=%s,id=%s",
+                  connectorName, System.identityHashCode(this)));
+      ManagementFactory.getPlatformMBeanServer().registerMBean(commitState, name);
+      return name;
+    } catch (Exception e) {
+      LOG.warn("Failed to register CommitState MBean, metrics will not be available via JMX", e);
+      return null;
+    }
   }
 
   void process() {
@@ -169,54 +191,163 @@ class Coordinator extends Channel {
     }
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   private void doCommit(boolean partialCommit) {
-    List<Map<TableReference, List<Envelope>>> commitMaps = commitState.tableCommitMaps();
+    Map<TableReference, List<CommitState.CommitGroup>> commitGroups =
+        commitState.tableCommitGroups();
     OffsetDateTime validThroughTs = commitState.validThroughTs(partialCommit);
+    Map<Integer, Long> ctlOffsets = controlTopicOffsets();
 
-    Map<Integer, Long> offsets = controlTopicOffsets();
-    int tableCount = 0;
-
-    // Commit each batch in a separate RowDelta to preserve sequence number ordering.
-    // Stale batches (from previous partial commit cycles) are committed first with lower
-    // sequence numbers, ensuring equality deletes from the current cycle apply correctly.
-    for (int i = 0; i < commitMaps.size(); i++) {
-      Map<TableReference, List<Envelope>> commitMap = commitMaps.get(i);
-      boolean isLastBatch = (i == commitMaps.size() - 1);
-
-      // Only store offsets and vtts on the last batch (current commitId).
-      // Storing on intermediate batches would cause the next batch's
-      // lastCommittedOffsetsForTable() to filter out its own envelopes.
-      final Map<Integer, Long> batchOffsets = isLastBatch ? offsets : null;
-      final OffsetDateTime batchVtts = isLastBatch ? validThroughTs : null;
-
-      Tasks.foreach(commitMap.entrySet())
-          .executeWith(exec)
-          .stopOnFailure()
-          .run(
-              entry -> {
-                commitToTable(entry.getKey(), entry.getValue(), batchOffsets, batchVtts);
-              });
-
-      tableCount += commitMap.size();
+    if (commitGroups.isEmpty()) {
+      LOG.info("Nothing to commit");
+      commitConsumerOffsets();
+      commitState.clearResponses();
+      Event event =
+          new Event(
+              config.connectGroupId(),
+              new CommitComplete(commitState.currentCommitId(), validThroughTs));
+      send(event);
+      return;
     }
-    
-    // we should only get here if all tables committed successfully...
-    commitConsumerOffsets();
-    commitState.clearResponses();
 
-    Event event =
-        new Event(
-            config.connectGroupId(),
-            new CommitComplete(commitState.currentCommitId(), validThroughTs));
-    send(event);
+    // Track successfully committed envelopes for selective removal.
+    // Synchronized because table commits run in parallel via the exec thread pool.
+    List<Envelope> committedEnvelopes = Collections.synchronizedList(new ArrayList<>());
 
-    LOG.info(
+    // Outer: tables in parallel (via exec thread pool).
+    // Inner: commitId groups sequentially per table, oldest first.
+    // If a group fails for a table, remaining groups for that table are skipped
+    // to preserve sequence number ordering. Other tables are unaffected.
+    Tasks.foreach(commitGroups.entrySet())
+        .executeWith(exec)
+        .run(
+            entry -> {
+              TableReference tableRef = entry.getKey();
+              List<CommitState.CommitGroup> groups = entry.getValue();
+
+              for (int i = 0; i < groups.size(); i++) {
+                CommitState.CommitGroup group = groups.get(i);
+                boolean isCurrentGroup = group.commitId().equals(commitState.currentCommitId());
+
+                // Stale groups must only write their own envelope offsets to the snapshot,
+                // not the global consumer position. Otherwise the global offsets "poison"
+                // subsequent groups: their envelopes appear already-committed and get
+                // filtered out. The current (last) group writes the global offsets.
+                Map<Integer, Long> groupOffsets;
+                if (isCurrentGroup) {
+                  groupOffsets = ctlOffsets;
+                } else {
+                  groupOffsets = Maps.newHashMap();
+                  for (Envelope env : group.envelopes()) {
+                    groupOffsets.merge(env.partition(), env.offset() + 1, Long::max);
+                  }
+                }
+
+                try {
+                  commitToTable(
+                      tableRef,
+                      group.envelopes(),
+                      group.commitId(),
+                      groupOffsets,
+                      isCurrentGroup ? validThroughTs : null);
+                  committedEnvelopes.addAll(group.envelopes());
+                  commitState.recordGroupSuccess(group.commitId());
+                } catch (Exception e) {
+                  commitState.recordGroupFailure(group.commitId());
+                  int remaining = groups.size() - i - 1;
+
+                  if (!isCurrentGroup && !commitState.isGroupBlocking(group.commitId())) {
+                    if (commitState.isStaleFailurePolicyFail()) {
+                      // Fail policy: throw to move the connector to FAILED state.
+                      throw new ConnectException(
+                          "Stale group "
+                              + group.commitId()
+                              + " for table "
+                              + tableRef.identifier()
+                              + " failed after "
+                              + commitState.getRetryCount(group.commitId())
+                              + " retries (policy=fail). Connector stopping.",
+                          e);
+                    }
+                    // Non-blocking policy: proceed with remaining groups.
+                    // Accepting ordering inversion risk to unblock current data.
+                    LOG.warn(
+                        "Stale group {} for table {} failed (attempt {}, exceeded {} "
+                            + "blocking retries, policy=non-blocking), proceeding with "
+                            + "remaining {} group(s). Ordering inversion may produce "
+                            + "duplicates for overlapping keys.",
+                        group.commitId(),
+                        tableRef.identifier(),
+                        commitState.getRetryCount(group.commitId()),
+                        config.commitStaleMaxBlockingRetries(),
+                        remaining,
+                        e);
+                    // Don't break — continue with next group
+                  } else {
+                    // Blocking mode: skip remaining groups to preserve ordering.
+                    LOG.warn(
+                        "Commit failed for table {} group {} ({}, attempt {}), "
+                            + "skipping {} remaining group(s) for this table",
+                        tableRef.identifier(),
+                        group.commitId(),
+                        isCurrentGroup ? "current" : "stale",
+                        commitState.getRetryCount(group.commitId()),
+                        remaining,
+                        e);
+                    break;
+                  }
+                }
+              }
+            });
+
+    // Remove only the envelopes whose groups committed successfully.
+    if (!committedEnvelopes.isEmpty()) {
+      commitState.removeEnvelopes(committedEnvelopes);
+    }
+
+    if (committedEnvelopes.isEmpty() && !commitGroups.isEmpty()) {
+      LOG.error(
+          "Commit {} failed: all groups across all tables failed to commit. "
+              + "{} group(s) remain in buffer for retry.",
+          commitState.currentCommitId(),
+          commitGroups.values().stream().mapToInt(List::size).sum());
+    }
+
+    // Advance consumer offsets and send CommitComplete only when the buffer is fully
+    // drained. If any groups remain (failed + their skipped successors), consumer
+    // offsets must NOT advance — those envelopes need to survive a restart.
+    if (commitState.isBufferEmpty()) {
+      commitConsumerOffsets();
+      Event event =
+          new Event(
+              config.connectGroupId(),
+              new CommitComplete(commitState.currentCommitId(), validThroughTs));
+      send(event);
+
+      LOG.info(
         "Coordinator {} completed commit {} complete, committed to {} table(s) in {} batch(es), valid-through {}",
         taskId,
         commitState.currentCommitId(),
         tableCount,
         commitMaps.size(),
         validThroughTs);
+
+    } else {
+      // Advance consumer offsets to the minimum uncommitted envelope offset per partition.
+      // This bounds re-consumption on restart to only uncommitted events, while ensuring
+      // those events survive the restart.
+      Map<Integer, Long> minUncommitted = commitState.remainingEnvelopeMinOffsets();
+      Map<Integer, Long> safeOffsets = Maps.newHashMap(controlTopicOffsets());
+      minUncommitted.forEach(safeOffsets::put);
+      commitConsumerOffsetsTo(safeOffsets);
+
+      LOG.warn(
+          "Commit {} partially complete, {} envelopes remain for retry. "
+              + "Consumer offsets advanced to min uncommitted: {}",
+          commitState.currentCommitId(),
+          commitState.bufferSize(),
+          minUncommitted);
+    }
   }
 
   private String offsetsToJson(Map<Integer, Long> offsets) {
@@ -231,6 +362,7 @@ class Coordinator extends Channel {
   private void commitToTable(
       TableReference tableReference,
       List<Envelope> envelopeList,
+      UUID commitId,
       Map<Integer, Long> controlTopicOffsets,
       OffsetDateTime validThroughTs) {
     TableIdentifier tableIdentifier = tableReference.identifier();
@@ -253,18 +385,15 @@ class Coordinator extends Channel {
 
     String branch = config.tableConfig(tableIdentifier.toString()).commitBranch();
 
+    // Control topic partition offsets may include a subset of partition ids if there were no
+    // records for other partitions.  Merge the updated topic partitions with the last committed
+    // offsets.
     Map<Integer, Long> committedOffsets = lastCommittedOffsetsForTable(table, branch);
-
-    // controlTopicOffsets is null for intermediate (stale) batches — offsets and vtts
-    // are only stored on the last batch to avoid interfering with subsequent batches.
-    String offsetsJson = null;
-    if (controlTopicOffsets != null) {
-      Map<Integer, Long> mergedOffsets =
-          Stream.of(committedOffsets, controlTopicOffsets)
-              .flatMap(map -> map.entrySet().stream())
-              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Long::max));
-      offsetsJson = offsetsToJson(mergedOffsets);
-    }
+    Map<Integer, Long> mergedOffsets =
+        Stream.of(committedOffsets, controlTopicOffsets)
+            .flatMap(map -> map.entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Long::max));
+    String offsetsJson = offsetsToJson(mergedOffsets);
 
     List<DataWritten> payloads =
         envelopeList.stream()
@@ -307,10 +436,8 @@ class Coordinator extends Channel {
         if (branch != null) {
           appendOp.toBranch(branch);
         }
-        if (offsetsJson != null) {
-          appendOp.set(snapshotOffsetsProp, offsetsJson);
-        }
-        appendOp.set(COMMIT_ID_SNAPSHOT_PROP, commitState.currentCommitId().toString());
+        appendOp.set(snapshotOffsetsProp, offsetsJson);
+        appendOp.set(COMMIT_ID_SNAPSHOT_PROP, commitId.toString());
         appendOp.set(TASK_ID_SNAPSHOT_PROP, taskId);
         if (validThroughTs != null) {
           appendOp.set(VALID_THROUGH_TS_SNAPSHOT_PROP, validThroughTs.toString());
@@ -323,10 +450,8 @@ class Coordinator extends Channel {
         if (branch != null) {
           deltaOp.toBranch(branch);
         }
-        if (offsetsJson != null) {
-          deltaOp.set(snapshotOffsetsProp, offsetsJson);
-        }
-        deltaOp.set(COMMIT_ID_SNAPSHOT_PROP, commitState.currentCommitId().toString());
+        deltaOp.set(snapshotOffsetsProp, offsetsJson);
+        deltaOp.set(COMMIT_ID_SNAPSHOT_PROP, commitId.toString());
         deltaOp.set(TASK_ID_SNAPSHOT_PROP, taskId);
         if (validThroughTs != null) {
           deltaOp.set(VALID_THROUGH_TS_SNAPSHOT_PROP, validThroughTs.toString());
@@ -340,8 +465,7 @@ class Coordinator extends Channel {
       Event event =
           new Event(
               config.connectGroupId(),
-              new CommitToTable(
-                  commitState.currentCommitId(), tableReference, snapshotId, validThroughTs));
+              new CommitToTable(commitId, tableReference, snapshotId, validThroughTs));
       send(event);
 
       LOG.info(
@@ -349,7 +473,7 @@ class Coordinator extends Channel {
           taskId,
           tableIdentifier,
           snapshotId,
-          commitState.currentCommitId(),
+          commitId,
           validThroughTs);
     }
   }
@@ -429,6 +553,14 @@ class Coordinator extends Channel {
 
   void terminate() {
     this.terminated = true;
+
+    if (commitStateMBeanName != null) {
+      try {
+        ManagementFactory.getPlatformMBeanServer().unregisterMBean(commitStateMBeanName);
+      } catch (Exception e) {
+        LOG.warn("Failed to unregister CommitState MBean", e);
+      }
+    }
 
     exec.shutdownNow();
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -200,7 +200,7 @@ class Coordinator extends Channel {
     }
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})
   private void doCommit(boolean partialCommit) {
     Map<TableReference, List<CommitState.CommitGroup>> commitGroups =
         commitState.tableCommitGroups();

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -103,9 +103,7 @@ public class ChannelTestBase {
     when(config.connectGroupId()).thenReturn(CONNECT_CONSUMER_GROUP_ID);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
     when(config.connectorName()).thenReturn("test-connector");
-    when(config.commitStaleTtlMs()).thenReturn(3_600_000);
     when(config.commitStaleMaxBlockingRetries()).thenReturn(3);
-    when(config.commitStaleFailurePolicy()).thenReturn("fail");
 
     TopicPartitionInfo partitionInfo = mock(TopicPartitionInfo.class);
     when(partitionInfo.partition()).thenReturn(0);

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -102,6 +102,10 @@ public class ChannelTestBase {
     when(config.commitThreads()).thenReturn(1);
     when(config.connectGroupId()).thenReturn(CONNECT_CONSUMER_GROUP_ID);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.connectorName()).thenReturn("test-connector");
+    when(config.commitStaleTtlMs()).thenReturn(3_600_000);
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(3);
+    when(config.commitStaleFailurePolicy()).thenReturn("fail");
 
     TopicPartitionInfo partitionInfo = mock(TopicPartitionInfo.class);
     when(partitionInfo.partition()).thenReturn(0);

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/EventTestUtil.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/EventTestUtil.java
@@ -64,6 +64,10 @@ class EventTestUtil {
   }
 
   static DataFile createDataFile() {
+    return createDataFile("path/to/file.parquet");
+  }
+
+  static DataFile createDataFile(String path) {
     PartitionData data = new PartitionData(SPEC.partitionType());
     data.set(0, 1L);
 
@@ -73,13 +77,17 @@ class EventTestUtil {
         .withFormat(FileFormat.PARQUET)
         .withMetrics(METRICS)
         .withPartition(data)
-        .withPath("path/to/file.parquet")
+        .withPath(path)
         .withSortOrder(ORDER)
         .withSplitOffsets(ImmutableList.of(4L))
         .build();
   }
 
   static DeleteFile createDeleteFile() {
+    return createDeleteFile("path/to/file.parquet");
+  }
+
+  static DeleteFile createDeleteFile(String path) {
     PartitionData data = new PartitionData(SPEC.partitionType());
     data.set(0, 1L);
 
@@ -90,7 +98,7 @@ class EventTestUtil {
         .withFormat(FileFormat.PARQUET)
         .withMetrics(METRICS)
         .withPartition(data)
-        .withPath("path/to/file.parquet")
+        .withPath(path)
         .withSortOrder(ORDER)
         .withSplitOffsets(ImmutableList.of(4L))
         .build();

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
@@ -36,14 +36,14 @@ import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestCommitState {
 
   private IcebergSinkConfig mockConfig() {
     IcebergSinkConfig cfg = mock(IcebergSinkConfig.class);
-    when(cfg.commitStaleTtlMs()).thenReturn(3_600_000);
     when(cfg.commitStaleMaxBlockingRetries()).thenReturn(3);
-    when(cfg.commitStaleFailurePolicy()).thenReturn("fail");
     return cfg;
   }
 
@@ -277,6 +277,32 @@ public class TestCommitState {
 
     commitState.clearResponses();
     assertThat(commitState.isBufferEmpty()).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 3})
+  public void testStaleGroupBlocksForNRetriesThenStopsBlocking(int maxRetries) {
+    // With maxRetries=N, the group blocks for N attempts (failures 1..N).
+    // On attempt N+1, isRetryAllowed returns false -> ConnectException path.
+    // retries=0: fail immediately (1st attempt). retries=3: pass 3 times, fail on 4th.
+    IcebergSinkConfig cfg = mock(IcebergSinkConfig.class);
+    when(cfg.commitStaleMaxBlockingRetries()).thenReturn(maxRetries);
+    CommitState commitState = new CommitState(cfg);
+
+    UUID staleId = UUID.randomUUID();
+    commitState.addResponse(createDataWrittenEnvelope(staleId));
+    commitState.startNewCommit();
+
+    // Group blocks for exactly maxRetries failures.
+    for (int i = 0; i < maxRetries; i++) {
+      commitState.recordGroupFailure(staleId);
+      assertThat(commitState.isRetryAllowed(staleId)).isTrue();
+    }
+
+    // The (maxRetries + 1)-th failure exhausts the budget.
+    commitState.recordGroupFailure(staleId);
+    assertThat(commitState.isRetryAllowed(staleId)).isFalse();
+    assertThat(commitState.getRetryCount(staleId)).isEqualTo(maxRetries + 1);
   }
 
   private Envelope createDataWrittenEnvelope(UUID commitId) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
@@ -23,21 +23,35 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.events.DataComplete;
+import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.Payload;
+import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 public class TestCommitState {
+
+  private IcebergSinkConfig mockConfig() {
+    IcebergSinkConfig cfg = mock(IcebergSinkConfig.class);
+    when(cfg.commitStaleTtlMs()).thenReturn(3_600_000);
+    when(cfg.commitStaleMaxBlockingRetries()).thenReturn(3);
+    when(cfg.commitStaleFailurePolicy()).thenReturn("fail");
+    return cfg;
+  }
+
   @Test
   public void testIsCommitReady() {
     TopicPartitionOffset tp = mock(TopicPartitionOffset.class);
 
-    CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
+    CommitState commitState = new CommitState(mockConfig());
     commitState.startNewCommit();
 
     DataComplete payload1 = mock(DataComplete.class);
@@ -129,7 +143,7 @@ public class TestCommitState {
     when(tp3.timestamp()).thenReturn(ts3);
     when(payload2.assignments()).thenReturn(ImmutableList.of(tp3));
 
-    CommitState commitState = new CommitState(mock(IcebergSinkConfig.class));
+    CommitState commitState = new CommitState(mockConfig());
     commitState.startNewCommit();
 
     commitState.addReady(wrapInEnvelope(payload1));
@@ -148,6 +162,129 @@ public class TestCommitState {
 
     assertThat(commitState.validThroughTs(false)).isNull();
     assertThat(commitState.validThroughTs(true)).isNull();
+  }
+
+  @Test
+  public void testTableCommitGroupsSingleCommitId() {
+    CommitState commitState = new CommitState(mockConfig());
+    commitState.startNewCommit();
+    UUID cid = commitState.currentCommitId();
+
+    commitState.addResponse(createDataWrittenEnvelope(cid));
+    commitState.addResponse(createDataWrittenEnvelope(cid));
+
+    Map<TableReference, List<CommitState.CommitGroup>> groups = commitState.tableCommitGroups();
+    assertThat(groups).hasSize(1);
+    List<CommitState.CommitGroup> tableGroups = groups.values().iterator().next();
+    assertThat(tableGroups).hasSize(1);
+    assertThat(tableGroups.get(0).commitId()).isEqualTo(cid);
+    assertThat(tableGroups.get(0).envelopes()).hasSize(2);
+  }
+
+  @Test
+  public void testTableCommitGroupsMultipleCommitIds() {
+    CommitState commitState = new CommitState(mockConfig());
+
+    // Cycle 1: stale events from a failed commit
+    UUID staleId = UUID.randomUUID();
+    commitState.addResponse(createDataWrittenEnvelope(staleId));
+
+    // Cycle 2: current events
+    commitState.startNewCommit();
+    UUID currentId = commitState.currentCommitId();
+    commitState.addResponse(createDataWrittenEnvelope(currentId));
+
+    Map<TableReference, List<CommitState.CommitGroup>> groups = commitState.tableCommitGroups();
+    assertThat(groups).hasSize(1);
+    List<CommitState.CommitGroup> tableGroups = groups.values().iterator().next();
+    assertThat(tableGroups).hasSize(2);
+    // Stale group first (insertion order)
+    assertThat(tableGroups.get(0).commitId()).isEqualTo(staleId);
+    assertThat(tableGroups.get(1).commitId()).isEqualTo(currentId);
+  }
+
+  @Test
+  public void testTableCommitGroupsPreservesInsertionOrder() {
+    CommitState commitState = new CommitState(mockConfig());
+
+    UUID idA = UUID.randomUUID();
+    UUID idB = UUID.randomUUID();
+
+    // Interleaved: A, B, A — groups should be ordered [A, B] by first-seen
+    commitState.addResponse(createDataWrittenEnvelope(idA));
+    commitState.addResponse(createDataWrittenEnvelope(idB));
+    commitState.addResponse(createDataWrittenEnvelope(idA));
+
+    commitState.startNewCommit();
+
+    Map<TableReference, List<CommitState.CommitGroup>> groups = commitState.tableCommitGroups();
+    List<CommitState.CommitGroup> tableGroups = groups.values().iterator().next();
+    assertThat(tableGroups).hasSize(2);
+    assertThat(tableGroups.get(0).commitId()).isEqualTo(idA);
+    assertThat(tableGroups.get(0).envelopes()).hasSize(2);
+    assertThat(tableGroups.get(1).commitId()).isEqualTo(idB);
+    assertThat(tableGroups.get(1).envelopes()).hasSize(1);
+  }
+
+  @Test
+  public void testStartNewCommitDoesNotClearBuffer() {
+    CommitState commitState = new CommitState(mockConfig());
+
+    // Add stale events before starting a new commit
+    UUID staleId = UUID.randomUUID();
+    commitState.addResponse(createDataWrittenEnvelope(staleId));
+
+    // Starting a new commit must NOT clear stale events — they are retained for
+    // per-group sequential commit in doCommit().
+    commitState.startNewCommit();
+    assertThat(commitState.tableCommitGroups()).isNotEmpty();
+    List<CommitState.CommitGroup> tableGroups =
+        commitState.tableCommitGroups().values().iterator().next();
+    assertThat(tableGroups.get(0).commitId()).isEqualTo(staleId);
+  }
+
+  @Test
+  public void testRemoveEnvelopesSelectiveRemoval() {
+    CommitState commitState = new CommitState(mockConfig());
+
+    Envelope stale1 = createDataWrittenEnvelope(UUID.randomUUID());
+    Envelope stale2 = createDataWrittenEnvelope(UUID.randomUUID());
+    commitState.addResponse(stale1);
+    commitState.addResponse(stale2);
+
+    commitState.startNewCommit();
+    Envelope current = createDataWrittenEnvelope(commitState.currentCommitId());
+    commitState.addResponse(current);
+
+    // Remove only the stale envelopes
+    commitState.removeEnvelopes(ImmutableList.of(stale1, stale2));
+
+    // Only current envelope remains
+    Map<TableReference, List<CommitState.CommitGroup>> groups = commitState.tableCommitGroups();
+    assertThat(groups).hasSize(1);
+    List<CommitState.CommitGroup> tableGroups = groups.values().iterator().next();
+    assertThat(tableGroups).hasSize(1);
+    assertThat(tableGroups.get(0).commitId()).isEqualTo(commitState.currentCommitId());
+  }
+
+  @Test
+  public void testIsBufferEmpty() {
+    CommitState commitState = new CommitState(mockConfig());
+    assertThat(commitState.isBufferEmpty()).isTrue();
+
+    commitState.addResponse(createDataWrittenEnvelope(UUID.randomUUID()));
+    assertThat(commitState.isBufferEmpty()).isFalse();
+
+    commitState.clearResponses();
+    assertThat(commitState.isBufferEmpty()).isTrue();
+  }
+
+  private Envelope createDataWrittenEnvelope(UUID commitId) {
+    TableReference tableRef = TableReference.of("catalog", TableIdentifier.of("db", "tbl"));
+    DataWritten payload = mock(DataWritten.class);
+    when(payload.commitId()).thenReturn(commitId);
+    when(payload.tableReference()).thenReturn(tableRef);
+    return wrapInEnvelope(payload);
   }
 
   private Envelope wrapInEnvelope(Payload payload) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -56,8 +56,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestCoordinator extends ChannelTestBase {
 
@@ -452,6 +455,407 @@ public class TestCoordinator extends ChannelTestBase {
                   return e.type() == PayloadType.COMMIT_COMPLETE;
                 });
     assertThat(hasCommitComplete).isFalse();
+  }
+
+  // =============================================================================
+  // Stale Group Retry Exhaustion — ConnectException Must Propagate
+  // =============================================================================
+
+  // TDD: these tests define DESIRED behavior. With the current implementation,
+  // commit() swallows ConnectException (Coordinator.java line ~174). The desired
+  // behavior is that ConnectException from exhausted stale retries propagates out
+  // of process() so Kafka Connect can stop the connector.
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 3})
+  public void testStaleGroupBlocksThenThrowsConnectException(int maxRetries) {
+    // For maxRetries=0: process() should throw ConnectException on the very first commit attempt.
+    // For maxRetries=3: process() blocks (no exception) for 3 cycles, then throws on cycle 4.
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(maxRetries);
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // Inject a stale DataWritten with a bad partition spec (fails commitToTable).
+    UUID staleCommitId = UUID.randomUUID();
+    PartitionSpec badPartitionSpec =
+        PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
+    DataFile badDataFile =
+        DataFiles.builder(badPartitionSpec)
+            .withPath(UUID.randomUUID() + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(100L)
+            .withRecordCount(5)
+            .build();
+    Event staleResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                staleCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(badDataFile),
+                ImmutableList.of()));
+    byte[] staleBytes = AvroUtil.encode(staleResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0, "key", staleBytes));
+
+    // First process(): starts commit (commitId1), consumes the stale event.
+    // commitIntervalMs=0 guarantees a new commit is started each cycle.
+    coordinator.process();
+
+    // Extract the commitId from the StartCommit sent by the first process().
+    byte[] bytes = producer.history().get(0).value();
+    Event startEvent = AvroUtil.decode(bytes);
+    UUID currentCommitId = ((StartCommit) startEvent.payload()).commitId();
+
+    // Add valid current-cycle DataWritten and DataComplete so the first real commit triggers.
+    Event currentResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                currentCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(EventTestUtil.createDataFile()),
+                ImmutableList.of()));
+    bytes = AvroUtil.encode(currentResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+
+    Event currentReady =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                currentCommitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+    bytes = AvroUtil.encode(currentReady);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
+
+    // Run maxRetries blocking cycles. Each cycle: the stale group fails but stays within the
+    // retry budget (count <= max), so no exception is thrown. On the (maxRetries + 1)-th failure,
+    // isRetryAllowed returns false and ConnectException is thrown — asserted below.
+    int offset = 3;
+    for (int i = 0; i < maxRetries; i++) {
+      // process() should NOT throw — the stale group is still within its retry budget.
+      coordinator.process();
+
+      // The coordinator started a new commit this cycle. Find the latest StartCommit.
+      UUID nextCommitId =
+          producer.history().stream()
+              .map(r -> AvroUtil.decode(r.value()))
+              .filter(e -> e.type() == PayloadType.START_COMMIT)
+              .reduce((first, second) -> second) // last element
+              .map(e -> ((StartCommit) e.payload()).commitId())
+              .orElseThrow(() -> new AssertionError("No StartCommit found in producer history"));
+
+      // Inject DataComplete so the next cycle's commit is ready to fire.
+      Event nextReady =
+          new Event(
+              config.connectGroupId(),
+              new DataComplete(
+                  nextCommitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+      bytes = AvroUtil.encode(nextReady);
+      consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", bytes));
+    }
+
+    // On the next process() the stale group has exceeded its retry budget — must throw.
+    assertThatThrownBy(coordinator::process).isInstanceOf(ConnectException.class);
+  }
+
+  @Test
+  public void testStaleGroupFailureStopsConnector() {
+    // With maxRetries=0 the very first commit attempt after a stale event must stop the connector.
+    // The ConnectException must propagate out of process() with a message containing
+    // "Connector stopping", and no CommitComplete must have been sent.
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(0);
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // Inject a stale DataWritten with a bad partition spec.
+    UUID staleCommitId = UUID.randomUUID();
+    PartitionSpec badPartitionSpec =
+        PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
+    DataFile badDataFile =
+        DataFiles.builder(badPartitionSpec)
+            .withPath(UUID.randomUUID() + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(100L)
+            .withRecordCount(5)
+            .build();
+    Event staleResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                staleCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(badDataFile),
+                ImmutableList.of()));
+    byte[] staleBytes = AvroUtil.encode(staleResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0, "key", staleBytes));
+
+    // First process(): starts commit, consumes stale event.
+    coordinator.process();
+
+    byte[] bytes = producer.history().get(0).value();
+    Event startEvent = AvroUtil.decode(bytes);
+    UUID currentCommitId = ((StartCommit) startEvent.payload()).commitId();
+
+    // Add valid current-cycle DataWritten + DataComplete so the commit triggers.
+    Event currentResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                currentCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(EventTestUtil.createDataFile()),
+                ImmutableList.of()));
+    bytes = AvroUtil.encode(currentResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+
+    Event currentReady =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                currentCommitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+    bytes = AvroUtil.encode(currentReady);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
+
+    // Second process(): stale group immediately exceeds retry budget (maxRetries=0).
+    // ConnectException must propagate out of process().
+    assertThatThrownBy(coordinator::process)
+        .isInstanceOf(ConnectException.class)
+        .hasMessageContaining("Connector stopping");
+
+    // The connector must not have sent a CommitComplete — it is stopping.
+    boolean hasCommitComplete =
+        producer.history().stream()
+            .anyMatch(
+                r -> {
+                  Event e = AvroUtil.decode(r.value());
+                  return e.type() == PayloadType.COMMIT_COMPLETE;
+                });
+    assertThat(hasCommitComplete).isFalse();
+  }
+
+  @Test
+  public void testZeroRetriesMultiTableCommitsGoodTableBeforeFailing() {
+    // With maxRetries=0, when the stale event targets tbl2 and good data targets tbl,
+    // tbl must receive its snapshot (committed before the exception) while tbl2 gets nothing.
+    // The ConnectException must still propagate out of process().
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(0);
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    // Create a second table as the stale event's target.
+    catalog.createTable(TableIdentifier.of("db", "tbl2"), SCHEMA);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // Inject a stale DataWritten targeting db.tbl2 with a bad partition spec.
+    UUID staleCommitId = UUID.randomUUID();
+    PartitionSpec badPartitionSpec =
+        PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
+    DataFile badDataFile =
+        DataFiles.builder(badPartitionSpec)
+            .withPath(UUID.randomUUID() + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(100L)
+            .withRecordCount(5)
+            .build();
+    Event staleResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                staleCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl2"), null),
+                ImmutableList.of(badDataFile),
+                ImmutableList.of()));
+    byte[] staleBytes = AvroUtil.encode(staleResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0, "key", staleBytes));
+
+    // First process(): starts commit, consumes stale event for tbl2.
+    coordinator.process();
+
+    byte[] bytes = producer.history().get(0).value();
+    Event startEvent = AvroUtil.decode(bytes);
+    UUID currentCommitId = ((StartCommit) startEvent.payload()).commitId();
+
+    // Valid DataWritten for db.tbl (the good table).
+    Event currentResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                currentCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(EventTestUtil.createDataFile()),
+                ImmutableList.of()));
+    bytes = AvroUtil.encode(currentResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+
+    Event currentReady =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                currentCommitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+    bytes = AvroUtil.encode(currentReady);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
+
+    // Second process(): tbl's current group commits successfully, then tbl2's stale group
+    // exhausts retries (maxRetries=0) and throws ConnectException.
+    assertThatThrownBy(coordinator::process).isInstanceOf(ConnectException.class);
+
+    // db.tbl must have 1 snapshot — committed before the exception was thrown.
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+
+    // db.tbl2 must have no snapshots — its stale group failed.
+    Table table2 = catalog.loadTable(TableIdentifier.of("db", "tbl2"));
+    assertThat(table2.snapshots()).isEmpty();
+  }
+
+  @Test
+  public void testMultiTablePartialCommitWithStaleExhaustion() {
+    // With maxRetries=3, the stale group for tbl2 blocks for 3 cycles while tbl accumulates
+    // snapshots each cycle. On cycle 4 (retry exhaustion) process() throws ConnectException.
+    // Final state: tbl has 3 snapshots, tbl2 has 0.
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(3);
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    catalog.createTable(TableIdentifier.of("db", "tbl2"), SCHEMA);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // Inject a stale DataWritten targeting db.tbl2 with a bad partition spec.
+    UUID staleCommitId = UUID.randomUUID();
+    PartitionSpec badPartitionSpec =
+        PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
+    DataFile badDataFile =
+        DataFiles.builder(badPartitionSpec)
+            .withPath(UUID.randomUUID() + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(100L)
+            .withRecordCount(5)
+            .build();
+    Event staleResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                staleCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl2"), null),
+                ImmutableList.of(badDataFile),
+                ImmutableList.of()));
+    byte[] staleBytes = AvroUtil.encode(staleResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0, "key", staleBytes));
+
+    // First process(): starts commit (commitId1), consumes the stale event.
+    coordinator.process();
+
+    // Run 3 blocking cycles (retries 1, 2, 3). On the 4th failure (count > maxRetries),
+    // isRetryAllowed returns false and ConnectException is thrown — asserted after the loop.
+    int offset = 1;
+    for (int cycle = 1; cycle <= 3; cycle++) {
+      UUID cycleCommitId =
+          producer.history().stream()
+              .map(r -> AvroUtil.decode(r.value()))
+              .filter(e -> e.type() == PayloadType.START_COMMIT)
+              .reduce((first, second) -> second) // last StartCommit
+              .map(e -> ((StartCommit) e.payload()).commitId())
+              .orElseThrow(() -> new AssertionError("No StartCommit found"));
+
+      Event cycleResponse =
+          new Event(
+              config.connectGroupId(),
+              new DataWritten(
+                  StructType.of(),
+                  cycleCommitId,
+                  TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                  ImmutableList.of(EventTestUtil.createDataFile()),
+                  ImmutableList.of()));
+      byte[] cycleResponseBytes = AvroUtil.encode(cycleResponse);
+      consumer.addRecord(
+          new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", cycleResponseBytes));
+
+      Event cycleReady =
+          new Event(
+              config.connectGroupId(),
+              new DataComplete(
+                  cycleCommitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+      byte[] cycleReadyBytes = AvroUtil.encode(cycleReady);
+      consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", cycleReadyBytes));
+
+      // Must not throw during blocking cycles.
+      coordinator.process();
+
+      // db.tbl gains one snapshot per successful blocking cycle.
+      table.refresh();
+      assertThat(ImmutableList.copyOf(table.snapshots())).hasSize(cycle);
+    }
+
+    // Cycle 4: stale group has now failed 3 times (blocking). This cycle is the 4th failure
+    // (count > maxRetries), so isRetryAllowed returns false → throws ConnectException.
+    // The good table (tbl) may still commit before the exception propagates.
+    UUID finalCommitId =
+        producer.history().stream()
+            .map(r -> AvroUtil.decode(r.value()))
+            .filter(e -> e.type() == PayloadType.START_COMMIT)
+            .reduce((first, second) -> second)
+            .map(e -> ((StartCommit) e.payload()).commitId())
+            .orElseThrow(() -> new AssertionError("No StartCommit found for final cycle"));
+
+    Event finalResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                finalCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(EventTestUtil.createDataFile()),
+                ImmutableList.of()));
+    byte[] finalResponseBytes = AvroUtil.encode(finalResponse);
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", finalResponseBytes));
+
+    Event finalReady =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                finalCommitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+    byte[] finalReadyBytes = AvroUtil.encode(finalReady);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", finalReadyBytes));
+
+    assertThatThrownBy(coordinator::process).isInstanceOf(ConnectException.class);
+
+    // db.tbl has 4 snapshots: 3 from blocking cycles + 1 from the final cycle
+    // (good table commits in parallel before the bad table's exception propagates).
+    table.refresh();
+    assertThat(ImmutableList.copyOf(table.snapshots())).hasSize(4);
+
+    // db.tbl2 has no snapshots — its stale group never committed.
+    Table table2 = catalog.loadTable(TableIdentifier.of("db", "tbl2"));
+    assertThat(table2.snapshots()).isEmpty();
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -451,8 +451,8 @@ public class TestCoordinator extends ChannelTestBase {
         producer.history().stream()
             .anyMatch(
                 r -> {
-                  Event e = AvroUtil.decode(r.value());
-                  return e.type() == PayloadType.COMMIT_COMPLETE;
+                  Event event = AvroUtil.decode(r.value());
+                  return event.type() == PayloadType.COMMIT_COMPLETE;
                 });
     assertThat(hasCommitComplete).isFalse();
   }
@@ -548,7 +548,7 @@ public class TestCoordinator extends ChannelTestBase {
               .map(r -> AvroUtil.decode(r.value()))
               .filter(e -> e.type() == PayloadType.START_COMMIT)
               .reduce((first, second) -> second) // last element
-              .map(e -> ((StartCommit) e.payload()).commitId())
+              .map(ev -> ((StartCommit) ev.payload()).commitId())
               .orElseThrow(() -> new AssertionError("No StartCommit found in producer history"));
 
       // Inject DataComplete so the next cycle's commit is ready to fire.
@@ -562,7 +562,9 @@ public class TestCoordinator extends ChannelTestBase {
     }
 
     // On the next process() the stale group has exceeded its retry budget — must throw.
-    assertThatThrownBy(coordinator::process).isInstanceOf(ConnectException.class);
+    assertThatThrownBy(coordinator::process)
+        .isInstanceOf(ConnectException.class)
+        .hasMessageContaining("Connector stopping");
   }
 
   @Test
@@ -642,8 +644,8 @@ public class TestCoordinator extends ChannelTestBase {
         producer.history().stream()
             .anyMatch(
                 r -> {
-                  Event e = AvroUtil.decode(r.value());
-                  return e.type() == PayloadType.COMMIT_COMPLETE;
+                  Event event = AvroUtil.decode(r.value());
+                  return event.type() == PayloadType.COMMIT_COMPLETE;
                 });
     assertThat(hasCommitComplete).isFalse();
   }
@@ -719,7 +721,9 @@ public class TestCoordinator extends ChannelTestBase {
 
     // Second process(): tbl's current group commits successfully, then tbl2's stale group
     // exhausts retries (maxRetries=0) and throws ConnectException.
-    assertThatThrownBy(coordinator::process).isInstanceOf(ConnectException.class);
+    assertThatThrownBy(coordinator::process)
+        .isInstanceOf(ConnectException.class)
+        .hasMessageContaining("Connector stopping");
 
     // db.tbl must have 1 snapshot — committed before the exception was thrown.
     table.refresh();
@@ -846,7 +850,9 @@ public class TestCoordinator extends ChannelTestBase {
     byte[] finalReadyBytes = AvroUtil.encode(finalReady);
     consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", finalReadyBytes));
 
-    assertThatThrownBy(coordinator::process).isInstanceOf(ConnectException.class);
+    assertThatThrownBy(coordinator::process)
+        .isInstanceOf(ConnectException.class)
+        .hasMessageContaining("Connector stopping");
 
     // db.tbl has 4 snapshots: 3 from blocking cycles + 1 from the final cycle
     // (good table commits in parallel before the bad table's exception propagates).
@@ -938,8 +944,8 @@ public class TestCoordinator extends ChannelTestBase {
         producer.history().stream()
             .anyMatch(
                 r -> {
-                  Event e = AvroUtil.decode(r.value());
-                  return e.type() == PayloadType.COMMIT_COMPLETE;
+                  Event event = AvroUtil.decode(r.value());
+                  return event.type() == PayloadType.COMMIT_COMPLETE;
                 });
     assertThat(hasCommitComplete).isFalse();
   }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -56,7 +56,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -133,6 +132,8 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCommitError() {
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(0);
+
     // this spec isn't registered with the table
     PartitionSpec badPartitionSpec =
         PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
@@ -155,6 +156,8 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCommitFailedExceptionPropagates() {
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(0);
+
     Table spiedTable = spy(table);
     AppendFiles spiedAppend = spy(table.newAppend());
     doThrow(new CommitFailedException("Glue detected concurrent update"))
@@ -246,6 +249,7 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testPartialCommitFailureMetric() {
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(1);
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(0);
 
@@ -332,6 +336,8 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCoordinatorCommittedOffsetValidation() {
+    when(config.commitStaleMaxBlockingRetries()).thenReturn(0);
+
     // This test demonstrates that the Coordinator's validateAndCommit method
     // prevents commits when another independent commit has updated the offsets
     // during the commit process
@@ -468,8 +474,8 @@ public class TestCoordinator extends ChannelTestBase {
 
   @ParameterizedTest
   @ValueSource(ints = {0, 3})
-  public void testStaleGroupBlocksThenThrowsConnectException(int maxRetries) {
-    // For maxRetries=0: process() should throw ConnectException on the very first commit attempt.
+  public void testStaleGroupBlocksThenThrowsException(int maxRetries) {
+    // For maxRetries=0: process() should throws on the very first commit attempt.
     // For maxRetries=3: process() blocks (no exception) for 3 cycles, then throws on cycle 4.
     when(config.commitStaleMaxBlockingRetries()).thenReturn(maxRetries);
     when(config.commitIntervalMs()).thenReturn(0);
@@ -563,8 +569,8 @@ public class TestCoordinator extends ChannelTestBase {
 
     // On the next process() the stale group has exceeded its retry budget — must throw.
     assertThatThrownBy(coordinator::process)
-        .isInstanceOf(ConnectException.class)
-        .hasMessageContaining("Connector stopping");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find partition spec");
   }
 
   @Test
@@ -636,8 +642,8 @@ public class TestCoordinator extends ChannelTestBase {
     // Second process(): stale group immediately exceeds retry budget (maxRetries=0).
     // ConnectException must propagate out of process().
     assertThatThrownBy(coordinator::process)
-        .isInstanceOf(ConnectException.class)
-        .hasMessageContaining("Connector stopping");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find partition spec");
 
     // The connector must not have sent a CommitComplete — it is stopping.
     boolean hasCommitComplete =
@@ -722,8 +728,8 @@ public class TestCoordinator extends ChannelTestBase {
     // Second process(): tbl's current group commits successfully, then tbl2's stale group
     // exhausts retries (maxRetries=0) and throws ConnectException.
     assertThatThrownBy(coordinator::process)
-        .isInstanceOf(ConnectException.class)
-        .hasMessageContaining("Connector stopping");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find partition spec");
 
     // db.tbl must have 1 snapshot — committed before the exception was thrown.
     table.refresh();
@@ -851,8 +857,8 @@ public class TestCoordinator extends ChannelTestBase {
     consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", finalReadyBytes));
 
     assertThatThrownBy(coordinator::process)
-        .isInstanceOf(ConnectException.class)
-        .hasMessageContaining("Connector stopping");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find partition spec");
 
     // db.tbl has 4 snapshots: 3 from blocking cycles + 1 from the final cycle
     // (good table commits in parallel before the bad table's exception propagates).

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -371,4 +371,172 @@ public class TestCoordinator extends ChannelTestBase {
     assertThat(table.snapshots()).hasSize(2);
     assertThat(table.currentSnapshot().summary()).containsEntry(OFFSETS_SNAPSHOT_PROP, "{\"0\":7}");
   }
+
+  @Test
+  public void testStaleGroupFailureSkipsCurrentGroup() {
+    // If a stale group fails to commit, remaining groups for that table must be
+    // skipped to preserve sequence number ordering. No snapshots should be created.
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // Inject a stale DataWritten with a bad partition spec (will fail validation).
+    UUID staleCommitId = UUID.randomUUID();
+    PartitionSpec badPartitionSpec =
+        PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
+    DataFile badDataFile =
+        DataFiles.builder(badPartitionSpec)
+            .withPath(UUID.randomUUID() + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(100L)
+            .withRecordCount(5)
+            .build();
+    Event staleResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                staleCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(badDataFile),
+                ImmutableList.of()));
+    byte[] staleBytes = AvroUtil.encode(staleResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0, "key", staleBytes));
+
+    // First process(): starts commit, consumes stale event.
+    coordinator.process();
+
+    byte[] bytes = producer.history().get(0).value();
+    Event startEvent = AvroUtil.decode(bytes);
+    UUID currentCommitId = ((StartCommit) startEvent.payload()).commitId();
+
+    // Add valid current-cycle events.
+    Event currentResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                currentCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(EventTestUtil.createDataFile()),
+                ImmutableList.of()));
+    bytes = AvroUtil.encode(currentResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+
+    Event currentReady =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                currentCommitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+    bytes = AvroUtil.encode(currentReady);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
+
+    // Second process(): stale group fails → current group skipped for this table.
+    coordinator.process();
+
+    table.refresh();
+    // No snapshots: both groups skipped due to stale failure.
+    assertThat(table.snapshots()).isEmpty();
+
+    // No CommitComplete sent (buffer not empty).
+    boolean hasCommitComplete =
+        producer.history().stream()
+            .anyMatch(
+                r -> {
+                  Event e = AvroUtil.decode(r.value());
+                  return e.type() == PayloadType.COMMIT_COMPLETE;
+                });
+    assertThat(hasCommitComplete).isFalse();
+  }
+
+  @Test
+  public void testStaleSucceedsCurrentFails() {
+    // When a stale group commits but the current group fails, the stale group's
+    // envelopes should be removed and its snapshot should exist. The current group's
+    // envelopes remain in the buffer for retry. No CommitComplete is sent.
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // Inject a stale DataWritten with valid data.
+    UUID staleCommitId = UUID.randomUUID();
+    Event staleResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                staleCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(EventTestUtil.createDataFile()),
+                ImmutableList.of()));
+    byte[] staleBytes = AvroUtil.encode(staleResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0, "key", staleBytes));
+
+    // First process(): starts commit, consumes stale event.
+    coordinator.process();
+
+    byte[] bytes = producer.history().get(0).value();
+    Event startEvent = AvroUtil.decode(bytes);
+    UUID currentCommitId = ((StartCommit) startEvent.payload()).commitId();
+
+    // Add current-cycle DataWritten with a bad partition spec (will fail).
+    PartitionSpec badPartitionSpec =
+        PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
+    DataFile badDataFile =
+        DataFiles.builder(badPartitionSpec)
+            .withPath(UUID.randomUUID() + ".parquet")
+            .withFormat(FileFormat.PARQUET)
+            .withFileSizeInBytes(100L)
+            .withRecordCount(5)
+            .build();
+    Event currentResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                currentCommitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(badDataFile),
+                ImmutableList.of()));
+    bytes = AvroUtil.encode(currentResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+
+    Event currentReady =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                currentCommitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+    bytes = AvroUtil.encode(currentReady);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
+
+    // Second process(): stale group succeeds, current group fails.
+    coordinator.process();
+
+    table.refresh();
+    // Stale group committed: 1 snapshot with stale commitId.
+    List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
+    assertThat(snapshots).hasSize(1);
+    assertThat(snapshots.get(0).summary())
+        .containsEntry(COMMIT_ID_SNAPSHOT_PROP, staleCommitId.toString());
+
+    // No CommitComplete sent (buffer not fully drained — current group's envelopes remain).
+    boolean hasCommitComplete =
+        producer.history().stream()
+            .anyMatch(
+                r -> {
+                  Event e = AvroUtil.decode(r.value());
+                  return e.type() == PayloadType.COMMIT_COMPLETE;
+                });
+    assertThat(hasCommitComplete).isFalse();
+  }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorPartialCommit.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorPartialCommit.java
@@ -82,8 +82,7 @@ public class TestCoordinatorPartialCommit extends ChannelTestBase {
                 "member0",
                 "client0",
                 "host0",
-                new MemberAssignment(
-                    ImmutableSet.of(new TopicPartition("topic", 1)))));
+                new MemberAssignment(ImmutableSet.of(new TopicPartition("topic", 1)))));
 
     SinkTaskContext context = mock(SinkTaskContext.class);
     Coordinator coordinator = new Coordinator(catalog, config, members, clientFactory, context);
@@ -124,8 +123,7 @@ public class TestCoordinatorPartialCommit extends ChannelTestBase {
     DataFile dataFileA = EventTestUtil.createDataFile("path/to/data-a.parquet");
     DeleteFile deleteFileA = EventTestUtil.createDeleteFile("path/to/delete-a.parquet");
 
-    TableReference tableRef =
-        TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null);
+    TableReference tableRef = TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null);
     Event staleDataWrittenA =
         new Event(
             config.connectGroupId(),
@@ -136,14 +134,12 @@ public class TestCoordinatorPartialCommit extends ChannelTestBase {
                 ImmutableList.of(dataFileA),
                 ImmutableList.of(deleteFileA)));
 
-    OffsetDateTime tsA =
-        OffsetDateTime.ofInstant(Instant.ofEpochMilli(1000L), ZoneOffset.UTC);
+    OffsetDateTime tsA = OffsetDateTime.ofInstant(Instant.ofEpochMilli(1000L), ZoneOffset.UTC);
     Event staleDataCompleteA =
         new Event(
             config.connectGroupId(),
             new DataComplete(
-                commitIdA,
-                ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, tsA))));
+                commitIdA, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, tsA))));
 
     // Current cycle B's DataWritten and DataComplete
     DataFile dataFileB = EventTestUtil.createDataFile("path/to/data-b.parquet");
@@ -159,21 +155,21 @@ public class TestCoordinatorPartialCommit extends ChannelTestBase {
                 ImmutableList.of(dataFileB),
                 ImmutableList.of(deleteFileB)));
 
-    OffsetDateTime tsB =
-        OffsetDateTime.ofInstant(Instant.ofEpochMilli(2000L), ZoneOffset.UTC);
+    OffsetDateTime tsB = OffsetDateTime.ofInstant(Instant.ofEpochMilli(2000L), ZoneOffset.UTC);
     Event dataCompleteB =
         new Event(
             config.connectGroupId(),
             new DataComplete(
-                commitIdB,
-                ImmutableList.of(new TopicPartitionOffset("topic", 1, 2L, tsB))));
+                commitIdB, ImmutableList.of(new TopicPartitionOffset("topic", 1, 2L, tsB))));
 
     // Control topic order: A's events arrive before B's (single partition, producer ordering)
     int offset = 1;
     consumer.addRecord(
-        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(staleDataWrittenA)));
+        new ConsumerRecord<>(
+            CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(staleDataWrittenA)));
     consumer.addRecord(
-        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(staleDataCompleteA)));
+        new ConsumerRecord<>(
+            CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(staleDataCompleteA)));
     consumer.addRecord(
         new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(dataWrittenB)));
     consumer.addRecord(

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorPartialCommit.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorPartialCommit.java
@@ -72,8 +72,9 @@ public class TestCoordinatorPartialCommit extends ChannelTestBase {
   @Test
   public void testStaleDataWrittenFromPartialCommitSeparatedIntoDistinctRowDeltas() {
     when(config.commitIntervalMs()).thenReturn(0);
-    // Timeout = 0 to trigger immediate partial commit
-    when(config.commitTimeoutMs()).thenReturn(0);
+    // Timeout = -1 to guarantee immediate partial commit (strictly-greater check in
+    // isCommitTimedOut means 0 can race when startNewCommit and the check share a millisecond)
+    when(config.commitTimeoutMs()).thenReturn(-1);
 
     // 1 worker with 1 partition so totalPartitionCount = 1
     List<MemberDescription> members =

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorPartialCommit.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorPartialCommit.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.connect.events.AvroUtil;
+import org.apache.iceberg.connect.events.DataComplete;
+import org.apache.iceberg.connect.events.DataWritten;
+import org.apache.iceberg.connect.events.Event;
+import org.apache.iceberg.connect.events.PayloadType;
+import org.apache.iceberg.connect.events.StartCommit;
+import org.apache.iceberg.connect.events.TableReference;
+import org.apache.iceberg.connect.events.TopicPartitionOffset;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.kafka.clients.admin.MemberAssignment;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces the bug where stale DataWritten events from a partial commit (timeout) are merged into
+ * the next commit cycle's RowDelta, causing equality deletes to not apply correctly due to
+ * identical sequence numbers.
+ *
+ * <p>Scenario:
+ *
+ * <ol>
+ *   <li>Commit cycle A: Worker 0 is still processing, Coordinator times out and performs a partial
+ *       commit (no DataWritten from Worker 0)
+ *   <li>Worker 0 sends DataWritten(A) + DataComplete(A) to control topic
+ *   <li>Commit cycle B starts, Coordinator consumes Worker 0's stale DataWritten(A)
+ *   <li>Without the fix: stale and current DataWritten merge into one RowDelta (same sequence
+ *       number)
+ *   <li>With the fix: stale DataWritten(A) commits first (seq=1), current DataWritten(B) commits
+ *       second (seq=2), so equality deletes from cycle B correctly apply to cycle A data
+ * </ol>
+ */
+public class TestCoordinatorPartialCommit extends ChannelTestBase {
+
+  @Test
+  public void testStaleDataWrittenFromPartialCommitSeparatedIntoDistinctRowDeltas() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    // Timeout = 0 to trigger immediate partial commit
+    when(config.commitTimeoutMs()).thenReturn(0);
+
+    // 1 worker with 1 partition so totalPartitionCount = 1
+    List<MemberDescription> members =
+        ImmutableList.of(
+            new MemberDescription(
+                "member0",
+                "client0",
+                "host0",
+                new MemberAssignment(
+                    ImmutableSet.of(new TopicPartition("topic", 1)))));
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator = new Coordinator(catalog, config, members, clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // === Commit cycle A: immediate timeout -> partial commit (no data) ===
+    coordinator.process();
+
+    Event startCommitA = AvroUtil.decode(producer.history().get(0).value());
+    assertThat(startCommitA.type()).isEqualTo(PayloadType.START_COMMIT);
+    UUID commitIdA = ((StartCommit) startCommitA.payload()).commitId();
+
+    // Verify: no snapshots after partial commit (no DataWritten was available)
+    table.refresh();
+    assertThat(table.snapshots()).isEmpty();
+
+    // === Commit cycle B: normal commit via isCommitReady ===
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+    coordinator.process();
+
+    // Find StartCommit(B)
+    UUID commitIdB = null;
+    for (int i = producer.history().size() - 1; i >= 0; i--) {
+      Event evt = AvroUtil.decode(producer.history().get(i).value());
+      if (evt.type() == PayloadType.START_COMMIT) {
+        UUID id = ((StartCommit) evt.payload()).commitId();
+        if (!id.equals(commitIdA)) {
+          commitIdB = id;
+          break;
+        }
+      }
+    }
+    assertThat(commitIdB).isNotNull();
+    assertThat(commitIdB).isNotEqualTo(commitIdA);
+
+    // Worker 0's late DataWritten(A) — was still processing during cycle A's timeout
+    DataFile dataFileA = EventTestUtil.createDataFile("path/to/data-a.parquet");
+    DeleteFile deleteFileA = EventTestUtil.createDeleteFile("path/to/delete-a.parquet");
+
+    TableReference tableRef =
+        TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null);
+    Event staleDataWrittenA =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                commitIdA, // stale: cycle A's commitId
+                tableRef,
+                ImmutableList.of(dataFileA),
+                ImmutableList.of(deleteFileA)));
+
+    OffsetDateTime tsA =
+        OffsetDateTime.ofInstant(Instant.ofEpochMilli(1000L), ZoneOffset.UTC);
+    Event staleDataCompleteA =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                commitIdA,
+                ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, tsA))));
+
+    // Current cycle B's DataWritten and DataComplete
+    DataFile dataFileB = EventTestUtil.createDataFile("path/to/data-b.parquet");
+    DeleteFile deleteFileB = EventTestUtil.createDeleteFile("path/to/delete-b.parquet");
+
+    Event dataWrittenB =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                commitIdB, // current: cycle B's commitId
+                tableRef,
+                ImmutableList.of(dataFileB),
+                ImmutableList.of(deleteFileB)));
+
+    OffsetDateTime tsB =
+        OffsetDateTime.ofInstant(Instant.ofEpochMilli(2000L), ZoneOffset.UTC);
+    Event dataCompleteB =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                commitIdB,
+                ImmutableList.of(new TopicPartitionOffset("topic", 1, 2L, tsB))));
+
+    // Control topic order: A's events arrive before B's (single partition, producer ordering)
+    int offset = 1;
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(staleDataWrittenA)));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(staleDataCompleteA)));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(dataWrittenB)));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset++, "key", AvroUtil.encode(dataCompleteB)));
+
+    // Process: DataComplete(B) triggers isCommitReady -> commit
+    when(config.commitIntervalMs()).thenReturn(Integer.MAX_VALUE);
+    coordinator.process();
+
+    // === Verification: two separate snapshots (stale A first, current B second) ===
+    table.refresh();
+    List<Snapshot> snapshots = ImmutableList.copyOf(table.snapshots());
+    assertThat(snapshots).hasSize(2);
+
+    // Snapshot 1: cycle A's files (stale, committed first with lower sequence number)
+    Snapshot snapshotA = snapshots.get(0);
+    assertThat(snapshotA.addedDataFiles(table.io())).hasSize(1);
+    assertThat(snapshotA.addedDeleteFiles(table.io())).hasSize(1);
+
+    // Snapshot 2: cycle B's files (current, committed second with higher sequence number)
+    Snapshot snapshotB = snapshots.get(1);
+    assertThat(snapshotB.addedDataFiles(table.io())).hasSize(1);
+    assertThat(snapshotB.addedDeleteFiles(table.io())).hasSize(1);
+
+    // Key assertion: sequence number ordering ensures equality deletes work correctly
+    // Cycle B's equality delete (seq=2) applies to cycle A's data (seq=1) because 1 < 2
+    assertThat(snapshotA.sequenceNumber()).isLessThan(snapshotB.sequenceNumber());
+
+    // Only the last batch (cycle B) should have the commit ID in snapshot properties
+    assertThat(snapshotB.summary()).containsEntry(COMMIT_ID_SNAPSHOT_PROP, commitIdB.toString());
+  }
+}


### PR DESCRIPTION
## Per-commitId group separation for stale DataWritten recovery

### Problem

When `Coordinator.doCommit()` fails or times out, stale `DataWritten` events from the
previous commit cycle persist in the buffer. On the next successful commit,
`tableCommitMap()` merges stale and current events into a single `RowDelta`. All files
receive the same Iceberg sequence number, which breaks equality delete semantics
(`data_sequence_number < delete_sequence_number` required, strictly less-than). This
causes duplicate rows in append workloads. (The same sequence-number collision would also
affect CDC/equality-delete workloads, though those are out of scope for this PR.)

Clearing the buffer on new commits is not safe either: workers that finished after a
partial-commit timeout have already committed source offsets via
`sendOffsetsToTransaction()`, so their `DataWritten` events cannot be re-produced.
Discarding them causes data loss.

### Solution

Stale events are retained in the buffer and committed separately — each commitId group in
its own `RowDelta` with a distinct Iceberg sequence number.

#### CommitState

- **`tableCommitGroups()`** groups buffered envelopes by table, then by commitId within
  each table. Uses `LinkedHashMap` to preserve control-topic consumption order — stale
  groups sort before current groups and receive lower sequence numbers.
- **`removeEnvelopes()`** selectively removes only successfully committed envelopes from
  the buffer. Failed groups are retained for retry in subsequent cycles.
- **Adaptive retry tracking** via `recordGroupFailure()` / `recordGroupSuccess()` /
  `isGroupBlocking()` — per-commitId retry counter using `ConcurrentHashMap`.
- **`CommitStateMXBean`** JMX interface exposing `StaleGroupCount` and `BufferSize` for
  operational monitoring.

#### Coordinator

- **`doCommit()`** iterates commitId groups per table sequentially (oldest first). Tables
  are committed in parallel via `Tasks.foreach()`.
- **Per-group offset isolation**: stale groups write only their own envelope offsets to
  the Iceberg snapshot, not the global consumer position. This prevents an offset
  poisoning scenario where subsequent groups' envelopes would be incorrectly filtered out
  by Iceberg's offset-based deduplication.
- **Sequence number ordering**: if a stale group fails, remaining groups for that table
  are skipped to preserve strictly increasing sequence numbers.
- **Retry exhaustion**: when a stale group exceeds `stale-max-blocking-retries`, a
  `ConnectException` is thrown and propagated to move the connector to `FAILED` state,
  forcing operator intervention.
- **Partial offset advancement**: when the buffer is not fully drained, consumer offsets
  advance to the minimum uncommitted envelope offset per partition, bounding
  re-consumption on restart.

#### Channel

- **`commitConsumerOffsetsTo(Map)`** commits specific partition offsets to Kafka, used for
  partial offset advancement when groups remain in the buffer.

### Configuration

| Property | Default | Description |
|----------|---------|-------------|
| `iceberg.control.commit.stale-max-blocking-retries` | `3` | Number of times a stale group blocks subsequent groups before failing the connector. `0` = fail immediately. |

### Test coverage

**CommitState unit tests** (`TestCommitState.java`):

- `testTableCommitGroupsSingleCommitId` — single group, correct envelope count
- `testTableCommitGroupsMultipleCommitIds` — stale + current groups, ordered correctly
- `testTableCommitGroupsPreservesInsertionOrder` — interleaved commitIds, first-seen order
- `testStartNewCommitDoesNotClearBuffer` — stale events survive across cycles
- `testRemoveEnvelopesSelectiveRemoval` — only specified envelopes removed
- `testIsBufferEmpty` — empty after clear, not empty after add

**Coordinator integration tests** (`TestCoordinator.java`):

- `testMultiGroupCommitProducesSequentialSnapshots` — stale + current groups produce 2
  snapshots with strictly increasing sequence numbers and distinct commitIds
- `testStaleGroupBlocksForNRetriesThenStopsBlocking` — parameterized (0, 3): `isGroupBlocking`
  blocks for N retries, stops on N+1
- `testStaleGroupBlocksThenThrowsConnectException` — parameterized (0, 3):
  `ConnectException` propagates after N+1 failures
- `testStaleGroupFailureStopsConnector` — exception contains "Connector stopping", no
  `CommitComplete` sent
- `testZeroRetriesMultiTableCommitsGoodTableBeforeFailing` — 2 tables, retries=0: good
  table snapshot saved before connector dies
- `testMultiTablePartialCommitWithStaleExhaustion` — 2 tables, retries=3: good table
  accumulates 4 snapshots, bad table gets 0, then `ConnectException`

**Recovery scenario test** (`TestRecoveryScenario.java`):

- `testSequentialCommitsProduceSeparateSnapshots` — sequential commits produce 2 snapshots
  with increasing sequence numbers

### Acknowledgements

The core per-commitId group separation approach was originally contributed by @koodin9,
who identified that clearing the buffer causes data loss in partial-commit scenarios and
implemented the fix of committing each commitId group in its own `RowDelta`. This PR
rebases that original implementation onto @koodin9's branch and extends it with production
hardening: selective buffer draining, per-group offset isolation, configurable retry
escalation, partial offset advancement, `ConnectException` propagation, and JMX monitoring.
The final design was shaped through collaborative review with @koodin9.
