### PR TITLE
Core: Call close on iterables returned by ManifestReader.liveEntries() in ManifestFilterManager

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -454,36 +455,40 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     boolean isDelete = reader.isDeleteManifestReader();
 
-    for (ManifestEntry<F> entry : reader.liveEntries()) {
-      F file = entry.file();
-      boolean markedForDelete =
-          deletePaths.contains(file.location())
-              || deleteFiles.contains(file)
-              || dropPartitions.contains(file.specId(), file.partition())
-              || (isDelete
-                  && entry.isLive()
-                  && entry.dataSequenceNumber() > 0
-                  && entry.dataSequenceNumber() < minSequenceNumber)
-              || (isDelete && isDanglingDV((DeleteFile) file));
+    try (CloseableIterable<ManifestEntry<F>> liveEntries = reader.liveEntries()) {
+      for (ManifestEntry<F> entry : liveEntries) {
+        F file = entry.file();
+        boolean markedForDelete =
+            deletePaths.contains(file.location())
+                || deleteFiles.contains(file)
+                || dropPartitions.contains(file.specId(), file.partition())
+                || (isDelete
+                    && entry.isLive()
+                    && entry.dataSequenceNumber() > 0
+                    && entry.dataSequenceNumber() < minSequenceNumber)
+                || (isDelete && isDanglingDV((DeleteFile) file));
 
-      if (markedForDelete || evaluator.rowsMightMatch(file)) {
-        boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
-        ValidationException.check(
-            allRowsMatch
-                || isDelete, // ignore delete files where some records may not match the expression
-            "Cannot delete file where some, but not all, rows match filter %s: %s",
-            this.deleteExpression,
-            file.location());
+        if (markedForDelete || evaluator.rowsMightMatch(file)) {
+          boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
+          ValidationException.check(
+              allRowsMatch || isDelete, // ignore delete files where some records may not match the
+              // expression
+              "Cannot delete file where some, but not all, rows match filter %s: %s",
+              this.deleteExpression,
+              file.location());
 
-        if (allRowsMatch) {
-          if (failAnyDelete) {
-            throw new DeleteException(reader.spec().partitionToPath(file.partition()));
+          if (allRowsMatch) {
+            if (failAnyDelete) {
+              throw new DeleteException(reader.spec().partitionToPath(file.partition()));
+            }
+
+            // as soon as a deleted file is detected, stop scanning
+            return true;
           }
-
-          // as soon as a deleted file is detected, stop scanning
-          return true;
         }
       }
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to close manifest entries: %s", manifest);
     }
 
     return false;
@@ -504,55 +509,55 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     try {
       ManifestWriter<F> writer = newManifestWriter(reader.spec());
-      try {
-        reader
-            .liveEntries()
-            .forEach(
-                entry -> {
-                  F file = entry.file();
-                  boolean isDanglingDV = isDelete && isDanglingDV((DeleteFile) file);
-                  boolean markedForDelete =
-                      isDanglingDV
-                          || deletePaths.contains(file.location())
-                          || deleteFiles.contains(file)
-                          || dropPartitions.contains(file.specId(), file.partition())
-                          || (isDelete
-                              && entry.isLive()
-                              && entry.dataSequenceNumber() > 0
-                              && entry.dataSequenceNumber() < minSequenceNumber);
-                  if (markedForDelete || evaluator.rowsMightMatch(file)) {
-                    boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
-                    ValidationException.check(
-                        allRowsMatch
-                            || isDelete, // ignore delete files where some records may not match
-                        // the expression
-                        "Cannot delete file where some, but not all, rows match filter %s: %s",
-                        this.deleteExpression,
+      try (CloseableIterable<ManifestEntry<F>> liveEntries = reader.liveEntries()) {
+        liveEntries.forEach(
+            entry -> {
+              F file = entry.file();
+              boolean isDanglingDV = isDelete && isDanglingDV((DeleteFile) file);
+              boolean markedForDelete =
+                  isDanglingDV
+                      || deletePaths.contains(file.location())
+                      || deleteFiles.contains(file)
+                      || dropPartitions.contains(file.specId(), file.partition())
+                      || (isDelete
+                          && entry.isLive()
+                          && entry.dataSequenceNumber() > 0
+                          && entry.dataSequenceNumber() < minSequenceNumber);
+              if (markedForDelete || evaluator.rowsMightMatch(file)) {
+                boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
+                ValidationException.check(
+                    allRowsMatch
+                        || isDelete, // ignore delete files where some records may not match
+                    // the expression
+                    "Cannot delete file where some, but not all, rows match filter %s: %s",
+                    this.deleteExpression,
+                    file.location());
+
+                if (allRowsMatch) {
+                  writer.delete(entry);
+                  F fileCopy = file.copyWithoutStats();
+
+                  if (deletedFiles.contains(file)) {
+                    LOG.warn(
+                        "Deleting a duplicate path from manifest {}: {}",
+                        manifest.path(),
                         file.location());
-
-                    if (allRowsMatch) {
-                      writer.delete(entry);
-                      F fileCopy = file.copyWithoutStats();
-
-                      if (deletedFiles.contains(file)) {
-                        LOG.warn(
-                            "Deleting a duplicate path from manifest {}: {}",
-                            manifest.path(),
-                            file.location());
-                        duplicateDeleteCount.incrementAndGet();
-                      } else {
-                        // only add the file to deletes if it is a new delete
-                        // this keeps the snapshot summary accurate for non-duplicate data
-                        deletedFiles.add(fileCopy);
-                      }
-                    } else {
-                      writer.existing(entry);
-                    }
-
+                    duplicateDeleteCount.incrementAndGet();
                   } else {
-                    writer.existing(entry);
+                    // only add the file to deletes if it is a new delete
+                    // this keeps the snapshot summary accurate for non-duplicate data
+                    deletedFiles.add(fileCopy);
                   }
-                });
+                } else {
+                  writer.existing(entry);
+                }
+
+              } else {
+                writer.existing(entry);
+              }
+            });
+      } catch (IOException e) {
+        throw new RuntimeIOException(e, "Failed to close manifest entries: %s", manifest);
       } finally {
         writer.close();
       }

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -738,6 +738,20 @@ public class TestDeleteFiles extends TestBase {
         statuses(Status.DELETED, Status.DELETED));
   }
 
+  @TestTemplate
+  public void testFilterManifestsWithLimitedIOPool() {
+    TestTables.TrackingFileIO io = new TestTables.TrackingFileIO(FILE_IO);
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations("limited-test", tableDir, io);
+    Table testTable =
+        TestTables.create(
+            tableDir, "limited-test", SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, ops);
+    commit(testTable, testTable.newFastAppend().appendFile(FILE_A), branch);
+    Snapshot deleteSnap = commit(testTable, testTable.newDelete().deleteFile(FILE_A), branch);
+    assertThat(deleteSnap.summary()).containsEntry(SnapshotSummary.DELETED_FILES_PROP, "1");
+    assertThat(io.peakCount()).isEqualTo(1);
+  }
+
   private static ByteBuffer longToBuffer(long value) {
     return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(0, value);
   }

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -26,12 +26,16 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -40,6 +44,7 @@ import org.apache.iceberg.util.StructLikeWrapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestDeleteFiles extends TestBase {
@@ -738,7 +743,53 @@ public class TestDeleteFiles extends TestBase {
         statuses(Status.DELETED, Status.DELETED));
   }
 
+  @TestTemplate
+  public void filterManifestsWithLimitedIOPool() {
+    AtomicInteger peakOpenStreams = new AtomicInteger(0);
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations("limited-test", tableDir, trackingIO(peakOpenStreams));
+    Table testTable =
+        TestTables.create(
+            tableDir, "limited-test", SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, ops);
+    commit(testTable, testTable.newFastAppend().appendFile(FILE_A), branch);
+    Snapshot deleteSnap = commit(testTable, testTable.newDelete().deleteFile(FILE_A), branch);
+    assertThat(deleteSnap.summary()).containsEntry(SnapshotSummary.DELETED_FILES_PROP, "1");
+    assertThat(peakOpenStreams.get()).isEqualTo(1);
+  }
+
   private static ByteBuffer longToBuffer(long value) {
     return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(0, value);
+  }
+
+  /** Returns a {@link FileIO} that records the peak number of concurrently open input streams. */
+  private static FileIO trackingIO(AtomicInteger peakOpenStreams) {
+    AtomicInteger openStreams = new AtomicInteger(0);
+    FileIO io = Mockito.spy(new TestTables.LocalFileIO());
+
+    Mockito.doAnswer(
+            newInputFile -> {
+              InputFile file = Mockito.spy((InputFile) newInputFile.callRealMethod());
+              Mockito.doAnswer(
+                      newStream -> {
+                        peakOpenStreams.accumulateAndGet(openStreams.incrementAndGet(), Math::max);
+                        SeekableInputStream stream =
+                            Mockito.spy((SeekableInputStream) newStream.callRealMethod());
+                        Mockito.doAnswer(
+                                close -> {
+                                  openStreams.decrementAndGet();
+                                  return close.callRealMethod();
+                                })
+                            .when(stream)
+                            .close();
+                        return stream;
+                      })
+                  .when(file)
+                  .newStream();
+              return file;
+            })
+        .when(io)
+        .newInputFile(Mockito.anyString());
+
+    return io;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -21,7 +21,9 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableMetadata.newTableMetadata;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -31,6 +33,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -408,6 +411,108 @@ public class TestTables {
     @Override
     public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
       throw new RuntimeException("Expected to mock this function");
+    }
+  }
+
+  /** A {@link FileIO} that enforces a limit on concurrent open input streams. */
+  public static class TrackingFileIO implements FileIO {
+
+    private final FileIO delegate;
+    private final AtomicInteger count = new AtomicInteger(0);
+    private final AtomicInteger peakCount = new AtomicInteger(0);
+
+    TrackingFileIO(FileIO delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public InputFile newInputFile(String path) {
+      return new TrackingInputFile(delegate.newInputFile(path), count, peakCount);
+    }
+
+    @Override
+    public OutputFile newOutputFile(String path) {
+      return delegate.newOutputFile(path);
+    }
+
+    @Override
+    public void deleteFile(String path) {
+      delegate.deleteFile(path);
+    }
+
+    public int peakCount() {
+      return peakCount.get();
+    }
+  }
+
+  private static class TrackingInputFile implements InputFile {
+
+    private final InputFile delegate;
+    private final AtomicInteger count;
+    private final AtomicInteger peakCount;
+
+    TrackingInputFile(InputFile delegate, AtomicInteger count, AtomicInteger peakCount) {
+      this.delegate = delegate;
+      this.count = count;
+      this.peakCount = peakCount;
+    }
+
+    @Override
+    public long getLength() {
+      return delegate.getLength();
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      peakCount.accumulateAndGet(count.incrementAndGet(), Math::max);
+      return new TrackingSeekableInputStream(delegate.newStream(), count);
+    }
+
+    @Override
+    public String location() {
+      return delegate.location();
+    }
+
+    @Override
+    public boolean exists() {
+      return delegate.exists();
+    }
+  }
+
+  private static class TrackingSeekableInputStream extends SeekableInputStream {
+
+    private final SeekableInputStream delegate;
+    private final AtomicInteger count;
+
+    TrackingSeekableInputStream(SeekableInputStream delegate, AtomicInteger count) {
+      this.delegate = delegate;
+      this.count = count;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return delegate.getPos();
+    }
+
+    @Override
+    public void seek(long newPos) throws IOException {
+      delegate.seek(newPos);
+    }
+
+    @Override
+    public int read() throws IOException {
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return delegate.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+      count.decrementAndGet();
     }
   }
 }


### PR DESCRIPTION
This PR prevents deadlocks while filtering manifest entries. The problem is `ManifestFilterManager.filterManifest` in some cases reads each manifest twice: first in `manifestHasDeletedFiles` and then in `filterManifestWithDeletedFiles`. If `manifestHasDeletedFiles` returns in the middle of entries iterable, the underlying connection is open until the ManifestReader is closed. `filterManifest` method is called for all manifests in parallel. When number of simultaneous connections is limited (for example by http-client.apache.max-connections) it can lead to a deadlock because all connections are held by `manifestHasDeletedFiles`.

The problem can be reproduced using spark-sql with S3FileIO and `http-client.apache.max-connections=1`:
```sql
create table manifestfiltermanager(id bigint)
  partitioned by (truncate(1, id))
  tblproperties('write.delete.mode'='merge-on-read');
-- create a data manifest with 100 entries
insert into manifestfiltermanager select id from range(100);
-- create a delete manifest with 50 entries
delete from manifestfiltermanager where id in (select id from range(0, 100, 2));
-- make delete files dangling (fails without https://github.com/apache/iceberg/pull/15712)
call system.rewrite_data_files('manifestfiltermanager', options => map('rewrite-all', 'true'));
-- ManifestFilterManager.manifestHasDeletedFiles reads first block of the delete manifest
-- and returns true before the end of liveEntries() iterable without closing it.
-- ManifestFilterManager.filterManifestWithDeletedFiles fails with ConnectionPoolTimeoutException
call system.rewrite_data_files('manifestfiltermanager', options => map('rewrite-all', 'true'));
```