### PR TITLE
Infra: Remove GitHub Actions from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,11 +19,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:


### PR DESCRIPTION
Related to https://github.com/apache/iceberg-python/issues/3186

Dont auto update since we now depend on github action being allowlisted by asf-infra first, https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml
