### PR TITLE
site: Update Rust status on the site

### DIFF
--- a/site/docs/status.md
+++ b/site/docs/status.md
@@ -86,9 +86,9 @@ This section lists the libraries that implement the Apache Iceberg specification
 | Update schema               | Y    | Y         | Y    | N  | Y   |
 | Update partition spec       | Y    | Y         | Y    | N  | Y   |
 | Update table properties     | Y    | Y         | Y    | Y  | Y   |
-| Replace sort order          | Y    | N         | N    | N  | Y   |
-| Update table location       | Y    | Y         | N    | N  | Y   |
-| Update statistics           | Y    | Y         | N    | N  | Y   |
+| Replace sort order          | Y    | N         | Y    | N  | Y   |
+| Update table location       | Y    | Y         | Y    | N  | Y   |
+| Update statistics           | Y    | Y         | Y    | N  | Y   |
 | Update partition statistics | Y    | N         | N    | N  | N   |
 | Expire snapshots            | Y    | N         | N    | N  | N   |
 | Manage snapshots            | Y    | N         | N    | N  | N   |
@@ -100,9 +100,9 @@ This section lists the libraries that implement the Apache Iceberg specification
 | Update schema               | Y    | Y         | N    | N  | Y   |
 | Update partition spec       | Y    | Y         | N    | N  | Y   |
 | Update table properties     | Y    | Y         | Y    | Y  | Y   |
-| Replace sort order          | Y    | N         | N    | N  | Y   |
-| Update table location       | Y    | Y         | N    | N  | Y   |
-| Update statistics           | Y    | Y         | N    | N  | Y   |
+| Replace sort order          | Y    | N         | Y    | N  | Y   |
+| Update table location       | Y    | Y         | Y    | N  | Y   |
+| Update statistics           | Y    | Y         | Y    | N  | Y   |
 | Update partition statistics | Y    | N         | N    | N  | N   |
 | Expire snapshots            | Y    | N         | N    | N  | N   |
 | Manage snapshots            | Y    | N         | N    | N  | N   |
@@ -113,7 +113,7 @@ This section lists the libraries that implement the Apache Iceberg specification
 
 | Operation         | Java | PyIceberg | Rust | Go | C++ |
 |-------------------|------|-----------|------|----|-----|
-| Append data files | Y    | Y         | N    | Y  | Y   |
+| Append data files | Y    | Y         | Y    | Y  | Y   |
 | Rewrite files     | Y    | Y         | N    | N  | N   |
 | Rewrite manifests | Y    | Y         | N    | Y  | N   |
 | Overwrite files   | Y    | Y         | N    | N  | N   |
@@ -123,7 +123,7 @@ This section lists the libraries that implement the Apache Iceberg specification
 
 | Operation         | Java | PyIceberg | Rust | Go | C++ |
 |-------------------|------|-----------|------|----|-----|
-| Append data files | Y    | Y         | N    | Y  | Y   |
+| Append data files | Y    | Y         | Y    | Y  | Y   |
 | Rewrite files     | Y    | Y         | N    | N  | N   |
 | Rewrite manifests | Y    | Y         | N    | Y  | N   |
 | Overwrite files   | Y    | Y         | N    | N  | N   |
@@ -145,12 +145,12 @@ This section lists the libraries that implement the Apache Iceberg specification
 | Operation                   | Java | PyIceberg | Rust | Go | C++ |
 |-----------------------------|------|-----------|------|----|-----|
 | Plan with data file         | Y    | Y         | Y    | Y  | Y   |
-| Plan with position deletes  | Y    | Y         | N    | Y  | Y   |
-| Plan with equality deletes  | Y    | Y         | N    | N  | Y   |
+| Plan with position deletes  | Y    | Y         | Y    | Y  | Y   |
+| Plan with equality deletes  | Y    | Y         | Y    | N  | Y   |
 | Plan with puffin statistics | Y    | N         | N    | N  | N   |
 | Read data file              | Y    | Y         | Y    | Y  | Y   |
