### PR TITLE
GCS: Throw NotFoundException for inexistent input GCS file

### DIFF
--- a/gcp/src/integration/java/org/apache/iceberg/gcp/gcs/TestGcsFileIO.java
+++ b/gcp/src/integration/java/org/apache/iceberg/gcp/gcs/TestGcsFileIO.java
@@ -31,7 +31,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,10 +38,12 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.IOUtil;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterAll;
@@ -222,14 +223,40 @@ public class TestGcsFileIO {
   }
 
   @Test
-  public void readMissingLocation() {
+  public void readMissingLocation() throws IOException {
     String location = String.format("gs://%s/path/to/data.parquet", BUCKET);
+    InputFile input = fileIO.newInputFile(location);
+
+    // Creating an input stream or changing the read position in it are local operations
+    try (SeekableInputStream in = input.newStream()) {
+      in.seek(1);
+    }
+
+    try (SeekableInputStream in = input.newStream()) {
+      assertThatThrownBy(in::read)
+          .isInstanceOf(NotFoundException.class)
+          .hasCauseInstanceOf(IOException.class)
+          .hasMessage("Location does not exist: gs://test-bucket/path/to/data.parquet");
+    }
+  }
+
+  @Test
+  public void readMissingLocationGcsAnalyticsCoreEnabled() throws IOException {
+    String location = String.format("gs://%s/path/to/data.parquet", BUCKET);
+    fileIO.initialize(
+        ImmutableMap.of(
+            GCPProperties.GCS_ANALYTICS_CORE_ENABLED,
+            "true",
+            GCPProperties.GCS_NO_AUTH,
+            "true",
+            GCPProperties.GCS_SERVICE_HOST,
+            String.format("http://localhost:%d", GCS_EMULATOR_PORT)));
     InputFile in = fileIO.newInputFile(location);
 
     assertThatThrownBy(() -> in.newStream().read())
-        .isInstanceOf(IOException.class)
-        .hasCauseInstanceOf(StorageException.class)
-        .hasMessageContaining("404 Not Found");
+        .isInstanceOf(NotFoundException.class)
+        .hasCauseInstanceOf(IOException.class)
+        .hasMessage("Location does not exist: gs://test-bucket/path/to/data.parquet");
   }
 
   @Test

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSExceptionUtil.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSExceptionUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.gcs;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.StorageException;
+import java.io.IOException;
+import org.apache.iceberg.exceptions.NotFoundException;
+
+final class GCSExceptionUtil {
+  private GCSExceptionUtil() {}
+
+  static void throwNotFoundIfNotPresent(IOException ioException, BlobId blobId) {
+    if (ioException.getCause() instanceof StorageException storageException
+        && storageException.getCode() == 404) {
+      throw new NotFoundException(ioException, "Location does not exist: %s", blobId.toGsUtilUri());
+    }
+  }
+}

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputFile.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputFile.java
@@ -94,11 +94,11 @@ class GCSInputFile extends BaseGCSFile implements InputFile {
   private SeekableInputStream newGoogleCloudStorageInputStream() throws IOException {
     if (null == blobSize) {
       return new GcsInputStreamWrapper(
-          GoogleCloudStorageInputStream.create(gcsFileSystem(), gcsItemId()), metrics());
+          GoogleCloudStorageInputStream.create(gcsFileSystem(), gcsItemId()), blobId(), metrics());
     }
 
     return new GcsInputStreamWrapper(
-        GoogleCloudStorageInputStream.create(gcsFileSystem(), gcsFileInfo()), metrics());
+        GoogleCloudStorageInputStream.create(gcsFileSystem(), gcsFileInfo()), blobId(), metrics());
   }
 
   private GcsItemId gcsItemId() {

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -127,7 +127,12 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
     singleByteBuffer.position(0);
 
     pos += 1;
-    channel.read(singleByteBuffer);
+    try {
+      channel.read(singleByteBuffer);
+    } catch (IOException e) {
+      GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
+      throw e;
+    }
     readBytes.increment();
     readOperations.increment();
 
@@ -174,7 +179,12 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
       throws IOException {
     buffer.position(off);
     buffer.limit(Math.min(off + len, buffer.capacity()));
-    return readChannel.read(buffer);
+    try {
+      return readChannel.read(buffer);
+    } catch (IOException e) {
+      GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
+      throw e;
+    }
   }
 
   @Override

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsInputStreamWrapper.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsInputStreamWrapper.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.gcp.gcs;
 import com.google.api.client.util.Preconditions;
 import com.google.cloud.gcs.analyticscore.client.GcsObjectRange;
 import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
+import com.google.cloud.storage.BlobId;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -37,10 +38,14 @@ class GcsInputStreamWrapper extends SeekableInputStream implements RangeReadable
   private final Counter readBytes;
   private final Counter readOperations;
   private final GoogleCloudStorageInputStream stream;
+  private final BlobId blobId;
 
-  GcsInputStreamWrapper(GoogleCloudStorageInputStream stream, MetricsContext metrics) {
+  GcsInputStreamWrapper(
+      GoogleCloudStorageInputStream stream, BlobId blobId, MetricsContext metrics) {
     Preconditions.checkArgument(null != stream, "Invalid input stream : null");
+    Preconditions.checkArgument(null != blobId, "Invalid blobId : null");
     this.stream = stream;
+    this.blobId = blobId;
     this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, MetricsContext.Unit.BYTES);
     this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS);
   }
