### PR TITLE
CI: Add back Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:


### PR DESCRIPTION
Revert of #15711

Now that we have merged #15797, we no longer need to worry about Github Workflows silently failing (https://github.com/apache/infrastructure-actions/issues/574)

This check will run for every PR and notify us if something failed: https://github.com/apache/iceberg/blob/main/.github/workflows/asf-allowlist-check.yml