### PR TITLE
Backport Arrow: Fix vectorized reads for Parquet TIMESTAMP_MILLIS types (#14499)

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -426,6 +426,10 @@ public final class VectorizedParquetDefinitionLevelReader
         for (int i = 0; i < numValues; i++) {
           nextVal(vector, bufferIdx, valuesReader, typeWidth, byteArray);
           nullabilityHolder.setNotNull(bufferIdx);
+          if (setArrowValidityVector) {
+            BitVectorHelper.setBit(vector.getValidityBuffer(), bufferIdx);
+          }
+
           bufferIdx++;
         }
       } else {
@@ -447,6 +451,9 @@ public final class VectorizedParquetDefinitionLevelReader
         if (packedValuesBuffer[packedValuesBufferIdx++] == maxDefLevel) {
           nextVal(vector, bufferIdx, valuesReader, typeWidth, byteArray);
           nullabilityHolder.setNotNull(bufferIdx);
+          if (setArrowValidityVector) {
+            BitVectorHelper.setBit(vector.getValidityBuffer(), bufferIdx);
+          }
         } else {
           setNull(nullabilityHolder, bufferIdx, vector.getValidityBuffer());
         }


### PR DESCRIPTION
Backports: https://github.com/apache/iceberg/pull/14499 to 1.10.x 

I just saw on the mailing list that people were suggesting patches for the 1.10.2 release so I decided to include this one. 

Feel free to close if the scope is too much for the patch release. I looked into the contribution guidelines but didn't find any specific info about this

Thanks