### PR TITLE
Docs: Fix missing semicolons in Java API Quickstart imports

### DIFF
--- a/docs/docs/java-api-quickstart.md
+++ b/docs/docs/java-api-quickstart.md
@@ -31,8 +31,8 @@ You can initialize a Hive catalog with a name and some properties.
 (see: [Catalog properties](configuration.md#catalog-properties))
 
 ```java
-import java.util.HashMap
-import java.util.Map
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.iceberg.hive.HiveCatalog;
 


### PR DESCRIPTION
The `Using a Hive catalog` code example in `docs/docs/java-api-quickstart.md` 
has two import statements missing semicolons:

- `import java.util.HashMap` → `import java.util.HashMap;`
- `import java.util.Map` → `import java.util.Map;`

All other import statements in the same file already have semicolons.
