### PR TITLE
Core: Fix NPE of generateRandomMetrics in FileGenerationUtil

### DIFF
--- a/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
@@ -280,13 +280,13 @@ public class FileGenerationUtil {
   }
 
   private static Pair<ByteBuffer, ByteBuffer> generateBounds(PrimitiveType type, MetricsMode mode) {
-    if (mode instanceof None || mode instanceof Counts) {
-      return Pair.of(null, null);
-    }
-
-    Comparator<Object> cmp = Comparators.forType(type);
     Object value1 = generateBound(type, mode);
     Object value2 = generateBound(type, mode);
+
+    if (value1 == null || value2 == null) {
+      return Pair.of(null, null);
+    }
+    Comparator<Object> cmp = Comparators.forType(type);
     if (cmp.compare(value1, value2) > 0) {
       ByteBuffer lowerBuffer = Conversions.toByteBuffer(type, value2);
       ByteBuffer upperBuffer = Conversions.toByteBuffer(type, value1);

--- a/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestFileGenerationUtil {
 
@@ -45,21 +45,6 @@ public class TestFileGenerationUtil {
           required(5, "timestamp_col", Types.TimestampType.withoutZone()),
           required(6, "timestamp_tz_col", Types.TimestampType.withZone()),
           required(7, "str_col", Types.StringType.get()));
-
-  enum MetricsModeCase {
-    NONE("none", false),
-    COUNTS("counts", false),
-    TRUNCATE("truncate(16)", true),
-    FULL("full", true);
-
-    final String modeName;
-    final boolean hasBounds;
-
-    MetricsModeCase(String modeName, boolean hasBounds) {
-      this.modeName = modeName;
-      this.hasBounds = hasBounds;
-    }
-  }
 
   @Test
   public void testBoundsWithDefaultMetricsConfig() {
@@ -103,12 +88,12 @@ public class TestFileGenerationUtil {
   }
 
   @ParameterizedTest
-  @EnumSource(MetricsModeCase.class)
+  @ValueSource(strings = {"none", "counts", "truncate(16)", "full"})
   @SuppressWarnings("deprecation")
-  void testBoundsForAllMetricsModes(MetricsModeCase modeCase) {
+  void testBoundsForAllMetricsModes(String metricsMode) {
     MetricsConfig metricsConfig =
         MetricsConfig.fromProperties(
-            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, modeCase.modeName));
+            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, metricsMode));
     Metrics metrics =
         FileGenerationUtil.generateRandomMetrics(
             SCHEMA,
@@ -116,25 +101,7 @@ public class TestFileGenerationUtil {
             ImmutableMap.of() /* no lower bounds */,
             ImmutableMap.of() /* no upper bounds */);
 
-    for (NestedField field : SCHEMA.columns()) {
-      ByteBuffer lower = metrics.lowerBounds().get(field.fieldId());
-      ByteBuffer upper = metrics.upperBounds().get(field.fieldId());
-      if (modeCase.hasBounds) {
-        assertThat(lower)
-            .as("lower bound for %s in mode %s", field.name(), modeCase.modeName)
-            .isNotNull();
-        assertThat(upper)
-            .as("upper bound for %s in mode %s", field.name(), modeCase.modeName)
-            .isNotNull();
-      } else {
-        assertThat(lower)
-            .as("lower bound for %s in mode %s", field.name(), modeCase.modeName)
-            .isNull();
-        assertThat(upper)
-            .as("upper bound for %s in mode %s", field.name(), modeCase.modeName)
-            .isNull();
-      }
-    }
+    checkBounds(metrics, metricsConfig);
   }
 
   private void checkBounds(Metrics metrics, MetricsConfig metricsConfig) {


### PR DESCRIPTION
fix NPE because NaturalOrderComparator.compare will not accept the null. And if the metrics mode is None or Count, today it returns null in FileGenerationUtil:: generateBound https://github.com/apache/iceberg/blob/32b2f00125261b93c29aca9068d78390135a80f1/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java#L298-L299

```java
Cannot invoke "java.lang.Comparable.compareTo(Object)" because "c1" is null
java.lang.NullPointerException: Cannot invoke "java.lang.Comparable.compareTo(Object)" because "c1" is null
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:52)
	at java.base/java.util.Comparators$NaturalOrderComparator.compare(Comparators.java:47)
	at org.apache.iceberg.FileGenerationUtil.generateBounds(FileGenerationUtil.java:290)
	at org.apache.iceberg.FileGenerationUtil.generateRandomMetrics(FileGenerationUtil.java:193)
	at org.apache.iceberg.TestFileGenerationUtil.testBoundsForAllMetricsModes(TestFileGenerationUtil.java:113)
```