### PR TITLE
Sink connector crashes on timestamps with fractional seconds and colon-separated UTC offset (Fixes #15838)

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -524,10 +524,19 @@ class RecordConverter {
     if (result.charAt(10) == ' ') {
       result = result.substring(0, 10) + 'T' + result.substring(11);
     }
-    if (result.length() > 22
-        && (result.charAt(19) == '+' || result.charAt(19) == '-')
-        && result.charAt(22) == ':') {
-      result = result.substring(0, 19) + result.substring(19).replace(":", "");
+    // Search for the timezone offset sign starting after the seconds portion (index 19+).
+    // With fractional seconds (e.g. "...T03:17:37.260514+00:00") the sign appears later
+    // than index 19, so we must locate it dynamically rather than assuming a fixed position.
+    int signIdx = -1;
+    for (int i = 19; i < result.length(); i++) {
+      char c = result.charAt(i);
+      if (c == '+' || c == '-') {
+        signIdx = i;
+        break;
+      }
+    }
+    if (signIdx != -1 && signIdx + 3 < result.length() && result.charAt(signIdx + 3) == ':') {
+      result = result.substring(0, signIdx + 3) + result.substring(signIdx + 4);
     }
     return result;
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -529,8 +529,8 @@ class RecordConverter {
     // than index 19, so we must locate it dynamically rather than assuming a fixed position.
     int signIdx = -1;
     for (int i = 19; i < result.length(); i++) {
-      char c = result.charAt(i);
-      if (c == '+' || c == '-') {
+      char ch = result.charAt(i);
+      if (ch == '+' || ch == '-') {
         signIdx = i;
         break;
       }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -570,6 +570,22 @@ public class TestRecordConverter {
   }
 
   @Test
+  public void testTimestampWithZoneAndFractionalSecondsConversion() {
+    // Timestamps with sub-second precision and a colon-separated UTC offset (e.g. +00:00)
+    // were previously mis-parsed because ensureTimestampFormat only checked for the timezone
+    // sign at the fixed index 19, which is only valid when there are no fractional seconds.
+    OffsetDateTime expected = OffsetDateTime.parse("2026-03-31T03:17:37.260514+00:00");
+    List<Object> inputs =
+        ImmutableList.of(
+            "2026-03-31T03:17:37.260514+00:00",
+            "2026-03-31T03:17:37.260514+0000",
+            "2026-03-31T03:17:37.260514Z",
+            "2026-03-31 03:17:37.260514+00:00",
+            "2026-03-31 03:17:37.260514+0000");
+    assertTimestampConvert(expected, inputs, TimestampType.withZone());
+  }
+
+  @Test
   public void testTimestampWithoutZoneConversion() {
     LocalDateTime expected = LocalDateTime.parse("2023-05-18T11:22:33");
     long expectedMillis = expected.atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
@@ -585,6 +601,23 @@ public class TestRecordConverter {
             "2023-05-18T11:22:33-0800",
             "2023-05-18 11:22:33-0800");
     assertTimestampConvert(expected, additionalInput, TimestampType.withoutZone());
+  }
+
+  @Test
+  public void testTimestampWithoutZoneAndFractionalSecondsConversion() {
+    // Fractional seconds with a colon-separated offset: timezone must be stripped and
+    // the colon in +HH:MM must be normalized before OFFSET_TIMESTAMP_FORMAT can parse it.
+    LocalDateTime expected = LocalDateTime.parse("2026-03-31T03:17:37.260514");
+    List<Object> inputs =
+        ImmutableList.of(
+            "2026-03-31T03:17:37.260514",
+            "2026-03-31 03:17:37.260514",
+            "2026-03-31T03:17:37.260514+00:00",
+            "2026-03-31 03:17:37.260514+00:00",
+            "2026-03-31T03:17:37.260514+0000",
+            "2026-03-31 03:17:37.260514+0000",
+            "2026-03-31T03:17:37.260514Z");
+    assertTimestampConvert(expected, inputs, TimestampType.withoutZone());
   }
 
   private void assertTimestampConvert(Temporal expected, long expectedMillis, TimestampType type) {


### PR DESCRIPTION
ensureTimestampFormat normalizes colon-separated offsets (+00:00 → +0000) so that the internal OFFSET_TIMESTAMP_FORMAT formatter (which uses appendOffset("+HHmm", "Z")) can parse them. However, it assumed the timezone sign is always at character index 19 — which is only true when there are no fractional seconds.

When the normalization was skipped, OFFSET_TIMESTAMP_FORMAT failed to parse the string (colon still present). The fallback LocalDateTime.parse with ISO_LOCAL_DATE_TIME then also failed because the +00:00 suffix was still attached. The combined failure produced a connector task crash.

This change replaces the hardcoded index-19 check with a forward scan starting at index 19, dynamically locating the timezone sign regardless of how many fractional-second digits precede it. The colon is then stripped at the correct position.

Closes #15838