### PR TITLE
Spark (3.4,3.5,4.0) : Include snapshotId and branch in SparkTable equals and hashCode

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
@@ -396,12 +397,13 @@ public class SparkTable
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
             .deleteFromRowFilter(deleteExpr);
 
+    String writeBranch = branch;
     if (SparkTableUtil.wapEnabled(table())) {
-      branch = SparkTableUtil.determineWriteBranch(sparkSession(), branch);
+      writeBranch = SparkTableUtil.determineWriteBranch(sparkSession(), branch);
     }
 
-    if (branch != null) {
-      deleteFiles.toBranch(branch);
+    if (writeBranch != null) {
+      deleteFiles.toBranch(writeBranch);
     }
 
     if (!CommitMetadata.commitProperties().isEmpty()) {
@@ -424,15 +426,16 @@ public class SparkTable
       return false;
     }
 
-    // use only name in order to correctly invalidate Spark cache
     SparkTable that = (SparkTable) other;
-    return icebergTable.name().equals(that.icebergTable.name());
+    return icebergTable.name().equals(that.icebergTable.name())
+        && Objects.equals(table().uuid(), that.table().uuid())
+        && Objects.equals(snapshotId, that.snapshotId)
+        && Objects.equals(branch, that.branch);
   }
 
   @Override
   public int hashCode() {
-    // use only name in order to correctly invalidate Spark cache
-    return icebergTable.name().hashCode();
+    return Objects.hash(icebergTable.name(), table().uuid(), snapshotId, branch);
   }
 
   private static CaseInsensitiveStringMap addSnapshotId(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
@@ -55,5 +57,59 @@ public class TestSparkTable extends CatalogTestBase {
     // different instances pointing to the same table must be equivalent
     assertThat(table1).as("References must be different").isNotSameAs(table2);
     assertThat(table1).as("Tables must be equivalent").isEqualTo(table2);
+  }
+
+  @TestTemplate
+  public void testTableInequalityWithDifferentSnapshots() throws NoSuchTableException {
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+
+    CatalogManager catalogManager = spark.sessionState().catalogManager();
+    TableCatalog catalog = (TableCatalog) catalogManager.catalog(catalogName);
+    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+    SparkTable table = (SparkTable) catalog.loadTable(identifier);
+
+    Table icebergTable = validationCatalog.loadTable(tableIdent);
+    long[] snapshotIds =
+        icebergTable.history().stream().mapToLong(HistoryEntry::snapshotId).toArray();
+
+    SparkTable tableAtSnapshot1 = table.copyWithSnapshotId(snapshotIds[0]);
+    SparkTable tableAtSnapshot2 = table.copyWithSnapshotId(snapshotIds[1]);
+
+    assertThat(tableAtSnapshot1)
+        .as("Tables at different snapshots must not be equal")
+        .isNotEqualTo(tableAtSnapshot2);
+    assertThat(tableAtSnapshot1.hashCode())
+        .as("Hash codes should differ for different snapshots")
+        .isNotEqualTo(tableAtSnapshot2.hashCode());
+  }
+
+  @TestTemplate
+  public void testTableInequalityWithDifferentBranches() throws NoSuchTableException {
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+
+    CatalogManager catalogManager = spark.sessionState().catalogManager();
+    TableCatalog catalog = (TableCatalog) catalogManager.catalog(catalogName);
+    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+
+    Table icebergTable = validationCatalog.loadTable(tableIdent);
+    icebergTable
+        .manageSnapshots()
+        .createBranch("testBranch", icebergTable.currentSnapshot().snapshotId())
+        .commit();
+
+    // reload after branch creation so the table sees the new ref
+    SparkTable table = (SparkTable) catalog.loadTable(identifier);
+    table.table().refresh();
+
+    SparkTable tableOnMain = table.copyWithBranch("main");
+    SparkTable tableOnBranch = table.copyWithBranch("testBranch");
+
+    assertThat(tableOnMain)
+        .as("Tables on different branches must not be equal")
+        .isNotEqualTo(tableOnBranch);
+    assertThat(tableOnMain.hashCode())
+        .as("Hash codes should differ for different branches")
+        .isNotEqualTo(tableOnBranch.hashCode());
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
@@ -396,12 +397,13 @@ public class SparkTable
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
             .deleteFromRowFilter(deleteExpr);
 
+    String writeBranch = branch;
     if (SparkTableUtil.wapEnabled(table())) {
-      branch = SparkTableUtil.determineWriteBranch(sparkSession(), branch);
+      writeBranch = SparkTableUtil.determineWriteBranch(sparkSession(), branch);
     }
 
-    if (branch != null) {
-      deleteFiles.toBranch(branch);
+    if (writeBranch != null) {
+      deleteFiles.toBranch(writeBranch);
     }
 
     if (!CommitMetadata.commitProperties().isEmpty()) {
@@ -424,15 +426,16 @@ public class SparkTable
       return false;
     }
 
-    // use only name in order to correctly invalidate Spark cache
     SparkTable that = (SparkTable) other;
-    return icebergTable.name().equals(that.icebergTable.name());
+    return icebergTable.name().equals(that.icebergTable.name())
+        && Objects.equals(table().uuid(), that.table().uuid())
+        && Objects.equals(snapshotId, that.snapshotId)
+        && Objects.equals(branch, that.branch);
   }
 
   @Override
   public int hashCode() {
-    // use only name in order to correctly invalidate Spark cache
-    return icebergTable.name().hashCode();
+    return Objects.hash(icebergTable.name(), table().uuid(), snapshotId, branch);
   }
 
   private static CaseInsensitiveStringMap addSnapshotId(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
@@ -55,5 +57,59 @@ public class TestSparkTable extends CatalogTestBase {
     // different instances pointing to the same table must be equivalent
     assertThat(table1).as("References must be different").isNotSameAs(table2);
     assertThat(table1).as("Tables must be equivalent").isEqualTo(table2);
+  }
+
+  @TestTemplate
+  public void testTableInequalityWithDifferentSnapshots() throws NoSuchTableException {
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+
+    CatalogManager catalogManager = spark.sessionState().catalogManager();
+    TableCatalog catalog = (TableCatalog) catalogManager.catalog(catalogName);
+    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+    SparkTable table = (SparkTable) catalog.loadTable(identifier);
+
+    Table icebergTable = validationCatalog.loadTable(tableIdent);
+    long[] snapshotIds =
+        icebergTable.history().stream().mapToLong(HistoryEntry::snapshotId).toArray();
+
+    SparkTable tableAtSnapshot1 = table.copyWithSnapshotId(snapshotIds[0]);
+    SparkTable tableAtSnapshot2 = table.copyWithSnapshotId(snapshotIds[1]);
+
+    assertThat(tableAtSnapshot1)
+        .as("Tables at different snapshots must not be equal")
+        .isNotEqualTo(tableAtSnapshot2);
+    assertThat(tableAtSnapshot1.hashCode())
+        .as("Hash codes should differ for different snapshots")
+        .isNotEqualTo(tableAtSnapshot2.hashCode());
+  }
+
+  @TestTemplate
+  public void testTableInequalityWithDifferentBranches() throws NoSuchTableException {
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+
+    CatalogManager catalogManager = spark.sessionState().catalogManager();
+    TableCatalog catalog = (TableCatalog) catalogManager.catalog(catalogName);
+    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+
+    Table icebergTable = validationCatalog.loadTable(tableIdent);
+    icebergTable
+        .manageSnapshots()
+        .createBranch("testBranch", icebergTable.currentSnapshot().snapshotId())
+        .commit();
+
+    // reload after branch creation so the table sees the new ref
+    SparkTable table = (SparkTable) catalog.loadTable(identifier);
+    table.table().refresh();
+
+    SparkTable tableOnMain = table.copyWithBranch("main");
+    SparkTable tableOnBranch = table.copyWithBranch("testBranch");
+
+    assertThat(tableOnMain)
+        .as("Tables on different branches must not be equal")
+        .isNotEqualTo(tableOnBranch);
+    assertThat(tableOnMain.hashCode())
+        .as("Hash codes should differ for different branches")
+        .isNotEqualTo(tableOnBranch.hashCode());
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
@@ -438,12 +439,13 @@ public class SparkTable
             .set("spark.app.id", sparkSession().sparkContext().applicationId())
             .deleteFromRowFilter(deleteExpr);
 
+    String writeBranch = branch;
     if (SparkTableUtil.wapEnabled(table())) {
-      branch = SparkTableUtil.determineWriteBranch(sparkSession(), branch);
+      writeBranch = SparkTableUtil.determineWriteBranch(sparkSession(), branch);
     }
 
-    if (branch != null) {
-      deleteFiles.toBranch(branch);
+    if (writeBranch != null) {
+      deleteFiles.toBranch(writeBranch);
     }
 
     if (!CommitMetadata.commitProperties().isEmpty()) {
@@ -466,15 +468,16 @@ public class SparkTable
       return false;
     }
 
-    // use only name in order to correctly invalidate Spark cache
     SparkTable that = (SparkTable) other;
-    return icebergTable.name().equals(that.icebergTable.name());
+    return icebergTable.name().equals(that.icebergTable.name())
+        && Objects.equals(table().uuid(), that.table().uuid())
+        && Objects.equals(snapshotId, that.snapshotId)
+        && Objects.equals(branch, that.branch);
   }
 
   @Override
   public int hashCode() {
-    // use only name in order to correctly invalidate Spark cache
-    return icebergTable.name().hashCode();
+    return Objects.hash(icebergTable.name(), table().uuid(), snapshotId, branch);
   }
 
   private static CaseInsensitiveStringMap addSnapshotId(

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
@@ -55,5 +57,59 @@ public class TestSparkTable extends CatalogTestBase {
     // different instances pointing to the same table must be equivalent
     assertThat(table1).as("References must be different").isNotSameAs(table2);
     assertThat(table1).as("Tables must be equivalent").isEqualTo(table2);
+  }
+
+  @TestTemplate
+  public void testTableInequalityWithDifferentSnapshots() throws NoSuchTableException {
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+
+    CatalogManager catalogManager = spark.sessionState().catalogManager();
+    TableCatalog catalog = (TableCatalog) catalogManager.catalog(catalogName);
+    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+    SparkTable table = (SparkTable) catalog.loadTable(identifier);
+
+    Table icebergTable = validationCatalog.loadTable(tableIdent);
+    long[] snapshotIds =
+        icebergTable.history().stream().mapToLong(HistoryEntry::snapshotId).toArray();
+
+    SparkTable tableAtSnapshot1 = table.copyWithSnapshotId(snapshotIds[0]);
+    SparkTable tableAtSnapshot2 = table.copyWithSnapshotId(snapshotIds[1]);
+
+    assertThat(tableAtSnapshot1)
+        .as("Tables at different snapshots must not be equal")
+        .isNotEqualTo(tableAtSnapshot2);
+    assertThat(tableAtSnapshot1.hashCode())
+        .as("Hash codes should differ for different snapshots")
+        .isNotEqualTo(tableAtSnapshot2.hashCode());
+  }
+
+  @TestTemplate
+  public void testTableInequalityWithDifferentBranches() throws NoSuchTableException {
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+
+    CatalogManager catalogManager = spark.sessionState().catalogManager();
+    TableCatalog catalog = (TableCatalog) catalogManager.catalog(catalogName);
+    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+
+    Table icebergTable = validationCatalog.loadTable(tableIdent);
+    icebergTable
+        .manageSnapshots()
+        .createBranch("testBranch", icebergTable.currentSnapshot().snapshotId())
+        .commit();
+
+    // reload after branch creation so the table sees the new ref
+    SparkTable table = (SparkTable) catalog.loadTable(identifier);
+    table.table().refresh();
+
+    SparkTable tableOnMain = table.copyWithBranch("main");
+    SparkTable tableOnBranch = table.copyWithBranch("testBranch");
+
+    assertThat(tableOnMain)
+        .as("Tables on different branches must not be equal")
+        .isNotEqualTo(tableOnBranch);
+    assertThat(tableOnMain.hashCode())
+        .as("Hash codes should differ for different branches")
+        .isNotEqualTo(tableOnBranch.hashCode());
   }
 }


### PR DESCRIPTION
SparkTable.equals() and hashCode() only compared the table name, causing Spark to return cached query results for time-travel and branch queries. When a user reads from branch 'main' and then branch 'audit', Spark's cache considered them equal and returned stale data from 'main'.

Include table().uuid(), snapshotId, and branch fields in equals() and hashCode() so that Spark correctly distinguishes tables loaded at different snapshots or branches. This matches the fix already applied in Spark 4.1 (current main).

Also avoid mutating the branch field in deleteWhere() by using a local variable for WAP branch resolution, since branch is now part of the table's identity.

Closes #15741