### PR TITLE
Core: Add Java reference implementation for relation load endpoints

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/CatalogObjectType.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/CatalogObjectType.java
@@ -16,15 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.rest;
+package org.apache.iceberg.catalog;
 
 import java.util.Locale;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
- * The type of a catalog object returned by the universal load relation endpoints. Currently {@link
- * #TABLE} and {@link #VIEW} are defined. Future spec versions may add values such as {@code
- * MATERIALIZED_VIEW}.
+ * The type of a catalog object. Currently {@link #TABLE} and {@link #VIEW} are defined. Future spec
+ * versions may add values such as {@code MATERIALIZED_VIEW}.
  */
 public enum CatalogObjectType {
   TABLE("table"),

--- a/api/src/main/java/org/apache/iceberg/catalog/Relation.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Relation.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.catalog;
+
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.view.View;
+
+/**
+ * A loaded catalog relation. A relation is either a table or a view. In the future, materialized
+ * views may set both the table and view fields.
+ */
+public class Relation {
+  private final CatalogObjectType objectType;
+  private final Table table;
+  private final View view;
+
+  private Relation(CatalogObjectType objectType, Table table, View view) {
+    this.objectType = objectType;
+    this.table = table;
+    this.view = view;
+  }
+
+  public static Relation forTable(Table table) {
+    Preconditions.checkArgument(table != null, "Invalid table: null");
+    return new Relation(CatalogObjectType.TABLE, table, null);
+  }
+
+  public static Relation forView(View view) {
+    Preconditions.checkArgument(view != null, "Invalid view: null");
+    return new Relation(CatalogObjectType.VIEW, null, view);
+  }
+
+  public CatalogObjectType objectType() {
+    return objectType;
+  }
+
+  /** Returns the table, or null if this relation is a view. */
+  public Table table() {
+    return table;
+  }
+
+  /** Returns the view, or null if this relation is a table. */
+  public View view() {
+    return view;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/catalog/Relation.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Relation.java
@@ -23,41 +23,62 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.view.View;
 
 /**
- * A loaded catalog relation. A relation is either a table or a view. In the future, materialized
- * views may set both the table and view fields.
+ * A loaded catalog relation. A relation is either a table, a view, or a not-found marker. In the
+ * future, materialized views may set both the table and view fields.
  */
 public class Relation {
+  private final TableIdentifier identifier;
   private final CatalogObjectType objectType;
   private final Table table;
   private final View view;
 
-  private Relation(CatalogObjectType objectType, Table table, View view) {
+  private Relation(
+      TableIdentifier identifier, CatalogObjectType objectType, Table table, View view) {
+    this.identifier = identifier;
     this.objectType = objectType;
     this.table = table;
     this.view = view;
   }
 
-  public static Relation forTable(Table table) {
+  public static Relation forTable(TableIdentifier identifier, Table table) {
+    Preconditions.checkArgument(identifier != null, "Invalid identifier: null");
     Preconditions.checkArgument(table != null, "Invalid table: null");
-    return new Relation(CatalogObjectType.TABLE, table, null);
+    return new Relation(identifier, CatalogObjectType.TABLE, table, null);
   }
 
-  public static Relation forView(View view) {
+  public static Relation forView(TableIdentifier identifier, View view) {
+    Preconditions.checkArgument(identifier != null, "Invalid identifier: null");
     Preconditions.checkArgument(view != null, "Invalid view: null");
-    return new Relation(CatalogObjectType.VIEW, null, view);
+    return new Relation(identifier, CatalogObjectType.VIEW, null, view);
   }
 
+  /** Create a relation representing a not-found object. */
+  public static Relation notFound(TableIdentifier identifier) {
+    Preconditions.checkArgument(identifier != null, "Invalid identifier: null");
+    return new Relation(identifier, null, null, null);
+  }
+
+  public TableIdentifier identifier() {
+    return identifier;
+  }
+
+  /** Returns the object type, or null if the object was not found. */
   public CatalogObjectType objectType() {
     return objectType;
   }
 
-  /** Returns the table, or null if this relation is a view. */
+  /** Returns the table, or null if this relation is a view or not found. */
   public Table table() {
     return table;
   }
 
-  /** Returns the view, or null if this relation is a table. */
+  /** Returns the view, or null if this relation is a table or not found. */
   public View view() {
     return view;
+  }
+
+  /** Returns true if the object was not found. */
+  public boolean isNotFound() {
+    return objectType == null;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java
@@ -387,4 +387,38 @@ public interface SessionCatalog {
       return false;
     }
   }
+
+  /**
+   * Load a single relation by identifier.
+   *
+   * <p>This mirrors {@link SupportsRelations#loadRelation(TableIdentifier)} but carries the session
+   * context so that {@link BaseSessionCatalog.AsCatalog} can forward the call to this session
+   * catalog.
+   *
+   * @param context session context
+   * @param identifier a table or view identifier
+   * @return the loaded relation
+   * @throws UnsupportedOperationException if the session catalog does not support loading relations
+   */
+  default Relation loadRelation(SessionContext context, TableIdentifier identifier) {
+    throw new UnsupportedOperationException(
+        this.getClass().getSimpleName() + " does not support loading relations");
+  }
+
+  /**
+   * Load multiple relations in a single batch request. Relations that are not found are skipped and
+   * will not appear in the returned list.
+   *
+   * <p>This mirrors {@link SupportsRelations#loadRelations(Set)} but carries the session context so
+   * that {@link BaseSessionCatalog.AsCatalog} can forward the call to this session catalog.
+   *
+   * @param context session context
+   * @param identifiers the set of identifiers to load
+   * @return the list of loaded relations, excluding not-found identifiers
+   * @throws UnsupportedOperationException if the session catalog does not support loading relations
+   */
+  default List<Relation> loadRelations(SessionContext context, Set<TableIdentifier> identifiers) {
+    throw new UnsupportedOperationException(
+        this.getClass().getSimpleName() + " does not support loading relations");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/catalog/SupportsRelations.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SupportsRelations.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.catalog;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Catalog methods for loading relations (tables and views) using a single endpoint.
+ *
+ * <p>Loading a relation resolves the identifier server-side and returns a discriminated result that
+ * indicates whether the object is a table or a view.
+ */
+public interface SupportsRelations {
+
+  /**
+   * Load a single relation by identifier.
+   *
+   * @param identifier a table or view identifier
+   * @return the loaded relation
+   * @throws org.apache.iceberg.exceptions.NotFoundException if no table or view exists for the
+   *     identifier
+   */
+  Relation loadRelation(TableIdentifier identifier);
+
+  /**
+   * Load multiple relations in a single batch request. Relations that are not found (404) are
+   * skipped and will not appear in the returned list.
+   *
+   * @param identifiers the set of identifiers to load
+   * @return the list of loaded relations, excluding not-found identifiers
+   */
+  List<Relation> loadRelations(Set<TableIdentifier> identifiers);
+}

--- a/api/src/test/java/org/apache/iceberg/catalog/TestCatalogObjectType.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestCatalogObjectType.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class TestCatalogObjectType {
+
+  @Test
+  void tableValue() {
+    assertThat(CatalogObjectType.TABLE.value()).isEqualTo("table");
+    assertThat(CatalogObjectType.TABLE.toString()).isEqualTo("table");
+  }
+
+  @Test
+  void viewValue() {
+    assertThat(CatalogObjectType.VIEW.value()).isEqualTo("view");
+    assertThat(CatalogObjectType.VIEW.toString()).isEqualTo("view");
+  }
+
+  @Test
+  void fromStringTable() {
+    assertThat(CatalogObjectType.fromString("table")).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(CatalogObjectType.fromString("TABLE")).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(CatalogObjectType.fromString("Table")).isEqualTo(CatalogObjectType.TABLE);
+  }
+
+  @Test
+  void fromStringView() {
+    assertThat(CatalogObjectType.fromString("view")).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(CatalogObjectType.fromString("VIEW")).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(CatalogObjectType.fromString("View")).isEqualTo(CatalogObjectType.VIEW);
+  }
+
+  @Test
+  void fromStringNull() {
+    assertThatThrownBy(() -> CatalogObjectType.fromString(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null");
+  }
+
+  @Test
+  void fromStringInvalid() {
+    assertThatThrownBy(() -> CatalogObjectType.fromString("invalid"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("invalid");
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/catalog/TestRelation.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestRelation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import org.apache.iceberg.Table;
+import org.apache.iceberg.view.View;
+import org.junit.jupiter.api.Test;
+
+class TestRelation {
+
+  @Test
+  void forTable() {
+    Table table = mock(Table.class);
+    Relation relation = Relation.forTable(table);
+
+    assertThat(relation.objectType()).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(relation.table()).isSameAs(table);
+    assertThat(relation.view()).isNull();
+  }
+
+  @Test
+  void forView() {
+    View view = mock(View.class);
+    Relation relation = Relation.forView(view);
+
+    assertThat(relation.objectType()).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(relation.view()).isSameAs(view);
+    assertThat(relation.table()).isNull();
+  }
+
+  @Test
+  void forTableNullThrows() {
+    assertThatThrownBy(() -> Relation.forTable(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null");
+  }
+
+  @Test
+  void forViewNullThrows() {
+    assertThatThrownBy(() -> Relation.forView(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null");
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/catalog/TestRelation.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestRelation.java
@@ -28,37 +28,75 @@ import org.junit.jupiter.api.Test;
 
 class TestRelation {
 
+  private static final TableIdentifier IDENT = TableIdentifier.of("ns", "tbl");
+
   @Test
   void forTable() {
     Table table = mock(Table.class);
-    Relation relation = Relation.forTable(table);
+    Relation relation = Relation.forTable(IDENT, table);
 
+    assertThat(relation.identifier()).isEqualTo(IDENT);
     assertThat(relation.objectType()).isEqualTo(CatalogObjectType.TABLE);
     assertThat(relation.table()).isSameAs(table);
     assertThat(relation.view()).isNull();
+    assertThat(relation.isNotFound()).isFalse();
   }
 
   @Test
   void forView() {
     View view = mock(View.class);
-    Relation relation = Relation.forView(view);
+    Relation relation = Relation.forView(IDENT, view);
 
+    assertThat(relation.identifier()).isEqualTo(IDENT);
     assertThat(relation.objectType()).isEqualTo(CatalogObjectType.VIEW);
     assertThat(relation.view()).isSameAs(view);
     assertThat(relation.table()).isNull();
+    assertThat(relation.isNotFound()).isFalse();
   }
 
   @Test
-  void forTableNullThrows() {
-    assertThatThrownBy(() -> Relation.forTable(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("null");
+  void notFound() {
+    Relation relation = Relation.notFound(IDENT);
+
+    assertThat(relation.identifier()).isEqualTo(IDENT);
+    assertThat(relation.objectType()).isNull();
+    assertThat(relation.table()).isNull();
+    assertThat(relation.view()).isNull();
+    assertThat(relation.isNotFound()).isTrue();
   }
 
   @Test
-  void forViewNullThrows() {
-    assertThatThrownBy(() -> Relation.forView(null))
+  void forTableNullIdentifierThrows() {
+    assertThatThrownBy(() -> Relation.forTable(null, mock(Table.class)))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("null");
+        .hasMessageContaining("identifier");
+  }
+
+  @Test
+  void forTableNullTableThrows() {
+    assertThatThrownBy(() -> Relation.forTable(IDENT, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("table");
+  }
+
+  @Test
+  void forViewNullIdentifierThrows() {
+    assertThatThrownBy(() -> Relation.forView(null, mock(View.class)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("identifier");
+  }
+
+  @Test
+  void forViewNullViewThrows() {
+    assertThatThrownBy(() -> Relation.forView(IDENT, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("view");
+  }
+
+  @Test
+  void notFoundNullIdentifierThrows() {
+    assertThatThrownBy(() -> Relation.notFound(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("identifier");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/catalog/BaseSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/catalog/BaseSessionCatalog.java
@@ -62,7 +62,7 @@ public abstract class BaseSessionCatalog implements SessionCatalog {
     return task.apply(asCatalog(context));
   }
 
-  public class AsCatalog implements Catalog, SupportsNamespaces {
+  public class AsCatalog implements Catalog, SupportsNamespaces, SupportsRelations {
     private final SessionContext context;
 
     private AsCatalog(SessionContext context) {
@@ -164,6 +164,16 @@ public abstract class BaseSessionCatalog implements SessionCatalog {
     @Override
     public boolean namespaceExists(Namespace namespace) {
       return BaseSessionCatalog.this.namespaceExists(context, namespace);
+    }
+
+    @Override
+    public Relation loadRelation(TableIdentifier identifier) {
+      return BaseSessionCatalog.this.loadRelation(context, identifier);
+    }
+
+    @Override
+    public List<Relation> loadRelations(Set<TableIdentifier> identifiers) {
+      return BaseSessionCatalog.this.loadRelations(context, identifiers);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -46,6 +46,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
@@ -776,7 +777,7 @@ public class CatalogHandlers {
         BatchLoadRelationResultItem.Builder itemBuilder =
             BatchLoadRelationResultItem.builder()
                 .withIdentifier(ident)
-                .withStatus(200)
+                .withStatus(HttpStatus.SC_OK)
                 .withResult(result);
 
         if (result.objectType() == CatalogObjectType.TABLE
@@ -787,7 +788,10 @@ public class CatalogHandlers {
         responseBuilder.addResult(itemBuilder.build());
       } catch (NoSuchTableException | NoSuchViewException e) {
         responseBuilder.addResult(
-            BatchLoadRelationResultItem.builder().withIdentifier(ident).withStatus(404).build());
+            BatchLoadRelationResultItem.builder()
+                .withIdentifier(ident)
+                .withStatus(HttpStatus.SC_NOT_FOUND)
+                .build());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -64,6 +64,7 @@ import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -80,6 +80,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
+import org.apache.iceberg.rest.requests.BatchLoadRelationRequestItem;
+import org.apache.iceberg.rest.requests.BatchLoadRelationsRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
@@ -90,6 +92,8 @@ import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.BatchLoadRelationResultItem;
+import org.apache.iceberg.rest.responses.BatchLoadRelationsResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
 import org.apache.iceberg.rest.responses.FetchScanTasksResponse;
@@ -97,6 +101,7 @@ import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadRelationResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
@@ -736,6 +741,64 @@ public class CatalogHandlers {
   public static LoadViewResponse loadView(ViewCatalog catalog, TableIdentifier viewIdentifier) {
     View view = catalog.loadView(viewIdentifier);
     return viewResponse(view);
+  }
+
+  public static LoadRelationResponse loadRelation(
+      Catalog catalog, ViewCatalog viewCatalog, TableIdentifier ident, SnapshotMode mode) {
+    try {
+      LoadTableResponse tableResponse = loadTable(catalog, ident, mode);
+      return LoadRelationResponse.builder().withTableResponse(tableResponse).build();
+    } catch (NoSuchTableException e) {
+      if (viewCatalog != null) {
+        try {
+          LoadViewResponse viewResponse = loadView(viewCatalog, ident);
+          return LoadRelationResponse.builder().withViewResponse(viewResponse).build();
+        } catch (NoSuchViewException ignored) {
+          // fall through to throw not-found
+        }
+      }
+    }
+
+    throw new NoSuchTableException("No table or view exists for identifier: %s", ident);
+  }
+
+  public static BatchLoadRelationsResponse batchLoadRelations(
+      Catalog catalog, ViewCatalog viewCatalog, BatchLoadRelationsRequest request) {
+    BatchLoadRelationsResponse.Builder responseBuilder = BatchLoadRelationsResponse.builder();
+
+    for (BatchLoadRelationRequestItem item : request.identifiers()) {
+      TableIdentifier ident = item.identifier();
+      SnapshotMode mode = snapshotModeFromString(item.snapshots());
+
+      try {
+        LoadRelationResponse result = loadRelation(catalog, viewCatalog, ident, mode);
+        BatchLoadRelationResultItem.Builder itemBuilder =
+            BatchLoadRelationResultItem.builder()
+                .withIdentifier(ident)
+                .withStatus(200)
+                .withResult(result);
+
+        if (result.objectType() == CatalogObjectType.TABLE
+            && result.tableResponse().metadataLocation() != null) {
+          itemBuilder.withEtag(result.tableResponse().metadataLocation());
+        }
+
+        responseBuilder.addResult(itemBuilder.build());
+      } catch (NoSuchTableException | NoSuchViewException e) {
+        responseBuilder.addResult(
+            BatchLoadRelationResultItem.builder().withIdentifier(ident).withStatus(404).build());
+      }
+    }
+
+    return responseBuilder.build();
+  }
+
+  private static SnapshotMode snapshotModeFromString(String value) {
+    if (value == null) {
+      return SnapshotMode.ALL;
+    }
+
+    return SnapshotMode.valueOf(value.toUpperCase(java.util.Locale.ROOT));
   }
 
   public static LoadViewResponse updateView(

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogObjectType.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogObjectType.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import java.util.Locale;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * The type of a catalog object returned by the universal load relation endpoints. Currently {@link
+ * #TABLE} and {@link #VIEW} are defined. Future spec versions may add values such as {@code
+ * MATERIALIZED_VIEW}.
+ */
+public enum CatalogObjectType {
+  TABLE("table"),
+  VIEW("view");
+
+  private final String value;
+
+  CatalogObjectType(String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+
+  public static CatalogObjectType fromString(String value) {
+    Preconditions.checkArgument(value != null, "Invalid catalog object type: null");
+    try {
+      return CatalogObjectType.valueOf(value.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(String.format("Invalid catalog object type: %s", value));
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -89,6 +89,11 @@ public class Endpoint {
   public static final Endpoint V1_REGISTER_VIEW =
       Endpoint.create("POST", ResourcePaths.V1_VIEW_REGISTER);
 
+  // relation endpoints
+  public static final Endpoint V1_LOAD_RELATION = Endpoint.create("GET", ResourcePaths.V1_RELATION);
+  public static final Endpoint V1_BATCH_LOAD_RELATIONS =
+      Endpoint.create("POST", ResourcePaths.V1_RELATIONS_BATCH_LOAD);
+
   private static final Splitter ENDPOINT_SPLITTER = Splitter.on(" ");
   private static final Joiner ENDPOINT_JOINER = Joiner.on(" ");
   private final String httpMethod;

--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -72,6 +72,10 @@ public class ErrorHandlers {
     return ViewCommitErrorHandler.INSTANCE;
   }
 
+  public static Consumer<ErrorResponse> relationErrorHandler() {
+    return RelationErrorHandler.INSTANCE;
+  }
+
   public static Consumer<ErrorResponse> tableCommitHandler() {
     return CommitErrorHandler.INSTANCE;
   }
@@ -207,6 +211,27 @@ public class ErrorHandlers {
         } else {
           throw new NoSuchPlanTaskException("%s", error.message());
         }
+      }
+
+      super.accept(error);
+    }
+  }
+
+  /** Relation level error handler (for universal load that resolves to table or view). */
+  private static class RelationErrorHandler extends DefaultErrorHandler {
+    private static final ErrorHandler INSTANCE = new RelationErrorHandler();
+
+    @Override
+    public void accept(ErrorResponse error) {
+      switch (error.code()) {
+        case 404:
+          if (NoSuchNamespaceException.class.getSimpleName().equals(error.type())) {
+            throw new NoSuchNamespaceException("%s", error.message());
+          } else {
+            throw new NotFoundException("%s", error.message());
+          }
+        case 409:
+          throw new AlreadyExistsException("%s", error.message());
       }
 
       super.accept(error);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -31,8 +31,10 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.Relation;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.SupportsRelations;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.ViewCatalog;
@@ -45,7 +47,12 @@ import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
 
 public class RESTCatalog
-    implements Catalog, ViewCatalog, SupportsNamespaces, Configurable<Object>, Closeable {
+    implements Catalog,
+        ViewCatalog,
+        SupportsNamespaces,
+        SupportsRelations,
+        Configurable<Object>,
+        Closeable {
   private final RESTSessionCatalog sessionCatalog;
   private final Catalog delegate;
   private final SupportsNamespaces nsDelegate;
@@ -339,5 +346,15 @@ public class RESTCatalog
   @Override
   public View registerView(TableIdentifier identifier, String metadataFileLocation) {
     return viewSessionCatalog.registerView(identifier, metadataFileLocation);
+  }
+
+  @Override
+  public Relation loadRelation(TableIdentifier identifier) {
+    return sessionCatalog.loadRelation(context, identifier);
+  }
+
+  @Override
+  public List<Relation> loadRelations(Set<TableIdentifier> identifiers) {
+    return sessionCatalog.loadRelations(context, identifiers);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -44,6 +44,8 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
 import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.rest.requests.BatchLoadRelationsRequest;
+import org.apache.iceberg.rest.requests.BatchLoadRelationsRequestParser;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequestParser;
 import org.apache.iceberg.rest.requests.CreateViewRequest;
@@ -64,6 +66,8 @@ import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequestParser;
+import org.apache.iceberg.rest.responses.BatchLoadRelationsResponse;
+import org.apache.iceberg.rest.responses.BatchLoadRelationsResponseParser;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.ConfigResponseParser;
 import org.apache.iceberg.rest.responses.ErrorResponse;
@@ -76,6 +80,8 @@ import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponseParser;
+import org.apache.iceberg.rest.responses.LoadRelationResponse;
+import org.apache.iceberg.rest.responses.LoadRelationResponseParser;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponseParser;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
@@ -160,7 +166,16 @@ public class RESTSerializers {
             ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseSerializer<>())
         .addDeserializer(LoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>())
         .addDeserializer(
-            ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>());
+            ImmutableLoadCredentialsResponse.class, new LoadCredentialsResponseDeserializer<>())
+        .addSerializer(LoadRelationResponse.class, new LoadRelationResponseSerializer<>())
+        .addDeserializer(LoadRelationResponse.class, new LoadRelationResponseDeserializer<>())
+        .addSerializer(BatchLoadRelationsRequest.class, new BatchLoadRelationsRequestSerializer<>())
+        .addDeserializer(
+            BatchLoadRelationsRequest.class, new BatchLoadRelationsRequestDeserializer<>())
+        .addSerializer(
+            BatchLoadRelationsResponse.class, new BatchLoadRelationsResponseSerializer<>())
+        .addDeserializer(
+            BatchLoadRelationsResponse.class, new BatchLoadRelationsResponseDeserializer<>());
 
     mapper.registerModule(module);
   }
@@ -620,6 +635,60 @@ public class RESTSerializers {
       return (T)
           FetchScanTasksResponseParser.fromJson(
               jsonNode, scanContext.getSpecsById(), scanContext.isCaseSensitive());
+    }
+  }
+
+  static class LoadRelationResponseSerializer<T extends LoadRelationResponse>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T response, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      LoadRelationResponseParser.toJson(response, gen);
+    }
+  }
+
+  static class LoadRelationResponseDeserializer<T extends LoadRelationResponse>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) LoadRelationResponseParser.fromJson(jsonNode);
+    }
+  }
+
+  static class BatchLoadRelationsRequestSerializer<T extends BatchLoadRelationsRequest>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      BatchLoadRelationsRequestParser.toJson(request, gen);
+    }
+  }
+
+  static class BatchLoadRelationsRequestDeserializer<T extends BatchLoadRelationsRequest>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) BatchLoadRelationsRequestParser.fromJson(jsonNode);
+    }
+  }
+
+  static class BatchLoadRelationsResponseSerializer<T extends BatchLoadRelationsResponse>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T response, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      BatchLoadRelationsResponseParser.toJson(response, gen);
+    }
+  }
+
+  static class BatchLoadRelationsResponseDeserializer<T extends BatchLoadRelationsResponse>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) BatchLoadRelationsResponseParser.fromJson(jsonNode);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -77,6 +77,7 @@ import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.requests.BatchLoadRelationsRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -89,11 +90,13 @@ import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.BatchLoadRelationsResponse;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadRelationResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
@@ -1469,6 +1472,40 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             endpoints);
 
     return new BaseView(ops, ViewUtil.fullViewName(name(), identifier));
+  }
+
+  /**
+   * Load a relation (table or view) using the universal load endpoint. The server resolves the
+   * identifier and returns a discriminated response.
+   */
+  public LoadRelationResponse loadRelation(SessionContext context, TableIdentifier identifier) {
+    Endpoint.check(endpoints, Endpoint.V1_LOAD_RELATION);
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    return client
+        .withAuthSession(contextualSession)
+        .get(
+            paths.relation(identifier),
+            LoadRelationResponse.class,
+            Map.of(),
+            ErrorHandlers.relationErrorHandler());
+  }
+
+  /**
+   * Batch load relations (tables and views) across namespaces using the batch load endpoint.
+   * Returns per-item results with status codes (200, 304, 404).
+   */
+  public BatchLoadRelationsResponse batchLoadRelations(
+      SessionContext context, BatchLoadRelationsRequest request) {
+    Endpoint.check(endpoints, Endpoint.V1_BATCH_LOAD_RELATIONS);
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    return client
+        .withAuthSession(contextualSession)
+        .post(
+            paths.batchLoadRelations(),
+            request,
+            BatchLoadRelationsResponse.class,
+            Map.of(),
+            ErrorHandlers.relationErrorHandler());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1501,6 +1501,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
    * Load a relation (table or view) using the universal load endpoint and construct the
    * corresponding {@link Table} or {@link View} object.
    */
+  @Override
   public Relation loadRelation(SessionContext context, TableIdentifier identifier) {
     Map<String, String> responseHeaders = Maps.newHashMap();
     TableWithETag cachedTable = tableCache.getIfPresent(context.sessionId(), identifier);
@@ -1539,6 +1540,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
    * Batch load relations (tables and views) using the batch load endpoint. Constructs {@link Table}
    * and {@link View} objects for each result. Not-found identifiers (404) are skipped.
    */
+  @Override
   public List<Relation> loadRelations(SessionContext context, Set<TableIdentifier> identifiers) {
     BatchLoadRelationsRequest.Builder requestBuilder = BatchLoadRelationsRequest.builder();
     for (TableIdentifier ident : identifiers) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -1558,7 +1559,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     for (BatchLoadRelationResultItem item : response.results()) {
       TableIdentifier ident = item.identifier();
       switch (item.status()) {
-        case 200:
+        case HttpStatus.SC_OK -> {
           LoadRelationResponse result = item.result();
           if (result.objectType() == CatalogObjectType.TABLE) {
             String eTag = item.etag();
@@ -1567,18 +1568,17 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
           } else {
             relations.add(buildViewRelation(context, ident, result.viewResponse()));
           }
-          break;
-        case 304:
+        }
+        case HttpStatus.SC_NOT_MODIFIED -> {
           TableWithETag cached = tableCache.getIfPresent(context.sessionId(), ident);
           if (cached != null) {
             relations.add(Relation.forTable(ident, cached.supplier().get()));
           }
-          break;
-        case 404:
-          break;
-        default:
-          LOG.warn("Unexpected status {} for identifier {}", item.status(), ident);
-          break;
+        }
+        case HttpStatus.SC_NOT_FOUND -> {}
+        default ->
+            throw new IllegalArgumentException(
+                String.format("Unexpected status %s for identifier %s", item.status(), ident));
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -48,7 +48,9 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.Transactions;
 import org.apache.iceberg.catalog.BaseViewSessionCatalog;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.Relation;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -77,6 +79,7 @@ import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.requests.BatchLoadRelationRequestItem;
 import org.apache.iceberg.rest.requests.BatchLoadRelationsRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
@@ -90,6 +93,7 @@ import org.apache.iceberg.rest.requests.RegisterViewRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.BatchLoadRelationResultItem;
 import org.apache.iceberg.rest.responses.BatchLoadRelationsResponse;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
@@ -1474,27 +1478,49 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     return new BaseView(ops, ViewUtil.fullViewName(name(), identifier));
   }
 
-  /**
-   * Load a relation (table or view) using the universal load endpoint. The server resolves the
-   * identifier and returns a discriminated response.
-   */
-  public LoadRelationResponse loadRelation(SessionContext context, TableIdentifier identifier) {
+  private LoadRelationResponse loadRelationInternal(
+      SessionContext context,
+      TableIdentifier identifier,
+      Map<String, String> headers,
+      Consumer<Map<String, String>> responseHeaders) {
     Endpoint.check(endpoints, Endpoint.V1_LOAD_RELATION);
     AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
     return client
         .withAuthSession(contextualSession)
         .get(
             paths.relation(identifier),
+            ImmutableMap.of(),
             LoadRelationResponse.class,
-            Map.of(),
-            ErrorHandlers.relationErrorHandler());
+            headers,
+            ErrorHandlers.relationErrorHandler(),
+            responseHeaders);
   }
 
   /**
-   * Batch load relations (tables and views) across namespaces using the batch load endpoint.
-   * Returns per-item results with status codes (200, 304, 404).
+   * Load a relation (table or view) using the universal load endpoint and construct the
+   * corresponding {@link Table} or {@link View} object.
    */
-  public BatchLoadRelationsResponse batchLoadRelations(
+  public Relation loadRelation(SessionContext context, TableIdentifier identifier) {
+    Map<String, String> responseHeaders = Maps.newHashMap();
+    TableWithETag cachedTable = tableCache.getIfPresent(context.sessionId(), identifier);
+
+    LoadRelationResponse response =
+        loadRelationInternal(
+            context, identifier, headersForLoadTable(cachedTable), responseHeaders::putAll);
+
+    if (response == null) {
+      Preconditions.checkNotNull(cachedTable, "Invalid load relation response: null");
+      return Relation.forTable(cachedTable.supplier().get());
+    }
+
+    if (response.objectType() == CatalogObjectType.TABLE) {
+      return buildTableRelation(context, identifier, response.tableResponse(), responseHeaders);
+    } else {
+      return buildViewRelation(context, identifier, response.viewResponse());
+    }
+  }
+
+  private BatchLoadRelationsResponse batchLoadRelationsInternal(
       SessionContext context, BatchLoadRelationsRequest request) {
     Endpoint.check(endpoints, Endpoint.V1_BATCH_LOAD_RELATIONS);
     AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
@@ -1506,6 +1532,57 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             BatchLoadRelationsResponse.class,
             Map.of(),
             ErrorHandlers.relationErrorHandler());
+  }
+
+  /**
+   * Batch load relations (tables and views) using the batch load endpoint. Constructs {@link Table}
+   * and {@link View} objects for each result. Not-found identifiers (404) are skipped.
+   */
+  public List<Relation> loadRelations(SessionContext context, Set<TableIdentifier> identifiers) {
+    BatchLoadRelationsRequest.Builder requestBuilder = BatchLoadRelationsRequest.builder();
+    for (TableIdentifier ident : identifiers) {
+      BatchLoadRelationRequestItem.Builder itemBuilder =
+          BatchLoadRelationRequestItem.builder().withIdentifier(ident);
+      TableWithETag cached = tableCache.getIfPresent(context.sessionId(), ident);
+      if (cached != null) {
+        itemBuilder.withEtag(cached.eTag());
+      }
+
+      requestBuilder.addIdentifier(itemBuilder.build());
+    }
+
+    BatchLoadRelationsResponse response =
+        batchLoadRelationsInternal(context, requestBuilder.build());
+
+    List<Relation> relations = Lists.newArrayList();
+    for (BatchLoadRelationResultItem item : response.results()) {
+      TableIdentifier ident = item.identifier();
+      switch (item.status()) {
+        case 200:
+          LoadRelationResponse result = item.result();
+          if (result.objectType() == CatalogObjectType.TABLE) {
+            String eTag = item.etag();
+            Map<String, String> headers = eTag != null ? Map.of(HttpHeaders.ETAG, eTag) : Map.of();
+            relations.add(buildTableRelation(context, ident, result.tableResponse(), headers));
+          } else {
+            relations.add(buildViewRelation(context, ident, result.viewResponse()));
+          }
+          break;
+        case 304:
+          TableWithETag cached = tableCache.getIfPresent(context.sessionId(), ident);
+          if (cached != null) {
+            relations.add(Relation.forTable(cached.supplier().get()));
+          }
+          break;
+        case 404:
+          break;
+        default:
+          LOG.warn("Unexpected status {} for identifier {}", item.status(), ident);
+          break;
+      }
+    }
+
+    return relations;
   }
 
   @Override
@@ -1584,6 +1661,49 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             endpoints);
 
     return new BaseView(ops, ViewUtil.fullViewName(name(), ident));
+  }
+
+  private Relation buildTableRelation(
+      SessionContext context,
+      TableIdentifier identifier,
+      LoadTableResponse tableResponse,
+      Map<String, String> responseHeaders) {
+    Map<String, String> tableConf = tableResponse.config();
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    AuthSession tableSession = authManager.tableSession(identifier, tableConf, contextualSession);
+    TableMetadata tableMetadata = tableResponse.tableMetadata();
+    List<Credential> credentials = tableResponse.credentials();
+    RESTClient tableClient = client.withAuthSession(tableSession);
+
+    Supplier<BaseTable> tableSupplier =
+        createTableSupplier(
+            identifier, tableMetadata, context, tableClient, tableConf, credentials);
+
+    String eTag = responseHeaders.getOrDefault(HttpHeaders.ETAG, null);
+    if (eTag != null) {
+      tableCache.put(context.sessionId(), identifier, tableSupplier, eTag);
+    }
+
+    return Relation.forTable(tableSupplier.get());
+  }
+
+  private Relation buildViewRelation(
+      SessionContext context, TableIdentifier identifier, LoadViewResponse viewResponse) {
+    Map<String, String> tableConf = viewResponse.config();
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    AuthSession tableSession = authManager.tableSession(identifier, tableConf, contextualSession);
+    ViewMetadata metadata = viewResponse.metadata();
+
+    RESTViewOperations ops =
+        newViewOps(
+            client.withAuthSession(tableSession),
+            paths.view(identifier),
+            Map::of,
+            mutationHeaders,
+            metadata,
+            endpoints);
+
+    return Relation.forView(new BaseView(ops, ViewUtil.fullViewName(name(), identifier)));
   }
 
   private static Map<String, String> headersForLoadTable(TableWithETag tableWithETag) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1510,7 +1510,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     if (response == null) {
       Preconditions.checkNotNull(cachedTable, "Invalid load relation response: null");
-      return Relation.forTable(cachedTable.supplier().get());
+      return Relation.forTable(identifier, cachedTable.supplier().get());
     }
 
     if (response.objectType() == CatalogObjectType.TABLE) {
@@ -1571,7 +1571,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         case 304:
           TableWithETag cached = tableCache.getIfPresent(context.sessionId(), ident);
           if (cached != null) {
-            relations.add(Relation.forTable(cached.supplier().get()));
+            relations.add(Relation.forTable(ident, cached.supplier().get()));
           }
           break;
         case 404:
@@ -1684,7 +1684,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       tableCache.put(context.sessionId(), identifier, tableSupplier, eTag);
     }
 
-    return Relation.forTable(tableSupplier.get());
+    return Relation.forTable(identifier, tableSupplier.get());
   }
 
   private Relation buildViewRelation(
@@ -1703,7 +1703,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             metadata,
             endpoints);
 
-    return Relation.forView(new BaseView(ops, ViewUtil.fullViewName(name(), identifier)));
+    return Relation.forView(
+        identifier, new BaseView(ops, ViewUtil.fullViewName(name(), identifier)));
   }
 
   private static Map<String, String> headersForLoadTable(TableWithETag tableWithETag) {

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -50,6 +50,9 @@ public class ResourcePaths {
   public static final String V1_VIEW = "/v1/{prefix}/namespaces/{namespace}/views/{view}";
   public static final String V1_VIEW_RENAME = "/v1/{prefix}/views/rename";
   public static final String V1_VIEW_REGISTER = "/v1/{prefix}/namespaces/{namespace}/register-view";
+  public static final String V1_RELATION =
+      "/v1/{prefix}/namespaces/{namespace}/relations/{relation}";
+  public static final String V1_RELATIONS_BATCH_LOAD = "/v1/{prefix}/relations/batch-load";
 
   public static ResourcePaths forCatalogProperties(Map<String, String> properties) {
     return new ResourcePaths(
@@ -154,6 +157,20 @@ public class ResourcePaths {
 
   public String registerView(Namespace ns) {
     return SLASH.join("v1", prefix, "namespaces", pathEncode(ns), "register-view");
+  }
+
+  public String relation(TableIdentifier ident) {
+    return SLASH.join(
+        "v1",
+        prefix,
+        "namespaces",
+        pathEncode(ident.namespace()),
+        "relations",
+        RESTUtil.encodeString(ident.name()));
+  }
+
+  public String batchLoadRelations() {
+    return SLASH.join("v1", prefix, "relations", "batch-load");
   }
 
   public String planTableScan(TableIdentifier ident) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRelationRequestItem.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRelationRequestItem.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * A single relation to load as part of a batch request. Optional {@link #etag()} and {@link
+ * #snapshots()} parameters apply only when the resolved relation is a table.
+ */
+public class BatchLoadRelationRequestItem {
+
+  private TableIdentifier identifier;
+  private String etag;
+  private String snapshots;
+
+  public BatchLoadRelationRequestItem() {
+    // Required for Jackson deserialization
+  }
+
+  private BatchLoadRelationRequestItem(TableIdentifier identifier, String etag, String snapshots) {
+    this.identifier = identifier;
+    this.etag = etag;
+    this.snapshots = snapshots;
+  }
+
+  public void validate() {
+    Preconditions.checkNotNull(identifier, "Invalid identifier: null");
+  }
+
+  public TableIdentifier identifier() {
+    return identifier;
+  }
+
+  public String etag() {
+    return etag;
+  }
+
+  public String snapshots() {
+    return snapshots;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("identifier", identifier)
+        .add("etag", etag)
+        .add("snapshots", snapshots)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private TableIdentifier identifier;
+    private String etag;
+    private String snapshots;
+
+    private Builder() {}
+
+    public Builder withIdentifier(TableIdentifier ident) {
+      this.identifier = ident;
+      return this;
+    }
+
+    public Builder withEtag(String etagValue) {
+      this.etag = etagValue;
+      return this;
+    }
+
+    public Builder withSnapshots(String snapshotsValue) {
+      this.snapshots = snapshotsValue;
+      return this;
+    }
+
+    public BatchLoadRelationRequestItem build() {
+      BatchLoadRelationRequestItem item =
+          new BatchLoadRelationRequestItem(identifier, etag, snapshots);
+      item.validate();
+      return item;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRelationRequestItemParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRelationRequestItemParser.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadRelationRequestItemParser {
+
+  private static final String IDENTIFIER = "identifier";
+  private static final String ETAG = "etag";
+  private static final String SNAPSHOTS = "snapshots";
+
+  private BatchLoadRelationRequestItemParser() {}
+
+  public static String toJson(BatchLoadRelationRequestItem item) {
+    return toJson(item, false);
+  }
+
+  public static String toJson(BatchLoadRelationRequestItem item, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(item, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadRelationRequestItem item, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != item, "Invalid batch load relation request item: null");
+
+    gen.writeStartObject();
+
+    gen.writeFieldName(IDENTIFIER);
+    TableIdentifierParser.toJson(item.identifier(), gen);
+
+    if (item.etag() != null) {
+      gen.writeStringField(ETAG, item.etag());
+    }
+
+    if (item.snapshots() != null) {
+      gen.writeStringField(SNAPSHOTS, item.snapshots());
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadRelationRequestItem fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadRelationRequestItemParser::fromJson);
+  }
+
+  public static BatchLoadRelationRequestItem fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load relation request item from null object");
+
+    BatchLoadRelationRequestItem.Builder builder =
+        BatchLoadRelationRequestItem.builder()
+            .withIdentifier(TableIdentifierParser.fromJson(JsonUtil.get(IDENTIFIER, json)));
+
+    if (json.hasNonNull(ETAG)) {
+      builder.withEtag(JsonUtil.getString(ETAG, json));
+    }
+
+    if (json.hasNonNull(SNAPSHOTS)) {
+      builder.withSnapshots(JsonUtil.getString(SNAPSHOTS, json));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRelationsRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRelationsRequest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.rest.RESTRequest;
+
+/** Request body for the batch load relations endpoint. */
+public class BatchLoadRelationsRequest implements RESTRequest {
+
+  private List<BatchLoadRelationRequestItem> identifiers;
+
+  public BatchLoadRelationsRequest() {
+    // Required for Jackson deserialization
+  }
+
+  private BatchLoadRelationsRequest(List<BatchLoadRelationRequestItem> identifiers) {
+    this.identifiers = identifiers;
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkArgument(
+        identifiers != null && !identifiers.isEmpty(), "Invalid identifiers: null or empty");
+  }
+
+  public List<BatchLoadRelationRequestItem> identifiers() {
+    return identifiers;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("identifiers", identifiers).toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final ImmutableList.Builder<BatchLoadRelationRequestItem> identifiers =
+        ImmutableList.builder();
+
+    private Builder() {}
+
+    public Builder addIdentifier(BatchLoadRelationRequestItem item) {
+      identifiers.add(item);
+      return this;
+    }
+
+    public Builder addAllIdentifiers(List<BatchLoadRelationRequestItem> items) {
+      identifiers.addAll(items);
+      return this;
+    }
+
+    public BatchLoadRelationsRequest build() {
+      BatchLoadRelationsRequest request = new BatchLoadRelationsRequest(identifiers.build());
+      request.validate();
+      return request;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRelationsRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/BatchLoadRelationsRequestParser.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadRelationsRequestParser {
+
+  private static final String IDENTIFIERS = "identifiers";
+
+  private BatchLoadRelationsRequestParser() {}
+
+  public static String toJson(BatchLoadRelationsRequest request) {
+    return toJson(request, false);
+  }
+
+  public static String toJson(BatchLoadRelationsRequest request, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadRelationsRequest request, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != request, "Invalid batch load relations request: null");
+
+    gen.writeStartObject();
+
+    gen.writeArrayFieldStart(IDENTIFIERS);
+    for (BatchLoadRelationRequestItem item : request.identifiers()) {
+      BatchLoadRelationRequestItemParser.toJson(item, gen);
+    }
+
+    gen.writeEndArray();
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadRelationsRequest fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadRelationsRequestParser::fromJson);
+  }
+
+  public static BatchLoadRelationsRequest fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load relations request from null object");
+
+    BatchLoadRelationsRequest.Builder builder = BatchLoadRelationsRequest.builder();
+
+    JsonNode identifiersNode = JsonUtil.get(IDENTIFIERS, json);
+    Preconditions.checkArgument(
+        identifiersNode.isArray(), "Cannot parse identifiers from non-array: %s", identifiersNode);
+
+    for (JsonNode itemNode : identifiersNode) {
+      builder.addIdentifier(BatchLoadRelationRequestItemParser.fromJson(itemNode));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationResultItem.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationResultItem.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.rest.responses;
 
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -48,9 +49,13 @@ public class BatchLoadRelationResultItem {
   public void validate() {
     Preconditions.checkNotNull(identifier, "Invalid identifier: null");
     Preconditions.checkArgument(
-        status == 200 || status == 304 || status == 404, "Invalid status: %s", status);
-    if (status == 200) {
-      Preconditions.checkArgument(result != null, "Invalid result: null when status is 200");
+        status == HttpStatus.SC_OK
+            || status == HttpStatus.SC_NOT_MODIFIED
+            || status == HttpStatus.SC_NOT_FOUND,
+        "Invalid status: %s",
+        status);
+    if (status == HttpStatus.SC_OK) {
+      Preconditions.checkArgument(result != null, "Invalid result: null when status is %s", status);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationResultItem.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationResultItem.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Per-item result in a batch load response. The {@link #status()} field indicates the outcome: 200
+ * for success with payload, 304 for not-modified (tables only), 404 for not found.
+ */
+public class BatchLoadRelationResultItem {
+
+  private TableIdentifier identifier;
+  private int status;
+  private LoadRelationResponse result;
+  private String etag;
+
+  public BatchLoadRelationResultItem() {
+    // Required for Jackson deserialization
+  }
+
+  private BatchLoadRelationResultItem(
+      TableIdentifier identifier, int status, LoadRelationResponse result, String etag) {
+    this.identifier = identifier;
+    this.status = status;
+    this.result = result;
+    this.etag = etag;
+  }
+
+  public void validate() {
+    Preconditions.checkNotNull(identifier, "Invalid identifier: null");
+    Preconditions.checkArgument(
+        status == 200 || status == 304 || status == 404, "Invalid status: %s", status);
+    if (status == 200) {
+      Preconditions.checkArgument(result != null, "Invalid result: null when status is 200");
+    }
+  }
+
+  public TableIdentifier identifier() {
+    return identifier;
+  }
+
+  public int status() {
+    return status;
+  }
+
+  public LoadRelationResponse result() {
+    return result;
+  }
+
+  public String etag() {
+    return etag;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("identifier", identifier)
+        .add("status", status)
+        .add("result", result)
+        .add("etag", etag)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private TableIdentifier identifier;
+    private int status;
+    private LoadRelationResponse result;
+    private String etag;
+
+    private Builder() {}
+
+    public Builder withIdentifier(TableIdentifier ident) {
+      this.identifier = ident;
+      return this;
+    }
+
+    public Builder withStatus(int statusCode) {
+      this.status = statusCode;
+      return this;
+    }
+
+    public Builder withResult(LoadRelationResponse resultResponse) {
+      this.result = resultResponse;
+      return this;
+    }
+
+    public Builder withEtag(String etagValue) {
+      this.etag = etagValue;
+      return this;
+    }
+
+    public BatchLoadRelationResultItem build() {
+      BatchLoadRelationResultItem item =
+          new BatchLoadRelationResultItem(identifier, status, result, etag);
+      item.validate();
+      return item;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationResultItemParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationResultItemParser.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadRelationResultItemParser {
+
+  private static final String IDENTIFIER = "identifier";
+  private static final String STATUS = "status";
+  private static final String RESULT = "result";
+  private static final String ETAG = "etag";
+
+  private BatchLoadRelationResultItemParser() {}
+
+  public static String toJson(BatchLoadRelationResultItem item) {
+    return toJson(item, false);
+  }
+
+  public static String toJson(BatchLoadRelationResultItem item, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(item, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadRelationResultItem item, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != item, "Invalid batch load relation result item: null");
+
+    gen.writeStartObject();
+
+    gen.writeFieldName(IDENTIFIER);
+    TableIdentifierParser.toJson(item.identifier(), gen);
+
+    gen.writeNumberField(STATUS, item.status());
+
+    if (item.result() != null) {
+      gen.writeFieldName(RESULT);
+      LoadRelationResponseParser.toJson(item.result(), gen);
+    }
+
+    if (item.etag() != null) {
+      gen.writeStringField(ETAG, item.etag());
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadRelationResultItem fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadRelationResultItemParser::fromJson);
+  }
+
+  public static BatchLoadRelationResultItem fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load relation result item from null object");
+
+    BatchLoadRelationResultItem.Builder builder =
+        BatchLoadRelationResultItem.builder()
+            .withIdentifier(TableIdentifierParser.fromJson(JsonUtil.get(IDENTIFIER, json)))
+            .withStatus(JsonUtil.getInt(STATUS, json));
+
+    if (json.hasNonNull(RESULT)) {
+      builder.withResult(LoadRelationResponseParser.fromJson(JsonUtil.get(RESULT, json)));
+    }
+
+    if (json.hasNonNull(ETAG)) {
+      builder.withEtag(JsonUtil.getString(ETAG, json));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationsForbiddenResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationsForbiddenResponse.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.rest.RESTResponse;
+
+/**
+ * Error response returned when the batch load request is forbidden due to lack of permissions on
+ * one or more requested relations. Extends the standard error model (allOf pattern) with a list of
+ * the identifiers that were not accessible.
+ *
+ * <p>The JSON shape is flat: {@code message}, {@code type}, {@code code} from ErrorModel plus
+ * {@code forbidden-identifiers}.
+ */
+public class BatchLoadRelationsForbiddenResponse implements RESTResponse {
+
+  private String message;
+  private String type;
+  private int code;
+  private List<TableIdentifier> forbiddenIdentifiers;
+
+  public BatchLoadRelationsForbiddenResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private BatchLoadRelationsForbiddenResponse(
+      String message, String type, int code, List<TableIdentifier> forbiddenIdentifiers) {
+    this.message = message;
+    this.type = type;
+    this.code = code;
+    this.forbiddenIdentifiers = forbiddenIdentifiers;
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkArgument(code == 403, "Invalid code for forbidden response: %s", code);
+    Preconditions.checkArgument(
+        forbiddenIdentifiers != null && !forbiddenIdentifiers.isEmpty(),
+        "Invalid forbidden-identifiers: null or empty");
+  }
+
+  public String message() {
+    return message;
+  }
+
+  public String type() {
+    return type;
+  }
+
+  public int code() {
+    return code;
+  }
+
+  public List<TableIdentifier> forbiddenIdentifiers() {
+    return forbiddenIdentifiers;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("message", message)
+        .add("type", type)
+        .add("code", code)
+        .add("forbiddenIdentifiers", forbiddenIdentifiers)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String message;
+    private String type;
+    private int code = 403;
+    private final ImmutableList.Builder<TableIdentifier> forbiddenIdentifiers =
+        ImmutableList.builder();
+
+    private Builder() {}
+
+    public Builder withMessage(String msg) {
+      this.message = msg;
+      return this;
+    }
+
+    public Builder withType(String errorType) {
+      this.type = errorType;
+      return this;
+    }
+
+    public Builder withCode(int errorCode) {
+      this.code = errorCode;
+      return this;
+    }
+
+    public Builder addForbiddenIdentifier(TableIdentifier ident) {
+      forbiddenIdentifiers.add(ident);
+      return this;
+    }
+
+    public Builder addAllForbiddenIdentifiers(List<TableIdentifier> idents) {
+      forbiddenIdentifiers.addAll(idents);
+      return this;
+    }
+
+    public BatchLoadRelationsForbiddenResponse build() {
+      BatchLoadRelationsForbiddenResponse response =
+          new BatchLoadRelationsForbiddenResponse(
+              message, type, code, forbiddenIdentifiers.build());
+      response.validate();
+      return response;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationsForbiddenResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationsForbiddenResponseParser.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadRelationsForbiddenResponseParser {
+
+  private static final String MESSAGE = "message";
+  private static final String TYPE = "type";
+  private static final String CODE = "code";
+  private static final String FORBIDDEN_IDENTIFIERS = "forbidden-identifiers";
+
+  private BatchLoadRelationsForbiddenResponseParser() {}
+
+  public static String toJson(BatchLoadRelationsForbiddenResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(BatchLoadRelationsForbiddenResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadRelationsForbiddenResponse response, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(
+        null != response, "Invalid batch load relations forbidden response: null");
+
+    gen.writeStartObject();
+
+    gen.writeStringField(MESSAGE, response.message());
+    gen.writeStringField(TYPE, response.type());
+    gen.writeNumberField(CODE, response.code());
+
+    gen.writeArrayFieldStart(FORBIDDEN_IDENTIFIERS);
+    for (org.apache.iceberg.catalog.TableIdentifier ident : response.forbiddenIdentifiers()) {
+      TableIdentifierParser.toJson(ident, gen);
+    }
+
+    gen.writeEndArray();
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadRelationsForbiddenResponse fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadRelationsForbiddenResponseParser::fromJson);
+  }
+
+  public static BatchLoadRelationsForbiddenResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load relations forbidden response from null object");
+
+    BatchLoadRelationsForbiddenResponse.Builder builder =
+        BatchLoadRelationsForbiddenResponse.builder()
+            .withMessage(JsonUtil.getStringOrNull(MESSAGE, json))
+            .withType(JsonUtil.getStringOrNull(TYPE, json))
+            .withCode(JsonUtil.getInt(CODE, json));
+
+    JsonNode forbiddenNode = JsonUtil.get(FORBIDDEN_IDENTIFIERS, json);
+    Preconditions.checkArgument(
+        forbiddenNode.isArray(),
+        "Cannot parse forbidden-identifiers from non-array: %s",
+        forbiddenNode);
+
+    for (JsonNode identNode : forbiddenNode) {
+      builder.addForbiddenIdentifier(TableIdentifierParser.fromJson(identNode));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationsResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationsResponse.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.rest.RESTResponse;
+
+/** Response body for the batch load relations endpoint. */
+public class BatchLoadRelationsResponse implements RESTResponse {
+
+  private List<BatchLoadRelationResultItem> results;
+  private List<TableIdentifier> unprocessedIdentifiers;
+
+  public BatchLoadRelationsResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private BatchLoadRelationsResponse(
+      List<BatchLoadRelationResultItem> results, List<TableIdentifier> unprocessedIdentifiers) {
+    this.results = results;
+    this.unprocessedIdentifiers = unprocessedIdentifiers;
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkNotNull(results, "Invalid results: null");
+  }
+
+  public List<BatchLoadRelationResultItem> results() {
+    return results;
+  }
+
+  public List<TableIdentifier> unprocessedIdentifiers() {
+    return unprocessedIdentifiers != null ? unprocessedIdentifiers : ImmutableList.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("results", results)
+        .add("unprocessedIdentifiers", unprocessedIdentifiers)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final ImmutableList.Builder<BatchLoadRelationResultItem> results =
+        ImmutableList.builder();
+    private ImmutableList.Builder<TableIdentifier> unprocessedIdentifiers;
+
+    private Builder() {}
+
+    public Builder addResult(BatchLoadRelationResultItem item) {
+      results.add(item);
+      return this;
+    }
+
+    public Builder addAllResults(List<BatchLoadRelationResultItem> items) {
+      results.addAll(items);
+      return this;
+    }
+
+    public Builder addUnprocessedIdentifier(TableIdentifier ident) {
+      if (unprocessedIdentifiers == null) {
+        unprocessedIdentifiers = ImmutableList.builder();
+      }
+
+      unprocessedIdentifiers.add(ident);
+      return this;
+    }
+
+    public Builder addAllUnprocessedIdentifiers(List<TableIdentifier> idents) {
+      if (unprocessedIdentifiers == null) {
+        unprocessedIdentifiers = ImmutableList.builder();
+      }
+
+      unprocessedIdentifiers.addAll(idents);
+      return this;
+    }
+
+    public BatchLoadRelationsResponse build() {
+      BatchLoadRelationsResponse response =
+          new BatchLoadRelationsResponse(
+              results.build(),
+              unprocessedIdentifiers != null ? unprocessedIdentifiers.build() : null);
+      response.validate();
+      return response;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationsResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/BatchLoadRelationsResponseParser.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class BatchLoadRelationsResponseParser {
+
+  private static final String RESULTS = "results";
+  private static final String UNPROCESSED_IDENTIFIERS = "unprocessed-identifiers";
+
+  private BatchLoadRelationsResponseParser() {}
+
+  public static String toJson(BatchLoadRelationsResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(BatchLoadRelationsResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(BatchLoadRelationsResponse response, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid batch load relations response: null");
+
+    gen.writeStartObject();
+
+    gen.writeArrayFieldStart(RESULTS);
+    for (BatchLoadRelationResultItem item : response.results()) {
+      BatchLoadRelationResultItemParser.toJson(item, gen);
+    }
+
+    gen.writeEndArray();
+
+    if (!response.unprocessedIdentifiers().isEmpty()) {
+      gen.writeArrayFieldStart(UNPROCESSED_IDENTIFIERS);
+      for (org.apache.iceberg.catalog.TableIdentifier ident : response.unprocessedIdentifiers()) {
+        TableIdentifierParser.toJson(ident, gen);
+      }
+
+      gen.writeEndArray();
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static BatchLoadRelationsResponse fromJson(String json) {
+    return JsonUtil.parse(json, BatchLoadRelationsResponseParser::fromJson);
+  }
+
+  public static BatchLoadRelationsResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse batch load relations response from null object");
+
+    BatchLoadRelationsResponse.Builder builder = BatchLoadRelationsResponse.builder();
+
+    JsonNode resultsNode = JsonUtil.get(RESULTS, json);
+    Preconditions.checkArgument(
+        resultsNode.isArray(), "Cannot parse results from non-array: %s", resultsNode);
+
+    for (JsonNode itemNode : resultsNode) {
+      builder.addResult(BatchLoadRelationResultItemParser.fromJson(itemNode));
+    }
+
+    if (json.hasNonNull(UNPROCESSED_IDENTIFIERS)) {
+      JsonNode unprocessedNode = json.get(UNPROCESSED_IDENTIFIERS);
+      Preconditions.checkArgument(
+          unprocessedNode.isArray(),
+          "Cannot parse unprocessed-identifiers from non-array: %s",
+          unprocessedNode);
+
+      for (JsonNode identNode : unprocessedNode) {
+        builder.addUnprocessedIdentifier(TableIdentifierParser.fromJson(identNode));
+      }
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadRelationResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadRelationResponse.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iceberg.rest.responses;
 
+import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.rest.CatalogObjectType;
 import org.apache.iceberg.rest.RESTResponse;
 
 /**

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadRelationResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadRelationResponse.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.CatalogObjectType;
+import org.apache.iceberg.rest.RESTResponse;
+
+/**
+ * Discriminated response for the universal relation load endpoint. The {@link #objectType()} field
+ * indicates whether the loaded relation is a table or a view, and exactly one of {@link
+ * #tableResponse()} or {@link #viewResponse()} is populated.
+ */
+public class LoadRelationResponse implements RESTResponse {
+
+  private CatalogObjectType objectType;
+  private LoadTableResponse tableResponse;
+  private LoadViewResponse viewResponse;
+
+  public LoadRelationResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private LoadRelationResponse(
+      CatalogObjectType objectType,
+      LoadTableResponse tableResponse,
+      LoadViewResponse viewResponse) {
+    this.objectType = objectType;
+    this.tableResponse = tableResponse;
+    this.viewResponse = viewResponse;
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkNotNull(objectType, "Invalid object-type: null");
+    switch (objectType) {
+      case TABLE:
+        Preconditions.checkArgument(
+            tableResponse != null, "Invalid table response: null for object-type table");
+        break;
+      case VIEW:
+        Preconditions.checkArgument(
+            viewResponse != null, "Invalid view response: null for object-type view");
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unsupported object-type: %s", objectType));
+    }
+  }
+
+  public CatalogObjectType objectType() {
+    return objectType;
+  }
+
+  public LoadTableResponse tableResponse() {
+    return tableResponse;
+  }
+
+  public LoadViewResponse viewResponse() {
+    return viewResponse;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("objectType", objectType)
+        .add("tableResponse", tableResponse)
+        .add("viewResponse", viewResponse)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private CatalogObjectType objectType;
+    private LoadTableResponse tableResponse;
+    private LoadViewResponse viewResponse;
+
+    private Builder() {}
+
+    public Builder withObjectType(CatalogObjectType type) {
+      this.objectType = type;
+      return this;
+    }
+
+    public Builder withTableResponse(LoadTableResponse table) {
+      this.objectType = CatalogObjectType.TABLE;
+      this.tableResponse = table;
+      return this;
+    }
+
+    public Builder withViewResponse(LoadViewResponse view) {
+      this.objectType = CatalogObjectType.VIEW;
+      this.viewResponse = view;
+      return this;
+    }
+
+    public LoadRelationResponse build() {
+      LoadRelationResponse response =
+          new LoadRelationResponse(objectType, tableResponse, viewResponse);
+      response.validate();
+      return response;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadRelationResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadRelationResponseParser.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.rest.responses;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.rest.CatalogObjectType;
 import org.apache.iceberg.util.JsonUtil;
 
 public class LoadRelationResponseParser {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadRelationResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadRelationResponseParser.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.CatalogObjectType;
+import org.apache.iceberg.util.JsonUtil;
+
+public class LoadRelationResponseParser {
+
+  private static final String OBJECT_TYPE = "object-type";
+  private static final String TABLE = "table";
+  private static final String VIEW = "view";
+
+  private LoadRelationResponseParser() {}
+
+  public static String toJson(LoadRelationResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(LoadRelationResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(LoadRelationResponse response, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid load relation response: null");
+
+    gen.writeStartObject();
+
+    gen.writeStringField(OBJECT_TYPE, response.objectType().value());
+
+    switch (response.objectType()) {
+      case TABLE:
+        gen.writeFieldName(TABLE);
+        LoadTableResponseParser.toJson(response.tableResponse(), gen);
+        break;
+      case VIEW:
+        gen.writeFieldName(VIEW);
+        LoadViewResponseParser.toJson(response.viewResponse(), gen);
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unsupported object-type: %s", response.objectType()));
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static LoadRelationResponse fromJson(String json) {
+    return JsonUtil.parse(json, LoadRelationResponseParser::fromJson);
+  }
+
+  public static LoadRelationResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse load relation response from null object");
+
+    CatalogObjectType objectType =
+        CatalogObjectType.fromString(JsonUtil.getString(OBJECT_TYPE, json));
+
+    LoadRelationResponse.Builder builder =
+        LoadRelationResponse.builder().withObjectType(objectType);
+
+    switch (objectType) {
+      case TABLE:
+        builder.withTableResponse(LoadTableResponseParser.fromJson(JsonUtil.get(TABLE, json)));
+        break;
+      case VIEW:
+        builder.withViewResponse(LoadViewResponseParser.fromJson(JsonUtil.get(VIEW, json)));
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unsupported object-type: %s", objectType));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.Transactions;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -535,7 +536,7 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
 
       case LOAD_RELATION:
         {
-          TableIdentifier ident = tableIdentFromPathVars(vars);
+          TableIdentifier ident = relationIdentFromPathVars(vars);
           LoadRelationResponse response =
               CatalogHandlers.loadRelation(
                   catalog,
@@ -772,6 +773,11 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
   private static TableIdentifier viewIdentFromPathVars(Map<String, String> pathVars) {
     return TableIdentifier.of(
         namespaceFromPathVars(pathVars), RESTUtil.decodeString(pathVars.get("view")));
+  }
+
+  private static TableIdentifier relationIdentFromPathVars(Map<String, String> pathVars) {
+    return TableIdentifier.of(
+        namespaceFromPathVars(pathVars), RESTUtil.decodeString(pathVars.get("relation")));
   }
 
   private static String planIDFromPathVars(Map<String, String> pathVars) {

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -63,6 +63,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
 import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
 import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.requests.BatchLoadRelationsRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -77,6 +78,7 @@ import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadRelationResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.util.Pair;
@@ -529,6 +531,41 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
                 responseType, CatalogHandlers.registerView(asViewCatalog, namespace, request));
           }
           break;
+        }
+
+      case LOAD_RELATION:
+        {
+          TableIdentifier ident = tableIdentFromPathVars(vars);
+          LoadRelationResponse response =
+              CatalogHandlers.loadRelation(
+                  catalog,
+                  asViewCatalog,
+                  ident,
+                  snapshotModeFromQueryParams(httpRequest.queryParameters()));
+
+          if (response.objectType() == CatalogObjectType.TABLE) {
+            String eTag =
+                ETagProvider.of(
+                    response.tableResponse().metadataLocation(), httpRequest.queryParameters());
+
+            Optional<HTTPHeaders.HTTPHeader> ifNoneMatchHeader =
+                httpRequest.headers().firstEntry(HttpHeaders.IF_NONE_MATCH);
+
+            if (ifNoneMatchHeader.isPresent() && eTag.equals(ifNoneMatchHeader.get().value())) {
+              return null;
+            }
+
+            responseHeaders.accept(ImmutableMap.of(HttpHeaders.ETAG, eTag));
+          }
+
+          return castResponse(responseType, response);
+        }
+
+      case BATCH_LOAD_RELATIONS:
+        {
+          BatchLoadRelationsRequest request = castRequest(BatchLoadRelationsRequest.class, body);
+          return castResponse(
+              responseType, CatalogHandlers.batchLoadRelations(catalog, asViewCatalog, request));
         }
 
       default:

--- a/core/src/test/java/org/apache/iceberg/rest/Route.java
+++ b/core/src/test/java/org/apache/iceberg/rest/Route.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.requests.BatchLoadRelationsRequest;
 import org.apache.iceberg.rest.requests.CommitTransactionRequest;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -34,6 +35,7 @@ import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.BatchLoadRelationsResponse;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
@@ -41,6 +43,7 @@ import org.apache.iceberg.rest.responses.FetchScanTasksResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadRelationResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
@@ -121,6 +124,13 @@ enum Route {
       ResourcePaths.V1_VIEW_REGISTER,
       RegisterViewRequest.class,
       LoadViewResponse.class),
+  LOAD_RELATION(
+      HTTPRequest.HTTPMethod.GET, ResourcePaths.V1_RELATION, null, LoadRelationResponse.class),
+  BATCH_LOAD_RELATIONS(
+      HTTPRequest.HTTPMethod.POST,
+      ResourcePaths.V1_RELATIONS_BATCH_LOAD,
+      BatchLoadRelationsRequest.class,
+      BatchLoadRelationsResponse.class),
   PLAN_TABLE_SCAN(
       HTTPRequest.HTTPMethod.POST,
       ResourcePaths.V1_TABLE_SCAN_PLAN_SUBMIT,

--- a/core/src/test/java/org/apache/iceberg/rest/TestCatalogHandlersRelation.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestCatalogHandlersRelation.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.io.IOException;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;

--- a/core/src/test/java/org/apache/iceberg/rest/TestCatalogHandlersRelation.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestCatalogHandlersRelation.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
+import org.apache.iceberg.rest.requests.BatchLoadRelationRequestItem;
+import org.apache.iceberg.rest.requests.BatchLoadRelationsRequest;
+import org.apache.iceberg.rest.responses.BatchLoadRelationResultItem;
+import org.apache.iceberg.rest.responses.BatchLoadRelationsResponse;
+import org.apache.iceberg.rest.responses.LoadRelationResponse;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.ViewBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestCatalogHandlersRelation {
+
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "x", Types.LongType.get()));
+  private static final Namespace NS = Namespace.of("ns");
+  private static final TableIdentifier TABLE_IDENT = TableIdentifier.of(NS, "tbl");
+  private static final TableIdentifier VIEW_IDENT = TableIdentifier.of(NS, "vw");
+  private static final TableIdentifier MISSING_IDENT = TableIdentifier.of(NS, "missing");
+
+  @TempDir File tempDir;
+
+  private InMemoryCatalog catalog;
+
+  @BeforeEach
+  void before() throws IOException {
+    catalog = new InMemoryCatalog();
+    catalog.initialize("test", java.util.Map.of("warehouse", tempDir.toURI().toString()));
+    catalog.createNamespace(NS);
+    catalog.createTable(TABLE_IDENT, SCHEMA);
+
+    ViewBuilder viewBuilder = catalog.buildView(VIEW_IDENT);
+    viewBuilder.withSchema(SCHEMA).withDefaultNamespace(NS).withQuery("spark", "SELECT 1").create();
+  }
+
+  @Test
+  void loadRelationTable() {
+    LoadRelationResponse response =
+        CatalogHandlers.loadRelation(catalog, catalog, TABLE_IDENT, SnapshotMode.ALL);
+    assertThat(response.objectType()).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(response.tableResponse()).isNotNull();
+    assertThat(response.tableResponse().tableMetadata().schema().columns()).hasSize(1);
+    assertThat(response.viewResponse()).isNull();
+  }
+
+  @Test
+  void loadRelationView() {
+    LoadRelationResponse response =
+        CatalogHandlers.loadRelation(catalog, catalog, VIEW_IDENT, SnapshotMode.ALL);
+    assertThat(response.objectType()).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(response.viewResponse()).isNotNull();
+    assertThat(response.tableResponse()).isNull();
+  }
+
+  @Test
+  void loadRelationNotFound() {
+    assertThatThrownBy(
+            () -> CatalogHandlers.loadRelation(catalog, catalog, MISSING_IDENT, SnapshotMode.ALL))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessageContaining("missing");
+  }
+
+  @Test
+  void batchLoadRelationsMixed() {
+    BatchLoadRelationsRequest request =
+        BatchLoadRelationsRequest.builder()
+            .addIdentifier(
+                BatchLoadRelationRequestItem.builder().withIdentifier(TABLE_IDENT).build())
+            .addIdentifier(
+                BatchLoadRelationRequestItem.builder().withIdentifier(VIEW_IDENT).build())
+            .addIdentifier(
+                BatchLoadRelationRequestItem.builder().withIdentifier(MISSING_IDENT).build())
+            .build();
+
+    BatchLoadRelationsResponse response =
+        CatalogHandlers.batchLoadRelations(catalog, catalog, request);
+
+    assertThat(response.results()).hasSize(3);
+
+    BatchLoadRelationResultItem tableItem = response.results().get(0);
+    assertThat(tableItem.identifier()).isEqualTo(TABLE_IDENT);
+    assertThat(tableItem.status()).isEqualTo(200);
+    assertThat(tableItem.result()).isNotNull();
+    assertThat(tableItem.result().objectType()).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(tableItem.etag()).isNotNull();
+
+    BatchLoadRelationResultItem viewItem = response.results().get(1);
+    assertThat(viewItem.identifier()).isEqualTo(VIEW_IDENT);
+    assertThat(viewItem.status()).isEqualTo(200);
+    assertThat(viewItem.result()).isNotNull();
+    assertThat(viewItem.result().objectType()).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(viewItem.etag()).isNull();
+
+    BatchLoadRelationResultItem missingItem = response.results().get(2);
+    assertThat(missingItem.identifier()).isEqualTo(MISSING_IDENT);
+    assertThat(missingItem.status()).isEqualTo(404);
+    assertThat(missingItem.result()).isNull();
+  }
+
+  @Test
+  void batchLoadRelationsWithSnapshotMode() {
+    BatchLoadRelationsRequest request =
+        BatchLoadRelationsRequest.builder()
+            .addIdentifier(
+                BatchLoadRelationRequestItem.builder()
+                    .withIdentifier(TABLE_IDENT)
+                    .withSnapshots("refs")
+                    .build())
+            .build();
+
+    BatchLoadRelationsResponse response =
+        CatalogHandlers.batchLoadRelations(catalog, catalog, request);
+
+    assertThat(response.results()).hasSize(1);
+    assertThat(response.results().get(0).status()).isEqualTo(200);
+    assertThat(response.results().get(0).result().objectType()).isEqualTo(CatalogObjectType.TABLE);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/TestCatalogHandlersRelation.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestCatalogHandlersRelation.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.catalog.Namespace;
@@ -111,21 +112,21 @@ class TestCatalogHandlersRelation {
 
     BatchLoadRelationResultItem tableItem = response.results().get(0);
     assertThat(tableItem.identifier()).isEqualTo(TABLE_IDENT);
-    assertThat(tableItem.status()).isEqualTo(200);
+    assertThat(tableItem.status()).isEqualTo(HttpStatus.SC_OK);
     assertThat(tableItem.result()).isNotNull();
     assertThat(tableItem.result().objectType()).isEqualTo(CatalogObjectType.TABLE);
     assertThat(tableItem.etag()).isNotNull();
 
     BatchLoadRelationResultItem viewItem = response.results().get(1);
     assertThat(viewItem.identifier()).isEqualTo(VIEW_IDENT);
-    assertThat(viewItem.status()).isEqualTo(200);
+    assertThat(viewItem.status()).isEqualTo(HttpStatus.SC_OK);
     assertThat(viewItem.result()).isNotNull();
     assertThat(viewItem.result().objectType()).isEqualTo(CatalogObjectType.VIEW);
     assertThat(viewItem.etag()).isNull();
 
     BatchLoadRelationResultItem missingItem = response.results().get(2);
     assertThat(missingItem.identifier()).isEqualTo(MISSING_IDENT);
-    assertThat(missingItem.status()).isEqualTo(404);
+    assertThat(missingItem.status()).isEqualTo(HttpStatus.SC_NOT_FOUND);
     assertThat(missingItem.result()).isNull();
   }
 
@@ -144,7 +145,7 @@ class TestCatalogHandlersRelation {
         CatalogHandlers.batchLoadRelations(catalog, catalog, request);
 
     assertThat(response.results()).hasSize(1);
-    assertThat(response.results().get(0).status()).isEqualTo(200);
+    assertThat(response.results().get(0).status()).isEqualTo(HttpStatus.SC_OK);
     assertThat(response.results().get(0).result().objectType()).isEqualTo(CatalogObjectType.TABLE);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalogRelation.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalogRelation.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.CatalogObjectType;
+import org.apache.iceberg.catalog.Relation;
+import org.apache.iceberg.catalog.SupportsRelations;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestRESTCatalogRelation extends TestBaseWithRESTServer {
+
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "x", Types.LongType.get()));
+  private static final TableIdentifier TABLE_IDENT = TableIdentifier.of(NS, "tbl");
+  private static final TableIdentifier VIEW_IDENT = TableIdentifier.of(NS, "vw");
+  private static final TableIdentifier MISSING_IDENT = TableIdentifier.of(NS, "missing");
+
+  @Override
+  protected String catalogName() {
+    return "test";
+  }
+
+  @BeforeEach
+  void createFixtures() {
+    backendCatalog.createNamespace(NS);
+    backendCatalog.createTable(TABLE_IDENT, SCHEMA);
+    backendCatalog
+        .buildView(VIEW_IDENT)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(NS)
+        .withQuery("spark", "SELECT 1")
+        .create();
+  }
+
+  @Test
+  void loadRelationTable() {
+    SupportsRelations relations = (SupportsRelations) restCatalog;
+    Relation relation = relations.loadRelation(TABLE_IDENT);
+
+    assertThat(relation.objectType()).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(relation.table()).isNotNull();
+    assertThat(relation.table().schema().columns()).hasSize(1);
+    assertThat(relation.view()).isNull();
+  }
+
+  @Test
+  void loadRelationView() {
+    SupportsRelations relations = (SupportsRelations) restCatalog;
+    Relation relation = relations.loadRelation(VIEW_IDENT);
+
+    assertThat(relation.objectType()).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(relation.view()).isNotNull();
+    assertThat(relation.view().schema().columns()).hasSize(1);
+    assertThat(relation.table()).isNull();
+  }
+
+  @Test
+  void loadRelationNotFound() {
+    SupportsRelations relations = (SupportsRelations) restCatalog;
+    assertThatThrownBy(() -> relations.loadRelation(MISSING_IDENT))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("missing");
+  }
+
+  @Test
+  void loadRelationsMultiple() {
+    SupportsRelations relations = (SupportsRelations) restCatalog;
+    Set<TableIdentifier> identifiers = ImmutableSet.of(TABLE_IDENT, VIEW_IDENT, MISSING_IDENT);
+
+    List<Relation> results = relations.loadRelations(identifiers);
+
+    assertThat(results).hasSize(2);
+
+    Relation tableRelation =
+        results.stream()
+            .filter(r -> r.objectType() == CatalogObjectType.TABLE)
+            .findFirst()
+            .orElseThrow();
+    assertThat(tableRelation.table()).isNotNull();
+    assertThat(tableRelation.table().schema().columns()).hasSize(1);
+
+    Relation viewRelation =
+        results.stream()
+            .filter(r -> r.objectType() == CatalogObjectType.VIEW)
+            .findFirst()
+            .orElseThrow();
+    assertThat(viewRelation.view()).isNotNull();
+    assertThat(viewRelation.view().schema().columns()).hasSize(1);
+  }
+
+  @Test
+  void loadRelationsEmpty() {
+    SupportsRelations relations = (SupportsRelations) restCatalog;
+    Set<TableIdentifier> identifiers = ImmutableSet.of(MISSING_IDENT);
+
+    List<Relation> results = relations.loadRelations(identifiers);
+    assertThat(results).isEmpty();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalogRelation.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalogRelation.java
@@ -64,10 +64,12 @@ class TestRESTCatalogRelation extends TestBaseWithRESTServer {
     SupportsRelations relations = (SupportsRelations) restCatalog;
     Relation relation = relations.loadRelation(TABLE_IDENT);
 
+    assertThat(relation.identifier()).isEqualTo(TABLE_IDENT);
     assertThat(relation.objectType()).isEqualTo(CatalogObjectType.TABLE);
     assertThat(relation.table()).isNotNull();
     assertThat(relation.table().schema().columns()).hasSize(1);
     assertThat(relation.view()).isNull();
+    assertThat(relation.isNotFound()).isFalse();
   }
 
   @Test
@@ -75,10 +77,12 @@ class TestRESTCatalogRelation extends TestBaseWithRESTServer {
     SupportsRelations relations = (SupportsRelations) restCatalog;
     Relation relation = relations.loadRelation(VIEW_IDENT);
 
+    assertThat(relation.identifier()).isEqualTo(VIEW_IDENT);
     assertThat(relation.objectType()).isEqualTo(CatalogObjectType.VIEW);
     assertThat(relation.view()).isNotNull();
     assertThat(relation.view().schema().columns()).hasSize(1);
     assertThat(relation.table()).isNull();
+    assertThat(relation.isNotFound()).isFalse();
   }
 
   @Test
@@ -103,6 +107,7 @@ class TestRESTCatalogRelation extends TestBaseWithRESTServer {
             .filter(r -> r.objectType() == CatalogObjectType.TABLE)
             .findFirst()
             .orElseThrow();
+    assertThat(tableRelation.identifier()).isEqualTo(TABLE_IDENT);
     assertThat(tableRelation.table()).isNotNull();
     assertThat(tableRelation.table().schema().columns()).hasSize(1);
 
@@ -111,6 +116,7 @@ class TestRESTCatalogRelation extends TestBaseWithRESTServer {
             .filter(r -> r.objectType() == CatalogObjectType.VIEW)
             .findFirst()
             .orElseThrow();
+    assertThat(viewRelation.identifier()).isEqualTo(VIEW_IDENT);
     assertThat(viewRelation.view()).isNotNull();
     assertThat(viewRelation.view().schema().columns()).hasSize(1);
   }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestBatchLoadRelationsRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestBatchLoadRelationsRequestParser.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.api.Test;
+
+class TestBatchLoadRelationsRequestParser {
+
+  @Test
+  void nullAndEmptyCheck() {
+    assertThatThrownBy(() -> BatchLoadRelationsRequestParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid batch load relations request: null");
+
+    assertThatThrownBy(() -> BatchLoadRelationsRequestParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse batch load relations request from null object");
+  }
+
+  @Test
+  void roundTripMinimal() {
+    BatchLoadRelationsRequest request =
+        BatchLoadRelationsRequest.builder()
+            .addIdentifier(
+                BatchLoadRelationRequestItem.builder()
+                    .withIdentifier(TableIdentifier.of(Namespace.of("ns"), "table1"))
+                    .build())
+            .build();
+
+    String json = BatchLoadRelationsRequestParser.toJson(request);
+    assertThat(json).contains("\"identifiers\":");
+
+    BatchLoadRelationsRequest deserialized = BatchLoadRelationsRequestParser.fromJson(json);
+    assertThat(deserialized.identifiers()).hasSize(1);
+    assertThat(deserialized.identifiers().get(0).identifier().name()).isEqualTo("table1");
+    assertThat(deserialized.identifiers().get(0).etag()).isNull();
+    assertThat(deserialized.identifiers().get(0).snapshots()).isNull();
+  }
+
+  @Test
+  void roundTripWithOptionalFields() {
+    BatchLoadRelationsRequest request =
+        BatchLoadRelationsRequest.builder()
+            .addIdentifier(
+                BatchLoadRelationRequestItem.builder()
+                    .withIdentifier(TableIdentifier.of(Namespace.of("ns"), "table1"))
+                    .withEtag("abc123")
+                    .withSnapshots("refs")
+                    .build())
+            .addIdentifier(
+                BatchLoadRelationRequestItem.builder()
+                    .withIdentifier(TableIdentifier.of(Namespace.of("ns2"), "view1"))
+                    .build())
+            .build();
+
+    String json = BatchLoadRelationsRequestParser.toJson(request);
+    BatchLoadRelationsRequest deserialized = BatchLoadRelationsRequestParser.fromJson(json);
+
+    assertThat(deserialized.identifiers()).hasSize(2);
+
+    BatchLoadRelationRequestItem first = deserialized.identifiers().get(0);
+    assertThat(first.identifier().name()).isEqualTo("table1");
+    assertThat(first.etag()).isEqualTo("abc123");
+    assertThat(first.snapshots()).isEqualTo("refs");
+
+    BatchLoadRelationRequestItem second = deserialized.identifiers().get(1);
+    assertThat(second.identifier().name()).isEqualTo("view1");
+    assertThat(second.etag()).isNull();
+    assertThat(second.snapshots()).isNull();
+  }
+
+  @Test
+  void invalidEmptyIdentifiers() {
+    assertThatThrownBy(() -> BatchLoadRelationsRequest.builder().build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null or empty");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadRelationsResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadRelationsResponseParser.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.CatalogObjectType;
+import org.junit.jupiter.api.Test;
+
+class TestBatchLoadRelationsResponseParser {
+
+  @Test
+  void nullAndEmptyCheck() {
+    assertThatThrownBy(() -> BatchLoadRelationsResponseParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid batch load relations response: null");
+
+    assertThatThrownBy(() -> BatchLoadRelationsResponseParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse batch load relations response from null object");
+  }
+
+  @Test
+  void roundTripWithTableResult() {
+    LoadTableResponse tableResponse =
+        LoadTableResponse.builder()
+            .withTableMetadata(TestLoadRelationResponseParser.tableMetadata())
+            .build();
+    LoadRelationResponse result =
+        LoadRelationResponse.builder().withTableResponse(tableResponse).build();
+
+    TableIdentifier ident = TableIdentifier.of(Namespace.of("ns"), "table1");
+    BatchLoadRelationsResponse response =
+        BatchLoadRelationsResponse.builder()
+            .addResult(
+                BatchLoadRelationResultItem.builder()
+                    .withIdentifier(ident)
+                    .withStatus(200)
+                    .withResult(result)
+                    .withEtag("metadata-location")
+                    .build())
+            .build();
+
+    String json = BatchLoadRelationsResponseParser.toJson(response);
+    BatchLoadRelationsResponse deserialized = BatchLoadRelationsResponseParser.fromJson(json);
+
+    assertThat(deserialized.results()).hasSize(1);
+    BatchLoadRelationResultItem item = deserialized.results().get(0);
+    assertThat(item.identifier().name()).isEqualTo("table1");
+    assertThat(item.status()).isEqualTo(200);
+    assertThat(item.result()).isNotNull();
+    assertThat(item.result().objectType()).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(item.etag()).isEqualTo("metadata-location");
+    assertThat(deserialized.unprocessedIdentifiers()).isEmpty();
+  }
+
+  @Test
+  void roundTripWithViewResult() {
+    LoadViewResponse viewResponse =
+        ImmutableLoadViewResponse.builder()
+            .metadataLocation("view-metadata-location")
+            .metadata(TestLoadRelationResponseParser.viewMetadata())
+            .build();
+    LoadRelationResponse result =
+        LoadRelationResponse.builder().withViewResponse(viewResponse).build();
+
+    TableIdentifier ident = TableIdentifier.of(Namespace.of("ns"), "view1");
+    BatchLoadRelationsResponse response =
+        BatchLoadRelationsResponse.builder()
+            .addResult(
+                BatchLoadRelationResultItem.builder()
+                    .withIdentifier(ident)
+                    .withStatus(200)
+                    .withResult(result)
+                    .build())
+            .build();
+
+    String json = BatchLoadRelationsResponseParser.toJson(response);
+    BatchLoadRelationsResponse deserialized = BatchLoadRelationsResponseParser.fromJson(json);
+
+    assertThat(deserialized.results()).hasSize(1);
+    BatchLoadRelationResultItem item = deserialized.results().get(0);
+    assertThat(item.status()).isEqualTo(200);
+    assertThat(item.result().objectType()).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(item.etag()).isNull();
+  }
+
+  @Test
+  void roundTripNotFound() {
+    TableIdentifier ident = TableIdentifier.of(Namespace.of("ns"), "missing");
+    BatchLoadRelationsResponse response =
+        BatchLoadRelationsResponse.builder()
+            .addResult(
+                BatchLoadRelationResultItem.builder().withIdentifier(ident).withStatus(404).build())
+            .build();
+
+    String json = BatchLoadRelationsResponseParser.toJson(response);
+    BatchLoadRelationsResponse deserialized = BatchLoadRelationsResponseParser.fromJson(json);
+
+    assertThat(deserialized.results()).hasSize(1);
+    assertThat(deserialized.results().get(0).status()).isEqualTo(404);
+    assertThat(deserialized.results().get(0).result()).isNull();
+  }
+
+  @Test
+  void roundTripNotModified() {
+    TableIdentifier ident = TableIdentifier.of(Namespace.of("ns"), "table1");
+    BatchLoadRelationsResponse response =
+        BatchLoadRelationsResponse.builder()
+            .addResult(
+                BatchLoadRelationResultItem.builder()
+                    .withIdentifier(ident)
+                    .withStatus(304)
+                    .withEtag("some-etag")
+                    .build())
+            .build();
+
+    String json = BatchLoadRelationsResponseParser.toJson(response);
+    BatchLoadRelationsResponse deserialized = BatchLoadRelationsResponseParser.fromJson(json);
+
+    assertThat(deserialized.results()).hasSize(1);
+    assertThat(deserialized.results().get(0).status()).isEqualTo(304);
+    assertThat(deserialized.results().get(0).result()).isNull();
+    assertThat(deserialized.results().get(0).etag()).isEqualTo("some-etag");
+  }
+
+  @Test
+  void roundTripWithUnprocessedIdentifiers() {
+    TableIdentifier ident1 = TableIdentifier.of(Namespace.of("ns"), "table1");
+    TableIdentifier unprocessed = TableIdentifier.of(Namespace.of("ns2"), "table2");
+
+    BatchLoadRelationsResponse response =
+        BatchLoadRelationsResponse.builder()
+            .addResult(
+                BatchLoadRelationResultItem.builder()
+                    .withIdentifier(ident1)
+                    .withStatus(404)
+                    .build())
+            .addUnprocessedIdentifier(unprocessed)
+            .build();
+
+    String json = BatchLoadRelationsResponseParser.toJson(response);
+    assertThat(json).contains("\"unprocessed-identifiers\":");
+
+    BatchLoadRelationsResponse deserialized = BatchLoadRelationsResponseParser.fromJson(json);
+    assertThat(deserialized.results()).hasSize(1);
+    assertThat(deserialized.unprocessedIdentifiers()).hasSize(1);
+    assertThat(deserialized.unprocessedIdentifiers().get(0).name()).isEqualTo("table2");
+  }
+
+  @Test
+  void invalidStatusRequiresResult() {
+    assertThatThrownBy(
+            () ->
+                BatchLoadRelationResultItem.builder()
+                    .withIdentifier(TableIdentifier.of(Namespace.of("ns"), "t"))
+                    .withStatus(200)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null when status is 200");
+  }
+
+  @Test
+  void invalidStatus() {
+    assertThatThrownBy(
+            () ->
+                BatchLoadRelationResultItem.builder()
+                    .withIdentifier(TableIdentifier.of(Namespace.of("ns"), "t"))
+                    .withStatus(500)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid status: 500");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadRelationsResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadRelationsResponseParser.java
@@ -22,9 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.rest.CatalogObjectType;
 import org.junit.jupiter.api.Test;
 
 class TestBatchLoadRelationsResponseParser {

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadRelationsResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestBatchLoadRelationsResponseParser.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -55,7 +56,7 @@ class TestBatchLoadRelationsResponseParser {
             .addResult(
                 BatchLoadRelationResultItem.builder()
                     .withIdentifier(ident)
-                    .withStatus(200)
+                    .withStatus(HttpStatus.SC_OK)
                     .withResult(result)
                     .withEtag("metadata-location")
                     .build())
@@ -67,7 +68,7 @@ class TestBatchLoadRelationsResponseParser {
     assertThat(deserialized.results()).hasSize(1);
     BatchLoadRelationResultItem item = deserialized.results().get(0);
     assertThat(item.identifier().name()).isEqualTo("table1");
-    assertThat(item.status()).isEqualTo(200);
+    assertThat(item.status()).isEqualTo(HttpStatus.SC_OK);
     assertThat(item.result()).isNotNull();
     assertThat(item.result().objectType()).isEqualTo(CatalogObjectType.TABLE);
     assertThat(item.etag()).isEqualTo("metadata-location");
@@ -90,7 +91,7 @@ class TestBatchLoadRelationsResponseParser {
             .addResult(
                 BatchLoadRelationResultItem.builder()
                     .withIdentifier(ident)
-                    .withStatus(200)
+                    .withStatus(HttpStatus.SC_OK)
                     .withResult(result)
                     .build())
             .build();
@@ -100,7 +101,7 @@ class TestBatchLoadRelationsResponseParser {
 
     assertThat(deserialized.results()).hasSize(1);
     BatchLoadRelationResultItem item = deserialized.results().get(0);
-    assertThat(item.status()).isEqualTo(200);
+    assertThat(item.status()).isEqualTo(HttpStatus.SC_OK);
     assertThat(item.result().objectType()).isEqualTo(CatalogObjectType.VIEW);
     assertThat(item.etag()).isNull();
   }
@@ -111,14 +112,17 @@ class TestBatchLoadRelationsResponseParser {
     BatchLoadRelationsResponse response =
         BatchLoadRelationsResponse.builder()
             .addResult(
-                BatchLoadRelationResultItem.builder().withIdentifier(ident).withStatus(404).build())
+                BatchLoadRelationResultItem.builder()
+                    .withIdentifier(ident)
+                    .withStatus(HttpStatus.SC_NOT_FOUND)
+                    .build())
             .build();
 
     String json = BatchLoadRelationsResponseParser.toJson(response);
     BatchLoadRelationsResponse deserialized = BatchLoadRelationsResponseParser.fromJson(json);
 
     assertThat(deserialized.results()).hasSize(1);
-    assertThat(deserialized.results().get(0).status()).isEqualTo(404);
+    assertThat(deserialized.results().get(0).status()).isEqualTo(HttpStatus.SC_NOT_FOUND);
     assertThat(deserialized.results().get(0).result()).isNull();
   }
 
@@ -130,7 +134,7 @@ class TestBatchLoadRelationsResponseParser {
             .addResult(
                 BatchLoadRelationResultItem.builder()
                     .withIdentifier(ident)
-                    .withStatus(304)
+                    .withStatus(HttpStatus.SC_NOT_MODIFIED)
                     .withEtag("some-etag")
                     .build())
             .build();
@@ -139,7 +143,7 @@ class TestBatchLoadRelationsResponseParser {
     BatchLoadRelationsResponse deserialized = BatchLoadRelationsResponseParser.fromJson(json);
 
     assertThat(deserialized.results()).hasSize(1);
-    assertThat(deserialized.results().get(0).status()).isEqualTo(304);
+    assertThat(deserialized.results().get(0).status()).isEqualTo(HttpStatus.SC_NOT_MODIFIED);
     assertThat(deserialized.results().get(0).result()).isNull();
     assertThat(deserialized.results().get(0).etag()).isEqualTo("some-etag");
   }
@@ -154,7 +158,7 @@ class TestBatchLoadRelationsResponseParser {
             .addResult(
                 BatchLoadRelationResultItem.builder()
                     .withIdentifier(ident1)
-                    .withStatus(404)
+                    .withStatus(HttpStatus.SC_NOT_FOUND)
                     .build())
             .addUnprocessedIdentifier(unprocessed)
             .build();
@@ -174,10 +178,10 @@ class TestBatchLoadRelationsResponseParser {
             () ->
                 BatchLoadRelationResultItem.builder()
                     .withIdentifier(TableIdentifier.of(Namespace.of("ns"), "t"))
-                    .withStatus(200)
+                    .withStatus(HttpStatus.SC_OK)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("null when status is 200");
+        .hasMessageContaining("Invalid result: null when status is " + HttpStatus.SC_OK);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadRelationResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadRelationResponseParser.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.rest.CatalogObjectType;
+import org.apache.iceberg.catalog.CatalogObjectType;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.view.ImmutableViewVersion;
 import org.apache.iceberg.view.ViewMetadata;

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadRelationResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadRelationResponseParser.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.rest.CatalogObjectType;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.ImmutableViewVersion;
+import org.apache.iceberg.view.ViewMetadata;
+import org.junit.jupiter.api.Test;
+
+class TestLoadRelationResponseParser {
+
+  @Test
+  void nullAndEmptyCheck() {
+    assertThatThrownBy(() -> LoadRelationResponseParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid load relation response: null");
+
+    assertThatThrownBy(() -> LoadRelationResponseParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse load relation response from null object");
+  }
+
+  @Test
+  void roundTripTableBranch() {
+    TableMetadata metadata = tableMetadata();
+    LoadTableResponse tableResponse =
+        LoadTableResponse.builder().withTableMetadata(metadata).build();
+
+    LoadRelationResponse response =
+        LoadRelationResponse.builder().withTableResponse(tableResponse).build();
+
+    assertThat(response.objectType()).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(response.tableResponse()).isNotNull();
+    assertThat(response.viewResponse()).isNull();
+
+    String json = LoadRelationResponseParser.toJson(response);
+    assertThat(json).contains("\"object-type\":\"table\"");
+    assertThat(json).contains("\"table\":{");
+
+    LoadRelationResponse deserialized = LoadRelationResponseParser.fromJson(json);
+    assertThat(deserialized.objectType()).isEqualTo(CatalogObjectType.TABLE);
+    assertThat(deserialized.tableResponse()).isNotNull();
+    assertThat(deserialized.tableResponse().tableMetadata().location()).isEqualTo("location");
+    assertThat(deserialized.viewResponse()).isNull();
+  }
+
+  @Test
+  void roundTripViewBranch() {
+    ViewMetadata metadata = viewMetadata();
+    LoadViewResponse viewResponse =
+        ImmutableLoadViewResponse.builder()
+            .metadataLocation("view-metadata-location")
+            .metadata(metadata)
+            .build();
+
+    LoadRelationResponse response =
+        LoadRelationResponse.builder().withViewResponse(viewResponse).build();
+
+    assertThat(response.objectType()).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(response.viewResponse()).isNotNull();
+    assertThat(response.tableResponse()).isNull();
+
+    String json = LoadRelationResponseParser.toJson(response);
+    assertThat(json).contains("\"object-type\":\"view\"");
+    assertThat(json).contains("\"view\":{");
+
+    LoadRelationResponse deserialized = LoadRelationResponseParser.fromJson(json);
+    assertThat(deserialized.objectType()).isEqualTo(CatalogObjectType.VIEW);
+    assertThat(deserialized.viewResponse()).isNotNull();
+    assertThat(deserialized.viewResponse().metadataLocation()).isEqualTo("view-metadata-location");
+    assertThat(deserialized.tableResponse()).isNull();
+  }
+
+  @Test
+  void invalidMissingObjectType() {
+    assertThatThrownBy(() -> LoadRelationResponseParser.fromJson("{\"table\":{}}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("object-type");
+  }
+
+  @Test
+  void invalidTableResponseNull() {
+    assertThatThrownBy(
+            () -> LoadRelationResponse.builder().withObjectType(CatalogObjectType.TABLE).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null for object-type table");
+  }
+
+  @Test
+  void invalidViewResponseNull() {
+    assertThatThrownBy(
+            () -> LoadRelationResponse.builder().withObjectType(CatalogObjectType.VIEW).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null for object-type view");
+  }
+
+  static TableMetadata tableMetadata() {
+    return TableMetadata.buildFromEmpty(2)
+        .assignUUID("386b9f01-002b-4d8c-b77f-42c3fd3b7c9b")
+        .setLocation("location")
+        .setCurrentSchema(new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
+        .addPartitionSpec(PartitionSpec.unpartitioned())
+        .addSortOrder(SortOrder.unsorted())
+        .discardChanges()
+        .withMetadataLocation("metadata-location")
+        .build();
+  }
+
+  static ViewMetadata viewMetadata() {
+    return ViewMetadata.buildFrom(
+            ViewMetadata.builder()
+                .setLocation("view-location")
+                .addSchema(new Schema(Types.NestedField.required(1, "y", Types.StringType.get())))
+                .addVersion(
+                    ImmutableViewVersion.builder()
+                        .versionId(1)
+                        .schemaId(0)
+                        .timestampMillis(23L)
+                        .defaultNamespace(org.apache.iceberg.catalog.Namespace.of("ns"))
+                        .build())
+                .setCurrentVersionId(1)
+                .build())
+        .setMetadataLocation("view-metadata-location")
+        .build();
+  }
+}


### PR DESCRIPTION
Add DTOs, parsers, handlers, and client methods for the universal relation load endpoints (GET /v1/{prefix}/namespaces/{namespace}/relations/{relation} and POST /v1/{prefix}/relations/batch-load) defined in the REST spec.

New types:
- CatalogObjectType enum (TABLE, VIEW)
- LoadRelationResponse with discriminated table/view branches
- BatchLoadRelationsRequest/Response with per-item status codes
- BatchLoadRelationsForbiddenResponse (allOf ErrorModel pattern)

Modified:
- ResourcePaths, Endpoint: new route constants and path builders
- RESTSerializers: registered serializers for new types
- ErrorHandlers: added relationErrorHandler
- CatalogHandlers: loadRelation and batchLoadRelations server handlers
- RESTSessionCatalog: loadRelation and batchLoadRelations client methods
- RESTCatalogAdapter, Route: test adapter handler cases

Made-with: Cursor
Model: claude-4.6-opus-high-thinking