### PR TITLE
AWS: handle premature connection close

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestFlakyS3InputStream.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
@@ -130,9 +131,18 @@ public class TestFlakyS3InputStream extends TestS3InputStream {
     return Stream.of(Arguments.of(new IOException("some generic non-retryable IO exception")));
   }
 
+  @SuppressWarnings("unchecked")
   private S3ClientWrapper flakyStreamClient(AtomicInteger counter, IOException failure) {
     S3ClientWrapper flakyClient = spy(new S3ClientWrapper(s3Client()));
-    doAnswer(invocation -> new FlakyInputStream(invocation.callRealMethod(), counter, failure))
+    doAnswer(
+            invocation -> {
+              ResponseInputStream<GetObjectResponse> delegate =
+                  (ResponseInputStream<GetObjectResponse>) invocation.callRealMethod();
+              return new ResponseInputStream<>(
+                  delegate.response(),
+                  AbortableInputStream.create(
+                      new FlakyInputStream(delegate, counter, failure), delegate));
+            })
         .when(flakyClient)
         .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
     return flakyClient;
@@ -190,8 +200,11 @@ public class TestFlakyS3InputStream extends TestS3InputStream {
     private final int round;
     private final IOException exception;
 
-    FlakyInputStream(Object invocationResponse, AtomicInteger counter, IOException exception) {
-      this.delegate = (ResponseInputStream<GetObjectResponse>) invocationResponse;
+    FlakyInputStream(
+        ResponseInputStream<GetObjectResponse> delegate,
+        AtomicInteger counter,
+        IOException exception) {
+      this.delegate = delegate;
       this.counter = counter;
       this.round = counter.get();
       this.exception = exception;
@@ -208,7 +221,7 @@ public class TestFlakyS3InputStream extends TestS3InputStream {
 
     @Override
     public int read() throws IOException {
-      checkCounter();
+      // No checkCounter(): single-byte read is used by abortStream() for EOF check only
       return delegate.read();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -55,6 +55,12 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS =
       ImmutableList.of(SSLException.class, SocketTimeoutException.class, SocketException.class);
 
+  private static boolean isPrematureConnectionClose(Throwable ex) {
+    return ex.getClass().getSimpleName().equals("ConnectionClosedException")
+        && ex.getMessage() != null
+        && ex.getMessage().startsWith("Premature end of Content-Length delimited message body");
+  }
+
   private final StackTraceElement[] createStack;
   private final S3Client s3;
   private final S3URI location;
@@ -72,6 +78,7 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private RetryPolicy<Object> retryPolicy =
       RetryPolicy.builder()
           .handle(RETRYABLE_EXCEPTIONS)
+          .handleIf(S3InputStream::isPrematureConnectionClose)
           .onRetry(
               e -> {
                 LOG.warn(

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -27,6 +27,7 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import javax.net.ssl.SSLException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIOMetricsContext;
@@ -43,10 +44,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
-import software.amazon.awssdk.http.Abortable;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 class S3InputStream extends SeekableInputStream implements RangeReadable {
@@ -55,10 +57,22 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS =
       ImmutableList.of(SSLException.class, SocketTimeoutException.class, SocketException.class);
 
-  private static boolean isPrematureConnectionClose(Throwable ex) {
+  private boolean isPrematureConnectionCloseApacheHttpClient(Throwable ex) {
+    // https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/impl/io/ContentLengthInputStream.java#L141
+    // https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/ConnectionClosedException.java#L68
     return ex.getClass().getSimpleName().equals("ConnectionClosedException")
         && ex.getMessage() != null
-        && ex.getMessage().startsWith("Premature end of Content-Length delimited message body");
+        && ex.getMessage()
+            .equals(
+                String.format(
+                    Locale.getDefault(),
+                    "Premature end of Content-Length delimited message body (expected: %,d; received: %,d)",
+                    streamEnd - streamStart,
+                    pos - streamStart));
+  }
+
+  private boolean isPrematureConnectionCloseUrlConnectionHttpClient(Object bytesRead) {
+    return Integer.valueOf(-1).equals(bytesRead) && pos < streamEnd;
   }
 
   private final StackTraceElement[] createStack;
@@ -66,7 +80,9 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private final S3URI location;
   private final S3FileIOProperties s3FileIOProperties;
 
-  private InputStream stream;
+  private ResponseInputStream<GetObjectResponse> stream;
+  private long streamStart = 0;
+  private long streamEnd = -1;
   private long pos = 0;
   private long next = 0;
   private boolean closed = false;
@@ -78,7 +94,8 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private RetryPolicy<Object> retryPolicy =
       RetryPolicy.builder()
           .handle(RETRYABLE_EXCEPTIONS)
-          .handleIf(S3InputStream::isPrematureConnectionClose)
+          .handleIf(this::isPrematureConnectionCloseApacheHttpClient)
+          .handleResultIf(this::isPrematureConnectionCloseUrlConnectionHttpClient)
           .onRetry(
               e -> {
                 LOG.warn(
@@ -249,6 +266,9 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
 
     try {
       stream = s3.getObject(requestBuilder.build(), ResponseTransformer.toInputStream());
+      streamStart = pos;
+      final Long streamLength = stream.response().contentLength();
+      streamEnd = streamLength == null ? -1 : streamStart + streamLength;
     } catch (NoSuchKeyException e) {
       throw new NotFoundException(e, "Location does not exist: %s", location);
     }
@@ -285,8 +305,8 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
 
   private void abortStream() {
     try {
-      if (stream instanceof Abortable && stream.read() != -1) {
-        ((Abortable) stream).abort();
+      if (stream.read() != -1) {
+        stream.abort();
       }
     } catch (Exception e) {
       LOG.warn("An error occurred while aborting the stream", e);

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -57,9 +57,18 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS =
       ImmutableList.of(SSLException.class, SocketTimeoutException.class, SocketException.class);
 
+  /**
+   * Returns true when the Apache HTTP client reports that S3 closed the response body before all
+   * declared Content-Length bytes were delivered. This happens when an S3 HTTP connection goes idle
+   * between Parquet row groups and S3 tears it down server-side. The message is reconstructed to
+   * distinguish this specific failure from unrelated {@code ConnectionClosedException} instances.
+   *
+   * @see <a
+   *     href="https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/impl/io/ContentLengthInputStream.java#L141">ContentLengthInputStream</a>
+   * @see <a
+   *     href="https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/ConnectionClosedException.java#L68">ConnectionClosedException</a>
+   */
   private boolean isPrematureConnectionCloseApacheHttpClient(Throwable ex) {
-    // https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/impl/io/ContentLengthInputStream.java#L141
-    // https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/ConnectionClosedException.java#L68
     return ex.getClass().getSimpleName().equals("ConnectionClosedException")
         && ex.getMessage() != null
         && ex.getMessage()
@@ -71,6 +80,13 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
                     pos - streamStart));
   }
 
+  /**
+   * Returns true when the URL connection HTTP client reports that S3 closed the response body
+   * before all declared Content-Length bytes were delivered. Unlike the Apache HTTP client, {@code
+   * UrlConnectionHttpClient} does not throw an exception on premature close; it silently returns -1
+   * from {@code read}. The {@code pos < streamEnd} guard distinguishes this from a legitimate EOF,
+   * which also returns -1 but only after all Content-Length bytes have been received.
+   */
   private boolean isPrematureConnectionCloseUrlConnectionHttpClient(Object bytesRead) {
     return Integer.valueOf(-1).equals(bytesRead) && pos < streamEnd;
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -57,27 +57,33 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS =
       ImmutableList.of(SSLException.class, SocketTimeoutException.class, SocketException.class);
 
+  private static final String[] APACHE_HTTP_CLIENT_PREMATURE_CONNECTION_CLOSE_FORMATS =
+      new String[] {
+        // https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/impl/io/ContentLengthInputStream.java#L141
+        "Premature end of Content-Length delimited message body (expected: %,d; received: %,d)",
+        // https://github.com/apache/httpcomponents-core/blob/rel/v5.4.3/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java#L138
+        "Premature end of Content-Length delimited message body (expected: %d; received: %d)",
+      };
+
   /**
    * Returns true when the Apache HTTP client reports that S3 closed the response body before all
    * declared Content-Length bytes were delivered. This happens when an S3 HTTP connection goes idle
    * between Parquet row groups and S3 tears it down server-side. The message is reconstructed to
    * distinguish this specific failure from unrelated {@code ConnectionClosedException} instances.
-   *
-   * @see <a
-   *     href="https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/impl/io/ContentLengthInputStream.java#L141">ContentLengthInputStream</a>
-   * @see <a
-   *     href="https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/ConnectionClosedException.java#L68">ConnectionClosedException</a>
    */
   private boolean isPrematureConnectionCloseApacheHttpClient(Throwable ex) {
-    return ex.getClass().getSimpleName().equals("ConnectionClosedException")
-        && ex.getMessage() != null
-        && ex.getMessage()
-            .equals(
-                String.format(
-                    Locale.getDefault(),
-                    "Premature end of Content-Length delimited message body (expected: %,d; received: %,d)",
-                    streamEnd - streamStart,
-                    pos - streamStart));
+    if (!ex.getClass().getSimpleName().equals("ConnectionClosedException")) {
+      return false;
+    }
+    Locale locale = Locale.getDefault(Locale.Category.FORMAT);
+    long expected = streamEnd - streamStart;
+    long received = pos - streamStart;
+    for (String format : APACHE_HTTP_CLIENT_PREMATURE_CONNECTION_CLOSE_FORMATS) {
+      if (String.format(locale, format, expected, received).equals(ex.getMessage())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -27,6 +27,7 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import javax.net.ssl.SSLException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIOMetricsContext;
@@ -43,10 +44,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
-import software.amazon.awssdk.http.Abortable;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 class S3InputStream extends SeekableInputStream implements RangeReadable {
@@ -55,10 +57,22 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS =
       ImmutableList.of(SSLException.class, SocketTimeoutException.class, SocketException.class);
 
-  private static boolean isPrematureConnectionClose(Throwable ex) {
+  private boolean isPrematureConnectionCloseApacheHttpClient(Throwable ex) {
+    // https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/impl/io/ContentLengthInputStream.java#L141
+    // https://github.com/apache/httpcomponents-core/blob/rel/v4.4.16/httpcore/src/main/java/org/apache/http/ConnectionClosedException.java#L68
     return ex.getClass().getSimpleName().equals("ConnectionClosedException")
         && ex.getMessage() != null
-        && ex.getMessage().startsWith("Premature end of Content-Length delimited message body");
+        && ex.getMessage()
+            .equals(
+                String.format(
+                    Locale.getDefault(),
+                    "Premature end of Content-Length delimited message body (expected: %,d; received: %,d)",
+                    streamEnd - streamStart,
+                    pos - streamStart));
+  }
+
+  private boolean isPrematureConnectionCloseUrlConnectionHttpClient(Object bytesRead) {
+    return Integer.valueOf(-1).equals(bytesRead) && pos < streamEnd;
   }
 
   private final StackTraceElement[] createStack;
@@ -66,7 +80,9 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private final S3URI location;
   private final S3FileIOProperties s3FileIOProperties;
 
-  private InputStream stream;
+  private ResponseInputStream<GetObjectResponse> stream;
+  private long streamStart = 0;
+  private long streamEnd = -1;
   private long pos = 0;
   private long next = 0;
   private boolean closed = false;
@@ -78,7 +94,8 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private RetryPolicy<Object> retryPolicy =
       RetryPolicy.builder()
           .handle(RETRYABLE_EXCEPTIONS)
-          .handleIf(S3InputStream::isPrematureConnectionClose)
+          .handleIf(this::isPrematureConnectionCloseApacheHttpClient)
+          .handleResultIf(this::isPrematureConnectionCloseUrlConnectionHttpClient)
           .onRetry(
               e -> {
                 LOG.warn(
@@ -266,6 +283,9 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
 
     try {
       stream = s3.getObject(requestBuilder.build(), ResponseTransformer.toInputStream());
+      streamStart = pos;
+      final Long streamLength = stream.response().contentLength();
+      streamEnd = streamLength == null ? -1 : streamStart + streamLength;
     } catch (NoSuchKeyException e) {
       throw new NotFoundException(e, "Location does not exist: %s", location);
     }
@@ -302,8 +322,8 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
 
   private void abortStream() {
     try {
-      if (stream instanceof Abortable && stream.read() != -1) {
-        ((Abortable) stream).abort();
+      if (stream.read() != -1) {
+        stream.abort();
       }
     } catch (Exception e) {
       LOG.warn("An error occurred while aborting the stream", e);

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -19,23 +19,34 @@
 package org.apache.iceberg.aws.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.ConnectionOptions;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.verify.VerificationTimes;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,7 +59,8 @@ public final class TestS3InputStream {
 
   @BeforeEach
   void before() {
-    when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class)))
+    lenient()
+        .when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class)))
         .thenReturn(inputStream);
     s3InputStream = new S3InputStream(s3Client, mock());
   }
@@ -68,34 +80,79 @@ public final class TestS3InputStream {
   }
 
   @Test
-  void testReadRetriesOnPrematureConnectionClose() throws IOException {
-    when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
-        .thenThrow(
-            new ConnectionClosedException(
-                "Premature end of Content-Length delimited message body (expected: 100; received: 50)"))
-        .thenReturn(1);
-
-    assertThat(s3InputStream.read(new byte[1], 0, 1)).isEqualTo(1);
-    verify(s3Client, times(2))
-        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+  void testReadRetriesOnPrematureConnectionCloseWithApacheHttpClient() throws IOException {
+    testReadRetriesOnPrematureConnectionClose(ApacheHttpClient.create());
   }
 
   @Test
-  void testReadDoesNotRetryOnOtherConnectionClosedException() throws IOException {
-    when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
-        .thenThrow(new ConnectionClosedException("Connection closed by peer"));
-
-    assertThatThrownBy(() -> s3InputStream.read(new byte[1], 0, 1))
-        .isInstanceOf(ConnectionClosedException.class)
-        .hasMessage("Connection closed by peer");
-    verify(s3Client, times(1))
-        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+  void testReadRetriesOnPrematureConnectionCloseWithUrlConnectionHttpClient() throws IOException {
+    testReadRetriesOnPrematureConnectionClose(UrlConnectionHttpClient.create());
   }
 
-  /** Simulates the shaded {@code org.apache.http.ConnectionClosedException}. */
-  private static class ConnectionClosedException extends IOException {
-    ConnectionClosedException(String message) {
-      super(message);
+  void testReadRetriesOnPrematureConnectionClose(SdkHttpClient httpClient) throws IOException {
+    int fileSize = 1024;
+    int blockSize = fileSize / 2;
+    byte[] block1 = new byte[blockSize];
+    Arrays.fill(block1, (byte) 1);
+    byte[] block2 = new byte[blockSize];
+    Arrays.fill(block2, (byte) 2);
+    byte[] response1 = Arrays.copyOf(block1, blockSize + blockSize / 2);
+    System.arraycopy(block2, 0, response1, blockSize, blockSize / 2);
+    byte[] response2 = Arrays.copyOfRange(block2, blockSize / 2, blockSize);
+
+    ClientAndServer mockServer = startClientAndServer();
+    try {
+      // First unbounded request: send block1 and the first half of block2,
+      // then close the socket to simulate stalled connection
+      mockServer
+          .when(request().withHeader("Range", "bytes=0-"))
+          .respond(
+              HttpResponse.response()
+                  .withStatusCode(206)
+                  .withHeader("Content-Range", "bytes 0-%s/%s".formatted(fileSize - 1, fileSize))
+                  .withBody(response1)
+                  .withConnectionOptions(
+                      ConnectionOptions.connectionOptions()
+                          .withContentLengthHeaderOverride(fileSize)
+                          .withCloseSocket(true)));
+      // Retry from the second half of block2: complete response
+      mockServer
+          .when(request().withHeader("Range", "bytes=%s-".formatted(response1.length)))
+          .respond(
+              HttpResponse.response()
+                  .withStatusCode(206)
+                  .withHeader(
+                      "Content-Range",
+                      "bytes %s-%s/%s".formatted(response1.length, fileSize - 1, fileSize))
+                  .withBody(response2));
+
+      try (S3Client s3Client =
+              S3Client.builder()
+                  .endpointOverride(URI.create("http://127.0.0.1:" + mockServer.getLocalPort()))
+                  .serviceConfiguration(
+                      S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                  .credentialsProvider(AnonymousCredentialsProvider.create())
+                  .region(Region.US_EAST_1)
+                  .httpClient(httpClient)
+                  .build();
+          S3InputStream stream =
+              new S3InputStream(s3Client, new S3URI("s3://test-bucket/test-key"))) {
+        // Read block1 from response1
+        byte[] buf1 = new byte[blockSize];
+        assertThat(stream.readNBytes(buf1, 0, blockSize)).isEqualTo(blockSize);
+        assertThat(buf1).isEqualTo(block1);
+        // Read the first half of block2 from response1,
+        // retry on "Premature end ..." (apache) or -1 (urlconnection),
+        // send a new range request from the current position
+        // and read the second half of block2 from response2
+        byte[] buf2 = new byte[blockSize];
+        assertThat(stream.readNBytes(buf2, 0, blockSize)).isEqualTo(blockSize);
+        assertThat(buf2).isEqualTo(block2);
+      }
+      // Confirm the retry opened a second request to the server.
+      mockServer.verify(request(), VerificationTimes.exactly(2));
+    } finally {
+      mockServer.stop();
     }
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -18,8 +18,12 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -61,5 +65,37 @@ public final class TestS3InputStream {
     s3InputStream.readTail(new byte[0], 0, 0);
 
     verify(inputStream).close();
+  }
+
+  @Test
+  void testReadRetriesOnPrematureConnectionClose() throws IOException {
+    when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
+        .thenThrow(
+            new ConnectionClosedException(
+                "Premature end of Content-Length delimited message body (expected: 100; received: 50)"))
+        .thenReturn(1);
+
+    assertThat(s3InputStream.read(new byte[1], 0, 1)).isEqualTo(1);
+    verify(s3Client, times(2))
+        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+  }
+
+  @Test
+  void testReadDoesNotRetryOnOtherConnectionClosedException() throws IOException {
+    when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
+        .thenThrow(new ConnectionClosedException("Connection closed by peer"));
+
+    assertThatThrownBy(() -> s3InputStream.read(new byte[1], 0, 1))
+        .isInstanceOf(ConnectionClosedException.class)
+        .hasMessage("Connection closed by peer");
+    verify(s3Client, times(1))
+        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+  }
+
+  /** Simulates the shaded {@code org.apache.http.ConnectionClosedException}. */
+  private static class ConnectionClosedException extends IOException {
+    ConnectionClosedException(String message) {
+      super(message);
+    }
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -19,8 +19,11 @@
 package org.apache.iceberg.aws.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -148,6 +151,38 @@ public final class TestS3InputStream {
       assertThat(bytesRead).isEqualTo(0);
       assertThat(readBytes.value()).isEqualTo(0);
       assertThat(readOperations.value()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  void testReadRetriesOnPrematureConnectionClose() throws IOException {
+    when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
+        .thenThrow(
+            new ConnectionClosedException(
+                "Premature end of Content-Length delimited message body (expected: 100; received: 50)"))
+        .thenReturn(1);
+
+    assertThat(s3InputStream.read(new byte[1], 0, 1)).isEqualTo(1);
+    verify(s3Client, times(2))
+        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+  }
+
+  @Test
+  void testReadDoesNotRetryOnOtherConnectionClosedException() throws IOException {
+    when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
+        .thenThrow(new ConnectionClosedException("Connection closed by peer"));
+
+    assertThatThrownBy(() -> s3InputStream.read(new byte[1], 0, 1))
+        .isInstanceOf(ConnectionClosedException.class)
+        .hasMessage("Connection closed by peer");
+    verify(s3Client, times(1))
+        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+  }
+
+  /** Simulates the shaded {@code org.apache.http.ConnectionClosedException}. */
+  private static class ConnectionClosedException extends IOException {
+    ConnectionClosedException(String message) {
+      super(message);
     }
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -19,17 +19,19 @@
 package org.apache.iceberg.aws.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.util.Arrays;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.metrics.CachingMetricsContext;
 import org.apache.iceberg.metrics.Counter;
@@ -39,8 +41,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.ConnectionOptions;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.verify.VerificationTimes;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,6 +65,9 @@ public final class TestS3InputStream {
 
   @BeforeEach
   void before() {
+    lenient()
+        .when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class)))
+        .thenReturn(inputStream);
     s3InputStream = new S3InputStream(s3Client, mock());
   }
 
@@ -155,34 +170,79 @@ public final class TestS3InputStream {
   }
 
   @Test
-  void testReadRetriesOnPrematureConnectionClose() throws IOException {
-    when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
-        .thenThrow(
-            new ConnectionClosedException(
-                "Premature end of Content-Length delimited message body (expected: 100; received: 50)"))
-        .thenReturn(1);
-
-    assertThat(s3InputStream.read(new byte[1], 0, 1)).isEqualTo(1);
-    verify(s3Client, times(2))
-        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+  void testReadRetriesOnPrematureConnectionCloseWithApacheHttpClient() throws IOException {
+    testReadRetriesOnPrematureConnectionClose(ApacheHttpClient.create());
   }
 
   @Test
-  void testReadDoesNotRetryOnOtherConnectionClosedException() throws IOException {
-    when(inputStream.read(any(byte[].class), anyInt(), anyInt()))
-        .thenThrow(new ConnectionClosedException("Connection closed by peer"));
-
-    assertThatThrownBy(() -> s3InputStream.read(new byte[1], 0, 1))
-        .isInstanceOf(ConnectionClosedException.class)
-        .hasMessage("Connection closed by peer");
-    verify(s3Client, times(1))
-        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+  void testReadRetriesOnPrematureConnectionCloseWithUrlConnectionHttpClient() throws IOException {
+    testReadRetriesOnPrematureConnectionClose(UrlConnectionHttpClient.create());
   }
 
-  /** Simulates the shaded {@code org.apache.http.ConnectionClosedException}. */
-  private static class ConnectionClosedException extends IOException {
-    ConnectionClosedException(String message) {
-      super(message);
+  void testReadRetriesOnPrematureConnectionClose(SdkHttpClient httpClient) throws IOException {
+    int fileSize = 1024;
+    int blockSize = fileSize / 2;
+    byte[] block1 = new byte[blockSize];
+    Arrays.fill(block1, (byte) 1);
+    byte[] block2 = new byte[blockSize];
+    Arrays.fill(block2, (byte) 2);
+    byte[] response1 = Arrays.copyOf(block1, blockSize + blockSize / 2);
+    System.arraycopy(block2, 0, response1, blockSize, blockSize / 2);
+    byte[] response2 = Arrays.copyOfRange(block2, blockSize / 2, blockSize);
+
+    ClientAndServer mockServer = startClientAndServer();
+    try {
+      // First unbounded request: send block1 and the first half of block2,
+      // then close the socket to simulate stalled connection
+      mockServer
+          .when(request().withHeader("Range", "bytes=0-"))
+          .respond(
+              HttpResponse.response()
+                  .withStatusCode(206)
+                  .withHeader("Content-Range", "bytes 0-%s/%s".formatted(fileSize - 1, fileSize))
+                  .withBody(response1)
+                  .withConnectionOptions(
+                      ConnectionOptions.connectionOptions()
+                          .withContentLengthHeaderOverride(fileSize)
+                          .withCloseSocket(true)));
+      // Retry from the second half of block2: complete response
+      mockServer
+          .when(request().withHeader("Range", "bytes=%s-".formatted(response1.length)))
+          .respond(
+              HttpResponse.response()
+                  .withStatusCode(206)
+                  .withHeader(
+                      "Content-Range",
+                      "bytes %s-%s/%s".formatted(response1.length, fileSize - 1, fileSize))
+                  .withBody(response2));
+
+      try (S3Client s3Client =
+              S3Client.builder()
+                  .endpointOverride(URI.create("http://127.0.0.1:" + mockServer.getLocalPort()))
+                  .serviceConfiguration(
+                      S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                  .credentialsProvider(AnonymousCredentialsProvider.create())
+                  .region(Region.US_EAST_1)
+                  .httpClient(httpClient)
+                  .build();
+          S3InputStream stream =
+              new S3InputStream(s3Client, new S3URI("s3://test-bucket/test-key"))) {
+        // Read block1 from response1
+        byte[] buf1 = new byte[blockSize];
+        assertThat(stream.readNBytes(buf1, 0, blockSize)).isEqualTo(blockSize);
+        assertThat(buf1).isEqualTo(block1);
+        // Read the first half of block2 from response1,
+        // retry on "Premature end ..." (apache) or -1 (urlconnection),
+        // send a new range request from the current position
+        // and read the second half of block2 from response2
+        byte[] buf2 = new byte[blockSize];
+        assertThat(stream.readNBytes(buf2, 0, blockSize)).isEqualTo(blockSize);
+        assertThat(buf2).isEqualTo(block2);
+      }
+      // Confirm the retry opened a second request to the server.
+      mockServer.verify(request(), VerificationTimes.exactly(2));
+    } finally {
+      mockServer.stop();
     }
   }
 }


### PR DESCRIPTION
During vectorized Parquet reads, `S3InputStream` opens an unbounded HTTP range request (`bytes=pos-`) and reads one row group eagerly into memory. While Spark processes that in-memory row group (which can take several minutes for large batches), the client stops reading from S3. The TCP receive buffer fills up, and S3 eventually tears down the stalled connection.

When the next row group read begins, the connection is already dead and Apache HTTP client throws `ConnectionClosedException: Premature end of Content-Length delimited message body (expected: x; received: y)` (when using [apache http client](https://github.com/apache/httpcomponents-core/blob/rel/v5.4.2/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java#L176-L178)). This only affects files with multiple row groups (typically >128 MB).

The existing retry policy handles `SSLException`, `SocketTimeoutException`, and `SocketException`, but not this case. This PR extends the retry predicate to reopen the stream at the saved position when this specific exception is encountered, while leaving all other `ConnectionClosedException` variants (e.g. from `abort()`) unaffected.

Fixes https://github.com/apache/iceberg/issues/9674 and https://github.com/apache/iceberg/issues/9679.
