### PR TITLE
Flink: Pass FileIO on Flink's read path

### DIFF
--- a/api/src/main/java/org/apache/iceberg/BatchScan.java
+++ b/api/src/main/java/org/apache/iceberg/BatchScan.java
@@ -74,7 +74,7 @@ public interface BatchScan extends Scan<BatchScan, ScanTask, ScanTaskGroup<ScanT
 
   /** Returns the {@link FileIO} instance to use when reading data files for this scan. */
   @Override
-  default Supplier<FileIO> io() {
+  default Supplier<FileIO> fileIO() {
     return table()::io;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/BatchScan.java
+++ b/api/src/main/java/org/apache/iceberg/BatchScan.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.util.function.Supplier;
 import org.apache.iceberg.io.FileIO;
 
 /** API for configuring a batch scan. */
@@ -73,7 +74,7 @@ public interface BatchScan extends Scan<BatchScan, ScanTask, ScanTaskGroup<ScanT
 
   /** Returns the {@link FileIO} instance to use when reading data files for this scan. */
   @Override
-  default FileIO io() {
-    return table().io();
+  default Supplier<FileIO> io() {
+    return table()::io;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/BatchScanAdapter.java
+++ b/api/src/main/java/org/apache/iceberg/BatchScanAdapter.java
@@ -41,8 +41,8 @@ public class BatchScanAdapter implements BatchScan {
   }
 
   @Override
-  public Supplier<FileIO> io() {
-    return scan.io();
+  public Supplier<FileIO> fileIO() {
+    return scan.fileIO();
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/BatchScanAdapter.java
+++ b/api/src/main/java/org/apache/iceberg/BatchScanAdapter.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
@@ -40,7 +41,7 @@ public class BatchScanAdapter implements BatchScan {
   }
 
   @Override
-  public FileIO io() {
+  public Supplier<FileIO> io() {
     return scan.io();
   }
 

--- a/api/src/main/java/org/apache/iceberg/Scan.java
+++ b/api/src/main/java/org/apache/iceberg/Scan.java
@@ -212,7 +212,7 @@ public interface Scan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>> {
   }
 
   /** Returns the {@link FileIO} instance to use when reading data files for this scan. */
-  default Supplier<FileIO> io() {
-    throw new UnsupportedOperationException("io() is not implemented: added in 1.11.0");
+  default Supplier<FileIO> fileIO() {
+    throw new UnsupportedOperationException("fileIO() is not implemented: added in 1.11.0");
   }
 }

--- a/api/src/main/java/org/apache/iceberg/Scan.java
+++ b/api/src/main/java/org/apache/iceberg/Scan.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
@@ -211,7 +212,7 @@ public interface Scan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>> {
   }
 
   /** Returns the {@link FileIO} instance to use when reading data files for this scan. */
-  default FileIO io() {
+  default Supplier<FileIO> io() {
     throw new UnsupportedOperationException("io() is not implemented: added in 1.11.0");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -194,7 +194,7 @@ abstract class BaseDistributedDataScan
   }
 
   private List<ManifestFile> findMatchingDataManifests(Snapshot snapshot) {
-    List<ManifestFile> dataManifests = snapshot.dataManifests(io().get());
+    List<ManifestFile> dataManifests = snapshot.dataManifests(io());
     scanMetrics().totalDataManifests().increment(dataManifests.size());
 
     List<ManifestFile> matchingDataManifests = filterManifests(dataManifests);
@@ -205,7 +205,7 @@ abstract class BaseDistributedDataScan
   }
 
   private List<ManifestFile> findMatchingDeleteManifests(Snapshot snapshot) {
-    List<ManifestFile> deleteManifests = snapshot.deleteManifests(io().get());
+    List<ManifestFile> deleteManifests = snapshot.deleteManifests(io());
     scanMetrics().totalDeleteManifests().increment(deleteManifests.size());
 
     List<ManifestFile> matchingDeleteManifests = filterManifests(deleteManifests);
@@ -293,7 +293,7 @@ abstract class BaseDistributedDataScan
   }
 
   private DeleteFileIndex planDeletesLocally(List<ManifestFile> deleteManifests) {
-    DeleteFileIndex.Builder builder = DeleteFileIndex.builderFor(io().get(), deleteManifests);
+    DeleteFileIndex.Builder builder = DeleteFileIndex.builderFor(io(), deleteManifests);
 
     if (shouldPlanWithExecutor() && deleteManifests.size() > 1) {
       builder.planWith(planExecutor());

--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -194,7 +194,7 @@ abstract class BaseDistributedDataScan
   }
 
   private List<ManifestFile> findMatchingDataManifests(Snapshot snapshot) {
-    List<ManifestFile> dataManifests = snapshot.dataManifests(io());
+    List<ManifestFile> dataManifests = snapshot.dataManifests(io().get());
     scanMetrics().totalDataManifests().increment(dataManifests.size());
 
     List<ManifestFile> matchingDataManifests = filterManifests(dataManifests);
@@ -205,7 +205,7 @@ abstract class BaseDistributedDataScan
   }
 
   private List<ManifestFile> findMatchingDeleteManifests(Snapshot snapshot) {
-    List<ManifestFile> deleteManifests = snapshot.deleteManifests(io());
+    List<ManifestFile> deleteManifests = snapshot.deleteManifests(io().get());
     scanMetrics().totalDeleteManifests().increment(deleteManifests.size());
 
     List<ManifestFile> matchingDeleteManifests = filterManifests(deleteManifests);
@@ -293,7 +293,7 @@ abstract class BaseDistributedDataScan
   }
 
   private DeleteFileIndex planDeletesLocally(List<ManifestFile> deleteManifests) {
-    DeleteFileIndex.Builder builder = DeleteFileIndex.builderFor(io(), deleteManifests);
+    DeleteFileIndex.Builder builder = DeleteFileIndex.builderFor(io().get(), deleteManifests);
 
     if (shouldPlanWithExecutor() && deleteManifests.size() > 1) {
       builder.planWith(planExecutor());

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
@@ -103,8 +104,8 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
   }
 
   @Override
-  public FileIO io() {
-    return table.io();
+  public Supplier<FileIO> io() {
+    return table::io;
   }
 
   protected Schema tableSchema() {

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -103,8 +103,16 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     return table;
   }
 
+  /**
+   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link BaseScan#fileIO()} instead.
+   */
+  @Deprecated
+  protected FileIO io() {
+    return table.io();
+  }
+
   @Override
-  public Supplier<FileIO> io() {
+  public Supplier<FileIO> fileIO() {
     return table::io;
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataScan.java
@@ -49,7 +49,7 @@ abstract class DataScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
       boolean withColumnStats) {
 
     ManifestGroup manifestGroup =
-        new ManifestGroup(io().get(), dataManifests, deleteManifests)
+        new ManifestGroup(io(), dataManifests, deleteManifests)
             .caseSensitive(isCaseSensitive())
             .select(withColumnStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS)
             .filterData(filter())

--- a/core/src/main/java/org/apache/iceberg/DataScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataScan.java
@@ -49,7 +49,7 @@ abstract class DataScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
       boolean withColumnStats) {
 
     ManifestGroup manifestGroup =
-        new ManifestGroup(io(), dataManifests, deleteManifests)
+        new ManifestGroup(io().get(), dataManifests, deleteManifests)
             .caseSensitive(isCaseSensitive())
             .select(withColumnStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS)
             .filterData(filter())

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Supplier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.requests.PlanTableScanRequest;
@@ -129,10 +130,12 @@ class RESTTableScan extends DataTableScan {
   }
 
   @Override
-  public FileIO io() {
-    Preconditions.checkState(
-        null != scanFileIO, "FileIO is not available: planFiles() must be called first");
-    return scanFileIO;
+  public Supplier<FileIO> io() {
+    return () -> {
+      Preconditions.checkState(
+          null != scanFileIO, "FileIO is not available: planFiles() must be called first");
+      return scanFileIO;
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -130,7 +130,7 @@ class RESTTableScan extends DataTableScan {
   }
 
   @Override
-  public Supplier<FileIO> io() {
+  public Supplier<FileIO> fileIO() {
     return () -> {
       Preconditions.checkState(
           null != scanFileIO, "FileIO is not available: planFiles() must be called first");

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -996,18 +996,19 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
     assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
 
     TableScan tableScan = table.newScan();
-    assertThatThrownBy(tableScan::io)
+    assertThatThrownBy(() -> tableScan.io().get())
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("FileIO is not available: planFiles() must be called first");
 
     // make sure remote scan planning is called and FileIO gets the planId
     assertThat(tableScan.planFiles()).hasSize(1);
     assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
-    assertThat(tableScan.io().properties()).containsKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
-    String planId = tableScan.io().properties().get(RESTCatalogProperties.REST_SCAN_PLAN_ID);
+    assertThat(tableScan.io().get().properties())
+        .containsKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
+    String planId = tableScan.io().get().properties().get(RESTCatalogProperties.REST_SCAN_PLAN_ID);
 
     TableScan newScan = table.newScan();
-    assertThatThrownBy(newScan::io)
+    assertThatThrownBy(() -> newScan.io().get())
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("FileIO is not available: planFiles() must be called first");
 
@@ -1016,8 +1017,9 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
     assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
 
     // make sure planIds are different for each scan
-    assertThat(newScan.io().properties()).containsKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
-    assertThat(newScan.io().properties().get(RESTCatalogProperties.REST_SCAN_PLAN_ID))
+    assertThat(newScan.io().get().properties())
+        .containsKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
+    assertThat(newScan.io().get().properties().get(RESTCatalogProperties.REST_SCAN_PLAN_ID))
         .isNotEqualTo(planId);
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -996,19 +996,20 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
     assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
 
     TableScan tableScan = table.newScan();
-    assertThatThrownBy(() -> tableScan.io().get())
+    assertThatThrownBy(() -> tableScan.fileIO().get())
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("FileIO is not available: planFiles() must be called first");
 
     // make sure remote scan planning is called and FileIO gets the planId
     assertThat(tableScan.planFiles()).hasSize(1);
     assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
-    assertThat(tableScan.io().get().properties())
+    assertThat(tableScan.fileIO().get().properties())
         .containsKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
-    String planId = tableScan.io().get().properties().get(RESTCatalogProperties.REST_SCAN_PLAN_ID);
+    String planId =
+        tableScan.fileIO().get().properties().get(RESTCatalogProperties.REST_SCAN_PLAN_ID);
 
     TableScan newScan = table.newScan();
-    assertThatThrownBy(() -> newScan.io().get())
+    assertThatThrownBy(() -> newScan.fileIO().get())
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("FileIO is not available: planFiles() must be called first");
 
@@ -1017,9 +1018,9 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
     assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
 
     // make sure planIds are different for each scan
-    assertThat(newScan.io().get().properties())
+    assertThat(newScan.fileIO().get().properties())
         .containsKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
-    assertThat(newScan.io().get().properties().get(RESTCatalogProperties.REST_SCAN_PLAN_ID))
+    assertThat(newScan.fileIO().get().properties().get(RESTCatalogProperties.REST_SCAN_PLAN_ID))
         .isNotEqualTo(planId);
   }
 

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -120,6 +120,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     testImplementation libs.awaitility
     testImplementation libs.assertj.core
     testImplementation libs.sqlite.jdbc
+    testRuntimeOnly libs.jetty.servlet
   }
 
   test {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iceberg.flink.source;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
@@ -34,6 +36,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -45,11 +48,11 @@ public class FlinkSplitPlanner {
 
   static FlinkInputSplit[] planInputSplits(
       Table table, ScanContext context, ExecutorService workerPool) {
-    try (CloseableIterable<CombinedScanTask> tasksIterable =
-        planTasks(table, context, workerPool)) {
-      List<CombinedScanTask> tasks = Lists.newArrayList(tasksIterable);
+    try (PlanResult planResult = planTasks(table, context, workerPool)) {
+      List<CombinedScanTask> tasks = Lists.newArrayList(planResult.tasks());
       FlinkInputSplit[] splits = new FlinkInputSplit[tasks.size()];
       boolean exposeLocality = context.exposeLocality();
+      Supplier<FileIO> fileIO = planResult.fileIO();
 
       Tasks.range(tasks.size())
           .stopOnFailure()
@@ -59,7 +62,7 @@ public class FlinkSplitPlanner {
                 CombinedScanTask task = tasks.get(index);
                 String[] hostnames = null;
                 if (exposeLocality) {
-                  hostnames = Util.blockLocations(table.io(), task);
+                  hostnames = Util.blockLocations(fileIO.get(), task);
                 }
                 splits[index] = new FlinkInputSplit(index, task, hostnames);
               });
@@ -72,17 +75,41 @@ public class FlinkSplitPlanner {
   /** This returns splits for the FLIP-27 source */
   public static List<IcebergSourceSplit> planIcebergSourceSplits(
       Table table, ScanContext context, ExecutorService workerPool) {
-    try (CloseableIterable<CombinedScanTask> tasksIterable =
-        planTasks(table, context, workerPool)) {
+    try (PlanResult planResult = planTasks(table, context, workerPool)) {
       return Lists.newArrayList(
-          CloseableIterable.transform(tasksIterable, IcebergSourceSplit::fromCombinedScanTask));
+          CloseableIterable.transform(
+              planResult.tasks(),
+              task -> IcebergSourceSplit.fromCombinedScanTask(task, planResult.fileIO().get())));
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to process task iterable: ", e);
     }
   }
 
-  static CloseableIterable<CombinedScanTask> planTasks(
-      Table table, ScanContext context, ExecutorService workerPool) {
+  /** Result of planning that includes the scan's FileIO for use when reading. */
+  private static class PlanResult implements Closeable {
+    private final CloseableIterable<CombinedScanTask> tasks;
+    private final Supplier<FileIO> fileIO;
+
+    PlanResult(CloseableIterable<CombinedScanTask> tasks, Supplier<FileIO> fileIO) {
+      this.tasks = tasks;
+      this.fileIO = fileIO;
+    }
+
+    CloseableIterable<CombinedScanTask> tasks() {
+      return tasks;
+    }
+
+    Supplier<FileIO> fileIO() {
+      return fileIO;
+    }
+
+    @Override
+    public void close() throws IOException {
+      tasks.close();
+    }
+  }
+
+  static PlanResult planTasks(Table table, ScanContext context, ExecutorService workerPool) {
     ScanMode scanMode = checkScanMode(context);
     if (scanMode == ScanMode.INCREMENTAL_APPEND_SCAN) {
       IncrementalAppendScan scan = table.newIncrementalAppendScan();
@@ -116,7 +143,7 @@ public class FlinkSplitPlanner {
         scan = scan.toSnapshot(context.endSnapshotId());
       }
 
-      return scan.planTasks();
+      return new PlanResult(scan.planTasks(), scan.fileIO());
     } else {
       TableScan scan = table.newScan();
       scan = refineScanWithBaseConfigs(scan, context, workerPool);
@@ -133,7 +160,7 @@ public class FlinkSplitPlanner {
         scan = scan.asOfTime(context.asOfTimestamp());
       }
 
-      return scan.planTasks();
+      return new PlanResult(scan.planTasks(), scan.fileIO());
     }
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/AvroGenericRecordReaderFunction.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/AvroGenericRecordReaderFunction.java
@@ -89,10 +89,11 @@ public class AvroGenericRecordReaderFunction extends DataIteratorReaderFunction<
 
   @Override
   protected DataIterator<GenericRecord> createDataIterator(IcebergSourceSplit split) {
+    FileIO ioForSplit = split.fileIO() != null ? split.fileIO() : io;
     return new DataIterator<>(
         new AvroGenericRecordFileScanTaskReader(rowDataReader, lazyConverter()),
         split.task(),
-        io,
+        ioForSplit,
         encryption);
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ConverterReaderFunction.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ConverterReaderFunction.java
@@ -73,12 +73,13 @@ public class ConverterReaderFunction<T> extends DataIteratorReaderFunction<T> {
 
   @Override
   protected DataIterator<T> createDataIterator(IcebergSourceSplit split) {
+    FileIO ioForSplit = split.fileIO() != null ? split.fileIO() : io;
     RowDataFileScanTaskReader rowDataReader =
         new RowDataFileScanTaskReader(tableSchema, readSchema, nameMapping, caseSensitive, filters);
     return new LimitableDataIterator<>(
         new ConverterFileScanTaskReader<>(rowDataReader, converter),
         split.task(),
-        io,
+        ioForSplit,
         encryption,
         lazyLimiter());
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/MetaDataReaderFunction.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/MetaDataReaderFunction.java
@@ -55,7 +55,8 @@ public class MetaDataReaderFunction extends DataIteratorReaderFunction<RowData> 
 
   @Override
   public DataIterator<RowData> createDataIterator(IcebergSourceSplit split) {
-    return new DataIterator<>(new DataTaskReader(readSchema), split.task(), io, encryption);
+    FileIO ioForSplit = split.fileIO() != null ? split.fileIO() : io;
+    return new DataIterator<>(new DataTaskReader(readSchema), split.task(), ioForSplit, encryption);
   }
 
   private static Schema readSchema(Schema tableSchema, Schema projectedSchema) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowDataReaderFunction.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowDataReaderFunction.java
@@ -91,10 +91,11 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
 
   @Override
   public DataIterator<RowData> createDataIterator(IcebergSourceSplit split) {
+    FileIO ioForSplit = split.fileIO() != null ? split.fileIO() : io;
     return new LimitableDataIterator<>(
         new RowDataFileScanTaskReader(tableSchema, readSchema, nameMapping, caseSensitive, filters),
         split.task(),
-        io,
+        ioForSplit,
         encryption,
         lazyLimiter());
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskParser;
 import org.apache.iceberg.flink.util.SerializerHelper;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -50,14 +51,19 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
   private int fileOffset;
   private long recordOffset;
 
+  /** FileIO from the scan */
+  @Nullable private final FileIO fileIO;
+
   // The splits are frequently serialized into checkpoints.
   // Caching the byte representation makes repeated serialization cheap.
   @Nullable private transient byte[] serializedBytesCache;
 
-  private IcebergSourceSplit(CombinedScanTask task, int fileOffset, long recordOffset) {
+  private IcebergSourceSplit(
+      CombinedScanTask task, int fileOffset, long recordOffset, @Nullable FileIO fileIO) {
     this.task = task;
     this.fileOffset = fileOffset;
     this.recordOffset = recordOffset;
+    this.fileIO = fileIO;
   }
 
   public static IcebergSourceSplit fromCombinedScanTask(CombinedScanTask combinedScanTask) {
@@ -66,7 +72,18 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
 
   public static IcebergSourceSplit fromCombinedScanTask(
       CombinedScanTask combinedScanTask, int fileOffset, long recordOffset) {
-    return new IcebergSourceSplit(combinedScanTask, fileOffset, recordOffset);
+    return new IcebergSourceSplit(combinedScanTask, fileOffset, recordOffset, null);
+  }
+
+  public static IcebergSourceSplit fromCombinedScanTask(
+      CombinedScanTask combinedScanTask, @Nullable FileIO fileIO) {
+    return new IcebergSourceSplit(combinedScanTask, 0, 0L, fileIO);
+  }
+
+  /** Returns the FileIO from the scan */
+  @Nullable
+  public FileIO fileIO() {
+    return fileIO;
   }
 
   public CombinedScanTask task() {
@@ -140,6 +157,10 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
     return serialize(3);
   }
 
+  byte[] serializeV4() throws IOException {
+    return serialize(4);
+  }
+
   private byte[] serialize(int version) throws IOException {
     if (serializedBytesCache == null) {
       DataOutputSerializer out = SERIALIZER_CACHE.get();
@@ -159,6 +180,17 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
         writeTaskJson(out, taskJson, version);
       }
 
+      if (version >= 4) {
+        if (fileIO != null) {
+          out.writeBoolean(true);
+          byte[] fileIOBytes = InstantiationUtil.serializeObject(fileIO);
+          out.writeInt(fileIOBytes.length);
+          out.write(fileIOBytes);
+        } else {
+          out.writeBoolean(false);
+        }
+      }
+
       serializedBytesCache = out.getCopyOfBuffer();
       out.clear();
     }
@@ -173,6 +205,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
         out.writeUTF(taskJson);
         break;
       case 3:
+      case 4:
         SerializerHelper.writeLongUTF(out, taskJson);
         break;
       default:
@@ -190,6 +223,11 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
     return deserialize(serialized, caseSensitive, 3);
   }
 
+  static IcebergSourceSplit deserializeV4(byte[] serialized, boolean caseSensitive)
+      throws IOException {
+    return deserialize(serialized, caseSensitive, 4);
+  }
+
   private static IcebergSourceSplit deserialize(
       byte[] serialized, boolean caseSensitive, int version) throws IOException {
     DataInputDeserializer in = new DataInputDeserializer(serialized);
@@ -204,8 +242,24 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
       tasks.add(task);
     }
 
-    CombinedScanTask combinedScanTask = new BaseCombinedScanTask(tasks);
-    return IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, fileOffset, recordOffset);
+    FileIO fileIO = null;
+    if (version >= 4) {
+      if (in.readBoolean()) {
+        int length = in.readInt();
+        byte[] fileIOBytes = new byte[length];
+        in.read(fileIOBytes);
+        try {
+          fileIO =
+              InstantiationUtil.deserializeObject(
+                  fileIOBytes, IcebergSourceSplit.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+          throw new RuntimeException("Failed to deserialize FileIO from split", e);
+        }
+      }
+    }
+
+    return new IcebergSourceSplit(
+        new BaseCombinedScanTask(tasks), fileOffset, recordOffset, fileIO);
   }
 
   private static String readTaskJson(DataInputDeserializer in, int version) throws IOException {
@@ -213,6 +267,7 @@ public class IcebergSourceSplit implements SourceSplit, Serializable {
       case 2:
         return in.readUTF();
       case 3:
+      case 4:
         return SerializerHelper.readLongUTF(in);
       default:
         throw new IllegalArgumentException("Unsupported version: " + version);

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
@@ -25,7 +25,7 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 @Internal
 public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<IcebergSourceSplit> {
-  private static final int VERSION = 3;
+  private static final int VERSION = 4;
 
   private final boolean caseSensitive;
 
@@ -40,7 +40,7 @@ public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<I
 
   @Override
   public byte[] serialize(IcebergSourceSplit split) throws IOException {
-    return split.serializeV3();
+    return split.serializeV4();
   }
 
   @Override
@@ -52,6 +52,8 @@ public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<I
         return IcebergSourceSplit.deserializeV2(serialized, caseSensitive);
       case 3:
         return IcebergSourceSplit.deserializeV3(serialized, caseSensitive);
+      case 4:
+        return IcebergSourceSplit.deserializeV4(serialized, caseSensitive);
       default:
         throw new IOException(
             String.format(

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestRemoteScanPlanning.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestRemoteScanPlanning.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source;
+
+import static org.apache.iceberg.TestBase.FILE_A;
+import static org.apache.iceberg.TestBase.SCHEMA;
+import static org.apache.iceberg.TestBase.SPEC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.Endpoint;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.ImmutableHTTPRequest;
+import org.apache.iceberg.rest.PlanStatus;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RESTCatalogProperties;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.TestBaseWithRESTServer;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.PlanTableScanResponse;
+import org.apache.iceberg.util.ThreadPools;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestRemoteScanPlanning extends TestBaseWithRESTServer {
+
+  @Override
+  protected String catalogName() {
+    return "flink-with-remote-scan-planning";
+  }
+
+  @Override
+  protected RESTCatalogAdapter createAdapterForServer() {
+    return Mockito.spy(
+        new RESTCatalogAdapter(backendCatalog) {
+          @SuppressWarnings("unchecked")
+          @Override
+          public <T extends RESTResponse> T execute(
+              HTTPRequest request,
+              Class<T> responseType,
+              Consumer<ErrorResponse> errorHandler,
+              Consumer<Map<String, String>> responseHeaders) {
+            Object body = roundTripSerialize(request.body(), "request");
+            HTTPRequest req = ImmutableHTTPRequest.builder().from(request).body(body).build();
+            T restResponse = super.execute(req, responseType, errorHandler, responseHeaders);
+            if (restResponse instanceof ConfigResponse response) {
+              restResponse =
+                  (T)
+                      ConfigResponse.builder()
+                          .withEndpoints(
+                              ImmutableList.<Endpoint>builder()
+                                  .addAll(response.endpoints())
+                                  .add(Endpoint.V1_SUBMIT_TABLE_SCAN_PLAN)
+                                  .build())
+                          .withOverrides(
+                              ImmutableMap.of(
+                                  RESTCatalogProperties.REST_SCAN_PLANNING_ENABLED, "true"))
+                          .build();
+            } else if (restResponse instanceof PlanTableScanResponse response
+                && PlanStatus.COMPLETED == response.planStatus()) {
+              return (T)
+                  PlanTableScanResponse.builder()
+                      .withPlanStatus(response.planStatus())
+                      .withPlanId(response.planId())
+                      .withFileScanTasks(response.fileScanTasks())
+                      .withSpecsById(response.specsById())
+                      .withCredentials(
+                          ImmutableList.of(
+                              ImmutableCredential.builder()
+                                  .prefix("gcs")
+                                  .putConfig("gcs.oauth2.token", "dummyToken")
+                                  .build()))
+                      .build();
+            }
+            return roundTripSerialize(restResponse, "response");
+          }
+        });
+  }
+
+  @Test
+  public void fileIOIsPropagated() {
+    restCatalog.createNamespace(NS);
+    Table table =
+        restCatalog
+            .buildTable(TableIdentifier.of(NS, "file_io_propagation"), SCHEMA)
+            .withPartitionSpec(SPEC)
+            .create();
+    table.newAppend().appendFile(FILE_A).commit();
+
+    assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
+
+    ScanContext scanContext = ScanContext.builder().project(table.schema()).build();
+    List<IcebergSourceSplit> splits =
+        FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, ThreadPools.getWorkerPool());
+
+    assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
+    assertThat(splits)
+        .isNotEmpty()
+        .anySatisfy(
+            split -> {
+              assertThat(split.fileIO()).isNotNull();
+              assertThat(split.fileIO().properties())
+                  .containsKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
+            });
+  }
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/source/TestRemoteScanPlanning.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/source/TestRemoteScanPlanning.java
@@ -16,15 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.spark.extensions;
+package org.apache.iceberg.spark.source;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.RESTCatalogProperties;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.sql.TestSelect;
+import org.apache.spark.sql.connector.read.Batch;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
@@ -45,5 +56,35 @@ public class TestRemoteScanPlanning extends TestSelect {
         SparkCatalogConfig.REST.catalogName() + ".default.binary_table"
       }
     };
+  }
+
+  @TestTemplate
+  public void fileIOIsPropagated() {
+    RESTCatalog catalog = new RESTCatalog();
+    catalog.setConf(new Configuration());
+    catalog.initialize(
+        "test",
+        ImmutableMap.<String, String>builder()
+            .putAll(restCatalog.properties())
+            .put(RESTCatalogProperties.REST_SCAN_PLANNING_ENABLED, "true")
+            .build());
+    Table table = catalog.loadTable(tableIdent);
+
+    SparkScanBuilder builder = new SparkScanBuilder(spark, table, CaseInsensitiveStringMap.empty());
+    verifyFileIOHasPlanId(builder.build().toBatch(), table);
+    verifyFileIOHasPlanId(builder.buildCopyOnWriteScan().toBatch(), table);
+  }
+
+  private void verifyFileIOHasPlanId(Batch batch, Table table) {
+    FileIO fileIOForScan =
+        (FileIO)
+            assertThat(batch)
+                .extracting("fileIO")
+                .isInstanceOf(Supplier.class)
+                .asInstanceOf(InstanceOfAssertFactories.type(Supplier.class))
+                .actual()
+                .get();
+    assertThat(fileIOForScan.properties()).containsKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
+    assertThat(table.io().properties()).doesNotContainKey(RESTCatalogProperties.REST_SCAN_PLAN_ID);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.formats.ReadBuilder;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.spark.OrcBatchReadConf;
@@ -51,13 +52,14 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
 
   BaseBatchReader(
       Table table,
+      FileIO fileIO,
       ScanTaskGroup<T> taskGroup,
       Schema expectedSchema,
       boolean caseSensitive,
       ParquetBatchReadConf parquetConf,
       OrcBatchReadConf orcConf,
       boolean cacheDeleteFilesOnExecutors) {
-    super(table, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
+    super(table, fileIO, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
     this.parquetConf = parquetConf;
     this.orcConf = orcConf;
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.data.DeleteLoader;
 import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
@@ -68,6 +69,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(BaseReader.class);
 
   private final Table table;
+  private final EncryptingFileIO fileIO;
   private final Schema expectedSchema;
   private final boolean caseSensitive;
   private final NameMapping nameMapping;
@@ -83,11 +85,13 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
 
   BaseReader(
       Table table,
+      FileIO fileIO,
       ScanTaskGroup<TaskT> taskGroup,
       Schema expectedSchema,
       boolean caseSensitive,
       boolean cacheDeleteFilesOnExecutors) {
     this.table = table;
+    this.fileIO = EncryptingFileIO.combine(fileIO, table().encryption());
     this.taskGroup = taskGroup;
     this.tasks = taskGroup.tasks().iterator();
     this.currentIterator = CloseableIterator.empty();
@@ -179,9 +183,8 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   private Map<String, InputFile> inputFiles() {
     if (lazyInputFiles == null) {
       this.lazyInputFiles =
-          EncryptingFileIO.combine(table().io(), table().encryption())
-              .bulkDecrypt(
-                  () -> taskGroup.tasks().stream().flatMap(this::referencedFiles).iterator());
+          fileIO.bulkDecrypt(
+              () -> taskGroup.tasks().stream().flatMap(this::referencedFiles).iterator());
     }
 
     return lazyInputFiles;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseRowReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseRowReader.java
@@ -28,17 +28,19 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.formats.ReadBuilder;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.spark.sql.catalyst.InternalRow;
 
 abstract class BaseRowReader<T extends ScanTask> extends BaseReader<InternalRow, T> {
   BaseRowReader(
       Table table,
+      FileIO fileIO,
       ScanTaskGroup<T> taskGroup,
       Schema expectedSchema,
       boolean caseSensitive,
       boolean cacheDeleteFilesOnExecutors) {
-    super(table, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
+    super(table, fileIO, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
   }
 
   protected CloseableIterable<InternalRow> newIterable(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.OrcBatchReadConf;
@@ -52,6 +53,7 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
       OrcBatchReadConf orcBatchReadConf) {
     this(
         partition.table(),
+        partition.io(),
         partition.taskGroup(),
         partition.projection(),
         partition.isCaseSensitive(),
@@ -62,6 +64,7 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
 
   BatchDataReader(
       Table table,
+      FileIO fileIO,
       ScanTaskGroup<FileScanTask> taskGroup,
       Schema expectedSchema,
       boolean caseSensitive,
@@ -70,6 +73,7 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
       boolean cacheDeleteFilesOnExecutors) {
     super(
         table,
+        fileIO,
         taskGroup,
         expectedSchema,
         caseSensitive,

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.rdd.InputFileBlockHolder;
@@ -50,6 +51,7 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   ChangelogRowReader(SparkInputPartition partition) {
     this(
         partition.table(),
+        partition.io(),
         partition.taskGroup(),
         partition.projection(),
         partition.isCaseSensitive(),
@@ -58,12 +60,14 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
 
   ChangelogRowReader(
       Table table,
+      FileIO fileIO,
       ScanTaskGroup<ChangelogScanTask> taskGroup,
       Schema expectedSchema,
       boolean caseSensitive,
       boolean cacheDeleteFilesOnExecutors) {
     super(
         table,
+        fileIO,
         taskGroup,
         ChangelogUtil.dropChangelogMetadata(expectedSchema),
         caseSensitive,

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
 
@@ -32,10 +33,11 @@ public class EqualityDeleteRowReader extends RowDataReader {
   public EqualityDeleteRowReader(
       CombinedScanTask task,
       Table table,
+      FileIO fileIO,
       Schema expectedSchema,
       boolean caseSensitive,
       boolean cacheDeleteFilesOnExecutors) {
-    super(table, task, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
+    super(table, fileIO, task, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
@@ -48,6 +49,7 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
   PositionDeletesRowReader(SparkInputPartition partition) {
     this(
         partition.table(),
+        partition.io(),
         partition.taskGroup(),
         partition.projection(),
         partition.isCaseSensitive(),
@@ -56,12 +58,12 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
 
   PositionDeletesRowReader(
       Table table,
+      FileIO fileIO,
       ScanTaskGroup<PositionDeletesScanTask> taskGroup,
       Schema expectedSchema,
       boolean caseSensitive,
       boolean cacheDeleteFilesOnExecutors) {
-
-    super(table, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
+    super(table, fileIO, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
 
     int numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} position delete file split(s) for table {}", numSplits, table.name());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.source.metrics.TaskNumDeletes;
@@ -47,6 +48,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
   RowDataReader(SparkInputPartition partition) {
     this(
         partition.table(),
+        partition.io(),
         partition.taskGroup(),
         partition.projection(),
         partition.isCaseSensitive(),
@@ -55,12 +57,13 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
 
   RowDataReader(
       Table table,
+      FileIO fileIO,
       ScanTaskGroup<FileScanTask> taskGroup,
       Schema expectedSchema,
       boolean caseSensitive,
       boolean cacheDeleteFilesOnExecutors) {
 
-    super(table, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
+    super(table, fileIO, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
 
     numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} file split(s) for table {}", numSplits, table.name());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.util.SerializableSupplier;
+import org.apache.spark.util.KnownSizeEstimation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class provides a serializable {@link FileIO} with a known size estimate. Spark calls its
+ * {@link org.apache.spark.util.SizeEstimator} class when broadcasting variables and this can be an
+ * expensive operation, so providing a known size estimate allows that operation to be skipped.
+ *
+ * <p>This class also implements {@link AutoCloseable} to avoid leaking resources upon broadcasting.
+ * Broadcast variables are destroyed and cleaned up on the driver and executors once they are
+ * garbage collected on the driver. The implementation ensures only resources used by copies of the
+ * main {@link FileIO} are released.
+ */
+public class SerializableFileIOWithSize
+    implements FileIO, HadoopConfigurable, KnownSizeEstimation, AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(SerializableFileIOWithSize.class);
+  private static final long SIZE_ESTIMATE = 32_768L;
+  private final transient Object serializationMarker;
+  private final FileIO fileIO;
+
+  private SerializableFileIOWithSize(FileIO fileIO) {
+    this.fileIO = fileIO;
+    this.serializationMarker = new Object();
+  }
+
+  @Override
+  public long estimatedSize() {
+    return SIZE_ESTIMATE;
+  }
+
+  public static FileIO wrap(FileIO fileIO) {
+    return new SerializableFileIOWithSize(fileIO);
+  }
+
+  @Override
+  public void close() {
+    if (null == serializationMarker) {
+      LOG.info("Closing FileIO");
+      fileIO.close();
+    }
+  }
+
+  @Override
+  public InputFile newInputFile(String path) {
+    return fileIO.newInputFile(path);
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    return fileIO.newOutputFile(path);
+  }
+
+  @Override
+  public void deleteFile(String path) {
+    fileIO.deleteFile(path);
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    fileIO.initialize(properties);
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return fileIO.properties();
+  }
+
+  @Override
+  public void serializeConfWith(
+      Function<Configuration, SerializableSupplier<Configuration>> confSerializer) {
+    if (fileIO instanceof HadoopConfigurable configurable) {
+      configurable.serializeConfWith(confSerializer);
+    }
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    if (fileIO instanceof HadoopConfigurable configurable) {
+      configurable.setConf(conf);
+    }
+  }
+
+  @Override
+  public Configuration getConf() {
+    if (fileIO instanceof HadoopConfigurable hadoopConfigurable) {
+      return hadoopConfigurable.getConf();
+    }
+
+    return null;
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
@@ -28,6 +29,7 @@ import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.spark.ImmutableOrcBatchReadConf;
 import org.apache.iceberg.spark.ImmutableParquetBatchReadConf;
 import org.apache.iceberg.spark.OrcBatchReadConf;
@@ -47,6 +49,7 @@ class SparkBatch implements Batch {
 
   private final JavaSparkContext sparkContext;
   private final Table table;
+  private final Supplier<FileIO> fileIO;
   private final SparkReadConf readConf;
   private final Types.StructType groupingKeyType;
   private final List<? extends ScanTaskGroup<?>> taskGroups;
@@ -60,6 +63,7 @@ class SparkBatch implements Batch {
   SparkBatch(
       JavaSparkContext sparkContext,
       Table table,
+      Supplier<FileIO> fileIO,
       SparkReadConf readConf,
       Types.StructType groupingKeyType,
       List<? extends ScanTaskGroup<?>> taskGroups,
@@ -67,6 +71,7 @@ class SparkBatch implements Batch {
       int scanHashCode) {
     this.sparkContext = sparkContext;
     this.table = table;
+    this.fileIO = fileIO;
     this.readConf = readConf;
     this.groupingKeyType = groupingKeyType;
     this.taskGroups = taskGroups;
@@ -83,6 +88,8 @@ class SparkBatch implements Batch {
     // broadcast the table metadata as input partitions will be sent to executors
     Broadcast<Table> tableBroadcast =
         sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
+    Broadcast<FileIO> fileIOBroadcast =
+        sparkContext.broadcast(SerializableFileIOWithSize.wrap(fileIO.get()));
     String projectionString = SchemaParser.toJson(projection);
     String[][] locations = computePreferredLocations();
 
@@ -94,6 +101,7 @@ class SparkBatch implements Batch {
               groupingKeyType,
               taskGroups.get(index),
               tableBroadcast,
+              fileIOBroadcast,
               projectionString,
               caseSensitive,
               locations != null ? locations[index] : SparkPlanningUtil.NO_LOCATION_PREFERENCE,
@@ -105,7 +113,7 @@ class SparkBatch implements Batch {
 
   private String[][] computePreferredLocations() {
     if (localityEnabled) {
-      return SparkPlanningUtil.fetchBlockLocations(table.io(), taskGroups);
+      return SparkPlanningUtil.fetchBlockLocations(fileIO.get(), taskGroups);
 
     } else if (executorCacheLocalityEnabled) {
       List<String> executorLocations = SparkUtil.executorLocations();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -105,6 +105,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
     return new SparkBatch(
         sparkContext,
         table,
+        null != scan ? scan.fileIO() : table::io,
         readConf,
         EMPTY_GROUPING_KEY_TYPE,
         taskGroups(),

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkInputPartition.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkInputPartition.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -34,6 +35,7 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
   private final Types.StructType groupingKeyType;
   private final ScanTaskGroup<?> taskGroup;
   private final Broadcast<Table> tableBroadcast;
+  private final Broadcast<FileIO> fileIOBroadcast;
   private final String projectionString;
   private final boolean caseSensitive;
   private final transient String[] preferredLocations;
@@ -45,6 +47,7 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
       Types.StructType groupingKeyType,
       ScanTaskGroup<?> taskGroup,
       Broadcast<Table> tableBroadcast,
+      Broadcast<FileIO> fileIOBroadcast,
       String projectionString,
       boolean caseSensitive,
       String[] preferredLocations,
@@ -52,6 +55,7 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
     this.groupingKeyType = groupingKeyType;
     this.taskGroup = taskGroup;
     this.tableBroadcast = tableBroadcast;
+    this.fileIOBroadcast = fileIOBroadcast;
     this.projectionString = projectionString;
     this.caseSensitive = caseSensitive;
     this.preferredLocations = preferredLocations;
@@ -79,6 +83,10 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
 
   public Table table() {
     return tableBroadcast.value();
+  }
+
+  public FileIO io() {
+    return fileIOBroadcast.value();
   }
 
   public boolean isCaseSensitive() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -26,6 +26,7 @@ import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
@@ -61,10 +62,12 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
   private static final Types.StructType EMPTY_GROUPING_KEY_TYPE = Types.StructType.of();
 
   private final Table table;
+  private final Supplier<FileIO> fileIO;
   private final SparkReadConf readConf;
   private final boolean caseSensitive;
   private final String projection;
   private final Broadcast<Table> tableBroadcast;
+  private final Broadcast<FileIO> fileIOBroadcast;
   private final long splitSize;
   private final int splitLookback;
   private final long splitOpenFileCost;
@@ -80,15 +83,18 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
   SparkMicroBatchStream(
       JavaSparkContext sparkContext,
       Table table,
+      Supplier<FileIO> fileIO,
       SparkReadConf readConf,
       Schema projection,
       String checkpointLocation) {
     this.table = table;
+    this.fileIO = fileIO;
     this.readConf = readConf;
     this.caseSensitive = readConf.caseSensitive();
     this.projection = SchemaParser.toJson(projection);
     this.localityPreferred = readConf.localityEnabled();
     this.tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
+    this.fileIOBroadcast = sparkContext.broadcast(SerializableFileIOWithSize.wrap(fileIO.get()));
     this.splitSize = readConf.splitSize();
     this.splitLookback = readConf.splitLookback();
     this.splitOpenFileCost = readConf.splitOpenFileCost();
@@ -158,6 +164,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
               EMPTY_GROUPING_KEY_TYPE,
               combinedScanTasks.get(index),
               tableBroadcast,
+              fileIOBroadcast,
               projection,
               caseSensitive,
               locations != null ? locations[index] : SparkPlanningUtil.NO_LOCATION_PREFERENCE,
@@ -168,7 +175,9 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
   }
 
   private String[][] computePreferredLocations(List<CombinedScanTask> taskGroups) {
-    return localityPreferred ? SparkPlanningUtil.fetchBlockLocations(table.io(), taskGroups) : null;
+    return localityPreferred
+        ? SparkPlanningUtil.fetchBlockLocations(fileIO.get(), taskGroups)
+        : null;
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -79,7 +79,15 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
       Schema projection,
       List<Expression> filters,
       Supplier<ScanReport> scanReportSupplier) {
-    super(spark, table, schema, readConf, projection, filters, scanReportSupplier);
+    super(
+        spark,
+        table,
+        null != scan ? scan.fileIO() : table::io,
+        schema,
+        readConf,
+        projection,
+        filters,
+        scanReportSupplier);
 
     this.scan = scan;
     this.preserveDataGrouping = readConf.preserveDataGrouping();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -101,6 +102,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
 
   private final JavaSparkContext sparkContext;
   private final Table table;
+  private final Supplier<FileIO> fileIO;
   private final Schema schema;
   private final SparkSession spark;
   private final SparkReadConf readConf;
@@ -115,6 +117,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   SparkScan(
       SparkSession spark,
       Table table,
+      Supplier<FileIO> fileIO,
       Schema schema,
       SparkReadConf readConf,
       Schema projection,
@@ -123,6 +126,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     this.spark = spark;
     this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
     this.table = table;
+    this.fileIO = fileIO;
     this.schema = schema;
     this.readConf = readConf;
     this.caseSensitive = readConf.caseSensitive();
@@ -169,12 +173,20 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   @Override
   public Batch toBatch() {
     return new SparkBatch(
-        sparkContext, table, readConf, groupingKeyType(), taskGroups(), projection, hashCode());
+        sparkContext,
+        table,
+        fileIO,
+        readConf,
+        groupingKeyType(),
+        taskGroups(),
+        projection,
+        hashCode());
   }
 
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
-    return new SparkMicroBatchStream(sparkContext, table, readConf, projection, checkpointLocation);
+    return new SparkMicroBatchStream(
+        sparkContext, table, fileIO, readConf, projection, checkpointLocation);
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkStagedScan.java
@@ -47,7 +47,7 @@ class SparkStagedScan extends SparkScan {
       Schema projection,
       String taskSetId,
       SparkReadConf readConf) {
-    super(spark, table, schema, readConf, projection, ImmutableList.of(), null);
+    super(spark, table, table::io, schema, readConf, projection, ImmutableList.of(), null);
     this.taskSetId = taskSetId;
     this.splitSize = readConf.splitSize();
     this.splitLookback = readConf.splitLookback();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
@@ -69,7 +69,11 @@ public abstract class TestBaseWithCatalog extends TestBase {
               // status even belonging to the same catalog. Reference:
               // https://www.sqlite.org/inmemorydb.html
               CatalogProperties.CLIENT_POOL_SIZE,
-              "1"));
+              "1",
+              "include-credentials",
+              "true",
+              "gcs.oauth2.token",
+              "dummyToken"));
 
   protected static RESTCatalog restCatalog;
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestBaseReader.java
@@ -90,7 +90,7 @@ public class TestBaseReader {
     private final Map<String, CloseableIntegerRange> tracker = Maps.newHashMap();
 
     ClosureTrackingReader(Table table, List<FileScanTask> tasks) {
-      super(table, new BaseCombinedScanTask(tasks), null, false, true);
+      super(table, table.io(), new BaseCombinedScanTask(tasks), null, false, true);
     }
 
     @Override

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
@@ -105,7 +105,7 @@ public class TestChangelogReader extends TestBase {
 
     for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
       ChangelogRowReader reader =
-          new ChangelogRowReader(table, taskGroup, table.schema(), false, true);
+          new ChangelogRowReader(table, table.io(), taskGroup, table.schema(), false, true);
       while (reader.next()) {
         rows.add(reader.get().copy());
       }
@@ -136,7 +136,7 @@ public class TestChangelogReader extends TestBase {
 
     for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
       ChangelogRowReader reader =
-          new ChangelogRowReader(table, taskGroup, table.schema(), false, true);
+          new ChangelogRowReader(table, table.io(), taskGroup, table.schema(), false, true);
       while (reader.next()) {
         rows.add(reader.get().copy());
       }
@@ -170,7 +170,7 @@ public class TestChangelogReader extends TestBase {
 
     for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
       ChangelogRowReader reader =
-          new ChangelogRowReader(table, taskGroup, table.schema(), false, true);
+          new ChangelogRowReader(table, table.io(), taskGroup, table.schema(), false, true);
       while (reader.next()) {
         rows.add(reader.get().copy());
       }
@@ -197,7 +197,7 @@ public class TestChangelogReader extends TestBase {
 
     for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
       ChangelogRowReader reader =
-          new ChangelogRowReader(table, taskGroup, table.schema(), false, true);
+          new ChangelogRowReader(table, table.io(), taskGroup, table.schema(), false, true);
       while (reader.next()) {
         rows.add(reader.get().copy());
       }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestPositionDeletesReader.java
@@ -180,6 +180,7 @@ public class TestPositionDeletesReader extends TestBase {
     try (PositionDeletesRowReader reader =
         new PositionDeletesRowReader(
             table,
+            table.io(),
             new BaseScanTaskGroup<>(null, ImmutableList.of(scanTask1)),
             projectedSchema,
             false,
@@ -219,6 +220,7 @@ public class TestPositionDeletesReader extends TestBase {
     try (PositionDeletesRowReader reader =
         new PositionDeletesRowReader(
             table,
+            table.io(),
             new BaseScanTaskGroup<>(null, ImmutableList.of(scanTask2)),
             projectedSchema,
             false,
@@ -290,6 +292,7 @@ public class TestPositionDeletesReader extends TestBase {
     try (PositionDeletesRowReader reader =
         new PositionDeletesRowReader(
             table,
+            table.io(),
             new BaseScanTaskGroup<>(null, ImmutableList.of(scanTask1)),
             projectedSchema,
             false,

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -333,7 +333,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
 
     for (CombinedScanTask task : tasks) {
       try (EqualityDeleteRowReader reader =
-          new EqualityDeleteRowReader(task, table, table.schema(), false, true)) {
+          new EqualityDeleteRowReader(task, table, table.io(), table.schema(), false, true)) {
         while (reader.next()) {
           actualRowSet.add(
               new InternalRowWrapper(
@@ -682,7 +682,14 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
       try (BatchDataReader reader =
           new BatchDataReader(
               // expected column is id, while the equality filter column is dt
-              dateTable, task, dateTable.schema().select("id"), false, conf, null, true)) {
+              dateTable,
+              dateTable.io(),
+              task,
+              dateTable.schema().select("id"),
+              false,
+              conf,
+              null,
+              true)) {
         while (reader.next()) {
           ColumnarBatch columnarBatch = reader.get();
           int numOfCols = columnarBatch.numCols();


### PR DESCRIPTION
When accessing/reading data files, the codebase is using the Table's `FileIO` instance through `table.io()` on Flink's read path. With remote scan planning the `FileIO` instance is configured with a PlanID + custom storage credentials inside `RESTTableScan`, but that instance is never propagated to the place(s) that actually perform the read., thus leading to errors.

This PR passes the `FileIO` obtained during remote/distributed scan planning next to the `Table` instance on Flink's read path. 

This is similar to https://github.com/apache/iceberg/pull/15448, where we applied the same approach on Spark's read path
