### PR TITLE
Flink: Remove JUnit4 dependency from Flink modules

### DIFF
--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -71,9 +71,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     testImplementation libs.flink120.connector.test.utils
     testImplementation libs.flink120.core
     testImplementation libs.flink120.runtime
-    testImplementation(libs.flink120.test.utilsjunit) {
-      exclude group: 'junit'
-    }
     testImplementation(libs.flink120.test.utils) {
       exclude group: "org.apache.curator", module: 'curator-test'
       exclude group: 'junit'

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -71,9 +71,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     testImplementation libs.flink20.connector.test.utils
     testImplementation libs.flink20.core
     testImplementation libs.flink20.runtime
-    testImplementation(libs.flink20.test.utilsjunit) {
-      exclude group: 'junit'
-    }
     testImplementation(libs.flink20.test.utils) {
       exclude group: "org.apache.curator", module: 'curator-test'
       exclude group: 'junit'

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -71,9 +71,6 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     testImplementation libs.flink21.connector.test.utils
     testImplementation libs.flink21.core
     testImplementation libs.flink21.runtime
-    testImplementation(libs.flink21.test.utilsjunit) {
-      exclude group: 'junit'
-    }
     testImplementation(libs.flink21.test.utils) {
       exclude group: "org.apache.curator", module: 'curator-test'
       exclude group: 'junit'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -188,17 +188,14 @@ flink120-connector-test-utils = { module = "org.apache.flink:flink-connector-tes
 flink120-core = { module = "org.apache.flink:flink-core", version.ref = "flink120" }
 flink120-runtime = { module = "org.apache.flink:flink-runtime", version.ref = "flink120" }
 flink120-test-utils = { module = "org.apache.flink:flink-test-utils", version.ref = "flink120" }
-flink120-test-utilsjunit = { module = "org.apache.flink:flink-test-utils-junit", version.ref = "flink120" }
 flink20-connector-test-utils = { module = "org.apache.flink:flink-connector-test-utils", version.ref = "flink20" }
 flink20-core = { module = "org.apache.flink:flink-core", version.ref = "flink20" }
 flink20-runtime = { module = "org.apache.flink:flink-runtime", version.ref = "flink20" }
 flink20-test-utils = { module = "org.apache.flink:flink-test-utils", version.ref = "flink20" }
-flink20-test-utilsjunit = { module = "org.apache.flink:flink-test-utils-junit", version.ref = "flink20" }
 flink21-connector-test-utils = { module = "org.apache.flink:flink-connector-test-utils", version.ref = "flink21" }
 flink21-core = { module = "org.apache.flink:flink-core", version.ref = "flink21" }
 flink21-runtime = { module = "org.apache.flink:flink-runtime", version.ref = "flink21" }
 flink21-test-utils = { module = "org.apache.flink:flink-test-utils", version.ref = "flink21" }
-flink21-test-utilsjunit = { module = "org.apache.flink:flink-test-utils-junit", version.ref = "flink21" }
 guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava" }
 jakarta-el-api = { module = "jakarta.el:jakarta.el-api", version.ref = "jakarta-el-api" }
 jakarta-servlet = {module = "jakarta.servlet:jakarta.servlet-api", version.ref = "jakarta-servlet-api"}


### PR DESCRIPTION
### What

Remove the explicit `flink-test-utils-junit` dependency from all three Flink version modules (v1.20, v2.0, v2.1) and clean up the corresponding library aliases from `libs.versions.toml`.

### Why

All Flink test code has already been migrated to JUnit5 in prior work (#13021, #10770), making the explicit `flink-test-utils-junit` dependency vestigial. The artifact remains available transitively through `flink-test-utils` and `flink-connector-test-utils`.

### Changes

- **`flink/v1.20/build.gradle`**, **`flink/v2.0/build.gradle`**, **`flink/v2.1/build.gradle`**: Removed explicit `flink-test-utils-junit` dependency
- **`gradle/libs.versions.toml`**: Removed 3 unused `flink-test-utils-junit` library aliases

### Note

This does not fully resolve #12937. JUnit4 (`junit:junit`) still reaches the test classpath transitively through `flink-connector-test-utils` and `flink-test-utils`, because Flink's internal test utilities still reference `org.junit.rules.ExternalResource` at runtime. Fully removing JUnit4 requires upstream changes in Flink first.