-| Read with position deletes  | Y    | Y         | N    | Y  | N   |
-| Read with equality deletes  | Y    | N         | N    | N  | N   |
+| Read with position deletes  | Y    | Y         | Y    | Y  | N   |
+| Read with equality deletes  | Y    | N         | Y    | N  | N   |
 
 ## Table Write Operations
 
@@ -166,7 +166,7 @@ This section lists the libraries that implement the Apache Iceberg specification
 |------------------------|------|-----------|------|----|-----|
 | Append data            | Y    | Y         | Y    | Y  | N   |
 | Write position deletes | Y    | N         | N    | N  | N   |
-| Write equality deletes | Y    | N         | N    | N  | N   |
+| Write equality deletes | Y    | N         | Y    | N  | N   |
 
 ## Catalogs
 
@@ -267,12 +267,12 @@ The sql catalog is a catalog backed by a sql database, which is called jdbc cata
 
 | Namespace Operation       | Java | PyIceberg | Rust | Go | C++ |
 |---------------------------|------|-----------|------|----|-----|
-| listNamespaces            | Y    | Y         | N    | Y  | N   |
-| createNamespace           | Y    | Y         | N    | Y  | N   |
+| listNamespaces            | Y    | Y         | Y    | Y  | N   |
+| createNamespace           | Y    | Y         | Y    | Y  | N   |
 | dropNamespace             | Y    | Y         | Y    | Y  | N   |
-| namespaceExists           | Y    | N         | N    | Y  | N   |
+| namespaceExists           | Y    | N         | Y    | Y  | N   |
 | updateNamespaceProperties | Y    | Y         | Y    | Y  | N   |
-| loadNamespaceMetadata     | Y    | Y         | N    | Y  | N   |
+| loadNamespaceMetadata     | Y    | Y         | Y    | Y  | N   |
 
 ### Glue Catalog
 
@@ -315,12 +315,12 @@ The sql catalog is a catalog backed by a sql database, which is called jdbc cata
 
 | Namespace Operation       | Java | PyIceberg | Rust | Go | C++ |
 |---------------------------|------|-----------|------|----|-----|
-| listNamespaces            | Y    | Y         | N    | Y  | N   |
-| createNamespace           | Y    | Y         | N    | Y  | N   |
-| dropNamespace             | Y    | Y         | N    | Y  | N   |
-| namespaceExists           | Y    | N         | N    | Y  | N   |
+| listNamespaces            | Y    | Y         | Y    | Y  | N   |
+| createNamespace           | Y    | Y         | Y    | Y  | N   |
+| dropNamespace             | Y    | Y         | Y    | Y  | N   |
+| namespaceExists           | Y    | N         | Y    | Y  | N   |
 | updateNamespaceProperties | Y    | Y         | Y    | Y  | N   |
-| loadNamespaceMetadata     | Y    | Y         | N    | Y  | N   |
+| loadNamespaceMetadata     | Y    | Y         | Y    | Y  | N   |
 
 ### Hive Metastore Catalog
 
@@ -363,9 +363,9 @@ The sql catalog is a catalog backed by a sql database, which is called jdbc cata
 
 | Namespace Operation       | Java | PyIceberg | Rust | Go | C++ |
 |---------------------------|------|-----------|------|----|-----|
-| listNamespaces            | Y    | Y         | N    | N  | N   |
-| createNamespace           | Y    | Y         | N    | N  | N   |
-| dropNamespace             | Y    | Y         | N    | N  | N   |
-| namespaceExists           | Y    | N         | N    | N  | N   |
+| listNamespaces            | Y    | Y         | Y    | N  | N   |
+| createNamespace           | Y    | Y         | Y    | N  | N   |
+| dropNamespace             | Y    | Y         | Y    | N  | N   |
+| namespaceExists           | Y    | N         | Y    | N  | N   |
 | updateNamespaceProperties | Y    | Y         | Y    | Y  | N   |
-| loadNamespaceMetadata     | Y    | Y         | N    | N  | N   |
+| loadNamespaceMetadata     | Y    | Y         | Y    | N  | N   |


### PR DESCRIPTION
We recently released iceberg-rust 0.9.0. It seems the rust status has not been updated for a long time. It's a good time to do a quick catch up :) 


Related to: https://github.com/apache/iceberg-rust/issues/2226