### PR TITLE
Build: Stop ignoring gradle directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ out
 build
 dependencies.lock
 **/dependencies.lock
-gradle/
 gradle/wrapper/gradle-wrapper.jar
 
 # rat library install location


### PR DESCRIPTION
While reviewing #15440, I noticed that changes under `gradle/`, including `libs.versions.toml`, are ignored by git. We should not ignore this file because it is the source of truth for dependency versions and is already maintained in the project history: https://github.com/apache/iceberg/commits/main/gradle/libs.versions.toml

Removing `gradle/` from `.gitignore` also makes `libs.versions.toml` show up in VS Code search results, which improves discoverability when reviewing or updating dependencies.

