### PR TITLE
Spark: Support session-level snapshot properties for actions

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotUpdateSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotUpdateSparkAction.java
@@ -32,6 +32,10 @@ abstract class BaseSnapshotUpdateSparkAction<ThisT> extends BaseSparkAction<This
 
   protected BaseSnapshotUpdateSparkAction(SparkSession spark) {
     super(spark);
+    summary.putAll(
+        PropertyUtil.propertiesWithPrefix(
+            JavaConverters.mapAsJavaMap(spark.conf().getAll()),
+            SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX));
   }
 
   public ThisT snapshotProperty(String property, String value) {
@@ -45,17 +49,6 @@ abstract class BaseSnapshotUpdateSparkAction<ThisT> extends BaseSparkAction<This
   }
 
   protected Map<String, String> commitSummary() {
-    Map<String, String> merged = Maps.newHashMap();
-
-    // session-level snapshot properties (lower priority)
-    merged.putAll(
-        PropertyUtil.propertiesWithPrefix(
-            JavaConverters.mapAsJavaMap(spark().conf().getAll()),
-            SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX));
-
-    // explicitly set snapshot properties (higher priority)
-    merged.putAll(summary);
-
-    return ImmutableMap.copyOf(merged);
+    return ImmutableMap.copyOf(summary);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotUpdateSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotUpdateSparkAction.java
@@ -21,7 +21,10 @@ package org.apache.iceberg.spark.actions;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkSQLProperties;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.SparkSession;
+import scala.collection.JavaConverters;
 
 abstract class BaseSnapshotUpdateSparkAction<ThisT> extends BaseSparkAction<ThisT> {
 
@@ -37,11 +40,22 @@ abstract class BaseSnapshotUpdateSparkAction<ThisT> extends BaseSparkAction<This
   }
 
   protected void commit(org.apache.iceberg.SnapshotUpdate<?> update) {
-    summary.forEach(update::set);
+    commitSummary().forEach(update::set);
     update.commit();
   }
 
   protected Map<String, String> commitSummary() {
-    return ImmutableMap.copyOf(summary);
+    Map<String, String> merged = Maps.newHashMap();
+
+    // session-level snapshot properties (lower priority)
+    merged.putAll(
+        PropertyUtil.propertiesWithPrefix(
+            JavaConverters.mapAsJavaMap(spark().conf().getAll()),
+            SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX));
+
+    // explicitly set snapshot properties (higher priority)
+    merged.putAll(summary);
+
+    return ImmutableMap.copyOf(merged);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotUpdateSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotUpdateSparkAction.java
@@ -44,7 +44,7 @@ abstract class BaseSnapshotUpdateSparkAction<ThisT> extends BaseSparkAction<This
   }
 
   protected void commit(org.apache.iceberg.SnapshotUpdate<?> update) {
-    commitSummary().forEach(update::set);
+    summary.forEach(update::set);
     update.commit();
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -111,9 +111,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
-import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.TestBase;
@@ -1946,8 +1946,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     spark.conf().set(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "key", "session-value");
     try {
-      Result ignored =
-          basicRewrite(table).snapshotProperty("key", "explicit-value").execute();
+      Result ignored = basicRewrite(table).snapshotProperty("key", "explicit-value").execute();
       assertThat(table.currentSnapshot().summary()).containsEntry("key", "explicit-value");
     } finally {
       spark.conf().unset(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "key");

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1931,26 +1931,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testSessionSnapshotProperty() {
     Table table = createTable(4);
 
-    spark.conf().set(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "session-key", "session-value");
-    try {
-      Result ignored = basicRewrite(table).execute();
-      assertThat(table.currentSnapshot().summary()).containsEntry("session-key", "session-value");
-    } finally {
-      spark.conf().unset(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "session-key");
-    }
+    withSQLConf(
+        ImmutableMap.of(
+            SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "session-key", "session-value"),
+        () -> {
+          Result ignored = basicRewrite(table).execute();
+          assertThat(table.currentSnapshot().summary())
+              .containsEntry("session-key", "session-value");
+        });
   }
 
   @TestTemplate
   public void testExplicitSnapshotPropertyOverridesSession() {
     Table table = createTable(4);
 
-    spark.conf().set(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "key", "session-value");
-    try {
-      Result ignored = basicRewrite(table).snapshotProperty("key", "explicit-value").execute();
-      assertThat(table.currentSnapshot().summary()).containsEntry("key", "explicit-value");
-    } finally {
-      spark.conf().unset(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "key");
-    }
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "key", "session-value"),
+        () -> {
+          Result ignored = basicRewrite(table).snapshotProperty("key", "explicit-value").execute();
+          assertThat(table.currentSnapshot().summary()).containsEntry("key", "explicit-value");
+        });
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -111,6 +111,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.ScanTaskSetManager;
+import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkTableUtil;
@@ -1924,6 +1925,33 @@ public class TestRewriteDataFilesAction extends TestBase {
           SnapshotSummary.CHANGED_PARTITION_COUNT_PROP
         };
     assertThat(table.currentSnapshot().summary()).containsKeys(commitMetricsKeys);
+  }
+
+  @TestTemplate
+  public void testSessionSnapshotProperty() {
+    Table table = createTable(4);
+
+    spark.conf().set(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "session-key", "session-value");
+    try {
+      Result ignored = basicRewrite(table).execute();
+      assertThat(table.currentSnapshot().summary()).containsEntry("session-key", "session-value");
+    } finally {
+      spark.conf().unset(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "session-key");
+    }
+  }
+
+  @TestTemplate
+  public void testExplicitSnapshotPropertyOverridesSession() {
+    Table table = createTable(4);
+
+    spark.conf().set(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "key", "session-value");
+    try {
+      Result ignored =
+          basicRewrite(table).snapshotProperty("key", "explicit-value").execute();
+      assertThat(table.currentSnapshot().summary()).containsEntry("key", "explicit-value");
+    } finally {
+      spark.conf().unset(SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX + "key");
+    }
   }
 
   @TestTemplate


### PR DESCRIPTION
Plumb spark.sql.iceberg.snapshot-property.* session config through BaseSnapshotUpdateSparkAction so that rewrite_data_files and other action-based procedures pick up custom snapshot properties, matching the existing behavior of the write path.

Will have follow up PR to port to other spark versions.