### PR TITLE
Core: Fix identity transform's predicate projection

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.transforms;
 import java.io.ObjectStreamException;
 import java.util.Set;
 import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.BoundReference;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -146,6 +147,11 @@ class Identity<T> implements Transform<T, T> {
 
   @Override
   public UnboundPredicate<T> projectStrict(String name, BoundPredicate<T> predicate) {
+    if (!(predicate.term() instanceof BoundReference)) {
+      // Not all visitors support non-reference terms. So it's not safe to project predicates
+      // containing one.
+      return null;
+    }
     if (predicate.isUnaryPredicate()) {
       return Expressions.predicate(predicate.op(), name);
     } else if (predicate.isLiteralPredicate()) {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
@@ -47,48 +47,83 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Or;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.UnboundPredicate;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestProjection {
   private static final Schema SCHEMA = new Schema(optional(16, "id", Types.LongType.get()));
 
-  @Test
-  public void testIdentityProjection() {
-    List<UnboundPredicate<?>> predicates =
-        Lists.newArrayList(
-            Expressions.notNull("id"),
-            Expressions.isNull("id"),
-            Expressions.lessThan("id", 100),
-            Expressions.lessThanOrEqual("id", 101),
-            Expressions.greaterThan("id", 102),
-            Expressions.greaterThanOrEqual("id", 103),
-            Expressions.equal("id", 104),
-            Expressions.notEqual("id", 105));
+  private static List<UnboundPredicate<?>> predicatesWithReference() {
+    return List.of(
+        Expressions.notNull("id"),
+        Expressions.isNull("id"),
+        Expressions.lessThan("id", 100),
+        Expressions.lessThanOrEqual("id", 101),
+        Expressions.greaterThan("id", 102),
+        Expressions.greaterThanOrEqual("id", 103),
+        Expressions.equal("id", 104),
+        Expressions.notEqual("id", 105));
+  }
 
+  private static List<UnboundPredicate<?>> predicatesWithTransform() {
+    return List.of(
+        Expressions.notNull(Expressions.truncate("id", 1)),
+        Expressions.isNull(Expressions.truncate("id", 1)),
+        Expressions.lessThan(Expressions.truncate("id", 1), 100),
+        Expressions.lessThanOrEqual(Expressions.truncate("id", 1), 101),
+        Expressions.greaterThan(Expressions.truncate("id", 1), 102),
+        Expressions.greaterThanOrEqual(Expressions.truncate("id", 1), 103),
+        Expressions.equal(Expressions.truncate("id", 1), 104),
+        Expressions.notEqual(Expressions.truncate("id", 1), 105));
+  }
+
+  @ParameterizedTest
+  @MethodSource("predicatesWithReference")
+  public void testIdentityProjection(UnboundPredicate<?> predicate) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
-    for (UnboundPredicate<?> predicate : predicates) {
-      // get the projected predicate
-      Expression expr = Projections.inclusive(spec).project(predicate);
-      UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
+    // get the projected predicate
+    Expression expr = Projections.inclusive(spec).project(predicate);
+    UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
 
-      // check inclusive the bound predicate to ensure the types are correct
-      BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), true));
+    // check inclusive the bound predicate to ensure the types are correct
+    BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), true));
 
-      assertThat(projected.ref().name())
-          .as("Field name should match partition struct field")
-          .isEqualTo("id");
-      assertThat(projected.op()).isEqualTo(bound.op());
+    assertThat(projected.ref().name())
+        .as("Field name should match partition struct field")
+        .isEqualTo("id");
+    assertThat(projected.op()).isEqualTo(bound.op());
 
