### PR TITLE
Spark: Support TimestampNTZ in SparkZOrderUDF

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -40,6 +40,7 @@ import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.types.TimestampType;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -308,6 +309,8 @@ class SparkZOrderUDF implements Serializable {
     } else if (type instanceof BooleanType) {
       return booleanToOrderedBytesUDF().apply(column);
     } else if (type instanceof TimestampType) {
+      return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
+    } else if (type instanceof TimestampNTZType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else if (type instanceof DateType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -49,9 +49,6 @@ import scala.collection.Seq;
 
 class SparkZOrderUDF implements Serializable {
   private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
-
-  private static final LocalDateTime TIMESTAMP_NTZ_LOCAL_EPOCH =
-      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0);
 
   /**
    * Every Spark task runs iteratively on a rows in a single thread so ThreadLocal should protect
@@ -195,7 +192,7 @@ class SparkZOrderUDF implements Serializable {
                   if (value == null) {
                     return PRIMITIVE_EMPTY;
                   }
-                  long micros = ChronoUnit.MICROS.between(TIMESTAMP_NTZ_LOCAL_EPOCH, value);
+                  long micros = DateTimeUtil.microsFromTimestamp(value);
                   return ZOrderByteUtils.longToOrderedBytes(
                           micros, inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE))
                       .array();

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -47,6 +49,9 @@ import scala.collection.Seq;
 
 class SparkZOrderUDF implements Serializable {
   private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
+
+  private static final LocalDateTime TIMESTAMP_NTZ_LOCAL_EPOCH =
+      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0);
 
   /**
    * Every Spark task runs iteratively on a rows in a single thread so ThreadLocal should protect
@@ -174,6 +179,29 @@ class SparkZOrderUDF implements Serializable {
                 },
                 DataTypes.BinaryType)
             .withName("LONG_ORDERED_BYTES");
+
+    this.inputCol++;
+    increaseOutputSize(ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
+
+    return udf;
+  }
+
+  private UserDefinedFunction timestampNtzToOrderedBytesUDF() {
+    int position = inputCol;
+    UserDefinedFunction udf =
+        functions
+            .udf(
+                (LocalDateTime value) -> {
+                  if (value == null) {
+                    return PRIMITIVE_EMPTY;
+                  }
+                  long micros = ChronoUnit.MICROS.between(TIMESTAMP_NTZ_LOCAL_EPOCH, value);
+                  return ZOrderByteUtils.longToOrderedBytes(
+                          micros, inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE))
+                      .array();
+                },
+                DataTypes.BinaryType)
+            .withName("TIMESTAMP_NTZ_ORDERED_BYTES");
 
     this.inputCol++;
     increaseOutputSize(ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
@@ -311,7 +339,7 @@ class SparkZOrderUDF implements Serializable {
     } else if (type instanceof TimestampType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else if (type instanceof TimestampNTZType) {
-      return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
+      return timestampNtzToOrderedBytesUDF().apply(column);
     } else if (type instanceof DateType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.data.FileHelpers.encrypt;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.current_date;
 import static org.apache.spark.sql.functions.date_add;
 import static org.apache.spark.sql.functions.expr;
@@ -127,6 +128,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -2607,6 +2609,23 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(readConf.cacheDeleteFilesOnExecutors())
         .as("Executor cache for delete files should be disabled in RewriteDataFilesSparkAction")
         .isFalse();
+  }
+
+  @TestTemplate
+  public void testZOrderUDFWithTimestampNTZType() {
+    SparkZOrderUDF zorderUDF = new SparkZOrderUDF(1, 16, 1024);
+    Dataset<Row> result =
+        spark
+            .sql("SELECT timestamp_ntz '2025-01-01 12:00:00' as test_col")
+            .withColumn(
+                "zorder_result",
+                zorderUDF.sortedLexicographically(col("test_col"), DataTypes.TimestampNTZType));
+
+    assertThat(result.schema().apply("zorder_result").dataType()).isEqualTo(DataTypes.BinaryType);
+    List<Row> rows = result.collectAsList();
+    Row row = rows.get(0);
+    byte[] zorderBytes = row.getAs("zorder_result");
+    assertThat(zorderBytes).isNotNull().isNotEmpty();
   }
 
   private double percentFilesRequired(Table table, String col, String value) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -40,6 +40,7 @@ import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.types.TimestampType;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -308,6 +309,8 @@ class SparkZOrderUDF implements Serializable {
     } else if (type instanceof BooleanType) {
       return booleanToOrderedBytesUDF().apply(column);
     } else if (type instanceof TimestampType) {
+      return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
+    } else if (type instanceof TimestampNTZType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else if (type instanceof DateType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -49,9 +49,6 @@ import scala.collection.Seq;
 
 class SparkZOrderUDF implements Serializable {
   private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
-
-  private static final LocalDateTime TIMESTAMP_NTZ_LOCAL_EPOCH =
-      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0);
 
   /**
    * Every Spark task runs iteratively on a rows in a single thread so ThreadLocal should protect
@@ -195,7 +192,7 @@ class SparkZOrderUDF implements Serializable {
                   if (value == null) {
                     return PRIMITIVE_EMPTY;
                   }
-                  long micros = ChronoUnit.MICROS.between(TIMESTAMP_NTZ_LOCAL_EPOCH, value);
+                  long micros = DateTimeUtil.microsFromTimestamp(value);
                   return ZOrderByteUtils.longToOrderedBytes(
                           micros, inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE))
                       .array();

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -47,6 +49,9 @@ import scala.collection.Seq;
 
 class SparkZOrderUDF implements Serializable {
   private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
+
+  private static final LocalDateTime TIMESTAMP_NTZ_LOCAL_EPOCH =
+      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0);
 
   /**
    * Every Spark task runs iteratively on a rows in a single thread so ThreadLocal should protect
@@ -174,6 +179,29 @@ class SparkZOrderUDF implements Serializable {
                 },
                 DataTypes.BinaryType)
             .withName("LONG_ORDERED_BYTES");
+
+    this.inputCol++;
+    increaseOutputSize(ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
+
+    return udf;
+  }
+
+  private UserDefinedFunction timestampNtzToOrderedBytesUDF() {
+    int position = inputCol;
+    UserDefinedFunction udf =
+        functions
+            .udf(
+                (LocalDateTime value) -> {
+                  if (value == null) {
+                    return PRIMITIVE_EMPTY;
+                  }
+                  long micros = ChronoUnit.MICROS.between(TIMESTAMP_NTZ_LOCAL_EPOCH, value);
+                  return ZOrderByteUtils.longToOrderedBytes(
+                          micros, inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE))
+                      .array();
+                },
+                DataTypes.BinaryType)
+            .withName("TIMESTAMP_NTZ_ORDERED_BYTES");
 
     this.inputCol++;
     increaseOutputSize(ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
@@ -311,7 +339,7 @@ class SparkZOrderUDF implements Serializable {
     } else if (type instanceof TimestampType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else if (type instanceof TimestampNTZType) {
-      return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
+      return timestampNtzToOrderedBytesUDF().apply(column);
     } else if (type instanceof DateType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.data.FileHelpers.encrypt;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.current_date;
 import static org.apache.spark.sql.functions.date_add;
 import static org.apache.spark.sql.functions.expr;
@@ -127,6 +128,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -2607,6 +2609,23 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(readConf.cacheDeleteFilesOnExecutors())
         .as("Executor cache for delete files should be disabled in RewriteDataFilesSparkAction")
         .isFalse();
+  }
+
+  @TestTemplate
+  public void testZOrderUDFWithTimestampNTZType() {
+    SparkZOrderUDF zorderUDF = new SparkZOrderUDF(1, 16, 1024);
+    Dataset<Row> result =
+        spark
+            .sql("SELECT timestamp_ntz '2025-01-01 12:00:00' as test_col")
+            .withColumn(
+                "zorder_result",
+                zorderUDF.sortedLexicographically(col("test_col"), DataTypes.TimestampNTZType));
+
+    assertThat(result.schema().apply("zorder_result").dataType()).isEqualTo(DataTypes.BinaryType);
+    List<Row> rows = result.collectAsList();
+    Row row = rows.get(0);
+    byte[] zorderBytes = row.getAs("zorder_result");
+    assertThat(zorderBytes).isNotNull().isNotEmpty();
   }
 
   private double percentFilesRequired(Table table, String col, String value) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -40,6 +40,7 @@ import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.types.TimestampType;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -308,6 +309,8 @@ class SparkZOrderUDF implements Serializable {
     } else if (type instanceof BooleanType) {
       return booleanToOrderedBytesUDF().apply(column);
     } else if (type instanceof TimestampType) {
+      return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
+    } else if (type instanceof TimestampNTZType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else if (type instanceof DateType) {
       return longToOrderedBytesUDF().apply(functions.unix_date(column).cast(DataTypes.LongType));

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -49,9 +49,6 @@ import scala.collection.Seq;
 
 class SparkZOrderUDF implements Serializable {
   private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
-
-  private static final LocalDateTime TIMESTAMP_NTZ_LOCAL_EPOCH =
-      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0);
 
   /**
    * Every Spark task runs iteratively on a rows in a single thread so ThreadLocal should protect
@@ -195,7 +192,7 @@ class SparkZOrderUDF implements Serializable {
                   if (value == null) {
                     return PRIMITIVE_EMPTY;
                   }
-                  long micros = ChronoUnit.MICROS.between(TIMESTAMP_NTZ_LOCAL_EPOCH, value);
+                  long micros = DateTimeUtil.microsFromTimestamp(value);
                   return ZOrderByteUtils.longToOrderedBytes(
                           micros, inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE))
                       .array();

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -47,6 +49,9 @@ import scala.collection.Seq;
 
 class SparkZOrderUDF implements Serializable {
   private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
+
+  private static final LocalDateTime TIMESTAMP_NTZ_LOCAL_EPOCH =
+      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0);
 
   /**
    * Every Spark task runs iteratively on a rows in a single thread so ThreadLocal should protect
@@ -174,6 +179,29 @@ class SparkZOrderUDF implements Serializable {
                 },
                 DataTypes.BinaryType)
             .withName("LONG_ORDERED_BYTES");
+
+    this.inputCol++;
+    increaseOutputSize(ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
+
+    return udf;
+  }
+
+  private UserDefinedFunction timestampNtzToOrderedBytesUDF() {
+    int position = inputCol;
+    UserDefinedFunction udf =
+        functions
+            .udf(
+                (LocalDateTime value) -> {
+                  if (value == null) {
+                    return PRIMITIVE_EMPTY;
+                  }
+                  long micros = ChronoUnit.MICROS.between(TIMESTAMP_NTZ_LOCAL_EPOCH, value);
+                  return ZOrderByteUtils.longToOrderedBytes(
+                          micros, inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE))
+                      .array();
+                },
+                DataTypes.BinaryType)
+            .withName("TIMESTAMP_NTZ_ORDERED_BYTES");
 
     this.inputCol++;
     increaseOutputSize(ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
@@ -311,7 +339,7 @@ class SparkZOrderUDF implements Serializable {
     } else if (type instanceof TimestampType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else if (type instanceof TimestampNTZType) {
-      return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
+      return timestampNtzToOrderedBytesUDF().apply(column);
     } else if (type instanceof DateType) {
       return longToOrderedBytesUDF().apply(functions.unix_date(column).cast(DataTypes.LongType));
     } else {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2129,6 +2129,23 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(zorderBytes).isNotNull().isNotEmpty();
   }
 
+  @TestTemplate
+  public void testZOrderUDFWithTimestampNTZType() {
+    SparkZOrderUDF zorderUDF = new SparkZOrderUDF(1, 16, 1024);
+    Dataset<Row> result =
+        spark
+            .sql("SELECT timestamp_ntz '2025-01-01 12:00:00' as test_col")
+            .withColumn(
+                "zorder_result",
+                zorderUDF.sortedLexicographically(col("test_col"), DataTypes.TimestampNTZType));
+
+    assertThat(result.schema().apply("zorder_result").dataType()).isEqualTo(DataTypes.BinaryType);
+    List<Row> rows = result.collectAsList();
+    Row row = rows.get(0);
+    byte[] zorderBytes = row.getAs("zorder_result");
+    assertThat(zorderBytes).isNotNull().isNotEmpty();
+  }
+
   protected void shouldRewriteDataFilesWithPartitionSpec(Table table, int outputSpecId) {
     List<DataFile> rewrittenFiles = currentDataFiles(table);
     assertThat(rewrittenFiles).allMatch(file -> file.specId() == outputSpecId);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -40,6 +40,7 @@ import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.types.TimestampType;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -308,6 +309,8 @@ class SparkZOrderUDF implements Serializable {
     } else if (type instanceof BooleanType) {
       return booleanToOrderedBytesUDF().apply(column);
     } else if (type instanceof TimestampType) {
+      return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
+    } else if (type instanceof TimestampNTZType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else if (type instanceof DateType) {
       return longToOrderedBytesUDF().apply(functions.unix_date(column).cast(DataTypes.LongType));

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -49,9 +49,6 @@ import scala.collection.Seq;
 
 class SparkZOrderUDF implements Serializable {
   private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
-
-  private static final LocalDateTime TIMESTAMP_NTZ_LOCAL_EPOCH =
-      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0);
 
   /**
    * Every Spark task runs iteratively on a rows in a single thread so ThreadLocal should protect
@@ -195,7 +192,7 @@ class SparkZOrderUDF implements Serializable {
                   if (value == null) {
                     return PRIMITIVE_EMPTY;
                   }
-                  long micros = ChronoUnit.MICROS.between(TIMESTAMP_NTZ_LOCAL_EPOCH, value);
+                  long micros = DateTimeUtil.microsFromTimestamp(value);
                   return ZOrderByteUtils.longToOrderedBytes(
                           micros, inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE))
                       .array();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderUDF.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import org.apache.iceberg.util.ZOrderByteUtils;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -47,6 +49,9 @@ import scala.collection.Seq;
 
 class SparkZOrderUDF implements Serializable {
   private static final byte[] PRIMITIVE_EMPTY = new byte[ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE];
+
+  private static final LocalDateTime TIMESTAMP_NTZ_LOCAL_EPOCH =
+      LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0);
 
   /**
    * Every Spark task runs iteratively on a rows in a single thread so ThreadLocal should protect
@@ -174,6 +179,29 @@ class SparkZOrderUDF implements Serializable {
                 },
                 DataTypes.BinaryType)
             .withName("LONG_ORDERED_BYTES");
+
+    this.inputCol++;
+    increaseOutputSize(ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
+
+    return udf;
+  }
+
+  private UserDefinedFunction timestampNtzToOrderedBytesUDF() {
+    int position = inputCol;
+    UserDefinedFunction udf =
+        functions
+            .udf(
+                (LocalDateTime value) -> {
+                  if (value == null) {
+                    return PRIMITIVE_EMPTY;
+                  }
+                  long micros = ChronoUnit.MICROS.between(TIMESTAMP_NTZ_LOCAL_EPOCH, value);
+                  return ZOrderByteUtils.longToOrderedBytes(
+                          micros, inputBuffer(position, ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE))
+                      .array();
+                },
+                DataTypes.BinaryType)
+            .withName("TIMESTAMP_NTZ_ORDERED_BYTES");
 
     this.inputCol++;
     increaseOutputSize(ZOrderByteUtils.PRIMITIVE_BUFFER_SIZE);
@@ -311,7 +339,7 @@ class SparkZOrderUDF implements Serializable {
     } else if (type instanceof TimestampType) {
       return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
     } else if (type instanceof TimestampNTZType) {
-      return longToOrderedBytesUDF().apply(column.cast(DataTypes.LongType));
+      return timestampNtzToOrderedBytesUDF().apply(column);
     } else if (type instanceof DateType) {
       return longToOrderedBytesUDF().apply(functions.unix_date(column).cast(DataTypes.LongType));
     } else {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2129,6 +2129,23 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(zorderBytes).isNotNull().isNotEmpty();
   }
 
+  @TestTemplate
+  public void testZOrderUDFWithTimestampNTZType() {
+    SparkZOrderUDF zorderUDF = new SparkZOrderUDF(1, 16, 1024);
+    Dataset<Row> result =
+        spark
+            .sql("SELECT timestamp_ntz '2025-01-01 12:00:00' as test_col")
+            .withColumn(
+                "zorder_result",
+                zorderUDF.sortedLexicographically(col("test_col"), DataTypes.TimestampNTZType));
+
+    assertThat(result.schema().apply("zorder_result").dataType()).isEqualTo(DataTypes.BinaryType);
+    List<Row> rows = result.collectAsList();
+    Row row = rows.get(0);
+    byte[] zorderBytes = row.getAs("zorder_result");
+    assertThat(zorderBytes).isNotNull().isNotEmpty();
+  }
+
   protected void shouldRewriteDataFilesWithPartitionSpec(Table table, int outputSpecId) {
     List<DataFile> rewrittenFiles = currentDataFiles(table);
     assertThat(rewrittenFiles).allMatch(file -> file.specId() == outputSpecId);


### PR DESCRIPTION
### Problem

`SparkZOrderUDF` only handled `TimestampType`, not `TimestampNTZType`, so `rewrite_data_files` + `zorder()` failed on `timestamp_ntz` columns.

### Changes

- Treat `TimestampNTZType` like `TimestampType` in `sortedLexicographically` (long → ordered bytes for Z-order).
- Tests for Z-order rewrite with `timestamp_ntz`.

Closes #15777