### PR TITLE
Arrow: Tighten VectorHolder constructor visibility to private

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -73,7 +73,7 @@ public class VectorHolder {
     icebergField = field;
   }
 
-  VectorHolder(FieldVector vec, Types.NestedField field, NullabilityHolder nulls) {
+  private VectorHolder(FieldVector vec, Types.NestedField field, NullabilityHolder nulls) {
     columnDescriptor = null;
     vector = vec;
     isDictionaryEncoded = false;


### PR DESCRIPTION
The 3-arg VectorHolder constructor (FieldVector, NestedField, NullabilityHolder) was package-private but all callers are within the same top-level class (PositionVectorHolder inner class and vectorHolder() factory method). 

Since Java static inner classes can access private members of the enclosing class, this constructor can safely be made private to reduce its visibility scope. 

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
