### PR TITLE
Core: Remove v4 references from javadocs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestInfo.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfo.java
@@ -21,7 +21,7 @@ package org.apache.iceberg;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.types.Types;
 
-/** Summary information about a manifest referenced by a v4 root manifest entry. */
+/** Summary information about a manifest referenced by a root manifest entry. */
 interface ManifestInfo {
   Types.NestedField ADDED_FILES_COUNT =
       Types.NestedField.required(

--- a/core/src/main/java/org/apache/iceberg/TrackedFile.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFile.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Types;
 
-/** A content file with optional deletion vector, tracked by a v4 manifest. */
+/** A file tracked by a manifest. */
 interface TrackedFile {
   Types.NestedField TRACKING =
       Types.NestedField.required(

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -21,7 +21,7 @@ package org.apache.iceberg;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.types.Types;
 
-/** Tracking information for a v4 manifest entry. */
+/** Tracking information for a manifest entry. */
 interface Tracking {
   Types.NestedField STATUS =
       Types.NestedField.required(


### PR DESCRIPTION
This fixes @RussellSpitzer 's  feedback on https://github.com/apache/iceberg/pull/15049 to avoid version-specific language that will go stale.