### PR TITLE
Infra: Fix failing Recurring JMH Benchmarks

### DIFF
--- a/.github/workflows/recurring-jmh-benchmarks.yml
+++ b/.github/workflows/recurring-jmh-benchmarks.yml
@@ -45,7 +45,7 @@ jobs:
                     "IcebergSourceNestedParquetDataReadBenchmark", "IcebergSourceNestedParquetDataWriteBenchmark",
                     "IcebergSourceParquetEqDeleteBenchmark", "IcebergSourceParquetMultiDeleteFileBenchmark",
                     "IcebergSourceParquetPosDeleteBenchmark", "IcebergSourceParquetWithUnrelatedDeleteBenchmark"]
-        spark_version: ['iceberg-spark-3.5']
+        spark_version: ['iceberg-spark-4.1']
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -69,9 +69,16 @@ jobs:
       - name: Run Benchmark
         run: ./gradlew :iceberg-spark:${{ matrix.spark_version }}:jmh -PjmhIncludeRegex=${{ matrix.benchmark }} -PjmhOutputPath=benchmark/${{ matrix.benchmark }}.txt -PjmhJsonOutputPath=benchmark/${{ matrix.benchmark }}.json
 
+      - name: Build artifact name
+        if: always()
+        run: |
+          name=$(echo -n "${{ matrix.spark_version }}-${{ matrix.benchmark }}")
+          echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
+
+      - uses: actions/upload-artifact@v7
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: ${{ always() }}
         with:
-          name: benchmark-results
+          name: benchmark-results ${{ env.ARTIFACT_NAME }}
           path: |
             **/benchmark/*


### PR DESCRIPTION
The job keeps failing on main branch: 
```
Cannot locate tasks that match ':iceberg-spark:iceberg-spark-3.5:jmh' as project 'iceberg-spark-3.5' not found in project ':iceberg-spark'.
```

The job also has another issue of conflicted artifact names. 

https://github.com/apache/iceberg/actions/workflows/recurring-jmh-benchmarks.yml