### PR TITLE
Spark 4.1: Control merge schema evolution by table property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -347,7 +347,7 @@ public class TableProperties {
   public static final boolean SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
 
   public static final String SPARK_WRITE_AUTO_SCHEMA_EVOLUTION =
-      "write.spark.auto-schema-evolution";
+      "write.spark.auto-schema-evolution.enabled";
   public static final boolean SPARK_WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT = true;
 
   public static final String SPARK_WRITE_ADVISORY_PARTITION_SIZE_BYTES =

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeSchemaEvolution.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeSchemaEvolution.java
@@ -271,7 +271,7 @@ public class TestMergeSchemaEvolution extends SparkRowLevelOperationsTestBase {
         "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"software\" }");
 
     sql(
-        "ALTER TABLE %s SET TBLPROPERTIES ('%s' 'false')",
+        "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'false')",
         tableName, TableProperties.SPARK_WRITE_AUTO_SCHEMA_EVOLUTION);
 
     createOrReplaceView(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -348,18 +348,18 @@ public class SparkTable extends BaseSparkTable
   }
 
   private static Set<TableCapability> computeCapabilities(Table table) {
-    ImmutableSet.Builder<TableCapability> caps = ImmutableSet.builder();
-    caps.addAll(BASE_CAPABILITIES);
+    ImmutableSet.Builder<TableCapability> tableCapabilities = ImmutableSet.builder();
+    tableCapabilities.addAll(BASE_CAPABILITIES);
 
     if (autoSchemaEvolution(table)) {
-      caps.add(TableCapability.AUTOMATIC_SCHEMA_EVOLUTION);
+      tableCapabilities.add(TableCapability.AUTOMATIC_SCHEMA_EVOLUTION);
     }
 
     if (acceptAnySchema(table)) {
-      caps.add(TableCapability.ACCEPT_ANY_SCHEMA);
+      tableCapabilities.add(TableCapability.ACCEPT_ANY_SCHEMA);
     }
 
-    return caps.build();
+    return tableCapabilities.build();
   }
 
   private static boolean acceptAnySchema(Table table) {


### PR DESCRIPTION
This pr allows allow a table property to control schema evolution.  Both the table property must be set, and WITH SCHEMA EVOLUTION clause issued in the SQL, for MERGE INTO schema evolution to hold.

This is synonymous with how a table property controlled schema evolution method (for INSERT), ie 'accept-any-schema'.