### PR TITLE
Spark: preload delete files to avoid deadlocks

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -219,6 +219,11 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
       this.asStructLike =
           new InternalRowWrapper(
               SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());
+      // Preload delete files to avoid deadlocking the connection pool:
+      // data file loading holds a connection while
+      // lazy delete file loading tries to acquire another.
+      deletedRowPositions();
+      eqDeletedRowFilter();
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -209,6 +209,11 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
       this.asStructLike =
           new InternalRowWrapper(
               SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());
+      // Preload delete files to avoid deadlocking the connection pool:
+      // data file loading holds a connection while
+      // lazy delete file loading tries to acquire another.
+      deletedRowPositions();
+      eqDeletedRowFilter();
     }
 
     @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -209,6 +209,11 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
       this.asStructLike =
           new InternalRowWrapper(
               SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());
+      // Preload delete files to avoid deadlocking the connection pool:
+      // data file loading holds a connection while
+      // lazy delete file loading tries to acquire another.
+      deletedRowPositions();
+      eqDeletedRowFilter();
     }
 
     @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -208,6 +208,11 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
       this.asStructLike =
           new InternalRowWrapper(
               SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());
+      // Preload delete files to avoid deadlocking the connection pool:
+      // data file loading holds a connection while
+      // lazy delete file loading tries to acquire another.
+      deletedRowPositions();
+      eqDeletedRowFilter();
     }
 
     @Override


### PR DESCRIPTION
In spark data file loading holds a connection while lazy delete file loading tries to acquire another. When number of simultaneous connections is limited (for example by `http-client.apache.max-connections`) it leads to a deadlock as soon as all connections are held by data files loading. To avoid the deadlock this PR adds delete file preloading to SparkDeleteFilter constructor.

The problem can be reproduced using spark-sql with S3FileIO and `spark.sql.catalog.iceberg.http-client.apache.max-connections=1`:
```sql
create table sparkdeletefilter(id bigint)
  tblproperties('write.delete.mode'='merge-on-read');
-- create a data file
insert into sparkdeletefilter select id from range(2);
-- create a delete file
delete from sparkdeletefilter where id in (select id from range(0, 2, 2));
-- Reader opens the data file first, keeps it open and
-- fails to load the delete file with ConnectionPoolTimeoutException
select count(id) from sparkdeletefilter;
```