@@ -57,7 +62,13 @@ class GcsInputStreamWrapper extends SeekableInputStream implements RangeReadable
 
   @Override
   public int read() throws IOException {
-    int readByte = stream.read();
+    int readByte;
+    try {
+      readByte = stream.read();
+    } catch (IOException e) {
+      GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
+      throw e;
+    }
     readBytes.increment();
     readOperations.increment();
     return readByte;
@@ -70,7 +81,13 @@ class GcsInputStreamWrapper extends SeekableInputStream implements RangeReadable
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
-    int bytesRead = stream.read(b, off, len);
+    int bytesRead;
+    try {
+      bytesRead = stream.read(b, off, len);
+    } catch (IOException e) {
+      GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
+      throw e;
+    }
     if (bytesRead > 0) {
       readBytes.increment(bytesRead);
     }
@@ -80,12 +97,22 @@ class GcsInputStreamWrapper extends SeekableInputStream implements RangeReadable
 
   @Override
   public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
-    stream.readFully(position, buffer, offset, length);
+    try {
+      stream.readFully(position, buffer, offset, length);
+    } catch (IOException e) {
+      GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
+      throw e;
+    }
   }
 
   @Override
   public int readTail(byte[] buffer, int offset, int length) throws IOException {
-    return stream.readTail(buffer, offset, length);
+    try {
+      return stream.readTail(buffer, offset, length);
+    } catch (IOException e) {
+      GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
+      throw e;
+    }
   }
 
   @Override
@@ -101,8 +128,12 @@ class GcsInputStreamWrapper extends SeekableInputStream implements RangeReadable
                         .setByteBufferFuture(fileRange.byteBuffer())
                         .build())
             .collect(Collectors.toList());
