### PR TITLE
Azure: Add scheduled refresh for storage credentials held by ADLSFileIO

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -25,10 +25,21 @@ import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
 import com.azure.storage.file.datalake.models.DataLakeStorageException;
 import com.azure.storage.file.datalake.models.ListPathsOptions;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -36,8 +47,13 @@ import org.apache.iceberg.io.DelegateFileIO;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.SerializableFunction;
 import org.apache.iceberg.util.SerializableMap;
@@ -47,13 +63,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** FileIO implementation backed by Azure Data Lake Storage Gen2. */
-public class ADLSFileIO implements DelegateFileIO {
+public class ADLSFileIO implements DelegateFileIO, SupportsStorageCredentials {
 
   private static final Logger LOG = LoggerFactory.getLogger(ADLSFileIO.class);
   private static final String DEFAULT_METRICS_IMPL =
       "org.apache.iceberg.hadoop.HadoopMetricsContext";
+  private static final String ROOT_PREFIX = "abfs";
 
   private static final HttpClient HTTP = HttpClient.createDefault();
+  private static volatile ScheduledExecutorService executorService;
 
   private AzureProperties azureProperties;
   private MetricsContext metrics = MetricsContext.nullMetrics();
@@ -61,6 +79,10 @@ public class ADLSFileIO implements DelegateFileIO {
   private VendedAdlsCredentialProvider vendedAdlsCredentialProvider;
   private SerializableFunction<ADLSLocation, DataLakeFileSystemClient> clientSupplier;
   private transient volatile Map<String, DataLakeFileSystemClient> clientCache;
+  private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
+  // use modifiable collection for Kryo serde
+  private volatile List<StorageCredential> storageCredentials = Lists.newArrayList();
+  private transient volatile ScheduledFuture<?> refreshFuture;
 
   /**
    * No-arg constructor to load the FileIO dynamically.
@@ -134,6 +156,9 @@ public class ADLSFileIO implements DelegateFileIO {
       synchronized (this) {
         if (clientCache == null) {
           clientCache = Maps.newConcurrentMap();
+          if (refreshFuture == null || refreshFuture.isCancelled() || refreshFuture.isDone()) {
+            scheduleCredentialRefresh();
+          }
         }
       }
     }
@@ -259,11 +284,105 @@ public class ADLSFileIO implements DelegateFileIO {
   }
 
   @Override
-  public void close() {
-    if (vendedAdlsCredentialProvider != null) {
-      vendedAdlsCredentialProvider.close();
+  public void setCredentials(List<StorageCredential> credentials) {
+    Preconditions.checkArgument(credentials != null, "Invalid storage credentials: null");
+    // stop any refresh that might be scheduled
+    if (refreshFuture != null) {
+      refreshFuture.cancel(true);
     }
 
-    DelegateFileIO.super.close();
+    // copy credentials into a modifiable collection for Kryo serde
+    this.storageCredentials = Lists.newArrayList(credentials);
+
+    // if the clients are already initialized, we need to allow them to be recreated
+    synchronized (this) {
+      if (clientCache != null) {
+        this.clientCache = null;
+      }
+    }
+  }
+
+  @Override
+  public List<StorageCredential> credentials() {
+    return ImmutableList.copyOf(storageCredentials);
+  }
+
+  private void scheduleCredentialRefresh() {
+    if (storageCredentials == null || storageCredentials.isEmpty()) {
+      return;
+    }
+
+    storageCredentials.stream()
+        .map(
+            cred ->
+                cred.config()
+                    .get(
+                        AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX
+                            + new ADLSLocation(cred.prefix()).storageAccount()))
+        .filter(Objects::nonNull)
+        .map(v -> Instant.ofEpochMilli(Long.parseLong(v)))
+        .min(Comparator.naturalOrder())
+        .ifPresent(
+            expiresAt -> {
+              Instant prefetchAt = expiresAt.minus(5, ChronoUnit.MINUTES);
+              long delay = Duration.between(Instant.now(), prefetchAt).toMillis();
+              this.refreshFuture =
+                  executorService()
+                      .schedule(this::refreshStorageCredentials, delay, TimeUnit.MILLISECONDS);
+            });
+  }
+
+  private void refreshStorageCredentials() {
+    if (isResourceClosed.get() || vendedAdlsCredentialProvider == null) {
+      return;
+    }
+
+    try {
+      List<StorageCredential> refreshed =
+          vendedAdlsCredentialProvider.fetchCredentials().credentials().stream()
+              .filter(c -> c.prefix().startsWith(ROOT_PREFIX))
+              .map(c -> StorageCredential.create(c.prefix(), c.config()))
+              .collect(Collectors.toList());
+
+      if (!refreshed.isEmpty() && !isResourceClosed.get()) {
+        this.storageCredentials = Lists.newArrayList(refreshed);
+        synchronized (this) {
+          this.clientCache = null;
+          scheduleCredentialRefresh();
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed to refresh storage credentials", e);
+    }
+  }
+
+  private static ScheduledExecutorService executorService() {
+    if (executorService == null) {
+      synchronized (ADLSFileIO.class) {
+        if (executorService == null) {
+          executorService =
+              ThreadPools.newExitingScheduledPool(
+                  "iceberg-adlsfileio-tasks", 1, Duration.ofSeconds(10));
+        }
+      }
+    }
+
+    return executorService;
+  }
+
+  @Override
+  public void close() {
+    if (isResourceClosed.compareAndSet(false, true)) {
+      if (vendedAdlsCredentialProvider != null) {
+        vendedAdlsCredentialProvider.close();
+      }
+
+      if (refreshFuture != null) {
+        refreshFuture.cancel(true);
+        refreshFuture = null;
+      }
+
+      DelegateFileIO.super.close();
+    }
   }
 }

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -315,6 +315,7 @@ public class ADLSFileIO implements DelegateFileIO, SupportsStorageCredentials {
     }
 
     storageCredentials.stream()
+        .filter(c -> c.prefix().startsWith(ROOT_PREFIX))
         .map(
             cred ->
                 cred.config()

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -25,10 +25,21 @@ import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
 import com.azure.storage.file.datalake.models.DataLakeStorageException;
 import com.azure.storage.file.datalake.models.ListPathsOptions;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -36,8 +47,13 @@ import org.apache.iceberg.io.DelegateFileIO;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.io.SupportsStorageCredentials;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.SerializableFunction;
 import org.apache.iceberg.util.SerializableMap;
@@ -47,13 +63,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** FileIO implementation backed by Azure Data Lake Storage Gen2. */
-public class ADLSFileIO implements DelegateFileIO {
+public class ADLSFileIO implements DelegateFileIO, SupportsStorageCredentials {
 
   private static final Logger LOG = LoggerFactory.getLogger(ADLSFileIO.class);
   private static final String DEFAULT_METRICS_IMPL =
       "org.apache.iceberg.hadoop.HadoopMetricsContext";
+  private static final String ROOT_PREFIX = "abfs";
 
   private static final HttpClient HTTP = HttpClient.createDefault();
+  private static volatile ScheduledExecutorService executorService;
 
   private AzureProperties azureProperties;
   private MetricsContext metrics = MetricsContext.nullMetrics();
@@ -61,6 +79,10 @@ public class ADLSFileIO implements DelegateFileIO {
   private VendedAdlsCredentialProvider vendedAdlsCredentialProvider;
   private SerializableFunction<ADLSLocation, DataLakeFileSystemClient> clientSupplier;
   private transient volatile Map<String, DataLakeFileSystemClient> clientCache;
+  private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
+  // use modifiable collection for Kryo serde
+  private volatile List<StorageCredential> storageCredentials = Lists.newArrayList();
+  private transient volatile ScheduledFuture<?> refreshFuture;
 
   /**
    * No-arg constructor to load the FileIO dynamically.
@@ -134,6 +156,9 @@ public class ADLSFileIO implements DelegateFileIO {
       synchronized (this) {
         if (clientCache == null) {
           clientCache = Maps.newConcurrentMap();
+          if (refreshFuture == null || refreshFuture.isCancelled() || refreshFuture.isDone()) {
+            scheduleCredentialRefresh();
+          }
         }
       }
     }
@@ -259,11 +284,107 @@ public class ADLSFileIO implements DelegateFileIO {
   }
 
   @Override
-  public void close() {
-    if (vendedAdlsCredentialProvider != null) {
-      vendedAdlsCredentialProvider.close();
+  public void setCredentials(List<StorageCredential> credentials) {
+    Preconditions.checkArgument(credentials != null, "Invalid storage credentials: null");
+    // stop any refresh that might be scheduled
+    if (refreshFuture != null) {
+      refreshFuture.cancel(true);
     }
 
-    DelegateFileIO.super.close();
+    // copy credentials into a modifiable collection for Kryo serde
+    this.storageCredentials = Lists.newArrayList(credentials);
+
+    // if the clients are already initialized, we need to allow them to be recreated
+    if (clientCache != null) {
+      synchronized (this) {
+        if (clientCache != null) {
+          this.clientCache = null;
+        }
+      }
+    }
+  }
+
+  @Override
+  public List<StorageCredential> credentials() {
+    return ImmutableList.copyOf(storageCredentials);
+  }
+
+  private void scheduleCredentialRefresh() {
+    if (storageCredentials == null || storageCredentials.isEmpty()) {
+      return;
+    }
+
+    storageCredentials.stream()
+        .map(
+            cred ->
+                cred.config()
+                    .get(
+                        AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX
+                            + new ADLSLocation(cred.prefix()).storageAccount()))
+        .filter(Objects::nonNull)
+        .map(v -> Instant.ofEpochMilli(Long.parseLong(v)))
+        .min(Comparator.naturalOrder())
+        .ifPresent(
+            expiresAt -> {
+              Instant prefetchAt = expiresAt.minus(5, ChronoUnit.MINUTES);
+              long delay = Duration.between(Instant.now(), prefetchAt).toMillis();
+              this.refreshFuture =
+                  executorService()
+                      .schedule(this::refreshStorageCredentials, delay, TimeUnit.MILLISECONDS);
+            });
+  }
+
+  private void refreshStorageCredentials() {
+    if (isResourceClosed.get() || vendedAdlsCredentialProvider == null) {
+      return;
+    }
+
+    try {
+      List<StorageCredential> refreshed =
+          vendedAdlsCredentialProvider.fetchCredentials().credentials().stream()
+              .filter(c -> c.prefix().startsWith(ROOT_PREFIX))
+              .map(c -> StorageCredential.create(c.prefix(), c.config()))
+              .collect(Collectors.toList());
+
+      if (!refreshed.isEmpty() && !isResourceClosed.get()) {
+        this.storageCredentials = Lists.newArrayList(refreshed);
+        synchronized (this) {
+          this.clientCache = null;
+          scheduleCredentialRefresh();
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed to refresh storage credentials", e);
+    }
+  }
+
+  private static ScheduledExecutorService executorService() {
+    if (executorService == null) {
+      synchronized (ADLSFileIO.class) {
+        if (executorService == null) {
+          executorService =
+              ThreadPools.newExitingScheduledPool(
+                  "iceberg-adlsfileio-tasks", 1, Duration.ofSeconds(10));
+        }
+      }
+    }
+
+    return executorService;
+  }
+
+  @Override
+  public void close() {
+    if (isResourceClosed.compareAndSet(false, true)) {
+      if (vendedAdlsCredentialProvider != null) {
+        vendedAdlsCredentialProvider.close();
+      }
+
+      if (refreshFuture != null) {
+        refreshFuture.cancel(true);
+        refreshFuture = null;
+      }
+
+      DelegateFileIO.super.close();
+    }
   }
 }

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/VendedAdlsCredentialProvider.java
@@ -169,7 +169,7 @@ public class VendedAdlsCredentialProvider implements Serializable, AutoCloseable
     return client;
   }
 
-  private LoadCredentialsResponse fetchCredentials() {
+  LoadCredentialsResponse fetchCredentials() {
     return httpClient()
         .get(
             credentialsEndpoint,

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
@@ -25,10 +25,14 @@ import static org.mockito.Mockito.when;
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.SerializableFunction;
 import org.junit.jupiter.api.Test;
@@ -245,6 +249,76 @@ public class TestADLSFileIO {
 
     assertThat(supplierInvocationCount.get()).isEqualTo(3);
     assertThat(client4).isSameAs(mockClient3);
+  }
+
+  @Test
+  public void setCredentialsRefreshesClients() {
+    AtomicInteger supplierInvocationCount = new AtomicInteger(0);
+
+    SerializableFunction<ADLSLocation, DataLakeFileSystemClient> supplier =
+        location -> {
+          supplierInvocationCount.incrementAndGet();
+          return mock(DataLakeFileSystemClient.class);
+        };
+
+    ADLSFileIO fileIO = new ADLSFileIO(supplier);
+
+    StorageCredential initialCredential =
+        StorageCredential.create(
+            "abfss://container@account.dfs.core.windows.net/dir",
+            ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account",
+                "initialSasToken",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + "account",
+                "1000"));
+
+    fileIO.setCredentials(ImmutableList.of(initialCredential));
+
+    DataLakeFileSystemClient initialClient =
+        fileIO.client("abfss://container@account.dfs.core.windows.net/path");
+    assertThat(supplierInvocationCount.get()).isEqualTo(1);
+
+    StorageCredential refreshedCredential =
+        StorageCredential.create(
+            "abfss://container@account.dfs.core.windows.net/dir",
+            ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account",
+                "refreshedSasToken",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + "account",
+                "2000"));
+
+    fileIO.setCredentials(ImmutableList.of(refreshedCredential));
+
+    DataLakeFileSystemClient refreshedClient =
+        fileIO.client("abfss://container@account.dfs.core.windows.net/path");
+    assertThat(supplierInvocationCount.get()).isEqualTo(2);
+    assertThat(refreshedClient).isNotSameAs(initialClient);
+
+    List<StorageCredential> credentials = fileIO.credentials();
+    assertThat(credentials).hasSize(1);
+    assertThat(credentials.get(0).config())
+        .containsEntry(AzureProperties.ADLS_SAS_TOKEN_PREFIX + "account", "refreshedSasToken")
+        .containsEntry(AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + "account", "2000");
+  }
+
+  @Test
+  public void noExceptionWhenClientCalledWithoutCredentials() {
+    DataLakeFileSystemClient mockClient = mock(DataLakeFileSystemClient.class);
+    AtomicInteger supplierInvocationCount = new AtomicInteger(0);
+
+    SerializableFunction<ADLSLocation, DataLakeFileSystemClient> supplier =
+        location -> {
+          supplierInvocationCount.incrementAndGet();
+          return mockClient;
+        };
+
+    ADLSFileIO fileIO = new ADLSFileIO(supplier);
+
+    DataLakeFileSystemClient client =
+        fileIO.client("abfss://container@account.dfs.core.windows.net/path");
+
+    assertThat(client).isSameAs(mockClient);
+    assertThat(supplierInvocationCount.get()).isEqualTo(1);
   }
 
   @Test

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIOCredentialRefresh.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIOCredentialRefresh.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.azure.adlsv2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.azure.AzureProperties;
+import org.apache.iceberg.io.StorageCredential;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
+import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
+import org.apache.iceberg.rest.responses.LoadCredentialsResponseParser;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.verify.VerificationTimes;
+
+class TestADLSFileIOCredentialRefresh {
+
+  private static final String STORAGE_ACCOUNT = "account1";
+  private static final String CREDENTIAL_PREFIX =
+      "abfss://container@account1.dfs.core.windows.net/dir";
+
+  private static ClientAndServer mockServer;
+  private static String credentialsUri;
+  private static String catalogUri;
+
+  @BeforeAll
+  static void beforeAll() {
+    mockServer = startClientAndServer(0);
+    int port = mockServer.getPort();
+    credentialsUri = String.format("http://127.0.0.1:%d/v1/credentials", port);
+    catalogUri = String.format("http://127.0.0.1:%d/v1", port);
+  }
+
+  @AfterAll
+  static void stopServer() {
+    mockServer.stop();
+  }
+
+  @BeforeEach
+  void before() {
+    mockServer.reset();
+  }
+
+  @Test
+  void credentialRefreshWithinFiveMinuteWindow() {
+    String nearExpiryMs = Long.toString(Instant.now().plus(3, ChronoUnit.MINUTES).toEpochMilli());
+
+    StorageCredential initialCredential =
+        StorageCredential.create(
+            CREDENTIAL_PREFIX,
+            ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                "initialSasToken",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                nearExpiryMs));
+
+    String refreshedExpiryMs =
+        Long.toString(Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli());
+    LoadCredentialsResponse refreshResponse =
+        ImmutableLoadCredentialsResponse.builder()
+            .addCredentials(
+                ImmutableCredential.builder()
+                    .prefix(CREDENTIAL_PREFIX)
+                    .config(
+                        ImmutableMap.of(
+                            AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                            "refreshedSasToken",
+                            AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                            refreshedExpiryMs))
+                    .build())
+            .build();
+
+    HttpRequest mockRequest = request("/v1/credentials").withMethod("GET");
+    HttpResponse mockResponse =
+        response(LoadCredentialsResponseParser.toJson(refreshResponse)).withStatusCode(200);
+    mockServer.when(mockRequest).respond(mockResponse);
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT,
+            credentialsUri,
+            CatalogProperties.URI,
+            catalogUri);
+
+    try (ADLSFileIO fileIO = new ADLSFileIO()) {
+      fileIO.initialize(properties);
+      fileIO.setCredentials(List.of(initialCredential));
+
+      // trigger client cache initialization which schedules the credential refresh
+      fileIO.client("abfss://container@account1.dfs.core.windows.net/file");
+
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(() -> mockServer.verify(mockRequest, VerificationTimes.atLeast(1)));
+
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(
+              () -> {
+                List<StorageCredential> credentials = fileIO.credentials();
+                assertThat(credentials).hasSize(1);
+                assertThat(credentials.get(0).config())
+                    .containsEntry(
+                        AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                        "refreshedSasToken")
+                    .containsEntry(
+                        AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                        refreshedExpiryMs);
+              });
+    }
+  }
+
+  @Test
+  void credentialRefreshSchedulesNextRefresh() {
+    String nearExpiryMs = Long.toString(Instant.now().plus(3, ChronoUnit.MINUTES).toEpochMilli());
+
+    StorageCredential initialCredential =
+        StorageCredential.create(
+            CREDENTIAL_PREFIX,
+            ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                "initialSasToken",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                nearExpiryMs));
+
+    // return credentials that also expire within 5 minutes so the next refresh fires immediately
+    String firstRefreshExpiryMs =
+        Long.toString(Instant.now().plus(2, ChronoUnit.MINUTES).toEpochMilli());
+    String secondRefreshExpiryMs =
+        Long.toString(Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli());
+
+    LoadCredentialsResponse firstRefreshResponse =
+        ImmutableLoadCredentialsResponse.builder()
+            .addCredentials(
+                ImmutableCredential.builder()
+                    .prefix(CREDENTIAL_PREFIX)
+                    .config(
+                        ImmutableMap.of(
+                            AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                            "firstRefreshedSasToken",
+                            AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                            firstRefreshExpiryMs))
+                    .build())
+            .build();
+
+    LoadCredentialsResponse secondRefreshResponse =
+        ImmutableLoadCredentialsResponse.builder()
+            .addCredentials(
+                ImmutableCredential.builder()
+                    .prefix(CREDENTIAL_PREFIX)
+                    .config(
+                        ImmutableMap.of(
+                            AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                            "secondRefreshedSasToken",
+                            AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                            secondRefreshExpiryMs))
+                    .build())
+            .build();
+
+    HttpRequest mockRequest = request("/v1/credentials").withMethod("GET");
+    mockServer
+        .when(mockRequest, org.mockserver.matchers.Times.once())
+        .respond(
+            response(LoadCredentialsResponseParser.toJson(firstRefreshResponse))
+                .withStatusCode(200));
+    mockServer
+        .when(mockRequest, org.mockserver.matchers.Times.unlimited())
+        .respond(
+            response(LoadCredentialsResponseParser.toJson(secondRefreshResponse))
+                .withStatusCode(200));
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT,
+            credentialsUri,
+            CatalogProperties.URI,
+            catalogUri);
+
+    try (ADLSFileIO fileIO = new ADLSFileIO()) {
+      fileIO.initialize(properties);
+      fileIO.setCredentials(List.of(initialCredential));
+
+      fileIO.client("abfss://container@account1.dfs.core.windows.net/file");
+
+      // the first refresh returns near-expiry credentials, which should schedule a second refresh
+      Awaitility.await()
+          .atMost(30, TimeUnit.SECONDS)
+          .untilAsserted(() -> mockServer.verify(mockRequest, VerificationTimes.atLeast(2)));
+
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(
+              () -> {
+                List<StorageCredential> credentials = fileIO.credentials();
+                assertThat(credentials).hasSize(1);
+                assertThat(credentials.get(0).config())
+                    .containsEntry(
+                        AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                        "secondRefreshedSasToken")
+                    .containsEntry(
+                        AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                        secondRefreshExpiryMs);
+              });
+    }
+  }
+
+  @Test
+  void noDuplicateRefreshAfterClientCacheRebuild() {
+    String nearExpiryMs = Long.toString(Instant.now().plus(3, ChronoUnit.MINUTES).toEpochMilli());
+
+    StorageCredential initialCredential =
+        StorageCredential.create(
+            CREDENTIAL_PREFIX,
+            ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                "initialSasToken",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                nearExpiryMs));
+
+    String refreshedExpiryMs =
+        Long.toString(Instant.now().plus(30, ChronoUnit.MINUTES).toEpochMilli());
+    LoadCredentialsResponse refreshResponse =
+        ImmutableLoadCredentialsResponse.builder()
+            .addCredentials(
+                ImmutableCredential.builder()
+                    .prefix(CREDENTIAL_PREFIX)
+                    .config(
+                        ImmutableMap.of(
+                            AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                            "refreshedSasToken",
+                            AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                            refreshedExpiryMs))
+                    .build())
+            .build();
+
+    HttpRequest mockRequest = request("/v1/credentials").withMethod("GET");
+    mockServer
+        .when(mockRequest)
+        .respond(
+            response(LoadCredentialsResponseParser.toJson(refreshResponse)).withStatusCode(200));
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT,
+            credentialsUri,
+            CatalogProperties.URI,
+            catalogUri);
+
+    try (ADLSFileIO fileIO = new ADLSFileIO()) {
+      fileIO.initialize(properties);
+      fileIO.setCredentials(List.of(initialCredential));
+
+      fileIO.client("abfss://container@account1.dfs.core.windows.net/file");
+
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(
+              () ->
+                  assertThat(fileIO.credentials().get(0).config())
+                      .containsEntry(
+                          AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                          "refreshedSasToken"));
+
+      // rebuilding the client cache should not schedule a duplicate refresh
+      fileIO.client("abfss://container@account1.dfs.core.windows.net/file");
+
+      Thread.sleep(3_000);
+      mockServer.verify(mockRequest, VerificationTimes.exactly(1));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Test
+  void clientCacheInvalidatedAfterBackgroundRefresh() {
+    String nearExpiryMs = Long.toString(Instant.now().plus(3, ChronoUnit.MINUTES).toEpochMilli());
+
+    StorageCredential initialCredential =
+        StorageCredential.create(
+            CREDENTIAL_PREFIX,
+            ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                "initialSasToken",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                nearExpiryMs));
+
+    String refreshedExpiryMs =
+        Long.toString(Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli());
+    LoadCredentialsResponse refreshResponse =
+        ImmutableLoadCredentialsResponse.builder()
+            .addCredentials(
+                ImmutableCredential.builder()
+                    .prefix(CREDENTIAL_PREFIX)
+                    .config(
+                        ImmutableMap.of(
+                            AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                            "refreshedSasToken",
+                            AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                            refreshedExpiryMs))
+                    .build())
+            .build();
+
+    HttpRequest mockRequest = request("/v1/credentials").withMethod("GET");
+    mockServer
+        .when(mockRequest)
+        .respond(
+            response(LoadCredentialsResponseParser.toJson(refreshResponse)).withStatusCode(200));
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT,
+            credentialsUri,
+            CatalogProperties.URI,
+            catalogUri);
+
+    try (ADLSFileIO fileIO = new ADLSFileIO()) {
+      fileIO.initialize(properties);
+      fileIO.setCredentials(List.of(initialCredential));
+
+      String path = "abfss://container@account1.dfs.core.windows.net/file";
+      DataLakeFileSystemClient clientBeforeRefresh = fileIO.client(path);
+
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(
+              () ->
+                  assertThat(fileIO.credentials().get(0).config())
+                      .containsEntry(
+                          AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                          "refreshedSasToken"));
+
+      DataLakeFileSystemClient clientAfterRefresh = fileIO.client(path);
+      assertThat(clientAfterRefresh).isNotSameAs(clientBeforeRefresh);
+    }
+  }
+}

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIOCredentialRefresh.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIOCredentialRefresh.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.azure.adlsv2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -365,6 +366,78 @@ class TestADLSFileIOCredentialRefresh {
 
       DataLakeFileSystemClient clientAfterRefresh = fileIO.client(path);
       assertThat(clientAfterRefresh).isNotSameAs(clientBeforeRefresh);
+    }
+  }
+
+  @Test
+  void credentialRefreshIgnoresCredentialsForOtherStorageSchemes() {
+    String nearExpiryMs = Long.toString(Instant.now().plus(3, ChronoUnit.MINUTES).toEpochMilli());
+
+    // ResolvingFileIO hands every SupportsStorageCredentials instance the full, unfiltered
+    // credential list, so a credential for another storage scheme must not break ADLSFileIO
+    StorageCredential nonAdlsCredential =
+        StorageCredential.create("s3://bucket/dir", ImmutableMap.of("s3.access-key-id", "keyId"));
+
+    StorageCredential adlsCredential =
+        StorageCredential.create(
+            CREDENTIAL_PREFIX,
+            ImmutableMap.of(
+                AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                "initialSasToken",
+                AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                nearExpiryMs));
+
+    String refreshedExpiryMs =
+        Long.toString(Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli());
+    LoadCredentialsResponse refreshResponse =
+        ImmutableLoadCredentialsResponse.builder()
+            .addCredentials(
+                ImmutableCredential.builder()
+                    .prefix(CREDENTIAL_PREFIX)
+                    .config(
+                        ImmutableMap.of(
+                            AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                            "refreshedSasToken",
+                            AzureProperties.ADLS_SAS_TOKEN_EXPIRES_AT_MS_PREFIX + STORAGE_ACCOUNT,
+                            refreshedExpiryMs))
+                    .build())
+            .build();
+
+    HttpRequest mockRequest = request("/v1/credentials").withMethod("GET");
+    HttpResponse mockResponse =
+        response(LoadCredentialsResponseParser.toJson(refreshResponse)).withStatusCode(200);
+    mockServer.when(mockRequest).respond(mockResponse);
+
+    Map<String, String> properties =
+        ImmutableMap.of(
+            AzureProperties.ADLS_REFRESH_CREDENTIALS_ENDPOINT,
+            credentialsUri,
+            CatalogProperties.URI,
+            catalogUri);
+
+    try (ADLSFileIO fileIO = new ADLSFileIO()) {
+      fileIO.initialize(properties);
+      fileIO.setCredentials(List.of(nonAdlsCredential, adlsCredential));
+
+      // scheduling the refresh must not fail while parsing the non-ADLS prefix
+      assertThatCode(() -> fileIO.client("abfss://container@account1.dfs.core.windows.net/file"))
+          .doesNotThrowAnyException();
+
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(() -> mockServer.verify(mockRequest, VerificationTimes.atLeast(1)));
+
+      Awaitility.await()
+          .atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(
+              () -> {
+                List<StorageCredential> credentials = fileIO.credentials();
+                assertThat(credentials).hasSize(1);
+                assertThat(credentials.get(0).config())
+                    .containsEntry(
+                        AzureProperties.ADLS_SAS_TOKEN_PREFIX + STORAGE_ACCOUNT,
+                        "refreshedSasToken");
+              });
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -622,6 +622,7 @@ project(':iceberg-azure') {
     testImplementation libs.mockserver.netty
     testImplementation libs.mockserver.client.java
     testImplementation libs.mockito.junit.jupiter
+    testImplementation libs.awaitility
   }
 
   sourceSets {


### PR DESCRIPTION
Closes #15852.

The `ADLSFileIO` implementation never refreshes the credentials that are held directly from the table load. The ADLS clients use a `VendedAdlsCredentialProvider` that internally refreshes via `SimpleTokenCache`, but those updates are not reflected back to the FileIO.

If an `ADLSFileIO` instance is serialized to remote workers, the credentials may be expired triggering a thundering herd of requests to refresh immediately.

This change addresses this problem by proactively updating the credentials in the FileIO so that only valid credentials are propagated to remote clients.

This applies the same changes as was already done for S3FileIO in https://github.com/apache/iceberg/pull/15678 and GCSFileIO in https://github.com/apache/iceberg/pull/15696.