### PR TITLE
Spark: Fix option validation in RewritePositionDeleteFilesSparkAction

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -304,7 +304,7 @@ public class RewritePositionDeleteFilesSparkAction
   }
 
   private void validateAndInitOptions() {
-    Set<String> validOptions = Sets.newHashSet(planner.validOptions());
+    Set<String> validOptions = Sets.newHashSet(runner.validOptions());
     validOptions.addAll(VALID_OPTIONS);
     validOptions.addAll(planner.validOptions());
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -304,7 +304,7 @@ public class RewritePositionDeleteFilesSparkAction
   }
 
   private void validateAndInitOptions() {
-    Set<String> validOptions = Sets.newHashSet(planner.validOptions());
+    Set<String> validOptions = Sets.newHashSet(runner.validOptions());
     validOptions.addAll(VALID_OPTIONS);
     validOptions.addAll(planner.validOptions());
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -304,7 +304,7 @@ public class RewritePositionDeleteFilesSparkAction
   }
 
   private void validateAndInitOptions() {
-    Set<String> validOptions = Sets.newHashSet(planner.validOptions());
+    Set<String> validOptions = Sets.newHashSet(runner.validOptions());
     validOptions.addAll(VALID_OPTIONS);
     validOptions.addAll(planner.validOptions());
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewritePositionDeleteFilesSparkAction.java
@@ -304,7 +304,7 @@ public class RewritePositionDeleteFilesSparkAction
   }
 
   private void validateAndInitOptions() {
-    Set<String> validOptions = Sets.newHashSet(planner.validOptions());
+    Set<String> validOptions = Sets.newHashSet(runner.validOptions());
     validOptions.addAll(VALID_OPTIONS);
     validOptions.addAll(planner.validOptions());
 


### PR DESCRIPTION
`validateAndInitOptions()` in `RewritePositionDeleteFilesSparkAction` adds `planner.validOptions()` twice instead of including `runner.validOptions()`, causing runner-specific options to be incorrectly rejected. 
Currently insignificant since position delete runners declare no exclusive options.