### PR TITLE
Core: Add batch load endpoints for tables and views

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 
 /** A Catalog API for table and namespace operations that includes session context. */
@@ -195,6 +196,24 @@ public interface SessionCatalog {
    * @throws NoSuchTableException if the table does not exist
    */
   Table loadTable(SessionContext context, TableIdentifier ident);
+
+  /**
+   * Loads multiple tables, typically in fewer round trips than repeated {@link #loadTable} calls,
+   * when the catalog supports a batch load operation.
+   *
+   * <p>Underlying implementations often use a batch protocol where each requested identifier has
+   * its own outcome rather than failing the entire batch when one table is missing.
+   *
+   * @param context session context
+   * @param idents table identifiers
+   * @return a closeable iterable produced by this batch load; how missing or not-modified
+   *     identifiers are represented depends on the catalog implementation
+   * @throws UnsupportedOperationException if batch table loading is not supported
+   */
+  default CloseableIterable<Table> batchLoadTables(
+      SessionContext context, Iterable<TableIdentifier> idents) {
+    throw new UnsupportedOperationException("Batch table loading is not supported");
+  }
 
   /**
    * Drop a table, without requesting that files are immediately deleted.

--- a/api/src/main/java/org/apache/iceberg/catalog/ViewSessionCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/ViewSessionCatalog.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
 
@@ -53,6 +54,25 @@ public interface ViewSessionCatalog {
    * @throws NoSuchViewException if the view does not exist
    */
   View loadView(SessionCatalog.SessionContext context, TableIdentifier identifier);
+
+  /**
+   * Loads multiple views, typically in fewer round trips than repeated {@link #loadView} calls,
+   * when the catalog supports a batch load operation.
+   *
+   * <p>Underlying implementations often use a batch protocol where each requested identifier has
+   * its own outcome (for example an HTTP status per item: loaded or not found) rather than failing
+   * the entire batch when one view is missing.
+   *
+   * @param context session context
+   * @param identifiers view identifiers
+   * @return a closeable iterable produced by this batch load; how missing identifiers are
+   *     represented depends on the catalog implementation
+   * @throws UnsupportedOperationException if batch view loading is not supported
+   */
+  default CloseableIterable<View> batchLoadViews(
+      SessionCatalog.SessionContext context, Iterable<TableIdentifier> identifiers) {
+    throw new UnsupportedOperationException("Batch view loading is not supported");
+  }
 
   /**
    * Check whether view exists.

--- a/core/src/main/java/org/apache/iceberg/rest/BaseHTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/BaseHTTPClient.java
@@ -117,6 +117,18 @@ public abstract class BaseHTTPClient implements RESTClient {
       String path,
       RESTRequest body,
       Class<T> responseType,
+      Map<String, String> queryParams,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    HTTPRequest request = buildRequest(HTTPMethod.POST, path, queryParams, headers, body);
+    return execute(request, responseType, errorHandler, h -> {});
+  }
+
+  @Override
+  public <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler,
       Consumer<Map<String, String>> responseHeaders) {

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -31,6 +31,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -76,10 +77,15 @@ import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
+import org.apache.iceberg.rest.requests.BatchLoadRequestedTable;
+import org.apache.iceberg.rest.requests.BatchLoadTablesRequest;
+import org.apache.iceberg.rest.requests.BatchLoadViewsRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
@@ -90,10 +96,18 @@ import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResponse;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResultItem;
+import org.apache.iceberg.rest.responses.BatchLoadViewsResponse;
+import org.apache.iceberg.rest.responses.BatchLoadViewsResultItem;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
 import org.apache.iceberg.rest.responses.FetchScanTasksResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
+import org.apache.iceberg.rest.responses.ImmutableBatchLoadTablesResponse;
+import org.apache.iceberg.rest.responses.ImmutableBatchLoadTablesResultItem;
+import org.apache.iceberg.rest.responses.ImmutableBatchLoadViewsResponse;
+import org.apache.iceberg.rest.responses.ImmutableBatchLoadViewsResultItem;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
@@ -572,6 +586,62 @@ public class CatalogHandlers {
 
   public static void renameTable(Catalog catalog, RenameTableRequest request) {
     catalog.renameTable(request.source(), request.destination());
+  }
+
+  public static BatchLoadTablesResponse batchLoadTables(
+      Catalog catalog, BatchLoadTablesRequest request, SnapshotMode mode) {
+    ImmutableList.Builder<BatchLoadTablesResultItem> results = ImmutableList.builder();
+
+    for (BatchLoadRequestedTable requested : request.tables()) {
+      TableIdentifier ident = requested.identifier();
+      ImmutableBatchLoadTablesResultItem.Builder itemBuilder =
+          ImmutableBatchLoadTablesResultItem.builder().identifier(ident);
+
+      try {
+        LoadTableResponse tableResponse = loadTable(catalog, ident, mode);
+
+        String etag =
+            ETagProvider.of(tableResponse.metadataLocation(), snapshotModeToQueryParam(mode));
+
+        if (null != requested.ifNonMatch() && etag.equals(requested.ifNonMatch())) {
+          itemBuilder.status(304).etag(etag);
+        } else {
+          itemBuilder.status(200).etag(etag).result(tableResponse);
+        }
+      } catch (NoSuchTableException e) {
+        itemBuilder.status(404);
+      }
+
+      results.add(itemBuilder.build());
+    }
+
+    return ImmutableBatchLoadTablesResponse.builder().results(results.build()).build();
+  }
+
+  public static BatchLoadViewsResponse batchLoadViews(
+      ViewCatalog catalog, BatchLoadViewsRequest request) {
+    ImmutableList.Builder<BatchLoadViewsResultItem> results = ImmutableList.builder();
+
+    for (TableIdentifier ident : request.views()) {
+      ImmutableBatchLoadViewsResultItem.Builder itemBuilder =
+          ImmutableBatchLoadViewsResultItem.builder().identifier(ident);
+
+      try {
+        LoadViewResponse viewResponse = loadView(catalog, ident);
+        itemBuilder.status(200).result(viewResponse);
+      } catch (NoSuchViewException e) {
+        itemBuilder.status(404);
+      }
+
+      results.add(itemBuilder.build());
+    }
+
+    return ImmutableBatchLoadViewsResponse.builder().views(results.build()).build();
+  }
+
+  private static Map<String, String> snapshotModeToQueryParam(SnapshotMode mode) {
+    return ImmutableMap.of(
+        RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER, mode.name().toLowerCase(Locale.ROOT));
   }
 
   private static boolean isCreate(UpdateTableRequest request) {

--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -64,6 +64,8 @@ public class Endpoint {
       Endpoint.create("POST", ResourcePaths.V1_TABLE_REGISTER);
   public static final Endpoint V1_REPORT_METRICS =
       Endpoint.create("POST", ResourcePaths.V1_TABLE_METRICS);
+  public static final Endpoint V1_BATCH_LOAD_TABLES =
+      Endpoint.create("POST", ResourcePaths.V1_TABLES_BATCH_LOAD);
   public static final Endpoint V1_TABLE_CREDENTIALS =
       Endpoint.create("GET", ResourcePaths.V1_TABLE_CREDENTIALS);
 
@@ -88,6 +90,8 @@ public class Endpoint {
       Endpoint.create("POST", ResourcePaths.V1_VIEW_RENAME);
   public static final Endpoint V1_REGISTER_VIEW =
       Endpoint.create("POST", ResourcePaths.V1_VIEW_REGISTER);
+  public static final Endpoint V1_BATCH_LOAD_VIEWS =
+      Endpoint.create("POST", ResourcePaths.V1_VIEWS_BATCH_LOAD);
 
   private static final Splitter ENDPOINT_SPLITTER = Splitter.on(" ");
   private static final Joiner ENDPOINT_JOINER = Joiner.on(" ");

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -195,6 +195,20 @@ public interface RESTClient extends Closeable {
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler);
 
+  default <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> queryParams,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    if (queryParams != null && !queryParams.isEmpty()) {
+      throw new UnsupportedOperationException("Query parameters are not supported");
+    }
+
+    return post(path, body, responseType, headers, errorHandler);
+  }
+
   default <T extends RESTResponse> T postForm(
       String path,
       Map<String, String> formData,

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -44,12 +44,18 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
 import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.rest.requests.BatchLoadTablesRequest;
+import org.apache.iceberg.rest.requests.BatchLoadTablesRequestParser;
+import org.apache.iceberg.rest.requests.BatchLoadViewsRequest;
+import org.apache.iceberg.rest.requests.BatchLoadViewsRequestParser;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequestParser;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
 import org.apache.iceberg.rest.requests.CreateViewRequestParser;
 import org.apache.iceberg.rest.requests.FetchScanTasksRequest;
 import org.apache.iceberg.rest.requests.FetchScanTasksRequestParser;
+import org.apache.iceberg.rest.requests.ImmutableBatchLoadTablesRequest;
+import org.apache.iceberg.rest.requests.ImmutableBatchLoadViewsRequest;
 import org.apache.iceberg.rest.requests.ImmutableCreateViewRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterViewRequest;
@@ -64,6 +70,10 @@ import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequestParser;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResponse;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResponseParser;
+import org.apache.iceberg.rest.responses.BatchLoadViewsResponse;
+import org.apache.iceberg.rest.responses.BatchLoadViewsResponseParser;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.ConfigResponseParser;
 import org.apache.iceberg.rest.responses.ErrorResponse;
@@ -72,6 +82,8 @@ import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
 import org.apache.iceberg.rest.responses.FetchPlanningResultResponseParser;
 import org.apache.iceberg.rest.responses.FetchScanTasksResponse;
 import org.apache.iceberg.rest.responses.FetchScanTasksResponseParser;
+import org.apache.iceberg.rest.responses.ImmutableBatchLoadTablesResponse;
+import org.apache.iceberg.rest.responses.ImmutableBatchLoadViewsResponse;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
@@ -160,7 +172,31 @@ public class RESTSerializers {
             ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseSerializer<>())
         .addDeserializer(LoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>())
         .addDeserializer(
-            ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>());
+            ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>())
+        .addSerializer(BatchLoadTablesRequest.class, new BatchLoadTablesRequestSerializer<>())
+        .addSerializer(
+            ImmutableBatchLoadTablesRequest.class, new BatchLoadTablesRequestSerializer<>())
+        .addDeserializer(BatchLoadTablesRequest.class, new BatchLoadTablesRequestDeserializer<>())
+        .addDeserializer(
+            ImmutableBatchLoadTablesRequest.class, new BatchLoadTablesRequestDeserializer<>())
+        .addSerializer(BatchLoadViewsRequest.class, new BatchLoadViewsRequestSerializer<>())
+        .addSerializer(
+            ImmutableBatchLoadViewsRequest.class, new BatchLoadViewsRequestSerializer<>())
+        .addDeserializer(BatchLoadViewsRequest.class, new BatchLoadViewsRequestDeserializer<>())
+        .addDeserializer(
+            ImmutableBatchLoadViewsRequest.class, new BatchLoadViewsRequestDeserializer<>())
+        .addSerializer(BatchLoadTablesResponse.class, new BatchLoadTablesResponseSerializer<>())
+        .addSerializer(
+            ImmutableBatchLoadTablesResponse.class, new BatchLoadTablesResponseSerializer<>())
+        .addDeserializer(BatchLoadTablesResponse.class, new BatchLoadTablesResponseDeserializer<>())
+        .addDeserializer(
+            ImmutableBatchLoadTablesResponse.class, new BatchLoadTablesResponseDeserializer<>())
+        .addSerializer(BatchLoadViewsResponse.class, new BatchLoadViewsResponseSerializer<>())
+        .addSerializer(
+            ImmutableBatchLoadViewsResponse.class, new BatchLoadViewsResponseSerializer<>())
+        .addDeserializer(BatchLoadViewsResponse.class, new BatchLoadViewsResponseDeserializer<>())
+        .addDeserializer(
+            ImmutableBatchLoadViewsResponse.class, new BatchLoadViewsResponseDeserializer<>());
 
     mapper.registerModule(module);
   }
@@ -648,6 +684,78 @@ public class RESTSerializers {
 
     boolean isCaseSensitive() {
       return caseSensitive;
+    }
+  }
+
+  static class BatchLoadTablesRequestSerializer<T extends BatchLoadTablesRequest>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      BatchLoadTablesRequestParser.toJson(request, gen);
+    }
+  }
+
+  static class BatchLoadTablesRequestDeserializer<T extends BatchLoadTablesRequest>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) BatchLoadTablesRequestParser.fromJson(jsonNode);
+    }
+  }
+
+  static class BatchLoadViewsRequestSerializer<T extends BatchLoadViewsRequest>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      BatchLoadViewsRequestParser.toJson(request, gen);
+    }
+  }
+
+  static class BatchLoadViewsRequestDeserializer<T extends BatchLoadViewsRequest>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) BatchLoadViewsRequestParser.fromJson(jsonNode);
+    }
+  }
+
+  static class BatchLoadTablesResponseSerializer<T extends BatchLoadTablesResponse>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T response, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      BatchLoadTablesResponseParser.toJson(response, gen);
+    }
+  }
+
+  static class BatchLoadTablesResponseDeserializer<T extends BatchLoadTablesResponse>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) BatchLoadTablesResponseParser.fromJson(jsonNode);
+    }
+  }
+
+  static class BatchLoadViewsResponseSerializer<T extends BatchLoadViewsResponse>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T response, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      BatchLoadViewsResponseParser.toJson(response, gen);
+    }
+  }
+
+  static class BatchLoadViewsResponseDeserializer<T extends BatchLoadViewsResponse>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) BatchLoadViewsResponseParser.fromJson(jsonNode);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -21,9 +21,13 @@ package org.apache.iceberg.rest;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -55,8 +59,11 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileIOTracker;
 import org.apache.iceberg.io.StorageCredential;
@@ -76,10 +83,16 @@ import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.requests.BatchLoadRequestedTable;
+import org.apache.iceberg.rest.requests.BatchLoadTablesRequest;
+import org.apache.iceberg.rest.requests.BatchLoadViewsRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
+import org.apache.iceberg.rest.requests.ImmutableBatchLoadRequestedTable;
+import org.apache.iceberg.rest.requests.ImmutableBatchLoadTablesRequest;
+import org.apache.iceberg.rest.requests.ImmutableBatchLoadViewsRequest;
 import org.apache.iceberg.rest.requests.ImmutableCreateViewRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterTableRequest;
 import org.apache.iceberg.rest.requests.ImmutableRegisterViewRequest;
@@ -88,6 +101,10 @@ import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResponse;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResultItem;
+import org.apache.iceberg.rest.responses.BatchLoadViewsResponse;
+import org.apache.iceberg.rest.responses.BatchLoadViewsResultItem;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
@@ -400,6 +417,60 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     invalidateTable(context, from);
   }
 
+  CloseableIterable<BatchLoadTablesResultItem> batchLoadTables(
+      SessionContext context, List<BatchLoadRequestedTable> tables) {
+    Endpoint.check(endpoints, Endpoint.V1_BATCH_LOAD_TABLES);
+
+    return new CloseableIterable<BatchLoadTablesResultItem>() {
+      @Override
+      public CloseableIterator<BatchLoadTablesResultItem> iterator() {
+        return new BatchLoadTablesIterator(context, tables);
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
+
+  @Override
+  public CloseableIterable<Table> batchLoadTables(
+      SessionContext context, Iterable<TableIdentifier> identifiers) {
+    List<BatchLoadRequestedTable> tables = Lists.newArrayList();
+    for (TableIdentifier identifier : identifiers) {
+      tables.add(ImmutableBatchLoadRequestedTable.builder().identifier(identifier).build());
+    }
+
+    return CloseableIterable.transform(
+        batchLoadTables(context, tables), item -> tableFromBatchLoadResult(context, item));
+  }
+
+  CloseableIterable<BatchLoadViewsResultItem> batchLoadViews(
+      SessionContext context, List<TableIdentifier> views) {
+    Endpoint.check(endpoints, Endpoint.V1_BATCH_LOAD_VIEWS);
+
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    BatchLoadViewsRequest request = ImmutableBatchLoadViewsRequest.builder().views(views).build();
+    BatchLoadViewsResponse response =
+        client
+            .withAuthSession(contextualSession)
+            .post(
+                paths.batchLoadViews(),
+                request,
+                BatchLoadViewsResponse.class,
+                Map.of(),
+                ErrorHandlers.defaultErrorHandler());
+
+    return CloseableIterable.withNoopClose(response.views());
+  }
+
+  @Override
+  public CloseableIterable<View> batchLoadViews(
+      SessionContext context, Iterable<TableIdentifier> identifiers) {
+    return CloseableIterable.transform(
+        batchLoadViews(context, Lists.newArrayList(identifiers)),
+        item -> viewFromBatchLoadResult(context, item));
+  }
+
   @Override
   public boolean tableExists(SessionContext context, TableIdentifier identifier) {
     try {
@@ -428,6 +499,72 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private static Map<String, String> snapshotModeToParam(SnapshotMode mode) {
     return ImmutableMap.of(
         RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER, mode.name().toLowerCase(Locale.US));
+  }
+
+  private Table tableFromBatchLoadResult(
+      SessionContext context, BatchLoadTablesResultItem batchResult) {
+    TableIdentifier identifier = batchResult.identifier();
+    if (batchResult.status() == 404) {
+      throw new NoSuchTableException("Table does not exist: %s", identifier);
+    }
+
+    Preconditions.checkState(
+        batchResult.status() == 200, "Invalid batch load table status: %s", batchResult.status());
+    Preconditions.checkState(batchResult.result() != null, "Invalid batch load table result: null");
+
+    LoadTableResponse response = batchResult.result();
+    Map<String, String> tableConf = response.config();
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    AuthSession tableSession = authManager.tableSession(identifier, tableConf, contextualSession);
+    RESTClient tableClient = client.withAuthSession(tableSession);
+    TableMetadata tableMetadata;
+
+    if (snapshotMode == SnapshotMode.REFS) {
+      tableMetadata =
+          TableMetadata.buildFrom(response.tableMetadata())
+              .withMetadataLocation(response.metadataLocation())
+              .setPreviousFileLocation(null)
+              .setSnapshotsSupplier(
+                  () ->
+                      loadInternal(context, identifier, SnapshotMode.ALL, Map.of(), h -> {})
+                          .tableMetadata()
+                          .snapshots())
+              .discardChanges()
+              .build();
+    } else {
+      tableMetadata = response.tableMetadata();
+    }
+
+    return createTableSupplier(
+            identifier, tableMetadata, context, tableClient, tableConf, response.credentials())
+        .get();
+  }
+
+  private View viewFromBatchLoadResult(
+      SessionContext context, BatchLoadViewsResultItem batchResult) {
+    TableIdentifier identifier = batchResult.identifier();
+    if (batchResult.status() == 404) {
+      throw new NoSuchViewException("View does not exist: %s", identifier);
+    }
+
+    Preconditions.checkState(
+        batchResult.status() == 200, "Invalid batch load view status: %s", batchResult.status());
+    Preconditions.checkState(batchResult.result() != null, "Invalid batch load view result: null");
+
+    LoadViewResponse response = batchResult.result();
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    AuthSession tableSession =
+        authManager.tableSession(identifier, response.config(), contextualSession);
+    RESTViewOperations ops =
+        newViewOps(
+            client.withAuthSession(tableSession),
+            paths.view(identifier),
+            Map::of,
+            mutationHeaders,
+            response.metadata(),
+            endpoints);
+
+    return new BaseView(ops, ViewUtil.fullViewName(name(), identifier));
   }
 
   private LoadTableResponse loadInternal(
@@ -1751,5 +1888,86 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
       return new BaseView(ops, ViewUtil.fullViewName(name(), identifier));
     }
+  }
+
+  private class BatchLoadTablesIterator implements CloseableIterator<BatchLoadTablesResultItem> {
+    private final SessionContext context;
+    private final Map<String, String> queryParams;
+    private final Set<List<BatchLoadRequestedTable>> seenPending;
+    private Iterator<BatchLoadTablesResultItem> currentBatch;
+    private List<BatchLoadRequestedTable> pending;
+
+    BatchLoadTablesIterator(SessionContext context, List<BatchLoadRequestedTable> tables) {
+      this.context = context;
+      this.queryParams = snapshotModeToParam(snapshotMode);
+      this.seenPending = new HashSet<>();
+      this.pending = ImmutableList.copyOf(tables);
+      this.seenPending.add(this.pending);
+      fetchNextBatch();
+    }
+
+    private void fetchNextBatch() {
+      if (pending == null || pending.isEmpty()) {
+        this.currentBatch = Collections.emptyIterator();
+        this.pending = null;
+        return;
+      }
+
+      AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+      BatchLoadTablesRequest request =
+          ImmutableBatchLoadTablesRequest.builder().tables(pending).build();
+      BatchLoadTablesResponse response =
+          client
+              .withAuthSession(contextualSession)
+              .post(
+                  paths.batchLoadTables(),
+                  request,
+                  BatchLoadTablesResponse.class,
+                  queryParams,
+                  Map.of(),
+                  ErrorHandlers.defaultErrorHandler());
+
+      this.currentBatch = response.results().iterator();
+
+      List<BatchLoadRequestedTable> unprocessed = response.unprocessedTables();
+      if (unprocessed != null && !unprocessed.isEmpty()) {
+        List<BatchLoadRequestedTable> nextPending = ImmutableList.copyOf(unprocessed);
+        if (!seenPending.add(nextPending)) {
+          throw new RESTException(
+              "Invalid batch load response: server did not make progress for tables: %s",
+              unprocessed);
+        }
+
+        this.pending = nextPending;
+      } else {
+        this.pending = null;
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (currentBatch.hasNext()) {
+        return true;
+      }
+
+      if (pending != null && !pending.isEmpty()) {
+        fetchNextBatch();
+        return currentBatch.hasNext();
+      }
+
+      return false;
+    }
+
+    @Override
+    public BatchLoadTablesResultItem next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      return currentBatch.next();
+    }
+
+    @Override
+    public void close() {}
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -39,6 +39,7 @@ public class ResourcePaths {
   public static final String V1_TABLE_METRICS =
       "/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics";
   public static final String V1_TABLE_RENAME = "/v1/{prefix}/tables/rename";
+  public static final String V1_TABLES_BATCH_LOAD = "/v1/{prefix}/tables/batch-load";
   public static final String V1_TABLE_SCAN_PLAN_SUBMIT =
       "/v1/{prefix}/namespaces/{namespace}/tables/{table}/plan";
   public static final String V1_TABLE_SCAN_PLAN =
@@ -49,6 +50,7 @@ public class ResourcePaths {
   public static final String V1_VIEWS = "/v1/{prefix}/namespaces/{namespace}/views";
   public static final String V1_VIEW = "/v1/{prefix}/namespaces/{namespace}/views/{view}";
   public static final String V1_VIEW_RENAME = "/v1/{prefix}/views/rename";
+  public static final String V1_VIEWS_BATCH_LOAD = "/v1/{prefix}/views/batch-load";
   public static final String V1_VIEW_REGISTER = "/v1/{prefix}/namespaces/{namespace}/register-view";
 
   public static ResourcePaths forCatalogProperties(Map<String, String> properties) {
@@ -119,6 +121,10 @@ public class ResourcePaths {
     return SLASH.join("v1", prefix, "tables", "rename");
   }
 
+  public String batchLoadTables() {
+    return SLASH.join("v1", prefix, "tables", "batch-load");
+  }
+
   public String metrics(TableIdentifier identifier) {
     return SLASH.join(
         "v1",
@@ -150,6 +156,10 @@ public class ResourcePaths {
 
   public String renameView() {
     return SLASH.join("v1", prefix, "views", "rename");
+  }
+
+  public String batchLoadViews() {
+    return SLASH.join("v1", prefix, "views", "batch-load");
   }
 
   public String registerView(Namespace ns) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRequestedTable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRequestedTable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import javax.annotation.Nullable;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface BatchLoadRequestedTable {
+
+  TableIdentifier identifier();
+
+  @Nullable
+  String ifNonMatch();
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRequestedTableParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRequestedTableParser.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadRequestedTableParser {
+
+  private static final String IDENTIFIER = "identifier";
+  private static final String IF_NON_MATCH = "if-non-match";
+
+  private BatchLoadRequestedTableParser() {}
+
+  public static String toJson(BatchLoadRequestedTable table) {
+    return toJson(table, false);
+  }
+
+  public static String toJson(BatchLoadRequestedTable table, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(table, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadRequestedTable table, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != table, "Invalid batch load requested table: null");
+
+    gen.writeStartObject();
+
+    gen.writeFieldName(IDENTIFIER);
+    TableIdentifierParser.toJson(table.identifier(), gen);
+
+    if (null != table.ifNonMatch()) {
+      gen.writeStringField(IF_NON_MATCH, table.ifNonMatch());
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadRequestedTable fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadRequestedTableParser::fromJson);
+  }
+
+  public static BatchLoadRequestedTable fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load requested table from null object");
+
+    TableIdentifier identifier = TableIdentifierParser.fromJson(JsonUtil.get(IDENTIFIER, json));
+
+    ImmutableBatchLoadRequestedTable.Builder builder =
+        ImmutableBatchLoadRequestedTable.builder().identifier(identifier);
+
+    if (json.hasNonNull(IF_NON_MATCH)) {
+      builder.ifNonMatch(JsonUtil.getString(IF_NON_MATCH, json));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadTablesRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadTablesRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import java.util.List;
+import org.apache.iceberg.rest.RESTRequest;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface BatchLoadTablesRequest extends RESTRequest {
+
+  List<BatchLoadRequestedTable> tables();
+
+  @Override
+  default void validate() {}
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadTablesRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadTablesRequestParser.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadTablesRequestParser {
+
+  private static final String TABLES = "tables";
+
+  private BatchLoadTablesRequestParser() {}
+
+  public static String toJson(BatchLoadTablesRequest request) {
+    return toJson(request, false);
+  }
+
+  public static String toJson(BatchLoadTablesRequest request, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadTablesRequest request, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != request, "Invalid batch load tables request: null");
+
+    gen.writeStartObject();
+
+    gen.writeArrayFieldStart(TABLES);
+    for (BatchLoadRequestedTable table : request.tables()) {
+      BatchLoadRequestedTableParser.toJson(table, gen);
+    }
+
+    gen.writeEndArray();
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadTablesRequest fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadTablesRequestParser::fromJson);
+  }
+
+  public static BatchLoadTablesRequest fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load tables request from null object");
+    Preconditions.checkArgument(json.hasNonNull(TABLES), "Cannot parse missing field: %s", TABLES);
+
+    ImmutableList.Builder<BatchLoadRequestedTable> tables = ImmutableList.builder();
+    JsonNode tablesNode = JsonUtil.get(TABLES, json);
+    Preconditions.checkArgument(
+        tablesNode.isArray(), "Cannot parse %s from non-array: %s", TABLES, tablesNode);
+
+    for (JsonNode tableNode : tablesNode) {
+      tables.add(BatchLoadRequestedTableParser.fromJson(tableNode));
+    }
+
+    return ImmutableBatchLoadTablesRequest.builder().tables(tables.build()).build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadViewsRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadViewsRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import java.util.List;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.RESTRequest;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface BatchLoadViewsRequest extends RESTRequest {
+
+  List<TableIdentifier> views();
+
+  @Override
+  default void validate() {}
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadViewsRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadViewsRequestParser.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadViewsRequestParser {
+
+  private static final String VIEWS = "views";
+
+  private BatchLoadViewsRequestParser() {}
+
+  public static String toJson(BatchLoadViewsRequest request) {
+    return toJson(request, false);
+  }
+
+  public static String toJson(BatchLoadViewsRequest request, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadViewsRequest request, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != request, "Invalid batch load views request: null");
+
+    gen.writeStartObject();
+
+    gen.writeArrayFieldStart(VIEWS);
+    for (TableIdentifier view : request.views()) {
+      TableIdentifierParser.toJson(view, gen);
+    }
+
+    gen.writeEndArray();
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadViewsRequest fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadViewsRequestParser::fromJson);
+  }
+
+  public static BatchLoadViewsRequest fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load views request from null object");
+    Preconditions.checkArgument(json.hasNonNull(VIEWS), "Cannot parse missing field: %s", VIEWS);
+
+    ImmutableList.Builder<TableIdentifier> views = ImmutableList.builder();
+    JsonNode viewsNode = JsonUtil.get(VIEWS, json);
+    Preconditions.checkArgument(
+        viewsNode.isArray(), "Cannot parse %s from non-array: %s", VIEWS, viewsNode);
+
+    for (JsonNode viewNode : viewsNode) {
+      views.add(TableIdentifierParser.fromJson(viewNode));
+    }
+
+    return ImmutableBatchLoadViewsRequest.builder().views(views.build()).build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadTablesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadTablesResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.requests.BatchLoadRequestedTable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface BatchLoadTablesResponse extends RESTResponse {
+
+  List<BatchLoadTablesResultItem> results();
+
+  @Nullable
+  List<BatchLoadRequestedTable> unprocessedTables();
+
+  @Override
+  default void validate() {}
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadTablesResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadTablesResponseParser.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.rest.requests.BatchLoadRequestedTable;
+import org.apache.iceberg.rest.requests.BatchLoadRequestedTableParser;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadTablesResponseParser {
+
+  private static final String RESULTS = "results";
+  private static final String UNPROCESSED_TABLES = "unprocessed-tables";
+
+  private BatchLoadTablesResponseParser() {}
+
+  public static String toJson(BatchLoadTablesResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(BatchLoadTablesResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadTablesResponse response, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid batch load tables response: null");
+
+    gen.writeStartObject();
+
+    gen.writeArrayFieldStart(RESULTS);
+    for (BatchLoadTablesResultItem item : response.results()) {
+      BatchLoadTablesResultItemParser.toJson(item, gen);
+    }
+
+    gen.writeEndArray();
+
+    List<BatchLoadRequestedTable> unprocessed = response.unprocessedTables();
+    if (null != unprocessed && !unprocessed.isEmpty()) {
+      gen.writeArrayFieldStart(UNPROCESSED_TABLES);
+      for (BatchLoadRequestedTable table : unprocessed) {
+        BatchLoadRequestedTableParser.toJson(table, gen);
+      }
+
+      gen.writeEndArray();
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadTablesResponse fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadTablesResponseParser::fromJson);
+  }
+
+  public static BatchLoadTablesResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load tables response from null object");
+    Preconditions.checkArgument(
+        json.hasNonNull(RESULTS), "Cannot parse missing field: %s", RESULTS);
+
+    ImmutableList.Builder<BatchLoadTablesResultItem> results = ImmutableList.builder();
+    JsonNode resultsNode = JsonUtil.get(RESULTS, json);
+    Preconditions.checkArgument(
+        resultsNode.isArray(), "Cannot parse %s from non-array: %s", RESULTS, resultsNode);
+
+    for (JsonNode itemNode : resultsNode) {
+      results.add(BatchLoadTablesResultItemParser.fromJson(itemNode));
+    }
+
+    ImmutableBatchLoadTablesResponse.Builder builder =
+        ImmutableBatchLoadTablesResponse.builder().results(results.build());
+
+    if (json.hasNonNull(UNPROCESSED_TABLES)) {
+      JsonNode unprocessedNode = JsonUtil.get(UNPROCESSED_TABLES, json);
+      Preconditions.checkArgument(
+          unprocessedNode.isArray(),
+          "Cannot parse %s from non-array: %s",
+          UNPROCESSED_TABLES,
+          unprocessedNode);
+
+      ImmutableList.Builder<BatchLoadRequestedTable> unprocessed = ImmutableList.builder();
+      for (JsonNode tableNode : unprocessedNode) {
+        unprocessed.add(BatchLoadRequestedTableParser.fromJson(tableNode));
+      }
+
+      builder.unprocessedTables(unprocessed.build());
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadTablesResultItem.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadTablesResultItem.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import javax.annotation.Nullable;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface BatchLoadTablesResultItem {
+
+  TableIdentifier identifier();
+
+  int status();
+
+  @Nullable
+  String etag();
+
+  @Nullable
+  LoadTableResponse result();
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadTablesResultItemParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadTablesResultItemParser.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadTablesResultItemParser {
+
+  private static final String IDENTIFIER = "identifier";
+  private static final String STATUS = "status";
+  private static final String ETAG = "etag";
+  private static final String RESULT = "result";
+
+  private BatchLoadTablesResultItemParser() {}
+
+  public static String toJson(BatchLoadTablesResultItem item) {
+    return toJson(item, false);
+  }
+
+  public static String toJson(BatchLoadTablesResultItem item, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(item, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadTablesResultItem item, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != item, "Invalid batch load tables result item: null");
+
+    gen.writeStartObject();
+
+    gen.writeFieldName(IDENTIFIER);
+    TableIdentifierParser.toJson(item.identifier(), gen);
+
+    gen.writeNumberField(STATUS, item.status());
+
+    if (null != item.etag()) {
+      gen.writeStringField(ETAG, item.etag());
+    }
+
+    if (null != item.result()) {
+      gen.writeFieldName(RESULT);
+      LoadTableResponseParser.toJson(item.result(), gen);
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadTablesResultItem fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadTablesResultItemParser::fromJson);
+  }
+
+  public static BatchLoadTablesResultItem fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load tables result item from null object");
+
+    TableIdentifier identifier = TableIdentifierParser.fromJson(JsonUtil.get(IDENTIFIER, json));
+    int status = JsonUtil.getInt(STATUS, json);
+
+    ImmutableBatchLoadTablesResultItem.Builder builder =
+        ImmutableBatchLoadTablesResultItem.builder().identifier(identifier).status(status);
+
+    if (json.hasNonNull(ETAG)) {
+      builder.etag(JsonUtil.getString(ETAG, json));
+    }
+
+    if (json.hasNonNull(RESULT)) {
+      builder.result(LoadTableResponseParser.fromJson(JsonUtil.get(RESULT, json)));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadViewsResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadViewsResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import org.apache.iceberg.rest.RESTResponse;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface BatchLoadViewsResponse extends RESTResponse {
+
+  List<BatchLoadViewsResultItem> views();
+
+  @Override
+  default void validate() {}
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadViewsResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadViewsResponseParser.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadViewsResponseParser {
+
+  private static final String VIEWS = "views";
+
+  private BatchLoadViewsResponseParser() {}
+
+  public static String toJson(BatchLoadViewsResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(BatchLoadViewsResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadViewsResponse response, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid batch load views response: null");
+
+    gen.writeStartObject();
+
+    gen.writeArrayFieldStart(VIEWS);
+    for (BatchLoadViewsResultItem item : response.views()) {
+      BatchLoadViewsResultItemParser.toJson(item, gen);
+    }
+
+    gen.writeEndArray();
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadViewsResponse fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadViewsResponseParser::fromJson);
+  }
+
+  public static BatchLoadViewsResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load views response from null object");
+    Preconditions.checkArgument(json.hasNonNull(VIEWS), "Cannot parse missing field: %s", VIEWS);
+
+    ImmutableList.Builder<BatchLoadViewsResultItem> views = ImmutableList.builder();
+    JsonNode viewsNode = JsonUtil.get(VIEWS, json);
+    Preconditions.checkArgument(
+        viewsNode.isArray(), "Cannot parse %s from non-array: %s", VIEWS, viewsNode);
+
+    for (JsonNode itemNode : viewsNode) {
+      views.add(BatchLoadViewsResultItemParser.fromJson(itemNode));
+    }
+
+    return ImmutableBatchLoadViewsResponse.builder().views(views.build()).build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadViewsResultItem.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadViewsResultItem.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import javax.annotation.Nullable;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface BatchLoadViewsResultItem {
+
+  TableIdentifier identifier();
+
+  int status();
+
+  @Nullable
+  LoadViewResponse result();
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadViewsResultItemParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadViewsResultItemParser.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadViewsResultItemParser {
+
+  private static final String IDENTIFIER = "identifier";
+  private static final String STATUS = "status";
+  private static final String RESULT = "result";
+
+  private BatchLoadViewsResultItemParser() {}
+
+  public static String toJson(BatchLoadViewsResultItem item) {
+    return toJson(item, false);
+  }
+
+  public static String toJson(BatchLoadViewsResultItem item, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(item, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadViewsResultItem item, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != item, "Invalid batch load views result item: null");
+
+    gen.writeStartObject();
+
+    gen.writeFieldName(IDENTIFIER);
+    TableIdentifierParser.toJson(item.identifier(), gen);
+
+    gen.writeNumberField(STATUS, item.status());
+
+    if (null != item.result()) {
+      gen.writeFieldName(RESULT);
+      LoadViewResponseParser.toJson(item.result(), gen);
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadViewsResultItem fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadViewsResultItemParser::fromJson);
+  }
+
+  public static BatchLoadViewsResultItem fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load views result item from null object");
+
+    TableIdentifier identifier = TableIdentifierParser.fromJson(JsonUtil.get(IDENTIFIER, json));
+    int status = JsonUtil.getInt(STATUS, json);
+
+    ImmutableBatchLoadViewsResultItem.Builder builder =
+        ImmutableBatchLoadViewsResultItem.builder().identifier(identifier).status(status);
+
+    if (json.hasNonNull(RESULT)) {
+      builder.result(LoadViewResponseParser.fromJson(JsonUtil.get(RESULT, json)));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -63,6 +63,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
 import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
 import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.requests.BatchLoadTablesRequest;
+import org.apache.iceberg.rest.requests.BatchLoadViewsRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -433,6 +435,14 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
           return null;
         }
 
+      case BATCH_LOAD_TABLES:
+        {
+          BatchLoadTablesRequest request = castRequest(BatchLoadTablesRequest.class, body);
+          SnapshotMode mode = snapshotModeFromQueryParams(httpRequest.queryParameters());
+          return castResponse(
+              responseType, CatalogHandlers.batchLoadTables(catalog, request, mode));
+        }
+
       case LIST_VIEWS:
         {
           if (null != asViewCatalog) {
@@ -527,6 +537,16 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
             RegisterViewRequest request = castRequest(RegisterViewRequest.class, body);
             return castResponse(
                 responseType, CatalogHandlers.registerView(asViewCatalog, namespace, request));
+          }
+          break;
+        }
+
+      case BATCH_LOAD_VIEWS:
+        {
+          if (null != asViewCatalog) {
+            BatchLoadViewsRequest request = castRequest(BatchLoadViewsRequest.class, body);
+            return castResponse(
+                responseType, CatalogHandlers.batchLoadViews(asViewCatalog, request));
           }
           break;
         }

--- a/core/src/test/java/org/apache/iceberg/rest/Route.java
+++ b/core/src/test/java/org/apache/iceberg/rest/Route.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.requests.BatchLoadTablesRequest;
+import org.apache.iceberg.rest.requests.BatchLoadViewsRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -34,6 +36,8 @@ import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResponse;
+import org.apache.iceberg.rest.responses.BatchLoadViewsResponse;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
@@ -90,6 +94,11 @@ enum Route {
   DROP_TABLE(HTTPRequest.HTTPMethod.DELETE, ResourcePaths.V1_TABLE),
   RENAME_TABLE(
       HTTPRequest.HTTPMethod.POST, ResourcePaths.V1_TABLE_RENAME, RenameTableRequest.class, null),
+  BATCH_LOAD_TABLES(
+      HTTPRequest.HTTPMethod.POST,
+      ResourcePaths.V1_TABLES_BATCH_LOAD,
+      BatchLoadTablesRequest.class,
+      BatchLoadTablesResponse.class),
   REPORT_METRICS(
       HTTPRequest.HTTPMethod.POST,
       ResourcePaths.V1_TABLE_METRICS,
@@ -121,6 +130,11 @@ enum Route {
       ResourcePaths.V1_VIEW_REGISTER,
       RegisterViewRequest.class,
       LoadViewResponse.class),
+  BATCH_LOAD_VIEWS(
+      HTTPRequest.HTTPMethod.POST,
+      ResourcePaths.V1_VIEWS_BATCH_LOAD,
+      BatchLoadViewsRequest.class,
+      BatchLoadViewsResponse.class),
   PLAN_TABLE_SCAN(
       HTTPRequest.HTTPMethod.POST,
       ResourcePaths.V1_TABLE_SCAN_PLAN_SUBMIT,

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
@@ -48,6 +49,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -76,15 +78,20 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewSessionCatalog;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.metrics.CommitReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -99,18 +106,25 @@ import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.AuthSessionUtil;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.rest.requests.BatchLoadRequestedTable;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.ImmutableBatchLoadRequestedTable;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResponse;
+import org.apache.iceberg.rest.responses.BatchLoadTablesResultItem;
+import org.apache.iceberg.rest.responses.BatchLoadViewsResultItem;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.ImmutableBatchLoadTablesResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.view.View;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.server.Server;
@@ -3773,5 +3787,459 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     ArgumentCaptor<HTTPRequest> captor = ArgumentCaptor.forClass(HTTPRequest.class);
     verify(adapter, atLeastOnce()).execute(captor.capture(), any(), any(), any());
     return captor.getAllValues();
+  }
+
+  @Test
+  public void testBatchLoadTablesRoundTrip() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog = catalog(adapter);
+
+    catalog.createNamespace(TABLE.namespace());
+    catalog.createTable(TABLE, SCHEMA);
+
+    TableIdentifier missingTable = TableIdentifier.of(TABLE.namespace(), "missing_table");
+
+    RESTSessionCatalog sessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+
+    List<BatchLoadRequestedTable> tables =
+        ImmutableList.of(
+            ImmutableBatchLoadRequestedTable.builder().identifier(TABLE).build(),
+            ImmutableBatchLoadRequestedTable.builder().identifier(missingTable).build());
+
+    List<BatchLoadTablesResultItem> results;
+    try (CloseableIterable<BatchLoadTablesResultItem> iterable =
+        sessionCatalog.batchLoadTables(context, tables)) {
+      results = Lists.newArrayList(iterable);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    assertThat(results).hasSize(2);
+
+    BatchLoadTablesResultItem foundItem =
+        results.stream().filter(r -> r.identifier().equals(TABLE)).findFirst().orElseThrow();
+    assertThat(foundItem.status()).isEqualTo(200);
+    assertThat(foundItem.result()).isNotNull();
+    assertThat(foundItem.result().tableMetadata()).isNotNull();
+
+    BatchLoadTablesResultItem missingItem =
+        results.stream().filter(r -> r.identifier().equals(missingTable)).findFirst().orElseThrow();
+    assertThat(missingItem.status()).isEqualTo(404);
+    assertThat(missingItem.result()).isNull();
+  }
+
+  @Test
+  public void testBatchLoadTablesRetryUnprocessed() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog = catalog(adapter);
+
+    catalog.createNamespace(TABLE.namespace());
+
+    TableIdentifier tbl1 = TableIdentifier.of(TABLE.namespace(), "tbl1");
+    TableIdentifier tbl2 = TableIdentifier.of(TABLE.namespace(), "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of(TABLE.namespace(), "tbl3");
+    catalog.createTable(tbl1, SCHEMA);
+    catalog.createTable(tbl2, SCHEMA);
+    catalog.createTable(tbl3, SCHEMA);
+
+    AtomicInteger batchCallCount = new AtomicInteger(0);
+
+    Mockito.doAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              BatchLoadTablesResponse realResponse =
+                  (BatchLoadTablesResponse) invocation.callRealMethod();
+
+              int call = batchCallCount.incrementAndGet();
+              if (call == 1) {
+                // first call: return only tbl1's result, mark tbl2 and tbl3 as unprocessed
+                BatchLoadTablesResultItem tbl1Result =
+                    realResponse.results().stream()
+                        .filter(r -> r.identifier().equals(tbl1))
+                        .findFirst()
+                        .orElseThrow();
+
+                return ImmutableBatchLoadTablesResponse.builder()
+                    .addResults(tbl1Result)
+                    .addUnprocessedTables(
+                        ImmutableBatchLoadRequestedTable.builder().identifier(tbl2).build(),
+                        ImmutableBatchLoadRequestedTable.builder().identifier(tbl3).build())
+                    .build();
+              }
+
+              // second call: return remaining tables normally
+              return realResponse;
+            })
+        .when(adapter)
+        .execute(
+            RequestMatcher.matches(HTTPMethod.POST, RESOURCE_PATHS.batchLoadTables()),
+            eq(BatchLoadTablesResponse.class),
+            any(),
+            any());
+
+    RESTSessionCatalog sessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+
+    List<BatchLoadRequestedTable> tables =
+        ImmutableList.of(
+            ImmutableBatchLoadRequestedTable.builder().identifier(tbl1).build(),
+            ImmutableBatchLoadRequestedTable.builder().identifier(tbl2).build(),
+            ImmutableBatchLoadRequestedTable.builder().identifier(tbl3).build());
+
+    List<BatchLoadTablesResultItem> results;
+    try (CloseableIterable<BatchLoadTablesResultItem> iterable =
+        sessionCatalog.batchLoadTables(context, tables)) {
+      results = Lists.newArrayList(iterable);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    assertThat(batchCallCount.get()).isEqualTo(2);
+    assertThat(results).hasSize(3);
+
+    for (TableIdentifier ident : ImmutableList.of(tbl1, tbl2, tbl3)) {
+      BatchLoadTablesResultItem item =
+          results.stream().filter(r -> r.identifier().equals(ident)).findFirst().orElseThrow();
+      assertThat(item.status()).isEqualTo(200);
+      assertThat(item.result()).isNotNull();
+      assertThat(item.result().tableMetadata()).isNotNull();
+    }
+  }
+
+  @Test
+  public void testBatchLoadTablesNotModified() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog = catalog(adapter);
+
+    catalog.createNamespace(TABLE.namespace());
+    catalog.createTable(TABLE, SCHEMA);
+
+    RESTSessionCatalog sessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+
+    BatchLoadTablesResultItem initialResult;
+    try (CloseableIterable<BatchLoadTablesResultItem> iterable =
+        sessionCatalog.batchLoadTables(
+            context,
+            ImmutableList.of(
+                ImmutableBatchLoadRequestedTable.builder().identifier(TABLE).build()))) {
+      initialResult = Lists.newArrayList(iterable).get(0);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    assertThat(initialResult.status()).isEqualTo(200);
+    assertThat(initialResult.etag()).isNotNull();
+
+    BatchLoadTablesResultItem cachedResult;
+    try (CloseableIterable<BatchLoadTablesResultItem> iterable =
+        sessionCatalog.batchLoadTables(
+            context,
+            ImmutableList.of(
+                ImmutableBatchLoadRequestedTable.builder()
+                    .identifier(TABLE)
+                    .ifNonMatch(initialResult.etag())
+                    .build()))) {
+      cachedResult = Lists.newArrayList(iterable).get(0);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    assertThat(cachedResult.status()).isEqualTo(304);
+    assertThat(cachedResult.etag()).isEqualTo(initialResult.etag());
+    assertThat(cachedResult.result()).isNull();
+  }
+
+  @Test
+  public void testBatchLoadTablesUsesSnapshotLoadingMode() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), config -> adapter);
+    catalog.initialize(
+        "test",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
+            SnapshotMode.REFS.name()));
+
+    catalog.createNamespace(TABLE.namespace());
+    Table table = catalog.createTable(TABLE, SCHEMA);
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/batch-load-a.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/batch-load-b.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build())
+        .commit();
+
+    RESTSessionCatalog sessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+
+    BatchLoadTablesResultItem result;
+    try (CloseableIterable<BatchLoadTablesResultItem> iterable =
+        sessionCatalog.batchLoadTables(
+            context,
+            ImmutableList.of(
+                ImmutableBatchLoadRequestedTable.builder().identifier(TABLE).build()))) {
+      result = Lists.newArrayList(iterable).get(0);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    assertThat(result.status()).isEqualTo(200);
+    assertThat(result.result()).isNotNull();
+    assertThat(result.result().tableMetadata().snapshots()).hasSize(1);
+
+    verify(adapter, times(1))
+        .execute(
+            matches(
+                HTTPMethod.POST,
+                RESOURCE_PATHS.batchLoadTables(),
+                Map.of(),
+                Map.of("snapshots", "refs")),
+            eq(BatchLoadTablesResponse.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void testBatchLoadTablesViaSessionCatalogInterface() throws IOException {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog = catalog(adapter);
+
+    catalog.createNamespace(TABLE.namespace());
+    catalog.createTable(TABLE, SCHEMA);
+
+    SessionCatalog sessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+    TableIdentifier missingTable = TableIdentifier.of(TABLE.namespace(), "missing_table");
+
+    try (CloseableIterable<Table> iterable =
+        sessionCatalog.batchLoadTables(context, ImmutableList.of(TABLE, missingTable))) {
+      CloseableIterator<Table> iterator = iterable.iterator();
+      Table loadedTable = iterator.next();
+      assertThat(loadedTable.name()).isEqualTo(String.format("%s.%s", catalog.name(), TABLE));
+      assertThatThrownBy(iterator::next)
+          .isInstanceOf(NoSuchTableException.class)
+          .hasMessage("Table does not exist: %s", missingTable);
+    }
+  }
+
+  @Test
+  public void testBatchLoadTablesFailsWhenUnprocessedTablesDoNotMakeProgress() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog = catalog(adapter);
+
+    catalog.createNamespace(TABLE.namespace());
+
+    AtomicInteger batchCallCount = new AtomicInteger(0);
+    Mockito.doAnswer(
+            invocation -> {
+              batchCallCount.incrementAndGet();
+              return ImmutableBatchLoadTablesResponse.builder()
+                  .results(ImmutableList.of())
+                  .addUnprocessedTables(
+                      ImmutableBatchLoadRequestedTable.builder().identifier(TABLE).build())
+                  .build();
+            })
+        .when(adapter)
+        .execute(
+            RequestMatcher.matches(HTTPMethod.POST, RESOURCE_PATHS.batchLoadTables()),
+            eq(BatchLoadTablesResponse.class),
+            any(),
+            any());
+
+    RESTSessionCatalog sessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+
+    assertThatThrownBy(
+            () -> {
+              try (CloseableIterable<BatchLoadTablesResultItem> iterable =
+                  sessionCatalog.batchLoadTables(
+                      context,
+                      ImmutableList.of(
+                          ImmutableBatchLoadRequestedTable.builder().identifier(TABLE).build()))) {
+                Lists.newArrayList(iterable);
+              }
+            })
+        .isInstanceOf(RESTException.class)
+        .hasMessageContaining("server did not make progress");
+
+    assertThat(batchCallCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void testBatchLoadTablesFailsWhenUnprocessedTablesRepeat() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog = catalog(adapter);
+
+    catalog.createNamespace(TABLE.namespace());
+
+    TableIdentifier tbl1 = TableIdentifier.of(TABLE.namespace(), "tbl1");
+    TableIdentifier tbl2 = TableIdentifier.of(TABLE.namespace(), "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of(TABLE.namespace(), "tbl3");
+    catalog.createTable(tbl1, SCHEMA);
+    catalog.createTable(tbl2, SCHEMA);
+    catalog.createTable(tbl3, SCHEMA);
+
+    AtomicInteger batchCallCount = new AtomicInteger(0);
+    Mockito.doAnswer(
+            invocation -> {
+              @SuppressWarnings("unchecked")
+              BatchLoadTablesResponse realResponse =
+                  (BatchLoadTablesResponse) invocation.callRealMethod();
+              int call = batchCallCount.incrementAndGet();
+              if (call == 1) {
+                BatchLoadTablesResultItem tbl1Result =
+                    realResponse.results().stream()
+                        .filter(r -> r.identifier().equals(tbl1))
+                        .findFirst()
+                        .orElseThrow();
+                return ImmutableBatchLoadTablesResponse.builder()
+                    .addResults(tbl1Result)
+                    .addUnprocessedTables(
+                        ImmutableBatchLoadRequestedTable.builder().identifier(tbl2).build(),
+                        ImmutableBatchLoadRequestedTable.builder().identifier(tbl3).build())
+                    .build();
+              } else if (call == 2) {
+                BatchLoadTablesResultItem tbl2Result =
+                    realResponse.results().stream()
+                        .filter(r -> r.identifier().equals(tbl2))
+                        .findFirst()
+                        .orElseThrow();
+                return ImmutableBatchLoadTablesResponse.builder()
+                    .addResults(tbl2Result)
+                    .addUnprocessedTables(
+                        ImmutableBatchLoadRequestedTable.builder().identifier(tbl3).build())
+                    .build();
+              } else {
+                BatchLoadTablesResultItem tbl3Result =
+                    realResponse.results().stream()
+                        .filter(r -> r.identifier().equals(tbl3))
+                        .findFirst()
+                        .orElseThrow();
+                return ImmutableBatchLoadTablesResponse.builder()
+                    .addResults(tbl3Result)
+                    .addUnprocessedTables(
+                        ImmutableBatchLoadRequestedTable.builder().identifier(tbl2).build(),
+                        ImmutableBatchLoadRequestedTable.builder().identifier(tbl3).build())
+                    .build();
+              }
+            })
+        .when(adapter)
+        .execute(
+            RequestMatcher.matches(HTTPMethod.POST, RESOURCE_PATHS.batchLoadTables()),
+            eq(BatchLoadTablesResponse.class),
+            any(),
+            any());
+
+    RESTSessionCatalog sessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+
+    assertThatThrownBy(
+            () -> {
+              try (CloseableIterable<BatchLoadTablesResultItem> iterable =
+                  sessionCatalog.batchLoadTables(
+                      context,
+                      ImmutableList.of(
+                          ImmutableBatchLoadRequestedTable.builder().identifier(tbl1).build(),
+                          ImmutableBatchLoadRequestedTable.builder().identifier(tbl2).build(),
+                          ImmutableBatchLoadRequestedTable.builder().identifier(tbl3).build()))) {
+                Lists.newArrayList(iterable);
+              }
+            })
+        .isInstanceOf(RESTException.class)
+        .hasMessageContaining("server did not make progress");
+
+    assertThat(batchCallCount.get()).isEqualTo(3);
+  }
+
+  @Test
+  public void testBatchLoadViewsRoundTrip() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog = catalog(adapter);
+
+    catalog.createNamespace(TABLE.namespace());
+
+    TableIdentifier viewIdent = TableIdentifier.of(TABLE.namespace(), "test_view");
+    catalog
+        .buildView(viewIdent)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(TABLE.namespace())
+        .withQuery("spark", "SELECT * FROM tbl")
+        .create();
+
+    TableIdentifier missingView = TableIdentifier.of(TABLE.namespace(), "missing_view");
+
+    RESTSessionCatalog sessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+
+    List<TableIdentifier> views = ImmutableList.of(viewIdent, missingView);
+
+    List<BatchLoadViewsResultItem> results;
+    try (CloseableIterable<BatchLoadViewsResultItem> iterable =
+        sessionCatalog.batchLoadViews(context, views)) {
+      results = Lists.newArrayList(iterable);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    assertThat(results).hasSize(2);
+
+    BatchLoadViewsResultItem foundItem =
+        results.stream().filter(r -> r.identifier().equals(viewIdent)).findFirst().orElseThrow();
+    assertThat(foundItem.status()).isEqualTo(200);
+    assertThat(foundItem.result()).isNotNull();
+
+    BatchLoadViewsResultItem missingItem =
+        results.stream().filter(r -> r.identifier().equals(missingView)).findFirst().orElseThrow();
+    assertThat(missingItem.status()).isEqualTo(404);
+    assertThat(missingItem.result()).isNull();
+  }
+
+  @Test
+  public void testBatchLoadViewsViaViewSessionCatalogInterface() throws IOException {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    RESTCatalog catalog = catalog(adapter);
+
+    catalog.createNamespace(TABLE.namespace());
+
+    TableIdentifier viewIdent = TableIdentifier.of(TABLE.namespace(), "test_view");
+    catalog
+        .buildView(viewIdent)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(TABLE.namespace())
+        .withQuery("spark", "SELECT * FROM tbl")
+        .create();
+
+    ViewSessionCatalog viewSessionCatalog = catalog.sessionCatalog();
+    SessionCatalog.SessionContext context = SessionCatalog.SessionContext.createEmpty();
+    TableIdentifier missingView = TableIdentifier.of(TABLE.namespace(), "missing_view");
+
+    try (CloseableIterable<View> iterable =
+        viewSessionCatalog.batchLoadViews(context, ImmutableList.of(viewIdent, missingView))) {
+      CloseableIterator<View> iterator = iterable.iterator();
+      View loadedView = iterator.next();
+      assertThat(loadedView.name()).isEqualTo(String.format("%s.%s", catalog.name(), viewIdent));
+      assertThatThrownBy(iterator::next)
+          .isInstanceOf(NoSuchViewException.class)
+          .hasMessage("View does not exist: %s", missingView);
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestBatchLoadRequestedTableParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestBatchLoadRequestedTableParser.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.api.Test;
+
+class TestBatchLoadRequestedTableParser {
+
+  @Test
+  void nullCheck() {
+    assertThatThrownBy(() -> BatchLoadRequestedTableParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid batch load requested table: null");
+
+    assertThatThrownBy(() -> BatchLoadRequestedTableParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse batch load requested table from null object");
+  }
+
+  @Test
+  void missingFields() {
+    assertThatThrownBy(() -> BatchLoadRequestedTableParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: identifier");
+  }
+
+  @Test
+  void roundTripSerdeMinimal() {
+    BatchLoadRequestedTable table =
+        ImmutableBatchLoadRequestedTable.builder()
+            .identifier(TableIdentifier.of(Namespace.of("ns"), "tbl"))
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"identifier\" : {\n"
+            + "    \"namespace\" : [ \"ns\" ],\n"
+            + "    \"name\" : \"tbl\"\n"
+            + "  }\n"
+            + "}";
+
+    String json = BatchLoadRequestedTableParser.toJson(table, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    assertThat(
+            BatchLoadRequestedTableParser.toJson(
+                BatchLoadRequestedTableParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+
+  @Test
+  void roundTripSerdeAllFields() {
+    BatchLoadRequestedTable table =
+        ImmutableBatchLoadRequestedTable.builder()
+            .identifier(TableIdentifier.of(Namespace.of("db", "schema"), "my_table"))
+            .ifNonMatch("abc123")
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"identifier\" : {\n"
+            + "    \"namespace\" : [ \"db\", \"schema\" ],\n"
+            + "    \"name\" : \"my_table\"\n"
+            + "  },\n"
+            + "  \"if-non-match\" : \"abc123\"\n"
+            + "}";
+
+    String json = BatchLoadRequestedTableParser.toJson(table, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    assertThat(
+            BatchLoadRequestedTableParser.toJson(
+                BatchLoadRequestedTableParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestBatchLoadTablesRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestBatchLoadTablesRequestParser.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.api.Test;
+
+class TestBatchLoadTablesRequestParser {
+
+  @Test
+  void nullCheck() {
+    assertThatThrownBy(() -> BatchLoadTablesRequestParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid batch load tables request: null");
+
+    assertThatThrownBy(() -> BatchLoadTablesRequestParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse batch load tables request from null object");
+  }
+
+  @Test
+  void missingFields() {
+    assertThatThrownBy(() -> BatchLoadTablesRequestParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: tables");
+  }
+
+  @Test
+  void roundTripSerde() {
+    BatchLoadTablesRequest request =
+        ImmutableBatchLoadTablesRequest.builder()
+            .addTables(
+                ImmutableBatchLoadRequestedTable.builder()
+                    .identifier(TableIdentifier.of(Namespace.of("ns1"), "tbl1"))
+                    .build(),
+                ImmutableBatchLoadRequestedTable.builder()
+                    .identifier(TableIdentifier.of(Namespace.of("ns2"), "tbl2"))
+                    .ifNonMatch("etag123")
+                    .build())
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"tables\" : [ {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns1\" ],\n"
+            + "      \"name\" : \"tbl1\"\n"
+            + "    }\n"
+            + "  }, {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns2\" ],\n"
+            + "      \"name\" : \"tbl2\"\n"
+            + "    },\n"
+            + "    \"if-non-match\" : \"etag123\"\n"
+            + "  } ]\n"
+            + "}";
+
+    String json = BatchLoadTablesRequestParser.toJson(request, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    assertThat(
+            BatchLoadTablesRequestParser.toJson(BatchLoadTablesRequestParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestBatchLoadViewsRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestBatchLoadViewsRequestParser.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.api.Test;
+
+class TestBatchLoadViewsRequestParser {
+
+  @Test
+  void nullCheck() {
+    assertThatThrownBy(() -> BatchLoadViewsRequestParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid batch load views request: null");
+
+    assertThatThrownBy(() -> BatchLoadViewsRequestParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse batch load views request from null object");
+  }
+
+  @Test
+  void missingFields() {
+    assertThatThrownBy(() -> BatchLoadViewsRequestParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: views");
+  }
+
+  @Test
+  void roundTripSerde() {
+    BatchLoadViewsRequest request =
+        ImmutableBatchLoadViewsRequest.builder()
+            .addViews(
+                TableIdentifier.of(Namespace.of("ns1"), "view1"),
+                TableIdentifier.of(Namespace.of("ns2"), "view2"))
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"views\" : [ {\n"
+            + "    \"namespace\" : [ \"ns1\" ],\n"
+            + "    \"name\" : \"view1\"\n"
+            + "  }, {\n"
+            + "    \"namespace\" : [ \"ns2\" ],\n"
+            + "    \"name\" : \"view2\"\n"
+            + "  } ]\n"
+            + "}";
+
+    String json = BatchLoadViewsRequestParser.toJson(request, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    assertThat(BatchLoadViewsRequestParser.toJson(BatchLoadViewsRequestParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadTablesResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadTablesResponseParser.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.requests.ImmutableBatchLoadRequestedTable;
+import org.junit.jupiter.api.Test;
+
+class TestBatchLoadTablesResponseParser {
+
+  @Test
+  void nullCheck() {
+    assertThatThrownBy(() -> BatchLoadTablesResponseParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid batch load tables response: null");
+
+    assertThatThrownBy(() -> BatchLoadTablesResponseParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse batch load tables response from null object");
+  }
+
+  @Test
+  void missingFields() {
+    assertThatThrownBy(() -> BatchLoadTablesResponseParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: results");
+  }
+
+  @Test
+  void roundTripSerdeNotFoundAndNotModified() {
+    BatchLoadTablesResponse response =
+        ImmutableBatchLoadTablesResponse.builder()
+            .addResults(
+                ImmutableBatchLoadTablesResultItem.builder()
+                    .identifier(TableIdentifier.of(Namespace.of("ns"), "not_found"))
+                    .status(404)
+                    .build(),
+                ImmutableBatchLoadTablesResultItem.builder()
+                    .identifier(TableIdentifier.of(Namespace.of("ns"), "cached"))
+                    .status(304)
+                    .etag("abc123")
+                    .build())
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"results\" : [ {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns\" ],\n"
+            + "      \"name\" : \"not_found\"\n"
+            + "    },\n"
+            + "    \"status\" : 404\n"
+            + "  }, {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns\" ],\n"
+            + "      \"name\" : \"cached\"\n"
+            + "    },\n"
+            + "    \"status\" : 304,\n"
+            + "    \"etag\" : \"abc123\"\n"
+            + "  } ]\n"
+            + "}";
+
+    String json = BatchLoadTablesResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    BatchLoadTablesResponse deserialized = BatchLoadTablesResponseParser.fromJson(json);
+    assertThat(deserialized.results()).hasSize(2);
+    assertThat(deserialized.results().get(0).status()).isEqualTo(404);
+    assertThat(deserialized.results().get(0).result()).isNull();
+    assertThat(deserialized.results().get(1).status()).isEqualTo(304);
+    assertThat(deserialized.results().get(1).etag()).isEqualTo("abc123");
+    assertThat(deserialized.unprocessedTables()).isNull();
+  }
+
+  @Test
+  void roundTripSerdeWithUnprocessedTables() {
+    BatchLoadTablesResponse response =
+        ImmutableBatchLoadTablesResponse.builder()
+            .addResults(
+                ImmutableBatchLoadTablesResultItem.builder()
+                    .identifier(TableIdentifier.of(Namespace.of("ns"), "tbl1"))
+                    .status(404)
+                    .build())
+            .addUnprocessedTables(
+                ImmutableBatchLoadRequestedTable.builder()
+                    .identifier(TableIdentifier.of(Namespace.of("ns"), "tbl2"))
+                    .build())
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"results\" : [ {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns\" ],\n"
+            + "      \"name\" : \"tbl1\"\n"
+            + "    },\n"
+            + "    \"status\" : 404\n"
+            + "  } ],\n"
+            + "  \"unprocessed-tables\" : [ {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns\" ],\n"
+            + "      \"name\" : \"tbl2\"\n"
+            + "    }\n"
+            + "  } ]\n"
+            + "}";
+
+    String json = BatchLoadTablesResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    BatchLoadTablesResponse deserialized = BatchLoadTablesResponseParser.fromJson(json);
+    assertThat(deserialized.results()).hasSize(1);
+    assertThat(deserialized.unprocessedTables()).hasSize(1);
+    assertThat(deserialized.unprocessedTables().get(0).identifier().name()).isEqualTo("tbl2");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadViewsResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadViewsResponseParser.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.api.Test;
+
+class TestBatchLoadViewsResponseParser {
+
+  @Test
+  void nullCheck() {
+    assertThatThrownBy(() -> BatchLoadViewsResponseParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid batch load views response: null");
+
+    assertThatThrownBy(() -> BatchLoadViewsResponseParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse batch load views response from null object");
+  }
+
+  @Test
+  void missingFields() {
+    assertThatThrownBy(() -> BatchLoadViewsResponseParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: views");
+  }
+
+  @Test
+  void roundTripSerdeNotFound() {
+    BatchLoadViewsResponse response =
+        ImmutableBatchLoadViewsResponse.builder()
+            .addViews(
+                ImmutableBatchLoadViewsResultItem.builder()
+                    .identifier(TableIdentifier.of(Namespace.of("ns"), "view1"))
+                    .status(404)
+                    .build(),
+                ImmutableBatchLoadViewsResultItem.builder()
+                    .identifier(TableIdentifier.of(Namespace.of("ns"), "view2"))
+                    .status(404)
+                    .build())
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"views\" : [ {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns\" ],\n"
+            + "      \"name\" : \"view1\"\n"
+            + "    },\n"
+            + "    \"status\" : 404\n"
+            + "  }, {\n"
+            + "    \"identifier\" : {\n"
+            + "      \"namespace\" : [ \"ns\" ],\n"
+            + "      \"name\" : \"view2\"\n"
+            + "    },\n"
+            + "    \"status\" : 404\n"
+            + "  } ]\n"
+            + "}";
+
+    String json = BatchLoadViewsResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+
+    BatchLoadViewsResponse deserialized = BatchLoadViewsResponseParser.fromJson(json);
+    assertThat(deserialized.views()).hasSize(2);
+    assertThat(deserialized.views().get(0).status()).isEqualTo(404);
+    assertThat(deserialized.views().get(0).result()).isNull();
+    assertThat(deserialized.views().get(1).status()).isEqualTo(404);
+  }
+}


### PR DESCRIPTION
Implement the Java side of the batch load REST endpoints (POST /v1/{prefix}/tables/batch-load and views/batch-load).

This includes request/response models, custom JSON parsers, serializer registration, routing, server-side handlers in CatalogHandlers, RESTCatalogAdapter routing, and client-side methods in RESTSessionCatalog returning CloseableIterable with automatic retry of unprocessed tables.

The OpenAPI spec changes are tracked in a separate PR (#15528).

Made-with: Cursor
Model: claude-4.6-opus-high-thinking

I carefully reviewed the changes and refined the implementation with a few iterations

* changed the `RESTSessionCatalog#batchLoadTables` return type from a list to an iterable so that results can be consumed in a streaming fashion in case of server pagination and client retries. This avoid holding a large amount of items in memory for large responses.
* Changed requestedSnapshots from String to SnapshotMode enum — In BatchLoadRequestedTable.java, the return type was changed from `String` to `SnapshotMode` enum, providing type safety. 
* Added retry integration test — testBatchLoadTablesRetryUnprocessed in TestRESTCatalog.java verifies the client's automatic retry behavior when the server returns unprocessed tables.