### PR TITLE
Flink Sink V2: Add PostCommitHook plugin interface

### DIFF
--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -394,6 +394,28 @@ To use SinkV2 based implementation, replace `FlinkSink` with `IcebergSink` in th
      - The `RANGE` distribution mode is not yet available for the `IcebergSink`
      - When using `IcebergSink` use `uidSuffix` instead of the `uidPrefix`
 
+### Post-commit hook
+
+The `IcebergSink` supports an optional `PostCommitHook` callback that is invoked after each
+successful Iceberg snapshot commit. This can be used for audit logging, synchronizing metadata
+to external catalogs, triggering compaction workflows, or tracking custom metadata such as
+watermarks.
+
+```java
+IcebergSink.forRowData(input)
+    .tableLoader(tableLoader)
+    .postCommitHook((snapshotId, summary) -> {
+        LOG.info("Committed snapshot {} with {} data files",
+            snapshotId, summary.get("added-data-files"));
+    })
+    .append();
+```
+
+!!! note
+    If the hook throws an exception, the Flink checkpoint fails but the Iceberg commit has
+    already succeeded. On recovery, the committed checkpoint is detected via the snapshot
+    summary and will not be re-committed. The hook is not re-invoked for that snapshot.
+
 ## Flink Dynamic Iceberg Sink
 
 The Flink Dynamic Iceberg Sink (Dynamic Sink) allows:

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -26,12 +26,14 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.TableLoader;
@@ -79,6 +81,7 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
   private ExecutorService workerPool;
   private int continuousEmptyCheckpoints = 0;
   private final boolean tableMaintenanceEnabled;
+  @Nullable private final PostCommitHook postCommitHook;
 
   IcebergCommitter(
       TableLoader tableLoader,
@@ -89,6 +92,28 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       String sinkId,
       IcebergFilesCommitterMetrics committerMetrics,
       boolean tableMaintenanceEnabled) {
+    this(
+        tableLoader,
+        branch,
+        snapshotProperties,
+        replacePartitions,
+        workerPoolSize,
+        sinkId,
+        committerMetrics,
+        tableMaintenanceEnabled,
+        null);
+  }
+
+  IcebergCommitter(
+      TableLoader tableLoader,
+      String branch,
+      Map<String, String> snapshotProperties,
+      boolean replacePartitions,
+      int workerPoolSize,
+      String sinkId,
+      IcebergFilesCommitterMetrics committerMetrics,
+      boolean tableMaintenanceEnabled,
+      @Nullable PostCommitHook postCommitHook) {
     this.branch = branch;
     this.snapshotProperties = snapshotProperties;
     this.replacePartitions = replacePartitions;
@@ -108,6 +133,7 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
             "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     this.continuousEmptyCheckpoints = 0;
     this.tableMaintenanceEnabled = tableMaintenanceEnabled;
+    this.postCommitHook = postCommitHook;
   }
 
   @Override
@@ -306,6 +332,13 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
         durationMs);
     if (committerMetrics != null) {
       committerMetrics.commitDuration(durationMs);
+    }
+
+    if (postCommitHook != null) {
+      Snapshot snapshot = table.snapshot(branch);
+      if (snapshot != null) {
+        postCommitHook.afterCommit(snapshot.snapshotId(), snapshot.summary());
+      }
     }
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -337,7 +337,17 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
     if (postCommitHook != null) {
       Snapshot snapshot = table.snapshot(branch);
       if (snapshot != null) {
-        postCommitHook.afterCommit(snapshot.snapshotId(), snapshot.summary());
+        try {
+          postCommitHook.afterCommit(snapshot.snapshotId(), snapshot.summary());
+        } catch (RuntimeException e) {
+          LOG.warn(
+              "Ignoring PostCommitHook failure after committing {} to table: {}, branch: {}, checkpointId {}.",
+              description,
+              table.name(),
+              branch,
+              checkpointId,
+              e);
+        }
       }
     }
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.SupportsConcurrentExecutionAttempts;
@@ -171,6 +172,8 @@ public class IcebergSink
   // equalityFieldIds instead.
   private final Set<String> equalityFieldColumns;
 
+  @Nullable private final PostCommitHook postCommitHook;
+
   private final transient List<MaintenanceTaskBuilder<?>> maintenanceTasks;
   private final transient FlinkMaintenanceConfig flinkMaintenanceConfig;
 
@@ -188,7 +191,8 @@ public class IcebergSink
       boolean overwriteMode,
       List<MaintenanceTaskBuilder<?>> maintenanceTasks,
       FlinkMaintenanceConfig flinkMaintenanceConfig,
