### PR TITLE
OpenAPI: Clarify signer property passthrough from server to client

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1485,6 +1485,11 @@ class LoadTableResult(BaseModel):
     If remote signing for a specific storage provider is enabled, clients must respect the following configurations when creating a remote signer client:
      - `signer.endpoint`: the remote signer endpoint. Required. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
      - `signer.uri`: the base URI to resolve `signer.endpoint` against. Optional. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
+     - `signer.properties.*`: additional properties to be passed through to the signer endpoint in remote sign
+       requests. Optional. If such properties are present, signer clients MUST pass them through to the signer
+       endpoint, in the `properties` field of the remote sign request body. For example, if
+       `signer.properties.key1 = value1` is present, then each remote sign request MUST contain the entry
+       `key1 = value1` in the request body's `properties` field.
 
     """
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3522,6 +3522,11 @@ components:
         If remote signing for a specific storage provider is enabled, clients must respect the following configurations when creating a remote signer client:
          - `signer.endpoint`: the remote signer endpoint. Required. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
          - `signer.uri`: the base URI to resolve `signer.endpoint` against. Optional. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
+         - `signer.properties.*`: additional properties to be passed through to the signer endpoint in remote sign
+           requests. Optional. If such properties are present, signer clients MUST pass them through to the signer
+           endpoint, in the `properties` field of the remote sign request body. For example, if
+           `signer.properties.key1 = value1` is present, then each remote sign request MUST contain the entry
+           `key1 = value1` in the request body's `properties` field.
       type: object
       required:
         - metadata


### PR DESCRIPTION
The `RemoteSignRequest` body already supports a `properties` field, but the spec does not describe how such properties could be leveraged.

Catalog servers, on the other hand, may want signer clients to include certain properties in sign requests, e.g. pre-computed RBAC data. But again, the spec does not describe how such properties should be communicated to clients.

This PR closes both gaps and formalizes a new `signer.properties.*` prefix for the `config` field of the `LoadTableResult` object. It also defines the expectations for signer clients when such properties are present.