### PR TITLE
Core: Add test to validate we can't delete map value during schema evolution

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -1185,11 +1185,11 @@ public class TestSchemaUpdate {
   public void testDeleteMapValue() {
     assertThatThrownBy(
             () ->
-                    new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
-                            .deleteColumn("locations.value")
-                            .apply())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageStartingWith("Cannot delete value type from map");
+                new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+                    .deleteColumn("locations.value")
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot delete value type from map");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -1182,6 +1182,17 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testDeleteMapValue() {
+    assertThatThrownBy(
+            () ->
+                    new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+                            .deleteColumn("locations.value")
+                            .apply())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageStartingWith("Cannot delete value type from map");
+  }
+
+  @Test
   public void testAddFieldToMapKey() {
     assertThatThrownBy(
             () ->


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/15766


