### PR TITLE
Flink Sink: Add WriteObserver plugin interface for per-record metadata

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommittable.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommittable.java
@@ -20,7 +20,10 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
 /**
@@ -36,12 +39,23 @@ class IcebergCommittable implements Serializable {
   private final String jobId;
   private final String operatorId;
   private final long checkpointId;
+  private final Map<String, String> observerMetadata;
 
   IcebergCommittable(byte[] manifest, String jobId, String operatorId, long checkpointId) {
+    this(manifest, jobId, operatorId, checkpointId, null);
+  }
+
+  IcebergCommittable(
+      byte[] manifest,
+      String jobId,
+      String operatorId,
+      long checkpointId,
+      @Nullable Map<String, String> observerMetadata) {
     this.manifest = manifest;
     this.jobId = jobId;
     this.operatorId = operatorId;
     this.checkpointId = checkpointId;
+    this.observerMetadata = observerMetadata != null ? observerMetadata : Collections.emptyMap();
   }
 
   byte[] manifest() {
@@ -58,6 +72,10 @@ class IcebergCommittable implements Serializable {
 
   Long checkpointId() {
     return checkpointId;
+  }
+
+  Map<String, String> observerMetadata() {
+    return observerMetadata;
   }
 
   @Override

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommittableSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommittableSerializer.java
@@ -20,9 +20,11 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Map;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 /**
  * This serializer is used for serializing the {@link IcebergCommittable} objects between the Writer
@@ -31,7 +33,7 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
  * <p>In both cases only the respective part is serialized.
  */
 public class IcebergCommittableSerializer implements SimpleVersionedSerializer<IcebergCommittable> {
-  private static final int VERSION = 1;
+  private static final int VERSION = 2;
 
   @Override
   public int getVersion() {
@@ -47,22 +49,62 @@ public class IcebergCommittableSerializer implements SimpleVersionedSerializer<I
     view.writeLong(committable.checkpointId());
     view.writeInt(committable.manifest().length);
     view.write(committable.manifest());
+
+    Map<String, String> metadata = committable.observerMetadata();
+    if (metadata != null && !metadata.isEmpty()) {
+      view.writeBoolean(true);
+      view.writeInt(metadata.size());
+      for (Map.Entry<String, String> entry : metadata.entrySet()) {
+        view.writeUTF(entry.getKey());
+        view.writeUTF(entry.getValue());
+      }
+    } else {
+      view.writeBoolean(false);
+    }
+
     return out.toByteArray();
   }
 
   @Override
   public IcebergCommittable deserialize(int version, byte[] serialized) throws IOException {
     if (version == 1) {
-      DataInputDeserializer view = new DataInputDeserializer(serialized);
-      String jobId = view.readUTF();
-      String operatorId = view.readUTF();
-      long checkpointId = view.readLong();
-      int manifestLen = view.readInt();
-      byte[] manifestBuf;
-      manifestBuf = new byte[manifestLen];
-      view.read(manifestBuf);
-      return new IcebergCommittable(manifestBuf, jobId, operatorId, checkpointId);
+      return deserializeV1(serialized);
+    } else if (version == 2) {
+      return deserializeV2(serialized);
     }
     throw new IOException("Unrecognized version or corrupt state: " + version);
+  }
+
+  private IcebergCommittable deserializeV1(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    String jobId = view.readUTF();
+    String operatorId = view.readUTF();
+    long checkpointId = view.readLong();
+    int manifestLen = view.readInt();
+    byte[] manifestBuf = new byte[manifestLen];
+    view.read(manifestBuf);
+    return new IcebergCommittable(manifestBuf, jobId, operatorId, checkpointId);
+  }
+
+  private IcebergCommittable deserializeV2(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    String jobId = view.readUTF();
+    String operatorId = view.readUTF();
+    long checkpointId = view.readLong();
+    int manifestLen = view.readInt();
+    byte[] manifestBuf = new byte[manifestLen];
+    view.read(manifestBuf);
+
+    Map<String, String> metadata = null;
+    boolean hasMetadata = view.readBoolean();
+    if (hasMetadata) {
+      int mapSize = view.readInt();
+      metadata = Maps.newHashMapWithExpectedSize(mapSize);
+      for (int i = 0; i < mapSize; i++) {
+        metadata.put(view.readUTF(), view.readUTF());
+      }
+    }
+
+    return new IcebergCommittable(manifestBuf, jobId, operatorId, checkpointId, metadata);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.iceberg.AppendFiles;
@@ -157,13 +158,20 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
     long checkpointId = commitRequestMap.lastKey();
     List<ManifestFile> manifests = Lists.newArrayList();
     NavigableMap<Long, WriteResult> pendingResults = Maps.newTreeMap();
+
+    // Merge observer metadata from all committables
+    Map<String, String> mergedObserverMetadata = Maps.newHashMap();
     for (Map.Entry<Long, CommitRequest<IcebergCommittable>> e : commitRequestMap.entrySet()) {
-      if (Arrays.equals(EMPTY_MANIFEST_DATA, e.getValue().getCommittable().manifest())) {
+      IcebergCommittable committable = e.getValue().getCommittable();
+      if (!committable.observerMetadata().isEmpty()) {
+        mergedObserverMetadata.putAll(committable.observerMetadata());
+      }
+      if (Arrays.equals(EMPTY_MANIFEST_DATA, committable.manifest())) {
         pendingResults.put(e.getKey(), EMPTY_WRITE_RESULT);
       } else {
         DeltaManifests deltaManifests =
             SimpleVersionedSerialization.readVersionAndDeSerialize(
-                DeltaManifestsSerializer.INSTANCE, e.getValue().getCommittable().manifest());
+                DeltaManifestsSerializer.INSTANCE, committable.manifest());
         pendingResults.put(
             e.getKey(),
             FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs()));
@@ -171,8 +179,10 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       }
     }
 
+    Map<String, String> observerMetadata =
+        mergedObserverMetadata.isEmpty() ? null : mergedObserverMetadata;
     CommitSummary summary = new CommitSummary(pendingResults);
-    commitPendingResult(pendingResults, summary, newFlinkJobId, operatorId);
+    commitPendingResult(pendingResults, summary, newFlinkJobId, operatorId, observerMetadata);
     if (committerMetrics != null) {
       committerMetrics.updateCommitSummary(summary);
     }
@@ -195,14 +205,15 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       NavigableMap<Long, WriteResult> pendingResults,
       CommitSummary summary,
       String newFlinkJobId,
-      String operatorId) {
+      String operatorId,
+      @Nullable Map<String, String> observerMetadata) {
     long totalFiles = summary.dataFilesCount() + summary.deleteFilesCount();
     continuousEmptyCheckpoints = totalFiles == 0 ? continuousEmptyCheckpoints + 1 : 0;
     if (totalFiles != 0 || continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0) {
       if (replacePartitions) {
-        replacePartitions(pendingResults, summary, newFlinkJobId, operatorId);
+        replacePartitions(pendingResults, summary, newFlinkJobId, operatorId, observerMetadata);
       } else {
-        commitDeltaTxn(pendingResults, summary, newFlinkJobId, operatorId);
+        commitDeltaTxn(pendingResults, summary, newFlinkJobId, operatorId, observerMetadata);
       }
       continuousEmptyCheckpoints = 0;
     } else {
@@ -215,7 +226,8 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       NavigableMap<Long, WriteResult> pendingResults,
       CommitSummary summary,
       String newFlinkJobId,
-      String operatorId) {
+      String operatorId,
+      @Nullable Map<String, String> observerMetadata) {
     long checkpointId = pendingResults.lastKey();
     Preconditions.checkState(
         summary.deleteFilesCount() == 0, "Cannot overwrite partitions with delete files.");
@@ -229,14 +241,16 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
     String description = "dynamic partition overwrite";
 
     logCommitSummary(summary, description);
-    commitOperation(dynamicOverwrite, description, newFlinkJobId, operatorId, checkpointId);
+    commitOperation(
+        dynamicOverwrite, description, newFlinkJobId, operatorId, checkpointId, observerMetadata);
   }
 
   private void commitDeltaTxn(
       NavigableMap<Long, WriteResult> pendingResults,
       CommitSummary summary,
       String newFlinkJobId,
-      String operatorId) {
+      String operatorId,
+      @Nullable Map<String, String> observerMetadata) {
     long checkpointId = pendingResults.lastKey();
     if (summary.deleteFilesCount() == 0) {
       // To be compatible with iceberg format V1.
@@ -250,7 +264,8 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       String description = "append";
       logCommitSummary(summary, description);
       // fail all commits as really its only one
-      commitOperation(appendFiles, description, newFlinkJobId, operatorId, checkpointId);
+      commitOperation(
+          appendFiles, description, newFlinkJobId, operatorId, checkpointId, observerMetadata);
     } else {
       // To be compatible with iceberg format V2.
       for (Map.Entry<Long, WriteResult> e : pendingResults.entrySet()) {
@@ -274,7 +289,8 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
 
         String description = "rowDelta";
         logCommitSummary(summary, description);
-        commitOperation(rowDelta, description, newFlinkJobId, operatorId, e.getKey());
+        commitOperation(
+            rowDelta, description, newFlinkJobId, operatorId, e.getKey(), observerMetadata);
       }
     }
   }
@@ -284,9 +300,13 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       String description,
       String newFlinkJobId,
       String operatorId,
-      long checkpointId) {
+      long checkpointId,
+      @Nullable Map<String, String> observerMetadata) {
 
     snapshotProperties.forEach(operation::set);
+    if (observerMetadata != null) {
+      observerMetadata.forEach(operation::set);
+    }
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
     // used by the sink.
     operation.set(SinkUtil.MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -303,10 +303,17 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       long checkpointId,
       @Nullable Map<String, String> observerMetadata) {
 
-    snapshotProperties.forEach(operation::set);
     if (observerMetadata != null) {
+      if (!snapshotProperties.isEmpty()) {
+        for (String key : observerMetadata.keySet()) {
+          if (snapshotProperties.containsKey(key)) {
+            LOG.warn("Observer metadata key '{}' will be overridden by snapshot property", key);
+          }
+        }
+      }
       observerMetadata.forEach(operation::set);
     }
+    snapshotProperties.forEach(operation::set);
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
     // used by the sink.
     operation.set(SinkUtil.MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -324,7 +324,10 @@ public class IcebergSink
     // parallelism to 1, this can be removed.
     return writeResults
         .global()
-        .transform(preCommitAggregatorUid, typeInformation, new IcebergWriteAggregator(tableLoader))
+        .transform(
+            preCommitAggregatorUid,
+            typeInformation,
+            new IcebergWriteAggregator(tableLoader, writeObserver))
         .uid(preCommitAggregatorUid)
         .setParallelism(1)
         .setMaxParallelism(1)

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.SupportsConcurrentExecutionAttempts;
@@ -174,6 +175,8 @@ public class IcebergSink
   private final transient List<MaintenanceTaskBuilder<?>> maintenanceTasks;
   private final transient FlinkMaintenanceConfig flinkMaintenanceConfig;
 
+  @Nullable private final WriteObserver writeObserver;
+
   private IcebergSink(
       TableLoader tableLoader,
       Table table,
@@ -188,7 +191,8 @@ public class IcebergSink
       boolean overwriteMode,
       List<MaintenanceTaskBuilder<?>> maintenanceTasks,
       FlinkMaintenanceConfig flinkMaintenanceConfig,
-      Set<String> equalityFieldColumns) {
+      Set<String> equalityFieldColumns,
+      @Nullable WriteObserver writeObserver) {
     this.tableLoader = tableLoader;
     this.snapshotProperties = snapshotProperties;
     this.uidSuffix = uidSuffix;
@@ -212,6 +216,7 @@ public class IcebergSink
     this.maintenanceTasks = maintenanceTasks;
     this.flinkMaintenanceConfig = flinkMaintenanceConfig;
     this.equalityFieldColumns = equalityFieldColumns;
+    this.writeObserver = writeObserver;
   }
 
   @Override
@@ -232,7 +237,8 @@ public class IcebergSink
         taskWriterFactory,
         metrics,
         context.getTaskInfo().getIndexOfThisSubtask(),
-        context.getTaskInfo().getAttemptNumber());
+        context.getTaskInfo().getAttemptNumber(),
+        writeObserver);
   }
 
   @Override
