### PR TITLE
REST Spec: add labels field for catalog metadata enrichment

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -649,6 +649,49 @@ class LoadCredentialsResponse(BaseModel):
     )
 
 
+class CatalogObjectLabels(RootModel[dict[str, str]]):
+    """
+    Catalog-object-level labels, attached to the object (table, view, ...) as a whole.
+    """
+
+    root: dict[str, str]
+
+
+class FieldLabels(BaseModel):
+    """
+    Labels attached to a single field, identified by field-id.
+    """
+
+    field_id: int = Field(
+        ...,
+        alias='field-id',
+        description='Field ID from the schema of the table or view',
+    )
+    labels: dict[str, str] = Field(
+        ..., description='Flat key-value labels for this field'
+    )
+
+
+class Labels(BaseModel):
+    """
+    Catalog-provided metadata enrichment (for example ownership,
+    classification, or cost attribution) returned with a table or view.
+    Labels are catalog-provided and optional; clients may ignore them, and
+    may cache them following the response ETag.
+    The spec does not require how a catalog produces or stores labels, nor
+    whether they are persisted or versioned. `objectLabels` carries
+    catalog-object-level labels; `fields` carries per-field labels, each
+    identified by field-id.
+
+    """
+
+    objectLabels: CatalogObjectLabels | None = None
+    fields: list[FieldLabels] | None = Field(
+        None,
+        description='Field-level labels. Each entry identifies its field by field-id.',
+    )
+
+
 class AsyncPlanningResult(BaseModel):
     status: Literal['submitted'] = Field(
         ..., description='Status of a server-side planning operation'
@@ -1766,6 +1809,7 @@ class LoadTableResult(BaseModel):
     remote_signing_config: RemoteSigningConfig | None = Field(
         None, alias='remote-signing-config'
     )
+    labels: Labels | None = None
 
 
 class ScanTasks(BaseModel):
@@ -1877,6 +1921,7 @@ class LoadViewResult(BaseModel):
     metadata_location: str = Field(..., alias='metadata-location')
     metadata: ViewMetadata
     config: dict[str, str] | None = None
+    labels: Labels | None = None
 
 
 class ScanReport(BaseModel):

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -797,6 +797,49 @@ class LoadCredentialsResponse(BaseModel):
     )
 
 
+class CatalogObjectLabels(RootModel[dict[str, str]]):
+    """
+    Flat key-value labels attached to the object (table, view, ...) as a whole.
+    """
+
+    root: dict[str, str]
+
+
+class FieldLabels(BaseModel):
+    """
+    Labels attached to a single field, identified by field-id.
+    """
+
+    field_id: int = Field(
+        ...,
+        alias='field-id',
+        description='Field ID from the schema of the table or view',
+    )
+    labels: dict[str, str] = Field(
+        ..., description='Flat key-value labels for this field'
+    )
+
+
+class Labels(BaseModel):
+    """
+    Catalog-provided metadata enrichment (for example ownership,
+    classification, or cost attribution) returned with a table or view.
+    Labels are catalog-provided and optional; clients may ignore them, and
+    may cache them following the response ETag.
+    The spec does not require how a catalog produces or stores labels, nor
+    whether they are persisted or versioned. `object-labels` carries
+    labels for the object as a whole; `fields` carries per-field labels,
+    each identified by field-id.
+
+    """
+
+    object_labels: CatalogObjectLabels | None = Field(None, alias='object-labels')
+    fields: list[FieldLabels] | None = Field(
+        None,
+        description='Field-level labels. Each entry identifies its field by field-id.',
+    )
+
+
 class AsyncPlanningResult(BaseModel):
     status: Literal['submitted'] = Field(
         ..., description='Status of a server-side planning operation'
@@ -1961,6 +2004,7 @@ class LoadTableResult(BaseModel):
         None, alias='remote-signing-config'
     )
     read_restrictions: ReadRestrictions | None = Field(None, alias='read-restrictions')
+    labels: Labels | None = None
 
 
 class ScanTasks(BaseModel):
@@ -2072,6 +2116,7 @@ class LoadViewResult(BaseModel):
     metadata_location: str = Field(..., alias='metadata-location')
     metadata: ViewMetadata
     config: dict[str, str] | None = None
