### PR TITLE
Flink Sink V2: Add CommitGate plugin interface for deferred commits

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CommitGate.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/CommitGate.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.Serializable;
+
+/**
+ * Gate that controls whether a checkpoint's committables should be emitted downstream.
+ *
+ * <p>When {@link #isCommitAllowed} returns {@code false}, the {@link IcebergWriteAggregator}
+ * buffers committables in Flink operator state and retries on the next checkpoint. When the gate
+ * transitions from closed to open, all buffered committables are flushed.
+ *
+ * <p>Use cases include:
+ *
+ * <ul>
+ *   <li>Honoring catalog maintenance windows
+ *   <li>External pause signals or rate limiting
+ * </ul>
+ */
+@FunctionalInterface
+public interface CommitGate extends Serializable {
+  boolean isCommitAllowed(long checkpointId);
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.SupportsConcurrentExecutionAttempts;
@@ -171,6 +172,8 @@ public class IcebergSink
   // equalityFieldIds instead.
   private final Set<String> equalityFieldColumns;
 
+  @Nullable private final CommitGate commitGate;
+
   private final transient List<MaintenanceTaskBuilder<?>> maintenanceTasks;
   private final transient FlinkMaintenanceConfig flinkMaintenanceConfig;
 
@@ -188,7 +191,8 @@ public class IcebergSink
       boolean overwriteMode,
       List<MaintenanceTaskBuilder<?>> maintenanceTasks,
       FlinkMaintenanceConfig flinkMaintenanceConfig,
-      Set<String> equalityFieldColumns) {
+      Set<String> equalityFieldColumns,
+      @Nullable CommitGate commitGate) {
     this.tableLoader = tableLoader;
     this.snapshotProperties = snapshotProperties;
     this.uidSuffix = uidSuffix;
@@ -212,6 +216,7 @@ public class IcebergSink
     this.maintenanceTasks = maintenanceTasks;
     this.flinkMaintenanceConfig = flinkMaintenanceConfig;
     this.equalityFieldColumns = equalityFieldColumns;
+    this.commitGate = commitGate;
   }
 
   @Override
@@ -318,7 +323,10 @@ public class IcebergSink
     // parallelism to 1, this can be removed.
     return writeResults
         .global()
-        .transform(preCommitAggregatorUid, typeInformation, new IcebergWriteAggregator(tableLoader))
+        .transform(
+            preCommitAggregatorUid,
+            typeInformation,
+            new IcebergWriteAggregator(tableLoader, commitGate))
         .uid(preCommitAggregatorUid)
         .setParallelism(1)
         .setMaxParallelism(1)
@@ -349,6 +357,7 @@ public class IcebergSink
     private ReadableConfig readableConfig = new Configuration();
     private List<String> equalityFieldColumns = null;
     private final List<MaintenanceTaskBuilder<?>> maintenanceTasks = Lists.newArrayList();
+    @Nullable private CommitGate commitGate;
 
     private Builder() {}
 
@@ -716,6 +725,19 @@ public class IcebergSink
       return this;
     }
 