-
-    stream.readVectored(objectRanges, allocate);
+    try {
+      stream.readVectored(objectRanges, allocate);
+    } catch (IOException e) {
+      GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
+      throw e;
+    }
   }
 
   @Override

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
@@ -163,6 +163,9 @@ public class TestGCSInputStream {
   @Test
   public void testClose() throws Exception {
     BlobId blobId = BlobId.fromGsUtilUri("gs://bucket/path/to/closed.dat");
+    byte[] data = randomData(1024 * 1024);
+    writeGCSData(blobId, data);
+
     SeekableInputStream closed =
         new GCSInputStream(storage, blobId, null, gcpProperties, MetricsContext.nullMetrics());
     closed.close();

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGcsInputStreamWrapper.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGcsInputStreamWrapper.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.gcp.gcs;
 
 import com.google.cloud.gcs.analyticscore.client.GcsObjectRange;
 import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
+import com.google.cloud.storage.BlobId;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -44,7 +45,10 @@ public class TestGcsInputStreamWrapper {
   @BeforeEach
   public void before() {
     inputStreamWrapper =
-        new GcsInputStreamWrapper(googleCloudStorageInputStream, MetricsContext.nullMetrics());
+        new GcsInputStreamWrapper(
+            googleCloudStorageInputStream,
+            BlobId.of("mockbucket", "mockname"),
+            MetricsContext.nullMetrics());
   }
 
   @Test


### PR DESCRIPTION
Signal early to the TableOperations that there is no retry needed for files which do not exist.


## Additional context

Relevant `apache/iceberg` code using this change

https://github.com/apache/iceberg/blob/a114e955e4f16d9b5636e675d9c59be92f5ab978/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java#L194-L200


Issue found while testing GCS credentials vending on `apache/iceberg-rest-fixture:1.10.1` on `trinodb/trino` https://github.com/trinodb/trino/pull/28423/


```
[qtp1357563986-31] WARN org.apache.iceberg.util.Tasks - Retrying task after failure: sleepTimeMs=403 Failed to read file: gs://trino-ci-test/gcs-vending-rest-test-w9a718ba0b/tpch/test_drop_table_with_missing_metadata_file_a422ditwmf-555e6d30e3834820993299f645ee11c1/metadata/00000-6a7be733-c273-463a-8700-0f02b17561b8.metadata.json
org.apache.iceberg.exceptions.RuntimeIOException: Failed to read file: gs://trino-ci-test/gcs-vending-rest-test-w9a718ba0b/tpch/test_drop_table_with_missing_metadata_file_a422ditwmf-555e6d30e3834820993299f645ee11c1/metadata/00000-6a7be733-c273-463a-8700-0f02b17561b8.metadata.json
	at org.apache.iceberg.TableMetadataParser.read(TableMetadataParser.java:311)
	at org.apache.iceberg.TableMetadataParser.read(TableMetadataParser.java:294)
	at org.apache.iceberg.BaseMetastoreTableOperations.lambda$refreshFromMetadataLocation$0(BaseMetastoreTableOperations.java:180)
	at org.apache.iceberg.BaseMetastoreTableOperations.lambda$refreshFromMetadataLocation$1(BaseMetastoreTableOperations.java:199)
	at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:413)
	at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:219)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:203)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:196)
	at org.apache.iceberg.BaseMetastoreTableOperations.refreshFromMetadataLocation(BaseMetastoreTableOperations.java:199)
	at org.apache.iceberg.BaseMetastoreTableOperations.refreshFromMetadataLocation(BaseMetastoreTableOperations.java:176)
	at org.apache.iceberg.BaseMetastoreTableOperations.refreshFromMetadataLocation(BaseMetastoreTableOperations.java:167)
	at org.apache.iceberg.jdbc.JdbcTableOperations.doRefresh(JdbcTableOperations.java:100)
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:88)
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:71)
	at org.apache.iceberg.BaseMetastoreCatalog.loadTable(BaseMetastoreCatalog.java:49)
	at org.apache.iceberg.rest.CatalogHandlers.loadTable(CatalogHandlers.java:329)
	at org.apache.iceberg.rest.RESTCatalogAdapter.handleRequest(RESTCatalogAdapter.java:420)
	at org.apache.iceberg.rest.RESTServerCatalogAdapter.handleRequest(RESTServerCatalogAdapter.java:42)
	at org.apache.iceberg.rest.RESTCatalogAdapter.execute(RESTCatalogAdapter.java:628)
	at org.apache.iceberg.rest.RESTCatalogAdapter.execute(RESTCatalogAdapter.java:609)
	at org.apache.iceberg.rest.RESTCatalogServlet.execute(RESTCatalogServlet.java:108)
	at org.apache.iceberg.rest.RESTCatalogServlet.doGet(RESTCatalogServlet.java:66)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:500)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:764)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:529)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:131)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:822)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:223)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1381)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:176)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:484)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:174)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1303)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:129)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
	at org.eclipse.jetty.server.Server.handle(Server.java:563)
	at org.eclipse.jetty.server.HttpChannel$RequestDispatchable.dispatch(HttpChannel.java:1598)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:753)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:501)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:287)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:314)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)
	at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:421)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:390)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:277)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:199)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:411)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:969)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1194)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1149)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.io.IOException: com.google.cloud.storage.StorageException: 404 Not Found
GET https://storage.googleapis.com/download/storage/v1/b/trino-ci-test/o/gcs-vending-rest-test-w9a718ba0b%2Ftpch%2Ftest_drop_table_with_missing_metadata_file_a422ditwmf-555e6d30e3834820993299f645ee11c1%2Fmetadata%2F00000-6a7be733-c273-463a-8700-0f02b17561b8.metadata.json?alt=media
No such object: trino-ci-test/gcs-vending-rest-test-w9a718ba0b/tpch/test_drop_table_with_missing_metadata_file_a422ditwmf-555e6d30e3834820993299f645ee11c1/metadata/00000-6a7be733-c273-463a-8700-0f02b17561b8.metadata.json
	at com.google.cloud.storage.BaseStorageReadChannel.read(BaseStorageReadChannel.java:143)
	at org.apache.iceberg.gcp.gcs.GCSInputStream.read(GCSInputStream.java:177)
	at org.apache.iceberg.gcp.gcs.GCSInputStream.read(GCSInputStream.java:141)
	at com.fasterxml.jackson.core.json.ByteSourceJsonBootstrapper.ensureLoaded(ByteSourceJsonBootstrapper.java:547)
	at com.fasterxml.jackson.core.json.ByteSourceJsonBootstrapper.detectEncoding(ByteSourceJsonBootstrapper.java:137)
	at com.fasterxml.jackson.core.json.ByteSourceJsonBootstrapper.constructParser(ByteSourceJsonBootstrapper.java:266)
	at com.fasterxml.jackson.core.JsonFactory._createParser(JsonFactory.java:1874)
	at com.fasterxml.jackson.core.JsonFactory.createParser(JsonFactory.java:1273)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3924)
	at org.apache.iceberg.TableMetadataParser.read(TableMetadataParser.java:309)
	... 54 more
Caused by: com.google.cloud.storage.StorageException: 404 Not Found
GET https://storage.googleapis.com/download/storage/v1/b/trino-ci-test/o/gcs-vending-rest-test-w9a718ba0b%2Ftpch%2Ftest_drop_table_with_missing_metadata_file_a422ditwmf-555e6d30e3834820993299f645ee11c1%2Fmetadata%2F00000-6a7be733-c273-463a-8700-0f02b17561b8.metadata.json?alt=media
```