### PR TITLE
Docker, Docs: Add MinIO source-build quickstart override

### DIFF
--- a/docker/iceberg-flink-quickstart/README.md
+++ b/docker/iceberg-flink-quickstart/README.md
@@ -75,6 +75,29 @@ Start up the Docker containers:
 docker compose -f docker/iceberg-flink-quickstart/docker-compose.yml up -d --build
 ```
 
+The compose stack pins MinIO images to tested release tags by default. This avoids an arm64 crash in
+`minio/minio:latest` (`RELEASE.2025-09-07T16-13-09Z`) that causes the `minio` service to exit with code `139`.
+Override the defaults if needed:
+
+```sh
+MINIO_IMAGE_TAG=RELEASE.2025-07-23T15-54-02Z \
+MINIO_MC_IMAGE_TAG=RELEASE.2025-07-21T05-28-08Z \
+docker compose -f docker/iceberg-flink-quickstart/docker-compose.yml up -d --build
+```
+
+Some MinIO releases exist on GitHub without a matching `minio/minio:<tag>` image on Docker Hub. To build
+MinIO from an upstream Git tag instead of pulling a published image, add the source-build override file:
+
+```sh
+MINIO_SOURCE_TAG=RELEASE.2025-10-15T17-29-55Z \
+docker compose \
+  -f docker/iceberg-flink-quickstart/docker-compose.yml \
+  -f docker/iceberg-flink-quickstart/docker-compose.minio-source.yml \
+  up -d --build
+```
+
+This uses Compose's remote Git build context support and builds the `minio` service from the selected tag.
+
 Execute the test script directly from the host:
 
 ```bash

--- a/docker/iceberg-flink-quickstart/docker-compose.minio-source.yml
+++ b/docker/iceberg-flink-quickstart/docker-compose.minio-source.yml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+services:
+  minio:
+    pull_policy: never
+    image: minio/minio:source-${MINIO_SOURCE_TAG:-RELEASE.2025-10-15T17-29-55Z}
+    build:
+      context: https://github.com/minio/minio.git#${MINIO_SOURCE_TAG:-RELEASE.2025-10-15T17-29-55Z}
+      dockerfile_inline: |
+        # Build MinIO from source because some upstream releases are not published as Docker Hub tags.
+        FROM --platform=$$BUILDPLATFORM golang:1.24 AS build
+        ARG TARGETOS
+        ARG TARGETARCH
+        WORKDIR /src
+        COPY . .
+        RUN CGO_ENABLED=0 GOOS=$$TARGETOS GOARCH=$$TARGETARCH go build -o /out/minio .
+
+        FROM debian:bookworm-slim
+        RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+        COPY --from=build /out/minio /usr/bin/minio
+        ENTRYPOINT ["/usr/bin/minio"]
+        CMD ["server", "/data", "--console-address", ":9001"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/docker/iceberg-flink-quickstart/docker-compose.yml
+++ b/docker/iceberg-flink-quickstart/docker-compose.yml
@@ -98,7 +98,7 @@ services:
 
   # MinIO for S3-compatible object storage
   minio:
-    image: minio/minio
+    image: minio/minio:${MINIO_IMAGE_TAG:-RELEASE.2025-07-23T15-54-02Z}
     hostname: minio
     environment:
       MINIO_ROOT_USER: admin
@@ -117,7 +117,7 @@ services:
 
   # Create the warehouse bucket
   create-bucket:
-    image: minio/mc
+    image: minio/mc:${MINIO_MC_IMAGE_TAG:-RELEASE.2025-07-21T05-28-08Z}
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
Pin the default MinIO images to tested tags and document an opt-in Compose override that builds MinIO from an upstream Git tag when a matching Docker image is not published.

Closes #15774

Co-authored-by: @Codex