### PR TITLE
Core: Pass storage credentials to ioBuilder-created FileIO in RESTSes…

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -60,6 +60,7 @@ import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileIOTracker;
 import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporters;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -1175,7 +1176,15 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private FileIO newFileIO(
       SessionContext context, Map<String, String> properties, List<Credential> storageCredentials) {
     if (null != ioBuilder) {
-      return ioBuilder.apply(context, properties);
+      FileIO fileIO = ioBuilder.apply(context, properties);
+      if (!storageCredentials.isEmpty()
+          && fileIO instanceof SupportsStorageCredentials ioWithCredentials) {
+        ioWithCredentials.setCredentials(
+            storageCredentials.stream()
+                .map(c -> StorageCredential.create(c.prefix(), c.config()))
+                .collect(Collectors.toList()));
+      }
+      return fileIO;
     } else {
       String ioImpl = properties.getOrDefault(CatalogProperties.FILE_IO_IMPL, DEFAULT_FILE_IO_IMPL);
       return CatalogUtil.loadFileIO(

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
@@ -67,6 +68,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TestCatalogUtil;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdatePartitionSpec;
 import org.apache.iceberg.UpdateSchema;
@@ -86,6 +88,8 @@ import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
 import org.apache.iceberg.metrics.CommitReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -99,6 +103,8 @@ import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.AuthSessionUtil;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
@@ -3738,6 +3744,71 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             () -> catalog.loadTable(TABLE).newFastAppend().appendFile(anotherFileOnMain).commit())
         .isInstanceOf(CommitFailedException.class)
         .hasMessageContaining("Validation failed, please retry");
+  }
+
+  @Test
+  public void testIoBuilderReceivesStorageCredentials() {
+    Credential credential =
+        ImmutableCredential.builder()
+            .prefix("s3://test-bucket/")
+            .putConfig("s3.access-key-id", "test-access-key")
+            .putConfig("s3.secret-access-key", "test-secret-key")
+            .build();
+
+    // Adapter that injects storage credentials into LoadTableResponse
+    RESTCatalogAdapter adapter =
+        new RESTCatalogAdapter(backendCatalog) {
+          @SuppressWarnings("unchecked")
+          @Override
+          public <T extends RESTResponse> T handleRequest(
+              Route route,
+              Map<String, String> vars,
+              HTTPRequest httpRequest,
+              Class<T> responseType,
+              Consumer<Map<String, String>> responseHeaders) {
+            T response =
+                super.handleRequest(route, vars, httpRequest, responseType, responseHeaders);
+            if (route == Route.LOAD_TABLE && response instanceof LoadTableResponse loadResponse) {
+              return (T)
+                  LoadTableResponse.builder()
+                      .withTableMetadata(loadResponse.tableMetadata())
+                      .addAllConfig(loadResponse.config())
+                      .addCredential(credential)
+                      .build();
+            }
+            return response;
+          }
+        };
+
+    AtomicReference<FileIO> createdFileIO = new AtomicReference<>();
+
+    try (RESTCatalog catalog =
+        catalog(
+            adapter,
+            clientBuilder ->
+                new RESTSessionCatalog(
+                    clientBuilder,
+                    (context, config) -> {
+                      TestCatalogUtil.TestFileIOWithStorageCredentials fileIO =
+                          new TestCatalogUtil.TestFileIOWithStorageCredentials();
+                      createdFileIO.set(fileIO);
+                      return fileIO;
+                    }))) {
+      catalog.createNamespace(NS);
+      catalog.createTable(TABLE, SCHEMA);
+      catalog.loadTable(TABLE);
+
+      assertThat(createdFileIO.get()).isInstanceOf(SupportsStorageCredentials.class);
+      List<StorageCredential> creds =
+          ((SupportsStorageCredentials) createdFileIO.get()).credentials();
+      assertThat(creds).hasSize(1);
+      assertThat(creds.get(0).prefix()).isEqualTo("s3://test-bucket/");
+      assertThat(creds.get(0).config())
+          .containsEntry("s3.access-key-id", "test-access-key")
+          .containsEntry("s3.secret-access-key", "test-secret-key");
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private RESTCatalog catalog(RESTCatalogAdapter adapter) {


### PR DESCRIPTION
## What

[RESTSessionCatalog.newFileIO()](cci:1://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java:1175:2-1197:3) has two code paths for creating a `FileIO`:

1. **ioBuilder path** — used when a custom `ioBuilder` is provided (e.g. by Trino)
2. **Reflection path** — used when `ioBuilder` is null, delegates to `CatalogUtil.loadFileIO()`

The reflection path correctly passes storage credentials (vended via [LoadTableResponse](cci:2://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java:40:0-141:1)) to
`FileIO` implementations that implement `SupportsStorageCredentials`. The `ioBuilder` path,
however, completely ignores the `storageCredentials` parameter — silently discarding them.

## Why this matters

This was introduced in #12591, which added storage credentials V3 support but only wired up
credential passing for the reflection path. The `ioBuilder` path was missed because Trino is
currently the only engine that uses it.

In practice, this means that when a REST catalog server vends storage credentials
(e.g. short-lived S3/GCS/ADLS tokens), any engine using a custom `ioBuilder` never receives
them. For Trino specifically, this blocks the ability to use vended credentials with their
custom `FileIO` — which is the subject of ongoing work in
[trinodb/trino#28425](https://github.com/trinodb/trino/pull/28425).

[confirmed as unintentional](https://github.com/trinodb/trino/pull/28425#discussion_r2980583819)

## The fix

After `ioBuilder.apply(context, properties)` creates the `FileIO`, we now check if the
instance implements `SupportsStorageCredentials` and call [setCredentials()](cci:1://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java:572:4-575:5) with the
converted credentials — matching exactly what `CatalogUtil.loadFileIO()` already does at
lines 418–419.

The change is 8 lines of logic, non-breaking, and covers all 5 call sites that flow through
[tableFileIO()](cci:1://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java:1199:2-1208:3) → [newFileIO()](cci:1://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java:1175:2-1197:3):
- [loadTable()](cci:1://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java:445:2-558:3)
- [registerTable()](cci:1://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java:670:2-720:3)
- `Builder.load()`
- [Builder.createTransaction()](cci:1://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java:991:4-1019:5)
- [Builder.replaceTransaction()](cci:1://file:///Users/rkaveti/Documents/rkaveti/iceberg/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java:1021:4-1084:5)
