### PR TITLE
Spark 3.4, 3.5, 4.0: test cleanup - eliminate unnecessary table refreshes

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -174,7 +174,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   private RewriteDataFilesSparkAction basicRewrite(Table table) {
     // Always compact regardless of input files
-    table.refresh();
     return actions()
         .rewriteDataFiles(table)
         .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1");
@@ -290,6 +289,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable();
 
     writeRecords(20, SCALE, 20);
+    table.refresh();
     shouldHaveFiles(table, 20);
     table.updateSpec().addField(Expressions.ref("c1")).commit();
 
@@ -363,7 +363,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).isEmpty();
 
@@ -413,7 +412,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).hasSize(1);
 
@@ -463,7 +461,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(0);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).hasSameSizeAs(dataFiles);
 
@@ -476,7 +473,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
@@ -493,7 +489,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> expectedRecords = currentData();
     long dataSizeBefore = testDataSize(table);
     Result result =
@@ -520,7 +515,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    table.refresh();
     List<Object[]> initialRecords = currentDataWithLineage();
     Set<Long> rowIds =
         initialRecords.stream().map(record -> (Long) record[0]).collect(Collectors.toSet());
@@ -552,7 +546,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> recordsWithLineageAfterDelete = currentDataWithLineage();
     rowIds.removeAll(rowIdsBeingRemoved);
     assertThat(rowIds)
@@ -631,7 +624,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
     assertThat(result.removedDeleteFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     assertThat(TestHelpers.dataFiles(table)).hasSize(1);
     assertThat(TestHelpers.deleteFiles(table)).isEmpty();
 
@@ -682,7 +674,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasSize(1);
 
     // partition evolution
-    table.refresh();
     table.updateSpec().addField(Expressions.ref("c3")).commit();
 
     // data seq = 4, write 2 new data files in both partitions for evolved spec
@@ -780,7 +771,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(1, 1, 1);
     shouldHaveFiles(table, 1);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
@@ -796,7 +786,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> expectedRecords = currentData();
     long dataSizeBefore = testDataSize(table);
 
@@ -833,7 +822,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
     List<Object[]> expectedRecords = currentData();
-    table.refresh();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     long dataSizeBefore = testDataSize(table);
 
@@ -849,7 +837,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
 
-    table.refresh();
     assertThat(table.currentSnapshot().sequenceNumber())
         .as("Table sequence number should be incremented")
         .isGreaterThan(oldSequenceNumber);
@@ -870,7 +857,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2, SCALE, properties);
     shouldHaveFiles(table, 8);
     List<Object[]> expectedRecords = currentData();
-    table.refresh();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     assertThat(oldSequenceNumber).as("Table sequence number should be 0").isZero();
     long dataSizeBefore = testDataSize(table);
@@ -887,7 +873,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
 
-    table.refresh();
     assertThat(table.currentSnapshot().sequenceNumber())
         .as("Table sequence number should still be 0")
         .isEqualTo(oldSequenceNumber);
@@ -981,6 +966,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     // Add one more small file, and one large file
     writeRecords(1, SCALE);
     writeRecords(1, SCALE * 3);
+    table.refresh();
     shouldHaveFiles(table, 3);
 
     List<Object[]> expectedRecords = currentData();
@@ -1070,8 +1056,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     shouldHaveSnapshots(table, 11);
     shouldHaveACleanCache(table);
 
