### PR TITLE
CI: Add zizmor workflow audit for unpinned actions

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,16 +17,6 @@
 # under the License.
 #
 
-# Audits GitHub Actions workflows for unpinned third-party actions.
-#
-# Actions referenced by mutable tag (e.g. `actions/checkout@v4`) can be
-# silently replaced by a compromised or force-pushed tag, allowing arbitrary
-# code execution inside CI. Pinning to a full commit SHA makes the reference
-# immutable and auditable.
-#
-# This job runs zizmor (https://docs.zizmor.sh/) in offline mode
-# and fails if any `uses:` step references an action without a commit-SHA pin.
-
 name: "Zizmor Workflow Audit"
 on:
   pull_request:
@@ -43,6 +33,11 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5
     - name: Run zizmor audit
+      # Runs zizmor (https://docs.zizmor.sh/) in offline mode to detect
+      # unpinned third-party actions. Actions referenced by mutable tag
+      # (e.g. `actions/checkout@v4`) can be silently replaced by a
+      # compromised or force-pushed tag, allowing arbitrary code execution
+      # in CI. Pinning to a full commit SHA makes the reference immutable.
       run: |
         findings=$(uvx --from zizmor zizmor \
           --offline \


### PR DESCRIPTION
Part of https://github.com/apache/iceberg/issues/15742
We've already moved all references to pinned commit hash in #15753

This adds a CI workflow that uses [zizmor](https://docs.zizmor.sh/) to detect unpinned third-party GitHub Actions in workflow files. 
Future violations will trigger this CI to fail.

### Problem

Actions referenced by mutable tag (e.g. `actions/checkout@v4`) can be silently replaced by a compromised or force-pushed tag, allowing arbitrary code execution inside CI. All `uses:` references should be pinned to a full commit SHA to make them immutable and auditable.

### Solution

Add a `zizmor.yml` workflow that:
- Triggers on PRs that modify `.github/workflows/**`
- Runs zizmor in offline mode to check for `unpinned-uses` findings
- Reports the file, line, and action for each violation
- Fails the check if any unpinned actions are found


## Testing
Ran CI on forked repo w/ a tagged pin, https://github.com/kevinjqliu/iceberg/pull/14
Fails CI ✅  https://github.com/kevinjqliu/iceberg/actions/runs/23516762295/job/68450916216?pr=14
```
Error: Found unpinned GitHub Actions:
.github/workflows/open-api.yml:49:15	astral-sh/setup-uv@v7
Error: Process completed with exit code 1.
```