@@ -349,6 +355,7 @@ public class IcebergSink
     private ReadableConfig readableConfig = new Configuration();
     private List<String> equalityFieldColumns = null;
     private final List<MaintenanceTaskBuilder<?>> maintenanceTasks = Lists.newArrayList();
+    @Nullable private WriteObserver writeObserver;
 
     private Builder() {}
 
@@ -716,6 +723,11 @@ public class IcebergSink
       return this;
     }
 
+    public Builder writeObserver(WriteObserver observer) {
+      this.writeObserver = observer;
+      return this;
+    }
+
     IcebergSink build() {
 
       Preconditions.checkArgument(
@@ -806,7 +818,8 @@ public class IcebergSink
           overwriteMode,
           maintenanceTasks,
           flinkMaintenanceConfig,
-          equalityFieldColumnsSet);
+          equalityFieldColumnsSet,
+          writeObserver);
     }
 
     /**

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSinkWriter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSinkWriter.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.flink.api.connector.sink2.CommittingSinkWriter;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.table.data.RowData;
@@ -46,6 +48,7 @@ class IcebergSinkWriter implements CommittingSinkWriter<RowData, WriteResult> {
   private TaskWriter<RowData> writer;
   private final int subTaskId;
   private final int attemptId;
+  @Nullable private final WriteObserver writeObserver;
 
   IcebergSinkWriter(
       String fullTableName,
@@ -53,6 +56,16 @@ class IcebergSinkWriter implements CommittingSinkWriter<RowData, WriteResult> {
       IcebergStreamWriterMetrics metrics,
       int subTaskId,
       int attemptId) {
+    this(fullTableName, taskWriterFactory, metrics, subTaskId, attemptId, null);
+  }
+
+  IcebergSinkWriter(
+      String fullTableName,
+      TaskWriterFactory<RowData> taskWriterFactory,
+      IcebergStreamWriterMetrics metrics,
+      int subTaskId,
+      int attemptId,
+      @Nullable WriteObserver writeObserver) {
     this.fullTableName = fullTableName;
     this.taskWriterFactory = taskWriterFactory;
     // Initialize the task writer factory.
@@ -62,6 +75,7 @@ class IcebergSinkWriter implements CommittingSinkWriter<RowData, WriteResult> {
     this.metrics = metrics;
     this.subTaskId = subTaskId;
     this.attemptId = attemptId;
+    this.writeObserver = writeObserver;
     LOG.debug(
         "Created Stream Writer for table {} subtask {} attemptId {}",
         fullTableName,
@@ -71,6 +85,9 @@ class IcebergSinkWriter implements CommittingSinkWriter<RowData, WriteResult> {
 
   @Override
   public void write(RowData element, Context context) throws IOException, InterruptedException {
+    if (writeObserver != null) {
+      writeObserver.observe(element, context);
+    }
     writer.write(element);
   }
 
@@ -108,6 +125,14 @@ class IcebergSinkWriter implements CommittingSinkWriter<RowData, WriteResult> {
         attemptId,
         result.dataFiles().length,
         result.deleteFiles().length);
+
+    if (writeObserver != null) {
+      Map<String, String> metadata = writeObserver.snapshotMetadata();
+      if (metadata != null && !metadata.isEmpty()) {
+        WriteObserverMetadataHolder.set(metadata);
+      }
+    }
+
     return Lists.newArrayList(result);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergWriteAggregator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergWriteAggregator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -54,6 +55,7 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
 
   private final Collection<WriteResult> results;
   private final TableLoader tableLoader;
+  @Nullable private final WriteObserver writeObserver;
   private final Map<String, String> accumulatedObserverMetadata = Maps.newHashMap();
 
   private long lastCheckpointId = CheckpointIDCounter.INITIAL_CHECKPOINT_ID - 1;
@@ -62,8 +64,13 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
   private transient Table table;
 
   IcebergWriteAggregator(TableLoader tableLoader) {
+    this(tableLoader, null);
+  }
+
+  IcebergWriteAggregator(TableLoader tableLoader, @Nullable WriteObserver writeObserver) {
     this.results = Sets.newHashSet();
     this.tableLoader = tableLoader;
+    this.writeObserver = writeObserver;
   }
 
   @Override
@@ -160,10 +167,18 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
       results.add(((CommittableWithLineage<WriteResult>) element.getValue()).getCommittable());
 
       // Read observer metadata set by WriteResultSerializer.deserialize() on this thread.
-      // Merge across parallel writer subtasks — last value wins for duplicate keys.
+      // Merge across parallel writer subtasks using the observer's merge strategy.
       Map<String, String> metadata = WriteObserverMetadataHolder.getAndClear();
       if (metadata != null && !metadata.isEmpty()) {
-        accumulatedObserverMetadata.putAll(metadata);
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+          accumulatedObserverMetadata.merge(
+              entry.getKey(),
+              entry.getValue(),
+              (existing, incoming) ->
+                  writeObserver != null
+                      ? writeObserver.mergeValue(entry.getKey(), existing, incoming)
+                      : incoming);
+        }
       }
     }
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergWriteAggregator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergWriteAggregator.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -34,6 +35,7 @@ import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +54,7 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
 
   private final Collection<WriteResult> results;
   private final TableLoader tableLoader;
+  private final Map<String, String> accumulatedObserverMetadata = Maps.newHashMap();
 
   private long lastCheckpointId = CheckpointIDCounter.INITIAL_CHECKPOINT_ID - 1;
 
@@ -106,12 +109,16 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
 
     this.lastCheckpointId = checkpointId;
 
+    Map<String, String> metadata =
+        accumulatedObserverMetadata.isEmpty() ? null : Maps.newHashMap(accumulatedObserverMetadata);
+
     IcebergCommittable committable =
         new IcebergCommittable(
             writeToManifest(results, checkpointId),
             getContainingTask().getEnvironment().getJobID().toString(),
             getRuntimeContext().getOperatorUniqueID(),
-            checkpointId);
+            checkpointId,
+            metadata);
     CommittableMessage<IcebergCommittable> summary =
         new CommittableSummary<>(0, 1, checkpointId, 1, 1, 0);
     output.collect(new StreamRecord<>(summary));
@@ -120,6 +127,7 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
     output.collect(new StreamRecord<>(message));
     LOG.info("Emitted commit message to downstream committer operator");
     results.clear();
+    accumulatedObserverMetadata.clear();
   }
 
   /**
@@ -150,6 +158,13 @@ class IcebergWriteAggregator extends AbstractStreamOperator<CommittableMessage<I
 
     if (element.isRecord() && element.getValue() instanceof CommittableWithLineage) {
       results.add(((CommittableWithLineage<WriteResult>) element.getValue()).getCommittable());
+
+      // Read observer metadata set by WriteResultSerializer.deserialize() on this thread.
+      // Merge across parallel writer subtasks — last value wins for duplicate keys.
+      Map<String, String> metadata = WriteObserverMetadataHolder.getAndClear();
+      if (metadata != null && !metadata.isEmpty()) {
+        accumulatedObserverMetadata.putAll(metadata);
+      }
     }
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/WriteObserver.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/WriteObserver.java
@@ -66,4 +66,20 @@ public interface WriteObserver extends Serializable {
   default Map<String, String> snapshotMetadata() {
     return Collections.emptyMap();
   }
+
+  /**
+   * Merges a metadata value when the same key appears from multiple writer subtasks.
+   *
+   * <p>Called by the aggregator when accumulating metadata from parallel writers. The default
+   * returns {@code incoming}, matching last-writer-wins behavior. Override for semantics like
+   * {@code Math.min} (watermarks) or {@code Math.max} (high watermarks).
+   *
+   * @param key the metadata key that appears in both the existing and incoming maps
+   * @param existing the previously accumulated value for this key
+   * @param incoming the new value from the current writer subtask
+   * @return the merged value to keep
+   */
+  default String mergeValue(String key, String existing, String incoming) {
+    return incoming;
+  }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/WriteObserver.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/WriteObserver.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Observer that is notified for each record written by {@link IcebergSinkWriter} and produces
+ * per-checkpoint metadata that flows through the sink pipeline to the Iceberg snapshot summary.
+ *
+ * <p>Use cases include per-record watermark extraction, data quality score tracking, or custom
+ * metadata that should be attached to each committed Iceberg snapshot.
+ *
+ * <p>The observer is called on the writer's task thread. {@link #observe(RowData,
+ * SinkWriter.Context)} is called for each record. At checkpoint time, {@link #snapshotMetadata()}
+ * is called to collect accumulated metadata, which is then carried through the aggregator to the
+ * committer and applied as additional Iceberg snapshot properties. The returned metadata map is
+ * merged across parallel writer subtasks in the aggregator.
+ *
+ * <p>Implementations must be {@link Serializable} because the observer travels through the Flink
+ * job graph (client → TaskManager) as part of {@link IcebergSink}.
+ */
+public interface WriteObserver extends Serializable {
+
+  /**
+   * Called for each record written by the sink writer.
+   *
+   * @param element the record being written
+   * @param context the sink writer context, providing access to the current Flink watermark
+   */
+  void observe(RowData element, SinkWriter.Context context);
+
+  /**
+   * Called at checkpoint time to collect accumulated metadata for this checkpoint interval.
+   *
+   * <p>The returned map entries are applied as additional Iceberg snapshot properties alongside the
+   * static {@code snapshotProperties} configured on the sink builder. Implementations should reset
+   * their internal accumulators after this call so the next checkpoint interval starts fresh.
+   *
+   * <p>When multiple writer subtasks produce metadata, the aggregator merges them by taking the
+   * last value for each key. For watermark-style metadata, implementations should use keys that
+   * include a subtask identifier, or the aggregator's merge logic should be considered.
+   *
+   * @return metadata key-value pairs to include in the snapshot summary, or an empty map
+   */
+  default Map<String, String> snapshotMetadata() {
+    return Collections.emptyMap();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/WriteObserverMetadataHolder.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/WriteObserverMetadataHolder.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Thread-local holder for passing {@link WriteObserver} metadata through the WriteResult
+ * serialization boundary.
+ *
+ * <p>On the writer side: {@link IcebergSinkWriter#prepareCommit()} stores metadata here, then
+ * {@link WriteResultSerializer#serialize} reads and clears it. Both run on the writer's task
+ * thread.
+ *
+ * <p>On the aggregator side: {@link WriteResultSerializer#deserialize} stores metadata here, then
+ * {@link IcebergWriteAggregator#processElement} reads and clears it. Both run on the aggregator's
+ * task thread.
+ *
+ * <p>This is safe because Flink processes elements sequentially on each task thread -- serialize
+ * and prepareCommit share one thread, deserialize and processElement share another.
+ */
+final class WriteObserverMetadataHolder {
+  private static final ThreadLocal<Map<String, String>> METADATA = new ThreadLocal<>();
+
+  private WriteObserverMetadataHolder() {}
+
+  static void set(@Nullable Map<String, String> metadata) {
+    METADATA.set(metadata);
+  }
+
+  @Nullable
+  static Map<String, String> getAndClear() {
+    Map<String, String> metadata = METADATA.get();
+    METADATA.remove();
+    return metadata;
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/WriteResultSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/WriteResultSerializer.java
@@ -20,16 +20,18 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Map;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 @Internal
 public class WriteResultSerializer implements SimpleVersionedSerializer<WriteResult> {
-  private static final int VERSION = 1;
+  private static final int VERSION = 2;
 
   @Override
   public int getVersion() {
@@ -40,24 +42,73 @@ public class WriteResultSerializer implements SimpleVersionedSerializer<WriteRes
   public byte[] serialize(WriteResult writeResult) throws IOException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+
     byte[] result = InstantiationUtil.serializeObject(writeResult);
+    view.writeInt(result.length);
     view.write(result);
+
+    Map<String, String> metadata = WriteObserverMetadataHolder.getAndClear();
+    if (metadata != null && !metadata.isEmpty()) {
+      view.writeBoolean(true);
+      view.writeInt(metadata.size());
+      for (Map.Entry<String, String> entry : metadata.entrySet()) {
+        view.writeUTF(entry.getKey());
+        view.writeUTF(entry.getValue());
+      }
+    } else {
+      view.writeBoolean(false);
+    }
+
     return out.toByteArray();
   }
 
   @Override
   public WriteResult deserialize(int version, byte[] serialized) throws IOException {
     if (version == 1) {
-      DataInputDeserializer view = new DataInputDeserializer(serialized);
-      byte[] resultBuf = new byte[serialized.length];
-      view.read(resultBuf);
-      try {
-        return InstantiationUtil.deserializeObject(
-            resultBuf, IcebergCommittableSerializer.class.getClassLoader());
-      } catch (ClassNotFoundException cnc) {
-        throw new IOException("Could not deserialize the WriteResult object", cnc);
-      }
+      return deserializeV1(serialized);
+    } else if (version == 2) {
+      return deserializeV2(serialized);
     }
     throw new IOException("Unrecognized version or corrupt state: " + version);
+  }
+
+  private WriteResult deserializeV1(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    byte[] resultBuf = new byte[serialized.length];
+    view.read(resultBuf);
+    try {
+      return InstantiationUtil.deserializeObject(
+          resultBuf, WriteResultSerializer.class.getClassLoader());
+    } catch (ClassNotFoundException cnc) {
+      throw new IOException("Could not deserialize the WriteResult object", cnc);
+    }
+  }
+
+  private WriteResult deserializeV2(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+
+    int resultLen = view.readInt();
+    byte[] resultBuf = new byte[resultLen];
+    view.read(resultBuf);
+    WriteResult writeResult;
+    try {
+      writeResult =
+          InstantiationUtil.deserializeObject(
+              resultBuf, WriteResultSerializer.class.getClassLoader());
+    } catch (ClassNotFoundException cnc) {
+      throw new IOException("Could not deserialize the WriteResult object", cnc);
+    }
+
+    boolean hasMetadata = view.readBoolean();
+    if (hasMetadata) {
+      int mapSize = view.readInt();
+      Map<String, String> metadata = Maps.newHashMapWithExpectedSize(mapSize);
+      for (int i = 0; i < mapSize; i++) {
+        metadata.put(view.readUTF(), view.readUTF());
+      }
+      WriteObserverMetadataHolder.set(metadata);
+    }
+
+    return writeResult;
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.io.WriteResult;
 
 class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicWriteResult> {
 
-  private static final int VERSION = 1;
+  private static final int VERSION = 2;
   private static final WriteResultSerializer WRITE_RESULT_SERIALIZER = new WriteResultSerializer();
 
   @Override
@@ -42,7 +42,10 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
     DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
     writeResult.key().serializeTo(view);
     view.writeInt(writeResult.specId());
+    int innerVersion = WRITE_RESULT_SERIALIZER.getVersion();
     byte[] result = WRITE_RESULT_SERIALIZER.serialize(writeResult.writeResult());
+    view.writeInt(innerVersion);
+    view.writeInt(result.length);
     view.write(result);
     return out.toByteArray();
   }
@@ -50,15 +53,32 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
   @Override
   public DynamicWriteResult deserialize(int version, byte[] serialized) throws IOException {
     if (version == 1) {
-      DataInputDeserializer view = new DataInputDeserializer(serialized);
-      TableKey key = TableKey.deserializeFrom(view);
-      int specId = view.readInt();
-      byte[] resultBuf = new byte[view.available()];
-      view.read(resultBuf);
-      WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(version, resultBuf);
-      return new DynamicWriteResult(key, specId, writeResult);
+      return deserializeV1(serialized);
+    } else if (version == 2) {
+      return deserializeV2(serialized);
     }
-
     throw new IOException("Unrecognized version or corrupt state: " + version);
+  }
+
+  private DynamicWriteResult deserializeV1(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    TableKey key = TableKey.deserializeFrom(view);
+    int specId = view.readInt();
+    byte[] resultBuf = new byte[view.available()];
+    view.read(resultBuf);
+    WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(1, resultBuf);
+    return new DynamicWriteResult(key, specId, writeResult);
+  }
+
+  private DynamicWriteResult deserializeV2(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    TableKey key = TableKey.deserializeFrom(view);
+    int specId = view.readInt();
+    int innerVersion = view.readInt();
+    int resultLen = view.readInt();
+    byte[] resultBuf = new byte[resultLen];
+    view.read(resultBuf);
+    WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(innerVersion, resultBuf);
+    return new DynamicWriteResult(key, specId, writeResult);
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommittableSerializer.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommittableSerializer.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+class TestIcebergCommittableSerializer {
+
+  private static final byte[] TEST_MANIFEST = new byte[] {1, 2, 3, 4};
+  private static final String JOB_ID = "test-job-id";
+  private static final String OPERATOR_ID = "test-operator-id";
+  private static final long CHECKPOINT_ID = 42L;
+
+  @Test
+  void testRoundtripWithoutMetadata() throws IOException {
+    IcebergCommittable committable =
+        new IcebergCommittable(TEST_MANIFEST, JOB_ID, OPERATOR_ID, CHECKPOINT_ID);
+
+    IcebergCommittableSerializer serializer = new IcebergCommittableSerializer();
+    IcebergCommittable copy =
+        serializer.deserialize(serializer.getVersion(), serializer.serialize(committable));
+
+    assertThat(copy.manifest()).isEqualTo(TEST_MANIFEST);
+    assertThat(copy.jobId()).isEqualTo(JOB_ID);
+    assertThat(copy.operatorId()).isEqualTo(OPERATOR_ID);
+    assertThat(copy.checkpointId()).isEqualTo(CHECKPOINT_ID);
+    assertThat(copy.observerMetadata()).isEmpty();
+  }
+
+  @Test
+  void testRoundtripWithMetadata() throws IOException {
+    Map<String, String> metadata = ImmutableMap.of("watermark", "1000", "quality", "high");
+    IcebergCommittable committable =
+        new IcebergCommittable(TEST_MANIFEST, JOB_ID, OPERATOR_ID, CHECKPOINT_ID, metadata);
+
+    IcebergCommittableSerializer serializer = new IcebergCommittableSerializer();
+    IcebergCommittable copy =
+        serializer.deserialize(serializer.getVersion(), serializer.serialize(committable));
+
+    assertThat(copy.manifest()).isEqualTo(TEST_MANIFEST);
+    assertThat(copy.jobId()).isEqualTo(JOB_ID);
+    assertThat(copy.operatorId()).isEqualTo(OPERATOR_ID);
+    assertThat(copy.checkpointId()).isEqualTo(CHECKPOINT_ID);
+    assertThat(copy.observerMetadata())
+        .containsEntry("watermark", "1000")
+        .containsEntry("quality", "high");
+  }
+
+  @Test
+  void testV1BackwardCompatibility() throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    view.writeUTF(JOB_ID);
+    view.writeUTF(OPERATOR_ID);
+    view.writeLong(CHECKPOINT_ID);
+    view.writeInt(TEST_MANIFEST.length);
+    view.write(TEST_MANIFEST);
+    byte[] v1Bytes = out.toByteArray();
+
+    IcebergCommittableSerializer serializer = new IcebergCommittableSerializer();
+    IcebergCommittable copy = serializer.deserialize(1, v1Bytes);
+
+    assertThat(copy.manifest()).isEqualTo(TEST_MANIFEST);
+    assertThat(copy.jobId()).isEqualTo(JOB_ID);
+    assertThat(copy.operatorId()).isEqualTo(OPERATOR_ID);
+    assertThat(copy.checkpointId()).isEqualTo(CHECKPOINT_ID);
+    assertThat(copy.observerMetadata()).isEmpty();
+  }
+
+  @Test
+  void testUnsupportedVersion() {
+    IcebergCommittable committable =
+        new IcebergCommittable(TEST_MANIFEST, JOB_ID, OPERATOR_ID, CHECKPOINT_ID);
+
+    IcebergCommittableSerializer serializer = new IcebergCommittableSerializer();
+    assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(committable)))
+        .hasMessage("Unrecognized version or corrupt state: -1")
+        .isInstanceOf(IOException.class);
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -1293,6 +1293,90 @@ class TestIcebergCommitter extends TestBase {
     return testHarness;
   }
 
+  @TestTemplate
+  public void testObserverMetadataInSnapshot() throws Exception {
+    IcebergCommitter committer = getCommitter();
+    assertSnapshotSize(0);
+
+    RowData rowData = SimpleDataUtil.createRowData(1, "hello");
+    DataFile dataFile = writeDataFile("data-observer-1", ImmutableList.of(rowData));
+    WriteResult writeResult = of(dataFile);
+    Map<String, String> observerMetadata = ImmutableMap.of("observer.key", "observer.value");
+
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestWithMetadata(jobId, 1, Lists.newArrayList(writeResult), observerMetadata);
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    assertSnapshotSize(1);
+    Map<String, String> summary = SimpleDataUtil.latestSnapshot(table, branch).summary();
+    assertThat(summary)
+        .containsEntry("observer.key", "observer.value")
+        .containsEntry("flink.test", "org.apache.iceberg.flink.sink.TestIcebergCommitter");
+  }
+
+  @TestTemplate
+  public void testObserverMetadataOverriddenBySnapshotProperties() throws Exception {
+    IcebergCommitter committer = getCommitter();
+    assertSnapshotSize(0);
+
+    RowData rowData = SimpleDataUtil.createRowData(1, "hello");
+    DataFile dataFile = writeDataFile("data-observer-2", ImmutableList.of(rowData));
+    WriteResult writeResult = of(dataFile);
+
+    Map<String, String> observerMetadata =
+        ImmutableMap.of("flink.test", "observer-should-lose", "observer.key", "observer.value");
+
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestWithMetadata(jobId, 1, Lists.newArrayList(writeResult), observerMetadata);
+    committer.commit(Lists.newArrayList(commitRequest));
+
+    assertSnapshotSize(1);
+    Map<String, String> summary = SimpleDataUtil.latestSnapshot(table, branch).summary();
+    assertThat(summary)
+        .containsEntry("flink.test", "org.apache.iceberg.flink.sink.TestIcebergCommitter")
+        .containsEntry("observer.key", "observer.value");
+  }
+
+  @TestTemplate
+  public void testObserverMetadataMergeAcrossSubtasks() throws Exception {
+    WriteObserver minMergeObserver =
+        new WriteObserver() {
+          @Override
+          public void observe(
+              RowData element, org.apache.flink.api.connector.sink2.SinkWriter.Context context) {}
+
+          @Override
+          public String mergeValue(String key, String existing, String incoming) {
+            return String.valueOf(Math.min(Long.parseLong(existing), Long.parseLong(incoming)));
+          }
+        };
+
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<WriteResult>, CommittableMessage<IcebergCommittable>>
+        testHarness =
+            new OneInputStreamOperatorTestHarness<>(
+                new IcebergWriteAggregator(tableLoader, minMergeObserver))) {
+
+      testHarness.open();
+
+      WriteObserverMetadataHolder.set(ImmutableMap.of("watermark", "1000"));
+      WriteResult result1 = WriteResult.builder().addDataFiles(dataFileTest1).build();
+      testHarness.processElement(new StreamRecord<>(new CommittableWithLineage<>(result1, 1, 0)));
+
+      WriteObserverMetadataHolder.set(ImmutableMap.of("watermark", "500"));
+      WriteResult result2 = WriteResult.builder().addDataFiles(dataFileTest2).build();
+      testHarness.processElement(new StreamRecord<>(new CommittableWithLineage<>(result2, 1, 1)));
+
+      testHarness.prepareSnapshotPreBarrier(1);
+
+      List<StreamElement> output = transformsToStreamElement(testHarness.getOutput());
+      assertThat(output).hasSize(2);
+      CommittableWithLineage<IcebergCommittable> committable =
+          extractAndAssertCommittableWithLineage(output.get(1));
+      assertThat(committable.getCommittable().observerMetadata()).containsEntry("watermark", "500");
+    }
+  }
+
   // ------------------------------- Utility Methods --------------------------------
 
   private IcebergCommitter getCommitter() {
@@ -1310,13 +1394,23 @@ class TestIcebergCommitter extends TestBase {
 
   private Committer.CommitRequest<IcebergCommittable> buildCommitRequestFor(
       String myJobID, long checkpoint, Collection<WriteResult> writeResults) throws IOException {
+    return buildCommitRequestWithMetadata(myJobID, checkpoint, writeResults, null);
+  }
+
+  private Committer.CommitRequest<IcebergCommittable> buildCommitRequestWithMetadata(
+      String myJobID,
+      long checkpoint,
+      Collection<WriteResult> writeResults,
+      Map<String, String> observerMetadata)
+      throws IOException {
     IcebergCommittable commit =
         new IcebergCommittable(
             buildIcebergWriteAggregator(myJobID, OPERATOR_ID)
                 .writeToManifest(writeResults, checkpoint),
             myJobID,
             OPERATOR_ID,
-            checkpoint);
+            checkpoint,
+            observerMetadata);
 
     CommittableWithLineage committableWithLineage =
         new CommittableWithLineage(commit, checkpoint, 1);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestWriteObserverMetadataHolder.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestWriteObserverMetadataHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+class TestWriteObserverMetadataHolder {
+
+  @Test
+  void testSetAndGetClearsThreadLocal() {
+    Map<String, String> metadata = ImmutableMap.of("key", "value");
+    WriteObserverMetadataHolder.set(metadata);
+
+    Map<String, String> retrieved = WriteObserverMetadataHolder.getAndClear();
+    assertThat(retrieved).isEqualTo(metadata);
+
+    assertThat(WriteObserverMetadataHolder.getAndClear()).isNull();
+  }
+
+  @Test
+  void testGetWithoutSetReturnsNull() {
+    assertThat(WriteObserverMetadataHolder.getAndClear()).isNull();
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestWriteResultSerializer.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestWriteResultSerializer.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+class TestWriteResultSerializer {
+
+  private static final DataFile DATA_FILE =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-1.parquet")
+          .withFileSizeInBytes(0)
+          .withMetrics(
+              new Metrics(
+                  42L,
+                  null,
+                  ImmutableMap.of(1, 5L),
+                  ImmutableMap.of(1, 0L),
+                  null,
+                  ImmutableMap.of(1, ByteBuffer.allocate(1)),
+                  ImmutableMap.of(1, ByteBuffer.allocate(1))))
+          .build();
+
+  @Test
+  void testRoundtripWithoutMetadata() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+
+    WriteResultSerializer serializer = new WriteResultSerializer();
+    WriteResult copy =
+        serializer.deserialize(serializer.getVersion(), serializer.serialize(writeResult));
+
+    assertThat(copy.dataFiles()).hasSize(1);
+    assertThat(copy.dataFiles()[0].path()).isEqualTo("/path/to/data-1.parquet");
+    assertThat(copy.dataFiles()[0].recordCount()).isEqualTo(42L);
+  }
+
+  @Test
+  void testRoundtripWithMetadata() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    Map<String, String> metadata = ImmutableMap.of("watermark", "1000", "quality", "high");
+
+    WriteResultSerializer serializer = new WriteResultSerializer();
+
+    WriteObserverMetadataHolder.set(metadata);
+    byte[] serialized = serializer.serialize(writeResult);
+
+    WriteResult copy = serializer.deserialize(serializer.getVersion(), serialized);
+    Map<String, String> recoveredMetadata = WriteObserverMetadataHolder.getAndClear();
+
+    assertThat(copy.dataFiles()).hasSize(1);
+    assertThat(copy.dataFiles()[0].path()).isEqualTo("/path/to/data-1.parquet");
+    assertThat(recoveredMetadata)
+        .containsEntry("watermark", "1000")
+        .containsEntry("quality", "high");
+  }
+
+  @Test
+  void testV1BackwardCompatibility() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+
+    byte[] v1Bytes = InstantiationUtil.serializeObject(writeResult);
+
+    WriteResultSerializer serializer = new WriteResultSerializer();
+    WriteResult copy = serializer.deserialize(1, v1Bytes);
+
+    assertThat(copy.dataFiles()).hasSize(1);
+    assertThat(copy.dataFiles()[0].path()).isEqualTo("/path/to/data-1.parquet");
+    assertThat(copy.dataFiles()[0].recordCount()).isEqualTo(42L);
+  }
+
+  @Test
+  void testUnsupportedVersion() {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+
+    WriteResultSerializer serializer = new WriteResultSerializer();
+    assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(writeResult)))
+        .hasMessage("Unrecognized version or corrupt state: -1")
+        .isInstanceOf(IOException.class);
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
@@ -21,8 +21,11 @@ package org.apache.iceberg.flink.sink.dynamic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.InstantiationUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Metrics;
@@ -66,6 +69,22 @@ class TestDynamicWriteResultSerializer {
   }
 
   @Test
+  void testV1BackwardCompatibility() throws IOException {
+    DynamicWriteResult dynamicWriteResult =
+        new DynamicWriteResult(TABLE_KEY, 1, WriteResult.builder().addDataFiles(DATA_FILE).build());
+
+    DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult copy = serializer.deserialize(1, serializeV1(dynamicWriteResult));
+
+    assertThat(copy.key()).isEqualTo(TABLE_KEY);
+    assertThat(copy.specId()).isEqualTo(1);
+    assertThat(copy.writeResult().dataFiles()).hasSize(1);
+    DataFile dataFile = copy.writeResult().dataFiles()[0];
+    assertThat(dataFile.path()).isEqualTo("/path/to/data-1.parquet");
+    assertThat(dataFile.recordCount()).isEqualTo(42L);
+  }
+
+  @Test
   void testUnsupportedVersion() {
     DynamicWriteResult dynamicWriteResult =
         new DynamicWriteResult(TABLE_KEY, 1, WriteResult.builder().addDataFiles(DATA_FILE).build());
@@ -74,5 +93,14 @@ class TestDynamicWriteResultSerializer {
     assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(dynamicWriteResult)))
         .hasMessage("Unrecognized version or corrupt state: -1")
         .isInstanceOf(IOException.class);
+  }
+
+  private byte[] serializeV1(DynamicWriteResult writeResult) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    writeResult.key().serializeTo(view);
+    view.writeInt(writeResult.specId());
+    view.write(InstantiationUtil.serializeObject(writeResult.writeResult()));
+    return out.toByteArray();
   }
 }


### PR DESCRIPTION
### Summary

Adds a `WriteObserver` plugin interface to `IcebergSink` (Sink V2) that observes each record written and produces per-checkpoint metadata that flows through the entire sink pipeline (writer → serializer → aggregator → committer) to the Iceberg snapshot summary.

Resolves #15783

### Motivation

Users need to extract per-record metadata (e.g., watermark timestamps, data quality scores) at the writer level and attach it to the committed Iceberg snapshot. Currently there is no way to propagate custom metadata from the writer through the aggregator to the committer without subclassing multiple internal classes.

### Changes

- New: `WriteObserver.java` -- interface with `observe(RowData, SinkWriter.Context)` and `default Map<String, String> snapshotMetadata()`
- New: `WriteObserverMetadataHolder.java` -- ThreadLocal holder for passing metadata through serialization boundaries
- Modified: `IcebergSinkWriter` -- calls observer per-record, collects metadata at checkpoint
- Modified: `WriteResultSerializer` -- v2 format carries observer metadata alongside WriteResult
- Modified: `IcebergWriteAggregator` -- merges metadata from writer subtasks
- Modified: `IcebergCommittable` + `IcebergCommittableSerializer` -- v2 format with observer metadata (backward-compatible with v1)
- Modified: `IcebergCommitter` -- applies observer metadata as snapshot properties
- Modified: `IcebergSink.Builder` -- new `writeObserver()` method

### Compatibility

- No behavioral change when the observer is not set (null default)
- Serializers v2 can deserialize v1 payloads (backward compatible)
- No changes to public API signatures of existing methods