### PR TITLE
Flink: Support table-name as fallback key for catalog-table in connector options

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -59,6 +59,7 @@ class FlinkCreateTableOptions {
       ConfigOptions.key("catalog-table")
           .stringType()
           .noDefaultValue()
+          .withFallbackKeys("table-name")
           .withDescription("Table name managed in the underlying iceberg catalog and database.");
 
   public static final ConfigOption<Map<String, String>> CATALOG_PROPS =

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -206,7 +206,9 @@ public class FlinkDynamicTableFactory
 
     String catalogTableProp = mergedProps.get(FlinkCreateTableOptions.CATALOG_TABLE.key());
     String tableNameProp = mergedProps.get("table-name");
-    if (catalogTableProp != null && tableNameProp != null && !catalogTableProp.equals(tableNameProp)) {
+    if (catalogTableProp != null
+        && tableNameProp != null
+        && !catalogTableProp.equals(tableNameProp)) {
       LOG.warn(
           "Both '{}' ({}) and 'table-name' ({}) are set with conflicting values; '{}' takes precedence.",
           FlinkCreateTableOptions.CATALOG_TABLE.key(),

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -42,9 +42,12 @@ import org.apache.iceberg.flink.source.IcebergTableSource;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FlinkDynamicTableFactory
     implements DynamicTableSinkFactory, DynamicTableSourceFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(FlinkDynamicTableFactory.class);
   static final String FACTORY_IDENTIFIER = "iceberg";
   private final FlinkCatalog catalog;
 
@@ -200,6 +203,17 @@ public class FlinkDynamicTableFactory
         FlinkCreateTableOptions.CATALOG_DATABASE);
 
     String catalogTable = flinkConf.get(FlinkCreateTableOptions.CATALOG_TABLE, tableName);
+
+    String catalogTableProp = mergedProps.get(FlinkCreateTableOptions.CATALOG_TABLE.key());
+    String tableNameProp = mergedProps.get("table-name");
+    if (catalogTableProp != null && tableNameProp != null && !catalogTableProp.equals(tableNameProp)) {
+      LOG.warn(
+          "Both '{}' ({}) and 'table-name' ({}) are set with conflicting values; '{}' takes precedence.",
+          FlinkCreateTableOptions.CATALOG_TABLE.key(),
+          catalogTableProp,
+          tableNameProp,
+          FlinkCreateTableOptions.CATALOG_TABLE.key());
+    }
 
     FlinkCatalog flinkCatalog = createCatalogLoader(mergedProps, catalogName);
     ObjectPath objectPath = new ObjectPath(catalogDatabase, catalogTable);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkAnonymousTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkAnonymousTable.java
@@ -62,4 +62,36 @@ public class TestFlinkAnonymousTable extends TestBase {
                 assertThat(warehouseDir.toPath().resolve("test_db").resolve("test").toFile())
                     .exists());
   }
+
+  @Test
+  public void testWriteAnonymousTableWithTableNameAlias() throws Exception {
+    // Verify that 'table-name' routes writes to the correct directory, matching the behavior of
+    // 'catalog-table'. Reproduces https://github.com/apache/iceberg/issues/15668.
+    File warehouseDir = Files.createTempDirectory(temporaryDirectory, "junit").toFile();
+    TableEnvironment tEnv = getTableEnv();
+    Table table =
+        tEnv.from(
+            TableDescriptor.forConnector("datagen")
+                .schema(Schema.newBuilder().column("f0", DataTypes.STRING()).build())
+                .option("number-of-rows", "3")
+                .build());
+
+    TableDescriptor descriptor =
+        TableDescriptor.forConnector("iceberg")
+            .schema(Schema.newBuilder().column("f0", DataTypes.STRING()).build())
+            .option("catalog-name", "hadoop_test")
+            .option("catalog-type", "hadoop")
+            .option("catalog-database", "test_db")
+            .option("table-name", "test_alias")
+            .option("warehouse", warehouseDir.getAbsolutePath())
+            .build();
+
+    table.insertInto(descriptor).execute();
+    Awaitility.await()
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(warehouseDir.toPath().resolve("test_db").resolve("test_alias").toFile())
+                    .exists());
+  }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -268,6 +268,53 @@ public class TestIcebergConnector extends TestBase {
   }
 
   @TestTemplate
+  public void testTableNameAlias() {
+    // Verify that 'table-name' works as an alias for 'catalog-table'.
+    // Reproduces https://github.com/apache/iceberg/issues/15668: using 'table-name' in the WITH
+    // clause previously silently created a new empty table named after the Flink DDL table name
+    // instead of routing reads/writes to the intended Iceberg table.
+    // Use tableName() so after() handles Hive metastore cleanup automatically.
+    Map<String, String> tableProps = createTableProps();
+    tableProps.remove("catalog-table");
+    tableProps.put("table-name", tableName());
+
+    sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+    sql("INSERT INTO %s VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')", TABLE_NAME);
+    assertThat(sql("SELECT * FROM %s", TABLE_NAME))
+        .containsExactlyInAnyOrder(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC"));
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    Catalog flinkCatalog = factory.createCatalog(catalogName, tableProps, new Configuration());
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), tableName()))).isTrue();
+
+    sql("DROP TABLE %s", TABLE_NAME);
+  }
+
+  @TestTemplate
+  public void testCatalogTableTakesPrecedenceOverTableName() {
+    // When both 'catalog-table' and 'table-name' are set with different values,
+    // 'catalog-table' must take precedence. tableName() resolves catalog-table from the
+    // parametrized properties, so after() handles Hive metastore cleanup automatically.
+    Map<String, String> tableProps = createTableProps();
+    tableProps.put("catalog-table", tableName());
+    tableProps.put("table-name", "table_name_loses");
+
+    sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+    sql("INSERT INTO %s VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')", TABLE_NAME);
+    assertThat(sql("SELECT * FROM %s", TABLE_NAME))
+        .containsExactlyInAnyOrder(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC"));
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    Catalog flinkCatalog = factory.createCatalog(catalogName, tableProps, new Configuration());
+    // Data must be stored under 'catalog-table' value, not 'table-name' value.
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), tableName()))).isTrue();
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), "table_name_loses")))
+        .isFalse();
+
+    sql("DROP TABLE %s", TABLE_NAME);
+  }
+
+  @TestTemplate
   public void testCatalogDatabaseConflictWithFlinkDatabase() {
     sql("CREATE DATABASE IF NOT EXISTS `%s`", databaseName());
     sql("USE `%s`", databaseName());
@@ -335,7 +382,8 @@ public class TestIcebergConnector extends TestBase {
   }
 
   private String tableName() {
-    return properties.getOrDefault("catalog-table", TABLE_NAME);
+    return properties.getOrDefault(
+        "catalog-table", properties.getOrDefault("table-name", TABLE_NAME));
   }
 
   private String databaseName() {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -59,6 +59,7 @@ class FlinkCreateTableOptions {
       ConfigOptions.key("catalog-table")
           .stringType()
           .noDefaultValue()
+          .withFallbackKeys("table-name")
           .withDescription("Table name managed in the underlying iceberg catalog and database.");
 
   public static final ConfigOption<Map<String, String>> CATALOG_PROPS =

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -206,7 +206,9 @@ public class FlinkDynamicTableFactory
 
     String catalogTableProp = mergedProps.get(FlinkCreateTableOptions.CATALOG_TABLE.key());
     String tableNameProp = mergedProps.get("table-name");
-    if (catalogTableProp != null && tableNameProp != null && !catalogTableProp.equals(tableNameProp)) {
+    if (catalogTableProp != null
+        && tableNameProp != null
+        && !catalogTableProp.equals(tableNameProp)) {
       LOG.warn(
           "Both '{}' ({}) and 'table-name' ({}) are set with conflicting values; '{}' takes precedence.",
           FlinkCreateTableOptions.CATALOG_TABLE.key(),

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -42,9 +42,12 @@ import org.apache.iceberg.flink.source.IcebergTableSource;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FlinkDynamicTableFactory
     implements DynamicTableSinkFactory, DynamicTableSourceFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(FlinkDynamicTableFactory.class);
   static final String FACTORY_IDENTIFIER = "iceberg";
   private final FlinkCatalog catalog;
 
@@ -200,6 +203,17 @@ public class FlinkDynamicTableFactory
         FlinkCreateTableOptions.CATALOG_DATABASE);
 
     String catalogTable = flinkConf.get(FlinkCreateTableOptions.CATALOG_TABLE, tableName);
+
+    String catalogTableProp = mergedProps.get(FlinkCreateTableOptions.CATALOG_TABLE.key());
+    String tableNameProp = mergedProps.get("table-name");
+    if (catalogTableProp != null && tableNameProp != null && !catalogTableProp.equals(tableNameProp)) {
+      LOG.warn(
+          "Both '{}' ({}) and 'table-name' ({}) are set with conflicting values; '{}' takes precedence.",
+          FlinkCreateTableOptions.CATALOG_TABLE.key(),
+          catalogTableProp,
+          tableNameProp,
+          FlinkCreateTableOptions.CATALOG_TABLE.key());
+    }
 
     FlinkCatalog flinkCatalog = createCatalogLoader(mergedProps, catalogName);
     ObjectPath objectPath = new ObjectPath(catalogDatabase, catalogTable);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestFlinkAnonymousTable.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestFlinkAnonymousTable.java
@@ -62,4 +62,36 @@ public class TestFlinkAnonymousTable extends TestBase {
                 assertThat(warehouseDir.toPath().resolve("test_db").resolve("test").toFile())
                     .exists());
   }
+
+  @Test
+  public void testWriteAnonymousTableWithTableNameAlias() throws Exception {
+    // Verify that 'table-name' routes writes to the correct directory, matching the behavior of
+    // 'catalog-table'. Reproduces https://github.com/apache/iceberg/issues/15668.
+    File warehouseDir = Files.createTempDirectory(temporaryDirectory, "junit").toFile();
+    TableEnvironment tEnv = getTableEnv();
+    Table table =
+        tEnv.from(
+            TableDescriptor.forConnector("datagen")
+                .schema(Schema.newBuilder().column("f0", DataTypes.STRING()).build())
+                .option("number-of-rows", "3")
+                .build());
+
+    TableDescriptor descriptor =
+        TableDescriptor.forConnector("iceberg")
+            .schema(Schema.newBuilder().column("f0", DataTypes.STRING()).build())
+            .option("catalog-name", "hadoop_test")
+            .option("catalog-type", "hadoop")
+            .option("catalog-database", "test_db")
+            .option("table-name", "test_alias")
+            .option("warehouse", warehouseDir.getAbsolutePath())
+            .build();
+
+    table.insertInto(descriptor).execute();
+    Awaitility.await()
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(warehouseDir.toPath().resolve("test_db").resolve("test_alias").toFile())
+                    .exists());
+  }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -268,6 +268,53 @@ public class TestIcebergConnector extends TestBase {
   }
 
   @TestTemplate
+  public void testTableNameAlias() {
+    // Verify that 'table-name' works as an alias for 'catalog-table'.
+    // Reproduces https://github.com/apache/iceberg/issues/15668: using 'table-name' in the WITH
+    // clause previously silently created a new empty table named after the Flink DDL table name
+    // instead of routing reads/writes to the intended Iceberg table.
+    // Use tableName() so after() handles Hive metastore cleanup automatically.
+    Map<String, String> tableProps = createTableProps();
+    tableProps.remove("catalog-table");
+    tableProps.put("table-name", tableName());
+
+    sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+    sql("INSERT INTO %s VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')", TABLE_NAME);
+    assertThat(sql("SELECT * FROM %s", TABLE_NAME))
+        .containsExactlyInAnyOrder(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC"));
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    Catalog flinkCatalog = factory.createCatalog(catalogName, tableProps, new Configuration());
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), tableName()))).isTrue();
+
+    sql("DROP TABLE %s", TABLE_NAME);
+  }
+
+  @TestTemplate
+  public void testCatalogTableTakesPrecedenceOverTableName() {
+    // When both 'catalog-table' and 'table-name' are set with different values,
+    // 'catalog-table' must take precedence. tableName() resolves catalog-table from the
+    // parametrized properties, so after() handles Hive metastore cleanup automatically.
+    Map<String, String> tableProps = createTableProps();
+    tableProps.put("catalog-table", tableName());
+    tableProps.put("table-name", "table_name_loses");
+
+    sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+    sql("INSERT INTO %s VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')", TABLE_NAME);
+    assertThat(sql("SELECT * FROM %s", TABLE_NAME))
+        .containsExactlyInAnyOrder(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC"));
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    Catalog flinkCatalog = factory.createCatalog(catalogName, tableProps, new Configuration());
+    // Data must be stored under 'catalog-table' value, not 'table-name' value.
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), tableName()))).isTrue();
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), "table_name_loses")))
+        .isFalse();
+
+    sql("DROP TABLE %s", TABLE_NAME);
+  }
+
+  @TestTemplate
   public void testCatalogDatabaseConflictWithFlinkDatabase() {
     sql("CREATE DATABASE IF NOT EXISTS `%s`", databaseName());
     sql("USE `%s`", databaseName());
@@ -335,7 +382,8 @@ public class TestIcebergConnector extends TestBase {
   }
 
   private String tableName() {
-    return properties.getOrDefault("catalog-table", TABLE_NAME);
+    return properties.getOrDefault(
+        "catalog-table", properties.getOrDefault("table-name", TABLE_NAME));
   }
 
   private String databaseName() {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -59,6 +59,7 @@ class FlinkCreateTableOptions {
       ConfigOptions.key("catalog-table")
           .stringType()
           .noDefaultValue()
+          .withFallbackKeys("table-name")
           .withDescription("Table name managed in the underlying iceberg catalog and database.");
 
   public static final ConfigOption<Map<String, String>> CATALOG_PROPS =

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -42,9 +42,12 @@ import org.apache.iceberg.flink.source.IcebergTableSource;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FlinkDynamicTableFactory
     implements DynamicTableSinkFactory, DynamicTableSourceFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(FlinkDynamicTableFactory.class);
   static final String FACTORY_IDENTIFIER = "iceberg";
   private final FlinkCatalog catalog;
 
@@ -200,6 +203,19 @@ public class FlinkDynamicTableFactory
         FlinkCreateTableOptions.CATALOG_DATABASE);
 
     String catalogTable = flinkConf.get(FlinkCreateTableOptions.CATALOG_TABLE, tableName);
+
+    String catalogTableProp = mergedProps.get(FlinkCreateTableOptions.CATALOG_TABLE.key());
+    String tableNameProp = mergedProps.get("table-name");
+    if (catalogTableProp != null
+        && tableNameProp != null
+        && !catalogTableProp.equals(tableNameProp)) {
+      LOG.warn(
+          "Both '{}' ({}) and 'table-name' ({}) are set with conflicting values; '{}' takes precedence.",
+          FlinkCreateTableOptions.CATALOG_TABLE.key(),
+          catalogTableProp,
+          tableNameProp,
+          FlinkCreateTableOptions.CATALOG_TABLE.key());
+    }
 
     FlinkCatalog flinkCatalog = createCatalogLoader(mergedProps, catalogName);
     ObjectPath objectPath = new ObjectPath(catalogDatabase, catalogTable);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkAnonymousTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkAnonymousTable.java
@@ -62,4 +62,36 @@ public class TestFlinkAnonymousTable extends TestBase {
                 assertThat(warehouseDir.toPath().resolve("test_db").resolve("test").toFile())
                     .exists());
   }
+
+  @Test
+  public void testWriteAnonymousTableWithTableNameAlias() throws Exception {
+    // Verify that 'table-name' routes writes to the correct directory, matching the behavior of
+    // 'catalog-table'. Reproduces https://github.com/apache/iceberg/issues/15668.
+    File warehouseDir = Files.createTempDirectory(temporaryDirectory, "junit").toFile();
+    TableEnvironment tEnv = getTableEnv();
+    Table table =
+        tEnv.from(
+            TableDescriptor.forConnector("datagen")
+                .schema(Schema.newBuilder().column("f0", DataTypes.STRING()).build())
+                .option("number-of-rows", "3")
+                .build());
+
+    TableDescriptor descriptor =
+        TableDescriptor.forConnector("iceberg")
+            .schema(Schema.newBuilder().column("f0", DataTypes.STRING()).build())
+            .option("catalog-name", "hadoop_test")
+            .option("catalog-type", "hadoop")
+            .option("catalog-database", "test_db")
+            .option("table-name", "test_alias")
+            .option("warehouse", warehouseDir.getAbsolutePath())
+            .build();
+
+    table.insertInto(descriptor).execute();
+    Awaitility.await()
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(warehouseDir.toPath().resolve("test_db").resolve("test_alias").toFile())
+                    .exists());
+  }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -268,6 +268,53 @@ public class TestIcebergConnector extends TestBase {
   }
 
   @TestTemplate