@@ -1097,8 +1081,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1126,8 +1108,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1159,8 +1139,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Rewrite Failed");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1194,8 +1172,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Cannot commit rewrite");
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1227,8 +1203,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Arbitrary Failure");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1262,8 +1236,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Rewrite Failed");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1302,8 +1274,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteFailures()).hasSize(3);
     assertThat(result.failedDataFilesCount()).isEqualTo(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1345,8 +1315,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteFailures()).hasSize(3);
     assertThat(result.failedDataFilesCount()).isEqualTo(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1392,8 +1360,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1432,8 +1398,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasMessageContaining(
             "1 rewrite commits failed. This is more than the maximum allowed failures of 0");
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1465,11 +1429,8 @@ public class TestRewriteDataFilesAction extends TestBase {
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "1");
     rewrite.execute();
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
-    table.refresh();
     assertThat(table.snapshots())
         .as("Table did not have the expected number of snapshots")
         // To tolerate 1 random commit failure
@@ -1545,8 +1506,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1575,8 +1534,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1612,8 +1569,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1643,8 +1598,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1659,6 +1612,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     int partitions = 4;
     Table table = createTable();
     writeRecords(20, SCALE, partitions);
+    table.refresh();
     shouldHaveLastCommitUnsorted(table, "c3");
 
     // Add a partition column so this requires repartitioning
@@ -1681,8 +1635,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1722,8 +1674,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(SnapshotChanges.builderFor(table).build().addedDataFiles())
         .as("Should have written 40+ files")
         .hasSizeGreaterThanOrEqualTo(40);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1802,8 +1752,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .as("Should have written 40+ files")
         .hasSizeGreaterThanOrEqualTo(40);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1866,8 +1814,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(SnapshotChanges.builderFor(table).build().addedDataFiles())
         .as("Should have written 1 file")
         .hasSize(1);
-
-    table.refresh();
 
     List<Row> postRaw =
         spark
@@ -2145,7 +2091,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveMultipleFiles(Table table) {
-    table.refresh();
     int numFiles = Iterables.size(table.newScan().planFiles());
     assertThat(numFiles)
         .as(String.format("Should have multiple files, had %d", numFiles))
@@ -2153,7 +2098,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveFiles(Table table, int numExpected) {
-    table.refresh();
     int numFiles = Iterables.size(table.newScan().planFiles());
     assertThat(numFiles).as("Did not have the expected number of files").isEqualTo(numExpected);
   }
@@ -2174,7 +2118,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveSnapshots(Table table, int expectedSnapshots) {
-    table.refresh();
     assertThat(table.snapshots())
         .as("Table did not have the expected number of snapshots")
         .hasSize(expectedSnapshots);
@@ -2227,7 +2170,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   private <T> List<Pair<Pair<T, T>, Pair<T, T>>> checkForOverlappingFiles(
       Table table, String column) {
-    table.refresh();
     NestedField field = table.schema().caseInsensitiveFindField(column);
     Class<T> javaClass = (Class<T>) field.type().typeId().javaClass();
 
@@ -2309,6 +2251,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   protected Table createTable(int files) {
     Table table = createTable();
     writeRecords(files, SCALE);
+    table.refresh();
     return table;
   }
 
@@ -2319,6 +2262,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
 
     writeRecords(files, numRecords, partitions);
+    table.refresh();
     return table;
   }
 
@@ -2371,11 +2315,11 @@ public class TestRewriteDataFilesAction extends TestBase {
         .mode("append")
         .save(tableLocation);
 
+    table.refresh();
     return table;
   }
 
   protected int averageFileSize(Table table) {
-    table.refresh();
     return (int)
         Streams.stream(table.newScan().planFiles())
             .mapToLong(FileScanTask::length)

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -251,7 +251,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
   @TestTemplate
   public void testRewriteFilter() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
@@ -260,7 +259,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> deleteFiles = deleteFiles(table);
     assertThat(deleteFiles).hasSize(8);
 
-    table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
     assertThat(expectedRecords).hasSize(12000);
@@ -536,7 +534,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
   @TestTemplate
   public void testRewriteFilterRemoveDangling() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles, true);
@@ -545,7 +542,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> deleteFiles = deleteFiles(table);
     assertThat(deleteFiles).hasSize(8);
 
-    table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
     assertThat(expectedRecords).hasSize(12000); // 16000 data - 4000 delete rows
@@ -705,7 +701,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> newSchemaDeleteFiles = except(deleteFiles(table), deleteFiles);
     assertThat(newSchemaDeleteFiles).hasSize(4);
 
-    table.refresh();
     List<Object[]> expectedDeletes = deleteRecords(table);
     List<Object[]> expectedRecords = records(table);
     assertThat(expectedDeletes).hasSize(4000); // 4 files * 1000 per file

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -174,7 +174,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   private RewriteDataFilesSparkAction basicRewrite(Table table) {
     // Always compact regardless of input files
-    table.refresh();
     return actions()
         .rewriteDataFiles(table)
         .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1");
@@ -290,6 +289,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable();
 
     writeRecords(20, SCALE, 20);
+    table.refresh();
     shouldHaveFiles(table, 20);
     table.updateSpec().addField(Expressions.ref("c1")).commit();
 
@@ -363,7 +363,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).isEmpty();
 
@@ -413,7 +412,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).hasSize(1);
 
@@ -463,7 +461,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(0);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).hasSameSizeAs(dataFiles);
 
@@ -476,7 +473,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
@@ -493,7 +489,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> expectedRecords = currentData();
     long dataSizeBefore = testDataSize(table);
     Result result =
@@ -520,7 +515,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    table.refresh();
     List<Object[]> initialRecords = currentDataWithLineage();
     Set<Long> rowIds =
         initialRecords.stream().map(record -> (Long) record[0]).collect(Collectors.toSet());
@@ -552,7 +546,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> recordsWithLineageAfterDelete = currentDataWithLineage();
     rowIds.removeAll(rowIdsBeingRemoved);
     assertThat(rowIds)
@@ -631,7 +624,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
     assertThat(result.removedDeleteFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     assertThat(TestHelpers.dataFiles(table)).hasSize(1);
     assertThat(TestHelpers.deleteFiles(table)).isEmpty();
 
@@ -682,7 +674,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasSize(1);
 
     // partition evolution
-    table.refresh();
     table.updateSpec().addField(Expressions.ref("c3")).commit();
 
     // data seq = 4, write 2 new data files in both partitions for evolved spec
@@ -780,7 +771,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(1, 1, 1);
     shouldHaveFiles(table, 1);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
@@ -796,7 +786,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> expectedRecords = currentData();
     long dataSizeBefore = testDataSize(table);
 
@@ -833,7 +822,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
     List<Object[]> expectedRecords = currentData();
-    table.refresh();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     long dataSizeBefore = testDataSize(table);
 
@@ -849,7 +837,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
 
-    table.refresh();
     assertThat(table.currentSnapshot().sequenceNumber())
         .as("Table sequence number should be incremented")
         .isGreaterThan(oldSequenceNumber);
@@ -870,7 +857,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2, SCALE, properties);
     shouldHaveFiles(table, 8);
     List<Object[]> expectedRecords = currentData();
-    table.refresh();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     assertThat(oldSequenceNumber).as("Table sequence number should be 0").isZero();
     long dataSizeBefore = testDataSize(table);
@@ -887,7 +873,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
 
-    table.refresh();
     assertThat(table.currentSnapshot().sequenceNumber())
         .as("Table sequence number should still be 0")
         .isEqualTo(oldSequenceNumber);
@@ -981,6 +966,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     // Add one more small file, and one large file
     writeRecords(1, SCALE);
     writeRecords(1, SCALE * 3);
+    table.refresh();
     shouldHaveFiles(table, 3);
 
     List<Object[]> expectedRecords = currentData();
@@ -1070,8 +1056,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     shouldHaveSnapshots(table, 11);
     shouldHaveACleanCache(table);
 
@@ -1097,8 +1081,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1126,8 +1108,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1159,8 +1139,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Rewrite Failed");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1194,8 +1172,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Cannot commit rewrite");
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1227,8 +1203,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Arbitrary Failure");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1262,8 +1236,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Rewrite Failed");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1302,8 +1274,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteFailures()).hasSize(3);
     assertThat(result.failedDataFilesCount()).isEqualTo(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1345,8 +1315,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteFailures()).hasSize(3);
     assertThat(result.failedDataFilesCount()).isEqualTo(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1392,8 +1360,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1432,8 +1398,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasMessageContaining(
             "1 rewrite commits failed. This is more than the maximum allowed failures of 0");
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1465,11 +1429,8 @@ public class TestRewriteDataFilesAction extends TestBase {
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "1");
     rewrite.execute();
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
-    table.refresh();
     assertThat(table.snapshots())
         .as("Table did not have the expected number of snapshots")
         // To tolerate 1 random commit failure
@@ -1545,8 +1506,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1575,8 +1534,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1612,8 +1569,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1643,8 +1598,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1659,6 +1612,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     int partitions = 4;
     Table table = createTable();
     writeRecords(20, SCALE, partitions);
+    table.refresh();
     shouldHaveLastCommitUnsorted(table, "c3");
 
     // Add a partition column so this requires repartitioning
@@ -1681,8 +1635,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1722,8 +1674,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(SnapshotChanges.builderFor(table).build().addedDataFiles())
         .as("Should have written 40+ files")
         .hasSizeGreaterThanOrEqualTo(40);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1802,8 +1752,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .as("Should have written 40+ files")
         .hasSizeGreaterThanOrEqualTo(40);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1866,8 +1814,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(SnapshotChanges.builderFor(table).build().addedDataFiles())
         .as("Should have written 1 file")
         .hasSize(1);
-
-    table.refresh();
 
     List<Row> postRaw =
         spark
@@ -2145,7 +2091,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveMultipleFiles(Table table) {
-    table.refresh();
     int numFiles = Iterables.size(table.newScan().planFiles());
     assertThat(numFiles)
         .as(String.format("Should have multiple files, had %d", numFiles))
@@ -2153,7 +2098,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveFiles(Table table, int numExpected) {
-    table.refresh();
     int numFiles = Iterables.size(table.newScan().planFiles());
     assertThat(numFiles).as("Did not have the expected number of files").isEqualTo(numExpected);
   }
@@ -2174,7 +2118,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveSnapshots(Table table, int expectedSnapshots) {
-    table.refresh();
     assertThat(table.snapshots())
         .as("Table did not have the expected number of snapshots")
         .hasSize(expectedSnapshots);
@@ -2227,7 +2170,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   private <T> List<Pair<Pair<T, T>, Pair<T, T>>> checkForOverlappingFiles(
       Table table, String column) {
-    table.refresh();
     NestedField field = table.schema().caseInsensitiveFindField(column);
     Class<T> javaClass = (Class<T>) field.type().typeId().javaClass();
 
@@ -2309,6 +2251,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   protected Table createTable(int files) {
     Table table = createTable();
     writeRecords(files, SCALE);
+    table.refresh();
     return table;
   }
 
@@ -2319,6 +2262,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
 
     writeRecords(files, numRecords, partitions);
+    table.refresh();
     return table;
   }
 
@@ -2371,11 +2315,11 @@ public class TestRewriteDataFilesAction extends TestBase {
         .mode("append")
         .save(tableLocation);
 
+    table.refresh();
     return table;
   }
 
   protected int averageFileSize(Table table) {
-    table.refresh();
     return (int)
         Streams.stream(table.newScan().planFiles())
             .mapToLong(FileScanTask::length)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -251,7 +251,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
   @TestTemplate
   public void testRewriteFilter() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
@@ -260,7 +259,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> deleteFiles = deleteFiles(table);
     assertThat(deleteFiles).hasSize(8);
 
-    table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
     assertThat(expectedRecords).hasSize(12000);
@@ -536,7 +534,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
   @TestTemplate
   public void testRewriteFilterRemoveDangling() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles, true);
@@ -545,7 +542,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> deleteFiles = deleteFiles(table);
     assertThat(deleteFiles).hasSize(8);
 
-    table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
     assertThat(expectedRecords).hasSize(12000); // 16000 data - 4000 delete rows
@@ -705,7 +701,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> newSchemaDeleteFiles = except(deleteFiles(table), deleteFiles);
     assertThat(newSchemaDeleteFiles).hasSize(4);
 
-    table.refresh();
     List<Object[]> expectedDeletes = deleteRecords(table);
     List<Object[]> expectedRecords = records(table);
     assertThat(expectedDeletes).hasSize(4000); // 4 files * 1000 per file

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -177,7 +177,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   private RewriteDataFilesSparkAction basicRewrite(Table table) {
     // Always compact regardless of input files
-    table.refresh();
     return actions()
         .rewriteDataFiles(table)
         .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1");
@@ -293,6 +292,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable();
 
     writeRecords(20, SCALE, 20);
+    table.refresh();
     shouldHaveFiles(table, 20);
     table.updateSpec().addField(Expressions.ref("c1")).commit();
 
@@ -366,7 +366,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).isEmpty();
 
@@ -416,7 +415,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).hasSize(1);
 
@@ -466,7 +464,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(0);
 
-    table.refresh();
     List<DataFile> newDataFiles = TestHelpers.dataFiles(table);
     assertThat(newDataFiles).hasSameSizeAs(dataFiles);
 
@@ -479,7 +476,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
@@ -496,7 +492,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> expectedRecords = currentData();
     long dataSizeBefore = testDataSize(table);
     Result result =
@@ -523,7 +518,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    table.refresh();
     List<Object[]> initialRecords = currentDataWithLineage();
     Set<Long> rowIds =
         initialRecords.stream().map(record -> (Long) record[0]).collect(Collectors.toSet());
@@ -555,7 +549,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> recordsWithLineageAfterDelete = currentDataWithLineage();
     rowIds.removeAll(rowIdsBeingRemoved);
     assertThat(rowIds)
@@ -634,7 +627,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewrittenDataFilesCount()).isEqualTo(numDataFiles);
     assertThat(result.removedDeleteFilesCount()).isEqualTo(numDataFiles);
 
-    table.refresh();
     assertThat(TestHelpers.dataFiles(table)).hasSize(1);
     assertThat(TestHelpers.deleteFiles(table)).isEmpty();
 
@@ -685,7 +677,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasSize(1);
 
     // partition evolution
-    table.refresh();
     table.updateSpec().addField(Expressions.ref("c3")).commit();
 
     // data seq = 4, write 2 new data files in both partitions for evolved spec
@@ -783,7 +774,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(1, 1, 1);
     shouldHaveFiles(table, 1);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
@@ -799,7 +789,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
 
     rowDelta.commit();
-    table.refresh();
     List<Object[]> expectedRecords = currentData();
     long dataSizeBefore = testDataSize(table);
 
@@ -836,7 +825,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
     List<Object[]> expectedRecords = currentData();
-    table.refresh();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     long dataSizeBefore = testDataSize(table);
 
@@ -852,7 +840,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
 
-    table.refresh();
     assertThat(table.currentSnapshot().sequenceNumber())
         .as("Table sequence number should be incremented")
         .isGreaterThan(oldSequenceNumber);
@@ -873,7 +860,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2, SCALE, properties);
     shouldHaveFiles(table, 8);
     List<Object[]> expectedRecords = currentData();
