### PR TITLE
Aliyun: Remove leaked transitive dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -459,8 +459,8 @@ project(':iceberg-aliyun') {
     implementation project(':iceberg-common')
 
     compileOnly libs.aliyun.sdk.oss
-    implementation libs.aliyun.credentials.java
-    implementation libs.aliyun.tea
+    compileOnly libs.aliyun.credentials.java
+    compileOnly libs.aliyun.tea
     compileOnly libs.jaxb.api
     compileOnly libs.activation
     compileOnly libs.jaxb.runtime


### PR DESCRIPTION
While reviewing dependency changes to the Spark runtime bundle in https://github.com/apache/iceberg/pull/15655, we discovered that the Aliyun module was leaking several dependencies as well, including `okio` and the Kotlin stdlib:

```diff
137,156c135
< |    +--- project :iceberg-common (*)
< |    +--- com.aliyun:credentials-java:0.3.12
< |    |    +--- com.aliyun:tea:[1.1.14, 2.0.0) -> 1.4.1
< |    |    |    +--- com.squareup.okhttp3:okhttp:4.12.0
< |    |    |    |    +--- com.squareup.okio:okio:3.6.0
< |    |    |    |    |    \--- com.squareup.okio:okio-jvm:3.6.0
< |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10
< |    |    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10
< |    |    |    |    |         |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10
< |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10
< |    |    |    |    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.10 (*)
< |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10
< |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.10 (*)
< |    |    |    \--- com.google.code.gson:gson:2.11.0
< |    |    |         \--- com.google.errorprone:error_prone_annotations:2.27.0
< |    |    +--- com.google.code.gson:gson:2.11.0 (*)
< |    |    +--- org.jacoco:org.jacoco.agent:0.8.8
< |    |    +--- com.sun.xml.bind:jaxb-core:2.3.0
< |    |    \--- com.sun.xml.bind:jaxb-impl:2.3.0
< |    \--- com.aliyun:tea:1.4.1 (*)
---
> |    \--- project :iceberg-common (*)
```

This was introduced in https://github.com/apache/iceberg/commit/e93eaab3. This PR changes the dependencies to `compileOnly` to exclude them from inclusion in runtime Jars.