### PR TITLE
ORC: Add _row_id and _last_updated_sequence_number raeder in Orc to support lineage

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/orc/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestGenericData.java
@@ -68,6 +68,11 @@ public class TestGenericData extends DataTestBase {
     return true;
   }
 
+  @Override
+  protected boolean supportsRowLineage() {
+    return true;
+  }
+
   /** Orc writers don't have notion of non-null / required fields. */
   @Override
   protected boolean allowsWritingNullValuesForRequiredFields() {

--- a/data/src/test/java/org/apache/iceberg/data/orc/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestGenericData.java
@@ -250,13 +250,15 @@ public class TestGenericData extends DataTestBase {
     try (CloseableIterable<Record> reader =
         ORC.read(Files.localInput(testFile))
             .project(schema)
-            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(schema, fileSchema))
+            .createReaderFunc(
+                fileSchema -> GenericOrcReader.buildReader(schema, fileSchema, ID_TO_CONSTANT))
             .build()) {
       rows = Lists.newArrayList(reader);
     }
 
     for (int i = 0; i < expected.size(); i += 1) {
-      DataTestHelpers.assertEquals(schema.asStruct(), expected.get(i), rows.get(i));
+      DataTestHelpers.assertEquals(
+          schema.asStruct(), expected.get(i), rows.get(i), ID_TO_CONSTANT, i);
     }
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReader.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReader.java
@@ -70,7 +70,7 @@ public class FlinkOrcReader implements OrcRowReader<RowData> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return FlinkOrcReaders.struct(fields, iStruct, idToConstant);
+      return FlinkOrcReaders.struct(record, fields, iStruct, idToConstant);
     }
 
     @Override

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReaders.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcReaders.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -91,8 +92,11 @@ class FlinkOrcReaders {
   }
 
   public static OrcValueReader<RowData> struct(
-      List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(readers, struct, idToConstant);
+      TypeDescription record,
+      List<OrcValueReader<?>> readers,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(record, readers, struct, idToConstant);
   }
 
   private static class StringReader implements OrcValueReader<StringData> {
@@ -265,8 +269,11 @@ class FlinkOrcReaders {
     private final int numFields;
 
     StructReader(
-        List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-      super(readers, struct, idToConstant);
+        TypeDescription record,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(record, readers, struct, idToConstant);
       this.numFields = struct.fields().size();
     }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -33,6 +33,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.stream.StreamSupport;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
@@ -44,8 +45,14 @@ import org.apache.iceberg.flink.maintenance.operator.MetricsReporterFactoryForTe
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 
 class TestRewriteDataFiles extends MaintenanceTaskTestBase {
+
+  private static final FileFormat[] FILE_FORMATS =
+      new FileFormat[] {FileFormat.AVRO, FileFormat.PARQUET, FileFormat.ORC};
+
   @Test
   void testRewriteUnpartitioned() throws Exception {
     Table table = createTable();
@@ -83,13 +90,14 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
             createRecord(4, "d")));
   }
 
-  @Test
-  void testRewriteUnpartitionedPreserveLineage() throws Exception {
-    Table table = createTable(3);
-    insert(table, 1, "a");
-    insert(table, 2, "b");
-    insert(table, 3, "c");
-    insert(table, 4, "d");
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testRewriteUnpartitionedPreserveLineage(FileFormat fileFormat) throws Exception {
+    Table table = createTable(3, fileFormat);
+    insert(table, 1, "a", fileFormat);
+    insert(table, 2, "b", fileFormat);
+    insert(table, 3, "c", fileFormat);
+    insert(table, 4, "d", fileFormat);
 
     assertFileNum(table, 4, 0);
 
@@ -123,15 +131,17 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
         schema);
   }
 
-  @Test
-  void testRewriteTheSameFilePreserveLineage() throws Exception {
-    Table table = createTable(3);
-    insert(table, 1, "a");
-    insert(table, 2, "b");
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testRewriteTheSameFilePreserveLineage(FileFormat fileFormat) throws Exception {
+    Table table = createTable(3, fileFormat);
+    insert(table, 1, "a", fileFormat);
+    insert(table, 2, "b", fileFormat);
     // Create a file with two lines of data to verify that the rowid is read correctly.
     insert(
         table,
-        ImmutableList.of(SimpleDataUtil.createRecord(3, "c"), SimpleDataUtil.createRecord(4, "d")));
+        ImmutableList.of(SimpleDataUtil.createRecord(3, "c"), SimpleDataUtil.createRecord(4, "d")),
+        fileFormat);
 
     assertFileNum(table, 3, 0);
 
@@ -167,13 +177,14 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
         schema);
   }
 
