### PR TITLE
Docs: Update Spark/Flink example versions in contribute.md

### DIFF
--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -111,7 +111,7 @@ Iceberg is built using Gradle with Java 17 or 21.
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`
 * To fix code style: `./gradlew spotlessApply`
-* To build particular Spark/Flink Versions: `./gradlew build -DsparkVersions=3.4,3.5 -DflinkVersions=1.14`
+* To build particular Spark/Flink Versions: `./gradlew build -DsparkVersions=3.5,4.0 -DflinkVersions=1.20,2.0`
 
 Iceberg table support is organized in library modules:
 


### PR DESCRIPTION
Update the example `./gradlew build` command in `contribute.md` to use
`-DsparkVersions=3.5,4.0 -DflinkVersions=1.20,2.0` (was `3.4,3.5` / `1.14`).

Flink 1.14 is no longer in `knownFlinkVersions`, so the current example
causes a Gradle build failure for new contributors.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