-      Set<String> equalityFieldColumns) {
+      Set<String> equalityFieldColumns,
+      @Nullable PostCommitHook postCommitHook) {
     this.tableLoader = tableLoader;
     this.snapshotProperties = snapshotProperties;
     this.uidSuffix = uidSuffix;
@@ -212,6 +216,7 @@ public class IcebergSink
     this.maintenanceTasks = maintenanceTasks;
     this.flinkMaintenanceConfig = flinkMaintenanceConfig;
     this.equalityFieldColumns = equalityFieldColumns;
+    this.postCommitHook = postCommitHook;
   }
 
   @Override
@@ -247,7 +252,8 @@ public class IcebergSink
         workerPoolSize,
         sinkId,
         metrics,
-        maintenanceEnabled);
+        maintenanceEnabled,
+        postCommitHook);
   }
 
   @Override
@@ -349,6 +355,7 @@ public class IcebergSink
     private ReadableConfig readableConfig = new Configuration();
     private List<String> equalityFieldColumns = null;
     private final List<MaintenanceTaskBuilder<?>> maintenanceTasks = Lists.newArrayList();
+    @Nullable private PostCommitHook postCommitHook;
 
     private Builder() {}
 
@@ -716,6 +723,11 @@ public class IcebergSink
       return this;
     }
 