-  @Test
-  void testRewritePartitionedPreserveLineage() throws Exception {
-    Table table = createPartitionedTable(3);
-    insertPartitioned(table, 1, "p1");
-    insertPartitioned(table, 2, "p1");
-    insertPartitioned(table, 3, "p2");
-    insertPartitioned(table, 4, "p2");
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testRewritePartitionedPreserveLineage(FileFormat fileFormat) throws Exception {
+    Table table = createPartitionedTable(3, fileFormat);
+    insertPartitioned(table, 1, "p1", fileFormat);
+    insertPartitioned(table, 2, "p1", fileFormat);
+    insertPartitioned(table, 3, "p2", fileFormat);
+    insertPartitioned(table, 4, "p2", fileFormat);
 
     assertFileNum(table, 4, 0);
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -133,10 +133,14 @@ public class OperatorTestBase {
   }
 
   protected static Table createTable() {
-    return createTable(2);
+    return createTable(2, FileFormat.PARQUET);
   }
 
   protected static Table createTable(int formatVersion) {
+    return createPartitionedTable(formatVersion, FileFormat.PARQUET);
+  }
+
+  protected static Table createTable(int formatVersion, FileFormat fileFormat) {
     return CATALOG_EXTENSION
         .catalog()
         .createTable(
@@ -145,6 +149,8 @@ public class OperatorTestBase {
             PartitionSpec.unpartitioned(),
             null,
             ImmutableMap.of(
+                "write.format.default",
+                fileFormat.name(),
                 TableProperties.FORMAT_VERSION,
                 String.valueOf(formatVersion),
                 "flink.max-continuous-empty-commits",
@@ -182,7 +188,7 @@ public class OperatorTestBase {
                 "format-version", String.valueOf(formatVersion), "write.upsert.enabled", "true"));
   }
 
-  protected static Table createPartitionedTable(int formatVersion) {
+  protected static Table createPartitionedTable(int formatVersion, FileFormat fileFormat) {
     return CATALOG_EXTENSION
         .catalog()
         .createTable(
@@ -191,6 +197,8 @@ public class OperatorTestBase {
             PartitionSpec.builderFor(SimpleDataUtil.SCHEMA).identity("data").build(),
             null,
             ImmutableMap.of(
+                "write.format.default",
+                fileFormat.name(),
                 "format-version",
                 String.valueOf(formatVersion),
                 "flink.max-continuous-empty-commits",
@@ -198,17 +206,27 @@ public class OperatorTestBase {
   }
 
   protected static Table createPartitionedTable() {
-    return createPartitionedTable(2);
+    return createPartitionedTable(2, FileFormat.PARQUET);
   }
 
   protected void insert(Table table, Integer id, String data) throws IOException {
-    new GenericAppenderHelper(table, FileFormat.PARQUET, warehouseDir)
+    insert(table, id, data, FileFormat.PARQUET);
+  }
+
+  protected void insert(Table table, Integer id, String data, FileFormat fileFormat)
+      throws IOException {
+    new GenericAppenderHelper(table, fileFormat, warehouseDir)
         .appendToTable(Lists.newArrayList(SimpleDataUtil.createRecord(id, data)));
     table.refresh();
   }
 
   protected void insert(Table table, List<Record> records) throws IOException {
-    new GenericAppenderHelper(table, FileFormat.PARQUET, warehouseDir).appendToTable(records);
+    insert(table, records, FileFormat.PARQUET);
+  }
+
+  protected void insert(Table table, List<Record> records, FileFormat fileFormat)
+      throws IOException {
+    new GenericAppenderHelper(table, fileFormat, warehouseDir).appendToTable(records);
     table.refresh();
   }
 
@@ -309,7 +327,12 @@ public class OperatorTestBase {
   }
 
   protected void insertPartitioned(Table table, Integer id, String data) throws IOException {
-    new GenericAppenderHelper(table, FileFormat.PARQUET, warehouseDir)
+    insertPartitioned(table, id, data, FileFormat.PARQUET);
+  }
+
+  protected void insertPartitioned(Table table, Integer id, String data, FileFormat fileFormat)
+      throws IOException {
+    new GenericAppenderHelper(table, fileFormat, warehouseDir)
         .appendToTable(
             TestHelpers.Row.of(data), Lists.newArrayList(SimpleDataUtil.createRecord(id, data)));
     table.refresh();

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
@@ -76,7 +76,7 @@ public class GenericOrcReader implements OrcRowReader<Record> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return GenericOrcReaders.struct(fields, expected, idToConstant);
+      return GenericOrcReaders.struct(record, fields, expected, idToConstant);
     }
 
     @Override

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.variants.VariantValue;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -58,7 +59,15 @@ public class GenericOrcReaders {
 
   public static OrcValueReader<Record> struct(
       List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(readers, struct, idToConstant);
+    return new StructReader(null, readers, struct, idToConstant);
+  }
+
+  public static OrcValueReader<Record> struct(
+      TypeDescription record,
+      List<OrcValueReader<?>> readers,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(record, readers, struct, idToConstant);
   }
 
   public static OrcValueReader<List<?>> array(OrcValueReader<?> elementReader) {
@@ -232,10 +241,11 @@ public class GenericOrcReaders {
     private final GenericRecord template;
 
     protected StructReader(
+        TypeDescription record,
         List<OrcValueReader<?>> readers,
         Types.StructType structType,
         Map<Integer, ?> idToConstant) {
-      super(readers, structType, idToConstant);
+      super(record, readers, structType, idToConstant);
       this.template = GenericRecord.create(structType);
     }
 

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
@@ -69,11 +69,11 @@ public class GenericOrcReaders {
   }
 
   public static OrcValueReader<Record> struct(
-      TypeDescription record,
+      TypeDescription orcType,
       List<OrcValueReader<?>> readers,
       Types.StructType struct,
       Map<Integer, ?> idToConstant) {
-    return new StructReader(record, readers, struct, idToConstant);
+    return new StructReader(orcType, readers, struct, idToConstant);
   }
 
   public static OrcValueReader<List<?>> array(OrcValueReader<?> elementReader) {
@@ -261,11 +261,11 @@ public class GenericOrcReaders {
     }
 
     protected StructReader(
-        TypeDescription record,
+        TypeDescription orcType,
         List<OrcValueReader<?>> readers,
         Types.StructType structType,
         Map<Integer, ?> idToConstant) {
-      super(record, readers, structType, idToConstant);
+      super(orcType, readers, structType, idToConstant);
       this.template = GenericRecord.create(structType);
     }
 

--- a/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
@@ -57,9 +57,15 @@ public class GenericOrcReaders {
 
   private GenericOrcReaders() {}
 
+  /**
+   * @deprecated Use {@link #struct(TypeDescription, List, Types.StructType, Map)} instead. This
+   *     method uses position-based binding which may cause field misalignment in MOR and lineage
+   *     scenarios.
+   */
+  @Deprecated
   public static OrcValueReader<Record> struct(
       List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(null, readers, struct, idToConstant);
+    return new StructReader(readers, struct, idToConstant);
   }
 
   public static OrcValueReader<Record> struct(
@@ -239,6 +245,20 @@ public class GenericOrcReaders {
 
   private static class StructReader extends OrcValueReaders.StructReader<Record> {
     private final GenericRecord template;
+
+    /**
+     * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
+     *     This constructor uses position-based binding which may cause field misalignment in MOR
+     *     and lineage scenarios.
+     */
+    @Deprecated
+    protected StructReader(
+        List<OrcValueReader<?>> readers,
+        Types.StructType structType,
+        Map<Integer, ?> idToConstant) {
+      super(readers, structType, idToConstant);
+      this.template = GenericRecord.create(structType);
+    }
 
     protected StructReader(
         TypeDescription record,

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -85,6 +85,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.orc.CompressionKind;
@@ -787,12 +788,19 @@ public class ORC {
 
     public <D> CloseableIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
-      Set<Integer> idsToExclude =
+      Set<Integer> topLevelIdsToExclude =
           Sets.difference(
               Sets.union(constantFieldIds, MetadataColumns.metadataFieldIds()),
               ImmutableSet.of(
                   MetadataColumns.ROW_ID.fieldId(),
                   MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()));
+
+      Set<Integer> idsToExclude = Sets.newHashSet(topLevelIdsToExclude);
+      for (Types.NestedField field : schema.columns()) {
+        if (topLevelIdsToExclude.contains(field.fieldId())) {
+          idsToExclude.addAll(TypeUtil.getProjectedIds(field.type()));
+        }
+      }
 
       return new OrcIterable<>(
           file,

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -85,7 +85,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.orc.CompressionKind;
@@ -788,19 +787,12 @@ public class ORC {
 
     public <D> CloseableIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
-      Set<Integer> topLevelIdsToExclude =
+      Set<Integer> idsToExclude =
           Sets.difference(
               Sets.union(constantFieldIds, MetadataColumns.metadataFieldIds()),
               ImmutableSet.of(
                   MetadataColumns.ROW_ID.fieldId(),
                   MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()));
-
-      Set<Integer> idsToExclude = Sets.newHashSet(topLevelIdsToExclude);
-      for (Types.NestedField field : schema.columns()) {
-        if (topLevelIdsToExclude.contains(field.fieldId())) {
-          idsToExclude.addAll(TypeUtil.getProjectedIds(field.type()));
-        }
-      }
 
       return new OrcIterable<>(
           file,

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -787,11 +787,17 @@ public class ORC {
 
     public <D> CloseableIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
+      Set<Integer> idsToExclude =
+          Sets.difference(
+              Sets.union(constantFieldIds, MetadataColumns.metadataFieldIds()),
+              ImmutableSet.of(
+                  MetadataColumns.ROW_ID.fieldId(),
+                  MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()));
+
       return new OrcIterable<>(
           file,
           conf,
-          TypeUtil.selectNot(
-              schema, Sets.union(constantFieldIds, MetadataColumns.metadataFieldIds())),
+          TypeUtil.selectNot(schema, idsToExclude),
           nameMapping,
           start,
           length,

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -141,9 +141,14 @@ public class OrcValueReaders {
       List<Types.NestedField> fields = struct.fields();
       this.readers = new OrcValueReader[fields.size()];
       this.isConstantOrMetadataField = new boolean[fields.size()];
-      for (int pos = 0, readerIndex = 0; pos < fields.size(); pos += 1) {
+      int readerIndex = 0;
+      for (int pos = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
-        if (idToConstant.containsKey(field.fieldId())) {
+        if (field.equals(MetadataColumns.ROW_ID)) {
+          readerIndex += handleRowIdField(pos, field, readers, readerIndex, idToConstant);
+        } else if (field.fieldId() == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
+          readerIndex += handleLastUpdatedSeqField(pos, field, readers, readerIndex, idToConstant);
+        } else if (idToConstant.containsKey(field.fieldId())) {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(idToConstant.get(field.fieldId()));
         } else if (field.equals(MetadataColumns.ROW_POSITION)) {
@@ -160,6 +165,51 @@ public class OrcValueReaders {
         } else {
           this.readers[pos] = readers.get(readerIndex++);
         }
+      }
+    }
+
+    private int handleRowIdField(
+        int pos,
+        Types.NestedField field,
+        List<OrcValueReader<?>> readerList,
+        int readerIndex,
+        Map<Integer, ?> idToConstant) {
+      Long firstRowId = (Long) idToConstant.get(field.fieldId());
+      if (firstRowId != null) {
+        OrcValueReader<Long> fileIdReader =
+            readerIndex < readerList.size()
+                ? (OrcValueReader<Long>) readerList.get(readerIndex)
+                : null;
+        this.readers[pos] = new RowIdReader(firstRowId, fileIdReader);
+        this.isConstantOrMetadataField[pos] = fileIdReader == null;
+        return fileIdReader != null ? 1 : 0;
+      } else {
+        this.isConstantOrMetadataField[pos] = true;
+        this.readers[pos] = constants(null);
+        return 0;
+      }
+    }
+
+    private int handleLastUpdatedSeqField(
+        int pos,
+        Types.NestedField field,
+        List<OrcValueReader<?>> readerList,
+        int readerIndex,
+        Map<Integer, ?> idToConstant) {
+      Long fileLastUpdated = (Long) idToConstant.get(field.fieldId());
+      Long firstRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
+      if (fileLastUpdated != null && firstRowId != null) {
+        OrcValueReader<Long> fileSeqReader =
+            readerIndex < readerList.size()
+                ? (OrcValueReader<Long>) readerList.get(readerIndex)
+                : null;
+        this.readers[pos] = new LastUpdatedSeqReader(fileLastUpdated, fileSeqReader);
+        this.isConstantOrMetadataField[pos] = fileSeqReader == null;
+        return fileSeqReader != null ? 1 : 0;
+      } else {
+        this.isConstantOrMetadataField[pos] = true;
+        this.readers[pos] = constants(null);
+        return 0;
       }
     }
 
@@ -233,6 +283,78 @@ public class OrcValueReaders {
     @Override
     public void setBatchContext(long newBatchOffsetInFile) {
       this.batchOffsetInFile = newBatchOffsetInFile;
+    }
+  }
+
+  private static class RowIdReader implements OrcValueReader<Long> {
+    private final long firstRowId;
+    private final OrcValueReader<Long> fileIdReader;
+    private final RowPositionReader posReader;
+
+    RowIdReader(long firstRowId, OrcValueReader<Long> fileIdReader) {
+      this.firstRowId = firstRowId;
+      this.fileIdReader = fileIdReader;
+      this.posReader = new RowPositionReader();
+    }
+
+    @Override
+    public Long read(ColumnVector vector, int row) {
+      if (fileIdReader != null) {
+        Long idFromFile = fileIdReader.read(vector, row);
+        if (idFromFile != null) {
+          return idFromFile;
+        }
+      }
+
+      long pos = posReader.read(null, row);
+      return firstRowId + pos;
+    }
+
+    @Override
+    public Long nonNullRead(ColumnVector vector, int row) {
+      return read(vector, row);
+    }
+
+    @Override
+    public void setBatchContext(long batchOffsetInFile) {
+      posReader.setBatchContext(batchOffsetInFile);
+      if (fileIdReader != null) {
+        fileIdReader.setBatchContext(batchOffsetInFile);
+      }
+    }
+  }
+
+  private static class LastUpdatedSeqReader implements OrcValueReader<Long> {
+    private final long fileLastUpdated;
+    private final OrcValueReader<Long> fileSeqReader;
+
+    LastUpdatedSeqReader(long fileLastUpdated, OrcValueReader<Long> fileSeqReader) {
+      this.fileLastUpdated = fileLastUpdated;
+      this.fileSeqReader = fileSeqReader;
+    }
+
+    @Override
+    public Long read(ColumnVector vector, int row) {
+      if (fileSeqReader != null) {
+        Long seqFromFile = fileSeqReader.read(vector, row);
+        if (seqFromFile != null) {
+          return seqFromFile;
+        }
+      }
+
+      return fileLastUpdated;
+    }
+
+    @Override
+    public Long nonNullRead(ColumnVector vector, int row) {
+      return read(vector, row);
+    }
+
+    @Override
+    public void setBatchContext(long batchOffsetInFile) {
+      if (fileSeqReader != null) {
+        fileSeqReader.setBatchContext(batchOffsetInFile);
+      }
     }
   }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -22,8 +22,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DoubleColumnVector;
@@ -135,20 +138,27 @@ public class OrcValueReaders {
   public abstract static class StructReader<T> implements OrcValueReader<T> {
     private final OrcValueReader<?>[] readers;
     private final boolean[] isConstantOrMetadataField;
+    private final int[] fieldVectorIndex;
 
+    /**
+     * @param readers readers for each field
+     * @param struct struct type
+     * @param idToConstant constant values by field id
+     * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
+     *     This constructor uses position-based binding which may cause field misalignment in MOR
+     *     scenarios. This don`t work lineage scenarios.
+     */
+    @Deprecated
     protected StructReader(
         List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
       List<Types.NestedField> fields = struct.fields();
       this.readers = new OrcValueReader[fields.size()];
       this.isConstantOrMetadataField = new boolean[fields.size()];
-      int readerIndex = 0;
-      for (int pos = 0; pos < fields.size(); pos += 1) {
+      this.fieldVectorIndex = null;
+
+      for (int pos = 0, readerIndex = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
-        if (field.equals(MetadataColumns.ROW_ID)) {
-          readerIndex += handleRowIdField(pos, field, readers, readerIndex, idToConstant);
-        } else if (field.equals(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER)) {
-          readerIndex += handleLastUpdatedSeqField(pos, field, readers, readerIndex, idToConstant);
-        } else if (idToConstant.containsKey(field.fieldId())) {
+        if (idToConstant.containsKey(field.fieldId())) {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(idToConstant.get(field.fieldId()));
         } else if (field.equals(MetadataColumns.ROW_POSITION)) {
@@ -159,7 +169,6 @@ public class OrcValueReaders {
           this.readers[pos] = constants(false);
         } else if (MetadataColumns.isMetadataColumn(field.name())
             || field.type().typeId() == Type.TypeID.UNKNOWN) {
-          // in case of any other metadata field, fill with nulls
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(null);
         } else {
@@ -168,48 +177,118 @@ public class OrcValueReaders {
       }
     }
 
-    private int handleRowIdField(
-        int pos,
-        Types.NestedField field,
-        List<OrcValueReader<?>> readerList,
-        int readerIndex,
+    protected StructReader(
+        TypeDescription record,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
         Map<Integer, ?> idToConstant) {
-      Long firstRowId = (Long) idToConstant.get(field.fieldId());
-      if (firstRowId != null) {
-        OrcValueReader<Long> fileIdReader =
-            readerIndex < readerList.size()
-                ? (OrcValueReader<Long>) readerList.get(readerIndex)
-                : null;
-        this.readers[pos] = new RowIdReader(firstRowId, fileIdReader);
-        this.isConstantOrMetadataField[pos] = fileIdReader == null;
-        return fileIdReader != null ? 1 : 0;
-      } else {
-        this.isConstantOrMetadataField[pos] = true;
-        this.readers[pos] = constants(null);
-        return 0;
+      List<Types.NestedField> fields = struct.fields();
+      this.readers = new OrcValueReader[fields.size()];
+      this.isConstantOrMetadataField = new boolean[fields.size()];
+      this.fieldVectorIndex = new int[fields.size()];
+
+      Map<Integer, OrcValueReader<?>> readersById = readersByFieldId(record, readers);
+      Map<Integer, Integer> fieldIdToVectorIndex = buildFieldIdToVectorIndex(record);
+
+      for (int pos = 0; pos < fields.size(); pos += 1) {
+        Types.NestedField field = fields.get(pos);
+        OrcValueReader<?> fileReader = readersById.get(field.fieldId());
+
+        if (field.equals(MetadataColumns.ROW_ID)) {
+          handleRowIdField(pos, field, fileReader, idToConstant, fieldIdToVectorIndex);
+        } else if (field.equals(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER)) {
+          handleLastUpdatedSeqField(pos, field, fileReader, idToConstant, fieldIdToVectorIndex);
+        } else if (idToConstant.containsKey(field.fieldId())) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(idToConstant.get(field.fieldId()));
+        } else if (field.equals(MetadataColumns.ROW_POSITION)) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = new RowPositionReader();
+        } else if (field.equals(MetadataColumns.IS_DELETED)) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(false);
+        } else if (fileReader != null) {
+          this.isConstantOrMetadataField[pos] = false;
+          this.fieldVectorIndex[pos] = fieldIdToVectorIndex.getOrDefault(field.fieldId(), -1);
+          this.readers[pos] = fileReader;
+        } else if (MetadataColumns.isMetadataColumn(field.name())
+            || field.type().typeId() == Type.TypeID.UNKNOWN) {
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(null);
+        } else {
+          throw new IllegalArgumentException(
+              String.format("Missing ORC reader for field %s (%s)", field.name(), field.fieldId()));
+        }
       }
     }
 
-    private int handleLastUpdatedSeqField(
+    private Map<Integer, Integer> buildFieldIdToVectorIndex(TypeDescription record) {
+      List<TypeDescription> children = record.getChildren();
+      Map<Integer, Integer> mapping = Maps.newHashMap();
+      for (int i = 0; i < children.size(); i++) {
+        mapping.put(ORCSchemaUtil.fieldId(children.get(i)), i);
+      }
+
+      return mapping;
+    }
+
+    private Map<Integer, OrcValueReader<?>> readersByFieldId(
+        TypeDescription record, List<OrcValueReader<?>> readerList) {
+      List<TypeDescription> children = record.getChildren();
+      Preconditions.checkState(
+          children.size() == readerList.size(),
+          "Invalid ORC reader binding: children=%s readers=%s",
+          children.size(),
+          readerList.size());
+
+      Map<Integer, OrcValueReader<?>> readersById = Maps.newHashMap();
+      for (int i = 0; i < children.size(); i += 1) {
+        readersById.put(ORCSchemaUtil.fieldId(children.get(i)), readerList.get(i));
+      }
+
+      return readersById;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void handleRowIdField(
         int pos,
         Types.NestedField field,
-        List<OrcValueReader<?>> readerList,
-        int readerIndex,
-        Map<Integer, ?> idToConstant) {
-      Long fileLastUpdated = (Long) idToConstant.get(field.fieldId());
-      Long firstRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
-      if (fileLastUpdated != null && firstRowId != null) {
-        OrcValueReader<Long> fileSeqReader =
-            readerIndex < readerList.size()
-                ? (OrcValueReader<Long>) readerList.get(readerIndex)
-                : null;
-        this.readers[pos] = new LastUpdatedSeqReader(fileLastUpdated, fileSeqReader);
-        this.isConstantOrMetadataField[pos] = fileSeqReader == null;
-        return fileSeqReader != null ? 1 : 0;
+        OrcValueReader<?> fileReader,
+        Map<Integer, ?> idToConstant,
+        Map<Integer, Integer> fieldIdToVectorIndex) {
+      Long firstRowId = (Long) idToConstant.get(field.fieldId());
+      if (firstRowId != null) {
+        OrcValueReader<Long> fileIdReader = (OrcValueReader<Long>) fileReader;
+        this.readers[pos] = new RowIdReader(firstRowId, fileIdReader);
+        this.isConstantOrMetadataField[pos] = fileIdReader == null;
+        if (fileIdReader != null) {
+          this.fieldVectorIndex[pos] = fieldIdToVectorIndex.getOrDefault(field.fieldId(), -1);
+        }
       } else {
         this.isConstantOrMetadataField[pos] = true;
         this.readers[pos] = constants(null);
-        return 0;
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void handleLastUpdatedSeqField(
+        int pos,
+        Types.NestedField field,
+        OrcValueReader<?> fileReader,
+        Map<Integer, ?> idToConstant,
+        Map<Integer, Integer> fieldIdToVectorIndex) {
+      Long fileLastUpdated = (Long) idToConstant.get(field.fieldId());
+      Long firstRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
+      if (fileLastUpdated != null && firstRowId != null) {
+        OrcValueReader<Long> fileSeqReader = (OrcValueReader<Long>) fileReader;
+        this.readers[pos] = new LastUpdatedSeqReader(fileLastUpdated, fileSeqReader);
+        this.isConstantOrMetadataField[pos] = fileSeqReader == null;
+        if (fileSeqReader != null) {
+          this.fieldVectorIndex[pos] = fieldIdToVectorIndex.getOrDefault(field.fieldId(), -1);
+        }
+      } else {
+        this.isConstantOrMetadataField[pos] = true;
+        this.readers[pos] = constants(null);
       }
     }
 
@@ -228,14 +307,17 @@ public class OrcValueReaders {
     }
 
     private T readInternal(T struct, ColumnVector[] columnVectors, int row) {
-      for (int c = 0, vectorIndex = 0; c < readers.length; ++c) {
+      int vectorIndex = 0;
+      for (int c = 0; c < readers.length; ++c) {
         ColumnVector vector;
         if (isConstantOrMetadataField[c]) {
           vector = null;
+        } else if (fieldVectorIndex != null) {
+          vector = columnVectors[fieldVectorIndex[c]];
         } else {
-          vector = columnVectors[vectorIndex];
-          vectorIndex++;
+          vector = columnVectors[vectorIndex++];
         }
+
         set(struct, c, reader(c).read(vector, row));
       }
       return struct;

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -146,7 +146,7 @@ public class OrcValueReaders {
         Types.NestedField field = fields.get(pos);
         if (field.equals(MetadataColumns.ROW_ID)) {
           readerIndex += handleRowIdField(pos, field, readers, readerIndex, idToConstant);
-        } else if (field.fieldId() == MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId()) {
+        } else if (field.equals(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER)) {
           readerIndex += handleLastUpdatedSeqField(pos, field, readers, readerIndex, idToConstant);
         } else if (idToConstant.containsKey(field.fieldId())) {
           this.isConstantOrMetadataField[pos] = true;

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -188,16 +188,17 @@ public class OrcValueReaders {
       this.fieldVectorIndex = new int[fields.size()];
 
       Map<Integer, OrcValueReader<?>> readersById = readersByFieldId(orcType, readers);
-      Map<Integer, Integer> fieldIdToVectorIndex = buildFieldIdToVectorIndex(orcType);
+      Map<Integer, Integer> fieldIdToDataIndex = buildFieldIdToVectorIndex(orcType);
 
       for (int pos = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
         OrcValueReader<?> fileReader = readersById.get(field.fieldId());
+        int dataIndex = fieldIdToDataIndex.getOrDefault(field.fieldId(), -1);
 
         if (field.equals(MetadataColumns.ROW_ID)) {
-          handleRowIdField(pos, field, fileReader, idToConstant, fieldIdToVectorIndex);
+          handleRowIdField(pos, field, fileReader, idToConstant, dataIndex);
         } else if (field.equals(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER)) {
-          handleLastUpdatedSeqField(pos, field, fileReader, idToConstant, fieldIdToVectorIndex);
+          handleLastUpdatedSeqField(pos, field, fileReader, idToConstant, dataIndex);
         } else if (idToConstant.containsKey(field.fieldId())) {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(idToConstant.get(field.fieldId()));
@@ -209,7 +210,7 @@ public class OrcValueReaders {
           this.readers[pos] = constants(false);
         } else if (fileReader != null) {
           this.isConstantOrMetadataField[pos] = false;
-          this.fieldVectorIndex[pos] = fieldIdToVectorIndex.getOrDefault(field.fieldId(), -1);
+          this.fieldVectorIndex[pos] = fieldIdToDataIndex.getOrDefault(field.fieldId(), -1);
           this.readers[pos] = fileReader;
         } else if (MetadataColumns.isMetadataColumn(field.name())
             || field.type().typeId() == Type.TypeID.UNKNOWN) {
@@ -255,14 +256,14 @@ public class OrcValueReaders {
         Types.NestedField field,
         OrcValueReader<?> fileReader,
         Map<Integer, ?> idToConstant,
-        Map<Integer, Integer> fieldIdToVectorIndex) {
+        int dataIndex) {
       Long firstRowId = (Long) idToConstant.get(field.fieldId());
       if (firstRowId != null) {
         OrcValueReader<Long> fileIdReader = (OrcValueReader<Long>) fileReader;
         this.readers[pos] = new RowIdReader(firstRowId, fileIdReader);
         this.isConstantOrMetadataField[pos] = fileIdReader == null;
         if (fileIdReader != null) {
-          this.fieldVectorIndex[pos] = fieldIdToVectorIndex.getOrDefault(field.fieldId(), -1);
+          this.fieldVectorIndex[pos] = dataIndex;
         }
       } else {
         this.isConstantOrMetadataField[pos] = true;
@@ -276,7 +277,7 @@ public class OrcValueReaders {
         Types.NestedField field,
         OrcValueReader<?> fileReader,
         Map<Integer, ?> idToConstant,
-        Map<Integer, Integer> fieldIdToVectorIndex) {
+        int dataIndex) {
       Long fileLastUpdated = (Long) idToConstant.get(field.fieldId());
       Long firstRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
       if (fileLastUpdated != null && firstRowId != null) {
@@ -284,7 +285,7 @@ public class OrcValueReaders {
         this.readers[pos] = new LastUpdatedSeqReader(fileLastUpdated, fileSeqReader);
         this.isConstantOrMetadataField[pos] = fileSeqReader == null;
         if (fileSeqReader != null) {
-          this.fieldVectorIndex[pos] = fieldIdToVectorIndex.getOrDefault(field.fieldId(), -1);
+          this.fieldVectorIndex[pos] = dataIndex;
         }
       } else {
         this.isConstantOrMetadataField[pos] = true;

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -138,7 +138,10 @@ public class OrcValueReaders {
   public abstract static class StructReader<T> implements OrcValueReader<T> {
     private final OrcValueReader<?>[] readers;
     private final boolean[] isConstantOrMetadataField;
-    private final int[] fieldVectorIndex;
+    // Maps each projected struct field position to the matching child index in the ORC schema.
+    // This allows fields to be read by Iceberg field ID when the projected struct order differs
+    // from the file schema.
+    private final int[] orcFieldIndex;
 
     /**
      * @param readers readers for each field
@@ -154,7 +157,7 @@ public class OrcValueReaders {
       List<Types.NestedField> fields = struct.fields();
       this.readers = new OrcValueReader[fields.size()];
       this.isConstantOrMetadataField = new boolean[fields.size()];
-      this.fieldVectorIndex = null;
+      this.orcFieldIndex = null;
 
       for (int pos = 0, readerIndex = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
@@ -185,20 +188,20 @@ public class OrcValueReaders {
       List<Types.NestedField> fields = struct.fields();
       this.readers = new OrcValueReader[fields.size()];
       this.isConstantOrMetadataField = new boolean[fields.size()];
-      this.fieldVectorIndex = new int[fields.size()];
+      this.orcFieldIndex = new int[fields.size()];
 
       Map<Integer, OrcValueReader<?>> readersById = readersByFieldId(orcType, readers);
-      Map<Integer, Integer> fieldIdToDataIndex = buildFieldIdToVectorIndex(orcType);
+      Map<Integer, Integer> fieldIdToOrcIndex = buildFieldIdToOrcIndex(orcType);
 
       for (int pos = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
         OrcValueReader<?> fileReader = readersById.get(field.fieldId());
-        int dataIndex = fieldIdToDataIndex.getOrDefault(field.fieldId(), -1);
+        int orcIndex = fieldIdToOrcIndex.getOrDefault(field.fieldId(), -1);
 
         if (field.equals(MetadataColumns.ROW_ID)) {
-          handleRowIdField(pos, field, fileReader, idToConstant, dataIndex);
+          handleRowIdField(pos, field, fileReader, idToConstant, orcIndex);
         } else if (field.equals(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER)) {
-          handleLastUpdatedSeqField(pos, field, fileReader, idToConstant, dataIndex);
+          handleLastUpdatedSeqField(pos, field, fileReader, idToConstant, orcIndex);
         } else if (idToConstant.containsKey(field.fieldId())) {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(idToConstant.get(field.fieldId()));
@@ -210,7 +213,7 @@ public class OrcValueReaders {
           this.readers[pos] = constants(false);
         } else if (fileReader != null) {
           this.isConstantOrMetadataField[pos] = false;
-          this.fieldVectorIndex[pos] = fieldIdToDataIndex.getOrDefault(field.fieldId(), -1);
+          this.orcFieldIndex[pos] = fieldIdToOrcIndex.getOrDefault(field.fieldId(), -1);
           this.readers[pos] = fileReader;
         } else if (MetadataColumns.isMetadataColumn(field.name())
             || field.type().typeId() == Type.TypeID.UNKNOWN) {
@@ -223,7 +226,7 @@ public class OrcValueReaders {
       }
     }
 
-    private Map<Integer, Integer> buildFieldIdToVectorIndex(TypeDescription orcType) {
+    private Map<Integer, Integer> buildFieldIdToOrcIndex(TypeDescription orcType) {
       List<TypeDescription> children = orcType.getChildren();
       Map<Integer, Integer> mapping = Maps.newHashMap();
       for (int i = 0; i < children.size(); i++) {
@@ -256,14 +259,14 @@ public class OrcValueReaders {
         Types.NestedField field,
         OrcValueReader<?> fileReader,
         Map<Integer, ?> idToConstant,
-        int dataIndex) {
+        int orcIndex) {
       Long firstRowId = (Long) idToConstant.get(field.fieldId());
       if (firstRowId != null) {
         OrcValueReader<Long> fileIdReader = (OrcValueReader<Long>) fileReader;
         this.readers[pos] = new RowIdReader(firstRowId, fileIdReader);
         this.isConstantOrMetadataField[pos] = fileIdReader == null;
         if (fileIdReader != null) {
-          this.fieldVectorIndex[pos] = dataIndex;
+          this.orcFieldIndex[pos] = orcIndex;
         }
       } else {
         this.isConstantOrMetadataField[pos] = true;
@@ -277,7 +280,7 @@ public class OrcValueReaders {
         Types.NestedField field,
         OrcValueReader<?> fileReader,
         Map<Integer, ?> idToConstant,
-        int dataIndex) {
+        int orcIndex) {
       Long fileLastUpdated = (Long) idToConstant.get(field.fieldId());
       Long firstRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
       if (fileLastUpdated != null && firstRowId != null) {
@@ -285,7 +288,7 @@ public class OrcValueReaders {
         this.readers[pos] = new LastUpdatedSeqReader(fileLastUpdated, fileSeqReader);
         this.isConstantOrMetadataField[pos] = fileSeqReader == null;
         if (fileSeqReader != null) {
-          this.fieldVectorIndex[pos] = dataIndex;
+          this.orcFieldIndex[pos] = orcIndex;
         }
       } else {
         this.isConstantOrMetadataField[pos] = true;
@@ -313,8 +316,8 @@ public class OrcValueReaders {
         ColumnVector vector;
         if (isConstantOrMetadataField[c]) {
           vector = null;
-        } else if (fieldVectorIndex != null) {
-          vector = columnVectors[fieldVectorIndex[c]];
+        } else if (orcFieldIndex != null) {
+          vector = columnVectors[orcFieldIndex[c]];
         } else {
           vector = columnVectors[vectorIndex++];
         }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -178,7 +178,7 @@ public class OrcValueReaders {
     }
 
     protected StructReader(
-        TypeDescription record,
+        TypeDescription orcType,
         List<OrcValueReader<?>> readers,
         Types.StructType struct,
         Map<Integer, ?> idToConstant) {
@@ -187,8 +187,8 @@ public class OrcValueReaders {
       this.isConstantOrMetadataField = new boolean[fields.size()];
       this.fieldVectorIndex = new int[fields.size()];
 
-      Map<Integer, OrcValueReader<?>> readersById = readersByFieldId(record, readers);
-      Map<Integer, Integer> fieldIdToVectorIndex = buildFieldIdToVectorIndex(record);
+      Map<Integer, OrcValueReader<?>> readersById = readersByFieldId(orcType, readers);
+      Map<Integer, Integer> fieldIdToVectorIndex = buildFieldIdToVectorIndex(orcType);
 
       for (int pos = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
@@ -222,8 +222,8 @@ public class OrcValueReaders {
       }
     }
 
-    private Map<Integer, Integer> buildFieldIdToVectorIndex(TypeDescription record) {
-      List<TypeDescription> children = record.getChildren();
+    private Map<Integer, Integer> buildFieldIdToVectorIndex(TypeDescription orcType) {
+      List<TypeDescription> children = orcType.getChildren();
       Map<Integer, Integer> mapping = Maps.newHashMap();
       for (int i = 0; i < children.size(); i++) {
         mapping.put(ORCSchemaUtil.fieldId(children.get(i)), i);
@@ -233,8 +233,8 @@ public class OrcValueReaders {
     }
 
     private Map<Integer, OrcValueReader<?>> readersByFieldId(
-        TypeDescription record, List<OrcValueReader<?>> readerList) {
-      List<TypeDescription> children = record.getChildren();
+        TypeDescription orcType, List<OrcValueReader<?>> readerList) {
+      List<TypeDescription> children = orcType.getChildren();
       Preconditions.checkState(
           children.size() == readerList.size(),
           "Invalid ORC reader binding: children=%s readers=%s",

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -146,7 +146,7 @@ public class OrcValueReaders {
      * @param idToConstant constant values by field id
      * @deprecated Use {@link #StructReader(TypeDescription, List, Types.StructType, Map)} instead.
      *     This constructor uses position-based binding which may cause field misalignment in MOR
-     *     scenarios. This don`t work lineage scenarios.
+     *     scenarios. This doesn't work lineage scenarios.
      */
     @Deprecated
     protected StructReader(

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRowLevelOperationsWithLineage.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRowLevelOperationsWithLineage.java
@@ -99,6 +99,18 @@ public abstract class TestRowLevelOperationsWithLineage extends SparkRowLevelOpe
         "testhadoop",
         SparkCatalog.class.getName(),
         ImmutableMap.of("type", "hadoop"),
+        FileFormat.ORC,
+        false,
+        WRITE_DISTRIBUTION_MODE_HASH,
+        true,
+        null,
+        LOCAL,
+        3
+      },
+      {
+        "testhadoop",
+        SparkCatalog.class.getName(),
+        ImmutableMap.of("type", "hadoop"),
         FileFormat.PARQUET,
         true,
         WRITE_DISTRIBUTION_MODE_HASH,

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -77,7 +77,7 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
         TypeDescription record,
         List<String> names,
         List<OrcValueReader<?>> fields) {
-      return SparkOrcValueReaders.struct(fields, expected, idToConstant);
+      return SparkOrcValueReaders.struct(record, fields, expected, idToConstant);
     }
 
     @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
+import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
@@ -70,8 +71,11 @@ public class SparkOrcValueReaders {
   }
 
   static OrcValueReader<?> struct(
-      List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-    return new StructReader(readers, struct, idToConstant);
+      TypeDescription record,
+      List<OrcValueReader<?>> readers,
+      Types.StructType struct,
+      Map<Integer, ?> idToConstant) {
+    return new StructReader(record, readers, struct, idToConstant);
   }
 
   static OrcValueReader<?> array(OrcValueReader<?> elementReader) {
@@ -143,8 +147,11 @@ public class SparkOrcValueReaders {
     private final int numFields;
 
     protected StructReader(
-        List<OrcValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
-      super(readers, struct, idToConstant);
+        TypeDescription record,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(record, readers, struct, idToConstant);
       this.numFields = struct.fields().size();
     }
 


### PR DESCRIPTION
While working on improving the TCK for File Format, we found that in V3 tables, we support lineage in Parquet and Avro, but we haven't implemented this feature in ORC. 

This PR aims to add `_row_id` and `_last_updated_sequence_number` reader in ORC to support lineage.

Replace positional binding with field-ID-based binding:
Build a Map<fieldId, OrcValueReader> from ORC projected schema children to bind readers by field ID instead of position.
Build a fieldVectorIndex[] array mapping each field to its exact position in StructColumnVector.fields, eliminating the linear vectorIndex++ pattern.
This ensures each field always reads from its correct reader and column vector regardless of constant/metadata field gaps. 

This pr don't implemented lineage in spark vector read in ORC, it will support it in the follow pr. 