### PR TITLE
ci: add cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 50
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -34,6 +36,8 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
zizmor covers dependabot too (`uvx zizmor --offline .github/`) 
It recommends adding 7 day cooldown period, https://docs.zizmor.sh/audits/#dependabot-cooldown