### PR TITLE
Spark: Add named constant for `NO_ADVISORY_PARTITION_SIZE`

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteRequirements.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteRequirements.java
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 /** A set of requirements such as distribution and ordering reported to Spark during writes. */
 public class SparkWriteRequirements {
 
-  public static final long NO_ADVISORY_PARTITION_SIZE = 0;
+  private static final long NO_ADVISORY_PARTITION_SIZE = 0;
   public static final SparkWriteRequirements EMPTY =
       new SparkWriteRequirements(
           Distributions.unspecified(), new SortOrder[0], NO_ADVISORY_PARTITION_SIZE);
@@ -39,7 +39,11 @@ public class SparkWriteRequirements {
       Distribution distribution, SortOrder[] ordering, long advisoryPartitionSize) {
     this.distribution = distribution;
     this.ordering = ordering;
-    this.advisoryPartitionSize = advisoryPartitionSize;
+    // Spark prohibits requesting a particular advisory partition size without distribution
+    this.advisoryPartitionSize =
+        distribution instanceof UnspecifiedDistribution
+            ? NO_ADVISORY_PARTITION_SIZE
+            : advisoryPartitionSize;
   }
 
   public Distribution distribution() {
@@ -55,9 +59,6 @@ public class SparkWriteRequirements {
   }
 
   public long advisoryPartitionSize() {
-    // Spark prohibits requesting a particular advisory partition size without distribution
-    return distribution instanceof UnspecifiedDistribution
-        ? NO_ADVISORY_PARTITION_SIZE
-        : advisoryPartitionSize;
+    return advisoryPartitionSize;
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteRequirements.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteRequirements.java
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 /** A set of requirements such as distribution and ordering reported to Spark during writes. */
 public class SparkWriteRequirements {
 
-  public static final long NO_ADVISORY_PARTITION_SIZE = 0;
+  private static final long NO_ADVISORY_PARTITION_SIZE = 0;
   public static final SparkWriteRequirements EMPTY =
       new SparkWriteRequirements(
           Distributions.unspecified(), new SortOrder[0], NO_ADVISORY_PARTITION_SIZE);
@@ -39,7 +39,11 @@ public class SparkWriteRequirements {
       Distribution distribution, SortOrder[] ordering, long advisoryPartitionSize) {
     this.distribution = distribution;
     this.ordering = ordering;
-    this.advisoryPartitionSize = advisoryPartitionSize;
+    // Spark prohibits requesting a particular advisory partition size without distribution
+    this.advisoryPartitionSize =
+        distribution instanceof UnspecifiedDistribution
+            ? NO_ADVISORY_PARTITION_SIZE
+            : advisoryPartitionSize;
   }
 
   public Distribution distribution() {
@@ -55,9 +59,6 @@ public class SparkWriteRequirements {
   }
 
   public long advisoryPartitionSize() {
-    // Spark prohibits requesting a particular advisory partition size without distribution
-    return distribution instanceof UnspecifiedDistribution
-        ? NO_ADVISORY_PARTITION_SIZE
-        : advisoryPartitionSize;
+    return advisoryPartitionSize;
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteRequirements.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteRequirements.java
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 /** A set of requirements such as distribution and ordering reported to Spark during writes. */
 public class SparkWriteRequirements {
 
-  public static final long NO_ADVISORY_PARTITION_SIZE = 0;
+  private static final long NO_ADVISORY_PARTITION_SIZE = 0;
   public static final SparkWriteRequirements EMPTY =
       new SparkWriteRequirements(
           Distributions.unspecified(), new SortOrder[0], NO_ADVISORY_PARTITION_SIZE);
@@ -39,7 +39,11 @@ public class SparkWriteRequirements {
       Distribution distribution, SortOrder[] ordering, long advisoryPartitionSize) {
     this.distribution = distribution;
     this.ordering = ordering;
-    this.advisoryPartitionSize = advisoryPartitionSize;
+    // Spark prohibits requesting a particular advisory partition size without distribution
+    this.advisoryPartitionSize =
+        distribution instanceof UnspecifiedDistribution
+            ? NO_ADVISORY_PARTITION_SIZE
+            : advisoryPartitionSize;
   }
 
   public Distribution distribution() {
@@ -55,9 +59,6 @@ public class SparkWriteRequirements {
   }
 
   public long advisoryPartitionSize() {
-    // Spark prohibits requesting a particular advisory partition size without distribution
-    return distribution instanceof UnspecifiedDistribution
-        ? NO_ADVISORY_PARTITION_SIZE
-        : advisoryPartitionSize;
+    return advisoryPartitionSize;
   }
 }


### PR DESCRIPTION
This PR extracts a named constant for `NO_ADVISORY_PARTITION_SIZE` in `SparkWriteRequirements`. I'm splitting this out of another PR which took another approach to a change and is [making this change as a byproduct](https://github.com/apache/iceberg/pull/15150#discussion_r2957379651).

Related PR: https://github.com/apache/iceberg/pull/15150