### PR TITLE
Core: Use partition filtering for dangling DV detection in ManifestFilterManager

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -88,6 +88,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   // this is only being used for the DeleteManifestFilterManager to detect orphaned DVs for removed
   // data file paths
   private Set<String> removedDataFilePaths = Sets.newHashSet();
+  private final PartitionSet removedDataFilePartitions;
 
   // cache filtered manifests to avoid extra work when commits fail.
   private final Map<ManifestFile, ManifestFile> filteredManifests = Maps.newConcurrentMap();
@@ -103,6 +104,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     this.specsById = specsById;
     this.deleteFilePartitions = PartitionSet.create(specsById);
     this.dropPartitions = PartitionSet.create(specsById);
+    this.removedDataFilePartitions = PartitionSet.create(specsById);
     this.workerPoolSupplier = executorSupplier;
   }
 
@@ -170,6 +172,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   protected void removeDanglingDeletesFor(Set<DataFile> dataFiles) {
     this.removedDataFilePaths =
         dataFiles.stream().map(ContentFile::location).collect(Collectors.toSet());
+    dataFiles.forEach(file -> removedDataFilePartitions.add(file.specId(), file.partition()));
   }
 
   /** Add a specific path to be deleted in the new snapshot. */
@@ -440,7 +443,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     } else if (!deleteFiles.isEmpty()) {
       return ManifestFileUtil.canContainAny(manifest, deleteFilePartitions, specsById);
     } else if (!removedDataFilePaths.isEmpty()) {
-      return true;
+      return ManifestFileUtil.canContainAny(manifest, removedDataFilePartitions, specsById);
     }
 
     return false;

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -779,6 +779,59 @@ public class TestRewriteFiles extends TestBase {
   }
 
   @TestTemplate
+  public void danglingDVDetectionSkipsNonOverlappingPartitions() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    // Commit data files + DVs to two separate partitions in separate commits
+    // so they end up in separate delete manifests
+    commit(table, table.newRowDelta().addRows(FILE_A).addDeletes(fileADeletes()), branch);
+    Snapshot snap1 = latestSnapshot(table, branch);
+
+    commit(table, table.newRowDelta().addRows(FILE_B).addDeletes(fileBDeletes()), branch);
+    Snapshot snap2 = latestSnapshot(table, branch);
+
+    // Verify we have 2 separate delete manifests (one per partition)
+    assertThat(snap2.deleteManifests(table.io())).hasSize(2);
+    ManifestFile deleteManifestForB = snap2.deleteManifests(table.io()).get(0);
+    ManifestFile deleteManifestForA = snap2.deleteManifests(table.io()).get(1);
+
+    // Remove only FILE_A (partition bucket=0) — this should make its DV dangling
+    commit(
+        table,
+        table.newRewrite().validateFromSnapshot(snap2.snapshotId()).deleteFile(FILE_A),
+        branch);
+
+    Snapshot rewriteSnap = latestSnapshot(table, branch);
+
+    // Verify the delete manifest for partition bucket=0 was rewritten
+    // (DV for FILE_A should be marked DELETED)
+    // and the delete manifest for partition bucket=1 was NOT rewritten
+    // (it should be the same manifest object, untouched)
+    List<ManifestFile> deleteManifests = rewriteSnap.deleteManifests(table.io());
+    assertThat(deleteManifests).hasSize(2);
+
+    // The delete manifest for FILE_B's partition should be unchanged (not rewritten)
+    assertThat(deleteManifests).contains(deleteManifestForB);
+
+    // The delete manifest for FILE_A's partition should be rewritten (different path)
+    assertThat(deleteManifests).doesNotContain(deleteManifestForA);
+
+    // Verify the rewritten manifest has FILE_A's DV as DELETED
+    ManifestFile rewrittenManifest =
+        deleteManifests.stream()
+            .filter(m -> !m.path().equals(deleteManifestForB.path()))
+            .findFirst()
+            .orElseThrow();
+    validateDeleteManifest(
+        rewrittenManifest,
+        dataSeqs(1L),
+        fileSeqs(1L),
+        ids(rewriteSnap.snapshotId()),
+        files(fileADeletes()),
+        statuses(ManifestEntry.Status.DELETED));
+  }
+
+  @TestTemplate
   public void removingDataFileAlsoRemovesDV() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     commit(

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -791,9 +791,19 @@ public class TestRewriteFiles extends TestBase {
     Snapshot snap2 = latestSnapshot(table, branch);
 
     // Verify we have 2 separate delete manifests (one per partition)
-    assertThat(snap2.deleteManifests(table.io())).hasSize(2);
-    ManifestFile deleteManifestForB = snap2.deleteManifests(table.io()).get(0);
-    ManifestFile deleteManifestForA = snap2.deleteManifests(table.io()).get(1);
+    List<ManifestFile> deleteManifestsBefore = snap2.deleteManifests(table.io());
+    assertThat(deleteManifestsBefore).hasSize(2);
+
+    ManifestFile deleteManifestForA =
+        deleteManifestsBefore.stream()
+            .filter(m -> m.snapshotId() == snap1.snapshotId())
+            .findFirst()
+            .orElseThrow();
+    ManifestFile deleteManifestForB =
+        deleteManifestsBefore.stream()
+            .filter(m -> m.snapshotId() == snap2.snapshotId())
+            .findFirst()
+            .orElseThrow();
 
     // Remove only FILE_A (partition bucket=0) — this should make its DV dangling
     commit(


### PR DESCRIPTION
In ManifestFilterManager#removeDanglingDeletesFor receives DataFiles which have partition info but only stores their paths as strings. This means ManifestFilterManager#canContainDroppedFiles returns true for every delete manifest since there's no partition info to filter against. The existing ManifestFilterManager#delete(F File) does this correctly, it stores both the file and a PartitionSet. then uses this information in ManifestFileUtil#canContainAny to skip manifests whose partition range doesn't overlap.