+  public void testTableNameAlias() {
+    // Verify that 'table-name' works as an alias for 'catalog-table'.
+    // Reproduces https://github.com/apache/iceberg/issues/15668: using 'table-name' in the WITH
+    // clause previously silently created a new empty table named after the Flink DDL table name
+    // instead of routing reads/writes to the intended Iceberg table.
+    // Use tableName() so after() handles Hive metastore cleanup automatically.
+    Map<String, String> tableProps = createTableProps();
+    tableProps.remove("catalog-table");
+    tableProps.put("table-name", tableName());
+
+    sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+    sql("INSERT INTO %s VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')", TABLE_NAME);
+    assertThat(sql("SELECT * FROM %s", TABLE_NAME))
+        .containsExactlyInAnyOrder(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC"));
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    Catalog flinkCatalog = factory.createCatalog(catalogName, tableProps, new Configuration());
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), tableName()))).isTrue();
+
+    sql("DROP TABLE %s", TABLE_NAME);
+  }
+
+  @TestTemplate
+  public void testCatalogTableTakesPrecedenceOverTableName() {
+    // When both 'catalog-table' and 'table-name' are set with different values,
+    // 'catalog-table' must take precedence. tableName() resolves catalog-table from the
+    // parametrized properties, so after() handles Hive metastore cleanup automatically.
+    Map<String, String> tableProps = createTableProps();
+    tableProps.put("catalog-table", tableName());
+    tableProps.put("table-name", "table_name_loses");
+
+    sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+    sql("INSERT INTO %s VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')", TABLE_NAME);
+    assertThat(sql("SELECT * FROM %s", TABLE_NAME))
+        .containsExactlyInAnyOrder(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC"));
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    Catalog flinkCatalog = factory.createCatalog(catalogName, tableProps, new Configuration());
+    // Data must be stored under 'catalog-table' value, not 'table-name' value.
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), tableName()))).isTrue();
+    assertThat(flinkCatalog.tableExists(new ObjectPath(databaseName(), "table_name_loses")))
+        .isFalse();
+
+    sql("DROP TABLE %s", TABLE_NAME);
+  }
+
+  @TestTemplate
   public void testCatalogDatabaseConflictWithFlinkDatabase() {
     sql("CREATE DATABASE IF NOT EXISTS `%s`", databaseName());
     sql("USE `%s`", databaseName());
@@ -335,7 +382,8 @@ public class TestIcebergConnector extends TestBase {
   }
 
   private String tableName() {
-    return properties.getOrDefault("catalog-table", TABLE_NAME);
+    return properties.getOrDefault(
+        "catalog-table", properties.getOrDefault("table-name", TABLE_NAME));
   }
 
   private String databaseName() {


### PR DESCRIPTION
When using the Flink Iceberg connector with 'connector'='iceberg', the
  'table-name' option in the WITH clause was silently ignored. The connector
  only recognized 'catalog-table' to specify the Iceberg table name, causing
  it to fall back to the Flink DDL table name, auto-create a new empty table,
  and return 0 rows on reads with no error.

  This commit adds 'table-name' as a fallback key for the existing CATALOG_TABLE
  ConfigOption via withFallbackKeys("table-name"), letting the Flink framework
  handle the lookup natively with the following precedence:
    catalog-table > table-name > Flink DDL table name

  A WARN log is emitted when both options are set with conflicting values.
  Changes are applied to all supported Flink versions (1.20, 2.0, 2.1).