### PR TITLE
Build: Harden GitHub Actions workflows against zizmor findings

### DIFF
--- a/.github/workflows/jmh-benchmarks.yml
+++ b/.github/workflows/jmh-benchmarks.yml
@@ -49,9 +49,12 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.ref }}
+          persist-credentials: false
       - id: set-matrix
+        env:
+          BENCHMARKS: ${{ github.event.inputs.benchmarks }}
         run: |
-          matrix=$(echo '[${{ github.event.inputs.benchmarks }}]' | jq '.[] | select(endswith("Benchmark")) | .')
+          matrix=$(echo "[$BENCHMARKS]" | jq '.[] | select(endswith("Benchmark")) | .')
           matrix=$(echo $matrix | sed 's/ /,/g' | sed 's/"/\"/g')
           echo "matrix=[$matrix]" >> $GITHUB_OUTPUT
           echo "foundlabel=$(echo "[$matrix]" | jq 'if . | length > 0 then true else false end')" >> $GITHUB_OUTPUT
@@ -60,12 +63,18 @@ jobs:
     needs: matrix
     runs-on: ubuntu-24.04
     steps:
-      - run: |
-          echo "Repo: ${{ github.event.inputs.repo }}"
-          echo "Ref: ${{ github.event.inputs.ref }}"
-          echo "Benchmarks: ${{ needs.matrix.outputs.matrix }}"
-          echo "Spark Project Version: ${{ needs.matrix.outputs.spark_version }}"
-          echo "Found Benchmarks? ${{ needs.matrix.outputs.foundlabel }}"
+      - env:
+          REPO: ${{ github.event.inputs.repo }}
+          REF: ${{ github.event.inputs.ref }}
+          BENCHMARKS: ${{ needs.matrix.outputs.matrix }}
+          SPARK_VERSION: ${{ needs.matrix.outputs.spark_version }}
+          FOUND_LABEL: ${{ needs.matrix.outputs.foundlabel }}
+        run: |
+          echo "Repo: $REPO"
+          echo "Ref: $REF"
+          echo "Benchmarks: $BENCHMARKS"
+          echo "Spark Project Version: $SPARK_VERSION"
+          echo "Found Benchmarks? $FOUND_LABEL"
 
   run-benchmark:
     if: ${{ needs.matrix.outputs.foundlabel == 'true' }}
@@ -83,6 +92,7 @@ jobs:
       with:
         repository: ${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.ref }}
+        persist-credentials: false
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         distribution: zulu
@@ -97,7 +107,10 @@ jobs:
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
 
     - name: Run Benchmark
-      run: ./gradlew :iceberg-spark:${{ github.event.inputs.spark_version }}:jmh -PjmhIncludeRegex=${{ matrix.benchmark }} -PjmhOutputPath=benchmark/${{ matrix.benchmark }}.txt
+      env:
+        SPARK_VERSION: ${{ github.event.inputs.spark_version }}
+        BENCHMARK: ${{ matrix.benchmark }}
+      run: ./gradlew :iceberg-spark:${SPARK_VERSION}:jmh -PjmhIncludeRegex=${BENCHMARK} -PjmhOutputPath=benchmark/${BENCHMARK}.txt
 
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: ${{ always() }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@
 #
 
 name: "Pull Request Labeler"
-on: pull_request_target
+on: pull_request_target # zizmor: ignore[dangerous-triggers]
 
 permissions:
   contents: read

--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -39,13 +39,16 @@ jobs:
   build:
     if: github.repository_owner == 'apache'
     runs-on: ubuntu-latest
+    environment: docker-publish
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
     - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         distribution: zulu
         java-version: 21
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+    - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
       with:
         path: |
           ~/.gradle/caches
@@ -55,13 +58,18 @@ jobs:
     - name: Build Iceberg Open API project
       run: ./gradlew :iceberg-open-api:shadowJar
     - name: Login to Docker Hub
+      env:
+        DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+        DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       run: |
-        docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+        docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_TOKEN"
     - name: Set the tagged version
       # for tag 'apache-iceberg-1.7.1', publish image 'apache/iceberg-rest-fixture:1.7.1'
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+      env:
+        REF: ${{ github.ref }}
       run: |
-        echo "DOCKER_IMAGE_VERSION=`echo ${{ github.ref }} | tr -d -c 0-9.`" >> "$GITHUB_ENV"
+        echo "DOCKER_IMAGE_VERSION=$(echo "$REF" | tr -d -c 0-9.)" >> "$GITHUB_ENV"
     - name: Set up QEMU
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
     - name: Set up Docker Buildx

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -32,11 +32,13 @@ jobs:
   publish-snapshot:
     if: github.repository_owner == 'apache'
     runs-on: ubuntu-24.04
+    environment: maven-publish
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # we need to fetch all tags so that getProjectVersion() in build.gradle correctly determines the next SNAPSHOT version from the newest tag
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
@@ -48,7 +50,10 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
-      - run: |
+      - env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PW: ${{ secrets.NEXUS_PW }}
+        run: |
           ./gradlew printVersion
-          ./gradlew -DallModules publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}
-          ./gradlew -DflinkVersions= -DsparkVersions=3.4,3.5,4.0 -DscalaVersion=2.13 -DkafkaVersions=3 publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}
+          ./gradlew -DallModules publishApachePublicationToMavenRepository -PmavenUser="$NEXUS_USER" -PmavenPassword="$NEXUS_PW"
+          ./gradlew -DflinkVersions= -DsparkVersions=3.4,3.5,4.0 -DscalaVersion=2.13 -DkafkaVersions=3 publishApachePublicationToMavenRepository -PmavenUser="$NEXUS_USER" -PmavenPassword="$NEXUS_PW"

