### PR TITLE
Core: Add TrackedFileStruct, implementation of v4 TrackedFile

### DIFF
--- a/api/src/main/java/org/apache/iceberg/FileContent.java
+++ b/api/src/main/java/org/apache/iceberg/FileContent.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import java.util.Locale;
+
 /** Content type stored in a file. */
 public enum FileContent {
   DATA(0),
@@ -29,13 +31,19 @@ public enum FileContent {
   private static final FileContent[] VALUES = FileContent.values();
 
   private final int id;
+  private final String lowerCaseName;
 
   FileContent(int id) {
     this.id = id;
+    this.lowerCaseName = name().toLowerCase(Locale.ROOT);
   }
 
   public int id() {
     return id;
+  }
+
+  public String lowerCaseName() {
+    return lowerCaseName;
   }
 
   public static FileContent fromId(int id) {

--- a/core/src/main/java/org/apache/iceberg/DeletionVector.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVector.java
@@ -61,4 +61,7 @@ interface DeletionVector {
 
   /** Returns the number of set bits (deleted rows) in the vector. */
   long cardinality();
+
+  /** Copies this deletion vector. */
+  DeletionVector copy();
 }

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -32,9 +32,9 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
           DeletionVector.CARDINALITY);
 
   private String location = null;
-  private long offset = 0L;
-  private long sizeInBytes = 0L;
-  private long cardinality = 0L;
+  private long offset = -1L;
+  private long sizeInBytes = -1L;
+  private long cardinality = -1L;
 
   DeletionVectorStruct(Types.StructType type) {
     super(BASE_TYPE, type);

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.types.Types;
 
 /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
 class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVector {
-  // struct type that corresponds to the positions used for internalGet and internalSet
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
           DeletionVector.LOCATION,

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import org.apache.iceberg.types.Types;
+
+/** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
+class DeletionVectorStruct implements DeletionVector, StructLike, Serializable {
+  private String location = null;
+  private long offset = 0L;
+  private long sizeInBytes = 0L;
+  private long cardinality = 0L;
+
+  DeletionVectorStruct(Types.StructType type) {}
+
+  private DeletionVectorStruct(DeletionVectorStruct toCopy) {
+    this.location = toCopy.location;
+    this.offset = toCopy.offset;
+    this.sizeInBytes = toCopy.sizeInBytes;
+    this.cardinality = toCopy.cardinality;
+  }
+
+  DeletionVectorStruct copy() {
+    return new DeletionVectorStruct(this);
+  }
+
+  @Override
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public long offset() {
+    return offset;
+  }
+
+  @Override
+  public long sizeInBytes() {
+    return sizeInBytes;
+  }
+
+  @Override
+  public long cardinality() {
+    return cardinality;
+  }
+
+  @Override
+  public int size() {
+    return 4;
+  }
+
+  @Override
+  public <T> T get(int pos, Class<T> javaClass) {
+    return javaClass.cast(getByPos(pos));
+  }
+
+  private Object getByPos(int pos) {
+    switch (pos) {
+      case 0:
+        return location;
+      case 1:
+        return offset;
+      case 2:
+        return sizeInBytes;
+      case 3:
+        return cardinality;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+  }
+
+  @Override
+  public <T> void set(int pos, T value) {
+    switch (pos) {
+      case 0:
+        this.location = (String) value;
+        break;
+      case 1:
+        this.offset = (Long) value;
+        break;
+      case 2:
+        this.sizeInBytes = (Long) value;
+        break;
+      case 3:
+        this.cardinality = (Long) value;
+        break;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -103,7 +103,7 @@ class DeletionVectorStruct implements DeletionVector, StructLike, Serializable {
         this.cardinality = (Long) value;
         break;
       default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        // ignore the object, it must be from a newer version of the format
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -98,7 +98,8 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
-        this.location = (String) value;
+        // always coerce to String for Serializable
+        this.location = value.toString();
         break;
       case 1:
         this.offset = (Long) value;

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 
 /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
-class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVector {
+class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVector, Serializable {
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
           DeletionVector.LOCATION,

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -50,11 +50,6 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
   }
 
   @Override
-  public DeletionVectorStruct copy() {
-    return new DeletionVectorStruct(this);
-  }
-
-  @Override
   public String location() {
     return location;
   }
@@ -72,6 +67,11 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
   @Override
   public long cardinality() {
     return cardinality;
+  }
+
+  @Override
+  public DeletionVectorStruct copy() {
+    return new DeletionVectorStruct(this);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -18,20 +18,25 @@
  */
 package org.apache.iceberg;
 
-import java.io.Serializable;
+import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 
 /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
-class DeletionVectorStruct implements DeletionVector, StructLike, Serializable {
+class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVector {
+  private static final Types.StructType BASE_TYPE = DeletionVector.schema();
+
   private String location = null;
   private long offset = 0L;
   private long sizeInBytes = 0L;
   private long cardinality = 0L;
 
-  DeletionVectorStruct(Types.StructType type) {}
+  DeletionVectorStruct(Types.StructType type) {
+    super(BASE_TYPE, type);
+  }
 
   private DeletionVectorStruct(DeletionVectorStruct toCopy) {
+    super(toCopy);
     this.location = toCopy.location;
     this.offset = toCopy.offset;
     this.sizeInBytes = toCopy.sizeInBytes;
@@ -63,12 +68,7 @@ class DeletionVectorStruct implements DeletionVector, StructLike, Serializable {
   }
 
   @Override
-  public int size() {
-    return 4;
-  }
-
-  @Override
-  public <T> T get(int pos, Class<T> javaClass) {
+  protected <T> T internalGet(int pos, Class<T> javaClass) {
     return javaClass.cast(getByPos(pos));
   }
 
@@ -88,7 +88,7 @@ class DeletionVectorStruct implements DeletionVector, StructLike, Serializable {
   }
 
   @Override
-  public <T> void set(int pos, T value) {
+  protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
         this.location = (String) value;

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 
 /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
@@ -104,5 +105,15 @@ class DeletionVectorStruct implements DeletionVector, StructLike, Serializable {
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("location", location)
+        .add("offset", offset)
+        .add("size_in_bytes", sizeInBytes)
+        .add("cardinality", cardinality)
+        .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -48,7 +48,8 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
     this.cardinality = toCopy.cardinality;
   }
 
-  DeletionVectorStruct copy() {
+  @Override
+  public DeletionVectorStruct copy() {
     return new DeletionVectorStruct(this);
   }
 

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -24,7 +24,13 @@ import org.apache.iceberg.types.Types;
 
 /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
 class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVector {
-  private static final Types.StructType BASE_TYPE = DeletionVector.schema();
+  // struct type that corresponds to the positions used for internalGet and internalSet
+  private static final Types.StructType BASE_TYPE =
+      Types.StructType.of(
+          DeletionVector.LOCATION,
+          DeletionVector.OFFSET,
+          DeletionVector.SIZE_IN_BYTES,
+          DeletionVector.CARDINALITY);
 
   private String location = null;
   private long offset = 0L;

--- a/core/src/main/java/org/apache/iceberg/ManifestInfo.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfo.java
@@ -110,4 +110,7 @@ interface ManifestInfo {
 
   /** Returns the number of entries marked as deleted in the DV, or null if not present. */
   Long dvCardinality();
+
+  /** Copies this manifest info. */
+  ManifestInfo copy();
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -27,7 +27,20 @@ import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link ManifestInfo}. */
 class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo {
-  private static final Types.StructType BASE_TYPE = ManifestInfo.schema();
+  // struct type that corresponds to the positions used for internalGet and internalSet
+  private static final Types.StructType BASE_TYPE =
+      Types.StructType.of(
+          ManifestInfo.ADDED_FILES_COUNT,
+          ManifestInfo.EXISTING_FILES_COUNT,
+          ManifestInfo.DELETED_FILES_COUNT,
+          ManifestInfo.REPLACED_FILES_COUNT,
+          ManifestInfo.ADDED_ROWS_COUNT,
+          ManifestInfo.EXISTING_ROWS_COUNT,
+          ManifestInfo.DELETED_ROWS_COUNT,
+          ManifestInfo.REPLACED_ROWS_COUNT,
+          ManifestInfo.MIN_SEQUENCE_NUMBER,
+          ManifestInfo.DV,
+          ManifestInfo.DV_CARDINALITY);
 
   private int addedFilesCount = 0;
   private int existingFilesCount = 0;

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link ManifestInfo}. */
-class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo {
+class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo, Serializable {
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
           ManifestInfo.ADDED_FILES_COUNT,

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -41,15 +41,15 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
           ManifestInfo.DV,
           ManifestInfo.DV_CARDINALITY);
 
-  private int addedFilesCount = 0;
-  private int existingFilesCount = 0;
-  private int deletedFilesCount = 0;
-  private int replacedFilesCount = 0;
-  private long addedRowsCount = 0L;
-  private long existingRowsCount = 0L;
-  private long deletedRowsCount = 0L;
-  private long replacedRowsCount = 0L;
-  private long minSequenceNumber = 0L;
+  private int addedFilesCount = -1;
+  private int existingFilesCount = -1;
+  private int deletedFilesCount = -1;
+  private int replacedFilesCount = -1;
+  private long addedRowsCount = -1L;
+  private long existingRowsCount = -1L;
+  private long deletedRowsCount = -1L;
+  private long replacedRowsCount = -1L;
+  private long minSequenceNumber = -1L;
   private byte[] dv = null;
   private Long dvCardinality = null;
 

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
+
+/** Mutable {@link StructLike} implementation of {@link ManifestInfo}. */
+class ManifestInfoStruct implements ManifestInfo, StructLike, Serializable {
+  private int addedFilesCount = 0;
+  private int existingFilesCount = 0;
+  private int deletedFilesCount = 0;
+  private int replacedFilesCount = 0;
+  private long addedRowsCount = 0L;
+  private long existingRowsCount = 0L;
+  private long deletedRowsCount = 0L;
+  private long replacedRowsCount = 0L;
+  private long minSequenceNumber = 0L;
+  private byte[] dv = null;
+  private Long dvCardinality = null;
+
+  ManifestInfoStruct(Types.StructType type) {}
+
+  private ManifestInfoStruct(ManifestInfoStruct toCopy) {
+    this.addedFilesCount = toCopy.addedFilesCount;
+    this.existingFilesCount = toCopy.existingFilesCount;
+    this.deletedFilesCount = toCopy.deletedFilesCount;
+    this.replacedFilesCount = toCopy.replacedFilesCount;
+    this.addedRowsCount = toCopy.addedRowsCount;
+    this.existingRowsCount = toCopy.existingRowsCount;
+    this.deletedRowsCount = toCopy.deletedRowsCount;
+    this.replacedRowsCount = toCopy.replacedRowsCount;
+    this.minSequenceNumber = toCopy.minSequenceNumber;
+    this.dv = toCopy.dv != null ? Arrays.copyOf(toCopy.dv, toCopy.dv.length) : null;
+    this.dvCardinality = toCopy.dvCardinality;
+  }
+
+  ManifestInfoStruct copy() {
+    return new ManifestInfoStruct(this);
+  }
+
+  @Override
+  public int addedFilesCount() {
+    return addedFilesCount;
+  }
+
+  @Override
+  public int existingFilesCount() {
+    return existingFilesCount;
+  }
+
+  @Override
+  public int deletedFilesCount() {
+    return deletedFilesCount;
+  }
+
+  @Override
+  public int replacedFilesCount() {
+    return replacedFilesCount;
+  }
+
+  @Override
+  public long addedRowsCount() {
+    return addedRowsCount;
+  }
+
+  @Override
+  public long existingRowsCount() {
+    return existingRowsCount;
+  }
+
+  @Override
+  public long deletedRowsCount() {
+    return deletedRowsCount;
+  }
+
+  @Override
+  public long replacedRowsCount() {
+    return replacedRowsCount;
+  }
+
+  @Override
+  public long minSequenceNumber() {
+    return minSequenceNumber;
+  }
+
+  @Override
+  public ByteBuffer dv() {
+    return dv != null ? ByteBuffer.wrap(dv) : null;
+  }
+
+  @Override
+  public Long dvCardinality() {
+    return dvCardinality;
+  }
+
+  @Override
+  public int size() {
+    return 11;
+  }
+
+  @Override
+  public <T> T get(int pos, Class<T> javaClass) {
+    return javaClass.cast(getByPos(pos));
+  }
+
+  private Object getByPos(int pos) {
+    switch (pos) {
+      case 0:
+        return addedFilesCount;
+      case 1:
+        return existingFilesCount;
+      case 2:
+        return deletedFilesCount;
+      case 3:
+        return replacedFilesCount;
+      case 4:
+        return addedRowsCount;
+      case 5:
+        return existingRowsCount;
+      case 6:
+        return deletedRowsCount;
+      case 7:
+        return replacedRowsCount;
+      case 8:
+        return minSequenceNumber;
+      case 9:
+        return dv();
+      case 10:
+        return dvCardinality;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+  }
+
+  @Override
+  public <T> void set(int pos, T value) {
+    switch (pos) {
+      case 0:
+        this.addedFilesCount = (Integer) value;
+        break;
+      case 1:
+        this.existingFilesCount = (Integer) value;
+        break;
+      case 2:
+        this.deletedFilesCount = (Integer) value;
+        break;
+      case 3:
+        this.replacedFilesCount = (Integer) value;
+        break;
+      case 4:
+        this.addedRowsCount = (Long) value;
+        break;
+      case 5:
+        this.existingRowsCount = (Long) value;
+        break;
+      case 6:
+        this.deletedRowsCount = (Long) value;
+        break;
+      case 7:
+        this.replacedRowsCount = (Long) value;
+        break;
+      case 8:
+        this.minSequenceNumber = (Long) value;
+        break;
+      case 9:
+        this.dv = ByteBuffers.toByteArray((ByteBuffer) value);
+        break;
+      case 10:
+        this.dvCardinality = (Long) value;
+        break;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.iceberg.avro.SupportsIndexProjection;

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -190,7 +190,7 @@ class ManifestInfoStruct implements ManifestInfo, StructLike, Serializable {
         this.dvCardinality = (Long) value;
         break;
       default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        // ignore the object, it must be from a newer version of the format
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link ManifestInfo}. */
 class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo {
-  // struct type that corresponds to the positions used for internalGet and internalSet
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
           ManifestInfo.ADDED_FILES_COUNT,

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -18,15 +18,17 @@
  */
 package org.apache.iceberg;
 
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link ManifestInfo}. */
-class ManifestInfoStruct implements ManifestInfo, StructLike, Serializable {
+class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo {
+  private static final Types.StructType BASE_TYPE = ManifestInfo.schema();
+
   private int addedFilesCount = 0;
   private int existingFilesCount = 0;
   private int deletedFilesCount = 0;
@@ -39,9 +41,12 @@ class ManifestInfoStruct implements ManifestInfo, StructLike, Serializable {
   private byte[] dv = null;
   private Long dvCardinality = null;
 
-  ManifestInfoStruct(Types.StructType type) {}
+  ManifestInfoStruct(Types.StructType type) {
+    super(BASE_TYPE, type);
+  }
 
   private ManifestInfoStruct(ManifestInfoStruct toCopy) {
+    super(toCopy);
     this.addedFilesCount = toCopy.addedFilesCount;
     this.existingFilesCount = toCopy.existingFilesCount;
     this.deletedFilesCount = toCopy.deletedFilesCount;
@@ -115,12 +120,7 @@ class ManifestInfoStruct implements ManifestInfo, StructLike, Serializable {
   }
 
   @Override
-  public int size() {
-    return 11;
-  }
-
-  @Override
-  public <T> T get(int pos, Class<T> javaClass) {
+  protected <T> T internalGet(int pos, Class<T> javaClass) {
     return javaClass.cast(getByPos(pos));
   }
 
@@ -154,7 +154,7 @@ class ManifestInfoStruct implements ManifestInfo, StructLike, Serializable {
   }
 
   @Override
-  public <T> void set(int pos, T value) {
+  protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
         this.addedFilesCount = (Integer) value;

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -74,11 +74,6 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
   }
 
   @Override
-  public ManifestInfoStruct copy() {
-    return new ManifestInfoStruct(this);
-  }
-
-  @Override
   public int addedFilesCount() {
     return addedFilesCount;
   }
@@ -131,6 +126,11 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
   @Override
   public Long dvCardinality() {
     return dvCardinality;
+  }
+
+  @Override
+  public ManifestInfoStruct copy() {
+    return new ManifestInfoStruct(this);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
@@ -191,5 +192,22 @@ class ManifestInfoStruct implements ManifestInfo, StructLike, Serializable {
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("added_files_count", addedFilesCount)
+        .add("existing_files_count", existingFilesCount)
+        .add("deleted_files_count", deletedFilesCount)
+        .add("replaced_files_count", replacedFilesCount)
+        .add("added_rows_count", addedRowsCount)
+        .add("existing_rows_count", existingRowsCount)
+        .add("deleted_rows_count", deletedRowsCount)
+        .add("replaced_rows_count", replacedRowsCount)
+        .add("min_sequence_number", minSequenceNumber)
+        .add("dv", dv == null ? "null" : "(binary)")
+        .add("dv_cardinality", dvCardinality == null ? "null" : dvCardinality)
+        .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -72,7 +72,8 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
     this.dvCardinality = toCopy.dvCardinality;
   }
 
-  ManifestInfoStruct copy() {
+  @Override
+  public ManifestInfoStruct copy() {
     return new ManifestInfoStruct(this);
   }
 

--- a/core/src/main/java/org/apache/iceberg/TrackedFile.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFile.java
@@ -163,10 +163,4 @@ interface TrackedFile {
   default TrackedFile copyWithoutStats() {
     return copyWithStats(Collections.emptySet());
   }
-
-  /** Returns the manifest location this entry was read from, or null. */
-  String manifestLocation();
-
-  /** Returns the ordinal position of this entry within the manifest. */
-  long manifestPos();
 }

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -26,19 +26,36 @@ import java.util.Locale;
 import java.util.Set;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
 class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, Serializable {
+  private static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
+
+  // struct type that corresponds to the positions used for internalGet and internalSet
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
-          ImmutableList.<Types.NestedField>builder()
-              .addAll(TrackedFile.schemaWithContentStats(Types.StructType.of()).fields())
-              .add(MetadataColumns.ROW_POSITION)
-              .build());
+          TrackedFile.TRACKING,
+          TrackedFile.CONTENT_TYPE,
+          TrackedFile.LOCATION,
+          TrackedFile.FILE_FORMAT,
+          TrackedFile.RECORD_COUNT,
+          TrackedFile.FILE_SIZE_IN_BYTES,
+          TrackedFile.SPEC_ID,
+          Types.NestedField.optional(
+              TrackedFile.CONTENT_STATS_ID,
+              TrackedFile.CONTENT_STATS_NAME,
+              EMPTY_STRUCT_TYPE,
+              TrackedFile.CONTENT_STATS_DOC),
+          TrackedFile.SORT_ORDER_ID,
+          TrackedFile.DELETION_VECTOR,
+          TrackedFile.MANIFEST_INFO,
+          TrackedFile.KEY_METADATA,
+          TrackedFile.SPLIT_OFFSETS,
+          TrackedFile.EQUALITY_IDS,
+          MetadataColumns.ROW_POSITION);
 
   private FileContent contentType = null;
   private String location = null;
@@ -116,6 +133,13 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         toCopy.equalityIds != null
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
             : null;
+  }
+
+  void setManifestContext(TrackedFile manifest) {
+    this.manifestContext = manifest;
+    if (tracking != null) {
+      ((TrackingStruct) tracking).setManifestContext(manifest);
+    }
   }
 
   @Override
@@ -214,13 +238,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   @Override
   public long manifestPos() {
     return manifestPos;
-  }
-
-  void setManifestContext(TrackedFile manifest) {
-    this.manifestContext = manifest;
-    if (tracking != null) {
-      ((TrackingStruct) tracking).setManifestContext(manifest);
-    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -21,10 +21,10 @@ package org.apache.iceberg;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.stats.BaseContentStats;
 import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -82,6 +82,10 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
     this.specId = toCopy.specId;
 
     this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
+    if (this.tracking != null && this.manifestContext != null) {
+      this.tracking.setManifestContext(this.manifestContext);
+    }
+
     this.sortOrderId = toCopy.sortOrderId;
     this.deletionVector = toCopy.deletionVector != null ? toCopy.deletionVector.copy() : null;
 
@@ -206,6 +210,9 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
 
   void setManifestContext(TrackedFile manifest) {
     this.manifestContext = manifest;
+    if (this.tracking != null) {
+      this.tracking.setManifestContext(manifest);
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -19,12 +19,14 @@
 package org.apache.iceberg;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.stats.BaseContentStats;
 import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
@@ -33,9 +35,9 @@ class TrackedFileStruct implements TrackedFile, StructLike {
   private static final EntryStatus[] STATUS_VALUES = EntryStatus.values();
 
   private TrackingStruct tracking;
-  private int contentType;
+  private FileContent contentType = FileContent.DATA;
   private String location;
-  private String fileFormat;
+  private FileFormat fileFormat;
   private long recordCount;
   private long fileSizeInBytes;
   private Integer specId;
@@ -44,8 +46,8 @@ class TrackedFileStruct implements TrackedFile, StructLike {
   private DeletionVectorStruct deletionVector;
   private ManifestInfoStruct manifestInfo;
   private ByteBuffer keyMetadata;
-  private List<Long> splitOffsets;
-  private List<Integer> equalityIds;
+  private long[] splitOffsets;
+  private int[] equalityIds;
   private String manifestLocation;
   private long manifestPos;
 
@@ -72,8 +74,14 @@ class TrackedFileStruct implements TrackedFile, StructLike {
 
     this.manifestInfo = toCopy.manifestInfo != null ? toCopy.manifestInfo.copy() : null;
     this.keyMetadata = toCopy.keyMetadata != null ? ByteBuffers.copy(toCopy.keyMetadata) : null;
-    this.splitOffsets = toCopy.splitOffsets != null ? List.copyOf(toCopy.splitOffsets) : null;
-    this.equalityIds = toCopy.equalityIds != null ? List.copyOf(toCopy.equalityIds) : null;
+    this.splitOffsets =
+        toCopy.splitOffsets != null
+            ? Arrays.copyOf(toCopy.splitOffsets, toCopy.splitOffsets.length)
+            : null;
+    this.equalityIds =
+        toCopy.equalityIds != null
+            ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
+            : null;
     this.manifestLocation = toCopy.manifestLocation;
     this.manifestPos = toCopy.manifestPos;
   }
@@ -89,7 +97,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
 
   @Override
   public FileContent contentType() {
-    return FILE_CONTENT_VALUES[contentType];
+    return contentType;
   }
 
   @Override
@@ -99,7 +107,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
 
   @Override
   public FileFormat fileFormat() {
-    return FileFormat.fromString(fileFormat);
+    return fileFormat;
   }
 
   @Override
@@ -144,12 +152,12 @@ class TrackedFileStruct implements TrackedFile, StructLike {
 
   @Override
   public List<Long> splitOffsets() {
-    return splitOffsets;
+    return splitOffsets != null ? ArrayUtil.toUnmodifiableLongList(splitOffsets) : null;
   }
 
   @Override
   public List<Integer> equalityIds() {
-    return equalityIds;
+    return equalityIds != null ? ArrayUtil.toUnmodifiableIntList(equalityIds) : null;
   }
 
   @Override
@@ -196,13 +204,13 @@ class TrackedFileStruct implements TrackedFile, StructLike {
         value = tracking;
         break;
       case 1:
-        value = contentType;
+        value = contentType.id();
         break;
       case 2:
         value = location;
         break;
       case 3:
-        value = fileFormat;
+        value = fileFormat != null ? fileFormat.toString() : null;
         break;
       case 4:
         value = recordCount;
@@ -229,10 +237,10 @@ class TrackedFileStruct implements TrackedFile, StructLike {
         value = keyMetadata;
         break;
       case 12:
-        value = splitOffsets;
+        value = splitOffsets();
         break;
       case 13:
-        value = equalityIds;
+        value = equalityIds();
         break;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
@@ -249,13 +257,13 @@ class TrackedFileStruct implements TrackedFile, StructLike {
         this.tracking = (TrackingStruct) value;
         break;
       case 1:
-        this.contentType = (Integer) value;
+        this.contentType = FILE_CONTENT_VALUES[(Integer) value];
         break;
       case 2:
         this.location = (String) value;
         break;
       case 3:
-        this.fileFormat = (String) value;
+        this.fileFormat = FileFormat.fromString(value.toString());
         break;
       case 4:
         this.recordCount = (Long) value;
@@ -287,10 +295,10 @@ class TrackedFileStruct implements TrackedFile, StructLike {
         this.keyMetadata = (ByteBuffer) value;
         break;
       case 12:
-        this.splitOffsets = (List<Long>) value;
+        this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
         break;
       case 13:
-        this.equalityIds = (List<Integer>) value;
+        this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
         break;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
@@ -299,7 +307,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
 
   /** Mutable {@link StructLike} implementation of {@link Tracking}. */
   static class TrackingStruct implements Tracking, StructLike {
-    private int status;
+    private EntryStatus status = EntryStatus.EXISTING;
     private Long snapshotId;
     private Long sequenceNumber;
     private Long fileSequenceNumber;
@@ -329,7 +337,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
 
     @Override
     public EntryStatus status() {
-      return STATUS_VALUES[status];
+      return status;
     }
 
     @Override
@@ -390,7 +398,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
       Object value;
       switch (pos) {
         case 0:
-          value = status;
+          value = status.id();
           break;
         case 1:
           value = snapshotId;
@@ -425,7 +433,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
     public <T> void set(int pos, T value) {
       switch (pos) {
         case 0:
-          this.status = (Integer) value;
+          this.status = STATUS_VALUES[(Integer) value];
           break;
         case 1:
           this.snapshotId = (Long) value;

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
@@ -53,8 +52,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
           TrackedFile.MANIFEST_INFO,
           TrackedFile.KEY_METADATA,
           TrackedFile.SPLIT_OFFSETS,
-          TrackedFile.EQUALITY_IDS,
-          MetadataColumns.ROW_POSITION);
+          TrackedFile.EQUALITY_IDS);
 
   private FileContent contentType = null;
   private String location = null;
@@ -72,10 +70,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   private byte[] keyMetadata = null;
   private long[] splitOffsets = null;
   private int[] equalityIds = null;
-
-  // not serialized to manifest, set by manifest readers
-  private transient TrackedFile manifestContext = null;
-  private long manifestPos = 0L;
 
   /** Used by internal readers to instantiate this class with a projection schema. */
   TrackedFileStruct(Types.StructType projection) {
@@ -97,19 +91,10 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.fileSizeInBytes = toCopy.fileSizeInBytes;
     this.specId = toCopy.specId;
 
-    this.manifestContext = toCopy.manifestContext;
-    this.manifestPos = toCopy.manifestPos;
-
-    this.tracking = toCopy.tracking != null ? ((TrackingStruct) toCopy.tracking).copy() : null;
-    if (tracking != null && manifestContext != null) {
-      ((TrackingStruct) tracking).setManifestContext(manifestContext);
-    }
+    this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
 
     this.sortOrderId = toCopy.sortOrderId;
-    this.deletionVector =
-        toCopy.deletionVector != null
-            ? ((DeletionVectorStruct) toCopy.deletionVector).copy()
-            : null;
+    this.deletionVector = toCopy.deletionVector != null ? toCopy.deletionVector.copy() : null;
 
     if (withStats && toCopy.contentStats != null) {
       ContentStats filtered = BaseContentStats.buildFrom(toCopy.contentStats, statsIds).build();
@@ -118,8 +103,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       this.contentStats = null;
     }
 
-    this.manifestInfo =
-        toCopy.manifestInfo != null ? ((ManifestInfoStruct) toCopy.manifestInfo).copy() : null;
+    this.manifestInfo = toCopy.manifestInfo != null ? toCopy.manifestInfo.copy() : null;
     this.keyMetadata =
         toCopy.keyMetadata != null
             ? Arrays.copyOf(toCopy.keyMetadata, toCopy.keyMetadata.length)
@@ -132,13 +116,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         toCopy.equalityIds != null
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
             : null;
-  }
-
-  void setManifestContext(TrackedFile manifest) {
-    this.manifestContext = manifest;
-    if (tracking != null) {
-      ((TrackingStruct) tracking).setManifestContext(manifest);
-    }
   }
 
   @Override
@@ -222,20 +199,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   }
 
   @Override
-  public String manifestLocation() {
-    if (tracking == null) {
-      return null;
-    }
-
-    return manifestContext != null ? manifestContext.location() : null;
-  }
-
-  @Override
-  public long manifestPos() {
-    return manifestPos;
-  }
-
-  @Override
   protected <T> T internalGet(int pos, Class<T> javaClass) {
     return javaClass.cast(getByPos(pos));
   }
@@ -245,7 +208,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       case 0:
         return tracking;
       case 1:
-        return contentType.id();
+        return contentType != null ? contentType.id() : null;
       case 2:
         return location;
       case 3:
@@ -270,8 +233,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         return splitOffsets();
       case 13:
         return equalityIds();
-      case 14:
-        return manifestPos;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
@@ -282,7 +243,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     switch (pos) {
       case 0:
         this.tracking = (Tracking) value;
-        ((TrackingStruct) tracking).setManifestContext(manifestContext);
         break;
       case 1:
         this.contentType = FileContent.fromId((Integer) value);
@@ -324,9 +284,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       case 13:
         this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
         break;
-      case 14:
-        this.manifestPos = (long) value;
-        break;
       default:
         // ignore the object, it must be from a newer version of the format
     }
@@ -335,7 +292,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("content", contentType.toString().toLowerCase(Locale.ROOT))
+        .add("content", contentType != null ? contentType.lowerCaseName() : null)
         .add("location", location)
         .add("file_format", fileFormat)
         .add("record_count", recordCount)

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.util.ByteBuffers;
 class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, Serializable {
   private static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
 
-  // struct type that corresponds to the positions used for internalGet and internalSet
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
           TrackedFile.TRACKING,

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -261,7 +261,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
@@ -272,7 +271,8 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         this.contentType = FILE_CONTENT_VALUES[(Integer) value];
         break;
       case 2:
-        this.location = (String) value;
+        // always coerce to String for Serializable
+        this.location = value.toString();
         break;
       case 3:
         this.fileFormat = FileFormat.fromString(value.toString());
@@ -311,7 +311,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         this.manifestPos = (long) value;
         break;
       default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        // ignore the object, it must be from a newer version of the format
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -57,7 +57,8 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
   private long[] splitOffsets = null;
   private int[] equalityIds = null;
 
-  // not serialized to manifest
+  // not serialized to manifest, set by manifest readers
+  private transient TrackedFile manifestContext = null;
   private String manifestLocation = null;
   private long manifestPos = 0L;
 
@@ -106,6 +107,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
             : null;
 
+    this.manifestContext = toCopy.manifestContext;
     this.manifestLocation = toCopy.manifestLocation;
     this.manifestPos = toCopy.manifestPos;
   }
@@ -200,8 +202,9 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
     return manifestPos;
   }
 
-  void setManifestLocation(String newManifestLocation) {
-    this.manifestLocation = newManifestLocation;
+  void setManifestContext(TrackedFile manifest) {
+    this.manifestContext = manifest;
+    this.manifestLocation = manifest != null ? manifest.location() : null;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -1,0 +1,729 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.stats.BaseContentStats;
+import org.apache.iceberg.stats.ContentStats;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ByteBuffers;
+
+/** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
+class TrackedFileStruct implements TrackedFile, StructLike {
+  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
+  private static final EntryStatus[] STATUS_VALUES = EntryStatus.values();
+
+  private TrackingStruct tracking;
+  private int contentType;
+  private String location;
+  private String fileFormat;
+  private long recordCount;
+  private long fileSizeInBytes;
+  private Integer specId;
+  private ContentStats contentStats;
+  private Integer sortOrderId;
+  private DeletionVectorStruct deletionVector;
+  private ManifestInfoStruct manifestInfo;
+  private ByteBuffer keyMetadata;
+  private List<Long> splitOffsets;
+  private List<Integer> equalityIds;
+  private String manifestLocation;
+  private long manifestPos;
+
+  TrackedFileStruct(Types.StructType type) {}
+
+  /** Copy constructor. */
+  private TrackedFileStruct(TrackedFileStruct toCopy, boolean withStats, Set<Integer> statsIds) {
+    this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
+    this.contentType = toCopy.contentType;
+    this.location = toCopy.location;
+    this.fileFormat = toCopy.fileFormat;
+    this.recordCount = toCopy.recordCount;
+    this.fileSizeInBytes = toCopy.fileSizeInBytes;
+    this.specId = toCopy.specId;
+    this.sortOrderId = toCopy.sortOrderId;
+    this.deletionVector = toCopy.deletionVector != null ? toCopy.deletionVector.copy() : null;
+
+    if (withStats && toCopy.contentStats != null) {
+      ContentStats filtered = BaseContentStats.buildFrom(toCopy.contentStats, statsIds).build();
+      this.contentStats = filtered.fieldStats().isEmpty() ? null : filtered;
+    } else {
+      this.contentStats = null;
+    }
+
+    this.manifestInfo = toCopy.manifestInfo != null ? toCopy.manifestInfo.copy() : null;
+    this.keyMetadata = toCopy.keyMetadata != null ? ByteBuffers.copy(toCopy.keyMetadata) : null;
+    this.splitOffsets = toCopy.splitOffsets != null ? List.copyOf(toCopy.splitOffsets) : null;
+    this.equalityIds = toCopy.equalityIds != null ? List.copyOf(toCopy.equalityIds) : null;
+    this.manifestLocation = toCopy.manifestLocation;
+    this.manifestPos = toCopy.manifestPos;
+  }
+
+  @Override
+  public Tracking tracking() {
+    return tracking;
+  }
+
+  TrackingStruct trackingStruct() {
+    return tracking;
+  }
+
+  @Override
+  public FileContent contentType() {
+    return FILE_CONTENT_VALUES[contentType];
+  }
+
+  @Override
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public FileFormat fileFormat() {
+    return FileFormat.fromString(fileFormat);
+  }
+
+  @Override
+  public long recordCount() {
+    return recordCount;
+  }
+
+  @Override
+  public long fileSizeInBytes() {
+    return fileSizeInBytes;
+  }
+
+  @Override
+  public Integer specId() {
+    return specId;
+  }
+
+  @Override
+  public ContentStats contentStats() {
+    return (ContentStats) contentStats;
+  }
+
+  @Override
+  public Integer sortOrderId() {
+    return sortOrderId;
+  }
+
+  @Override
+  public DeletionVector deletionVector() {
+    return deletionVector;
+  }
+
+  @Override
+  public ManifestInfo manifestInfo() {
+    return manifestInfo;
+  }
+
+  @Override
+  public ByteBuffer keyMetadata() {
+    return keyMetadata;
+  }
+
+  @Override
+  public List<Long> splitOffsets() {
+    return splitOffsets;
+  }
+
+  @Override
+  public List<Integer> equalityIds() {
+    return equalityIds;
+  }
+
+  @Override
+  public TrackedFile copy() {
+    return new TrackedFileStruct(this, true, null);
+  }
+
+  @Override
+  public TrackedFile copyWithStats(Set<Integer> requestedColumnIds) {
+    return new TrackedFileStruct(this, true, requestedColumnIds);
+  }
+
+  @Override
+  public String manifestLocation() {
+    return manifestLocation;
+  }
+
+  @Override
+  public long manifestPos() {
+    return manifestPos;
+  }
+
+  void setManifestLocation(String newManifestLocation) {
+    this.manifestLocation = newManifestLocation;
+  }
+
+  void setManifestPos(long newManifestPos) {
+    this.manifestPos = newManifestPos;
+  }
+
+  // StructLike implementation - field ordinals match TrackedFile.schemaWithContentStats() order
+
+  @Override
+  public int size() {
+    return 14;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T get(int pos, Class<T> javaClass) {
+    Object value;
+    switch (pos) {
+      case 0:
+        value = tracking;
+        break;
+      case 1:
+        value = contentType;
+        break;
+      case 2:
+        value = location;
+        break;
+      case 3:
+        value = fileFormat;
+        break;
+      case 4:
+        value = recordCount;
+        break;
+      case 5:
+        value = fileSizeInBytes;
+        break;
+      case 6:
+        value = specId;
+        break;
+      case 7:
+        value = contentStats;
+        break;
+      case 8:
+        value = sortOrderId;
+        break;
+      case 9:
+        value = deletionVector;
+        break;
+      case 10:
+        value = manifestInfo;
+        break;
+      case 11:
+        value = keyMetadata;
+        break;
+      case 12:
+        value = splitOffsets;
+        break;
+      case 13:
+        value = equalityIds;
+        break;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+
+    return (T) value;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> void set(int pos, T value) {
+    switch (pos) {
+      case 0:
+        this.tracking = (TrackingStruct) value;
+        break;
+      case 1:
+        this.contentType = (Integer) value;
+        break;
+      case 2:
+        this.location = (String) value;
+        break;
+      case 3:
+        this.fileFormat = (String) value;
+        break;
+      case 4:
+        this.recordCount = (Long) value;
+        break;
+      case 5:
+        this.fileSizeInBytes = (Long) value;
+        break;
+      case 6:
+        this.specId = (Integer) value;
+        break;
+      case 7:
+        Preconditions.checkArgument(
+            value == null || value instanceof ContentStats,
+            "Expected ContentStats but found: %s",
+            value == null ? "null" : value.getClass().getName());
+
+        this.contentStats = (ContentStats) value;
+        break;
+      case 8:
+        this.sortOrderId = (Integer) value;
+        break;
+      case 9:
+        this.deletionVector = (DeletionVectorStruct) value;
+        break;
+      case 10:
+        this.manifestInfo = (ManifestInfoStruct) value;
+        break;
+      case 11:
+        this.keyMetadata = (ByteBuffer) value;
+        break;
+      case 12:
+        this.splitOffsets = (List<Long>) value;
+        break;
+      case 13:
+        this.equalityIds = (List<Integer>) value;
+        break;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+  }
+
+  /** Mutable {@link StructLike} implementation of {@link Tracking}. */
+  static class TrackingStruct implements Tracking, StructLike {
+    private int status;
+    private Long snapshotId;
+    private Long sequenceNumber;
+    private Long fileSequenceNumber;
+    private Long dvSnapshotId;
+    private Long firstRowId;
+    private ByteBuffer deletedPositions;
+    private ByteBuffer replacedPositions;
+
+    TrackingStruct(Types.StructType type) {}
+
+    private TrackingStruct(TrackingStruct toCopy) {
+      this.status = toCopy.status;
+      this.snapshotId = toCopy.snapshotId;
+      this.sequenceNumber = toCopy.sequenceNumber;
+      this.fileSequenceNumber = toCopy.fileSequenceNumber;
+      this.dvSnapshotId = toCopy.dvSnapshotId;
+      this.firstRowId = toCopy.firstRowId;
+      this.deletedPositions =
+          toCopy.deletedPositions != null ? ByteBuffers.copy(toCopy.deletedPositions) : null;
+      this.replacedPositions =
+          toCopy.replacedPositions != null ? ByteBuffers.copy(toCopy.replacedPositions) : null;
+    }
+
+    TrackingStruct copy() {
+      return new TrackingStruct(this);
+    }
+
+    @Override
+    public EntryStatus status() {
+      return STATUS_VALUES[status];
+    }
+
+    @Override
+    public Long snapshotId() {
+      return snapshotId;
+    }
+
+    @Override
+    public Long dataSequenceNumber() {
+      return sequenceNumber;
+    }
+
+    @Override
+    public Long fileSequenceNumber() {
+      return fileSequenceNumber;
+    }
+
+    @Override
+    public Long dvSnapshotId() {
+      return dvSnapshotId;
+    }
+
+    @Override
+    public Long firstRowId() {
+      return firstRowId;
+    }
+
+    @Override
+    public ByteBuffer deletedPositions() {
+      return deletedPositions;
+    }
+
+    @Override
+    public ByteBuffer replacedPositions() {
+      return replacedPositions;
+    }
+
+    void setSnapshotId(Long newSnapshotId) {
+      this.snapshotId = newSnapshotId;
+    }
+
+    void setSequenceNumber(Long newSequenceNumber) {
+      this.sequenceNumber = newSequenceNumber;
+    }
+
+    void setFirstRowId(Long newFirstRowId) {
+      this.firstRowId = newFirstRowId;
+    }
+
+    @Override
+    public int size() {
+      return 8;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(int pos, Class<T> javaClass) {
+      Object value;
+      switch (pos) {
+        case 0:
+          value = status;
+          break;
+        case 1:
+          value = snapshotId;
+          break;
+        case 2:
+          value = sequenceNumber;
+          break;
+        case 3:
+          value = fileSequenceNumber;
+          break;
+        case 4:
+          value = dvSnapshotId;
+          break;
+        case 5:
+          value = firstRowId;
+          break;
+        case 6:
+          value = deletedPositions;
+          break;
+        case 7:
+          value = replacedPositions;
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      }
+
+      return (T) value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> void set(int pos, T value) {
+      switch (pos) {
+        case 0:
+          this.status = (Integer) value;
+          break;
+        case 1:
+          this.snapshotId = (Long) value;
+          break;
+        case 2:
+          this.sequenceNumber = (Long) value;
+          break;
+        case 3:
+          this.fileSequenceNumber = (Long) value;
+          break;
+        case 4:
+          this.dvSnapshotId = (Long) value;
+          break;
+        case 5:
+          this.firstRowId = (Long) value;
+          break;
+        case 6:
+          this.deletedPositions = (ByteBuffer) value;
+          break;
+        case 7:
+          this.replacedPositions = (ByteBuffer) value;
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      }
+    }
+  }
+
+  /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
+  static class DeletionVectorStruct implements DeletionVector, StructLike {
+    private String location;
+    private long offset;
+    private long sizeInBytes;
+    private long cardinality;
+
+    DeletionVectorStruct(Types.StructType type) {}
+
+    private DeletionVectorStruct(DeletionVectorStruct toCopy) {
+      this.location = toCopy.location;
+      this.offset = toCopy.offset;
+      this.sizeInBytes = toCopy.sizeInBytes;
+      this.cardinality = toCopy.cardinality;
+    }
+
+    DeletionVectorStruct copy() {
+      return new DeletionVectorStruct(this);
+    }
+
+    @Override
+    public String location() {
+      return location;
+    }
+
+    @Override
+    public long offset() {
+      return offset;
+    }
+
+    @Override
+    public long sizeInBytes() {
+      return sizeInBytes;
+    }
+
+    @Override
+    public long cardinality() {
+      return cardinality;
+    }
+
+    @Override
+    public int size() {
+      return 4;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(int pos, Class<T> javaClass) {
+      Object value;
+      switch (pos) {
+        case 0:
+          value = location;
+          break;
+        case 1:
+          value = offset;
+          break;
+        case 2:
+          value = sizeInBytes;
+          break;
+        case 3:
+          value = cardinality;
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      }
+
+      return (T) value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> void set(int pos, T value) {
+      switch (pos) {
+        case 0:
+          this.location = (String) value;
+          break;
+        case 1:
+          this.offset = (Long) value;
+          break;
+        case 2:
+          this.sizeInBytes = (Long) value;
+          break;
+        case 3:
+          this.cardinality = (Long) value;
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      }
+    }
+  }
+
+  /** Mutable {@link StructLike} implementation of {@link ManifestInfo}. */
+  static class ManifestInfoStruct implements ManifestInfo, StructLike {
+    private int addedFilesCount;
+    private int existingFilesCount;
+    private int deletedFilesCount;
+    private int replacedFilesCount;
+    private long addedRowsCount;
+    private long existingRowsCount;
+    private long deletedRowsCount;
+    private long replacedRowsCount;
+    private long minSequenceNumber;
+    private ByteBuffer dv;
+    private Long dvCardinality;
+
+    ManifestInfoStruct(Types.StructType type) {}
+
+    private ManifestInfoStruct(ManifestInfoStruct toCopy) {
+      this.addedFilesCount = toCopy.addedFilesCount;
+      this.existingFilesCount = toCopy.existingFilesCount;
+      this.deletedFilesCount = toCopy.deletedFilesCount;
+      this.replacedFilesCount = toCopy.replacedFilesCount;
+      this.addedRowsCount = toCopy.addedRowsCount;
+      this.existingRowsCount = toCopy.existingRowsCount;
+      this.deletedRowsCount = toCopy.deletedRowsCount;
+      this.replacedRowsCount = toCopy.replacedRowsCount;
+      this.minSequenceNumber = toCopy.minSequenceNumber;
+      this.dv = toCopy.dv != null ? ByteBuffers.copy(toCopy.dv) : null;
+      this.dvCardinality = toCopy.dvCardinality;
+    }
+
+    ManifestInfoStruct copy() {
+      return new ManifestInfoStruct(this);
+    }
+
+    @Override
+    public int addedFilesCount() {
+      return addedFilesCount;
+    }
+
+    @Override
+    public int existingFilesCount() {
+      return existingFilesCount;
+    }
+
+    @Override
+    public int deletedFilesCount() {
+      return deletedFilesCount;
+    }
+
+    @Override
+    public int replacedFilesCount() {
+      return replacedFilesCount;
+    }
+
+    @Override
+    public long addedRowsCount() {
+      return addedRowsCount;
+    }
+
+    @Override
+    public long existingRowsCount() {
+      return existingRowsCount;
+    }
+
+    @Override
+    public long deletedRowsCount() {
+      return deletedRowsCount;
+    }
+
+    @Override
+    public long replacedRowsCount() {
+      return replacedRowsCount;
+    }
+
+    @Override
+    public long minSequenceNumber() {
+      return minSequenceNumber;
+    }
+
+    @Override
+    public ByteBuffer dv() {
+      return dv;
+    }
+
+    @Override
+    public Long dvCardinality() {
+      return dvCardinality;
+    }
+
+    @Override
+    public int size() {
+      return 11;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(int pos, Class<T> javaClass) {
+      Object value;
+      switch (pos) {
+        case 0:
+          value = addedFilesCount;
+          break;
+        case 1:
+          value = existingFilesCount;
+          break;
+        case 2:
+          value = deletedFilesCount;
+          break;
+        case 3:
+          value = replacedFilesCount;
+          break;
+        case 4:
+          value = addedRowsCount;
+          break;
+        case 5:
+          value = existingRowsCount;
+          break;
+        case 6:
+          value = deletedRowsCount;
+          break;
+        case 7:
+          value = replacedRowsCount;
+          break;
+        case 8:
+          value = minSequenceNumber;
+          break;
+        case 9:
+          value = dv;
+          break;
+        case 10:
+          value = dvCardinality;
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      }
+
+      return (T) value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> void set(int pos, T value) {
+      switch (pos) {
+        case 0:
+          this.addedFilesCount = (Integer) value;
+          break;
+        case 1:
+          this.existingFilesCount = (Integer) value;
+          break;
+        case 2:
+          this.deletedFilesCount = (Integer) value;
+          break;
+        case 3:
+          this.replacedFilesCount = (Integer) value;
+          break;
+        case 4:
+          this.addedRowsCount = (Long) value;
+          break;
+        case 5:
+          this.existingRowsCount = (Long) value;
+          break;
+        case 6:
+          this.deletedRowsCount = (Long) value;
+          break;
+        case 7:
+          this.replacedRowsCount = (Long) value;
+          break;
+        case 8:
+          this.minSequenceNumber = (Long) value;
+          break;
+        case 9:
+          this.dv = (ByteBuffer) value;
+          break;
+        case 10:
+          this.dvCardinality = (Long) value;
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -174,11 +174,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
 
   @Override
   public Integer specId() {
-    if (specId != null) {
-      return specId;
-    }
-
-    return manifestContext != null ? manifestContext.specId() : null;
+    return specId;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +32,7 @@ import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
-class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
+class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, Serializable {
   private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -22,8 +22,10 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import org.apache.iceberg.avro.SupportsIndexProjection;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.stats.BaseContentStats;
 import org.apache.iceberg.stats.ContentStats;
@@ -311,5 +313,25 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("content", contentType.toString().toLowerCase(Locale.ROOT))
+        .add("location", location)
+        .add("file_format", fileFormat)
+        .add("record_count", recordCount)
+        .add("file_size_in_bytes", fileSizeInBytes)
+        .add("spec_id", specId())
+        .add("tracking", tracking)
+        .add("content_stats", contentStats)
+        .add("sort_order_id", sortOrderId)
+        .add("deletion_vector", deletionVector)
+        .add("manifest_info", manifestInfo)
+        .add("key_metadata", keyMetadata == null ? "null" : "(redacted)")
+        .add("split_offsets", splitOffsets == null ? "null" : splitOffsets())
+        .add("equality_ids", equalityIds == null ? "null" : equalityIds())
+        .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -59,7 +59,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
 
   // not serialized to manifest, set by manifest readers
   private transient TrackedFile manifestContext = null;
-  private String manifestLocation = null;
   private long manifestPos = 0L;
 
   /** Used by internal readers to instantiate this class with a projection schema. */
@@ -108,7 +107,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
             : null;
 
     this.manifestContext = toCopy.manifestContext;
-    this.manifestLocation = toCopy.manifestLocation;
     this.manifestPos = toCopy.manifestPos;
   }
 
@@ -144,7 +142,11 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
 
   @Override
   public Integer specId() {
-    return specId;
+    if (specId != null) {
+      return specId;
+    }
+
+    return manifestContext != null ? manifestContext.specId() : null;
   }
 
   @Override
@@ -194,7 +196,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
 
   @Override
   public String manifestLocation() {
-    return manifestLocation;
+    return manifestContext != null ? manifestContext.location() : null;
   }
 
   @Override
@@ -204,7 +206,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
 
   void setManifestContext(TrackedFile manifest) {
     this.manifestContext = manifest;
-    this.manifestLocation = manifest != null ? manifest.location() : null;
   }
 
   @Override
@@ -255,6 +256,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
     switch (pos) {
       case 0:
         this.tracking = (TrackingStruct) value;
+        this.tracking.setManifestContext(this.manifestContext);
         break;
       case 1:
         this.contentType = FILE_CONTENT_VALUES[(Integer) value];

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -84,6 +84,9 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.fileSizeInBytes = toCopy.fileSizeInBytes;
     this.specId = toCopy.specId;
 
+    this.manifestContext = toCopy.manifestContext;
+    this.manifestPos = toCopy.manifestPos;
+
     this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
     if (this.tracking != null && this.manifestContext != null) {
       this.tracking.setManifestContext(this.manifestContext);
@@ -112,9 +115,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         toCopy.equalityIds != null
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
             : null;
-
-    this.manifestContext = toCopy.manifestContext;
-    this.manifestPos = toCopy.manifestPos;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -81,6 +81,23 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     super(BASE_TYPE.fields().size());
   }
 
+  /** Constructor that accepts required fields. */
+  TrackedFileStruct(
+      Tracking tracking,
+      FileContent contentType,
+      String location,
+      FileFormat fileFormat,
+      long recordCount,
+      long fileSizeInBytes) {
+    super(BASE_TYPE.fields().size());
+    this.tracking = tracking;
+    this.contentType = contentType;
+    this.location = location;
+    this.fileFormat = fileFormat;
+    this.recordCount = recordCount;
+    this.fileSizeInBytes = fileSizeInBytes;
+  }
+
   /** Copy constructor. */
   private TrackedFileStruct(TrackedFileStruct toCopy, boolean withStats, Set<Integer> statsIds) {
     super(toCopy);

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -18,11 +18,11 @@
  */
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.stats.BaseContentStats;
 import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Types;
@@ -30,38 +30,42 @@ import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
-class TrackedFileStruct implements TrackedFile, StructLike {
+class TrackedFileStruct implements TrackedFile, StructLike, Serializable {
   private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
-  private static final EntryStatus[] STATUS_VALUES = EntryStatus.values();
 
-  private TrackingStruct tracking;
   private FileContent contentType = FileContent.DATA;
-  private String location;
-  private FileFormat fileFormat;
-  private long recordCount;
-  private long fileSizeInBytes;
-  private Integer specId;
-  private ContentStats contentStats;
-  private Integer sortOrderId;
-  private DeletionVectorStruct deletionVector;
-  private ManifestInfoStruct manifestInfo;
-  private ByteBuffer keyMetadata;
-  private long[] splitOffsets;
-  private int[] equalityIds;
-  private String manifestLocation;
-  private long manifestPos;
+  private String location = null;
+  private FileFormat fileFormat = null;
+  private long recordCount = 0L;
+  private long fileSizeInBytes = 0L;
+  private Integer specId = null;
+
+  // optional fields
+  private TrackingStruct tracking = null;
+  private ContentStats contentStats = null;
+  private Integer sortOrderId = null;
+  private DeletionVectorStruct deletionVector = null;
+  private ManifestInfoStruct manifestInfo = null;
+  private byte[] keyMetadata = null;
+  private long[] splitOffsets = null;
+  private int[] equalityIds = null;
+
+  // not serialized to manifest
+  private String manifestLocation = null;
+  private long manifestPos = 0L;
 
   TrackedFileStruct(Types.StructType type) {}
 
   /** Copy constructor. */
   private TrackedFileStruct(TrackedFileStruct toCopy, boolean withStats, Set<Integer> statsIds) {
-    this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
     this.contentType = toCopy.contentType;
     this.location = toCopy.location;
     this.fileFormat = toCopy.fileFormat;
     this.recordCount = toCopy.recordCount;
     this.fileSizeInBytes = toCopy.fileSizeInBytes;
     this.specId = toCopy.specId;
+
+    this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
     this.sortOrderId = toCopy.sortOrderId;
     this.deletionVector = toCopy.deletionVector != null ? toCopy.deletionVector.copy() : null;
 
@@ -73,7 +77,10 @@ class TrackedFileStruct implements TrackedFile, StructLike {
     }
 
     this.manifestInfo = toCopy.manifestInfo != null ? toCopy.manifestInfo.copy() : null;
-    this.keyMetadata = toCopy.keyMetadata != null ? ByteBuffers.copy(toCopy.keyMetadata) : null;
+    this.keyMetadata =
+        toCopy.keyMetadata != null
+            ? Arrays.copyOf(toCopy.keyMetadata, toCopy.keyMetadata.length)
+            : null;
     this.splitOffsets =
         toCopy.splitOffsets != null
             ? Arrays.copyOf(toCopy.splitOffsets, toCopy.splitOffsets.length)
@@ -82,16 +89,13 @@ class TrackedFileStruct implements TrackedFile, StructLike {
         toCopy.equalityIds != null
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
             : null;
+
     this.manifestLocation = toCopy.manifestLocation;
     this.manifestPos = toCopy.manifestPos;
   }
 
   @Override
   public Tracking tracking() {
-    return tracking;
-  }
-
-  TrackingStruct trackingStruct() {
     return tracking;
   }
 
@@ -127,7 +131,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
 
   @Override
   public ContentStats contentStats() {
-    return (ContentStats) contentStats;
+    return contentStats;
   }
 
   @Override
@@ -147,7 +151,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
 
   @Override
   public ByteBuffer keyMetadata() {
-    return keyMetadata;
+    return keyMetadata != null ? ByteBuffer.wrap(keyMetadata) : null;
   }
 
   @Override
@@ -196,57 +200,43 @@ class TrackedFileStruct implements TrackedFile, StructLike {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public <T> T get(int pos, Class<T> javaClass) {
-    Object value;
+    return javaClass.cast(getByPos(pos));
+  }
+
+  private Object getByPos(int pos) {
     switch (pos) {
       case 0:
-        value = tracking;
-        break;
+        return tracking;
       case 1:
-        value = contentType.id();
-        break;
+        return contentType.id();
       case 2:
-        value = location;
-        break;
+        return location;
       case 3:
-        value = fileFormat != null ? fileFormat.toString() : null;
-        break;
+        return fileFormat != null ? fileFormat.toString() : null;
       case 4:
-        value = recordCount;
-        break;
+        return recordCount;
       case 5:
-        value = fileSizeInBytes;
-        break;
+        return fileSizeInBytes;
       case 6:
-        value = specId;
-        break;
+        return specId;
       case 7:
-        value = contentStats;
-        break;
+        return contentStats;
       case 8:
-        value = sortOrderId;
-        break;
+        return sortOrderId;
       case 9:
-        value = deletionVector;
-        break;
+        return deletionVector;
       case 10:
-        value = manifestInfo;
-        break;
+        return manifestInfo;
       case 11:
-        value = keyMetadata;
-        break;
+        return keyMetadata();
       case 12:
-        value = splitOffsets();
-        break;
+        return splitOffsets();
       case 13:
-        value = equalityIds();
-        break;
+        return equalityIds();
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
-
-    return (T) value;
   }
 
   @Override
@@ -275,11 +265,6 @@ class TrackedFileStruct implements TrackedFile, StructLike {
         this.specId = (Integer) value;
         break;
       case 7:
-        Preconditions.checkArgument(
-            value == null || value instanceof ContentStats,
-            "Expected ContentStats but found: %s",
-            value == null ? "null" : value.getClass().getName());
-
         this.contentStats = (ContentStats) value;
         break;
       case 8:
@@ -292,7 +277,7 @@ class TrackedFileStruct implements TrackedFile, StructLike {
         this.manifestInfo = (ManifestInfoStruct) value;
         break;
       case 11:
-        this.keyMetadata = (ByteBuffer) value;
+        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
         break;
       case 12:
         this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
@@ -302,436 +287,6 @@ class TrackedFileStruct implements TrackedFile, StructLike {
         break;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-    }
-  }
-
-  /** Mutable {@link StructLike} implementation of {@link Tracking}. */
-  static class TrackingStruct implements Tracking, StructLike {
-    private EntryStatus status = EntryStatus.EXISTING;
-    private Long snapshotId;
-    private Long sequenceNumber;
-    private Long fileSequenceNumber;
-    private Long dvSnapshotId;
-    private Long firstRowId;
-    private ByteBuffer deletedPositions;
-    private ByteBuffer replacedPositions;
-
-    TrackingStruct(Types.StructType type) {}
-
-    private TrackingStruct(TrackingStruct toCopy) {
-      this.status = toCopy.status;
-      this.snapshotId = toCopy.snapshotId;
-      this.sequenceNumber = toCopy.sequenceNumber;
-      this.fileSequenceNumber = toCopy.fileSequenceNumber;
-      this.dvSnapshotId = toCopy.dvSnapshotId;
-      this.firstRowId = toCopy.firstRowId;
-      this.deletedPositions =
-          toCopy.deletedPositions != null ? ByteBuffers.copy(toCopy.deletedPositions) : null;
-      this.replacedPositions =
-          toCopy.replacedPositions != null ? ByteBuffers.copy(toCopy.replacedPositions) : null;
-    }
-
-    TrackingStruct copy() {
-      return new TrackingStruct(this);
-    }
-
-    @Override
-    public EntryStatus status() {
-      return status;
-    }
-
-    @Override
-    public Long snapshotId() {
-      return snapshotId;
-    }
-
-    @Override
-    public Long dataSequenceNumber() {
-      return sequenceNumber;
-    }
-
-    @Override
-    public Long fileSequenceNumber() {
-      return fileSequenceNumber;
-    }
-
-    @Override
-    public Long dvSnapshotId() {
-      return dvSnapshotId;
-    }
-
-    @Override
-    public Long firstRowId() {
-      return firstRowId;
-    }
-
-    @Override
-    public ByteBuffer deletedPositions() {
-      return deletedPositions;
-    }
-
-    @Override
-    public ByteBuffer replacedPositions() {
-      return replacedPositions;
-    }
-
-    void setSnapshotId(Long newSnapshotId) {
-      this.snapshotId = newSnapshotId;
-    }
-
-    void setSequenceNumber(Long newSequenceNumber) {
-      this.sequenceNumber = newSequenceNumber;
-    }
-
-    void setFirstRowId(Long newFirstRowId) {
-      this.firstRowId = newFirstRowId;
-    }
-
-    @Override
-    public int size() {
-      return 8;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> T get(int pos, Class<T> javaClass) {
-      Object value;
-      switch (pos) {
-        case 0:
-          value = status.id();
-          break;
-        case 1:
-          value = snapshotId;
-          break;
-        case 2:
-          value = sequenceNumber;
-          break;
-        case 3:
-          value = fileSequenceNumber;
-          break;
-        case 4:
-          value = dvSnapshotId;
-          break;
-        case 5:
-          value = firstRowId;
-          break;
-        case 6:
-          value = deletedPositions;
-          break;
-        case 7:
-          value = replacedPositions;
-          break;
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
-
-      return (T) value;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> void set(int pos, T value) {
-      switch (pos) {
-        case 0:
-          this.status = STATUS_VALUES[(Integer) value];
-          break;
-        case 1:
-          this.snapshotId = (Long) value;
-          break;
-        case 2:
-          this.sequenceNumber = (Long) value;
-          break;
-        case 3:
-          this.fileSequenceNumber = (Long) value;
-          break;
-        case 4:
-          this.dvSnapshotId = (Long) value;
-          break;
-        case 5:
-          this.firstRowId = (Long) value;
-          break;
-        case 6:
-          this.deletedPositions = (ByteBuffer) value;
-          break;
-        case 7:
-          this.replacedPositions = (ByteBuffer) value;
-          break;
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
-    }
-  }
-
-  /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
-  static class DeletionVectorStruct implements DeletionVector, StructLike {
-    private String location;
-    private long offset;
-    private long sizeInBytes;
-    private long cardinality;
-
-    DeletionVectorStruct(Types.StructType type) {}
-
-    private DeletionVectorStruct(DeletionVectorStruct toCopy) {
-      this.location = toCopy.location;
-      this.offset = toCopy.offset;
-      this.sizeInBytes = toCopy.sizeInBytes;
-      this.cardinality = toCopy.cardinality;
-    }
-
-    DeletionVectorStruct copy() {
-      return new DeletionVectorStruct(this);
-    }
-
-    @Override
-    public String location() {
-      return location;
-    }
-
-    @Override
-    public long offset() {
-      return offset;
-    }
-
-    @Override
-    public long sizeInBytes() {
-      return sizeInBytes;
-    }
-
-    @Override
-    public long cardinality() {
-      return cardinality;
-    }
-
-    @Override
-    public int size() {
-      return 4;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> T get(int pos, Class<T> javaClass) {
-      Object value;
-      switch (pos) {
-        case 0:
-          value = location;
-          break;
-        case 1:
-          value = offset;
-          break;
-        case 2:
-          value = sizeInBytes;
-          break;
-        case 3:
-          value = cardinality;
-          break;
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
-
-      return (T) value;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> void set(int pos, T value) {
-      switch (pos) {
-        case 0:
-          this.location = (String) value;
-          break;
-        case 1:
-          this.offset = (Long) value;
-          break;
-        case 2:
-          this.sizeInBytes = (Long) value;
-          break;
-        case 3:
-          this.cardinality = (Long) value;
-          break;
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
-    }
-  }
-
-  /** Mutable {@link StructLike} implementation of {@link ManifestInfo}. */
-  static class ManifestInfoStruct implements ManifestInfo, StructLike {
-    private int addedFilesCount;
-    private int existingFilesCount;
-    private int deletedFilesCount;
-    private int replacedFilesCount;
-    private long addedRowsCount;
-    private long existingRowsCount;
-    private long deletedRowsCount;
-    private long replacedRowsCount;
-    private long minSequenceNumber;
-    private ByteBuffer dv;
-    private Long dvCardinality;
-
-    ManifestInfoStruct(Types.StructType type) {}
-
-    private ManifestInfoStruct(ManifestInfoStruct toCopy) {
-      this.addedFilesCount = toCopy.addedFilesCount;
-      this.existingFilesCount = toCopy.existingFilesCount;
-      this.deletedFilesCount = toCopy.deletedFilesCount;
-      this.replacedFilesCount = toCopy.replacedFilesCount;
-      this.addedRowsCount = toCopy.addedRowsCount;
-      this.existingRowsCount = toCopy.existingRowsCount;
-      this.deletedRowsCount = toCopy.deletedRowsCount;
-      this.replacedRowsCount = toCopy.replacedRowsCount;
-      this.minSequenceNumber = toCopy.minSequenceNumber;
-      this.dv = toCopy.dv != null ? ByteBuffers.copy(toCopy.dv) : null;
-      this.dvCardinality = toCopy.dvCardinality;
-    }
-
-    ManifestInfoStruct copy() {
-      return new ManifestInfoStruct(this);
-    }
-
-    @Override
-    public int addedFilesCount() {
-      return addedFilesCount;
-    }
-
-    @Override
-    public int existingFilesCount() {
-      return existingFilesCount;
-    }
-
-    @Override
-    public int deletedFilesCount() {
-      return deletedFilesCount;
-    }
-
-    @Override
-    public int replacedFilesCount() {
-      return replacedFilesCount;
-    }
-
-    @Override
-    public long addedRowsCount() {
-      return addedRowsCount;
-    }
-
-    @Override
-    public long existingRowsCount() {
-      return existingRowsCount;
-    }
-
-    @Override
-    public long deletedRowsCount() {
-      return deletedRowsCount;
-    }
-
-    @Override
-    public long replacedRowsCount() {
-      return replacedRowsCount;
-    }
-
-    @Override
-    public long minSequenceNumber() {
-      return minSequenceNumber;
-    }
-
-    @Override
-    public ByteBuffer dv() {
-      return dv;
-    }
-
-    @Override
-    public Long dvCardinality() {
-      return dvCardinality;
-    }
-
-    @Override
-    public int size() {
-      return 11;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> T get(int pos, Class<T> javaClass) {
-      Object value;
-      switch (pos) {
-        case 0:
-          value = addedFilesCount;
-          break;
-        case 1:
-          value = existingFilesCount;
-          break;
-        case 2:
-          value = deletedFilesCount;
-          break;
-        case 3:
-          value = replacedFilesCount;
-          break;
-        case 4:
-          value = addedRowsCount;
-          break;
-        case 5:
-          value = existingRowsCount;
-          break;
-        case 6:
-          value = deletedRowsCount;
-          break;
-        case 7:
-          value = replacedRowsCount;
-          break;
-        case 8:
-          value = minSequenceNumber;
-          break;
-        case 9:
-          value = dv;
-          break;
-        case 10:
-          value = dvCardinality;
-          break;
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
-
-      return (T) value;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> void set(int pos, T value) {
-      switch (pos) {
-        case 0:
-          this.addedFilesCount = (Integer) value;
-          break;
-        case 1:
-          this.existingFilesCount = (Integer) value;
-          break;
-        case 2:
-          this.deletedFilesCount = (Integer) value;
-          break;
-        case 3:
-          this.replacedFilesCount = (Integer) value;
-          break;
-        case 4:
-          this.addedRowsCount = (Long) value;
-          break;
-        case 5:
-          this.existingRowsCount = (Long) value;
-          break;
-        case 6:
-          this.deletedRowsCount = (Long) value;
-          break;
-        case 7:
-          this.replacedRowsCount = (Long) value;
-          break;
-        case 8:
-          this.minSequenceNumber = (Long) value;
-          break;
-        case 9:
-          this.dv = (ByteBuffer) value;
-          break;
-        case 10:
-          this.dvCardinality = (Long) value;
-          break;
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -27,15 +27,12 @@ import java.util.Set;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.stats.BaseContentStats;
-import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
 class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, Serializable {
-  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
           ImmutableList.<Types.NestedField>builder()
@@ -43,19 +40,19 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
               .add(MetadataColumns.ROW_POSITION)
               .build());
 
-  private FileContent contentType = FileContent.DATA;
+  private FileContent contentType = null;
   private String location = null;
   private FileFormat fileFormat = null;
-  private long recordCount = 0L;
-  private long fileSizeInBytes = 0L;
+  private long recordCount = -1L;
+  private long fileSizeInBytes = -1L;
   private Integer specId = null;
 
   // optional fields
-  private TrackingStruct tracking = null;
+  private Tracking tracking = null;
   private ContentStats contentStats = null;
   private Integer sortOrderId = null;
-  private DeletionVectorStruct deletionVector = null;
-  private ManifestInfoStruct manifestInfo = null;
+  private DeletionVector deletionVector = null;
+  private ManifestInfo manifestInfo = null;
   private byte[] keyMetadata = null;
   private long[] splitOffsets = null;
   private int[] equalityIds = null;
@@ -87,13 +84,16 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.manifestContext = toCopy.manifestContext;
     this.manifestPos = toCopy.manifestPos;
 
-    this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
-    if (this.tracking != null && this.manifestContext != null) {
-      this.tracking.setManifestContext(this.manifestContext);
+    this.tracking = toCopy.tracking != null ? ((TrackingStruct) toCopy.tracking).copy() : null;
+    if (tracking != null && manifestContext != null) {
+      ((TrackingStruct) tracking).setManifestContext(manifestContext);
     }
 
     this.sortOrderId = toCopy.sortOrderId;
-    this.deletionVector = toCopy.deletionVector != null ? toCopy.deletionVector.copy() : null;
+    this.deletionVector =
+        toCopy.deletionVector != null
+            ? ((DeletionVectorStruct) toCopy.deletionVector).copy()
+            : null;
 
     if (withStats && toCopy.contentStats != null) {
       ContentStats filtered = BaseContentStats.buildFrom(toCopy.contentStats, statsIds).build();
@@ -102,7 +102,8 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       this.contentStats = null;
     }
 
-    this.manifestInfo = toCopy.manifestInfo != null ? toCopy.manifestInfo.copy() : null;
+    this.manifestInfo =
+        toCopy.manifestInfo != null ? ((ManifestInfoStruct) toCopy.manifestInfo).copy() : null;
     this.keyMetadata =
         toCopy.keyMetadata != null
             ? Arrays.copyOf(toCopy.keyMetadata, toCopy.keyMetadata.length)
@@ -203,6 +204,10 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
 
   @Override
   public String manifestLocation() {
+    if (tracking == null) {
+      return null;
+    }
+
     return manifestContext != null ? manifestContext.location() : null;
   }
 
@@ -213,8 +218,8 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
 
   void setManifestContext(TrackedFile manifest) {
     this.manifestContext = manifest;
-    if (this.tracking != null) {
-      this.tracking.setManifestContext(manifest);
+    if (tracking != null) {
+      ((TrackingStruct) tracking).setManifestContext(manifest);
     }
   }
 
@@ -264,11 +269,11 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
-        this.tracking = (TrackingStruct) value;
-        this.tracking.setManifestContext(this.manifestContext);
+        this.tracking = (Tracking) value;
+        ((TrackingStruct) tracking).setManifestContext(manifestContext);
         break;
       case 1:
-        this.contentType = FILE_CONTENT_VALUES[(Integer) value];
+        this.contentType = FileContent.fromId((Integer) value);
         break;
       case 2:
         // always coerce to String for Serializable
@@ -293,10 +298,10 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         this.sortOrderId = (Integer) value;
         break;
       case 9:
-        this.deletionVector = (DeletionVectorStruct) value;
+        this.deletionVector = (DeletionVector) value;
         break;
       case 10:
-        this.manifestInfo = (ManifestInfoStruct) value;
+        this.manifestInfo = (ManifestInfo) value;
         break;
       case 11:
         this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.avro.SupportsIndexProjection;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.stats.BaseContentStats;
 import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Types;
@@ -33,7 +34,11 @@ import org.apache.iceberg.util.ByteBuffers;
 class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
   private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
   private static final Types.StructType BASE_TYPE =
-      TrackedFile.schemaWithContentStats(Types.StructType.of());
+      Types.StructType.of(
+          ImmutableList.<Types.NestedField>builder()
+              .addAll(TrackedFile.schemaWithContentStats(Types.StructType.of()).fields())
+              .add(MetadataColumns.ROW_POSITION)
+              .build());
 
   private FileContent contentType = FileContent.DATA;
   private String location = null;
@@ -199,10 +204,6 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
     this.manifestLocation = newManifestLocation;
   }
 
-  void setManifestPos(long newManifestPos) {
-    this.manifestPos = newManifestPos;
-  }
-
   @Override
   protected <T> T internalGet(int pos, Class<T> javaClass) {
     return javaClass.cast(getByPos(pos));
@@ -238,6 +239,8 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
         return splitOffsets();
       case 13:
         return equalityIds();
+      case 14:
+        return manifestPos;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
@@ -288,6 +291,9 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
         break;
       case 13:
         this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
+        break;
+      case 14:
+        this.manifestPos = (long) value;
         break;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -18,11 +18,11 @@
  */
 package org.apache.iceberg;
 
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.stats.BaseContentStats;
 import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Types;
@@ -30,8 +30,10 @@ import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
-class TrackedFileStruct implements TrackedFile, StructLike, Serializable {
+class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile {
   private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
+  private static final Types.StructType BASE_TYPE =
+      TrackedFile.schemaWithContentStats(Types.StructType.of());
 
   private FileContent contentType = FileContent.DATA;
   private String location = null;
@@ -54,10 +56,19 @@ class TrackedFileStruct implements TrackedFile, StructLike, Serializable {
   private String manifestLocation = null;
   private long manifestPos = 0L;
 
-  TrackedFileStruct(Types.StructType type) {}
+  /** Used by internal readers to instantiate this class with a projection schema. */
+  TrackedFileStruct(Types.StructType projection) {
+    super(BASE_TYPE, projection);
+  }
+
+  /** No-projection constructor for direct construction. */
+  TrackedFileStruct() {
+    super(BASE_TYPE.fields().size());
+  }
 
   /** Copy constructor. */
   private TrackedFileStruct(TrackedFileStruct toCopy, boolean withStats, Set<Integer> statsIds) {
+    super(toCopy);
     this.contentType = toCopy.contentType;
     this.location = toCopy.location;
     this.fileFormat = toCopy.fileFormat;
@@ -192,15 +203,8 @@ class TrackedFileStruct implements TrackedFile, StructLike, Serializable {
     this.manifestPos = newManifestPos;
   }
 
-  // StructLike implementation - field ordinals match TrackedFile.schemaWithContentStats() order
-
   @Override
-  public int size() {
-    return 14;
-  }
-
-  @Override
-  public <T> T get(int pos, Class<T> javaClass) {
+  protected <T> T internalGet(int pos, Class<T> javaClass) {
     return javaClass.cast(getByPos(pos));
   }
 
@@ -241,7 +245,7 @@ class TrackedFileStruct implements TrackedFile, StructLike, Serializable {
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T> void set(int pos, T value) {
+  protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
         this.tracking = (TrackingStruct) value;

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -106,4 +106,13 @@ interface Tracking {
 
   /** Returns the bitmap of positions replaced in this snapshot. */
   ByteBuffer replacedPositions();
+
+  /** Returns the manifest location this entry was read from, or null. */
+  String manifestLocation();
+
+  /** Returns the ordinal position of this entry within the manifest. */
+  long manifestPos();
+
+  /** Copies this tracking information. */
+  Tracking copy();
 }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -49,12 +49,16 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   private byte[] deletedPositions = null;
   private byte[] replacedPositions = null;
 
-  // not serialized, set by manifest readers
+  // set by manifest readers, not written to manifests
   private String manifestLocation = null;
   private long manifestPos = -1L;
 
   TrackingStruct(Types.StructType type) {
     super(BASE_TYPE, type);
+  }
+
+  TrackingStruct() {
+    super(BASE_TYPE.fields().size());
   }
 
   private TrackingStruct(TrackingStruct toCopy) {
@@ -89,7 +93,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
         }
 
         if (fileSequenceNumber == null) {
-          this.fileSequenceNumber = manifestTracking.dataSequenceNumber();
+          this.fileSequenceNumber = manifestTracking.fileSequenceNumber();
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -100,18 +100,6 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
     return replacedPositions != null ? ByteBuffer.wrap(replacedPositions) : null;
   }
 
-  void setSnapshotId(long newSnapshotId) {
-    this.snapshotId = newSnapshotId;
-  }
-
-  void setSequenceNumber(long newSequenceNumber) {
-    this.sequenceNumber = newSequenceNumber;
-  }
-
-  void setFirstRowId(long newFirstRowId) {
-    this.firstRowId = newFirstRowId;
-  }
-
   @Override
   public int size() {
     return 8;

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -36,19 +36,21 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
           Tracking.DV_SNAPSHOT_ID,
           Tracking.FIRST_ROW_ID,
           Tracking.DELETED_POSITIONS,
-          Tracking.REPLACED_POSITIONS);
+          Tracking.REPLACED_POSITIONS,
+          MetadataColumns.ROW_POSITION);
 
   private EntryStatus status = null;
   private Long snapshotId = null;
-  private Long sequenceNumber = null;
+  private Long dataSequenceNumber = null;
   private Long fileSequenceNumber = null;
   private Long dvSnapshotId = null;
   private Long firstRowId = null;
   private byte[] deletedPositions = null;
   private byte[] replacedPositions = null;
 
-  // not serialized, set by manifest readers for metadata inheritance
-  private transient TrackedFile manifestContext = null;
+  // not serialized, set by manifest readers
+  private String manifestLocation = null;
+  private long manifestPos = 0L;
 
   TrackingStruct(Types.StructType type) {
     super(BASE_TYPE, type);
@@ -58,7 +60,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
     super(toCopy);
     this.status = toCopy.status;
     this.snapshotId = toCopy.snapshotId;
-    this.sequenceNumber = toCopy.sequenceNumber;
+    this.dataSequenceNumber = toCopy.dataSequenceNumber;
     this.fileSequenceNumber = toCopy.fileSequenceNumber;
     this.dvSnapshotId = toCopy.dvSnapshotId;
     this.firstRowId = toCopy.firstRowId;
@@ -70,14 +72,39 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
         toCopy.replacedPositions != null
             ? Arrays.copyOf(toCopy.replacedPositions, toCopy.replacedPositions.length)
             : null;
+    this.manifestLocation = toCopy.manifestLocation;
+    this.manifestPos = toCopy.manifestPos;
   }
 
-  TrackingStruct copy() {
+  @Override
+  public TrackingStruct copy() {
     return new TrackingStruct(this);
   }
 
-  void setManifestContext(TrackedFile manifest) {
-    this.manifestContext = manifest;
+  void inheritFrom(Tracking manifestTracking) {
+    if (manifestTracking != null) {
+      if (snapshotId == null) {
+        this.snapshotId = manifestTracking.snapshotId();
+      }
+
+      if (status == EntryStatus.ADDED) {
+        if (dataSequenceNumber == null) {
+          this.dataSequenceNumber = manifestTracking.dataSequenceNumber();
+        }
+
+        if (fileSequenceNumber == null) {
+          this.fileSequenceNumber = manifestTracking.dataSequenceNumber();
+        }
+      }
+    }
+  }
+
+  void setManifestLocation(String location) {
+    this.manifestLocation = location;
+  }
+
+  void setManifestPos(long pos) {
+    this.manifestPos = pos;
   }
 
   @Override
@@ -87,37 +114,17 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
 
   @Override
   public Long snapshotId() {
-    if (snapshotId != null) {
-      return snapshotId;
-    }
-
-    return manifestContext != null ? manifestContext.tracking().snapshotId() : null;
+    return snapshotId;
   }
 
   @Override
   public Long dataSequenceNumber() {
-    if (sequenceNumber != null) {
-      return sequenceNumber;
-    }
-
-    if (manifestContext != null && status == EntryStatus.ADDED) {
-      return manifestContext.tracking().dataSequenceNumber();
-    }
-
-    return null;
+    return dataSequenceNumber;
   }
 
   @Override
   public Long fileSequenceNumber() {
-    if (fileSequenceNumber != null) {
-      return fileSequenceNumber;
-    }
-
-    if (manifestContext != null && status == EntryStatus.ADDED) {
-      return manifestContext.tracking().dataSequenceNumber();
-    }
-
-    return null;
+    return fileSequenceNumber;
   }
 
   @Override
@@ -138,6 +145,16 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
   @Override
   public ByteBuffer replacedPositions() {
     return replacedPositions != null ? ByteBuffer.wrap(replacedPositions) : null;
+  }
+
+  @Override
+  public String manifestLocation() {
+    return manifestLocation;
+  }
+
+  @Override
+  public long manifestPos() {
+    return manifestPos;
   }
 
   @Override
@@ -163,6 +180,8 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
         return deletedPositions();
       case 7:
         return replacedPositions();
+      case 8:
+        return manifestPos;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
@@ -178,7 +197,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
         this.snapshotId = (Long) value;
         break;
       case 2:
-        this.sequenceNumber = (Long) value;
+        this.dataSequenceNumber = (Long) value;
         break;
       case 3:
         this.fileSequenceNumber = (Long) value;
@@ -195,6 +214,9 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
       case 7:
         this.replacedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
         break;
+      case 8:
+        this.manifestPos = (long) value;
+        break;
       default:
         // ignore the object, it must be from a newer version of the format
     }
@@ -205,7 +227,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
     return MoreObjects.toStringHelper(this)
         .add("status", status)
         .add("snapshot_id", snapshotId == null ? "null" : snapshotId)
-        .add("data_sequence_number", sequenceNumber == null ? "null" : sequenceNumber)
+        .add("data_sequence_number", dataSequenceNumber == null ? "null" : dataSequenceNumber)
         .add("file_sequence_number", fileSequenceNumber == null ? "null" : fileSequenceNumber)
         .add("dv_snapshot_id", dvSnapshotId == null ? "null" : dvSnapshotId)
         .add("first_row_id", firstRowId == null ? "null" : firstRowId)

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -87,9 +87,11 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
         this.snapshotId = manifestTracking.snapshotId();
       }
 
+      // both sequence numbers inherit from file sequence number because manifests
+      // do not distinguish between data and file sequence numbers
       if (status == EntryStatus.ADDED) {
         if (dataSequenceNumber == null) {
-          this.dataSequenceNumber = manifestTracking.dataSequenceNumber();
+          this.dataSequenceNumber = manifestTracking.fileSequenceNumber();
         }
 
         if (fileSequenceNumber == null) {

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -18,16 +18,16 @@
  */
 package org.apache.iceberg;
 
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link Tracking}. */
-class TrackingStruct implements Tracking, StructLike, Serializable {
-  private static final EntryStatus[] STATUS_VALUES = EntryStatus.values();
+class TrackingStruct extends SupportsIndexProjection implements Tracking {
+  private static final Types.StructType BASE_TYPE = Tracking.schema();
 
   private EntryStatus status = EntryStatus.EXISTING;
   private Long snapshotId = null;
@@ -41,9 +41,12 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
   // not serialized, set by manifest readers for metadata inheritance
   private transient TrackedFile manifestContext = null;
 
-  TrackingStruct(Types.StructType type) {}
+  TrackingStruct(Types.StructType type) {
+    super(BASE_TYPE, type);
+  }
 
   private TrackingStruct(TrackingStruct toCopy) {
+    super(toCopy);
     this.status = toCopy.status;
     this.snapshotId = toCopy.snapshotId;
     this.sequenceNumber = toCopy.sequenceNumber;
@@ -129,12 +132,7 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
   }
 
   @Override
-  public int size() {
-    return 8;
-  }
-
-  @Override
-  public <T> T get(int pos, Class<T> javaClass) {
+  protected <T> T internalGet(int pos, Class<T> javaClass) {
     return javaClass.cast(getByPos(pos));
   }
 
@@ -162,10 +160,10 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
   }
 
   @Override
-  public <T> void set(int pos, T value) {
+  protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
-        this.status = STATUS_VALUES[(Integer) value];
+        this.status = EntryStatus.fromId((Integer) value);
         break;
       case 1:
         this.snapshotId = (Long) value;

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
+
+/** Mutable {@link StructLike} implementation of {@link Tracking}. */
+class TrackingStruct implements Tracking, StructLike, Serializable {
+  private static final EntryStatus[] STATUS_VALUES = EntryStatus.values();
+
+  private EntryStatus status = EntryStatus.EXISTING;
+  private Long snapshotId = null;
+  private Long sequenceNumber = null;
+  private Long fileSequenceNumber = null;
+  private Long dvSnapshotId = null;
+  private Long firstRowId = null;
+  private byte[] deletedPositions = null;
+  private byte[] replacedPositions = null;
+
+  TrackingStruct(Types.StructType type) {}
+
+  private TrackingStruct(TrackingStruct toCopy) {
+    this.status = toCopy.status;
+    this.snapshotId = toCopy.snapshotId;
+    this.sequenceNumber = toCopy.sequenceNumber;
+    this.fileSequenceNumber = toCopy.fileSequenceNumber;
+    this.dvSnapshotId = toCopy.dvSnapshotId;
+    this.firstRowId = toCopy.firstRowId;
+    this.deletedPositions =
+        toCopy.deletedPositions != null
+            ? Arrays.copyOf(toCopy.deletedPositions, toCopy.deletedPositions.length)
+            : null;
+    this.replacedPositions =
+        toCopy.replacedPositions != null
+            ? Arrays.copyOf(toCopy.replacedPositions, toCopy.replacedPositions.length)
+            : null;
+  }
+
+  TrackingStruct copy() {
+    return new TrackingStruct(this);
+  }
+
+  @Override
+  public EntryStatus status() {
+    return status;
+  }
+
+  @Override
+  public Long snapshotId() {
+    return snapshotId;
+  }
+
+  @Override
+  public Long dataSequenceNumber() {
+    return sequenceNumber;
+  }
+
+  @Override
+  public Long fileSequenceNumber() {
+    return fileSequenceNumber;
+  }
+
+  @Override
+  public Long dvSnapshotId() {
+    return dvSnapshotId;
+  }
+
+  @Override
+  public Long firstRowId() {
+    return firstRowId;
+  }
+
+  @Override
+  public ByteBuffer deletedPositions() {
+    return deletedPositions != null ? ByteBuffer.wrap(deletedPositions) : null;
+  }
+
+  @Override
+  public ByteBuffer replacedPositions() {
+    return replacedPositions != null ? ByteBuffer.wrap(replacedPositions) : null;
+  }
+
+  void setSnapshotId(Long newSnapshotId) {
+    this.snapshotId = newSnapshotId;
+  }
+
+  void setSequenceNumber(Long newSequenceNumber) {
+    this.sequenceNumber = newSequenceNumber;
+  }
+
+  void setFirstRowId(Long newFirstRowId) {
+    this.firstRowId = newFirstRowId;
+  }
+
+  @Override
+  public int size() {
+    return 8;
+  }
+
+  @Override
+  public <T> T get(int pos, Class<T> javaClass) {
+    return javaClass.cast(getByPos(pos));
+  }
+
+  private Object getByPos(int pos) {
+    switch (pos) {
+      case 0:
+        return status.id();
+      case 1:
+        return snapshotId;
+      case 2:
+        return sequenceNumber;
+      case 3:
+        return fileSequenceNumber;
+      case 4:
+        return dvSnapshotId;
+      case 5:
+        return firstRowId;
+      case 6:
+        return deletedPositions();
+      case 7:
+        return replacedPositions();
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+  }
+
+  @Override
+  public <T> void set(int pos, T value) {
+    switch (pos) {
+      case 0:
+        this.status = STATUS_VALUES[(Integer) value];
+        break;
+      case 1:
+        this.snapshotId = (Long) value;
+        break;
+      case 2:
+        this.sequenceNumber = (Long) value;
+        break;
+      case 3:
+        this.fileSequenceNumber = (Long) value;
+        break;
+      case 4:
+        this.dvSnapshotId = (Long) value;
+        break;
+      case 5:
+        this.firstRowId = (Long) value;
+        break;
+      case 6:
+        this.deletedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
+        break;
+      case 7:
+        this.replacedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
+        break;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -37,6 +37,9 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
   private byte[] deletedPositions = null;
   private byte[] replacedPositions = null;
 
+  // not serialized, set by manifest readers for metadata inheritance
+  private transient TrackedFile manifestContext = null;
+
   TrackingStruct(Types.StructType type) {}
 
   private TrackingStruct(TrackingStruct toCopy) {
@@ -60,6 +63,10 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
     return new TrackingStruct(this);
   }
 
+  void setManifestContext(TrackedFile manifest) {
+    this.manifestContext = manifest;
+  }
+
   @Override
   public EntryStatus status() {
     return status;
@@ -67,17 +74,37 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
 
   @Override
   public Long snapshotId() {
-    return snapshotId;
+    if (snapshotId != null) {
+      return snapshotId;
+    }
+
+    return manifestContext != null ? manifestContext.tracking().snapshotId() : null;
   }
 
   @Override
   public Long dataSequenceNumber() {
-    return sequenceNumber;
+    if (sequenceNumber != null) {
+      return sequenceNumber;
+    }
+
+    if (manifestContext != null && status == EntryStatus.ADDED) {
+      return manifestContext.tracking().dataSequenceNumber();
+    }
+
+    return null;
   }
 
   @Override
   public Long fileSequenceNumber() {
-    return fileSequenceNumber;
+    if (fileSequenceNumber != null) {
+      return fileSequenceNumber;
+    }
+
+    if (manifestContext != null && status == EntryStatus.ADDED) {
+      return manifestContext.tracking().dataSequenceNumber();
+    }
+
+    return null;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link Tracking}. */
-class TrackingStruct extends SupportsIndexProjection implements Tracking {
+class TrackingStruct extends SupportsIndexProjection implements Tracking, Serializable {
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
           Tracking.STATUS,

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
@@ -190,5 +191,19 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("status", status)
+        .add("snapshot_id", snapshotId == null ? "null" : snapshotId)
+        .add("data_sequence_number", sequenceNumber == null ? "null" : sequenceNumber)
+        .add("file_sequence_number", fileSequenceNumber == null ? "null" : fileSequenceNumber)
+        .add("dv_snapshot_id", dvSnapshotId == null ? "null" : dvSnapshotId)
+        .add("first_row_id", firstRowId == null ? "null" : firstRowId)
+        .add("deleted_positions", deletedPositions == null ? "null" : "(binary)")
+        .add("replaced_positions", replacedPositions == null ? "null" : "(binary)")
+        .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -77,11 +77,6 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     this.manifestPos = toCopy.manifestPos;
   }
 
-  @Override
-  public TrackingStruct copy() {
-    return new TrackingStruct(this);
-  }
-
   void inheritFrom(Tracking manifestTracking) {
     if (manifestTracking != null) {
       if (snapshotId == null) {
@@ -102,10 +97,6 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
 
   void setManifestLocation(String location) {
     this.manifestLocation = location;
-  }
-
-  void setManifestPos(long pos) {
-    this.manifestPos = pos;
   }
 
   @Override
@@ -156,6 +147,11 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   @Override
   public long manifestPos() {
     return manifestPos;
+  }
+
+  @Override
+  public TrackingStruct copy() {
+    return new TrackingStruct(this);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -100,15 +100,15 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
     return replacedPositions != null ? ByteBuffer.wrap(replacedPositions) : null;
   }
 
-  void setSnapshotId(Long newSnapshotId) {
+  void setSnapshotId(long newSnapshotId) {
     this.snapshotId = newSnapshotId;
   }
 
-  void setSequenceNumber(Long newSequenceNumber) {
+  void setSequenceNumber(long newSequenceNumber) {
     this.sequenceNumber = newSequenceNumber;
   }
 
-  void setFirstRowId(Long newFirstRowId) {
+  void setFirstRowId(long newFirstRowId) {
     this.firstRowId = newFirstRowId;
   }
 

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link Tracking}. */
 class TrackingStruct extends SupportsIndexProjection implements Tracking {
-  // struct type that corresponds to the positions used for internalGet and internalSet
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
           Tracking.STATUS,

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -27,7 +27,17 @@ import org.apache.iceberg.util.ByteBuffers;
 
 /** Mutable {@link StructLike} implementation of {@link Tracking}. */
 class TrackingStruct extends SupportsIndexProjection implements Tracking {
-  private static final Types.StructType BASE_TYPE = Tracking.schema();
+  // struct type that corresponds to the positions used for internalGet and internalSet
+  private static final Types.StructType BASE_TYPE =
+      Types.StructType.of(
+          Tracking.STATUS,
+          Tracking.SNAPSHOT_ID,
+          Tracking.SEQUENCE_NUMBER,
+          Tracking.FILE_SEQUENCE_NUMBER,
+          Tracking.DV_SNAPSHOT_ID,
+          Tracking.FIRST_ROW_ID,
+          Tracking.DELETED_POSITIONS,
+          Tracking.REPLACED_POSITIONS);
 
   private EntryStatus status = null;
   private Long snapshotId = null;

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -29,7 +29,7 @@ import org.apache.iceberg.util.ByteBuffers;
 class TrackingStruct extends SupportsIndexProjection implements Tracking {
   private static final Types.StructType BASE_TYPE = Tracking.schema();
 
-  private EntryStatus status = EntryStatus.EXISTING;
+  private EntryStatus status = null;
   private Long snapshotId = null;
   private Long sequenceNumber = null;
   private Long fileSequenceNumber = null;
@@ -141,11 +141,11 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking {
       case 0:
         return status.id();
       case 1:
-        return snapshotId;
+        return snapshotId();
       case 2:
-        return sequenceNumber;
+        return dataSequenceNumber();
       case 3:
-        return fileSequenceNumber;
+        return fileSequenceNumber();
       case 4:
         return dvSnapshotId;
       case 5:

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -189,7 +189,7 @@ class TrackingStruct implements Tracking, StructLike, Serializable {
         this.replacedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
         break;
       default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        // ignore the object, it must be from a newer version of the format
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.iceberg.avro.SupportsIndexProjection;
@@ -50,7 +51,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
 
   // not serialized, set by manifest readers
   private String manifestLocation = null;
-  private long manifestPos = 0L;
+  private long manifestPos = -1L;
 
   TrackingStruct(Types.StructType type) {
     super(BASE_TYPE, type);
@@ -165,7 +166,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   private Object getByPos(int pos) {
     switch (pos) {
       case 0:
-        return status.id();
+        return status != null ? status.id() : null;
       case 1:
         return snapshotId();
       case 2:

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -28,7 +28,7 @@ class TestDeletionVectorStruct {
 
   @Test
   void fieldAccess() {
-    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
 
     dv.set(0, "s3://bucket/data/dv.puffin");
     dv.set(1, 256L);
@@ -43,7 +43,7 @@ class TestDeletionVectorStruct {
 
   @Test
   void copy() {
-    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
 
     dv.set(0, "s3://bucket/data/dv.puffin");
     dv.set(1, 256L);
@@ -60,13 +60,33 @@ class TestDeletionVectorStruct {
 
   @Test
   void size() {
-    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     assertThat(dv.size()).isEqualTo(4);
   }
 
   @Test
+  void projectedStructLike() {
+    // project only location (field ID 155) and cardinality (field ID 156)
+    Types.StructType projection =
+        Types.StructType.of(DeletionVector.LOCATION, DeletionVector.CARDINALITY);
+
+    DeletionVectorStruct dv = new DeletionVectorStruct(projection);
+    assertThat(dv.size()).isEqualTo(2);
+
+    // projected position 0 maps to internal position 0 (location)
+    // projected position 1 maps to internal position 3 (cardinality)
+    dv.set(0, "s3://bucket/data/dv.puffin");
+    dv.set(1, 42L);
+
+    assertThat(dv.location()).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(dv.cardinality()).isEqualTo(42L);
+    assertThat(dv.get(0, String.class)).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(dv.get(1, Long.class)).isEqualTo(42L);
+  }
+
+  @Test
   void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
-    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     dv.set(0, "s3://bucket/data/dv.puffin");
     dv.set(1, 256L);
     dv.set(2, 128L);
@@ -82,7 +102,7 @@ class TestDeletionVectorStruct {
 
   @Test
   void kryoSerializationRoundTrip() throws IOException {
-    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     dv.set(0, "s3://bucket/data/dv.puffin");
     dv.set(1, 256L);
     dv.set(2, 128L);

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestDeletionVectorStruct {
+
+  @Test
+  void fieldAccess() {
+    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+
+    dv.set(0, "s3://bucket/data/dv.puffin");
+    dv.set(1, 256L);
+    dv.set(2, 128L);
+    dv.set(3, 42L);
+
+    assertThat(dv.location()).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(dv.offset()).isEqualTo(256L);
+    assertThat(dv.sizeInBytes()).isEqualTo(128L);
+    assertThat(dv.cardinality()).isEqualTo(42L);
+  }
+
+  @Test
+  void copy() {
+    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+
+    dv.set(0, "s3://bucket/data/dv.puffin");
+    dv.set(1, 256L);
+    dv.set(2, 128L);
+    dv.set(3, 42L);
+
+    DeletionVectorStruct copy = dv.copy();
+
+    assertThat(copy.location()).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(copy.offset()).isEqualTo(256L);
+    assertThat(copy.sizeInBytes()).isEqualTo(128L);
+    assertThat(copy.cardinality()).isEqualTo(42L);
+  }
+
+  @Test
+  void size() {
+    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    assertThat(dv.size()).isEqualTo(4);
+  }
+
+  @Test
+  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    dv.set(0, "s3://bucket/data/dv.puffin");
+    dv.set(1, 256L);
+    dv.set(2, 128L);
+    dv.set(3, 42L);
+
+    DeletionVectorStruct deserialized = TestHelpers.roundTripSerialize(dv);
+
+    assertThat(deserialized.location()).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(deserialized.offset()).isEqualTo(256L);
+    assertThat(deserialized.sizeInBytes()).isEqualTo(128L);
+    assertThat(deserialized.cardinality()).isEqualTo(42L);
+  }
+
+  @Test
+  void kryoSerializationRoundTrip() throws IOException {
+    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    dv.set(0, "s3://bucket/data/dv.puffin");
+    dv.set(1, 256L);
+    dv.set(2, 128L);
+    dv.set(3, 42L);
+
+    DeletionVectorStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(dv);
+
+    assertThat(deserialized.location()).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(deserialized.offset()).isEqualTo(256L);
+    assertThat(deserialized.sizeInBytes()).isEqualTo(128L);
+    assertThat(deserialized.cardinality()).isEqualTo(42L);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 class TestDeletionVectorStruct {
 
   @Test
-  void fieldAccess() {
+  void testFieldAccess() {
     DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
 
     dv.set(0, "s3://bucket/data/dv.puffin");
@@ -42,7 +42,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void copy() {
+  void testCopy() {
     DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
 
     dv.set(0, "s3://bucket/data/dv.puffin");
@@ -59,13 +59,13 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void size() {
+  void testSize() {
     DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     assertThat(dv.size()).isEqualTo(4);
   }
 
   @Test
-  void projectedStructLike() {
+  void testProjectedStructLike() {
     // project only location (field ID 155) and cardinality (field ID 156)
     Types.StructType projection =
         Types.StructType.of(DeletionVector.LOCATION, DeletionVector.CARDINALITY);
@@ -85,7 +85,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+  void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     dv.set(0, "s3://bucket/data/dv.puffin");
     dv.set(1, 256L);
@@ -101,7 +101,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void kryoSerializationRoundTrip() throws IOException {
+  void testKryoSerializationRoundTrip() throws IOException {
     DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     dv.set(0, "s3://bucket/data/dv.puffin");
     dv.set(1, 256L);

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestManifestInfoStruct {
+
+  @Test
+  void fieldAccess() {
+    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+
+    info.set(0, 10);
+    info.set(1, 20);
+    info.set(2, 3);
+    info.set(3, 2);
+    info.set(4, 1000L);
+    info.set(5, 2000L);
+    info.set(6, 300L);
+    info.set(7, 200L);
+    info.set(8, 5L);
+    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
+    info.set(10, 1L);
+
+    assertThat(info.addedFilesCount()).isEqualTo(10);
+    assertThat(info.existingFilesCount()).isEqualTo(20);
+    assertThat(info.deletedFilesCount()).isEqualTo(3);
+    assertThat(info.replacedFilesCount()).isEqualTo(2);
+    assertThat(info.addedRowsCount()).isEqualTo(1000L);
+    assertThat(info.existingRowsCount()).isEqualTo(2000L);
+    assertThat(info.deletedRowsCount()).isEqualTo(300L);
+    assertThat(info.replacedRowsCount()).isEqualTo(200L);
+    assertThat(info.minSequenceNumber()).isEqualTo(5L);
+    assertThat(info.dv()).isNotNull();
+    assertThat(info.dvCardinality()).isEqualTo(1L);
+  }
+
+  @Test
+  void copy() {
+    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+
+    info.set(0, 10);
+    info.set(1, 20);
+    info.set(2, 3);
+    info.set(3, 2);
+    info.set(4, 1000L);
+    info.set(5, 2000L);
+    info.set(6, 300L);
+    info.set(7, 200L);
+    info.set(8, 5L);
+    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
+    info.set(10, 1L);
+
+    ManifestInfoStruct copy = info.copy();
+
+    assertThat(copy.addedFilesCount()).isEqualTo(10);
+    assertThat(copy.existingFilesCount()).isEqualTo(20);
+    assertThat(copy.deletedFilesCount()).isEqualTo(3);
+    assertThat(copy.replacedFilesCount()).isEqualTo(2);
+    assertThat(copy.addedRowsCount()).isEqualTo(1000L);
+    assertThat(copy.existingRowsCount()).isEqualTo(2000L);
+    assertThat(copy.deletedRowsCount()).isEqualTo(300L);
+    assertThat(copy.replacedRowsCount()).isEqualTo(200L);
+    assertThat(copy.minSequenceNumber()).isEqualTo(5L);
+    assertThat(copy.dvCardinality()).isEqualTo(1L);
+
+    // verify deep copy of dv ByteBuffer
+    assertThat(copy.dv()).isNotSameAs(info.dv());
+  }
+
+  @Test
+  void nullableFields() {
+    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+
+    info.set(0, 0);
+    info.set(1, 0);
+    info.set(2, 0);
+    info.set(3, 0);
+    info.set(4, 0L);
+    info.set(5, 0L);
+    info.set(6, 0L);
+    info.set(7, 0L);
+    info.set(8, 0L);
+
+    assertThat(info.dv()).isNull();
+    assertThat(info.dvCardinality()).isNull();
+  }
+
+  @Test
+  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+    info.set(0, 10);
+    info.set(1, 20);
+    info.set(2, 3);
+    info.set(3, 2);
+    info.set(4, 1000L);
+    info.set(5, 2000L);
+    info.set(6, 300L);
+    info.set(7, 200L);
+    info.set(8, 5L);
+    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
+    info.set(10, 1L);
+
+    ManifestInfoStruct deserialized = TestHelpers.roundTripSerialize(info);
+
+    assertThat(deserialized.addedFilesCount()).isEqualTo(10);
+    assertThat(deserialized.existingFilesCount()).isEqualTo(20);
+    assertThat(deserialized.minSequenceNumber()).isEqualTo(5L);
+    assertThat(deserialized.dv()).isEqualTo(ByteBuffer.wrap(new byte[] {0xF}));
+    assertThat(deserialized.dvCardinality()).isEqualTo(1L);
+  }
+
+  @Test
+  void kryoSerializationRoundTrip() throws IOException {
+    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+    info.set(0, 10);
+    info.set(1, 20);
+    info.set(2, 3);
+    info.set(3, 2);
+    info.set(4, 1000L);
+    info.set(5, 2000L);
+    info.set(6, 300L);
+    info.set(7, 200L);
+    info.set(8, 5L);
+    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
+    info.set(10, 1L);
+
+    ManifestInfoStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(info);
+
+    assertThat(deserialized.addedFilesCount()).isEqualTo(10);
+    assertThat(deserialized.existingFilesCount()).isEqualTo(20);
+    assertThat(deserialized.minSequenceNumber()).isEqualTo(5L);
+    assertThat(deserialized.dv()).isEqualTo(ByteBuffer.wrap(new byte[] {0xF}));
+    assertThat(deserialized.dvCardinality()).isEqualTo(1L);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -29,7 +29,7 @@ class TestManifestInfoStruct {
 
   @Test
   void fieldAccess() {
-    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
     info.set(0, 10);
     info.set(1, 20);
@@ -58,7 +58,7 @@ class TestManifestInfoStruct {
 
   @Test
   void copy() {
-    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
     info.set(0, 10);
     info.set(1, 20);
@@ -91,7 +91,7 @@ class TestManifestInfoStruct {
 
   @Test
   void nullableFields() {
-    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
     info.set(0, 0);
     info.set(1, 0);
@@ -108,8 +108,28 @@ class TestManifestInfoStruct {
   }
 
   @Test
+  void projectedStructLike() {
+    // project only added_files_count (field ID 504) and min_sequence_number (field ID 516)
+    Types.StructType projection =
+        Types.StructType.of(ManifestInfo.ADDED_FILES_COUNT, ManifestInfo.MIN_SEQUENCE_NUMBER);
+
+    ManifestInfoStruct info = new ManifestInfoStruct(projection);
+    assertThat(info.size()).isEqualTo(2);
+
+    // projected position 0 maps to internal position 0 (added_files_count)
+    // projected position 1 maps to internal position 8 (min_sequence_number)
+    info.set(0, 10);
+    info.set(1, 5L);
+
+    assertThat(info.addedFilesCount()).isEqualTo(10);
+    assertThat(info.minSequenceNumber()).isEqualTo(5L);
+    assertThat(info.get(0, Integer.class)).isEqualTo(10);
+    assertThat(info.get(1, Long.class)).isEqualTo(5L);
+  }
+
+  @Test
   void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
-    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
     info.set(0, 10);
     info.set(1, 20);
     info.set(2, 3);
@@ -133,7 +153,7 @@ class TestManifestInfoStruct {
 
   @Test
   void kryoSerializationRoundTrip() throws IOException {
-    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
     info.set(0, 10);
     info.set(1, 20);
     info.set(2, 3);

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 class TestManifestInfoStruct {
 
   @Test
-  void fieldAccess() {
+  void testFieldAccess() {
     ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
     info.set(0, 10);
@@ -57,7 +57,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void copy() {
+  void testCopy() {
     ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
     info.set(0, 10);
@@ -85,12 +85,12 @@ class TestManifestInfoStruct {
     assertThat(copy.minSequenceNumber()).isEqualTo(5L);
     assertThat(copy.dvCardinality()).isEqualTo(1L);
 
-    // verify deep copy of dv ByteBuffer
-    assertThat(copy.dv()).isNotSameAs(info.dv());
+    // verify deep copy of dv byte array
+    assertThat(copy.dv().array()).isNotSameAs(info.dv().array());
   }
 
   @Test
-  void nullableFields() {
+  void testNullableFields() {
     ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
     info.set(0, 0);
@@ -108,7 +108,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void projectedStructLike() {
+  void testProjectedStructLike() {
     // project only added_files_count (field ID 504) and min_sequence_number (field ID 516)
     Types.StructType projection =
         Types.StructType.of(ManifestInfo.ADDED_FILES_COUNT, ManifestInfo.MIN_SEQUENCE_NUMBER);
@@ -128,7 +128,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+  void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
     info.set(0, 10);
     info.set(1, 20);
@@ -146,13 +146,19 @@ class TestManifestInfoStruct {
 
     assertThat(deserialized.addedFilesCount()).isEqualTo(10);
     assertThat(deserialized.existingFilesCount()).isEqualTo(20);
+    assertThat(deserialized.deletedFilesCount()).isEqualTo(3);
+    assertThat(deserialized.replacedFilesCount()).isEqualTo(2);
+    assertThat(deserialized.addedRowsCount()).isEqualTo(1000L);
+    assertThat(deserialized.existingRowsCount()).isEqualTo(2000L);
+    assertThat(deserialized.deletedRowsCount()).isEqualTo(300L);
+    assertThat(deserialized.replacedRowsCount()).isEqualTo(200L);
     assertThat(deserialized.minSequenceNumber()).isEqualTo(5L);
     assertThat(deserialized.dv()).isEqualTo(ByteBuffer.wrap(new byte[] {0xF}));
     assertThat(deserialized.dvCardinality()).isEqualTo(1L);
   }
 
   @Test
-  void kryoSerializationRoundTrip() throws IOException {
+  void testKryoSerializationRoundTrip() throws IOException {
     ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
     info.set(0, 10);
     info.set(1, 20);
@@ -170,6 +176,12 @@ class TestManifestInfoStruct {
 
     assertThat(deserialized.addedFilesCount()).isEqualTo(10);
     assertThat(deserialized.existingFilesCount()).isEqualTo(20);
+    assertThat(deserialized.deletedFilesCount()).isEqualTo(3);
+    assertThat(deserialized.replacedFilesCount()).isEqualTo(2);
+    assertThat(deserialized.addedRowsCount()).isEqualTo(1000L);
+    assertThat(deserialized.existingRowsCount()).isEqualTo(2000L);
+    assertThat(deserialized.deletedRowsCount()).isEqualTo(300L);
+    assertThat(deserialized.replacedRowsCount()).isEqualTo(200L);
     assertThat(deserialized.minSequenceNumber()).isEqualTo(5L);
     assertThat(deserialized.dv()).isEqualTo(ByteBuffer.wrap(new byte[] {0xF}));
     assertThat(deserialized.dvCardinality()).isEqualTo(1L);

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -104,7 +104,8 @@ class TestTrackedFileStruct {
     file.set(4, 0L);
     file.set(5, 0L);
 
-    file.setManifestLocation("s3://bucket/metadata/manifest.avro");
+    file.setManifestContext(
+        TestTrackedFileStruct.createManifestContext("s3://bucket/metadata/manifest.avro"));
     file.set(14, 7L);
 
     assertThat(file.manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
@@ -257,8 +258,8 @@ class TestTrackedFileStruct {
     assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
     assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
-    assertThat(deserialized.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
     assertThat(deserialized.manifestPos()).isEqualTo(3L);
+    assertThat(deserialized.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
   }
 
   @Test
@@ -279,8 +280,8 @@ class TestTrackedFileStruct {
     assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
     assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
-    assertThat(deserialized.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
     assertThat(deserialized.manifestPos()).isEqualTo(3L);
+    assertThat(deserialized.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
   }
 
   static TrackedFileStruct createFullTrackedFile() {
@@ -309,7 +310,8 @@ class TestTrackedFileStruct {
     file.set(11, ByteBuffer.wrap(new byte[] {1, 2, 3}));
     file.set(12, ImmutableList.of(50L));
 
-    file.setManifestLocation("s3://bucket/manifest.avro");
+    file.setManifestContext(
+        TestTrackedFileStruct.createManifestContext("s3://bucket/manifest.avro"));
     file.set(14, 3L);
 
     return file;
@@ -376,5 +378,15 @@ class TestTrackedFileStruct {
     file.set(7, (StructLike) stats);
 
     return file;
+  }
+
+  static TrackedFile createManifestContext(String location) {
+    TrackedFileStruct manifest = new TrackedFileStruct();
+    manifest.set(1, FileContent.DATA_MANIFEST.id());
+    manifest.set(2, location);
+    manifest.set(3, "avro");
+    manifest.set(4, 0L);
+    manifest.set(5, 0L);
+    return manifest;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -1,0 +1,646 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.stats.BaseContentStats;
+import org.apache.iceberg.stats.BaseFieldStats;
+import org.apache.iceberg.stats.ContentStats;
+import org.apache.iceberg.stats.FieldStats;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestTrackedFileStruct {
+
+  @Test
+  void trackedFileStructFieldAccess() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "s3://bucket/data/file.parquet");
+    file.set(3, "parquet");
+    file.set(4, 100L);
+    file.set(5, 1024L);
+    file.set(6, 0);
+
+    assertThat(file.contentType()).isEqualTo(FileContent.DATA);
+    assertThat(file.location()).isEqualTo("s3://bucket/data/file.parquet");
+    assertThat(file.fileFormat()).isEqualTo(FileFormat.PARQUET);
+    assertThat(file.recordCount()).isEqualTo(100L);
+    assertThat(file.fileSizeInBytes()).isEqualTo(1024L);
+    assertThat(file.specId()).isEqualTo(0);
+
+    assertThat(file.tracking()).isNull();
+    assertThat(file.deletionVector()).isNull();
+    assertThat(file.sortOrderId()).isNull();
+    assertThat(file.contentStats()).isNull();
+    assertThat(file.manifestInfo()).isNull();
+    assertThat(file.keyMetadata()).isNull();
+    assertThat(file.splitOffsets()).isNull();
+    assertThat(file.equalityIds()).isNull();
+  }
+
+  @Test
+  void trackedFileStructOptionalFields() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+
+    file.set(1, FileContent.EQUALITY_DELETES.id());
+    file.set(2, "s3://bucket/data/eq-delete.avro");
+    file.set(3, "avro");
+    file.set(4, 50L);
+    file.set(5, 512L);
+    file.set(6, 1);
+    file.set(8, 5);
+    file.set(11, ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    file.set(12, ImmutableList.of(100L, 200L));
+    file.set(13, ImmutableList.of(1, 2, 3));
+
+    assertThat(file.contentType()).isEqualTo(FileContent.EQUALITY_DELETES);
+    assertThat(file.sortOrderId()).isEqualTo(5);
+    assertThat(file.keyMetadata()).isNotNull();
+    assertThat(file.splitOffsets()).containsExactly(100L, 200L);
+    assertThat(file.equalityIds()).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  void trackingStructFieldAccess() {
+    TrackedFileStruct.TrackingStruct tracking =
+        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+
+    // Tracking.schema() ordinals: 0=status, 1=snapshotId, 2=sequenceNumber,
+    // 3=fileSequenceNumber, 4=dvSnapshotId, 5=firstRowId, 6=deletedPositions,
+    // 7=replacedPositions
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
+    tracking.set(2, 10L);
+    tracking.set(3, 11L);
+    tracking.set(4, 43L);
+    tracking.set(5, 1000L);
+
+    assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(tracking.snapshotId()).isEqualTo(42L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(11L);
+    assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
+    assertThat(tracking.firstRowId()).isEqualTo(1000L);
+    assertThat(tracking.deletedPositions()).isNull();
+    assertThat(tracking.replacedPositions()).isNull();
+  }
+
+  @Test
+  void trackingStructReaderSideFieldsOnTrackedFile() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "test");
+    file.set(3, "parquet");
+    file.set(4, 0L);
+    file.set(5, 0L);
+
+    file.setManifestLocation("s3://bucket/metadata/manifest.avro");
+    file.setManifestPos(7L);
+
+    assertThat(file.manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
+    assertThat(file.manifestPos()).isEqualTo(7L);
+  }
+
+  @Test
+  void trackingStructSetters() {
+    TrackedFileStruct.TrackingStruct tracking =
+        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.setSnapshotId(100L);
+    tracking.setSequenceNumber(200L);
+    tracking.setFirstRowId(300L);
+
+    assertThat(tracking.snapshotId()).isEqualTo(100L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(200L);
+    assertThat(tracking.firstRowId()).isEqualTo(300L);
+  }
+
+  @Test
+  void trackingStructCopy() {
+    TrackedFileStruct.TrackingStruct tracking =
+        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
+    tracking.set(2, 10L);
+    tracking.set(6, ByteBuffer.wrap(new byte[] {1, 2}));
+
+    TrackedFileStruct.TrackingStruct copy = tracking.copy();
+
+    assertThat(copy.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(copy.snapshotId()).isEqualTo(42L);
+    assertThat(copy.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(copy.deletedPositions()).isNotNull();
+
+    // verify deep copy of ByteBuffer
+    assertThat(copy.deletedPositions()).isNotSameAs(tracking.deletedPositions());
+  }
+
+  @Test
+  void trackingStructAllStatuses() {
+    for (EntryStatus status : EntryStatus.values()) {
+      TrackedFileStruct.TrackingStruct tracking =
+          new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+      tracking.set(0, status.id());
+      assertThat(tracking.status()).isEqualTo(status);
+    }
+  }
+
+  @Test
+  void deletionVectorStructFieldAccess() {
+    TrackedFileStruct.DeletionVectorStruct dv =
+        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
+
+    dv.set(0, "s3://bucket/data/dv.puffin");
+    dv.set(1, 256L);
+    dv.set(2, 128L);
+    dv.set(3, 42L);
+
+    assertThat(dv.location()).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(dv.offset()).isEqualTo(256L);
+    assertThat(dv.sizeInBytes()).isEqualTo(128L);
+    assertThat(dv.cardinality()).isEqualTo(42L);
+  }
+
+  @Test
+  void deletionVectorStructCopy() {
+    TrackedFileStruct.DeletionVectorStruct dv =
+        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
+
+    dv.set(0, "s3://bucket/data/dv.puffin");
+    dv.set(1, 256L);
+    dv.set(2, 128L);
+    dv.set(3, 42L);
+
+    TrackedFileStruct.DeletionVectorStruct copy = dv.copy();
+
+    assertThat(copy.location()).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(copy.offset()).isEqualTo(256L);
+    assertThat(copy.sizeInBytes()).isEqualTo(128L);
+    assertThat(copy.cardinality()).isEqualTo(42L);
+  }
+
+  @Test
+  void deletionVectorStructSize() {
+    TrackedFileStruct.DeletionVectorStruct dv =
+        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
+    assertThat(dv.size()).isEqualTo(4);
+  }
+
+  @Test
+  void manifestInfoStructFieldAccess() {
+    TrackedFileStruct.ManifestInfoStruct info =
+        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
+
+    info.set(0, 10);
+    info.set(1, 20);
+    info.set(2, 3);
+    info.set(3, 2);
+    info.set(4, 1000L);
+    info.set(5, 2000L);
+    info.set(6, 300L);
+    info.set(7, 200L);
+    info.set(8, 5L);
+    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
+    info.set(10, 1L);
+
+    assertThat(info.addedFilesCount()).isEqualTo(10);
+    assertThat(info.existingFilesCount()).isEqualTo(20);
+    assertThat(info.deletedFilesCount()).isEqualTo(3);
+    assertThat(info.replacedFilesCount()).isEqualTo(2);
+    assertThat(info.addedRowsCount()).isEqualTo(1000L);
+    assertThat(info.existingRowsCount()).isEqualTo(2000L);
+    assertThat(info.deletedRowsCount()).isEqualTo(300L);
+    assertThat(info.replacedRowsCount()).isEqualTo(200L);
+    assertThat(info.minSequenceNumber()).isEqualTo(5L);
+    assertThat(info.dv()).isNotNull();
+    assertThat(info.dvCardinality()).isEqualTo(1L);
+  }
+
+  @Test
+  void manifestInfoStructCopy() {
+    TrackedFileStruct.ManifestInfoStruct info =
+        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
+
+    info.set(0, 10);
+    info.set(1, 20);
+    info.set(2, 3);
+    info.set(3, 2);
+    info.set(4, 1000L);
+    info.set(5, 2000L);
+    info.set(6, 300L);
+    info.set(7, 200L);
+    info.set(8, 5L);
+    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
+    info.set(10, 1L);
+
+    TrackedFileStruct.ManifestInfoStruct copy = info.copy();
+
+    assertThat(copy.addedFilesCount()).isEqualTo(10);
+    assertThat(copy.existingFilesCount()).isEqualTo(20);
+    assertThat(copy.deletedFilesCount()).isEqualTo(3);
+    assertThat(copy.replacedFilesCount()).isEqualTo(2);
+    assertThat(copy.addedRowsCount()).isEqualTo(1000L);
+    assertThat(copy.existingRowsCount()).isEqualTo(2000L);
+    assertThat(copy.deletedRowsCount()).isEqualTo(300L);
+    assertThat(copy.replacedRowsCount()).isEqualTo(200L);
+    assertThat(copy.minSequenceNumber()).isEqualTo(5L);
+    assertThat(copy.dvCardinality()).isEqualTo(1L);
+
+    // verify deep copy of dv ByteBuffer
+    assertThat(copy.dv()).isNotSameAs(info.dv());
+  }
+
+  @Test
+  void manifestInfoStructNullableFields() {
+    TrackedFileStruct.ManifestInfoStruct info =
+        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
+
+    info.set(0, 0);
+    info.set(1, 0);
+    info.set(2, 0);
+    info.set(3, 0);
+    info.set(4, 0L);
+    info.set(5, 0L);
+    info.set(6, 0L);
+    info.set(7, 0L);
+    info.set(8, 0L);
+
+    assertThat(info.dv()).isNull();
+    assertThat(info.dvCardinality()).isNull();
+  }
+
+  @Test
+  void trackedFileStructWithTracking() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct.TrackingStruct tracking =
+        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
+
+    file.set(0, tracking);
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "s3://bucket/data/file.parquet");
+    file.set(3, "parquet");
+    file.set(4, 100L);
+    file.set(5, 1024L);
+    file.set(6, 0);
+
+    file.setManifestLocation("s3://bucket/manifest.avro");
+
+    assertThat(file.tracking()).isNotNull();
+    assertThat(file.tracking().status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(file.tracking().snapshotId()).isEqualTo(42L);
+    assertThat(file.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(file.trackingStruct()).isSameAs(tracking);
+  }
+
+  @Test
+  void trackedFileStructWithDeletionVector() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct.DeletionVectorStruct dv =
+        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
+
+    dv.set(0, "s3://bucket/dv.puffin");
+    dv.set(1, 100L);
+    dv.set(2, 50L);
+    dv.set(3, 5L);
+
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "s3://bucket/data/file.parquet");
+    file.set(3, "parquet");
+    file.set(4, 100L);
+    file.set(5, 1024L);
+    file.set(6, 0);
+    file.set(9, dv);
+
+    assertThat(file.deletionVector()).isNotNull();
+    assertThat(file.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
+    assertThat(file.deletionVector().offset()).isEqualTo(100L);
+    assertThat(file.deletionVector().sizeInBytes()).isEqualTo(50L);
+    assertThat(file.deletionVector().cardinality()).isEqualTo(5L);
+  }
+
+  @Test
+  void trackedFileStructWithManifestInfo() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct.ManifestInfoStruct info =
+        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
+
+    info.set(0, 5);
+    info.set(1, 10);
+    info.set(2, 1);
+    info.set(3, 0);
+    info.set(4, 500L);
+    info.set(5, 1000L);
+    info.set(6, 100L);
+    info.set(7, 0L);
+    info.set(8, 3L);
+
+    file.set(1, FileContent.DATA_MANIFEST.id());
+    file.set(2, "s3://bucket/metadata/manifest.avro");
+    file.set(3, "avro");
+    file.set(4, 0L);
+    file.set(5, 2048L);
+    file.set(6, 0);
+    file.set(10, info);
+
+    assertThat(file.manifestInfo()).isNotNull();
+    assertThat(file.manifestInfo().addedFilesCount()).isEqualTo(5);
+    assertThat(file.manifestInfo().existingFilesCount()).isEqualTo(10);
+  }
+
+  @Test
+  void copyPreservesAllFields() {
+    TrackedFileStruct file = createFullTrackedFile();
+
+    TrackedFile copy = file.copy();
+    assertThat(copy).isInstanceOf(TrackedFileStruct.class);
+
+    assertThat(copy.contentType()).isEqualTo(FileContent.DATA);
+    assertThat(copy.location()).isEqualTo("s3://bucket/data/file.parquet");
+    assertThat(copy.fileFormat()).isEqualTo(FileFormat.PARQUET);
+    assertThat(copy.tracking().status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(copy.tracking().snapshotId()).isEqualTo(42L);
+    assertThat(copy.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
+    assertThat(copy.specId()).isEqualTo(0);
+    assertThat(copy.sortOrderId()).isEqualTo(1);
+    assertThat(copy.recordCount()).isEqualTo(100L);
+    assertThat(copy.fileSizeInBytes()).isEqualTo(1024L);
+    assertThat(copy.keyMetadata()).isNotNull();
+    assertThat(copy.splitOffsets()).containsExactly(50L);
+    assertThat(copy.equalityIds()).isNull();
+    assertThat(copy.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(copy.manifestPos()).isEqualTo(3L);
+  }
+
+  @Test
+  void copyWithoutStatsDropsStats() {
+    TrackedFileStruct file = createTrackedFileWithStats();
+    assertThat(file.contentStats()).isNotNull();
+
+    TrackedFile copy = file.copyWithoutStats();
+
+    assertThat(copy.contentType()).isEqualTo(FileContent.DATA);
+    assertThat(copy.location()).isEqualTo("s3://bucket/data/file.parquet");
+    assertThat(copy.contentStats()).isNull();
+  }
+
+  @Test
+  void copyWithStatsFilters() {
+    TrackedFileStruct file = createTrackedFileWithStats();
+    Set<Integer> keepFieldIds = ImmutableSet.of(1);
+
+    TrackedFile copy = file.copyWithStats(keepFieldIds);
+
+    assertThat(copy.contentStats()).isNotNull();
+    ContentStats stats = copy.contentStats();
+    assertThat(stats.fieldStats()).hasSize(1);
+    assertThat(stats.fieldStats().get(0).fieldId()).isEqualTo(1);
+  }
+
+  @Test
+  void copyIsDeep() {
+    TrackedFileStruct file = createFullTrackedFile();
+
+    TrackedFile copy = file.copy();
+
+    // tracking should be a deep copy
+    assertThat(((TrackedFileStruct) copy).trackingStruct()).isNotSameAs(file.trackingStruct());
+
+    // keyMetadata should be a deep copy
+    assertThat(copy.keyMetadata()).isNotSameAs(file.keyMetadata());
+  }
+
+  @Test
+  void structLikeSize() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    assertThat(file.size()).isEqualTo(14);
+  }
+
+  @Test
+  void structLikeGetSet() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+
+    file.set(1, FileContent.DATA.id());
+    assertThat(file.get(1, Integer.class)).isEqualTo(FileContent.DATA.id());
+
+    file.set(2, "test-location");
+    assertThat(file.get(2, String.class)).isEqualTo("test-location");
+
+    file.set(4, 999L);
+    assertThat(file.get(4, Long.class)).isEqualTo(999L);
+  }
+
+  @Test
+  void structLikeInvalidOrdinalThrows() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+
+    assertThatThrownBy(() -> file.get(14, Object.class))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Unknown field ordinal: 14");
+
+    assertThatThrownBy(() -> file.set(14, "value"))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Unknown field ordinal: 14");
+  }
+
+  @Test
+  void contentStatsReturnedWhenPresent() {
+    TrackedFileStruct file = createTrackedFileWithStats();
+    assertThat(file.contentStats()).isNotNull();
+    assertThat(file.contentStats().fieldStats()).hasSize(2);
+  }
+
+  @Test
+  void contentStatsRejectsRawStructLike() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    StructLike rawStruct = new PartitionData(Types.StructType.of());
+
+    assertThatThrownBy(() -> file.set(7, rawStruct))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Expected ContentStats but found");
+  }
+
+  @Test
+  void contentStatsNullWhenNotSet() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "test");
+    file.set(3, "parquet");
+    file.set(4, 0L);
+    file.set(5, 0L);
+    file.set(6, 0);
+
+    assertThat(file.contentStats()).isNull();
+  }
+
+  @Test
+  void manifestLocationOnTrackedFile() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    assertThat(file.manifestLocation()).isNull();
+
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "test");
+    file.set(3, "parquet");
+    file.set(4, 0L);
+    file.set(5, 0L);
+    file.set(6, 0);
+
+    file.setManifestLocation("s3://bucket/manifest.avro");
+
+    assertThat(file.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+  }
+
+  @Test
+  void allFileContentTypesSupported() {
+    for (FileContent content : FileContent.values()) {
+      TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+      file.set(1, content.id());
+      assertThat(file.contentType()).isEqualTo(content);
+    }
+  }
+
+  @Test
+  void isLiveDelegatesFromTracking() {
+    TrackedFileStruct.TrackingStruct tracking =
+        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    assertThat(tracking.isLive()).isTrue();
+
+    tracking.set(0, EntryStatus.EXISTING.id());
+    assertThat(tracking.isLive()).isTrue();
+
+    tracking.set(0, EntryStatus.DELETED.id());
+    assertThat(tracking.isLive()).isFalse();
+
+    tracking.set(0, EntryStatus.REPLACED.id());
+    assertThat(tracking.isLive()).isFalse();
+  }
+
+  private static TrackedFileStruct createFullTrackedFile() {
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct.TrackingStruct tracking =
+        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+    TrackedFileStruct.DeletionVectorStruct dv =
+        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
+    tracking.set(2, 10L);
+
+    dv.set(0, "s3://bucket/dv.puffin");
+    dv.set(1, 100L);
+    dv.set(2, 50L);
+    dv.set(3, 5L);
+
+    file.set(0, tracking);
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "s3://bucket/data/file.parquet");
+    file.set(3, "parquet");
+    file.set(4, 100L);
+    file.set(5, 1024L);
+    file.set(6, 0);
+    file.set(8, 1);
+    file.set(9, dv);
+    file.set(11, ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    file.set(12, ImmutableList.of(50L));
+
+    file.setManifestLocation("s3://bucket/manifest.avro");
+    file.setManifestPos(3L);
+
+    return file;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static TrackedFileStruct createTrackedFileWithStats() {
+    Types.StructType statsStruct =
+        Types.StructType.of(
+            Types.NestedField.optional(
+                10000,
+                "1",
+                Types.StructType.of(
+                    Types.NestedField.optional(10001, "value_count", Types.LongType.get()),
+                    Types.NestedField.optional(10002, "null_value_count", Types.LongType.get()),
+                    Types.NestedField.optional(10003, "nan_value_count", Types.LongType.get()),
+                    Types.NestedField.optional(10006, "lower_bound", Types.IntegerType.get()),
+                    Types.NestedField.optional(10007, "upper_bound", Types.IntegerType.get()))),
+            Types.NestedField.optional(
+                20000,
+                "2",
+                Types.StructType.of(
+                    Types.NestedField.optional(20001, "value_count", Types.LongType.get()),
+                    Types.NestedField.optional(20002, "null_value_count", Types.LongType.get()),
+                    Types.NestedField.optional(20003, "nan_value_count", Types.LongType.get()),
+                    Types.NestedField.optional(20006, "lower_bound", Types.FloatType.get()),
+                    Types.NestedField.optional(20007, "upper_bound", Types.FloatType.get()))));
+
+    List<FieldStats<?>> fieldStatsList =
+        ImmutableList.of(
+            (FieldStats<?>)
+                BaseFieldStats.<Integer>builder()
+                    .fieldId(1)
+                    .type(Types.IntegerType.get())
+                    .valueCount(100L)
+                    .nullValueCount(5L)
+                    .lowerBound(1)
+                    .upperBound(1000)
+                    .build(),
+            (FieldStats<?>)
+                BaseFieldStats.<Float>builder()
+                    .fieldId(2)
+                    .type(Types.FloatType.get())
+                    .valueCount(200L)
+                    .nullValueCount(10L)
+                    .nanValueCount(3L)
+                    .lowerBound(1.0f)
+                    .upperBound(100.0f)
+                    .build());
+
+    BaseContentStats stats =
+        BaseContentStats.builder()
+            .withStatsStruct(statsStruct)
+            .withFieldStats(fieldStatsList)
+            .build();
+
+    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "s3://bucket/data/file.parquet");
+    file.set(3, "parquet");
+    file.set(4, 100L);
+    file.set(5, 1024L);
+    file.set(6, 0);
+    file.set(7, (StructLike) stats);
+
+    return file;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -105,7 +105,7 @@ class TestTrackedFileStruct {
     file.set(5, 0L);
 
     file.setManifestLocation("s3://bucket/metadata/manifest.avro");
-    file.setManifestPos(7L);
+    file.set(14, 7L);
 
     assertThat(file.manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
     assertThat(file.manifestPos()).isEqualTo(7L);
@@ -173,7 +173,7 @@ class TestTrackedFileStruct {
   @Test
   void structLikeSize() {
     TrackedFileStruct file = new TrackedFileStruct();
-    assertThat(file.size()).isEqualTo(14);
+    assertThat(file.size()).isEqualTo(15);
   }
 
   @Test
@@ -310,7 +310,7 @@ class TestTrackedFileStruct {
     file.set(12, ImmutableList.of(50L));
 
     file.setManifestLocation("s3://bucket/manifest.avro");
-    file.setManifestPos(3L);
+    file.set(14, 3L);
 
     return file;
   }

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -30,22 +30,10 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 class TestTrackedFileStruct {
-  private static final Types.StructType TRACKING_WITH_POS =
-      Types.StructType.of(
-          Tracking.STATUS,
-          Tracking.SNAPSHOT_ID,
-          Tracking.SEQUENCE_NUMBER,
-          Tracking.FILE_SEQUENCE_NUMBER,
-          Tracking.DV_SNAPSHOT_ID,
-          Tracking.FIRST_ROW_ID,
-          Tracking.DELETED_POSITIONS,
-          Tracking.REPLACED_POSITIONS,
-          MetadataColumns.ROW_POSITION);
-
   @Test
   void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    TrackingStruct tracking = new TrackingStruct();
     DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
@@ -102,7 +90,7 @@ class TestTrackedFileStruct {
   void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = new TrackingStruct(TRACKING_WITH_POS);
+    TrackingStruct tracking = new TrackingStruct();
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
     tracking.set(8, 7L);
@@ -116,6 +104,62 @@ class TestTrackedFileStruct {
 
     assertThat(file.tracking().manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
     assertThat(file.tracking().manifestPos()).isEqualTo(7L);
+  }
+
+  @Test
+  void testInheritFrom() {
+    TrackingStruct tracking = new TrackingStruct();
+    tracking.set(0, EntryStatus.ADDED.id());
+
+    TrackingStruct manifestTracking = new TrackingStruct();
+    manifestTracking.set(1, 99L);
+    manifestTracking.set(2, 10L);
+    manifestTracking.set(3, 20L);
+
+    tracking.inheritFrom(manifestTracking);
+
+    assertThat(tracking.snapshotId()).isEqualTo(99L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(20L);
+  }
+
+  @Test
+  void testInheritFromDoesNotOverrideExisting() {
+    TrackingStruct tracking = new TrackingStruct();
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 1L);
+    tracking.set(2, 2L);
+    tracking.set(3, 3L);
+
+    TrackingStruct manifestTracking = new TrackingStruct();
+    manifestTracking.set(1, 99L);
+    manifestTracking.set(2, 10L);
+    manifestTracking.set(3, 20L);
+
+    tracking.inheritFrom(manifestTracking);
+
+    assertThat(tracking.snapshotId()).isEqualTo(1L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(2L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(3L);
+  }
+
+  @Test
+  void testInheritFromOnlyForAdded() {
+    TrackingStruct tracking = new TrackingStruct();
+    tracking.set(0, EntryStatus.EXISTING.id());
+
+    TrackingStruct manifestTracking = new TrackingStruct();
+    manifestTracking.set(1, 99L);
+    manifestTracking.set(2, 10L);
+    manifestTracking.set(3, 20L);
+
+    tracking.inheritFrom(manifestTracking);
+
+    // snapshotId is inherited regardless of status
+    assertThat(tracking.snapshotId()).isEqualTo(99L);
+    // sequence numbers are only inherited for ADDED entries
+    assertThat(tracking.dataSequenceNumber()).isNull();
+    assertThat(tracking.fileSequenceNumber()).isNull();
   }
 
   @Test
@@ -291,7 +335,7 @@ class TestTrackedFileStruct {
   }
 
   static TrackedFileStruct createFullTrackedFile() {
-    TrackingStruct tracking = new TrackingStruct(TRACKING_WITH_POS);
+    TrackingStruct tracking = new TrackingStruct();
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
     tracking.set(2, 10L);

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -91,46 +91,14 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void manifestContextInheritsToTrackingSetBeforeContext() {
-    TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
-    // snapshotId and sequenceNumber left null. Should inherit from context
-
-    file.set(0, tracking);
-    file.set(1, FileContent.DATA.id());
-    file.set(2, "s3://bucket/data/file.parquet");
-    file.set(3, "parquet");
-    file.set(4, 100L);
-    file.set(5, 1024L);
-
-    // context set after tracking -- must propagate to already-set tracking
-    TrackedFileStruct manifest = new TrackedFileStruct();
-    TrackingStruct manifestTracking = new TrackingStruct(Tracking.schema());
-    manifestTracking.set(0, EntryStatus.ADDED.id());
-    manifestTracking.set(1, 42L);
-    manifestTracking.set(2, 10L);
-    manifest.set(0, manifestTracking);
-    manifest.set(1, FileContent.DATA_MANIFEST.id());
-    manifest.set(2, "s3://bucket/manifest.avro");
-    manifest.set(3, "avro");
-    manifest.set(4, 0L);
-    manifest.set(5, 0L);
-
-    file.setManifestContext(manifest);
-
-    assertThat(file.tracking().snapshotId()).isEqualTo(42L);
-    assertThat(file.tracking().dataSequenceNumber()).isEqualTo(10L);
-    assertThat(file.tracking().fileSequenceNumber()).isEqualTo(10L);
-    assertThat(file.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
-  }
-
-  @Test
   void readerSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
+    tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
+    tracking.setManifestPos(7L);
+
     file.set(0, tracking);
     file.set(1, FileContent.DATA.id());
     file.set(2, "test");
@@ -138,12 +106,8 @@ class TestTrackedFileStruct {
     file.set(4, 0L);
     file.set(5, 0L);
 
-    file.setManifestContext(
-        TestTrackedFileStruct.createManifestContext("s3://bucket/metadata/manifest.avro"));
-    file.set(14, 7L);
-
-    assertThat(file.manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
-    assertThat(file.manifestPos()).isEqualTo(7L);
+    assertThat(file.tracking().manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
+    assertThat(file.tracking().manifestPos()).isEqualTo(7L);
   }
 
   @Test
@@ -166,16 +130,17 @@ class TestTrackedFileStruct {
     assertThat(copy.keyMetadata()).isNotNull();
     assertThat(copy.splitOffsets()).containsExactly(50L);
     assertThat(copy.equalityIds()).isNull();
-    assertThat(copy.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
-    assertThat(copy.manifestPos()).isEqualTo(3L);
+    assertThat(copy.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(copy.tracking().manifestPos()).isEqualTo(3L);
   }
 
   @Test
-  void copyPreservesManifestContextInheritance() {
+  void copyPreservesManifestLocation() {
     TrackedFileStruct file = new TrackedFileStruct();
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
-    // leave snapshotId and sequenceNumber null so they inherit from manifest context
+    tracking.set(1, 42L);
+    tracking.set(2, 10L);
 
     file.set(0, tracking);
     file.set(1, FileContent.DATA.id());
@@ -184,31 +149,13 @@ class TestTrackedFileStruct {
     file.set(4, 100L);
     file.set(5, 1024L);
 
-    TrackedFileStruct manifest = new TrackedFileStruct();
-    TrackingStruct manifestTracking = new TrackingStruct(Tracking.schema());
-    manifestTracking.set(0, EntryStatus.ADDED.id());
-    manifestTracking.set(1, 42L);
-    manifestTracking.set(2, 10L);
-    manifest.set(0, manifestTracking);
-    manifest.set(1, FileContent.DATA_MANIFEST.id());
-    manifest.set(2, "s3://bucket/manifest.avro");
-    manifest.set(3, "avro");
-    manifest.set(4, 0L);
-    manifest.set(5, 0L);
-
-    file.setManifestContext(manifest);
-
-    // verify inheritance works before copy
-    assertThat(file.tracking().snapshotId()).isEqualTo(42L);
-    assertThat(file.tracking().dataSequenceNumber()).isEqualTo(10L);
+    tracking.setManifestLocation("s3://bucket/manifest.avro");
 
     TrackedFile copy = file.copy();
 
-    // inherited values must survive the copy
     assertThat(copy.tracking().snapshotId()).isEqualTo(42L);
     assertThat(copy.tracking().dataSequenceNumber()).isEqualTo(10L);
-    assertThat(copy.tracking().fileSequenceNumber()).isEqualTo(10L);
-    assertThat(copy.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(copy.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
   }
 
   @Test
@@ -249,7 +196,7 @@ class TestTrackedFileStruct {
   @Test
   void structLikeSize() {
     TrackedFileStruct file = new TrackedFileStruct();
-    assertThat(file.size()).isEqualTo(15);
+    assertThat(file.size()).isEqualTo(14);
   }
 
   @Test
@@ -333,8 +280,8 @@ class TestTrackedFileStruct {
     assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
     assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
-    assertThat(deserialized.manifestPos()).isEqualTo(3L);
-    assertThat(deserialized.manifestLocation()).isNull();
+    assertThat(deserialized.tracking().manifestPos()).isEqualTo(3L);
+    assertThat(deserialized.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
   }
 
   @Test
@@ -355,8 +302,8 @@ class TestTrackedFileStruct {
     assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
     assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
-    assertThat(deserialized.manifestPos()).isEqualTo(3L);
-    assertThat(deserialized.manifestLocation()).isNull();
+    assertThat(deserialized.tracking().manifestPos()).isEqualTo(3L);
+    assertThat(deserialized.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
   }
 
   static TrackedFileStruct createFullTrackedFile() {
@@ -367,6 +314,8 @@ class TestTrackedFileStruct {
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
     tracking.set(2, 10L);
+    tracking.setManifestLocation("s3://bucket/manifest.avro");
+    tracking.setManifestPos(3L);
 
     dv.set(0, "s3://bucket/dv.puffin");
     dv.set(1, 100L);
@@ -384,10 +333,6 @@ class TestTrackedFileStruct {
     file.set(9, dv);
     file.set(11, ByteBuffer.wrap(new byte[] {1, 2, 3}));
     file.set(12, ImmutableList.of(50L));
-
-    file.setManifestContext(
-        TestTrackedFileStruct.createManifestContext("s3://bucket/manifest.avro"));
-    file.set(14, 3L);
 
     return file;
   }
@@ -453,15 +398,5 @@ class TestTrackedFileStruct {
     file.set(7, (StructLike) stats);
 
     return file;
-  }
-
-  static TrackedFile createManifestContext(String location) {
-    TrackedFileStruct manifest = new TrackedFileStruct();
-    manifest.set(1, FileContent.DATA_MANIFEST.id());
-    manifest.set(2, location);
-    manifest.set(3, "avro");
-    manifest.set(4, 0L);
-    manifest.set(5, 0L);
-    return manifest;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -95,6 +95,41 @@ class TestTrackedFileStruct {
   }
 
   @Test
+  void manifestContextInheritsToTrackingSetBeforeContext() {
+    TrackedFileStruct file = new TrackedFileStruct();
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.set(0, EntryStatus.ADDED.id());
+    // snapshotId and sequenceNumber left null. Should inherit from context
+
+    file.set(0, tracking);
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "s3://bucket/data/file.parquet");
+    file.set(3, "parquet");
+    file.set(4, 100L);
+    file.set(5, 1024L);
+
+    // context set after tracking -- must propagate to already-set tracking
+    TrackedFileStruct manifest = new TrackedFileStruct();
+    TrackingStruct manifestTracking = new TrackingStruct(Types.StructType.of());
+    manifestTracking.set(0, EntryStatus.ADDED.id());
+    manifestTracking.set(1, 42L);
+    manifestTracking.set(2, 10L);
+    manifest.set(0, manifestTracking);
+    manifest.set(1, FileContent.DATA_MANIFEST.id());
+    manifest.set(2, "s3://bucket/manifest.avro");
+    manifest.set(3, "avro");
+    manifest.set(4, 0L);
+    manifest.set(5, 0L);
+
+    file.setManifestContext(manifest);
+
+    assertThat(file.tracking().snapshotId()).isEqualTo(42L);
+    assertThat(file.tracking().dataSequenceNumber()).isEqualTo(10L);
+    assertThat(file.tracking().fileSequenceNumber()).isEqualTo(10L);
+    assertThat(file.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+  }
+
+  @Test
   void readerSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -38,26 +38,32 @@ class TestTrackedFileStruct {
   @Test
   void trackedFileStructFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct.TrackingStruct tracking =
+        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+    TrackedFileStruct.DeletionVectorStruct dv =
+        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
+    TrackedFileStruct.ManifestInfoStruct info =
+        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
 
-    file.set(1, FileContent.DATA.id());
-    file.set(2, "s3://bucket/data/file.parquet");
-    file.set(3, "parquet");
-    file.set(4, 100L);
-    file.set(5, 1024L);
-    file.set(6, 0);
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
 
-    assertThat(file.contentType()).isEqualTo(FileContent.DATA);
-    assertThat(file.location()).isEqualTo("s3://bucket/data/file.parquet");
-    assertThat(file.fileFormat()).isEqualTo(FileFormat.PARQUET);
-    assertThat(file.recordCount()).isEqualTo(100L);
-    assertThat(file.fileSizeInBytes()).isEqualTo(1024L);
-    assertThat(file.specId()).isEqualTo(0);
-  }
+    dv.set(0, "s3://bucket/dv.puffin");
+    dv.set(1, 100L);
+    dv.set(2, 50L);
+    dv.set(3, 5L);
 
-  @Test
-  void trackedFileStructOptionalFields() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    info.set(0, 10);
+    info.set(1, 20);
+    info.set(2, 3);
+    info.set(3, 2);
+    info.set(4, 1000L);
+    info.set(5, 2000L);
+    info.set(6, 300L);
+    info.set(7, 200L);
+    info.set(8, 5L);
 
+    file.set(0, tracking);
     file.set(1, FileContent.EQUALITY_DELETES.id());
     file.set(2, "s3://bucket/data/eq-delete.avro");
     file.set(3, "avro");
@@ -65,13 +71,28 @@ class TestTrackedFileStruct {
     file.set(5, 512L);
     file.set(6, 1);
     file.set(8, 5);
+    file.set(9, dv);
+    file.set(10, info);
     file.set(11, ByteBuffer.wrap(new byte[] {1, 2, 3}));
     file.set(12, ImmutableList.of(100L, 200L));
     file.set(13, ImmutableList.of(1, 2, 3));
 
+    assertThat(file.tracking()).isNotNull();
+    assertThat(file.tracking().status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(file.tracking().snapshotId()).isEqualTo(42L);
     assertThat(file.contentType()).isEqualTo(FileContent.EQUALITY_DELETES);
+    assertThat(file.location()).isEqualTo("s3://bucket/data/eq-delete.avro");
+    assertThat(file.fileFormat()).isEqualTo(FileFormat.AVRO);
+    assertThat(file.recordCount()).isEqualTo(50L);
+    assertThat(file.fileSizeInBytes()).isEqualTo(512L);
+    assertThat(file.specId()).isEqualTo(1);
     assertThat(file.sortOrderId()).isEqualTo(5);
-    assertThat(file.keyMetadata()).isNotNull();
+    assertThat(file.deletionVector()).isNotNull();
+    assertThat(file.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
+    assertThat(file.deletionVector().cardinality()).isEqualTo(5L);
+    assertThat(file.manifestInfo()).isNotNull();
+    assertThat(file.manifestInfo().addedFilesCount()).isEqualTo(10);
+    assertThat(file.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(file.splitOffsets()).containsExactly(100L, 200L);
     assertThat(file.equalityIds()).containsExactly(1, 2, 3);
   }
@@ -81,9 +102,6 @@ class TestTrackedFileStruct {
     TrackedFileStruct.TrackingStruct tracking =
         new TrackedFileStruct.TrackingStruct(Types.StructType.of());
 
-    // Tracking.schema() ordinals: 0=status, 1=snapshotId, 2=sequenceNumber,
-    // 3=fileSequenceNumber, 4=dvSnapshotId, 5=firstRowId, 6=deletedPositions,
-    // 7=replacedPositions
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
     tracking.set(2, 10L);

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -259,7 +259,7 @@ class TestTrackedFileStruct {
     assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
     assertThat(deserialized.manifestPos()).isEqualTo(3L);
-    assertThat(deserialized.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(deserialized.manifestLocation()).isNull();
   }
 
   @Test
@@ -281,7 +281,7 @@ class TestTrackedFileStruct {
     assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
     assertThat(deserialized.manifestPos()).isEqualTo(3L);
-    assertThat(deserialized.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(deserialized.manifestLocation()).isNull();
   }
 
   static TrackedFileStruct createFullTrackedFile() {

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -38,7 +37,7 @@ class TestTrackedFileStruct {
 
   @Test
   void trackedFileStructFieldAccess() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct file = new TrackedFileStruct();
     TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
     DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
     ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
@@ -97,7 +96,7 @@ class TestTrackedFileStruct {
 
   @Test
   void readerSideFields() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct file = new TrackedFileStruct();
 
     file.set(1, FileContent.DATA.id());
     file.set(2, "test");
@@ -173,13 +172,13 @@ class TestTrackedFileStruct {
 
   @Test
   void structLikeSize() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct file = new TrackedFileStruct();
     assertThat(file.size()).isEqualTo(14);
   }
 
   @Test
   void structLikeGetSet() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct file = new TrackedFileStruct();
 
     file.set(1, FileContent.DATA.id());
     assertThat(file.get(1, Integer.class)).isEqualTo(FileContent.DATA.id());
@@ -192,16 +191,23 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void structLikeInvalidOrdinalThrows() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+  void projectedStructLike() {
+    // project only location (field ID 100) and file_size_in_bytes (field ID 104)
+    Types.StructType projection =
+        Types.StructType.of(TrackedFile.LOCATION, TrackedFile.FILE_SIZE_IN_BYTES);
 
-    assertThatThrownBy(() -> file.get(14, Object.class))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("Unknown field ordinal: 14");
+    TrackedFileStruct file = new TrackedFileStruct(projection);
+    assertThat(file.size()).isEqualTo(2);
 
-    assertThatThrownBy(() -> file.set(14, "value"))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("Unknown field ordinal: 14");
+    // projected position 0 maps to internal position 2 (location)
+    // projected position 1 maps to internal position 5 (file_size_in_bytes)
+    file.set(0, "s3://bucket/file.parquet");
+    file.set(1, 1024L);
+
+    assertThat(file.location()).isEqualTo("s3://bucket/file.parquet");
+    assertThat(file.fileSizeInBytes()).isEqualTo(1024L);
+    assertThat(file.get(0, String.class)).isEqualTo("s3://bucket/file.parquet");
+    assertThat(file.get(1, Long.class)).isEqualTo(1024L);
   }
 
   @Test
@@ -213,7 +219,7 @@ class TestTrackedFileStruct {
 
   @Test
   void contentStatsNullWhenNotSet() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct file = new TrackedFileStruct();
     file.set(1, FileContent.DATA.id());
     file.set(2, "test");
     file.set(3, "parquet");
@@ -227,7 +233,7 @@ class TestTrackedFileStruct {
   @Test
   void allFileContentTypesSupported() {
     for (FileContent content : FileContent.values()) {
-      TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+      TrackedFileStruct file = new TrackedFileStruct();
       file.set(1, content.id());
       assertThat(file.contentType()).isEqualTo(content);
     }
@@ -278,7 +284,7 @@ class TestTrackedFileStruct {
   }
 
   static TrackedFileStruct createFullTrackedFile() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct file = new TrackedFileStruct();
     TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
     DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
 
@@ -360,7 +366,7 @@ class TestTrackedFileStruct {
             .withFieldStats(fieldStatsList)
             .build();
 
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
+    TrackedFileStruct file = new TrackedFileStruct();
     file.set(1, FileContent.DATA.id());
     file.set(2, "s3://bucket/data/file.parquet");
     file.set(3, "parquet");

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -172,6 +172,47 @@ class TestTrackedFileStruct {
   }
 
   @Test
+  void copyPreservesManifestContextInheritance() {
+    TrackedFileStruct file = new TrackedFileStruct();
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.set(0, EntryStatus.ADDED.id());
+    // leave snapshotId and sequenceNumber null so they inherit from manifest context
+
+    file.set(0, tracking);
+    file.set(1, FileContent.DATA.id());
+    file.set(2, "s3://bucket/data/file.parquet");
+    file.set(3, "parquet");
+    file.set(4, 100L);
+    file.set(5, 1024L);
+
+    TrackedFileStruct manifest = new TrackedFileStruct();
+    TrackingStruct manifestTracking = new TrackingStruct(Types.StructType.of());
+    manifestTracking.set(0, EntryStatus.ADDED.id());
+    manifestTracking.set(1, 42L);
+    manifestTracking.set(2, 10L);
+    manifest.set(0, manifestTracking);
+    manifest.set(1, FileContent.DATA_MANIFEST.id());
+    manifest.set(2, "s3://bucket/manifest.avro");
+    manifest.set(3, "avro");
+    manifest.set(4, 0L);
+    manifest.set(5, 0L);
+
+    file.setManifestContext(manifest);
+
+    // verify inheritance works before copy
+    assertThat(file.tracking().snapshotId()).isEqualTo(42L);
+    assertThat(file.tracking().dataSequenceNumber()).isEqualTo(10L);
+
+    TrackedFile copy = file.copy();
+
+    // inherited values must survive the copy
+    assertThat(copy.tracking().snapshotId()).isEqualTo(42L);
+    assertThat(copy.tracking().dataSequenceNumber()).isEqualTo(10L);
+    assertThat(copy.tracking().fileSequenceNumber()).isEqualTo(10L);
+    assertThat(copy.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+  }
+
+  @Test
   void copyWithoutStatsDropsStats() {
     TrackedFileStruct file = createTrackedFileWithStats();
     assertThat(file.contentStats()).isNotNull();

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -30,9 +30,20 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 class TestTrackedFileStruct {
+  private static final Types.StructType TRACKING_WITH_POS =
+      Types.StructType.of(
+          Tracking.STATUS,
+          Tracking.SNAPSHOT_ID,
+          Tracking.SEQUENCE_NUMBER,
+          Tracking.FILE_SEQUENCE_NUMBER,
+          Tracking.DV_SNAPSHOT_ID,
+          Tracking.FIRST_ROW_ID,
+          Tracking.DELETED_POSITIONS,
+          Tracking.REPLACED_POSITIONS,
+          MetadataColumns.ROW_POSITION);
 
   @Test
-  void trackedFileStructFieldAccess() {
+  void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
@@ -80,24 +91,21 @@ class TestTrackedFileStruct {
     assertThat(file.fileSizeInBytes()).isEqualTo(512L);
     assertThat(file.specId()).isEqualTo(1);
     assertThat(file.sortOrderId()).isEqualTo(5);
-    assertThat(file.deletionVector()).isNotNull();
-    assertThat(file.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
-    assertThat(file.deletionVector().cardinality()).isEqualTo(5L);
-    assertThat(file.manifestInfo()).isNotNull();
-    assertThat(file.manifestInfo().addedFilesCount()).isEqualTo(10);
+    assertThat(file.deletionVector()).isSameAs(dv);
+    assertThat(file.manifestInfo()).isSameAs(info);
     assertThat(file.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(file.splitOffsets()).containsExactly(100L, 200L);
     assertThat(file.equalityIds()).containsExactly(1, 2, 3);
   }
 
   @Test
-  void readerSideFields() {
+  void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    TrackingStruct tracking = new TrackingStruct(TRACKING_WITH_POS);
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
-    tracking.setManifestPos(7L);
+    tracking.set(8, 7L);
 
     file.set(0, tracking);
     file.set(1, FileContent.DATA.id());
@@ -111,7 +119,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void copyPreservesAllFields() {
+  void testCopy() {
     TrackedFileStruct file = createFullTrackedFile();
 
     TrackedFile copy = file.copy();
@@ -135,31 +143,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void copyPreservesManifestLocation() {
-    TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-    tracking.set(2, 10L);
-
-    file.set(0, tracking);
-    file.set(1, FileContent.DATA.id());
-    file.set(2, "s3://bucket/data/file.parquet");
-    file.set(3, "parquet");
-    file.set(4, 100L);
-    file.set(5, 1024L);
-
-    tracking.setManifestLocation("s3://bucket/manifest.avro");
-
-    TrackedFile copy = file.copy();
-
-    assertThat(copy.tracking().snapshotId()).isEqualTo(42L);
-    assertThat(copy.tracking().dataSequenceNumber()).isEqualTo(10L);
-    assertThat(copy.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
-  }
-
-  @Test
-  void copyWithoutStatsDropsStats() {
+  void testCopyWithoutStats() {
     TrackedFileStruct file = createTrackedFileWithStats();
     assertThat(file.contentStats()).isNotNull();
 
@@ -171,7 +155,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void copyWithStatsFilters() {
+  void testCopyWithStatsFilters() {
     TrackedFileStruct file = createTrackedFileWithStats();
     Set<Integer> keepFieldIds = ImmutableSet.of(1);
 
@@ -184,7 +168,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void copyIsDeep() {
+  void testCopyIsDeep() {
     TrackedFileStruct file = createFullTrackedFile();
 
     TrackedFile copy = file.copy();
@@ -194,13 +178,13 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void structLikeSize() {
+  void testStructLikeSize() {
     TrackedFileStruct file = new TrackedFileStruct();
     assertThat(file.size()).isEqualTo(14);
   }
 
   @Test
-  void structLikeGetSet() {
+  void testStructLikeGetSet() {
     TrackedFileStruct file = new TrackedFileStruct();
 
     file.set(1, FileContent.DATA.id());
@@ -214,7 +198,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void projectedStructLike() {
+  void testProjectedStructLike() {
     // project only location (field ID 100) and file_size_in_bytes (field ID 104)
     Types.StructType projection =
         Types.StructType.of(TrackedFile.LOCATION, TrackedFile.FILE_SIZE_IN_BYTES);
@@ -234,14 +218,14 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void contentStatsReturnedWhenPresent() {
+  void testContentStatsReturnedWhenPresent() {
     TrackedFileStruct file = createTrackedFileWithStats();
     assertThat(file.contentStats()).isNotNull();
     assertThat(file.contentStats().fieldStats()).hasSize(2);
   }
 
   @Test
-  void contentStatsNullWhenNotSet() {
+  void testContentStatsNullWhenNotSet() {
     TrackedFileStruct file = new TrackedFileStruct();
     file.set(1, FileContent.DATA.id());
     file.set(2, "test");
@@ -254,7 +238,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void allFileContentTypesSupported() {
+  void testAllFileContentTypesSupported() {
     for (FileContent content : FileContent.values()) {
       TrackedFileStruct file = new TrackedFileStruct();
       file.set(1, content.id());
@@ -263,7 +247,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+  void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     TrackedFileStruct file = createFullTrackedFile();
 
     TrackedFileStruct deserialized = TestHelpers.roundTripSerialize(file);
@@ -285,7 +269,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void kryoSerializationRoundTrip() throws IOException {
+  void testKryoSerializationRoundTrip() throws IOException {
     TrackedFileStruct file = createFullTrackedFile();
 
     TrackedFileStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(file);
@@ -307,27 +291,27 @@ class TestTrackedFileStruct {
   }
 
   static TrackedFileStruct createFullTrackedFile() {
-    TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
-
+    TrackingStruct tracking = new TrackingStruct(TRACKING_WITH_POS);
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
     tracking.set(2, 10L);
     tracking.setManifestLocation("s3://bucket/manifest.avro");
-    tracking.setManifestPos(3L);
+    tracking.set(8, 3L);
 
+    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     dv.set(0, "s3://bucket/dv.puffin");
     dv.set(1, 100L);
     dv.set(2, 50L);
     dv.set(3, 5L);
 
-    file.set(0, tracking);
-    file.set(1, FileContent.DATA.id());
-    file.set(2, "s3://bucket/data/file.parquet");
-    file.set(3, "parquet");
-    file.set(4, 100L);
-    file.set(5, 1024L);
+    TrackedFileStruct file =
+        new TrackedFileStruct(
+            tracking,
+            FileContent.DATA,
+            "s3://bucket/data/file.parquet",
+            FileFormat.PARQUET,
+            100L,
+            1024L);
     file.set(6, 0);
     file.set(8, 1);
     file.set(9, dv);
@@ -388,14 +372,16 @@ class TestTrackedFileStruct {
             .withFieldStats(fieldStatsList)
             .build();
 
-    TrackedFileStruct file = new TrackedFileStruct();
-    file.set(1, FileContent.DATA.id());
-    file.set(2, "s3://bucket/data/file.parquet");
-    file.set(3, "parquet");
-    file.set(4, 100L);
-    file.set(5, 1024L);
+    TrackedFileStruct file =
+        new TrackedFileStruct(
+            null,
+            FileContent.DATA,
+            "s3://bucket/data/file.parquet",
+            FileFormat.PARQUET,
+            100L,
+            1024L);
     file.set(6, 0);
-    file.set(7, (StructLike) stats);
+    file.set(7, stats);
 
     return file;
   }

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -107,62 +107,6 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void testInheritFrom() {
-    TrackingStruct tracking = new TrackingStruct();
-    tracking.set(0, EntryStatus.ADDED.id());
-
-    TrackingStruct manifestTracking = new TrackingStruct();
-    manifestTracking.set(1, 99L);
-    manifestTracking.set(2, 10L);
-    manifestTracking.set(3, 20L);
-
-    tracking.inheritFrom(manifestTracking);
-
-    assertThat(tracking.snapshotId()).isEqualTo(99L);
-    assertThat(tracking.dataSequenceNumber()).isEqualTo(10L);
-    assertThat(tracking.fileSequenceNumber()).isEqualTo(20L);
-  }
-
-  @Test
-  void testInheritFromDoesNotOverrideExisting() {
-    TrackingStruct tracking = new TrackingStruct();
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 1L);
-    tracking.set(2, 2L);
-    tracking.set(3, 3L);
-
-    TrackingStruct manifestTracking = new TrackingStruct();
-    manifestTracking.set(1, 99L);
-    manifestTracking.set(2, 10L);
-    manifestTracking.set(3, 20L);
-
-    tracking.inheritFrom(manifestTracking);
-
-    assertThat(tracking.snapshotId()).isEqualTo(1L);
-    assertThat(tracking.dataSequenceNumber()).isEqualTo(2L);
-    assertThat(tracking.fileSequenceNumber()).isEqualTo(3L);
-  }
-
-  @Test
-  void testInheritFromOnlyForAdded() {
-    TrackingStruct tracking = new TrackingStruct();
-    tracking.set(0, EntryStatus.EXISTING.id());
-
-    TrackingStruct manifestTracking = new TrackingStruct();
-    manifestTracking.set(1, 99L);
-    manifestTracking.set(2, 10L);
-    manifestTracking.set(3, 20L);
-
-    tracking.inheritFrom(manifestTracking);
-
-    // snapshotId is inherited regardless of status
-    assertThat(tracking.snapshotId()).isEqualTo(99L);
-    // sequence numbers are only inherited for ADDED entries
-    assertThat(tracking.dataSequenceNumber()).isNull();
-    assertThat(tracking.fileSequenceNumber()).isNull();
-  }
-
-  @Test
   void testCopy() {
     TrackedFileStruct file = createFullTrackedFile();
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -26,10 +26,6 @@ import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.stats.BaseContentStats;
-import org.apache.iceberg.stats.BaseFieldStats;
-import org.apache.iceberg.stats.ContentStats;
-import org.apache.iceberg.stats.FieldStats;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -38,9 +34,9 @@ class TestTrackedFileStruct {
   @Test
   void trackedFileStructFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
-    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
-    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
+    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
@@ -97,7 +93,7 @@ class TestTrackedFileStruct {
   @Test
   void manifestContextInheritsToTrackingSetBeforeContext() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     // snapshotId and sequenceNumber left null. Should inherit from context
 
@@ -110,7 +106,7 @@ class TestTrackedFileStruct {
 
     // context set after tracking -- must propagate to already-set tracking
     TrackedFileStruct manifest = new TrackedFileStruct();
-    TrackingStruct manifestTracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct manifestTracking = new TrackingStruct(Tracking.schema());
     manifestTracking.set(0, EntryStatus.ADDED.id());
     manifestTracking.set(1, 42L);
     manifestTracking.set(2, 10L);
@@ -133,6 +129,9 @@ class TestTrackedFileStruct {
   void readerSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(0, EntryStatus.ADDED.id());
+    file.set(0, tracking);
     file.set(1, FileContent.DATA.id());
     file.set(2, "test");
     file.set(3, "parquet");
@@ -174,7 +173,7 @@ class TestTrackedFileStruct {
   @Test
   void copyPreservesManifestContextInheritance() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     // leave snapshotId and sequenceNumber null so they inherit from manifest context
 
@@ -186,7 +185,7 @@ class TestTrackedFileStruct {
     file.set(5, 1024L);
 
     TrackedFileStruct manifest = new TrackedFileStruct();
-    TrackingStruct manifestTracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct manifestTracking = new TrackingStruct(Tracking.schema());
     manifestTracking.set(0, EntryStatus.ADDED.id());
     manifestTracking.set(1, 42L);
     manifestTracking.set(2, 10L);
@@ -362,8 +361,8 @@ class TestTrackedFileStruct {
 
   static TrackedFileStruct createFullTrackedFile() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
-    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
 
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
@@ -38,12 +39,9 @@ class TestTrackedFileStruct {
   @Test
   void trackedFileStructFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
-    TrackedFileStruct.TrackingStruct tracking =
-        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
-    TrackedFileStruct.DeletionVectorStruct dv =
-        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
-    TrackedFileStruct.ManifestInfoStruct info =
-        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
+    ManifestInfoStruct info = new ManifestInfoStruct(Types.StructType.of());
 
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
@@ -98,29 +96,7 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void trackingStructFieldAccess() {
-    TrackedFileStruct.TrackingStruct tracking =
-        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
-
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-    tracking.set(2, 10L);
-    tracking.set(3, 11L);
-    tracking.set(4, 43L);
-    tracking.set(5, 1000L);
-
-    assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(tracking.snapshotId()).isEqualTo(42L);
-    assertThat(tracking.dataSequenceNumber()).isEqualTo(10L);
-    assertThat(tracking.fileSequenceNumber()).isEqualTo(11L);
-    assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
-    assertThat(tracking.firstRowId()).isEqualTo(1000L);
-    assertThat(tracking.deletedPositions()).isNull();
-    assertThat(tracking.replacedPositions()).isNull();
-  }
-
-  @Test
-  void trackingStructReaderSideFieldsOnTrackedFile() {
+  void readerSideFields() {
     TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
 
     file.set(1, FileContent.DATA.id());
@@ -134,257 +110,6 @@ class TestTrackedFileStruct {
 
     assertThat(file.manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
     assertThat(file.manifestPos()).isEqualTo(7L);
-  }
-
-  @Test
-  void trackingStructSetters() {
-    TrackedFileStruct.TrackingStruct tracking =
-        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
-
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.setSnapshotId(100L);
-    tracking.setSequenceNumber(200L);
-    tracking.setFirstRowId(300L);
-
-    assertThat(tracking.snapshotId()).isEqualTo(100L);
-    assertThat(tracking.dataSequenceNumber()).isEqualTo(200L);
-    assertThat(tracking.firstRowId()).isEqualTo(300L);
-  }
-
-  @Test
-  void trackingStructCopy() {
-    TrackedFileStruct.TrackingStruct tracking =
-        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
-
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-    tracking.set(2, 10L);
-    tracking.set(6, ByteBuffer.wrap(new byte[] {1, 2}));
-
-    TrackedFileStruct.TrackingStruct copy = tracking.copy();
-
-    assertThat(copy.status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(copy.snapshotId()).isEqualTo(42L);
-    assertThat(copy.dataSequenceNumber()).isEqualTo(10L);
-    assertThat(copy.deletedPositions()).isNotNull();
-
-    // verify deep copy of ByteBuffer
-    assertThat(copy.deletedPositions()).isNotSameAs(tracking.deletedPositions());
-  }
-
-  @Test
-  void trackingStructAllStatuses() {
-    for (EntryStatus status : EntryStatus.values()) {
-      TrackedFileStruct.TrackingStruct tracking =
-          new TrackedFileStruct.TrackingStruct(Types.StructType.of());
-      tracking.set(0, status.id());
-      assertThat(tracking.status()).isEqualTo(status);
-    }
-  }
-
-  @Test
-  void deletionVectorStructFieldAccess() {
-    TrackedFileStruct.DeletionVectorStruct dv =
-        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
-
-    dv.set(0, "s3://bucket/data/dv.puffin");
-    dv.set(1, 256L);
-    dv.set(2, 128L);
-    dv.set(3, 42L);
-
-    assertThat(dv.location()).isEqualTo("s3://bucket/data/dv.puffin");
-    assertThat(dv.offset()).isEqualTo(256L);
-    assertThat(dv.sizeInBytes()).isEqualTo(128L);
-    assertThat(dv.cardinality()).isEqualTo(42L);
-  }
-
-  @Test
-  void deletionVectorStructCopy() {
-    TrackedFileStruct.DeletionVectorStruct dv =
-        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
-
-    dv.set(0, "s3://bucket/data/dv.puffin");
-    dv.set(1, 256L);
-    dv.set(2, 128L);
-    dv.set(3, 42L);
-
-    TrackedFileStruct.DeletionVectorStruct copy = dv.copy();
-
-    assertThat(copy.location()).isEqualTo("s3://bucket/data/dv.puffin");
-    assertThat(copy.offset()).isEqualTo(256L);
-    assertThat(copy.sizeInBytes()).isEqualTo(128L);
-    assertThat(copy.cardinality()).isEqualTo(42L);
-  }
-
-  @Test
-  void deletionVectorStructSize() {
-    TrackedFileStruct.DeletionVectorStruct dv =
-        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
-    assertThat(dv.size()).isEqualTo(4);
-  }
-
-  @Test
-  void manifestInfoStructFieldAccess() {
-    TrackedFileStruct.ManifestInfoStruct info =
-        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
-
-    info.set(0, 10);
-    info.set(1, 20);
-    info.set(2, 3);
-    info.set(3, 2);
-    info.set(4, 1000L);
-    info.set(5, 2000L);
-    info.set(6, 300L);
-    info.set(7, 200L);
-    info.set(8, 5L);
-    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
-    info.set(10, 1L);
-
-    assertThat(info.addedFilesCount()).isEqualTo(10);
-    assertThat(info.existingFilesCount()).isEqualTo(20);
-    assertThat(info.deletedFilesCount()).isEqualTo(3);
-    assertThat(info.replacedFilesCount()).isEqualTo(2);
-    assertThat(info.addedRowsCount()).isEqualTo(1000L);
-    assertThat(info.existingRowsCount()).isEqualTo(2000L);
-    assertThat(info.deletedRowsCount()).isEqualTo(300L);
-    assertThat(info.replacedRowsCount()).isEqualTo(200L);
-    assertThat(info.minSequenceNumber()).isEqualTo(5L);
-    assertThat(info.dv()).isNotNull();
-    assertThat(info.dvCardinality()).isEqualTo(1L);
-  }
-
-  @Test
-  void manifestInfoStructCopy() {
-    TrackedFileStruct.ManifestInfoStruct info =
-        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
-
-    info.set(0, 10);
-    info.set(1, 20);
-    info.set(2, 3);
-    info.set(3, 2);
-    info.set(4, 1000L);
-    info.set(5, 2000L);
-    info.set(6, 300L);
-    info.set(7, 200L);
-    info.set(8, 5L);
-    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
-    info.set(10, 1L);
-
-    TrackedFileStruct.ManifestInfoStruct copy = info.copy();
-
-    assertThat(copy.addedFilesCount()).isEqualTo(10);
-    assertThat(copy.existingFilesCount()).isEqualTo(20);
-    assertThat(copy.deletedFilesCount()).isEqualTo(3);
-    assertThat(copy.replacedFilesCount()).isEqualTo(2);
-    assertThat(copy.addedRowsCount()).isEqualTo(1000L);
-    assertThat(copy.existingRowsCount()).isEqualTo(2000L);
-    assertThat(copy.deletedRowsCount()).isEqualTo(300L);
-    assertThat(copy.replacedRowsCount()).isEqualTo(200L);
-    assertThat(copy.minSequenceNumber()).isEqualTo(5L);
-    assertThat(copy.dvCardinality()).isEqualTo(1L);
-
-    // verify deep copy of dv ByteBuffer
-    assertThat(copy.dv()).isNotSameAs(info.dv());
-  }
-
-  @Test
-  void manifestInfoStructNullableFields() {
-    TrackedFileStruct.ManifestInfoStruct info =
-        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
-
-    info.set(0, 0);
-    info.set(1, 0);
-    info.set(2, 0);
-    info.set(3, 0);
-    info.set(4, 0L);
-    info.set(5, 0L);
-    info.set(6, 0L);
-    info.set(7, 0L);
-    info.set(8, 0L);
-
-    assertThat(info.dv()).isNull();
-    assertThat(info.dvCardinality()).isNull();
-  }
-
-  @Test
-  void trackedFileStructWithTracking() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
-    TrackedFileStruct.TrackingStruct tracking =
-        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
-
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-
-    file.set(0, tracking);
-    file.set(1, FileContent.DATA.id());
-    file.set(2, "s3://bucket/data/file.parquet");
-    file.set(3, "parquet");
-    file.set(4, 100L);
-    file.set(5, 1024L);
-    file.set(6, 0);
-
-    file.setManifestLocation("s3://bucket/manifest.avro");
-
-    assertThat(file.tracking()).isNotNull();
-    assertThat(file.tracking().status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(file.tracking().snapshotId()).isEqualTo(42L);
-    assertThat(file.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
-    assertThat(file.trackingStruct()).isSameAs(tracking);
-  }
-
-  @Test
-  void trackedFileStructWithDeletionVector() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
-    TrackedFileStruct.DeletionVectorStruct dv =
-        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
-
-    dv.set(0, "s3://bucket/dv.puffin");
-    dv.set(1, 100L);
-    dv.set(2, 50L);
-    dv.set(3, 5L);
-
-    file.set(1, FileContent.DATA.id());
-    file.set(2, "s3://bucket/data/file.parquet");
-    file.set(3, "parquet");
-    file.set(4, 100L);
-    file.set(5, 1024L);
-    file.set(6, 0);
-    file.set(9, dv);
-
-    assertThat(file.deletionVector()).isNotNull();
-    assertThat(file.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
-    assertThat(file.deletionVector().offset()).isEqualTo(100L);
-    assertThat(file.deletionVector().sizeInBytes()).isEqualTo(50L);
-    assertThat(file.deletionVector().cardinality()).isEqualTo(5L);
-  }
-
-  @Test
-  void trackedFileStructWithManifestInfo() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
-    TrackedFileStruct.ManifestInfoStruct info =
-        new TrackedFileStruct.ManifestInfoStruct(Types.StructType.of());
-
-    info.set(0, 5);
-    info.set(1, 10);
-    info.set(2, 1);
-    info.set(3, 0);
-    info.set(4, 500L);
-    info.set(5, 1000L);
-    info.set(6, 100L);
-    info.set(7, 0L);
-    info.set(8, 3L);
-
-    file.set(1, FileContent.DATA_MANIFEST.id());
-    file.set(2, "s3://bucket/metadata/manifest.avro");
-    file.set(3, "avro");
-    file.set(4, 0L);
-    file.set(5, 2048L);
-    file.set(6, 0);
-    file.set(10, info);
-
-    assertThat(file.manifestInfo()).isNotNull();
-    assertThat(file.manifestInfo().addedFilesCount()).isEqualTo(5);
-    assertThat(file.manifestInfo().existingFilesCount()).isEqualTo(10);
   }
 
   @Test
@@ -442,9 +167,6 @@ class TestTrackedFileStruct {
 
     TrackedFile copy = file.copy();
 
-    // tracking should be a deep copy
-    assertThat(((TrackedFileStruct) copy).trackingStruct()).isNotSameAs(file.trackingStruct());
-
     // keyMetadata should be a deep copy
     assertThat(copy.keyMetadata()).isNotSameAs(file.keyMetadata());
   }
@@ -490,16 +212,6 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void contentStatsRejectsRawStructLike() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
-    StructLike rawStruct = new PartitionData(Types.StructType.of());
-
-    assertThatThrownBy(() -> file.set(7, rawStruct))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Expected ContentStats but found");
-  }
-
-  @Test
   void contentStatsNullWhenNotSet() {
     TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
     file.set(1, FileContent.DATA.id());
@@ -513,23 +225,6 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void manifestLocationOnTrackedFile() {
-    TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
-    assertThat(file.manifestLocation()).isNull();
-
-    file.set(1, FileContent.DATA.id());
-    file.set(2, "test");
-    file.set(3, "parquet");
-    file.set(4, 0L);
-    file.set(5, 0L);
-    file.set(6, 0);
-
-    file.setManifestLocation("s3://bucket/manifest.avro");
-
-    assertThat(file.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
-  }
-
-  @Test
   void allFileContentTypesSupported() {
     for (FileContent content : FileContent.values()) {
       TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
@@ -539,29 +234,53 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void isLiveDelegatesFromTracking() {
-    TrackedFileStruct.TrackingStruct tracking =
-        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
+  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+    TrackedFileStruct file = createFullTrackedFile();
 
-    tracking.set(0, EntryStatus.ADDED.id());
-    assertThat(tracking.isLive()).isTrue();
+    TrackedFileStruct deserialized = TestHelpers.roundTripSerialize(file);
 
-    tracking.set(0, EntryStatus.EXISTING.id());
-    assertThat(tracking.isLive()).isTrue();
-
-    tracking.set(0, EntryStatus.DELETED.id());
-    assertThat(tracking.isLive()).isFalse();
-
-    tracking.set(0, EntryStatus.REPLACED.id());
-    assertThat(tracking.isLive()).isFalse();
+    assertThat(deserialized.contentType()).isEqualTo(FileContent.DATA);
+    assertThat(deserialized.location()).isEqualTo("s3://bucket/data/file.parquet");
+    assertThat(deserialized.fileFormat()).isEqualTo(FileFormat.PARQUET);
+    assertThat(deserialized.recordCount()).isEqualTo(100L);
+    assertThat(deserialized.fileSizeInBytes()).isEqualTo(1024L);
+    assertThat(deserialized.specId()).isEqualTo(0);
+    assertThat(deserialized.sortOrderId()).isEqualTo(1);
+    assertThat(deserialized.tracking().status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(deserialized.tracking().snapshotId()).isEqualTo(42L);
+    assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
+    assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(deserialized.splitOffsets()).containsExactly(50L);
+    assertThat(deserialized.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(deserialized.manifestPos()).isEqualTo(3L);
   }
 
-  private static TrackedFileStruct createFullTrackedFile() {
+  @Test
+  void kryoSerializationRoundTrip() throws IOException {
+    TrackedFileStruct file = createFullTrackedFile();
+
+    TrackedFileStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(file);
+
+    assertThat(deserialized.contentType()).isEqualTo(FileContent.DATA);
+    assertThat(deserialized.location()).isEqualTo("s3://bucket/data/file.parquet");
+    assertThat(deserialized.fileFormat()).isEqualTo(FileFormat.PARQUET);
+    assertThat(deserialized.recordCount()).isEqualTo(100L);
+    assertThat(deserialized.fileSizeInBytes()).isEqualTo(1024L);
+    assertThat(deserialized.specId()).isEqualTo(0);
+    assertThat(deserialized.sortOrderId()).isEqualTo(1);
+    assertThat(deserialized.tracking().status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(deserialized.tracking().snapshotId()).isEqualTo(42L);
+    assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
+    assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(deserialized.splitOffsets()).containsExactly(50L);
+    assertThat(deserialized.manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(deserialized.manifestPos()).isEqualTo(3L);
+  }
+
+  static TrackedFileStruct createFullTrackedFile() {
     TrackedFileStruct file = new TrackedFileStruct(Types.StructType.of());
-    TrackedFileStruct.TrackingStruct tracking =
-        new TrackedFileStruct.TrackingStruct(Types.StructType.of());
-    TrackedFileStruct.DeletionVectorStruct dv =
-        new TrackedFileStruct.DeletionVectorStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    DeletionVectorStruct dv = new DeletionVectorStruct(Types.StructType.of());
 
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
@@ -591,7 +310,7 @@ class TestTrackedFileStruct {
   }
 
   @SuppressWarnings("unchecked")
-  private static TrackedFileStruct createTrackedFileWithStats() {
+  static TrackedFileStruct createTrackedFileWithStats() {
     Types.StructType statsStruct =
         Types.StructType.of(
             Types.NestedField.optional(

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -52,15 +52,6 @@ class TestTrackedFileStruct {
     assertThat(file.recordCount()).isEqualTo(100L);
     assertThat(file.fileSizeInBytes()).isEqualTo(1024L);
     assertThat(file.specId()).isEqualTo(0);
-
-    assertThat(file.tracking()).isNull();
-    assertThat(file.deletionVector()).isNull();
-    assertThat(file.sortOrderId()).isNull();
-    assertThat(file.contentStats()).isNull();
-    assertThat(file.manifestInfo()).isNull();
-    assertThat(file.keyMetadata()).isNull();
-    assertThat(file.splitOffsets()).isNull();
-    assertThat(file.equalityIds()).isNull();
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -111,8 +111,8 @@ class TestTrackingStruct {
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.inheritFrom(createManifestTracking(100L, 50L, 60L));
 
-    // sequence numbers are null and status is ADDED, should inherit
-    assertThat(tracking.dataSequenceNumber()).isEqualTo(50L);
+    // sequence numbers are null and status is ADDED, should inherit from file sequence number
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(60L);
     assertThat(tracking.fileSequenceNumber()).isEqualTo(60L);
   }
 
@@ -155,6 +155,8 @@ class TestTrackingStruct {
     assertThat(tracking.fileSequenceNumber()).isNull();
   }
 
+  // uses distinct data and file sequence numbers to verify that inheritance uses file sequence
+  // number
   private static Tracking createManifestTracking(
       long snapshotId, long dataSequenceNumber, long fileSequenceNumber) {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -29,7 +29,7 @@ class TestTrackingStruct {
 
   @Test
   void fieldAccess() {
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
 
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
@@ -50,7 +50,7 @@ class TestTrackingStruct {
 
   @Test
   void copy() {
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
 
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
@@ -71,7 +71,7 @@ class TestTrackingStruct {
   @Test
   void allStatuses() {
     for (EntryStatus status : EntryStatus.values()) {
-      TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+      TrackingStruct tracking = new TrackingStruct(Tracking.schema());
       tracking.set(0, status.id());
       assertThat(tracking.status()).isEqualTo(status);
     }
@@ -79,7 +79,7 @@ class TestTrackingStruct {
 
   @Test
   void isLive() {
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
 
     tracking.set(0, EntryStatus.ADDED.id());
     assertThat(tracking.isLive()).isTrue();
@@ -97,7 +97,7 @@ class TestTrackingStruct {
   @Test
   void inheritSnapshotIdFromManifestContext() {
     TrackedFile manifest = createManifestContext(100L, 50L);
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.setManifestContext(manifest);
     tracking.set(0, EntryStatus.ADDED.id());
 
@@ -108,7 +108,7 @@ class TestTrackingStruct {
   @Test
   void inheritSequenceNumberForAddedEntries() {
     TrackedFile manifest = createManifestContext(100L, 50L);
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.setManifestContext(manifest);
     tracking.set(0, EntryStatus.ADDED.id());
 
@@ -120,7 +120,7 @@ class TestTrackingStruct {
   @Test
   void doNotInheritSequenceNumberForExistingEntries() {
     TrackedFile manifest = createManifestContext(100L, 50L);
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.setManifestContext(manifest);
     tracking.set(0, EntryStatus.EXISTING.id());
 
@@ -132,7 +132,7 @@ class TestTrackingStruct {
   @Test
   void explicitValuesOverrideManifestContext() {
     TrackedFile manifest = createManifestContext(100L, 50L);
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.setManifestContext(manifest);
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 200L);
@@ -147,7 +147,7 @@ class TestTrackingStruct {
 
   @Test
   void noDefaultingWithoutManifestContext() {
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
 
     // no manifest context, nulls stay null
@@ -158,7 +158,7 @@ class TestTrackingStruct {
 
   private static TrackedFile createManifestContext(long snapshotId, long sequenceNumber) {
     TrackedFileStruct manifest = new TrackedFileStruct();
-    TrackingStruct manifestTracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct manifestTracking = new TrackingStruct(Tracking.schema());
     manifestTracking.set(0, EntryStatus.ADDED.id());
     manifestTracking.set(1, snapshotId);
     manifestTracking.set(2, sequenceNumber);
@@ -172,8 +172,27 @@ class TestTrackingStruct {
   }
 
   @Test
+  void projectedStructLike() {
+    // project only snapshot_id (field ID 1) and first_row_id (field ID 142)
+    Types.StructType projection = Types.StructType.of(Tracking.SNAPSHOT_ID, Tracking.FIRST_ROW_ID);
+
+    TrackingStruct tracking = new TrackingStruct(projection);
+    assertThat(tracking.size()).isEqualTo(2);
+
+    // projected position 0 maps to internal position 1 (snapshot_id)
+    // projected position 1 maps to internal position 5 (first_row_id)
+    tracking.set(0, 42L);
+    tracking.set(1, 1000L);
+
+    assertThat(tracking.snapshotId()).isEqualTo(42L);
+    assertThat(tracking.firstRowId()).isEqualTo(1000L);
+    assertThat(tracking.get(0, Long.class)).isEqualTo(42L);
+    assertThat(tracking.get(1, Long.class)).isEqualTo(1000L);
+  }
+
+  @Test
   void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
     tracking.set(2, 10L);
@@ -189,7 +208,7 @@ class TestTrackingStruct {
 
   @Test
   void kryoSerializationRoundTrip() throws IOException {
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
     tracking.set(2, 10L);

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestTrackingStruct {
+
+  @Test
+  void fieldAccess() {
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
+    tracking.set(2, 10L);
+    tracking.set(3, 11L);
+    tracking.set(4, 43L);
+    tracking.set(5, 1000L);
+
+    assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(tracking.snapshotId()).isEqualTo(42L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(11L);
+    assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
+    assertThat(tracking.firstRowId()).isEqualTo(1000L);
+    assertThat(tracking.deletedPositions()).isNull();
+    assertThat(tracking.replacedPositions()).isNull();
+  }
+
+  @Test
+  void setters() {
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.setSnapshotId(100L);
+    tracking.setSequenceNumber(200L);
+    tracking.setFirstRowId(300L);
+
+    assertThat(tracking.snapshotId()).isEqualTo(100L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(200L);
+    assertThat(tracking.firstRowId()).isEqualTo(300L);
+  }
+
+  @Test
+  void copy() {
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
+    tracking.set(2, 10L);
+    tracking.set(6, ByteBuffer.wrap(new byte[] {1, 2}));
+
+    TrackingStruct copy = tracking.copy();
+
+    assertThat(copy.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(copy.snapshotId()).isEqualTo(42L);
+    assertThat(copy.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(copy.deletedPositions()).isNotNull();
+
+    // verify deep copy of ByteBuffer
+    assertThat(copy.deletedPositions()).isNotSameAs(tracking.deletedPositions());
+  }
+
+  @Test
+  void allStatuses() {
+    for (EntryStatus status : EntryStatus.values()) {
+      TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+      tracking.set(0, status.id());
+      assertThat(tracking.status()).isEqualTo(status);
+    }
+  }
+
+  @Test
+  void isLive() {
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+
+    tracking.set(0, EntryStatus.ADDED.id());
+    assertThat(tracking.isLive()).isTrue();
+
+    tracking.set(0, EntryStatus.EXISTING.id());
+    assertThat(tracking.isLive()).isTrue();
+
+    tracking.set(0, EntryStatus.DELETED.id());
+    assertThat(tracking.isLive()).isFalse();
+
+    tracking.set(0, EntryStatus.REPLACED.id());
+    assertThat(tracking.isLive()).isFalse();
+  }
+
+  @Test
+  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
+    tracking.set(2, 10L);
+    tracking.set(6, ByteBuffer.wrap(new byte[] {1, 2}));
+
+    TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
+
+    assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(deserialized.snapshotId()).isEqualTo(42L);
+    assertThat(deserialized.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
+  }
+
+  @Test
+  void kryoSerializationRoundTrip() throws IOException {
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 42L);
+    tracking.set(2, 10L);
+    tracking.set(6, ByteBuffer.wrap(new byte[] {1, 2}));
+
+    TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
+
+    assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(deserialized.snapshotId()).isEqualTo(42L);
+    assertThat(deserialized.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -24,11 +24,13 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class TestTrackingStruct {
 
   @Test
-  void fieldAccess() {
+  void testFieldAccess() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
 
     tracking.set(0, EntryStatus.ADDED.id());
@@ -49,7 +51,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void copy() {
+  void testCopy() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
 
     tracking.set(0, EntryStatus.ADDED.id());
@@ -68,17 +70,16 @@ class TestTrackingStruct {
     assertThat(copy.deletedPositions()).isNotSameAs(tracking.deletedPositions());
   }
 
-  @Test
-  void allStatuses() {
-    for (EntryStatus status : EntryStatus.values()) {
-      TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-      tracking.set(0, status.id());
-      assertThat(tracking.status()).isEqualTo(status);
-    }
+  @ParameterizedTest
+  @EnumSource(EntryStatus.class)
+  void testAllStatuses(EntryStatus status) {
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(0, status.id());
+    assertThat(tracking.status()).isEqualTo(status);
   }
 
   @Test
-  void isLive() {
+  void testIsLive() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
 
     tracking.set(0, EntryStatus.ADDED.id());
@@ -95,7 +96,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void inheritSnapshotId() {
+  void testInheritSnapshotId() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.inheritFrom(createManifestTracking(100L, 50L));
@@ -105,7 +106,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void inheritSequenceNumberForAddedEntries() {
+  void testInheritSequenceNumberForAddedEntries() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.inheritFrom(createManifestTracking(100L, 50L));
@@ -116,7 +117,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void doNotInheritSequenceNumberForExistingEntries() {
+  void testDoNotInheritSequenceNumberForExistingEntries() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.EXISTING.id());
     tracking.inheritFrom(createManifestTracking(100L, 50L));
@@ -127,7 +128,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void explicitValuesOverrideInheritance() {
+  void testExplicitValuesOverrideInheritance() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 200L);
@@ -142,7 +143,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void noDefaultingWithoutInheritance() {
+  void testNoDefaultingWithoutInheritance() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
 
@@ -161,7 +162,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void projectedStructLike() {
+  void testProjectedStructLike() {
     // project only snapshot_id (field ID 1) and first_row_id (field ID 142)
     Types.StructType projection = Types.StructType.of(Tracking.SNAPSHOT_ID, Tracking.FIRST_ROW_ID);
 
@@ -180,7 +181,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+  void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);
@@ -196,7 +197,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void kryoSerializationRoundTrip() throws IOException {
+  void testKryoSerializationRoundTrip() throws IOException {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 42L);

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -95,6 +95,83 @@ class TestTrackingStruct {
   }
 
   @Test
+  void inheritSnapshotIdFromManifestContext() {
+    TrackedFile manifest = createManifestContext(100L, 50L);
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.setManifestContext(manifest);
+    tracking.set(0, EntryStatus.ADDED.id());
+
+    // snapshotId is null, should inherit from manifest
+    assertThat(tracking.snapshotId()).isEqualTo(100L);
+  }
+
+  @Test
+  void inheritSequenceNumberForAddedEntries() {
+    TrackedFile manifest = createManifestContext(100L, 50L);
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.setManifestContext(manifest);
+    tracking.set(0, EntryStatus.ADDED.id());
+
+    // sequence numbers are null and status is ADDED, should inherit
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(50L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(50L);
+  }
+
+  @Test
+  void doNotInheritSequenceNumberForExistingEntries() {
+    TrackedFile manifest = createManifestContext(100L, 50L);
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.setManifestContext(manifest);
+    tracking.set(0, EntryStatus.EXISTING.id());
+
+    // sequence numbers are null but status is EXISTING, should not inherit
+    assertThat(tracking.dataSequenceNumber()).isNull();
+    assertThat(tracking.fileSequenceNumber()).isNull();
+  }
+
+  @Test
+  void explicitValuesOverrideManifestContext() {
+    TrackedFile manifest = createManifestContext(100L, 50L);
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.setManifestContext(manifest);
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, 200L);
+    tracking.set(2, 75L);
+    tracking.set(3, 76L);
+
+    // explicit values should take precedence
+    assertThat(tracking.snapshotId()).isEqualTo(200L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(75L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(76L);
+  }
+
+  @Test
+  void noDefaultingWithoutManifestContext() {
+    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
+    tracking.set(0, EntryStatus.ADDED.id());
+
+    // no manifest context, nulls stay null
+    assertThat(tracking.snapshotId()).isNull();
+    assertThat(tracking.dataSequenceNumber()).isNull();
+    assertThat(tracking.fileSequenceNumber()).isNull();
+  }
+
+  private static TrackedFile createManifestContext(long snapshotId, long sequenceNumber) {
+    TrackedFileStruct manifest = new TrackedFileStruct();
+    TrackingStruct manifestTracking = new TrackingStruct(Types.StructType.of());
+    manifestTracking.set(0, EntryStatus.ADDED.id());
+    manifestTracking.set(1, snapshotId);
+    manifestTracking.set(2, sequenceNumber);
+    manifest.set(0, manifestTracking);
+    manifest.set(1, FileContent.DATA_MANIFEST.id());
+    manifest.set(2, "s3://bucket/manifest.avro");
+    manifest.set(3, "avro");
+    manifest.set(4, 0L);
+    manifest.set(5, 0L);
+    return manifest;
+  }
+
+  @Test
   void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
     tracking.set(0, EntryStatus.ADDED.id());

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -99,7 +99,7 @@ class TestTrackingStruct {
   void testInheritSnapshotId() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
-    tracking.inheritFrom(createManifestTracking(100L, 50L));
+    tracking.inheritFrom(createManifestTracking(100L, 50L, 60L));
 
     // snapshotId is null, should inherit from manifest
     assertThat(tracking.snapshotId()).isEqualTo(100L);
@@ -109,18 +109,18 @@ class TestTrackingStruct {
   void testInheritSequenceNumberForAddedEntries() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
-    tracking.inheritFrom(createManifestTracking(100L, 50L));
+    tracking.inheritFrom(createManifestTracking(100L, 50L, 60L));
 
     // sequence numbers are null and status is ADDED, should inherit
     assertThat(tracking.dataSequenceNumber()).isEqualTo(50L);
-    assertThat(tracking.fileSequenceNumber()).isEqualTo(50L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(60L);
   }
 
   @Test
   void testDoNotInheritSequenceNumberForExistingEntries() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.EXISTING.id());
-    tracking.inheritFrom(createManifestTracking(100L, 50L));
+    tracking.inheritFrom(createManifestTracking(100L, 50L, 60L));
 
     // sequence numbers are null but status is EXISTING, should not inherit
     assertThat(tracking.dataSequenceNumber()).isNull();
@@ -134,7 +134,7 @@ class TestTrackingStruct {
     tracking.set(1, 200L);
     tracking.set(2, 75L);
     tracking.set(3, 76L);
-    tracking.inheritFrom(createManifestTracking(100L, 50L));
+    tracking.inheritFrom(createManifestTracking(100L, 50L, 60L));
 
     // explicit values should take precedence
     assertThat(tracking.snapshotId()).isEqualTo(200L);
@@ -153,11 +153,13 @@ class TestTrackingStruct {
     assertThat(tracking.fileSequenceNumber()).isNull();
   }
 
-  private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
+  private static Tracking createManifestTracking(
+      long snapshotId, long dataSequenceNumber, long fileSequenceNumber) {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, snapshotId);
-    tracking.set(2, sequenceNumber);
+    tracking.set(2, dataSequenceNumber);
+    tracking.set(3, fileSequenceNumber);
     return tracking;
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -95,11 +95,10 @@ class TestTrackingStruct {
   }
 
   @Test
-  void inheritSnapshotIdFromManifestContext() {
-    TrackedFile manifest = createManifestContext(100L, 50L);
+  void inheritSnapshotId() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.setManifestContext(manifest);
     tracking.set(0, EntryStatus.ADDED.id());
+    tracking.inheritFrom(createManifestTracking(100L, 50L));
 
     // snapshotId is null, should inherit from manifest
     assertThat(tracking.snapshotId()).isEqualTo(100L);
@@ -107,10 +106,9 @@ class TestTrackingStruct {
 
   @Test
   void inheritSequenceNumberForAddedEntries() {
-    TrackedFile manifest = createManifestContext(100L, 50L);
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.setManifestContext(manifest);
     tracking.set(0, EntryStatus.ADDED.id());
+    tracking.inheritFrom(createManifestTracking(100L, 50L));
 
     // sequence numbers are null and status is ADDED, should inherit
     assertThat(tracking.dataSequenceNumber()).isEqualTo(50L);
@@ -119,10 +117,9 @@ class TestTrackingStruct {
 
   @Test
   void doNotInheritSequenceNumberForExistingEntries() {
-    TrackedFile manifest = createManifestContext(100L, 50L);
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.setManifestContext(manifest);
     tracking.set(0, EntryStatus.EXISTING.id());
+    tracking.inheritFrom(createManifestTracking(100L, 50L));
 
     // sequence numbers are null but status is EXISTING, should not inherit
     assertThat(tracking.dataSequenceNumber()).isNull();
@@ -130,14 +127,13 @@ class TestTrackingStruct {
   }
 
   @Test
-  void explicitValuesOverrideManifestContext() {
-    TrackedFile manifest = createManifestContext(100L, 50L);
+  void explicitValuesOverrideInheritance() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.setManifestContext(manifest);
     tracking.set(0, EntryStatus.ADDED.id());
     tracking.set(1, 200L);
     tracking.set(2, 75L);
     tracking.set(3, 76L);
+    tracking.inheritFrom(createManifestTracking(100L, 50L));
 
     // explicit values should take precedence
     assertThat(tracking.snapshotId()).isEqualTo(200L);
@@ -146,29 +142,22 @@ class TestTrackingStruct {
   }
 
   @Test
-  void noDefaultingWithoutManifestContext() {
+  void noDefaultingWithoutInheritance() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.ADDED.id());
 
-    // no manifest context, nulls stay null
+    // no inheritance, nulls stay null
     assertThat(tracking.snapshotId()).isNull();
     assertThat(tracking.dataSequenceNumber()).isNull();
     assertThat(tracking.fileSequenceNumber()).isNull();
   }
 
-  private static TrackedFile createManifestContext(long snapshotId, long sequenceNumber) {
-    TrackedFileStruct manifest = new TrackedFileStruct();
-    TrackingStruct manifestTracking = new TrackingStruct(Tracking.schema());
-    manifestTracking.set(0, EntryStatus.ADDED.id());
-    manifestTracking.set(1, snapshotId);
-    manifestTracking.set(2, sequenceNumber);
-    manifest.set(0, manifestTracking);
-    manifest.set(1, FileContent.DATA_MANIFEST.id());
-    manifest.set(2, "s3://bucket/manifest.avro");
-    manifest.set(3, "avro");
-    manifest.set(4, 0L);
-    manifest.set(5, 0L);
-    return manifest;
+  private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(1, snapshotId);
+    tracking.set(2, sequenceNumber);
+    return tracking;
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -120,11 +120,13 @@ class TestTrackingStruct {
   void testDoNotInheritSequenceNumberForExistingEntries() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(0, EntryStatus.EXISTING.id());
+    tracking.set(2, 5L);
+    tracking.set(3, 6L);
     tracking.inheritFrom(createManifestTracking(100L, 50L, 60L));
 
-    // sequence numbers are null but status is EXISTING, should not inherit
-    assertThat(tracking.dataSequenceNumber()).isNull();
-    assertThat(tracking.fileSequenceNumber()).isNull();
+    // sequence numbers are not inherited for EXISTING entries
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(5L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(6L);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -49,20 +49,6 @@ class TestTrackingStruct {
   }
 
   @Test
-  void setters() {
-    TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
-
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.setSnapshotId(100L);
-    tracking.setSequenceNumber(200L);
-    tracking.setFirstRowId(300L);
-
-    assertThat(tracking.snapshotId()).isEqualTo(100L);
-    assertThat(tracking.dataSequenceNumber()).isEqualTo(200L);
-    assertThat(tracking.firstRowId()).isEqualTo(300L);
-  }
-
-  @Test
   void copy() {
     TrackingStruct tracking = new TrackingStruct(Types.StructType.of());
 


### PR DESCRIPTION
Implements `TrackedFile` and its nested interfaces (`Tracking`, `DeletionVector`, `ManifestInfo`) as mutable structs. 

This is a followup of https://github.com/apache/iceberg/pull/15049
Design doc: [s.apache.org/iceberg-single-file-commit](https://s.apache.org/iceberg-single-file-commit)
Prototype PR: https://github.com/apache/iceberg/pull/14533