+    public Builder postCommitHook(PostCommitHook hook) {
+      this.postCommitHook = hook;
+      return this;
+    }
+
     IcebergSink build() {
 
       Preconditions.checkArgument(
@@ -806,7 +818,8 @@ public class IcebergSink
           overwriteMode,
           maintenanceTasks,
           flinkMaintenanceConfig,
-          equalityFieldColumnsSet);
+          equalityFieldColumnsSet,
+          postCommitHook);
     }
 
     /**

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/PostCommitHook.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/PostCommitHook.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.flink.annotation.Experimental;
+
+/**
+ * Callback invoked after each successful Iceberg snapshot commit.
+ *
+ * <p>Implementations can react to committed snapshots for use cases such as:
+ *
+ * <ul>
+ *   <li>Audit logging of committed snapshots
+ *   <li>Synchronizing metadata to external catalogs
+ *   <li>Triggering compaction or maintenance workflows
+ *   <li>Tracking custom metadata across commits, e.g. watermark
+ * </ul>
+ *
+ * <p><b>Why PostCommitHook instead of {@code Listeners}/{@code CreateSnapshotEvent}?</b>
+ *
+ * <p>Iceberg provides a static {@code Listeners} registry that fires {@code CreateSnapshotEvent}
+ * after every snapshot commit. However, that mechanism has limitations in a Flink environment:
+ *
+ * <ul>
+ *   <li>{@code Listeners} is JVM-global with no {@code unregister()} method. A single Flink
+ *       TaskManager JVM can host multiple sink instances for different tables, making it impossible
+ *       to scope a listener to a specific sink or clean it up on job restart.
+ *   <li>{@code SnapshotProducer} silently swallows listener exceptions ({@code LOG.warn}), so the
+ *       caller has no control over error propagation.
+ *   <li>{@code CreateSnapshotEvent} provides only a table name string with no handle to the {@code
+ *       Table}, {@code TableLoader}, or catalog, preventing follow-up operations without
+ *       independently bootstrapping catalog access.
+ * </ul>
+ *
+ * <p>{@code PostCommitHook} addresses all three: it is per-sink-instance scoped, lets the
+ * implementer control error propagation, and runs inside {@code IcebergCommitter} where {@code
+ * TableLoader} and the Flink checkpoint lifecycle are available.
+ *
+ * <p><b>Error semantics</b>
+ *
+ * <p>The hook is called after the Iceberg commit succeeds but before the Flink checkpoint
+ * completes. If the hook throws an exception, the Flink checkpoint fails but the Iceberg commit has
+ * already succeeded. On recovery, the committed checkpoint is detected via {@code
+ * MAX_COMMITTED_CHECKPOINT_ID} in the snapshot summary and will not be re-committed. The hook will
+ * <b>not</b> be re-invoked for that snapshot.
+ */
+@Experimental
+@FunctionalInterface
+public interface PostCommitHook extends Serializable {
+  void afterCommit(long snapshotId, Map<String, String> snapshotSummary);
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/PostCommitHook.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/PostCommitHook.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.apache.flink.annotation.Experimental;
 
 /**
- * Callback invoked after each successful Iceberg snapshot commit.
+ * Best-effort callback invoked after a successful Iceberg snapshot commit.
  *
  * <p>Implementations can react to committed snapshots for use cases such as:
  *
@@ -50,17 +50,28 @@ import org.apache.flink.annotation.Experimental;
  *       independently bootstrapping catalog access.
  * </ul>
  *
- * <p>{@code PostCommitHook} addresses all three: it is per-sink-instance scoped, lets the
- * implementer control error propagation, and runs inside {@code IcebergCommitter} where {@code
- * TableLoader} and the Flink checkpoint lifecycle are available.
+ * <p>{@code PostCommitHook} addresses the first and third limitations directly: it is
+ * per-sink-instance scoped and runs inside {@code IcebergCommitter} where {@code TableLoader} and
+ * the Flink checkpoint lifecycle are available. Unlike {@code Listeners}, the sink can also make
+ * hook failures explicit in its own logs.
+ *
+ * <p><b>Invocation semantics</b>
+ *
+ * <p>The hook is invoked inline after a commit becomes visible on the target branch. A single Flink
+ * checkpoint may produce multiple snapshots, in which case the hook may be invoked multiple times
+ * in commit order. Checkpoints that do not produce a snapshot do not invoke the hook.
  *
  * <p><b>Error semantics</b>
  *
  * <p>The hook is called after the Iceberg commit succeeds but before the Flink checkpoint
- * completes. If the hook throws an exception, the Flink checkpoint fails but the Iceberg commit has
- * already succeeded. On recovery, the committed checkpoint is detected via {@code
- * MAX_COMMITTED_CHECKPOINT_ID} in the snapshot summary and will not be re-committed. The hook will
- * <b>not</b> be re-invoked for that snapshot.
+ * completes. If the hook throws a {@link RuntimeException}, the sink logs the failure and ignores
+ * it so the successful Iceberg commit can still complete its normal cleanup path. The hook failure
+ * does not fail the Flink checkpoint and is not retried for an already-committed snapshot.
+ *
+ * <p>On recovery, committed checkpoints are detected via {@code MAX_COMMITTED_CHECKPOINT_ID} in the
+ * snapshot summary and will not be re-committed. If the process fails after the Iceberg commit
+ * succeeds but before the hook runs, the hook is not replayed for that snapshot. {@link Error}s
+ * thrown by the hook are not intercepted.
  */
 @Experimental
 @FunctionalInterface

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -23,11 +23,12 @@ import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommitt
 import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommittableWithLineage;
 import static org.apache.iceberg.flink.sink.SinkTestUtil.transformsToStreamElement;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
@@ -118,6 +119,11 @@ class TestIcebergCommitter extends TestBase {
 
   private final String jobId = "jobId";
   private final long dataFIleRowCount = 5L;
+
+  // Mockito mock for the most recent committer created by getCommitter(). Exposed for tests that
+  // need to verify committer-metrics interactions (e.g., updateCommitSummary ran after a failing
+  // PostCommitHook).
+  private IcebergFilesCommitterMetrics lastCommitterMetrics;
 
   private final TestCommittableMessageTypeSerializer committableMessageTypeSerializer =
       new TestCommittableMessageTypeSerializer();
@@ -1323,7 +1329,7 @@ class TestIcebergCommitter extends TestBase {
   }
 
   @TestTemplate
-  public void testPostCommitHookExceptionPropagates() throws Exception {
+  public void testPostCommitHookExceptionIsIgnored() throws Exception {
     PostCommitHook hook =
         (snapshotId, summary) -> {
           throw new RuntimeException("hook failure");
@@ -1336,15 +1342,30 @@ class TestIcebergCommitter extends TestBase {
     Committer.CommitRequest<IcebergCommittable> commitRequest =
         buildCommitRequestFor(jobId, 1, Lists.newArrayList(writeResult));
 
-    assertThatThrownBy(() -> committer.commit(Lists.newArrayList(commitRequest)))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessage("hook failure");
+    // Before commit: the write-aggregator produced a Flink-side manifest file that must be
+    // cleaned up after a successful Iceberg commit, even if the post-commit hook then throws.
+    assertFlinkManifests(1);
+
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    // The Iceberg commit did succeed before the hook threw; the checkpoint is recorded.
+    assertMaxCommittedCheckpointId(jobId, 1);
+    assertSnapshotSize(1);
+
+    // Cleanup must still run even though the hook threw. Without the fix,
+    // FlinkManifestUtil.deleteCommittedManifests is skipped and the manifest file leaks
+    // permanently (on recovery the checkpoint is treated as already committed, so the cleanup
+    // path never re-runs).
+    assertFlinkManifests(0);
+
+    // Commit-summary metrics must also still run.
+    verify(lastCommitterMetrics).updateCommitSummary(any());
   }
 
   // ------------------------------- Utility Methods --------------------------------
 
   private IcebergCommitter getCommitter() {
-    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    lastCommitterMetrics = mock(IcebergFilesCommitterMetrics.class);
     return new IcebergCommitter(
         tableLoader,
         branch,
@@ -1352,12 +1373,12 @@ class TestIcebergCommitter extends TestBase {
         false,
         10,
         "sinkId",
-        metric,
+        lastCommitterMetrics,
         false);
   }
 
   private IcebergCommitter getCommitter(PostCommitHook hook) {
-    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    lastCommitterMetrics = mock(IcebergFilesCommitterMetrics.class);
     return new IcebergCommitter(
         tableLoader,
         branch,
@@ -1365,7 +1386,7 @@ class TestIcebergCommitter extends TestBase {
         false,
         10,
         "sinkId",
-        metric,
+        lastCommitterMetrics,
         false,
         hook);
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommitt
 import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommittableWithLineage;
 import static org.apache.iceberg.flink.sink.SinkTestUtil.transformsToStreamElement;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -38,6 +39,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
@@ -1293,6 +1296,51 @@ class TestIcebergCommitter extends TestBase {
     return testHarness;
   }
 
+  @TestTemplate
+  public void testPostCommitHookFiresWithCorrectSnapshotData() throws Exception {
+    AtomicLong capturedSnapshotId = new AtomicLong();
+    AtomicReference<Map<String, String>> capturedSummary = new AtomicReference<>();
+    PostCommitHook hook =
+        (snapshotId, summary) -> {
+          capturedSnapshotId.set(snapshotId);
+          capturedSummary.set(summary);
+        };
+
+    IcebergCommitter committer = getCommitter(hook);
+    RowData rowData = SimpleDataUtil.createRowData(1, "hello");
+    DataFile dataFile = writeDataFile("data-hook", ImmutableList.of(rowData));
+    WriteResult writeResult = of(dataFile);
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1, Lists.newArrayList(writeResult));
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    table.refresh();
+    Snapshot snapshot = SimpleDataUtil.latestSnapshot(table, branch);
+    assertThat(capturedSnapshotId.get()).isEqualTo(snapshot.snapshotId());
+    assertThat(capturedSummary.get())
+        .containsEntry("added-data-files", "1")
+        .containsEntry("flink.test", TestIcebergCommitter.class.getName());
+  }
+
+  @TestTemplate
+  public void testPostCommitHookExceptionPropagates() throws Exception {
+    PostCommitHook hook =
+        (snapshotId, summary) -> {
+          throw new RuntimeException("hook failure");
+        };
+
+    IcebergCommitter committer = getCommitter(hook);
+    RowData rowData = SimpleDataUtil.createRowData(1, "hello");
+    DataFile dataFile = writeDataFile("data-hook-fail", ImmutableList.of(rowData));
+    WriteResult writeResult = of(dataFile);
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1, Lists.newArrayList(writeResult));
+
+    assertThatThrownBy(() -> committer.commit(Lists.newArrayList(commitRequest)))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("hook failure");
+  }
+
   // ------------------------------- Utility Methods --------------------------------
 
   private IcebergCommitter getCommitter() {
@@ -1306,6 +1354,20 @@ class TestIcebergCommitter extends TestBase {
         "sinkId",
         metric,
         false);
+  }
+
+  private IcebergCommitter getCommitter(PostCommitHook hook) {
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    return new IcebergCommitter(
+        tableLoader,
+        branch,
+        Collections.singletonMap("flink.test", TestIcebergCommitter.class.getName()),
+        false,
+        10,
+        "sinkId",
+        metric,
+        false,
+        hook);
   }
 
   private Committer.CommitRequest<IcebergCommittable> buildCommitRequestFor(


### PR DESCRIPTION
### Summary

Adds a `PostCommitHook` plugin interface to `IcebergSink` that is invoked after each successful Iceberg commit. This enables use cases like updating table properties with watermark metadata, triggering notifications, recording metrics, or synchronizing external metadata stores.

Resolves #15768.

### Changes

- New: `PostCommitHook.java` -- `@FunctionalInterface` with a single method: `void afterCommit(long snapshotId, Map<String, String> summary)`
- Modified: `IcebergCommitter` -- accepts optional hook, invokes it after successful commit
- Modified: `IcebergSink.Builder` -- new `postCommitHook()` method, passed through to committer

### Compatibility

- No behavioral change when the hook is not set (null default)
- No changes to public API signatures of existing methods
- Fully backward compatible