### PR TITLE
Gradle: bump shadow-gradle-plugin to 9.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.gradleup.shadow:shadow-gradle-plugin:8.3.10'
+    classpath 'com.gradleup.shadow:shadow-gradle-plugin:9.4.1'
     classpath 'com.palantir.baseline:gradle-baseline-java:6.90.0'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:8.4.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -80,7 +80,7 @@ subprojects {
             if (tasks.matching({task -> task.name == 'shadowJar'}).isEmpty()) {
               from components.java
             } else {
-              project.shadow.component(it)
+              from components.shadow
             }
 
             artifact sourceJar


### PR DESCRIPTION
This PR closes this issue: https://github.com/apache/iceberg/issues/15161

The only breaking changes with transition from v8 -> v9 seems to be shadow component usage in `deploy.gradle` which I fixed.