### PR TITLE
Spark: Validate Z-order rewrite does not conflict with internal ICEZVALUE column name

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
@@ -176,6 +176,13 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
     Set<Integer> identityPartitionFieldIds = table.spec().identitySourceIds();
     boolean caseSensitive = SparkUtil.caseSensitive(spark);
 
+    Preconditions.checkArgument(
+        caseSensitive
+            ? schema.findField(Z_COLUMN) == null
+            : schema.caseInsensitiveFindField(Z_COLUMN) == null,
+        "Cannot zorder because the table has a column named '%s', which conflicts with Iceberg's internal Z-order column name",
+        Z_COLUMN);
+
     List<String> validZOrderColNames = Lists.newArrayList();
 
     for (String colName : inputZOrderColNames) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1767,6 +1767,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testZOrderWithZColumnCollision() {
+    Schema schema =
+        new Schema(
+            optional(1, "c1", Types.IntegerType.get()),
+            optional(2, "c2", Types.StringType.get()),
+            optional(3, "ICEZVALUE", Types.StringType.get()));
+
+    Table table =
+        TABLES.create(
+            schema,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
+
+    assertThatThrownBy(() -> basicRewrite(table).zOrder("c1", "c2").execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot zorder because the table has a column named 'ICEZVALUE'");
+  }
+
+  @TestTemplate
   public void testZOrderSort() {
     int originalFiles = 20;
     Table table = createTable(originalFiles);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
@@ -176,6 +176,13 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
     Set<Integer> identityPartitionFieldIds = table.spec().identitySourceIds();
     boolean caseSensitive = SparkUtil.caseSensitive(spark);
 
+    Preconditions.checkArgument(
+        caseSensitive
+            ? schema.findField(Z_COLUMN) == null
+            : schema.caseInsensitiveFindField(Z_COLUMN) == null,
+        "Cannot zorder because the table has a column named '%s', which conflicts with Iceberg's internal Z-order column name",
+        Z_COLUMN);
+
     List<String> validZOrderColNames = Lists.newArrayList();
 
     for (String colName : inputZOrderColNames) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1767,6 +1767,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testZOrderWithZColumnCollision() {
+    Schema schema =
+        new Schema(
+            optional(1, "c1", Types.IntegerType.get()),
+            optional(2, "c2", Types.StringType.get()),
+            optional(3, "ICEZVALUE", Types.StringType.get()));
+
+    Table table =
+        TABLES.create(
+            schema,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
+
+    assertThatThrownBy(() -> basicRewrite(table).zOrder("c1", "c2").execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot zorder because the table has a column named 'ICEZVALUE'");
+  }
+
+  @TestTemplate
   public void testZOrderSort() {
     int originalFiles = 20;
     Table table = createTable(originalFiles);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
@@ -176,6 +176,13 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
     Set<Integer> identityPartitionFieldIds = table.spec().identitySourceIds();
     boolean caseSensitive = SparkUtil.caseSensitive(spark);
 
+    Preconditions.checkArgument(
+        caseSensitive
+            ? schema.findField(Z_COLUMN) == null
+            : schema.caseInsensitiveFindField(Z_COLUMN) == null,
+        "Cannot zorder because the table has a column named '%s', which conflicts with Iceberg's internal Z-order column name",
+        Z_COLUMN);
+
     List<String> validZOrderColNames = Lists.newArrayList();
 
     for (String colName : inputZOrderColNames) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1770,6 +1770,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testZOrderWithZColumnCollision() {
+    Schema schema =
+        new Schema(
+            optional(1, "c1", Types.IntegerType.get()),
+            optional(2, "c2", Types.StringType.get()),
+            optional(3, "ICEZVALUE", Types.StringType.get()));
+
+    Table table =
+        TABLES.create(
+            schema,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
+
+    assertThatThrownBy(() -> basicRewrite(table).zOrder("c1", "c2").execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot zorder because the table has a column named 'ICEZVALUE'");
+  }
+
+  @TestTemplate
   public void testZOrderSort() {
     int originalFiles = 20;
     Table table = createTable(originalFiles);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderFileRewriteRunner.java
@@ -176,6 +176,13 @@ class SparkZOrderFileRewriteRunner extends SparkShufflingFileRewriteRunner {
     Set<Integer> identityPartitionFieldIds = table.spec().identitySourceIds();
     boolean caseSensitive = SparkUtil.caseSensitive(spark);
 
+    Preconditions.checkArgument(
+        caseSensitive
+            ? schema.findField(Z_COLUMN) == null
+            : schema.caseInsensitiveFindField(Z_COLUMN) == null,
+        "Cannot zorder because the table has a column named '%s', which conflicts with Iceberg's internal Z-order column name",
+        Z_COLUMN);
+
     List<String> validZOrderColNames = Lists.newArrayList();
 
     for (String colName : inputZOrderColNames) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1770,6 +1770,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testZOrderWithZColumnCollision() {
+    Schema schema =
+        new Schema(
+            optional(1, "c1", Types.IntegerType.get()),
+            optional(2, "c2", Types.StringType.get()),
+            optional(3, "ICEZVALUE", Types.StringType.get()));
+
+    Table table =
+        TABLES.create(
+            schema,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
+
+    assertThatThrownBy(() -> basicRewrite(table).zOrder("c1", "c2").execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot zorder because the table has a column named 'ICEZVALUE'");
+  }
+
+  @TestTemplate
   public void testZOrderSort() {
     int originalFiles = 20;
     Table table = createTable(originalFiles);


### PR DESCRIPTION
Tables with a column named `ICEZVALUE` fail with a misleading error during
Z-order rewrite because `SparkZOrderFileRewriteRunner` internally uses a
column with that name.

Adds an early `Preconditions.checkArgument` in `SparkZOrderFileRewriteRunner`
before any DataFrame operation, throwing a clear exception
if the table schema already contains a column named `ICEZVALUE`.

Closes #15708