-    table.refresh();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     assertThat(oldSequenceNumber).as("Table sequence number should be 0").isZero();
     long dataSizeBefore = testDataSize(table);
@@ -890,7 +876,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
 
-    table.refresh();
     assertThat(table.currentSnapshot().sequenceNumber())
         .as("Table sequence number should still be 0")
         .isEqualTo(oldSequenceNumber);
@@ -984,6 +969,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     // Add one more small file, and one large file
     writeRecords(1, SCALE);
     writeRecords(1, SCALE * 3);
+    table.refresh();
     shouldHaveFiles(table, 3);
 
     List<Object[]> expectedRecords = currentData();
@@ -1073,8 +1059,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     shouldHaveSnapshots(table, 11);
     shouldHaveACleanCache(table);
 
@@ -1100,8 +1084,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1129,8 +1111,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1162,8 +1142,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Rewrite Failed");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1197,8 +1175,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Cannot commit rewrite");
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1230,8 +1206,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Arbitrary Failure");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1265,8 +1239,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThatThrownBy(spyRewrite::execute)
         .isInstanceOf(CommitFailedException.class)
         .hasMessage("Rewrite Failed");
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1305,8 +1277,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteFailures()).hasSize(3);
     assertThat(result.failedDataFilesCount()).isEqualTo(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1348,8 +1318,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteFailures()).hasSize(3);
     assertThat(result.failedDataFilesCount()).isEqualTo(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1395,8 +1363,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 6 fileGroups").hasSize(6);
     assertThat(result.rewrittenBytesCount()).isGreaterThan(0L).isLessThan(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1435,8 +1401,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasMessageContaining(
             "1 rewrite commits failed. This is more than the maximum allowed failures of 0");
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1468,11 +1432,8 @@ public class TestRewriteDataFilesAction extends TestBase {
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_FAILED_COMMITS, "1");
     rewrite.execute();
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
-    table.refresh();
     assertThat(table.snapshots())
         .as("Table did not have the expected number of snapshots")
         // To tolerate 1 random commit failure
@@ -1548,8 +1509,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1578,8 +1537,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1615,8 +1572,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1646,8 +1601,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1662,6 +1615,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     int partitions = 4;
     Table table = createTable();
     writeRecords(20, SCALE, partitions);
+    table.refresh();
     shouldHaveLastCommitUnsorted(table, "c3");
 
     // Add a partition column so this requires repartitioning
@@ -1684,8 +1638,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     assertThat(result.rewriteResults()).as("Should have 1 fileGroups").hasSize(1);
     assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1725,8 +1677,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(SnapshotChanges.builderFor(table).build().addedDataFiles())
         .as("Should have written 40+ files")
         .hasSizeGreaterThanOrEqualTo(40);
-
-    table.refresh();
 
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
@@ -1805,8 +1755,6 @@ public class TestRewriteDataFilesAction extends TestBase {
         .as("Should have written 40+ files")
         .hasSizeGreaterThanOrEqualTo(40);
 
-    table.refresh();
-
     List<Object[]> postRewriteData = currentData();
     assertEquals("We shouldn't have changed the data", originalData, postRewriteData);
 
@@ -1870,8 +1818,6 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(SnapshotChanges.builderFor(table).build().addedDataFiles())
         .as("Should have written 1 file")
         .hasSize(1);
-
-    table.refresh();
 
     List<Row> postRaw =
         spark
@@ -2178,7 +2124,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveMultipleFiles(Table table) {
-    table.refresh();
     int numFiles = Iterables.size(table.newScan().planFiles());
     assertThat(numFiles)
         .as(String.format("Should have multiple files, had %d", numFiles))
@@ -2186,7 +2131,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveFiles(Table table, int numExpected) {
-    table.refresh();
     List<FileScanTask> files =
         StreamSupport.stream(table.newScan().planFiles().spliterator(), false)
             .collect(Collectors.toList());
@@ -2209,7 +2153,6 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveSnapshots(Table table, int expectedSnapshots) {
-    table.refresh();
     assertThat(table.snapshots())
         .as("Table did not have the expected number of snapshots")
         .hasSize(expectedSnapshots);
@@ -2262,7 +2205,6 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   private <T> List<Pair<Pair<T, T>, Pair<T, T>>> checkForOverlappingFiles(
       Table table, String column) {
-    table.refresh();
     NestedField field = table.schema().caseInsensitiveFindField(column);
     Class<T> javaClass = (Class<T>) field.type().typeId().javaClass();
 
@@ -2344,6 +2286,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   protected Table createTable(int files) {
     Table table = createTable();
     writeRecords(files, SCALE);
+    table.refresh();
     return table;
   }
 
@@ -2354,6 +2297,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
 
     writeRecords(files, numRecords, partitions);
+    table.refresh();
     return table;
   }
 
@@ -2406,11 +2350,11 @@ public class TestRewriteDataFilesAction extends TestBase {
         .mode("append")
         .save(tableLocation);
 
+    table.refresh();
     return table;
   }
 
   protected int averageFileSize(Table table) {
-    table.refresh();
     return (int)
         Streams.stream(table.newScan().planFiles())
             .mapToLong(FileScanTask::length)

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -251,7 +251,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
   @TestTemplate
   public void testRewriteFilter() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
@@ -260,7 +259,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> deleteFiles = deleteFiles(table);
     assertThat(deleteFiles).hasSize(8);
 
-    table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
     assertThat(expectedRecords).hasSize(12000);
@@ -536,7 +534,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
   @TestTemplate
   public void testRewriteFilterRemoveDangling() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
-    table.refresh();
 
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles, true);
@@ -545,7 +542,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> deleteFiles = deleteFiles(table);
     assertThat(deleteFiles).hasSize(8);
 
-    table.refresh();
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
     assertThat(expectedRecords).hasSize(12000); // 16000 data - 4000 delete rows
@@ -705,7 +701,6 @@ public class TestRewritePositionDeleteFilesAction extends CatalogTestBase {
     List<DeleteFile> newSchemaDeleteFiles = except(deleteFiles(table), deleteFiles);
     assertThat(newSchemaDeleteFiles).hasSize(4);
 
-    table.refresh();
     List<Object[]> expectedDeletes = deleteRecords(table);
     List<Object[]> expectedRecords = records(table);
     assertThat(expectedDeletes).hasSize(4000); // 4 files * 1000 per file


### PR DESCRIPTION
Port of https://github.com/apache/iceberg/pull/15765 to other Spark versions.