### PR TITLE
Flink Sink V2: Add OutputFileFactoryProvider plugin interface

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.SupportsConcurrentExecutionAttempts;
@@ -171,6 +172,8 @@ public class IcebergSink
   // equalityFieldIds instead.
   private final Set<String> equalityFieldColumns;
 
+  @Nullable private final OutputFileFactoryProvider outputFileFactoryProvider;
+
   private final transient List<MaintenanceTaskBuilder<?>> maintenanceTasks;
   private final transient FlinkMaintenanceConfig flinkMaintenanceConfig;
 
@@ -188,7 +191,8 @@ public class IcebergSink
       boolean overwriteMode,
       List<MaintenanceTaskBuilder<?>> maintenanceTasks,
       FlinkMaintenanceConfig flinkMaintenanceConfig,
-      Set<String> equalityFieldColumns) {
+      Set<String> equalityFieldColumns,
+      @Nullable OutputFileFactoryProvider outputFileFactoryProvider) {
     this.tableLoader = tableLoader;
     this.snapshotProperties = snapshotProperties;
     this.uidSuffix = uidSuffix;
@@ -212,6 +216,7 @@ public class IcebergSink
     this.maintenanceTasks = maintenanceTasks;
     this.flinkMaintenanceConfig = flinkMaintenanceConfig;
     this.equalityFieldColumns = equalityFieldColumns;
+    this.outputFileFactoryProvider = outputFileFactoryProvider;
   }
 
   @Override
@@ -224,7 +229,10 @@ public class IcebergSink
             dataFileFormat,
             writeProperties,
             equalityFieldIds,
-            upsertMode);
+            upsertMode,
+            table.schema(),
+            table.spec(),
+            outputFileFactoryProvider);
     IcebergStreamWriterMetrics metrics =
         new IcebergStreamWriterMetrics(context.metricGroup(), table.name());
     return new IcebergSinkWriter(
@@ -349,6 +357,7 @@ public class IcebergSink
     private ReadableConfig readableConfig = new Configuration();
     private List<String> equalityFieldColumns = null;
     private final List<MaintenanceTaskBuilder<?>> maintenanceTasks = Lists.newArrayList();
+    @Nullable private OutputFileFactoryProvider outputFileFactoryProvider;
 
     private Builder() {}
 
@@ -716,6 +725,18 @@ public class IcebergSink
       return this;
     }
 
