### PR TITLE
Core: Reject deleting all fields from a nested struct

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -646,7 +646,6 @@ class SchemaUpdate implements UpdateSchema {
       }
 
       if (hasChange) {
-        // TODO: What happens if there are no fields left?
         return Types.StructType.of(newFields);
       }
 
@@ -682,6 +681,10 @@ class SchemaUpdate implements UpdateSchema {
           return Types.StructType.of(fields);
         }
       }
+
+      Preconditions.checkArgument(
+          !fieldResult.isStructType() || !fieldResult.asStructType().fields().isEmpty(),
+          "Cannot delete all fields from a struct. To remove the struct, delete the struct column instead");
 
       return fieldResult;
     }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -1077,6 +1077,45 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testDeleteAllFieldsFromNestedStruct() {
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+                    .deleteColumn("preferences.feature1")
+                    .deleteColumn("preferences.feature2")
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot delete all fields from a struct. To remove the struct, delete the struct column instead");
+  }
+
+  @Test
+  public void testDeleteAllFieldsFromMapValueStruct() {
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+                    .deleteColumn("locations.lat")
+                    .deleteColumn("locations.long")
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot delete all fields from a struct. To remove the struct, delete the struct column instead");
+  }
+
+  @Test
+  public void testDeleteAllFieldsFromListElementStruct() {
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+                    .deleteColumn("points.x")
+                    .deleteColumn("points.y")
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot delete all fields from a struct. To remove the struct, delete the struct column instead");
+  }
+
+  @Test
   public void testRenameMissingColumn() {
     assertThatThrownBy(
             () -> {


### PR DESCRIPTION
## What

Previously `SchemaUpdate.ApplyChanges` silently produced an empty struct type,
which is undefined behavior. This change rejects it with an `IllegalArgumentException`.

This is consistent with the existing guards in the same class that already reject
deleting element types from lists (`"Cannot delete element type from list"`) and
value types from maps (`"Cannot delete value type from map"`). Structs were the
only container type missing this validation.

## How

Added a `Preconditions.checkArgument` in `ApplyChanges.field()` that checks whether
the final field result is a struct with no fields. The check runs **after** additions
are applied, so the "delete-all-then-add" pattern (e.g. deleting a field then
re-adding it under a different ID) still works correctly.

Deleting the struct column itself is unaffected — that returns `null` early via the
`deletes` check before our validation is ever reached.

## Testing

Added three tests covering the three contexts where nested structs appear:
- `testDeleteAllFieldsFromNestedStruct` — direct struct column (`preferences`)
- `testDeleteAllFieldsFromMapValueStruct` — map value struct (`locations`)
- `testDeleteAllFieldsFromListElementStruct` — list element struct (`points`)

All 102 existing `TestSchemaUpdate` tests pass.