### PR TITLE
Core: Expose MetricsConfig.from method with 3-parameter version

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -223,7 +223,7 @@ public final class MetricsConfig implements Serializable {
    * @param order sort order columns, will be promoted to truncate(16)
    * @return metrics configuration
    */
-  private static MetricsConfig from(Map<String, String> props, Schema schema, SortOrder order) {
+  public static MetricsConfig from(Map<String, String> props, Schema schema, SortOrder order) {
     int maxInferredDefaultColumns = maxInferredColumnDefaults(props);
     Map<String, MetricsMode> columnModes = Maps.newHashMap();
 


### PR DESCRIPTION
This method is used from Trino ([IcebergPageSink](https://github.com/trinodb/trino/blob/master/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java#L170)), and migrating it to `forTable(Table table)` is a bit difficult since Table isn't available in this class. Additionally, MetricsConfig isn't Jackson-serializable. 

I propose reverting the deprecation, though I'm open to alternative approaches, e.g. exposing a method of 3 parameters `(Map<String, String> props, Schema schema, SortOrder order)`