### PR TITLE
ci: pin third-party actions to Apache-approved SHAs

### DIFF
--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
       - name: Install dependencies
         working-directory: ./open-api
         run: make install


### PR DESCRIPTION
Pin `astral-sh/setup-uv` to commit SHAs from Apache's [infrastructure-actions allowlist](https://github.com/apache/infrastructure-actions/blob/07f5f9d2b05fe0ec9886e3ef0a9d79797817f0cb/approved_patterns.yml#L9)

Fixes https://github.com/apache/infrastructure-actions/issues/550
