### PR TITLE
Docs: Replace deprecated 'compile' with 'implementation' in Gradle snippet

### DIFF
--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -45,7 +45,7 @@ To add a dependency on Iceberg in Gradle, add the following to `build.gradle`:
 
 ```
 dependencies {
-  compile 'org.apache.iceberg:iceberg-core:{{ icebergVersion }}'
+  implementation 'org.apache.iceberg:iceberg-core:{{ icebergVersion }}'
 }
 ```
 


### PR DESCRIPTION
The Gradle snippet on the Releases page uses the `compile` configuration,
which was removed in Gradle 7. Update to `implementation` to match current
Gradle conventions. The Maven snippet is already correct.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
