### PR TITLE
Docs: clarify SparkSessionCatalog function limitations

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -113,12 +113,14 @@ Spark's built-in catalog supports existing v1 and v2 tables tracked in a Hive Me
 This configuration can use same Hive Metastore for both Iceberg and non-Iceberg tables.
 
 `SparkSessionCatalog` is useful when you want `spark_catalog` to work with both Iceberg and non-Iceberg
-tables in the same metastore. It is not a full replacement for a dedicated Iceberg catalog, though.
-Spark before 4.2.0 does not support `V2Function` in the session catalog. See
-[SPARK-54760](https://issues.apache.org/jira/browse/SPARK-54760) for details. As a result,
-catalog-scoped SQL functions such as `system.bucket`, `system.days`, and `system.iceberg_version`
-are not available through `spark_catalog`. To workaround this limitation, configure a separate
-Iceberg catalog with `org.apache.iceberg.spark.SparkCatalog` and call them through that catalog.
+tables in the same metastore.
+
+!!! note
+    Spark before 4.2.0 does not support `V2Function` in the session catalog. See
+    [SPARK-54760](https://issues.apache.org/jira/browse/SPARK-54760) ([apache/spark#53531](https://github.com/apache/spark/pull/53531)) for details. As a result,
+    catalog-scoped SQL functions such as `system.bucket`, `system.days`, and `system.iceberg_version`
+    are not available through `spark_catalog`. To work around this limitation, configure a separate
+    Iceberg catalog with `org.apache.iceberg.spark.SparkCatalog` and call them through that catalog.
 
 ### Using catalog specific Hadoop configuration values
 

--- a/docs/docs/spark-queries.md
+++ b/docs/docs/spark-queries.md
@@ -55,7 +55,7 @@ built-in catalog.
     Spark before 4.2.0 does not support `V2Function` in the session catalog.
     Queries such as `SELECT spark_catalog.system.bucket(16, id)` fail even when
     `spark_catalog` is configured with `org.apache.iceberg.spark.SparkSessionCatalog`.
-    See [SPARK-54760](https://issues.apache.org/jira/browse/SPARK-54760) for details.
+    See [SPARK-54760](https://issues.apache.org/jira/browse/SPARK-54760) ([apache/spark#53531](https://github.com/apache/spark/pull/53531)) for details.
     To use Iceberg SQL functions, call them through a catalog configured with
     `org.apache.iceberg.spark.SparkCatalog`.
 


### PR DESCRIPTION
Follow up https://github.com/apache/iceberg/pull/15697 and fix the https://github.com/apache/iceberg/pull/15697#issuecomment-4107805537 for `SparkSessionCatalog`.
Clarify the limitations for build-in Spark SQL functions while using `SparkSessionCatalog`.