### PR TITLE
[Connect] Introducing config option to allow INT64 logical timestamps…

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -79,6 +79,8 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.schema-force-optional";
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
+  private static final String TABLES_SCHEMA_LOGICAL_TIMESTAMP_WITHOUT_ZONE_PROP =
+      "iceberg.tables.schema-logical-timestamp-without-zone";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PREFIX_PROP = "iceberg.control.group-id-prefix";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -175,6 +177,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         false,
         Importance.MEDIUM,
         "Set to true to add any missing record fields to the table schema, false otherwise");
+    configDef.define(
+        TABLES_SCHEMA_LOGICAL_TIMESTAMP_WITHOUT_ZONE_PROP,
+        ConfigDef.Type.BOOLEAN,
+        false,
+        Importance.LOW,
+        "Set to true to force timestamp columns to be without timezone, false for with timezone");
     configDef.define(
         CATALOG_NAME_PROP,
         ConfigDef.Type.STRING,
@@ -446,6 +454,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public boolean schemaCaseInsensitive() {
     return getBoolean(TABLES_SCHEMA_CASE_INSENSITIVE_PROP);
+  }
+
+  public boolean schemaLogicalTimestampWithoutZone() {
+    return getBoolean(TABLES_SCHEMA_LOGICAL_TIMESTAMP_WITHOUT_ZONE_PROP);
   }
 
   public JsonConverter jsonConverter() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
@@ -249,7 +249,11 @@ class SchemaUtils {
           return IntegerType.get();
         case INT64:
           if (Timestamp.LOGICAL_NAME.equals(valueSchema.name())) {
-            return TimestampType.withZone();
+            if (config.schemaLogicalTimestampWithoutZone()) {
+              return TimestampType.withoutZone();
+            } else {
+              return TimestampType.withZone();
+            }
           }
           return LongType.get();
         case FLOAT32:

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUtils.java
@@ -271,6 +271,16 @@ public class TestSchemaUtils {
   }
 
   @Test
+  public void testToIcebergTypeLogicalTimestampWithoutZone() {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.schemaLogicalTimestampWithoutZone()).thenReturn(true);
+
+    Type timestampType = SchemaUtils.toIcebergType(Timestamp.SCHEMA, config);
+    assertThat(timestampType).isInstanceOf(TimestampType.class);
+    assertThat(((TimestampType) timestampType).shouldAdjustToUTC()).isFalse();
+  }
+
+  @Test
   public void testInferIcebergType() {
     IcebergSinkConfig config = mock(IcebergSinkConfig.class);
 


### PR DESCRIPTION
Addresses the issue described here:

https://github.com/apache/iceberg/issues/15761

Currently fields of type INT64 with logical name Timestamp are created as iceberg type TimestampType.withZone(), which is not fully supported by Athena.
