### PR TITLE
REST Spec: Clarify identifier uniqueness across tables and views

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -94,6 +94,13 @@ class Namespace(RootModel[list[str]]):
     )
 
 
+class CatalogObjectType(RootModel[Literal['table', 'view']]):
+    root: Literal['table', 'view'] = Field(
+        ...,
+        description='The type of a named catalog object within a namespace. Identifiers MUST be unique across all catalog object types within the same namespace; a table and a view with the same name in the same namespace are not allowed. Known types are listed below.',
+    )
+
+
 class PageToken(RootModel[str | None]):
     root: str | None = Field(
         None,

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -94,13 +94,6 @@ class Namespace(RootModel[list[str]]):
     )
 
 
-class CatalogObjectType(RootModel[Literal['table', 'view']]):
-    root: Literal['table', 'view'] = Field(
-        ...,
-        description='The type of a named catalog object within a namespace. Identifiers MUST be unique across all catalog object types within the same namespace; a table and a view with the same name in the same namespace are not allowed. Known types are listed below.',
-    )
-
-
 class PageToken(RootModel[str | None]):
     root: str | None = Field(
         None,

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -5108,7 +5108,7 @@ components:
       summary: The requested table identifier already exists
       value: {
         "error": {
-          "message": "The given table already exists",
+          "message": "The requested table identifier already exists",
           "type": "AlreadyExistsException",
           "code": 409
         }
@@ -5118,7 +5118,7 @@ components:
       summary: The requested view identifier already exists
       value: {
         "error": {
-          "message": "The given view already exists",
+          "message": "The requested view identifier already exists",
           "type": "AlreadyExistsException",
           "code": 409
         }

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -598,7 +598,7 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The identifier is already used by an existing catalog object (see `CatalogObjectType`)
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
@@ -918,7 +918,7 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The identifier is already used by an existing catalog object (see `CatalogObjectType`)
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
@@ -1304,7 +1304,7 @@ paths:
         406:
           $ref: '#/components/responses/UnsupportedOperationResponse'
         409:
-          description: Conflict - The target identifier to rename to is already used by an existing catalog object (see `CatalogObjectType`)
+          description: Conflict - The target identifier to rename to already exists as a table or view
           content:
             application/json:
               schema:
@@ -1550,7 +1550,7 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The identifier is already used by an existing catalog object (see `CatalogObjectType`)
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
@@ -1828,7 +1828,7 @@ paths:
         406:
           $ref: '#/components/responses/UnsupportedOperationResponse'
         409:
-          description: Conflict - The target identifier to rename to is already used by an existing catalog object (see `CatalogObjectType`)
+          description: Conflict - The target identifier to rename to already exists as a table or view
           content:
             application/json:
               schema:
@@ -1882,7 +1882,7 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The identifier is already used by an existing catalog object (see `CatalogObjectType`)
+          description: Conflict - The identifier already exists as a table or view
           content:
             application/json:
               schema:
@@ -2190,16 +2190,6 @@ components:
       items:
         type: string
       example: [ "accounting", "tax" ]
-
-    CatalogObjectType:
-      type: string
-      description:
-        The type of a named catalog object within a namespace. Identifiers MUST be unique
-        across all catalog object types within the same namespace; a table and a view with
-        the same name in the same namespace are not allowed. Known types are listed below.
-      enum:
-        - table
-        - view
 
     PageToken:
       description:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -598,7 +598,7 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The table already exists
+          description: Conflict - The identifier is already used by an existing catalog object (see `CatalogObjectType`)
           content:
             application/json:
               schema:
@@ -918,7 +918,7 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The table already exists
+          description: Conflict - The identifier is already used by an existing catalog object (see `CatalogObjectType`)
           content:
             application/json:
               schema:
@@ -1304,7 +1304,7 @@ paths:
         406:
           $ref: '#/components/responses/UnsupportedOperationResponse'
         409:
-          description: Conflict - The target identifier to rename to already exists as a table or view
+          description: Conflict - The target identifier to rename to is already used by an existing catalog object (see `CatalogObjectType`)
           content:
             application/json:
               schema:
@@ -1550,7 +1550,7 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The view already exists
+          description: Conflict - The identifier is already used by an existing catalog object (see `CatalogObjectType`)
           content:
             application/json:
               schema:
@@ -1828,7 +1828,7 @@ paths:
         406:
           $ref: '#/components/responses/UnsupportedOperationResponse'
         409:
-          description: Conflict - The target identifier to rename to already exists as a table or view
+          description: Conflict - The target identifier to rename to is already used by an existing catalog object (see `CatalogObjectType`)
           content:
             application/json:
               schema:
@@ -1882,7 +1882,7 @@ paths:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
         409:
-          description: Conflict - The identifier already exists as a table or view
+          description: Conflict - The identifier is already used by an existing catalog object (see `CatalogObjectType`)
           content:
             application/json:
               schema:
@@ -2190,6 +2190,16 @@ components:
       items:
         type: string
       example: [ "accounting", "tax" ]
+
+    CatalogObjectType:
+      type: string
+      description:
+        The type of a named catalog object within a namespace. Identifiers MUST be unique
+        across all catalog object types within the same namespace; a table and a view with
+        the same name in the same namespace are not allowed. Known types are listed below.
+      enum:
+        - table
+        - view
 
     PageToken:
       description:


### PR DESCRIPTION
Table and view identifiers share the same namespace scope, so a table and a view with the same name in the same namespace are not allowed. The rename and register-view endpoints already enforced this with "already exists as a table or view", but createTable, registerTable, and createView only guarded against same-type conflicts.

This change makes all six write operations consistent by using the new CatalogObjectType schema, which enumerates the known object types (table, view) and states the uniqueness invariant explicitly. The 409 conflict descriptions are updated to:
  - "The identifier is already used by an existing catalog object (see `CatalogObjectType`)"
  - "The target identifier to rename to is already used by an existing catalog object (see `CatalogObjectType`)"

Made-with: Cursor
Model: claude-4.6-sonnet-medium-thinking