### PR TITLE
AWS: Close custom AwsCredentialsProvider in RESTSigV4AuthSession

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthSession.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/RESTSigV4AuthSession.java
@@ -97,12 +97,10 @@ public class RESTSigV4AuthSession implements AuthSession {
 
   @Override
   public void close() {
-    if (closeableGroup != null) {
-      try {
-        closeableGroup.close();
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
+    try {
+      closeableGroup.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4AuthSession.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4AuthSession.java
@@ -311,28 +311,27 @@ class TestRESTSigV4AuthSession {
   }
 
   @Test
-  void closeWithCloseableCredentialsProvider() throws Exception {
+  void closeWithCloseableCredentialsProvider() {
     AuthSession delegate = Mockito.mock(AuthSession.class);
     CloseableAwsCredentialsProvider credentialsProvider =
         Mockito.mock(CloseableAwsCredentialsProvider.class);
-    AwsProperties properties = Mockito.mock(AwsProperties.class);
-    when(properties.restSigningRegion()).thenReturn(Region.US_WEST_2);
-    when(properties.restSigningName()).thenReturn("execute-api");
-    when(properties.restCredentialsProvider()).thenReturn(credentialsProvider);
-
-    RESTSigV4AuthSession session = new RESTSigV4AuthSession(signer, delegate, properties);
-    session.close();
-
-    Mockito.verify(delegate).close();
-    Mockito.verify(credentialsProvider).close();
+    closeWithCloseableCredentialsProvider(delegate, credentialsProvider);
   }
 
   @Test
-  void closeSuppressesFailure() throws Exception {
+  void closeSuppressesFailure() {
     AuthSession delegate = Mockito.mock(AuthSession.class);
     Mockito.doThrow(new RuntimeException("delegate close failed")).when(delegate).close();
     CloseableAwsCredentialsProvider credentialsProvider =
         Mockito.mock(CloseableAwsCredentialsProvider.class);
+    Mockito.doThrow(new RuntimeException("credentials provider close failed"))
+        .when(credentialsProvider)
+        .close();
+    closeWithCloseableCredentialsProvider(delegate, credentialsProvider);
+  }
+
+  private void closeWithCloseableCredentialsProvider(
+      AuthSession delegate, CloseableAwsCredentialsProvider credentialsProvider) {
     AwsProperties properties = Mockito.mock(AwsProperties.class);
     when(properties.restSigningRegion()).thenReturn(Region.US_WEST_2);
     when(properties.restSigningName()).thenReturn("execute-api");


### PR DESCRIPTION
## Summary

`RESTSigV4AuthSession` holds an `AwsCredentialsProvider` obtained from `AwsProperties.restCredentialsProvider()`, which may be `AutoCloseable` (e.g. `DefaultCredentialsProvider`, `StsCredentialsProvider`). Previously, `close()` only closed the delegate `AuthSession` but never closed the credentials provider, causing a resource leak.

This PR uses a `CloseableGroup` to manage both the delegate and the credentials provider (when it implements `AutoCloseable`), ensuring both are properly closed. Close failures are suppressed so that one failing resource doesn't prevent the other from being closed.