### PR TITLE
site: add back privacy plugin

### DIFF
--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -28,7 +28,7 @@ AWS provides a [comprehensive suite of services](https://aws.amazon.com/what-is/
 
 ### [BladePipe](https://bladepipe.com)
 
-BladePipe is a real-time end-to-end data integration tool, offering 40+ out-of-the-box connectors. It provides a one-stop data movement solution, including schema evolution, data migration and sync, verification and correction, monitoring and alerting. With sub-second latency, BladePipe captures change data from MySQL, Oracle, PostgreSQL and other sources and streams it to Iceberg and more, all without writing a single line of code. It offers [on-premise and BYOC deployment options](https://www.bladepipe.com/pricing). Learn more about how to build a pipeline with BladePipe [here](https://www.bladepipe.com/docs/quick/quick_start_byoc).
+BladePipe is a real-time end-to-end data integration tool, offering 40+ out-of-the-box connectors. It provides a one-stop data movement solution, including schema evolution, data migration and sync, verification and correction, monitoring and alerting. With sub-second latency, BladePipe captures change data from MySQL, Oracle, PostgreSQL and other sources and streams it to Iceberg and more, all without writing a single line of code. It offers [on-premise and BYOC deployment options](https://www.bladepipe.com/pricing). Learn more about how to build a pipeline with BladePipe [here](https://doc.bladepipe.com/quick/quick_start_byoc).
 
 ### [Bodo](https://bodo.ai)
 

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -66,7 +66,9 @@ plugins:
         rss_created: rss.xml
   - macros
   - monorepo
-  - privacy
+  - privacy:
+      assets_exclude:
+        - '*bladepipe.com/*'
   - offline:
       enabled: !ENV [OFFLINE, false]
   - redirects:


### PR DESCRIPTION
Follow up to #15643, we should probably add back `privacy` plugin for compliance with GDPR 
https://squidfunk.github.io/mkdocs-material/plugins/privacy/

`make build` was erroring with 
```
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/iceberg/iceberg/site/.cache/plugin/privacy/assets/external/doc.bladepipe.com/assets/images/1-afd4d16b1739f59151ceb30d6189cfc4.png'
```
Fixed by excluding `*bladepipe.com/*` from `privacy` plugin. It tries to fetch assets an assert thats missing. 