+    labels: Labels | None = None
 
 
 class ScanReport(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3849,6 +3849,51 @@ components:
           items:
             $ref: '#/components/schemas/StorageCredential'
 
+    CatalogObjectLabels:
+      type: object
+      description: >-
+        Catalog-object-level labels, attached to the object (table, view, ...)
+        as a whole.
+      additionalProperties:
+        type: string
+
+    FieldLabels:
+      type: object
+      description: Labels attached to a single field, identified by field-id.
+      required:
+        - field-id
+        - labels
+      properties:
+        field-id:
+          type: integer
+          description: Field ID from the schema of the table or view
+        labels:
+          type: object
+          description: Flat key-value labels for this field
+          additionalProperties:
+            type: string
+
+    Labels:
+      type: object
+      description: |
+        Catalog-provided metadata enrichment (for example ownership,
+        classification, or cost attribution) returned with a table or view.
+        Labels are catalog-provided and optional; clients may ignore them, and
+        may cache them following the response ETag.
+        The spec does not require how a catalog produces or stores labels, nor
+        whether they are persisted or versioned. `objectLabels` carries
+        catalog-object-level labels; `fields` carries per-field labels, each
+        identified by field-id.
+      properties:
+        objectLabels:
+          $ref: '#/components/schemas/CatalogObjectLabels'
+        fields:
+          type: array
+          description: >-
+            Field-level labels. Each entry identifies its field by field-id.
+          items:
+            $ref: '#/components/schemas/FieldLabels'
+
     LoadTableResult:
       description: |
         Result used when a table is successfully loaded.
@@ -3917,6 +3962,8 @@ components:
             $ref: '#/components/schemas/StorageCredential'
         remote-signing-config:
           $ref: '#/components/schemas/RemoteSigningConfig'
+        labels:
+          $ref: '#/components/schemas/Labels'
 
     ScanTasks:
       type: object
@@ -4216,6 +4263,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        labels:
+          $ref: '#/components/schemas/Labels'
 
     RegisterViewRequest:
       type: object

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4170,6 +4170,48 @@ components:
           items:
             $ref: '#/components/schemas/StorageCredential'
 
+    CatalogObjectLabels:
+      type: object
+      description: Flat key-value labels attached to the object (table, view, ...) as a whole.
+      additionalProperties:
+        type: string
+
+    FieldLabels:
+      type: object
+      description: Labels attached to a single field, identified by field-id.
+      required:
+        - field-id
+        - labels
+      properties:
+        field-id:
+          type: integer
+          description: Field ID from the schema of the table or view
+        labels:
+          type: object
+          description: Flat key-value labels for this field
+          additionalProperties:
+            type: string
+
+    Labels:
+      type: object
+      description: |
+        Catalog-provided metadata enrichment (for example ownership,
+        classification, or cost attribution) returned with a table or view.
+        Labels are catalog-provided and optional; clients may ignore them, and
+        may cache them following the response ETag.
+        The spec does not require how a catalog produces or stores labels, nor
+        whether they are persisted or versioned. `object-labels` carries
+        labels for the object as a whole; `fields` carries per-field labels,
+        each identified by field-id.
+      properties:
+        object-labels:
+          $ref: '#/components/schemas/CatalogObjectLabels'
+        fields:
+          type: array
+          description: Field-level labels. Each entry identifies its field by field-id.
+          items:
+            $ref: '#/components/schemas/FieldLabels'
+
     LoadTableResult:
       description: |
         Result used when a table is successfully loaded.
@@ -4240,6 +4282,8 @@ components:
           $ref: '#/components/schemas/RemoteSigningConfig'
         read-restrictions:
           $ref: '#/components/schemas/ReadRestrictions'
+        labels:
+          $ref: '#/components/schemas/Labels'
 
     ScanTasks:
       type: object
@@ -4539,6 +4583,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        labels:
+          $ref: '#/components/schemas/Labels'
 
     RegisterViewRequest:
       type: object


### PR DESCRIPTION
Adds an optional `labels` field to the REST catalog spec for **catalog-owned metadata enrichment**.

## Motivation

A catalog maintains operational context about the objects it serves — ownership, classification, cost attribution, semantic hints — but the spec gives it no standard place to return that context. Today catalogs work around this by extending load responses with vendor-specific fields that OSS engines can't consume. Labels provide one standard channel instead.

Labels are catalog-owned and ephemeral: generated per request, never written to `metadata.json`, no commits or snapshots, no versioning with table history. They are not table state, and different catalogs serving the same object may legitimately return different labels. Catalogs may populate them; engines may use them or ignore them entirely.

This is deliberately kept out of properties. Properties are table state — writer-owned, persisted, and they travel with the table across catalogs. Catalog enrichment is the opposite, so putting it in properties would conflate authority and force it to travel where it shouldn't. The boundary is the table spec (properties) vs. the IRC spec (labels).

## What changed

New `Labels` (`table` flat key-values + `columns` keyed by `field-id` for stability across schema evolution) and `ColumnLabels` schemas; `labels` field added to `LoadTableResult` and `LoadViewResult`.

Read-only and backward compatible (`labels` is optional; older clients ignore it). Namespace labels and the write path (`UpdateLabels`) are follow-ups.

Proposal and design doc: #15521.
