### PR TITLE
Core: Fix TestReplacePartitions using wrong table for validation

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -445,6 +445,10 @@ public class TestBase {
     validateSnapshot(old, snap, null, newFiles);
   }
 
+  void validateSnapshot(Table validationTable, Snapshot old, Snapshot snap, DataFile... newFiles) {
+    validateSnapshot(validationTable, old, snap, null, newFiles);
+  }
+
   void validateSnapshot(Snapshot old, Snapshot snap, long sequenceNumber, DataFile... newFiles) {
     validateSnapshot(old, snap, (Long) sequenceNumber, newFiles);
   }
@@ -472,6 +476,16 @@ public class TestBase {
   }
 
   void validateSnapshot(Snapshot old, Snapshot snap, Long sequenceNumber, DataFile... newFiles) {
+    validateSnapshot(table, old, snap, sequenceNumber, newFiles);
+  }
+
+  @SuppressWarnings("checkstyle:HiddenField")
+  void validateSnapshot(
+      Table validationTable,
+      Snapshot old,
+      Snapshot snap,
+      Long sequenceNumber,
+      DataFile... newFiles) {
     assertThat(old != null ? Sets.newHashSet(old.deleteManifests(FILE_IO)) : ImmutableSet.of())
         .as("Should not change delete manifests")
         .isEqualTo(Sets.newHashSet(snap.deleteManifests(FILE_IO)));
@@ -492,7 +506,7 @@ public class TestBase {
     Iterator<String> newPaths = paths(newFiles).iterator();
 
     for (ManifestEntry<DataFile> entry :
-        ManifestFiles.read(manifest, FILE_IO, table.specs()).entries()) {
+        ManifestFiles.read(manifest, FILE_IO, validationTable.specs()).entries()) {
       DataFile file = entry.file();
       if (sequenceNumber != null) {
         V1Assert.assertEquals(
@@ -530,7 +544,9 @@ public class TestBase {
 
     assertThat(newPaths.hasNext()).as("Should find all files in the manifest").isFalse();
 
-    assertThat(snap.schemaId()).as("Schema ID should match").isEqualTo(table.schema().schemaId());
+    assertThat(snap.schemaId())
+        .as("Schema ID should match")
+        .isEqualTo(validationTable.schema().schemaId());
   }
 
   void validateTableFiles(Table tbl, DataFile... expectedFiles) {
@@ -794,8 +810,18 @@ public class TestBase {
       Iterator<Long> ids,
       Iterator<DataFile> expectedFiles,
       Iterator<ManifestEntry.Status> expectedStatuses) {
+    validateManifestEntries(table, manifest, ids, expectedFiles, expectedStatuses);
+  }
+
+  @SuppressWarnings("checkstyle:HiddenField")
+  void validateManifestEntries(
+      Table validationTable,
+      ManifestFile manifest,
+      Iterator<Long> ids,
+      Iterator<DataFile> expectedFiles,
+      Iterator<ManifestEntry.Status> expectedStatuses) {
     for (ManifestEntry<DataFile> entry :
-        ManifestFiles.read(manifest, FILE_IO, table.specs()).entries()) {
+        ManifestFiles.read(manifest, FILE_IO, validationTable.specs()).entries()) {
       DataFile file = entry.file();
       DataFile expected = expectedFiles.next();
       final ManifestEntry.Status expectedStatus = expectedStatuses.next();

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -188,14 +188,17 @@ public class TestReplacePartitions extends TestBase {
 
     assertThat(TestTables.metadataVersion("unpartitioned")).isEqualTo(0);
 
-    commit(table, unpartitioned.newAppend().appendFile(FILE_A), branch);
+    commit(unpartitioned, unpartitioned.newAppend().appendFile(FILE_A), branch);
     // make sure the data was successfully added
     assertThat(TestTables.metadataVersion("unpartitioned")).isEqualTo(1);
     validateSnapshot(
-        null, latestSnapshot(TestTables.readMetadata("unpartitioned"), branch), FILE_A);
+        unpartitioned,
+        null,
+        latestSnapshot(TestTables.readMetadata("unpartitioned"), branch),
+        FILE_A);
 
     ReplacePartitions replacePartitions = unpartitioned.newReplacePartitions().addFile(FILE_B);
-    commit(table, replacePartitions, branch);
+    commit(unpartitioned, replacePartitions, branch);
 
     assertThat(TestTables.metadataVersion("unpartitioned")).isEqualTo(2);
     TableMetadata replaceMetadata = TestTables.readMetadata("unpartitioned");
@@ -204,12 +207,14 @@ public class TestReplacePartitions extends TestBase {
     assertThat(latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io())).hasSize(2);
 
     validateManifestEntries(
+        unpartitioned,
         latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io()).get(0),
         ids(replaceId),
         files(FILE_B),
         statuses(Status.ADDED));
 
     validateManifestEntries(
+        unpartitioned,
         latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io()).get(1),
         ids(replaceId),
         files(FILE_A),
@@ -223,6 +228,7 @@ public class TestReplacePartitions extends TestBase {
 
     commit(tableVoid, tableVoid.newAppend().appendFile(FILE_ALL_VOID_UNPARTITIONED_A), branch);
     validateSnapshot(
+        tableVoid,
         null,
         latestSnapshot(TestTables.readMetadata("allvoidUnpartitioned"), branch),
         FILE_ALL_VOID_UNPARTITIONED_A);
@@ -240,12 +246,14 @@ public class TestReplacePartitions extends TestBase {
     assertThat(manifestFiles).hasSize(2);
 
     validateManifestEntries(
+        tableVoid,
         manifestFiles.get(0),
         ids(replaceId),
         files(FILE_ALL_VOID_UNPARTITIONED_B),
         statuses(Status.ADDED));
 
     validateManifestEntries(
+        tableVoid,
         manifestFiles.get(1),
         ids(replaceId),
         files(FILE_ALL_VOID_UNPARTITIONED_A),
@@ -264,15 +272,18 @@ public class TestReplacePartitions extends TestBase {
     assertThat(TestTables.metadataVersion("unpartitioned")).isEqualTo(1);
 
     AppendFiles appendFiles = unpartitioned.newAppend().appendFile(FILE_A);
-    commit(table, appendFiles, branch);
+    commit(unpartitioned, appendFiles, branch);
 
     // make sure the data was successfully added
     assertThat(TestTables.metadataVersion("unpartitioned")).isEqualTo(2);
     validateSnapshot(
-        null, latestSnapshot(TestTables.readMetadata("unpartitioned"), branch), FILE_A);
+        unpartitioned,
+        null,
+        latestSnapshot(TestTables.readMetadata("unpartitioned"), branch),
+        FILE_A);
 
     ReplacePartitions replacePartitions = unpartitioned.newReplacePartitions().addFile(FILE_B);
-    commit(table, replacePartitions, branch);
+    commit(unpartitioned, replacePartitions, branch);
 
     assertThat(TestTables.metadataVersion("unpartitioned")).isEqualTo(3);
     TableMetadata replaceMetadata = TestTables.readMetadata("unpartitioned");
@@ -281,6 +292,7 @@ public class TestReplacePartitions extends TestBase {
     assertThat(latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io())).hasSize(1);
 
     validateManifestEntries(
+        unpartitioned,
         latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io()).get(0),
         ids(replaceId, replaceId),
         files(FILE_B, FILE_A),


### PR DESCRIPTION
Discovered when fixing - #15634 

Previously this wasn't an issue because the validation table was close enough to the tables being tested that everything worked out. Parquet manifests changed the structure for partitioned vs unpartitioned tables, the validation table was partitioned so validation began to fail.

----

Three test methods in TestReplacePartitions operate on separate unpartitioned or all-void tables but were passing the wrong table instance to commit() and validation helpers:

- testReplaceWithUnpartitionedTable used commit(table, ...) instead of commit(unpartitioned, ...) for operations on the unpartitioned table
- testReplaceAndMergeWithUnpartitionedTable had the same issue
- validateSnapshot and validateManifestEntries were called without specifying which table to use for reading manifests, defaulting to the partitioned test table instead of the actual target table

The commit(table, ...) bug was introduced in #6650 when the test was refactored from direct toBranch().commit() calls to use the commit() helper. The validation calls for the all-void unpartitioned table (added in #14186) also used the default overloads that read manifests via the wrong table's specs.

This adds Table-accepting overloads for validateSnapshot and validateManifestEntries in TestBase and updates the affected tests to pass the correct table instance.

Cursor + Claude-4.6-opus-high