-      if (bound.isLiteralPredicate()) {
-        assertThat(projected.literal().value())
-            .isEqualTo(bound.asLiteralPredicate().literal().value());
-      } else {
-        assertThat(projected.literal()).isNull();
-      }
+    if (bound.isLiteralPredicate()) {
+      assertThat(projected.literal().value())
+          .isEqualTo(bound.asLiteralPredicate().literal().value());
+    } else {
+      assertThat(projected.literal()).isNull();
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource("predicatesWithTransform")
+  public void testPredicateWithTransformIdentityProjection(UnboundPredicate<?> predicate) {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
+
+    // get the inclusively projected predicate
+    Expression inclusiveProjection = Projections.inclusive(spec).project(predicate);
+
+    // transforms cannot be safely projected so an inclusive projection should be always true
+    assertThat(Expressions.alwaysTrue().isEquivalentTo(inclusiveProjection))
+        .as("Inclusive projections of unsupported transforms should be always true")
+        .isTrue();
+
+    // get the strictly projected predicate
+    Expression strictProjection = Projections.strict(spec).project(predicate);
+
+    // transforms cannot be safely projected so a strict projection should be always false
+    assertThat(Expressions.alwaysFalse().isEquivalentTo(strictProjection))
+        .as("Strict projections of unsupported transforms should be always false")
+        .isTrue();
   }
 
   @Test
@@ -113,40 +148,28 @@ public class TestProjection {
         .isEqualTo(1658837594123456789L);
   }
 
-  @Test
-  public void testCaseInsensitiveIdentityProjection() {
-    List<UnboundPredicate<?>> predicates =
-        Lists.newArrayList(
-            Expressions.notNull("ID"),
-            Expressions.isNull("ID"),
-            Expressions.lessThan("ID", 100),
-            Expressions.lessThanOrEqual("ID", 101),
-            Expressions.greaterThan("ID", 102),
-            Expressions.greaterThanOrEqual("ID", 103),
-            Expressions.equal("ID", 104),
-            Expressions.notEqual("ID", 105));
-
+  @ParameterizedTest
+  @MethodSource("predicatesWithReference")
+  public void testCaseInsensitiveIdentityProjection(UnboundPredicate<?> predicate) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
-    for (UnboundPredicate<?> predicate : predicates) {
-      // get the projected predicate
-      Expression expr = Projections.inclusive(spec, false).project(predicate);
-      UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
+    // get the projected predicate
+    Expression expr = Projections.inclusive(spec, false).project(predicate);
+    UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
 
-      // check inclusive the bound predicate to ensure the types are correct
-      BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), false));
+    // check inclusive the bound predicate to ensure the types are correct
+    BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), false));
 
-      assertThat(projected.ref().name())
-          .as("Field name should match partition struct field")
-          .isEqualTo("id");
-      assertThat(projected.op()).isEqualTo(bound.op());
+    assertThat(projected.ref().name())
+        .as("Field name should match partition struct field")
+        .isEqualTo("id");
+    assertThat(projected.op()).isEqualTo(bound.op());
 
-      if (bound.isLiteralPredicate()) {
-        assertThat(projected.literal().value())
-            .isEqualTo(bound.asLiteralPredicate().literal().value());
-      } else {
-        assertThat(projected.literal()).isNull();
-      }
+    if (bound.isLiteralPredicate()) {
+      assertThat(projected.literal().value())
+          .isEqualTo(bound.asLiteralPredicate().literal().value());
+    } else {
+      assertThat(projected.literal()).isNull();
     }
   }
 
@@ -158,77 +181,54 @@ public class TestProjection {
         .hasMessageContaining("Cannot find field 'ID' in struct");
   }
 
-  @Test
-  public void testStrictIdentityProjection() {
-    List<UnboundPredicate<?>> predicates =
-        Lists.newArrayList(
-            Expressions.notNull("id"),
-            Expressions.isNull("id"),
-            Expressions.lessThan("id", 100),
-            Expressions.lessThanOrEqual("id", 101),
-            Expressions.greaterThan("id", 102),
-            Expressions.greaterThanOrEqual("id", 103),
-            Expressions.equal("id", 104),
-            Expressions.notEqual("id", 105));
-
+  @ParameterizedTest
+  @MethodSource("predicatesWithReference")
+  public void testStrictIdentityProjection(UnboundPredicate<?> predicate) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
-    for (UnboundPredicate<?> predicate : predicates) {
-      // get the projected predicate
-      Expression expr = Projections.strict(spec).project(predicate);
-      UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
+    // get the projected predicate
+    Expression expr = Projections.strict(spec).project(predicate);
+    UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
 
-      // check inclusive the bound predicate to ensure the types are correct
-      BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), true));
+    // check inclusive the bound predicate to ensure the types are correct
+    BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), true));
 
-      assertThat(projected.ref().name())
-          .as("Field name should match partition struct field")
-          .isEqualTo("id");
-      assertThat(projected.op()).isEqualTo(bound.op());
+    assertThat(projected.ref().name())
+        .as("Field name should match partition struct field")
+        .isEqualTo("id");
+    assertThat(projected.op()).isEqualTo(bound.op());
 
