### PR TITLE
Core: Optimize RoaringPositionBitmap.setRange with native range API

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/RoaringPositionBitmap.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/RoaringPositionBitmap.java
@@ -79,14 +79,21 @@ class RoaringPositionBitmap {
   }
 
   /**
-   * Sets a range of positions in the bitmap. If {@code posStartInclusive} is greater than or equal
-   * to {@code posEndExclusive}, this method does nothing.
+   * Sets a range of positions in the bitmap. If {@code posStartInclusive} equals {@code
+   * posEndExclusive}, this method does nothing.
    *
    * @param posStartInclusive the start position of the range (inclusive)
    * @param posEndExclusive the end position of the range (exclusive)
+   * @throws IllegalArgumentException if posStartInclusive &gt; posEndExclusive
    */
   public void setRange(long posStartInclusive, long posEndExclusive) {
-    if (posStartInclusive >= posEndExclusive) {
+    Preconditions.checkArgument(
+        posStartInclusive <= posEndExclusive,
+        "Start position must not exceed end position: [%s, %s)",
+        posStartInclusive,
+        posEndExclusive);
+
+    if (posStartInclusive == posEndExclusive) {
       return;
     }
 

--- a/core/src/test/java/org/apache/iceberg/deletes/TestRoaringPositionBitmap.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestRoaringPositionBitmap.java
@@ -153,13 +153,14 @@ public class TestRoaringPositionBitmap {
     assertThat(equalRange.isEmpty()).isTrue();
     assertThat(equalRange.cardinality()).isEqualTo(0);
     assertThat(equalRange.contains(10)).isFalse();
+  }
 
-    RoaringPositionBitmap reversedRange = new RoaringPositionBitmap();
-    reversedRange.setRange(100, 50);
-    assertThat(reversedRange.isEmpty()).isTrue();
-    assertThat(reversedRange.cardinality()).isEqualTo(0);
-    assertThat(reversedRange.contains(50)).isFalse();
-    assertThat(reversedRange.contains(100)).isFalse();
+  @TestTemplate
+  public void testSetRangeReversedThrows() {
+    RoaringPositionBitmap bitmap = new RoaringPositionBitmap();
+    assertThatThrownBy(() -> bitmap.setRange(100, 50))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Start position must not exceed end position");
   }
 
   @TestTemplate


### PR DESCRIPTION
Replace the per-position loop in `RoaringPositionBitmap.setRange()` with `RoaringBitmap.add(long, long)` bulk range insertion. 

The new implementation splits the 64-bit range at key boundaries and delegates each segment to the native API, which operates at the container level internally. This also eliminates per-position validation and bitmap array growth checks.