--- a/.github/workflows/recurring-jmh-benchmarks.yml
+++ b/.github/workflows/recurring-jmh-benchmarks.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.ref }}
+          persist-credentials: false
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu

--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -37,12 +37,17 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.x
       - name: Deploy Iceberg documentation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           make deploy
         working-directory: ./site


### PR DESCRIPTION
This PR addresses security findings reported by [zizmor](https://docs.zizmor.sh/), a static analysis tool for GitHub Actions workflows.

Follow up to #15788

### Changes

#### 1. Add `persist-credentials: false` to `actions/checkout` — fixes `artipacked` (Medium)

**Files:**
- `.github/workflows/jmh-benchmarks.yml` (2 jobs)
- `.github/workflows/publish-iceberg-rest-fixture-docker.yml`
- `.github/workflows/publish-snapshot.yml`
- `.github/workflows/recurring-jmh-benchmarks.yml`

**Why:** By default, `actions/checkout` persists the GitHub token in `.git/config`. If a subsequent step uploads the workspace as an artifact, the token could be exfiltrated. Setting `persist-credentials: false` ensures the token is not written to disk after checkout.

See: https://docs.zizmor.sh/audits/#artipacked

#### 2. Use `persist-credentials: false` with explicit `git remote set-url` — fixes `artipacked` (Medium)

**Files:**
- `.github/workflows/site-ci.yml`

**Why:** This workflow needs push access for `mkdocs gh-deploy`. Instead of relying on persisted checkout credentials, we set `persist-credentials: false` and explicitly configure the remote URL with `$GITHUB_TOKEN` via an `env:` block scoped to the deploy step.

See: https://docs.zizmor.sh/audits/#artipacked

#### 3. Move `${{ }}` expressions from `run:` into step `env:` blocks — fixes `template-injection` (High)

**Files:**
- `.github/workflows/jmh-benchmarks.yml` (3 jobs)
- `.github/workflows/publish-iceberg-rest-fixture-docker.yml`

**Why:** Expressions like `${{ github.event.inputs.* }}` and `${{ github.ref }}` are expanded before the shell starts, so a crafted input can inject arbitrary shell commands. Moving them into `env:` blocks passes them as environment variables, which are treated as data, not code.

See: https://docs.zizmor.sh/audits/#template-injection

#### 4. Replace `actions/cache` with `actions/cache/restore` — fixes `cache-poisoning` (High)

**Files:**
- `.github/workflows/publish-iceberg-rest-fixture-docker.yml`

**Why:** `actions/cache` both reads and writes cache entries. In a privileged workflow (triggered by `push`/`schedule`/`workflow_dispatch`), a cache written by an untrusted PR workflow could introduce poisoned dependencies. `actions/cache/restore` is read-only and never writes back.

See: https://docs.zizmor.sh/audits/#cache-poisoning

#### 5. Move secrets into `env:` blocks and add `environment:` to jobs — fixes `secrets-outside-env` (Medium)

**Files:**
- `.github/workflows/publish-iceberg-rest-fixture-docker.yml` (`environment: docker-publish`)
- `.github/workflows/publish-snapshot.yml` (`environment: maven-publish`)

**Why:** Inline `${{ secrets.* }}` in `run:` commands embeds secrets as literal text in shell command args. Moving them to `env:` blocks avoids this. Adding `environment:` enables GitHub's [deployment protection rules](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) (required reviewers, wait timers, branch restrictions).

**Note:** The `docker-publish` and `maven-publish` environments must be created in repo settings. GitHub will auto-create them with no protection rules on first run — admins should then configure appropriate protections.

See: https://docs.zizmor.sh/audits/#secrets-outside-env

#### 6. Suppress `dangerous-triggers` for `labeler.yml` — acknowledged (High)

**Files:**
- `.github/workflows/labeler.yml`

**Why:** `pull_request_target` is the only trigger that grants `pull-requests: write` for labeling PRs from forks. This is safe because the workflow never checks out PR code, has no `run:` steps, only invokes the pinned `actions/labeler`, and uses minimal permissions (`contents: read`, `pull-requests: write`). Added `# zizmor: ignore[dangerous-triggers]`.

See: https://docs.zizmor.sh/audits/#dangerous-triggers

### Testing

| Workflow | How to verify |
|---|---|
| `jmh-benchmarks.yml` | Trigger via `workflow_dispatch` with standard inputs; verify matrix computation and benchmark execution |
| `recurring-jmh-benchmarks.yml` | Wait for weekly schedule or trigger manually; verify benchmarks run |
| `site-ci.yml` | Push a docs change to `main`; verify mkdocs deploys to `asf-site` branch |
| `publish-iceberg-rest-fixture-docker.yml` | Trigger via `workflow_dispatch` or tag push; verify Docker image is built and pushed. **Requires `docker-publish` environment in repo settings** |
| `publish-snapshot.yml` | Wait for nightly schedule; verify Maven publish succeeds. **Requires `maven-publish` environment in repo settings** |
| `labeler.yml` | Open a PR; verify labels are applied correctly |