### PR TITLE
Core: Fix RejectedExecutionException in InMemoryLockManager when multiple catalogs share default lock manager

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -106,7 +106,11 @@ public class LockManagers {
       return heartbeatThreads;
     }
 
-    /** Returns the shared scheduler for lock heartbeats. */
+    /**
+     * Returns the shared scheduler for lock heartbeats.
+     *
+     * <p>Callers must not shut down this scheduler. It is shared across lock manager instances.
+     */
     public ScheduledExecutorService scheduler() {
       if (scheduler == null) {
         synchronized (BaseLockManager.class) {

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -106,18 +106,11 @@ public class LockManagers {
       return heartbeatThreads;
     }
 
-    /**
-     * Returns the shared scheduler for lock heartbeats.
-     *
-     * <p>Callers must not shut down this scheduler. It is shared across lock manager instances.
-     */
+    /** Returns the shared scheduler for lock heartbeats. */
     public ScheduledExecutorService scheduler() {
-      // The shared scheduler is intentionally never shut down by BaseLockManager#close(),
-      // but callers can still obtain and shut it down directly. Recreate it defensively if
-      // this happens to avoid RejectedExecutionException when scheduling heartbeats.
-      if (scheduler == null || scheduler.isShutdown()) {
+      if (scheduler == null) {
         synchronized (BaseLockManager.class) {
-          if (scheduler == null || scheduler.isShutdown()) {
+          if (scheduler == null) {
             scheduler =
                 MoreExecutors.getExitingScheduledExecutorService(
                     (ScheduledThreadPoolExecutor)

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -106,6 +106,11 @@ public class LockManagers {
       return heartbeatThreads;
     }
 
+    /**
+     * Returns the shared scheduler for lock heartbeats.
+     *
+     * <p>Callers must not shut down this scheduler. It is shared across lock manager instances.
+     */
     public ScheduledExecutorService scheduler() {
       // The shared scheduler is intentionally never shut down by BaseLockManager#close(),
       // but callers can still obtain and shut it down directly. Recreate it defensively if

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -18,11 +18,9 @@
  */
 package org.apache.iceberg.util;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -109,9 +107,12 @@ public class LockManagers {
     }
 
     public ScheduledExecutorService scheduler() {
-      if (scheduler == null) {
+      // The shared scheduler is intentionally never shut down by BaseLockManager#close(),
+      // but callers can still obtain and shut it down directly. Recreate it defensively if
+      // this happens to avoid RejectedExecutionException when scheduling heartbeats.
+      if (scheduler == null || scheduler.isShutdown()) {
         synchronized (BaseLockManager.class) {
-          if (scheduler == null) {
+          if (scheduler == null || scheduler.isShutdown()) {
             scheduler =
                 MoreExecutors.getExitingScheduledExecutorService(
                     (ScheduledThreadPoolExecutor)
@@ -159,16 +160,10 @@ public class LockManagers {
 
     @Override
     public void close() throws Exception {
-      if (scheduler != null) {
-        List<Runnable> tasks = scheduler.shutdownNow();
-        tasks.forEach(
-            task -> {
-              if (task instanceof Future) {
-                ((Future<?>) task).cancel(true);
-              }
-            });
-        scheduler = null;
-      }
+      // The scheduler is a shared static resource used across all BaseLockManager instances.
+      // Individual instances must not shut it down, as other instances may still be using it.
+      // The scheduler uses daemon threads and will be terminated at JVM exit by the shutdown
+      // hook registered via MoreExecutors.getExitingScheduledExecutorService.
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.CatalogProperties;
@@ -174,5 +175,17 @@ public class TestInMemoryLockManager {
     assertThat(results.stream().filter(s -> s).count())
         .as("only 1 thread should have acquired the lock")
         .isOne();
+  }
+
+  @Test
+  public void testAcquireSucceedsWhenSharedSchedulerWasShutDown() throws Exception {
+    ScheduledExecutorService sharedScheduler = lockManager.scheduler();
+
+    sharedScheduler.shutdownNow();
+    assertThat(sharedScheduler.isShutdown()).isTrue();
+
+    assertThat(lockManager.acquire(lockEntityId, ownerId))
+        .as("acquire must succeed even when the shared scheduler was previously shut down")
+        .isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.CatalogProperties;
@@ -177,15 +176,4 @@ public class TestInMemoryLockManager {
         .isOne();
   }
 
-  @Test
-  public void testAcquireSucceedsWhenSharedSchedulerWasShutDown() throws Exception {
-    ScheduledExecutorService sharedScheduler = lockManager.scheduler();
-
-    sharedScheduler.shutdownNow();
-    assertThat(sharedScheduler.isShutdown()).isTrue();
-
-    assertThat(lockManager.acquire(lockEntityId, ownerId))
-        .as("acquire must succeed even when the shared scheduler was previously shut down")
-        .isTrue();
-  }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
@@ -175,5 +175,4 @@ public class TestInMemoryLockManager {
         .as("only 1 thread should have acquired the lock")
         .isOne();
   }
-
 }


### PR DESCRIPTION
Closes #15861 
Closes #14165

---

Co-authored-by: Claude Sonnet 4.6