### PR TITLE
CI: Add ASF allowlist check workflow

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -17,6 +17,10 @@
 # under the License.
 #
 
+# Verifies all GitHub Actions refs are on the ASF allowlist.
+# Actions not on the allowlist silently fail with "Startup failure" — no logs,
+# no notifications, and PRs may appear green because no checks ran.
+# See https://github.com/apache/infrastructure-actions/issues/574
 name: "ASF Allowlist Check"
 
 on:
@@ -39,4 +43,5 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
-    - uses: apache/infrastructure-actions/allowlist-check@main
+    # Intentionally unpinned to always use the latest allowlist from the ASF.
+    - uses: apache/infrastructure-actions/allowlist-check@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Adds a CI workflow that verifies all `uses:` refs in workflow files are on the [ASF allowlist](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml) using [`apache/infrastructure-actions/allowlist-check`](https://github.com/apache/infrastructure-actions/tree/main/allowlist-check).

### Why

Actions not on the ASF org-level allowlist silently fail with "Startup failure" —
no logs, no notifications, and PRs may appear green because no checks actually ran.
See https://github.com/apache/infrastructure-actions/issues/574.

### What

- New workflow `.github/workflows/asf-allowlist-check.yml`
- Triggers on PRs and pushes to `main` that modify `.github/**`
- Intentionally pinned to `@main` to always check against the latest allowlist