+    /**
+     * Sets a custom {@link OutputFileFactoryProvider} to control how output files are created.
+     *
+     * <p>When set, the provided factory replaces the default {@link
+     * org.apache.iceberg.io.OutputFileFactory} in the writer pipeline. When not set (null), the
+     * default factory is used.
+     */
+    public Builder outputFileFactoryProvider(OutputFileFactoryProvider provider) {
+      this.outputFileFactoryProvider = provider;
+      return this;
+    }
+
     IcebergSink build() {
 
       Preconditions.checkArgument(
@@ -806,7 +827,8 @@ public class IcebergSink
           overwriteMode,
           maintenanceTasks,
           flinkMaintenanceConfig,
-          equalityFieldColumnsSet);
+          equalityFieldColumnsSet,
+          outputFileFactoryProvider);
     }
 
     /**

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/OutputFileFactoryProvider.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/OutputFileFactoryProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.Serializable;
+import org.apache.flink.annotation.Experimental;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.io.OutputFileFactory;
+
+/**
+ * Plugin interface for providing a custom {@link OutputFileFactory}.
+ *
+ * <p>Implementations can customize how output files are created, enabling use cases such as:
+ *
+ * <ul>
+ *   <li>Custom file naming or path rewriting
+ *   <li>Routing writes to non-standard storage endpoints
+ *   <li>Region-specific or environment-specific file placement
+ * </ul>
+ *
+ * <p>When set on {@link IcebergSink.Builder#outputFileFactoryProvider}, the provided factory
+ * replaces the default {@link OutputFileFactory} created by {@link RowDataTaskWriterFactory}.
+ */
+@Experimental
+@FunctionalInterface
+public interface OutputFileFactoryProvider extends Serializable {
+  OutputFileFactory create(
+      Table table, int taskId, int attemptId, FileFormat format, PartitionSpec spec);
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/OutputFileFactoryProvider.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/OutputFileFactoryProvider.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.util.SerializableSupplier;
 
 /**
  * Plugin interface for providing a custom {@link OutputFileFactory}.
@@ -43,5 +44,9 @@ import org.apache.iceberg.io.OutputFileFactory;
 @FunctionalInterface
 public interface OutputFileFactoryProvider extends Serializable {
   OutputFileFactory create(
-      Table table, int taskId, int attemptId, FileFormat format, PartitionSpec spec);
+      SerializableSupplier<Table> tableSupplier,
+      int taskId,
+      int attemptId,
+      FileFormat format,
+      PartitionSpec spec);
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.FileFormat;
@@ -53,6 +54,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
   private final Set<Integer> equalityFieldIds;
   private final boolean upsert;
   private final FileWriterFactory<RowData> fileWriterFactory;
+  @Nullable private final OutputFileFactoryProvider outputFileFactoryProvider;
   private boolean useDv;
 
   private transient OutputFileFactory outputFileFactory;
@@ -105,7 +107,32 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
       boolean upsert,
       Schema schema,
       PartitionSpec spec) {
+    this(
+        tableSupplier,
+        flinkSchema,
+        targetFileSizeBytes,
+        format,
+        writeProperties,
+        equalityFieldIds,
+        upsert,
+        schema,
+        spec,
+        null);
+  }
+
+  public RowDataTaskWriterFactory(
+      SerializableSupplier<Table> tableSupplier,
+      RowType flinkSchema,
+      long targetFileSizeBytes,
+      FileFormat format,
+      Map<String, String> writeProperties,
+      Collection<Integer> equalityFieldIds,
+      boolean upsert,
+      Schema schema,
+      PartitionSpec spec,
+      @Nullable OutputFileFactoryProvider outputFileFactoryProvider) {
     this.tableSupplier = tableSupplier;
+    this.outputFileFactoryProvider = outputFileFactoryProvider;
 
     Table table;
     if (tableSupplier instanceof CachingTableSupplier) {
@@ -174,12 +201,19 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     refreshTable();
     this.useDv = TableUtil.formatVersion(table) > 2;
 
-    this.outputFileFactory =
-        OutputFileFactory.builderFor(table, taskId, attemptId)
-            .format(format)
-            .ioSupplier(() -> tableSupplier.get().io())
-            .defaultSpec(spec)
-            .build();
+    if (outputFileFactoryProvider != null) {
+      this.outputFileFactory =
+          Preconditions.checkNotNull(
+              outputFileFactoryProvider.create(table, taskId, attemptId, format, spec),
+              "OutputFileFactoryProvider must not return null");
+    } else {
+      this.outputFileFactory =
+          OutputFileFactory.builderFor(table, taskId, attemptId)
+              .format(format)
+              .ioSupplier(() -> tableSupplier.get().io())
+              .defaultSpec(spec)
+              .build();
+    }
   }
 
   @Override

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.flink.sink;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -45,7 +44,7 @@ import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.SerializableSupplier;
 
 public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
-  private final Supplier<Table> tableSupplier;
+  private final SerializableSupplier<Table> tableSupplier;
   private final Schema schema;
   private final RowType flinkSchema;
   private final PartitionSpec spec;
@@ -204,7 +203,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     if (outputFileFactoryProvider != null) {
       this.outputFileFactory =
           Preconditions.checkNotNull(
-              outputFileFactoryProvider.create(table, taskId, attemptId, format, spec),
+              outputFileFactoryProvider.create(tableSupplier, taskId, attemptId, format, spec),
               "OutputFileFactoryProvider must not return null");
     } else {
       this.outputFileFactory =

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestOutputFileFactoryProvider.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestOutputFileFactoryProvider.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestOutputFileFactoryProvider {
+  private static final long TARGET_FILE_SIZE = 128 * 1024 * 1024;
+
+  @TempDir protected java.nio.file.Path temporaryFolder;
+
+  private Table table;
+
+  @BeforeEach
+  public void before() throws IOException {
+    File folder = Files.createTempDirectory(temporaryFolder, "junit").toFile();
+    table = SimpleDataUtil.createTable(folder.getAbsolutePath(), ImmutableMap.of(), false);
+  }
+
+  @Test
+  public void testCustomProviderIsUsed() throws IOException {
+    AtomicBoolean providerCalled = new AtomicBoolean(false);
+
+    OutputFileFactoryProvider provider =
+        (tbl, taskId, attemptId, format, spec) -> {
+          providerCalled.set(true);
+          return OutputFileFactory.builderFor(tbl, taskId, attemptId)
+              .format(format)
+              .defaultSpec(spec)
+              .build();
+        };
+
+    TaskWriterFactory<RowData> factory = createTaskWriterFactory(provider);
+    factory.initialize(0, 0);
+
+    assertThat(providerCalled.get()).isTrue();
+
+    try (TaskWriter<RowData> writer = factory.create()) {
+      writer.write(SimpleDataUtil.createRowData(1, "a"));
+      DataFile[] dataFiles = writer.dataFiles();
+      assertThat(dataFiles).hasSize(1);
+    }
+  }
+
+  @Test
+  public void testDefaultBehaviorWhenProviderIsNull() throws IOException {
+    TaskWriterFactory<RowData> factory = createTaskWriterFactory(null);
+    factory.initialize(0, 0);
+
+    try (TaskWriter<RowData> writer = factory.create()) {
+      writer.write(SimpleDataUtil.createRowData(1, "a"));
+      DataFile[] dataFiles = writer.dataFiles();
+      assertThat(dataFiles).hasSize(1);
+    }
+  }
+
+  @Test
+  public void testProviderReceivesCorrectArguments() {
+    int expectedTaskId = 42;
+    int expectedAttemptId = 7;
+
+    AtomicInteger capturedTaskId = new AtomicInteger(-1);
+    AtomicInteger capturedAttemptId = new AtomicInteger(-1);
+    AtomicReference<FileFormat> capturedFormat = new AtomicReference<>();
+    AtomicReference<PartitionSpec> capturedSpec = new AtomicReference<>();
+
+    OutputFileFactoryProvider provider =
+        (tbl, taskId, attemptId, format, spec) -> {
+          capturedTaskId.set(taskId);
+          capturedAttemptId.set(attemptId);
+          capturedFormat.set(format);
+          capturedSpec.set(spec);
+          return OutputFileFactory.builderFor(tbl, taskId, attemptId)
+              .format(format)
+              .defaultSpec(spec)
+              .build();
+        };
+
+    TaskWriterFactory<RowData> factory = createTaskWriterFactory(provider);
+    factory.initialize(expectedTaskId, expectedAttemptId);
+
+    assertThat(capturedTaskId.get()).isEqualTo(expectedTaskId);
+    assertThat(capturedAttemptId.get()).isEqualTo(expectedAttemptId);
+    assertThat(capturedFormat.get()).isEqualTo(FileFormat.PARQUET);
+    assertThat(capturedSpec.get()).isEqualTo(table.spec());
+  }
+
+  @Test
+  public void testProviderReturningNullThrows() {
+    OutputFileFactoryProvider provider = (tbl, taskId, attemptId, format, spec) -> null;
+
+    TaskWriterFactory<RowData> factory = createTaskWriterFactory(provider);
+
+    assertThatThrownBy(() -> factory.initialize(0, 0))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("OutputFileFactoryProvider must not return null");
+  }
+
+  private TaskWriterFactory<RowData> createTaskWriterFactory(OutputFileFactoryProvider provider) {
+    return new RowDataTaskWriterFactory(
+        (org.apache.iceberg.util.SerializableSupplier<Table>) () -> table,
+        SimpleDataUtil.ROW_TYPE,
+        TARGET_FILE_SIZE,
+        FileFormat.PARQUET,
+        Collections.emptyMap(),
+        null,
+        false,
+        table.schema(),
+        table.spec(),
+        provider);
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestOutputFileFactoryProvider.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestOutputFileFactoryProvider.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.SerializableSupplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -59,9 +60,9 @@ public class TestOutputFileFactoryProvider {
     AtomicBoolean providerCalled = new AtomicBoolean(false);
 
     OutputFileFactoryProvider provider =
-        (tbl, taskId, attemptId, format, spec) -> {
+        (tableSupplier, taskId, attemptId, format, spec) -> {
           providerCalled.set(true);
-          return OutputFileFactory.builderFor(tbl, taskId, attemptId)
+          return OutputFileFactory.builderFor(tableSupplier.get(), taskId, attemptId)
               .format(format)
               .defaultSpec(spec)
               .build();
@@ -96,18 +97,20 @@ public class TestOutputFileFactoryProvider {
     int expectedTaskId = 42;
     int expectedAttemptId = 7;
 
+    AtomicReference<SerializableSupplier<Table>> capturedSupplier = new AtomicReference<>();
     AtomicInteger capturedTaskId = new AtomicInteger(-1);
     AtomicInteger capturedAttemptId = new AtomicInteger(-1);
     AtomicReference<FileFormat> capturedFormat = new AtomicReference<>();
     AtomicReference<PartitionSpec> capturedSpec = new AtomicReference<>();
 
     OutputFileFactoryProvider provider =
-        (tbl, taskId, attemptId, format, spec) -> {
+        (tableSupplier, taskId, attemptId, format, spec) -> {
+          capturedSupplier.set(tableSupplier);
           capturedTaskId.set(taskId);
           capturedAttemptId.set(attemptId);
           capturedFormat.set(format);
           capturedSpec.set(spec);
-          return OutputFileFactory.builderFor(tbl, taskId, attemptId)
+          return OutputFileFactory.builderFor(tableSupplier.get(), taskId, attemptId)
               .format(format)
               .defaultSpec(spec)
               .build();
@@ -116,6 +119,8 @@ public class TestOutputFileFactoryProvider {
     TaskWriterFactory<RowData> factory = createTaskWriterFactory(provider);
     factory.initialize(expectedTaskId, expectedAttemptId);
 
+    assertThat(capturedSupplier.get()).isNotNull();
+    assertThat(capturedSupplier.get().get()).isSameAs(table);
     assertThat(capturedTaskId.get()).isEqualTo(expectedTaskId);
     assertThat(capturedAttemptId.get()).isEqualTo(expectedAttemptId);
     assertThat(capturedFormat.get()).isEqualTo(FileFormat.PARQUET);
@@ -123,8 +128,40 @@ public class TestOutputFileFactoryProvider {
   }
 
   @Test
+  public void testProviderReceivesLiveSupplier() throws IOException {
+    File refreshedFolder = Files.createTempDirectory(temporaryFolder, "refreshed").toFile();
+    Table refreshed =
+        SimpleDataUtil.createTable(refreshedFolder.getAbsolutePath(), ImmutableMap.of(), false);
+
+    AtomicReference<Table> currentTable = new AtomicReference<>(table);
+    AtomicReference<SerializableSupplier<Table>> capturedSupplier = new AtomicReference<>();
+
+    OutputFileFactoryProvider provider =
+        (tableSupplier, taskId, attemptId, format, spec) -> {
+          capturedSupplier.set(tableSupplier);
+          return OutputFileFactory.builderFor(tableSupplier.get(), taskId, attemptId)
+              .format(format)
+              .ioSupplier(() -> tableSupplier.get().io())
+              .defaultSpec(spec)
+              .build();
+        };
+
+    SerializableSupplier<Table> liveSupplier = currentTable::get;
+    TaskWriterFactory<RowData> factory = createTaskWriterFactory(provider, liveSupplier);
+    factory.initialize(0, 0);
+
+    assertThat(capturedSupplier.get().get()).isSameAs(table);
+
+    // Swap the underlying table; the provider-held supplier must observe the new value rather
+    // than a snapshot captured at initialize() time.
+    currentTable.set(refreshed);
+
+    assertThat(capturedSupplier.get().get()).isSameAs(refreshed);
+  }
+
+  @Test
   public void testProviderReturningNullThrows() {
-    OutputFileFactoryProvider provider = (tbl, taskId, attemptId, format, spec) -> null;
+    OutputFileFactoryProvider provider = (tableSupplier, taskId, attemptId, format, spec) -> null;
 
     TaskWriterFactory<RowData> factory = createTaskWriterFactory(provider);
 
@@ -134,8 +171,13 @@ public class TestOutputFileFactoryProvider {
   }
 
   private TaskWriterFactory<RowData> createTaskWriterFactory(OutputFileFactoryProvider provider) {
+    return createTaskWriterFactory(provider, () -> table);
+  }
+
+  private TaskWriterFactory<RowData> createTaskWriterFactory(
+      OutputFileFactoryProvider provider, SerializableSupplier<Table> tableSupplier) {
     return new RowDataTaskWriterFactory(
-        (org.apache.iceberg.util.SerializableSupplier<Table>) () -> table,
+        tableSupplier,
         SimpleDataUtil.ROW_TYPE,
         TARGET_FILE_SIZE,
         FileFormat.PARQUET,


### PR DESCRIPTION
### Summary

Adds an `OutputFileFactoryProvider` plugin interface to `IcebergSink` that allows external implementations to customize how `OutputFileFactory` instances are created. This enables use cases like custom file naming, path rewriting, or alternative storage routing without subclassing internal writer factories.

Resolves #15763.

### Changes

- New: `OutputFileFactoryProvider.java` -- `@FunctionalInterface` with a single method: `OutputFileFactory create(Table, int taskId, int attemptId, FileFormat, PartitionSpec)`
- Modified: `RowDataTaskWriterFactory` -- accepts optional provider, uses it in `initialize()` when present
- Modified: `IcebergSink.Builder` -- new `outputFileFactoryProvider()` method, passed through to writer factory

### Compatibility

- No behavioral change when the provider is not set (null default)
- No changes to public API signatures of existing methods
- Fully backward compatible