+    /**
+     * Sets a {@link CommitGate} that controls whether committables are emitted or buffered.
+     *
+     * <p>When the gate is set and returns {@code false} from {@link
+     * CommitGate#isCommitAllowed(long)}, the {@link IcebergWriteAggregator} buffers committables in
+     * Flink operator state until the gate reopens. When {@code null} (the default), all
+     * committables are emitted immediately.
+     */
+    public Builder commitGate(CommitGate gate) {
+      this.commitGate = gate;
+      return this;
+    }
+
     IcebergSink build() {
 
       Preconditions.checkArgument(
@@ -806,7 +828,8 @@ public class IcebergSink
           overwriteMode,
           maintenanceTasks,
           flinkMaintenanceConfig,
-          equalityFieldColumnsSet);
+          equalityFieldColumnsSet,
+          commitGate);
     }
 
     /**

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergWriteAggregator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergWriteAggregator.java
@@ -20,6 +20,11 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -34,6 +39,7 @@ import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,18 +55,29 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
 
   private static final Logger LOG = LoggerFactory.getLogger(IcebergWriteAggregator.class);
   private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
+  private static final IcebergCommittableSerializer COMMITTABLE_SERIALIZER =
+      new IcebergCommittableSerializer();
 
   private final Collection<WriteResult> results;
   private final TableLoader tableLoader;
+  @Nullable private final CommitGate commitGate;
 
   private long lastCheckpointId = CheckpointIDCounter.INITIAL_CHECKPOINT_ID - 1;
 
   private transient ManifestOutputFileFactory icebergManifestOutputFileFactory;
   private transient Table table;
+  private transient ListState<byte[]> pendingCommittablesState;
+  private transient boolean wasPausedPreviously = false;
+  private transient boolean forceFlush = false;
 
   IcebergWriteAggregator(TableLoader tableLoader) {
+    this(tableLoader, null);
+  }
+
+  IcebergWriteAggregator(TableLoader tableLoader, @Nullable CommitGate commitGate) {
     this.results = Sets.newHashSet();
     this.tableLoader = tableLoader;
+    this.commitGate = commitGate;
   }
 
   @Override
@@ -68,6 +85,14 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
     context
         .getRestoredCheckpointId()
         .ifPresent(checkpointId -> this.lastCheckpointId = checkpointId);
+
+    if (commitGate != null) {
+      ListStateDescriptor<byte[]> descriptor =
+          new ListStateDescriptor<>(
+              "iceberg-aggregator-pending-committables", BytePrimitiveArraySerializer.INSTANCE);
+      pendingCommittablesState = context.getOperatorStateStore().getListState(descriptor);
+      wasPausedPreviously = pendingCommittablesState.get().iterator().hasNext();
+    }
   }
 
   @Override
@@ -91,7 +116,12 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
 
   @Override
   public void finish() throws IOException {
-    prepareSnapshotPreBarrier(lastCheckpointId + 1);
+    forceFlush = true;
+    try {
+      prepareSnapshotPreBarrier(lastCheckpointId + 1);
+    } finally {
+      forceFlush = false;
+    }
   }
 
   @Override
@@ -106,20 +136,65 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
 
     this.lastCheckpointId = checkpointId;
 
+    boolean isGated =
+        commitGate != null && !forceFlush && !commitGate.isCommitAllowed(checkpointId);
+
+    if (wasPausedPreviously && !isGated && pendingCommittablesState != null) {
+      flushBufferedCommittables();
+    }
+
     IcebergCommittable committable =
         new IcebergCommittable(
             writeToManifest(results, checkpointId),
             getContainingTask().getEnvironment().getJobID().toString(),
             getRuntimeContext().getOperatorUniqueID(),
             checkpointId);
-    CommittableMessage<IcebergCommittable> summary =
-        new CommittableSummary<>(0, 1, checkpointId, 1, 1, 0);
-    output.collect(new StreamRecord<>(summary));
-    CommittableMessage<IcebergCommittable> message =
-        new CommittableWithLineage<>(committable, checkpointId, 0);
-    output.collect(new StreamRecord<>(message));
-    LOG.info("Emitted commit message to downstream committer operator");
+
+    if (isGated) {
+      try {
+        byte[] serialized =
+            SimpleVersionedSerialization.writeVersionAndSerialize(
+                COMMITTABLE_SERIALIZER, committable);
+        pendingCommittablesState.add(serialized);
+      } catch (Exception e) {
+        throw new IOException("Failed to serialize committable for buffering", e);
+      }
+      LOG.info("Commit gate closed for checkpoint {}. Buffering committable.", checkpointId);
+      wasPausedPreviously = true;
+    } else {
+      emitCommittable(committable, checkpointId);
+      LOG.info("Emitted commit message to downstream committer operator");
+      wasPausedPreviously = false;
+    }
+
     results.clear();
+  }
+
+  private void flushBufferedCommittables() throws IOException {
+    List<IcebergCommittable> buffered = Lists.newArrayList();
+    try {
+      for (byte[] serialized : pendingCommittablesState.get()) {
+        buffered.add(
+            SimpleVersionedSerialization.readVersionAndDeSerialize(
+                COMMITTABLE_SERIALIZER, serialized));
+      }
+    } catch (Exception e) {
+      throw new IOException("Failed to deserialize buffered committable", e);
+    }
+
+    if (!buffered.isEmpty()) {
+      buffered.sort((c1, c2) -> Long.compare(c1.checkpointId(), c2.checkpointId()));
+      for (IcebergCommittable c : buffered) {
+        emitCommittable(c, c.checkpointId());
+      }
+      pendingCommittablesState.clear();
+      LOG.info("Commit gate opened. Flushed {} buffered committables", buffered.size());
+    }
+  }
+
+  private void emitCommittable(IcebergCommittable committable, long checkpointId) {
+    output.collect(new StreamRecord<>(new CommittableSummary<>(0, 1, checkpointId, 1, 1, 0)));
+    output.collect(new StreamRecord<>(new CommittableWithLineage<>(committable, checkpointId, 0)));
   }
 
   /**

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergWriteAggregatorCommitGate.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergWriteAggregatorCommitGate.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.apache.iceberg.flink.sink.ManifestOutputFileFactory.FLINK_MANIFEST_LOCATION;
+import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommittableWithLineage;
+import static org.apache.iceberg.flink.sink.SinkTestUtil.transformsToStreamElement;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestIcebergWriteAggregatorCommitGate {
+
+  @TempDir private File temporaryFolder;
+  @TempDir private File flinkManifestFolder;
+
+  private Table table;
+  private TableLoader tableLoader;
+
+  private final DataFile dataFile =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data.parquet")
+          .withFileSizeInBytes(100)
+          .withRecordCount(5)
+          .build();
+
+  @BeforeEach
+  void before() {
+    String tablePath = temporaryFolder.getAbsolutePath() + "/test";
+    assertThat(new File(tablePath).mkdir()).isTrue();
+    table =
+        SimpleDataUtil.createTable(
+            tablePath,
+            ImmutableMap.of(
+                TableProperties.FORMAT_VERSION,
+                "2",
+                FLINK_MANIFEST_LOCATION,
+                flinkManifestFolder.getAbsolutePath()),
+            false);
+    tableLoader = TableLoader.fromHadoopTable(tablePath);
+  }
+
+  private OneInputStreamOperatorTestHarness<
+          CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+      createHarness(IcebergWriteAggregator aggregator) throws Exception {
+    OneInputStreamOperatorTestHarness<
+            CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+        harness = new OneInputStreamOperatorTestHarness<>(aggregator, 1, 1, 0);
+    harness.setup();
+    return harness;
+  }
+
+  private void processWriteResult(
+      OneInputStreamOperatorTestHarness<
+              CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+          harness,
+      long checkpointId)
+      throws Exception {
+    WriteResult wr = WriteResult.builder().addDataFiles(dataFile).build();
+    harness.processElement(new StreamRecord<>(new CommittableWithLineage<>(wr, checkpointId, 0)));
+  }
+
+  private static void assertCommittableCheckpointId(StreamElement element, long expectedId) {
+    CommittableWithLineage<IcebergCommittable> committable =
+        extractAndAssertCommittableWithLineage(element);
+    assertThat(committable.getCommittable().checkpointId()).isEqualTo(expectedId);
+  }
+
+  @Test
+  void testNoGateEmitsNormally() throws Exception {
+    IcebergWriteAggregator aggregator = new IcebergWriteAggregator(tableLoader, null);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+        harness = createHarness(aggregator)) {
+      harness.open();
+
+      processWriteResult(harness, 1L);
+      aggregator.prepareSnapshotPreBarrier(1L);
+
+      List<StreamElement> output = transformsToStreamElement(harness.getOutput());
+      assertThat(output).hasSize(2);
+      assertCommittableCheckpointId(output.get(1), 1L);
+    }
+  }
+
+  @Test
+  void testGateClosedBuffersCommittable() throws Exception {
+    IcebergWriteAggregator aggregator =
+        new IcebergWriteAggregator(tableLoader, checkpointId -> false);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+        harness = createHarness(aggregator)) {
+      harness.open();
+
+      processWriteResult(harness, 1L);
+      aggregator.prepareSnapshotPreBarrier(1L);
+
+      assertThat(harness.getOutput()).isEmpty();
+    }
+  }
+
+  @Test
+  void testGateClosedThenOpenedFlushesBuffered() throws Exception {
+    AtomicBoolean allowed = new AtomicBoolean(false);
+    IcebergWriteAggregator aggregator =
+        new IcebergWriteAggregator(tableLoader, checkpointId -> allowed.get());
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+        harness = createHarness(aggregator)) {
+      harness.open();
+
+      processWriteResult(harness, 1L);
+      aggregator.prepareSnapshotPreBarrier(1L);
+      harness.snapshot(1L, 1L);
+      assertThat(harness.getOutput()).isEmpty();
+
+      processWriteResult(harness, 2L);
+      aggregator.prepareSnapshotPreBarrier(2L);
+      harness.snapshot(2L, 2L);
+      assertThat(harness.getOutput()).isEmpty();
+
+      allowed.set(true);
+      processWriteResult(harness, 3L);
+      aggregator.prepareSnapshotPreBarrier(3L);
+
+      List<StreamElement> output = transformsToStreamElement(harness.getOutput());
+      assertThat(output).hasSize(6);
+      assertCommittableCheckpointId(output.get(1), 1L);
+      assertCommittableCheckpointId(output.get(3), 2L);
+      assertCommittableCheckpointId(output.get(5), 3L);
+    }
+  }
+
+  @Test
+  void testFinishBypassesGate() throws Exception {
+    IcebergWriteAggregator aggregator =
+        new IcebergWriteAggregator(tableLoader, checkpointId -> false);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+        harness = createHarness(aggregator)) {
+      harness.open();
+
+      processWriteResult(harness, 1L);
+      aggregator.prepareSnapshotPreBarrier(1L);
+      harness.snapshot(1L, 1L);
+      assertThat(harness.getOutput()).isEmpty();
+
+      processWriteResult(harness, 2L);
+      aggregator.finish();
+
+      List<StreamElement> output = transformsToStreamElement(harness.getOutput());
+      assertThat(output).hasSize(4);
+      assertCommittableCheckpointId(output.get(1), 1L);
+      assertCommittableCheckpointId(output.get(3), 2L);
+    }
+  }
+
+  @Test
+  void testStateRestoreWithBufferedCommittables() throws Exception {
+    OperatorSubtaskState snapshot;
+
+    IcebergWriteAggregator aggregator1 =
+        new IcebergWriteAggregator(tableLoader, checkpointId -> false);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+        harness = createHarness(aggregator1)) {
+      harness.open();
+
+      processWriteResult(harness, 1L);
+      aggregator1.prepareSnapshotPreBarrier(1L);
+      snapshot = harness.snapshot(1L, 1L);
+      assertThat(harness.getOutput()).isEmpty();
+    }
+
+    IcebergWriteAggregator aggregator2 =
+        new IcebergWriteAggregator(tableLoader, checkpointId -> true);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+        harness = createHarness(aggregator2)) {
+      harness.initializeState(snapshot);
+      harness.open();
+
+      processWriteResult(harness, 2L);
+      aggregator2.prepareSnapshotPreBarrier(2L);
+
+      List<StreamElement> output = transformsToStreamElement(harness.getOutput());
+      assertThat(output).hasSize(4);
+      assertCommittableCheckpointId(output.get(1), 1L);
+      assertCommittableCheckpointId(output.get(3), 2L);
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Adds a `CommitGate` plugin interface to `IcebergSink` that controls whether committables are emitted downstream or buffered in Flink `ListState`. This enables use cases like pausing commits during catalog maintenance operations while keeping the Flink job running.

Resolves #15770.

### Changes

- New: `CommitGate.java` -- `@FunctionalInterface` with a single method: `boolean isCommitAllowed(long checkpointId)`
- Modified: `IcebergWriteAggregator` -- accepts optional gate, adds `ListState` for buffering, gate check + buffer/flush logic in `prepareSnapshotPreBarrier()`, state initialization in `initializeState()`
- Modified: `IcebergSink.Builder` -- new `commitGate()` method, passed through to aggregator

### Compatibility

- No behavioral change when the gate is not set (null default)
- Buffered committables are checkpointed in `ListState`, so recovery works correctly
- No changes to public API signatures of existing methods
- Fully backward compatible