### PR TITLE
Spec: Add 404 response for config endpoint

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -163,7 +163,14 @@ paths:
         403:
           $ref: '#/components/responses/ForbiddenResponse'
         404:
-          $ref: '#/components/responses/NoSuchWarehouseResponse'
+          description: Not Found - Warehouse provided in the `warehouse` query parameter is not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                NoSuchWarehouseExample:
+                  $ref: '#/components/examples/NoSuchWarehouseError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         503:
@@ -4662,20 +4669,6 @@ components:
             }
           }
 
-    NoSuchWarehouseResponse:
-      description: Not Found - The given warehouse does not exist.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/IcebergErrorResponse'
-          example: {
-            "error": {
-              "message": "The given warehouse does not exist",
-              "type": "NoSuchWarehouseException",
-              "code": 404
-            }
-          }
-
     #  Note that this is a representative example response for use as a shorthand in the spec.
     #  The fields `message` and `type` as indicated here are not presently prescriptive.
     UnsupportedOperationResponse:
@@ -4974,6 +4967,16 @@ components:
         "error": {
           "message": "The given view does not exist",
           "type": "NoSuchViewException",
+          "code": 404
+        }
+      }
+
+    NoSuchWarehouseError:
+      summary: The requested warehouse does not exist
+      value: {
+        "error": {
+          "message": "The given warehouse does not exist",
+          "type": "NoSuchWarehouseException",
           "code": 404
         }
       }


### PR DESCRIPTION
## Summary

This PR proposes adding HTTP 404 as a documented response for the `/v1/config` endpoint in the REST Catalog OpenAPI specification.

## Rationale

The `/v1/config` endpoint allows an optional query parameter for a warehouse identifier, e.g. `/v1/config?warehouse=mywarehouse`.  But the openapi spec does not specify what should happen if the requested warehouse does not exist.

We noticed that Snowflake Open Catalog already returns a 404 for non-existent warehouses:

```json
{
  "error": {
    "message": "Unable to find warehouse NONEXISTENT_WAREHOUSE_12345",
    "type": "NotFoundException",
    "code": 404
  }
}
```

This PR therefore formalizes what Snowflake Open Catalog is already doing in production.  It seems sensible to formalize the 404 response code, because this is consistent with other Iceberg REST endpoints which allow a 404 response code for missing resources (tables, namespaces, views).

## Our use case

At my company we triage Iceberg exceptions according to their type.  For example, an exception for a missing resource might get triaged to the team responsible for providing that resource.

Currently, the Iceberg core library yields the generic `RESTException` if a warehouse does not exist.  It is difficult to automatically triage the generic `RESTException`.  It would help us if Iceberg could yield the `NoSuchWarehouseException` instead, so our application code can more confidently triage this runtime issue.

We expect other Iceberg users have similar operational workflows where distinguishing warehouse configuration errors from other failures would improve their incident response.

## Context

Split from #14965 per @danielcweeks's suggestion to discuss and vote on the spec change separately from the implementation.

See the dev list thread: https://lists.apache.org/thread/07t5rfcxn3bbbpp75fkr2h1mwdp2o4mn