-      if (bound.isLiteralPredicate()) {
-        assertThat(projected.literal().value())
-            .isEqualTo(bound.asLiteralPredicate().literal().value());
-      } else {
-        assertThat(projected.literal()).isNull();
-      }
+    if (bound.isLiteralPredicate()) {
+      assertThat(projected.literal().value())
+          .isEqualTo(bound.asLiteralPredicate().literal().value());
+    } else {
+      assertThat(projected.literal()).isNull();
     }
   }
 
-  @Test
-  public void testCaseInsensitiveStrictIdentityProjection() {
-    List<UnboundPredicate<?>> predicates =
-        Lists.newArrayList(
-            Expressions.notNull("ID"),
-            Expressions.isNull("ID"),
-            Expressions.lessThan("ID", 100),
-            Expressions.lessThanOrEqual("ID", 101),
-            Expressions.greaterThan("ID", 102),
-            Expressions.greaterThanOrEqual("ID", 103),
-            Expressions.equal("ID", 104),
-            Expressions.notEqual("ID", 105));
+  @ParameterizedTest
+  @MethodSource("predicatesWithReference")
+  public void testCaseInsensitiveStrictIdentityProjection(UnboundPredicate<?> predicate) {
 
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
-    for (UnboundPredicate<?> predicate : predicates) {
-      // get the projected predicate
-      Expression expr = Projections.strict(spec, false).project(predicate);
-      UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
+    // get the projected predicate
+    Expression expr = Projections.strict(spec, false).project(predicate);
+    UnboundPredicate<?> projected = assertAndUnwrapUnbound(expr);
 
-      // check inclusive the bound predicate to ensure the types are correct
-      BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), false));
+    // check inclusive the bound predicate to ensure the types are correct
+    BoundPredicate<?> bound = assertAndUnwrap(predicate.bind(spec.schema().asStruct(), false));
 
-      assertThat(projected.ref().name())
-          .as("Field name should match partition struct field")
-          .isEqualTo("id");
-      assertThat(projected.op()).isEqualTo(bound.op());
+    assertThat(projected.ref().name())
+        .as("Field name should match partition struct field")
+        .isEqualTo("id");
+    assertThat(projected.op()).isEqualTo(bound.op());
 
-      if (bound.isLiteralPredicate()) {
-        assertThat(projected.literal().value())
-            .isEqualTo(bound.asLiteralPredicate().literal().value());
-      } else {
-        assertThat(projected.literal()).isNull();
-      }
+    if (bound.isLiteralPredicate()) {
+      assertThat(projected.literal().value())
+          .isEqualTo(bound.asLiteralPredicate().literal().value());
+    } else {
+      assertThat(projected.literal()).isNull();
     }
   }
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
@@ -67,6 +67,19 @@ public class TestProjection {
         Expressions.notEqual("id", 105));
   }
 
+  private static List<UnboundPredicate<?>> predicatesWithUpperCaseReference() {
+    return List.of(
+            Expressions.notNull("ID"),
+            Expressions.isNull("ID"),
+            Expressions.lessThan("ID", 100),
+            Expressions.lessThanOrEqual("ID", 101),
+            Expressions.greaterThan("ID", 102),
+            Expressions.greaterThanOrEqual("ID", 103),
+            Expressions.equal("ID", 104),
+            Expressions.notEqual("ID", 105));
+  }
+
+
   private static List<UnboundPredicate<?>> predicatesWithTransform() {
     return List.of(
         Expressions.notNull(Expressions.truncate("id", 1)),
@@ -149,7 +162,7 @@ public class TestProjection {
   }
 
   @ParameterizedTest
-  @MethodSource("predicatesWithReference")
+  @MethodSource("predicatesWithUpperCaseReference")
   public void testCaseInsensitiveIdentityProjection(UnboundPredicate<?> predicate) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
 
@@ -207,7 +220,7 @@ public class TestProjection {
   }
 
   @ParameterizedTest
-  @MethodSource("predicatesWithReference")
+  @MethodSource("predicatesWithUpperCaseReference")
   public void testCaseInsensitiveStrictIdentityProjection(UnboundPredicate<?> predicate) {
 
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();


### PR DESCRIPTION
The Identity transformation projection functions left out the predicate's term part if it was not a reference. This lead to type mismatch errors or incorrect results. In this case unfortunately we cannot safely project the term part as not all visitors support non-reference terms.

Refactored TestProjection tests to use the ParameterizedTest feature for better visibility.

Closes https://github.com/apache/iceberg/issues/15502

Coded with the help of Github Copilot and claude-sonnet-4.6 (code completion)
(Recreated after https://github.com/apache/iceberg/pull/15665 was messed up)