### PR TITLE
Flink: Fix HashKeyGenerator SelectorKey cache ignoring writeParallelism and distributionMode

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -87,7 +87,9 @@ class HashKeyGenerator {
             tableSpec != null ? tableSpec.specId() : null,
             dynamicRecord.schema(),
             dynamicRecord.spec(),
-            dynamicRecord.equalityFields());
+            dynamicRecord.equalityFields(),
+            MoreObjects.firstNonNull(dynamicRecord.distributionMode(), DistributionMode.NONE),
+            Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism));
     KeySelector<RowData, Integer> keySelector =
         keySelectorCache.computeIfAbsent(
             cacheKey,
@@ -322,6 +324,8 @@ class HashKeyGenerator {
     private final Schema schema;
     private final PartitionSpec spec;
     private final Set<String> equalityFields;
+    private final DistributionMode distributionMode;
+    private final int writeParallelism;
 
     SelectorKey(
         String tableName,
@@ -330,7 +334,9 @@ class HashKeyGenerator {
         @Nullable Integer tableSpecId,
         Schema schema,
         PartitionSpec spec,
-        Set<String> equalityFields) {
+        Set<String> equalityFields,
+        DistributionMode distributionMode,
+        int writeParallelism) {
       this.tableName = tableName;
       this.branch = branch;
       this.schemaId = tableSchemaId;
@@ -338,6 +344,8 @@ class HashKeyGenerator {
       this.schema = tableSchemaId == null ? schema : null;
       this.spec = tableSpecId == null ? spec : null;
       this.equalityFields = equalityFields;
+      this.distributionMode = distributionMode;
+      this.writeParallelism = writeParallelism;
     }
 
     @Override
@@ -357,12 +365,23 @@ class HashKeyGenerator {
           && Objects.equals(specId, that.specId)
           && Objects.equals(schema, that.schema)
           && Objects.equals(spec, that.spec)
-          && Objects.equals(equalityFields, that.equalityFields);
+          && Objects.equals(equalityFields, that.equalityFields)
+          && distributionMode == that.distributionMode
+          && writeParallelism == that.writeParallelism;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(tableName, branch, schemaId, specId, schema, spec, equalityFields);
+      return Objects.hash(
+          tableName,
+          branch,
+          schemaId,
+          specId,
+          schema,
+          spec,
+          equalityFields,
+          distributionMode,
+          writeParallelism);
     }
 
     @Override
@@ -375,6 +394,8 @@ class HashKeyGenerator {
           .add("schema", schema)
           .add("spec", spec)
           .add("equalityFields", equalityFields)
+          .add("distributionMode", distributionMode)
+          .add("writeParallelism", writeParallelism)
           .toString();
     }
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -401,6 +401,74 @@ class TestHashKeyGenerator {
     assertThat(writeKey1).isEqualTo(writeKey3);
   }
 
+  @Test
+  void testCacheMissOnWriteParallelismChange() throws Exception {
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(10, maxWriteParallelism);
+    Map<HashKeyGenerator.SelectorKey, KeySelector<RowData, Integer>> keySelectorCache =
+        generator.getKeySelectorCache();
+
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+    DynamicRecord record1 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            SCHEMA,
+            GenericRowData.of(1, StringData.fromString("foo")),
+            unpartitioned,
+            DistributionMode.NONE,
+            2);
+    DynamicRecord record2 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            SCHEMA,
+            GenericRowData.of(1, StringData.fromString("foo")),
+            unpartitioned,
+            DistributionMode.NONE,
+            4);
+
+    generator.generateKey(record1);
+    assertThat(keySelectorCache).hasSize(1);
+
+    generator.generateKey(record2);
+    assertThat(keySelectorCache).hasSize(2);
+  }
+
+  @Test
+  void testCacheMissOnDistributionModeChange() throws Exception {
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(10, maxWriteParallelism);
+    Map<HashKeyGenerator.SelectorKey, KeySelector<RowData, Integer>> keySelectorCache =
+        generator.getKeySelectorCache();
+
+    PartitionSpec partitioned = PartitionSpec.builderFor(SCHEMA).identity("id").build();
+    DynamicRecord record1 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            SCHEMA,
+            GenericRowData.of(1, StringData.fromString("foo")),
+            partitioned,
+            DistributionMode.NONE,
+            2);
+    DynamicRecord record2 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            SCHEMA,
+            GenericRowData.of(1, StringData.fromString("foo")),
+            partitioned,
+            DistributionMode.HASH,
+            2);
+
+    generator.generateKey(record1);
+    assertThat(keySelectorCache).hasSize(1);
+
+    generator.generateKey(record2);
+    assertThat(keySelectorCache).hasSize(2);
+  }
+
   private static int getWriteKey(
       HashKeyGenerator generator,
       PartitionSpec spec,


### PR DESCRIPTION
## Problem

`HashKeyGenerator.SelectorKey` was missing `writeParallelism` and `distributionMode` from its `equals()` and `hashCode()` methods. As a result, `computeIfAbsent` always hit the cache after the first record for a given table, silently reusing a stale `KeySelector` even when these values changed.

This contradicts the class-level Javadoc which states:
> "Caching ensures that a new key selector is also created when … the user-provided metadata changes (e.g. distribution mode, write parallelism)."

## Fix

Add `writeParallelism` and `distributionMode` to `SelectorKey`'s fields, `equals()`, `hashCode()`, and `toString()`. The effective values passed to the cache key match those used in the `computeIfAbsent` lambda — `distributionMode` normalized via `firstNonNull(..., NONE)` and `writeParallelism` capped at `maxWriteParallelism`.

## Note

`writeParallelism` and `distributionMode` should remain stable per table during a streaming job. Changing these values mid-stream — especially when equality fields are set — can cause routing changes that break equality delete co-location, as the subtask assignment is not monotonic across different `writeParallelism` values (i.e., the subtask set for parallelism N is not guaranteed to be a subset of the set for parallelism N+1).

Making the subtask assignment monotonic (e.g., via a consistent ordering based on `maxWriteParallelism`) could address this limitation in a follow-up.

## Testing

Added two regression tests to `TestHashKeyGenerator`:
- `testCacheMissOnWriteParallelismChange`
- `testCacheMissOnDistributionModeChange`

Closes #15731