### PR TITLE
Open API: Fix LICENSE and NOTICE files

### DIFF
--- a/open-api/LICENSE
+++ b/open-api/LICENSE
@@ -460,6 +460,13 @@ License: Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/e
 
 --------------------------------------------------------------------------------
 
+This product bundles Jakarta Servlet API.
+
+Project URL: https://projects.eclipse.org/projects/ee4j.servlet
+License: Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+
+--------------------------------------------------------------------------------
+
 This product bundles JUnit.
 Project URL: https://junit.org/junit5/
 License: Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
@@ -527,6 +534,41 @@ License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 This product bundles AWS EventStream for Java.
 Project URL: https://github.com/awslabs/aws-eventstream-java
 License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Bouncy Castle Provider.
+
+Project URL: https://www.bouncycastle.org/java.html
+License: MIT - https://www.bouncycastle.org/about/license/
+LICENSE
+Copyright (c) 2000 - 2023 The Legion of the Bouncy
+Castle Inc. (https://www.bouncycastle.org)
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions of
+the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT
+WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
@@ -965,6 +1007,27 @@ License: MIT
 | LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 | OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 | THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+This product bundles JCIP Annotations.
+
+Project URL: http://stephenc.github.com/jcip-annotations
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Android Annotations.
+
+Project URL: http://source.android.com/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Nimbus Jose JWT.
+
+Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 

--- a/open-api/LICENSE
+++ b/open-api/LICENSE
@@ -339,556 +339,773 @@ License: https://www.apache.org/licenses/LICENSE-2.0
 
 This product bundles Jackson JSON Processor.
 
+Copyright: 2007-2020 Tatu Saloranta and other contributors
 Project URL: https://github.com/FasterXML/jackson
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.18.0
-Project URL: https://github.com/FasterXML/jackson
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Caffeine by Ben Manes.
+Copyright: 2014-2020 Ben Manes and contributors
+Project URL: https://github.com/ben-manes/caffeine
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+
+--------------------------------------------------------------------------------
+This product bundles Google Error Prone Annotations.
+Copyright: Copyright 2011-2019 The Error Prone Authors
+Project URL: https://github.com/google/error-prone
+License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.0
-Project URL: https://github.com/FasterXML/jackson-core
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.18.0
-Project URL: https://github.com/FasterXML/jackson
-License (from POM): Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.github.ben-manes.caffeine  Name: caffeine  Version: 2.9.3
-Project URL (from POM): https://github.com/ben-manes/caffeine
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-Group: com.google.errorprone  Name: error_prone_annotations  Version: 2.10.0
-License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: commons-codec  Name: commons-codec  Version: 1.17.0
+This product bundles Apache Commons Codec.
 Project URL: https://commons.apache.org/proper/commons-codec/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: commons-io  Name: commons-io  Version: 2.16.1
+This product bundles Apache Commons IO.
 Project URL: https://commons.apache.org/proper/commons-io/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: dev.failsafe  Name: failsafe  Version: 3.3.2
-License (from POM): Apache License, Version 2.0 - http://apache.org/licenses/LICENSE-2.0
+This product bundles failsafe.
+Copyright: Jonathan Halterman and friends
+Project URL: https://failsafe.dev/
+License: Apache License, Version 2.0 - http://apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.airlift  Name: aircompressor  Version: 2.0.3
-Project URL (from POM): https://github.com/airlift/aircompressor
-License (from POM): Apache License 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
+This product bundles Airlift Aircompressor.
+Copyright: 2011-2020 Aircompressor authors.
+Project URL: https://github.com/airlift/aircompressor
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.avro  Name: avro  Version: 1.12.0
+This product bundles Apache Avro.
+Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://avro.apache.org
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.commons  Name: commons-compress  Version: 1.26.2
+This product bundles Apache Commons Compress.
 Project URL: https://commons.apache.org/proper/commons-compress/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.commons  Name: commons-lang3  Version: 3.14.0
+This product bundles Apache Commons Lang.
 Project URL: https://commons.apache.org/proper/commons-lang/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.commons  Name: commons-configuration2  Version: 2.10.1
+This product bundles Apache Commons Configuration.
 Project URL: https://commons.apache.org/proper/commons-configuration/
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.hadoop  Name: hadoop-common  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Apache Hadoop.
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.hadoop  Name: hadoop-auth  Version: 3.3.6
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Apache HttpComponents (core and client).
+Copyright: 1999-2022 The Apache Software Foundation.
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.httpcomponents.client5  Name: httpclient5  Version: 5.4.3
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles checkerframework checker-qual.
+Copyright: 2004-2020 the Checker Framework developers
+Project URL: https://github.com/typetools/checker-framework
+License: MIT
+| The annotations are licensed under the MIT License.  (The text of this
+| license appears below.)  More specifically, all the parts of the Checker
+| Framework that you might want to include with your own program use the
+| MIT License.  This is the checker-qual.jar file and all the files that
+| appear in it:  every file in a qual/ directory, plus utility files such
+| as NullnessUtil.java, RegexUtil.java, SignednessUtil.java, etc.
+| In addition, the cleanroom implementations of third-party annotations,
+| which the Checker Framework recognizes as aliases for its own
+| annotations, are licensed under the MIT License.
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: org.apache.httpcomponents.core5  Name: httpcore5  Version: 5.3
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
-Group: org.apache.httpcomponents.core5  Name: httpcore5-h2  Version: 5.3
-License (from POM): Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.checkerframework  Name: checker-qual  Version: 3.19.0
-Project URL (from POM): https://checkerframework.org
-License (from POM): The MIT License - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-http  Version: 11.0.25
+This product bundles Eclipse Jetty.
 Project URL: https://eclipse.dev/jetty/
-License (from POM): Apache Software License - Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 2.0 - https://www.eclipse.org/legal/epl-2.0/
+License: Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.eclipse.jetty  Name: jetty-io  Version: 11.0.25
-Project URL: https://eclipse.dev/jetty/
-License (from POM): Apache Software License - Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 2.0 - https://www.eclipse.org/legal/epl-2.0/
+This product bundles JUnit.
+Project URL: https://junit.org/junit5/
+License: Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.eclipse.jetty  Name: jetty-security  Version: 11.0.25
-Project URL: https://eclipse.dev/jetty/
-License (from POM): Apache Software License - Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 2.0 - https://www.eclipse.org/legal/epl-2.0/
+This product bundles OpenTest4J.
+Project URL: https://github.com/ota4j-team/opentest4j
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.eclipse.jetty  Name: jetty-server  Version: 11.0.25
-Project URL: https://eclipse.dev/jetty/
-License (from POM): Apache Software License - Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 2.0 - https://www.eclipse.org/legal/epl-2.0/
+This product bundles RoaringBitmap.
+Copyright: (c) 2013-... the RoaringBitmap authors
+Project URL: https://github.com/RoaringBitmap/RoaringBitmap
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: org.eclipse.jetty  Name: jetty-servlet  Version: 11.0.25
-Project URL: https://eclipse.dev/jetty/
-License (from POM): Apache Software License - Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 2.0 - https://www.eclipse.org/legal/epl-2.0/
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty  Name: jetty-util  Version: 11.0.25
-Project URL: https://eclipse.dev/jetty/
-License (from POM): Apache Software License - Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 2.0 - https://www.eclipse.org/legal/epl-2.0/
-
---------------------------------------------------------------------------------
-
-Group: org.eclipse.jetty.toolchain  Name: jetty-jakarta-servlet-api  Version: 5.0.2
-Project URL (from POM): https://eclipse.org/jetty
-License (from POM): Apache Software License - Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
-License (from POM): Eclipse Public License - Version 1.0 - http://www.eclipse.org/org/documents/epl-v10.php
-
---------------------------------------------------------------------------------
-
-Group: org.junit  Name: junit-bom  Version: 5.11.3
-Project URL (from POM): https://junit.org/junit5/
-License (from POM): Eclipse Public License v2.0 - https://www.eclipse.org/legal/epl-v20.html
-
---------------------------------------------------------------------------------
-
-Group: org.junit.jupiter  Name: junit-jupiter  Version: 5.11.3
-Project URL (from POM): https://junit.org/junit5/
-License (from POM): Eclipse Public License v2.0 - https://www.eclipse.org/legal/epl-v20.html
-
---------------------------------------------------------------------------------
-
-Group: org.junit.jupiter  Name: junit-jupiter-api  Version: 5.11.3
-Project URL (from POM): https://junit.org/junit5/
-License (from POM): Eclipse Public License v2.0 - https://www.eclipse.org/legal/epl-v20.html
-
---------------------------------------------------------------------------------
-
-Group: org.junit.jupiter  Name: junit-jupiter-engine  Version: 5.11.3
-Project URL (from POM): https://junit.org/junit5/
-License (from POM): Eclipse Public License v2.0 - https://www.eclipse.org/legal/epl-v20.html
-
---------------------------------------------------------------------------------
-
-Group: org.junit.jupiter  Name: junit-jupiter-params  Version: 5.11.3
-Project URL (from POM): https://junit.org/junit5/
-License (from POM): Eclipse Public License v2.0 - https://www.eclipse.org/legal/epl-v20.html
-
---------------------------------------------------------------------------------
-
-Group: org.junit.platform  Name: junit-platform-commons  Version: 1.11.3
-Project URL (from POM): https://junit.org/junit5/
-License (from POM): Eclipse Public License v2.0 - https://www.eclipse.org/legal/epl-v20.html
-
---------------------------------------------------------------------------------
-
-Group: org.junit.platform  Name: junit-platform-engine  Version: 1.11.3
-Project URL (from POM): https://junit.org/junit5/
-License (from POM): Eclipse Public License v2.0 - https://www.eclipse.org/legal/epl-v20.html
-
---------------------------------------------------------------------------------
-
-Group: org.opentest4j  Name: opentest4j  Version: 1.3.0
-Project URL (from POM): https://github.com/ota4j-team/opentest4j
-License (from POM): The Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.roaringbitmap  Name: RoaringBitmap  Version: 1.6.10
-Project URL (from POM): https://github.com/RoaringBitmap/RoaringBitmap
-License (from POM): Apache 2 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.slf4j  Name: slf4j-api  Version: 2.0.17
+This product bundles SLF4J.
 Project URL: http://www.slf4j.org
-License (from POM): MIT License - http://www.opensource.org/licenses/mit-license.php
+License: MIT
+| Copyright (c) 2004-2025 QOS.ch
+|  All rights reserved.
+| 
+|  Permission is hereby granted, free  of charge, to any person obtaining
+|  a  copy  of this  software  and  associated  documentation files  (the
+|  "Software"), to  deal in  the Software without  restriction, including
+|  without limitation  the rights to  use, copy, modify,  merge, publish,
+|  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+|  permit persons to whom the Software  is furnished to do so, subject to
+|  the following conditions:
+| 
+|  The  above  copyright  notice  and  this permission  notice  shall  be
+|  included in all copies or substantial portions of the Software.
+| 
+|  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+|  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+|  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+|  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+|  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+|  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+|  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: org.xerial  Name: sqlite-jdbc  Version: 3.47.0.0
-Project URL (from POM): https://github.com/xerial/sqlite-jdbc
-License (from POM): The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles SQLite JDBC.
+Project URL: https://github.com/xerial/sqlite-jdbc
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: annotations  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles AWS SDK for Java.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: apache-client  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles AWS SDK CRT for Java.
+Project URL: https://aws.amazon.com/sdkforjava
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: arns  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles AWS EventStream for Java.
+Project URL: https://github.com/awslabs/aws-eventstream-java
+License: Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: auth  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google API Common.
+License: BSD 3-Clause
+| Copyright 2016, Google Inc.
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|    * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-core  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google GAX.
+Project URL: https://github.com/googleapis/gax-java
+License: BSD 3-Clause
+| Copyright 2016, Google Inc. All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-json-protocol  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google API Client.
+Project URL: https://developers.google.com/api-client-library/java/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-query-protocol  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google API gRPC.
+Project URL: https://github.com/googleapis/java-bigquerystorage/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: aws-xml-protocol  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google APIs.
+Project URL: https://github.com/googleapis/googleapis
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Auth Library.
+License: BSD 3-Clause
+| Copyright 2014, Google Inc. All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|    * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+| 
+|    * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: checksums-spi  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Auto Value.
+Project URL: https://github.com/google/auto/tree/master/value
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: crt-core  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Cloud APIs for Java.
+Project URL: https://github.com/googleapis/google-cloud-java
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: dynamodb  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Cloud Storage.
+Project URL: https://github.com/googleapis/java-storage
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: endpoints-spi  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Azure SDK for Java.
+
+Project URL: https://github.com/Azure/azure-sdk-for-java
+License: MIT
+| The MIT License (MIT)
+| 
+| Copyright (c) 2015 Microsoft
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: glue  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Netty.
+
+Project URL: https://netty.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Reactor Core.
+
+Project URL: https://github.com/reactor/reactor-core
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Reactor Netty.
+
+Project URL: https://github.com/reactor/reactor-netty
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-aws-eventstream  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Reactive Streams.
+
+Project URL: http://reactive-streams.org/
+License: MIT
+| MIT No Attribution
+| 
+| Copyright 2014 Reactive Streams
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-auth-spi  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles JCTools (via Netty).
+
+Project URL: https://github.com/JCTools/JCTools
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: http-client-spi  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Cloud BigQuery Client for Java.
+
+Project URL: https://github.com/googleapis/java-bigquery
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: iam  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles GCS Analytics.
+
+Project URL: https://github.com/GoogleCloudPlatform/gcs-analytics-core
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: identity-spi  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Cloud APIs.
+
+Project URL: https://github.com/googleapis/java-core
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: json-utils  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Gson.
+
+Project URL: https://github.com/google/gson/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: kms  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Findbugs jsr305.
+
+Project URL: http://findbugs.sourceforge.net/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: lakeformation  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google flatbuffers.
+
+Project URL: https://github.com/google/flatbuffers
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: metrics-spi  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Guava.
+
+Project URL: https://github.com/google/guava/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: netty-nio-client  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google Http Client.
+
+Project URL: https://www.google.com/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: profiles  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google j2objc.
+
+Project URL: https://github.com/google/j2objc/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: protocol-core  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google OAuth Client.
+
+Project URL: https://www.google.com/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: regions  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Google protobuf.
+
+Project URL: https://developers.google.com/protocol-buffers/
+License: BSD 3-Clause
+| Copyright 2008 Google Inc.  All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+| 
+|     * Redistributions of source code must retain the above copyright
+| notice, this list of conditions and the following disclaimer.
+|     * Redistributions in binary form must reproduce the above
+| copyright notice, this list of conditions and the following disclaimer
+| in the documentation and/or other materials provided with the
+| distribution.
+|     * Neither the name of Google Inc. nor the names of its
+| contributors may be used to endorse or promote products derived from
+| this software without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+| OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+| SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+| LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+| DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+| THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: retries  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles gRPC.
+
+Project URL: https://github.com/grpc/grpc-java
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: retries-spi  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles OpenCensus.
+
+Project URL: https://github.com/census-instrumentation/opencensus-java
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: s3  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles OpenTelemetry.
+
+Project URL: https://opentelemetry.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sdk-core  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Apache Arrow.
+
+Project URL: https://arrow.apache.org
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sso  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles org.json.
+
+Project URL: https://github.com/douglascrockford/JSON-java
+License: Public Domain - https://github.com/stleary/JSON-java/blob/master/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: sts  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Apache Commons Logging.
+
+Project URL: http://commons.apache.org/proper/commons-logging/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: third-party-jackson-core  Version: 2.29.6
-Project URL (from POM): https://aws.amazon.com/sdkforjava
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Apache Commons Net.
+
+Project URL: https://commons.apache.org/proper/commons-net/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.awssdk  Name: utils  Version: 2.29.6
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Apache Commons Collections.
+
+Project URL: http://commons.apache.org/collections/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: software.amazon.eventstream  Name: eventstream  Version: 1.0.1
-Project URL (from POM): https://github.com/awslabs/aws-eventstream-java
-License (from POM): Apache License, Version 2.0 - https://aws.amazon.com/apache2.0
+This product bundles Apache Commons Math.
+
+Project URL: http://commons.apache.org/math/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: api-common  Version: 2.40.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD-3-Clause - https://github.com/googleapis/api-common-java/blob/main/LICENSE
+This product bundles Apache Commons Text.
+
+Project URL: https://commons.apache.org/proper/commons-text
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: gax  Version: 2.57.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+This product bundles Apache Log4j.
+
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: gax-grpc  Version: 2.57.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+This product bundles Jettison.
+
+Project URL: https://github.com/jettison-json/jettison
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api  Name: gax-httpjson  Version: 2.57.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD-3-Clause - https://github.com/googleapis/gax-java/blob/master/LICENSE
+This product bundles Jakarta Activation API.
+
+Project URL: https://www.eclipse.org
+License: Eclipse Public License v. 2.0 - https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api-client  Name: google-api-client  Version: 2.7.0
-Project URL (from manifest): https://developers.google.com/api-client-library/java/
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Javax Servlet API.
+
+Project URL: http://servlet-spec.java.net
+License: CDDL 1.1 - https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: gapic-google-cloud-storage-v2  Version: 2.44.1-beta
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Javax Annotation API.
+
+Project URL: https://javaee.github.io/glassfish
+License: CDDL 1.1 - https://github.com/javaee/javax.annotation/blob/master/LICENSE
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: grpc-google-cloud-storage-v2  Version: 2.44.1-beta
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Animal Sniffer Annotations.
+
+License: MIT
+| The MIT License
+| 
+| Copyright (c) 2009 codehaus.org.
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in
+| all copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+| THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: proto-google-cloud-storage-v2  Version: 2.44.1-beta
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Conscrypt (openjdk-uber).
+
+Project URL: https://conscrypt.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: proto-google-common-protos  Version: 2.48.0
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles ThreeTen BP.
+
+Project URL: https://www.threeten.org/threetenbp
+License: BSD 3-Clause
+| Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos.
+| 
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+| 
+| * Redistributions of source code must retain the above copyright notice,
+|   this list of conditions and the following disclaimer.
+| 
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+| 
+| * Neither the name of JSR-310 nor the names of its contributors
+|   may be used to endorse or promote products derived from this software
+|   without specific prior written permission.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.api.grpc  Name: proto-google-iam-v1  Version: 1.43.0
-Project URL (from POM): https://github.com/googleapis/sdk-platform-java
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles ThreeTen Extra.
+
+Project URL: https://www.threeten.org/threeten-extra
+License: BSD 3-Clause
+| All rights reserved.
+|
+| * Redistribution and use in source and binary forms, with or without
+|   modification, are permitted provided that the following conditions are met:
+|
+| * Redistributions of source code must retain the above copyright notice,
+|   this list of conditions and the following disclaimer.
+|
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+|
+| * Neither the name of JSR-310 nor the names of its contributors
+|   may be used to endorse or promote products derived from this software
+|   without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.apis  Name: google-api-services-storage  Version: v1-rev20241008-2.0.0
-License (from POM): The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Stax2 API.
+
+Project URL: http://github.com/FasterXML/stax2-api
+License: BSD 2-Clause
+| BSD 2-Clause License
+| 
+| Copyright (c) 2008+, FasterXML, LLC
+| All rights reserved.
+| 
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are met:
+| 
+| * Redistributions of source code must retain the above copyright notice, this
+|   list of conditions and the following disclaimer.
+| 
+| * Redistributions in binary form must reproduce the above copyright notice,
+|   this list of conditions and the following disclaimer in the documentation
+|   and/or other materials provided with the distribution.
+| 
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+| FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+| DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+| SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+| CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+| OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.google.auth  Name: google-auth-library-credentials  Version: 1.29.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD New license - http://opensource.org/licenses/BSD-3-Clause
+This product bundles Woodstox.
+
+Project URL: https://github.com/FasterXML/woodstox
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.google.auth  Name: google-auth-library-oauth2-http  Version: 1.29.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-License (from POM): BSD New license - http://opensource.org/licenses/BSD-3-Clause
-
---------------------------------------------------------------------------------
-
-Group: com.google.auto.value  Name: auto-value-annotations  Version: 1.11.0
-Project URL (from POM): https://github.com/google/auto/tree/main/value
-License (from POM): Apache 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core  Version: 2.47.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core-grpc  Version: 2.47.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-core-http  Version: 2.47.0
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.google.cloud  Name: google-cloud-storage  Version: 2.47.1
-Project URL (from POM): https://github.com/googleapis/java-storage
-License (from POM): Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-Group: com.microsoft.azure  Name: msal4j  Version: 1.17.2
-Project URL (from manifest): https://github.com/AzureAD/microsoft-authentication-library-for-java
-Manifest License: "MIT License" (Not packaged)
-Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
-License (from POM): MIT License
---------------------------------------------------------------------------------
-
-Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.3.0
-Project URL (from POM): https://github.com/AzureAD/microsoft-authentication-library-for-java
-License (from POM): MIT License
+This product bundles Microsoft Authentication Library for Java.
+Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
+License: MIT
+|     MIT License
+| 
+|     Copyright (c) Microsoft Corporation. All rights reserved.
+| 
+|     Permission is hereby granted, free of charge, to any person obtaining a copy
+|     of this software and associated documentation files (the "Software"), to deal
+|     in the Software without restriction, including without limitation the rights
+|     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+|     copies of the Software, and to permit persons to whom the Software is
+|     furnished to do so, subject to the following conditions:
+| 
+|     The above copyright notice and this permission notice shall be included in all
+|     copies or substantial portions of the Software.
+| 
+|     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+|     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+|     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+|     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+|     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+|     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+|     SOFTWARE
 --------------------------------------------------------------------------------

--- a/open-api/NOTICE
+++ b/open-api/NOTICE
@@ -7,8 +7,54 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
+This product bundles Apache Parquet Format with the following in its NOTICE file:
+| Apache Parquet Format
+| Copyright 2022 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This product bundles Jakarta Activation API with the following in its NOTICE file:
+| # Notices for Eclipse Project for JAF
+|
+| This content is produced and maintained by the Eclipse Project for JAF project.
+|
+| * Project home: https://projects.eclipse.org/projects/ee4j.jaf
+|
+| ## Copyright
+|
+| All content is the property of the respective authors or their employers. For
+| more information regarding authorship of content, please consult the listed
+| source code repository logs.
+|
+| ## Declared Project Licenses
+|
+| This program and the accompanying materials are made available under the terms
+| of the Eclipse Distribution License v. 1.0,
+| which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+|
+| SPDX-License-Identifier: BSD-3-Clause
+|
+| ## Source Code
+|
+| The project maintains the following source code repositories:
+|
+| * https://github.com/eclipse-ee4j/jaf
+|
+| ## Third-party Content
+|
+| This project leverages the following third party content.
+|
+| JUnit (4.12)
+|
+| * License: Eclipse Public License
+
+--------------------------------------------------------------------------------
+
 This project includes code from Kite, developed at Cloudera, Inc. with
-the following copyright notice:
+the following in its NOTICE file:
 
 | Copyright 2013 Cloudera Inc.
 |
@@ -26,228 +72,254 @@ the following copyright notice:
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains code from the following projects:
-
---------------------------------------------------------------------------------
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
-and the licenses and copyrights that apply to that code.
-
---------------------------------------------------------------------------------
-Apache Commons Codec
-Copyright 2002-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-Apache Commons IO
-Copyright 2002-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-Apache Avro
-Copyright 2009-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-Apache Commons Compress
-Copyright 2002-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-Apache Commons Lang
-Copyright 2001-2023 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-Apache Commons Configuration
-Copyright 2001-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-Apache HttpClient
-Copyright 1999-2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-Apache HttpComponents Core HTTP/1.1
-Copyright 2005-2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
-Apache HttpComponents Core HTTP/2
-Copyright 2005-2021 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
+This product bundles Jackson JSON Processor with the following in its NOTICE file:
+| # Jackson JSON processor
+|
+| Jackson is a high-performance, Free/Open Source JSON processing library.
+| It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+| been in development since 2007.
+| It is currently developed by a community of developers.
+|
+| ## Copyright
+|
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+|
+| ## Licensing
+|
+| Jackson 2.x core and extension components are licensed under Apache License 2.0
+| To find the details that apply to this artifact see the accompanying LICENSE file.
+|
+| ## Credits
+|
+| A list of contributors may be found from CREDITS(-2.x) file, which is included
+| in some artifacts (usually source distributions); but is always available
+| from the source code management (SCM) system project uses.
+|
+| ## FastDoubleParser
+|
+| jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+| That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+| under the following copyright.
+|
+| Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+|
+| See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+| and the licenses and copyrights that apply to that code.
 
 --------------------------------------------------------------------------------
 
-Apache Hadoop
-Copyright 2006 and onwards The Apache Software Foundation.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-Export Control Notice
----------------------
-
-This distribution includes cryptographic software.  The country in
-which you currently reside may have restrictions on the import,
-possession, use, and/or re-export to another country, of
-encryption software.  BEFORE using any encryption software, please
-check your country's laws, regulations and policies concerning the
-import, possession, or use, and re-export of encryption software, to
-see if this is permitted.  See <http://www.wassenaar.org/> for more
-information.
-
-The U.S. Government Department of Commerce, Bureau of Industry and
-Security (BIS), has classified this software as Export Commodity
-Control Number (ECCN) 5D002.C.1, which includes information security
-software using or performing cryptographic functions with asymmetric
-algorithms.  The form and manner of this Apache Software Foundation
-distribution makes it eligible for export under the License Exception
-ENC Technology Software Unrestricted (TSU) exception (see the BIS
-Export Administration Regulations, Section 740.13) for both object
-code and source code.
-
-The following provides more details on the included cryptographic software:
-
-This software uses the SSL libraries from the Jetty project written
-by mortbay.org.
-Hadoop Yarn Server Web Proxy uses the BouncyCastle Java
-cryptography APIs written by the Legion of the Bouncy Castle Inc.
+This product bundles Apache Commons Codec with the following in its NOTICE file:
+| Apache Commons Codec
+| Copyright 2002-2024 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-Notices for Eclipse Jetty
-=========================
-This content is produced and maintained by the Eclipse Jetty project.
+This product bundles Apache Commons IO with the following in its NOTICE file:
+| Apache Commons IO
+| Copyright 2002-2024 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-Project home: https://jetty.org/
+--------------------------------------------------------------------------------
 
-Trademarks
-----------
-Eclipse Jetty, and Jetty are trademarks of the Eclipse Foundation.
+This product bundles Apache Avro with the following in its NOTICE file:
+| Apache Avro
+| Copyright 2009-2024 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-Copyright
----------
-All contributions are the property of the respective authors or of
-entities to which copyright has been assigned by the authors (eg. employer).
+--------------------------------------------------------------------------------
 
-Declared Project Licenses
--------------------------
-This artifacts of this project are made available under the terms of:
+This product bundles Apache Commons Compress with the following in its NOTICE file:
+| Apache Commons Compress
+| Copyright 2002-2024 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-  * the Eclipse Public License v2.0
-    https://www.eclipse.org/legal/epl-2.0
-    SPDX-License-Identifier: EPL-2.0
+--------------------------------------------------------------------------------
 
-  or
+This product bundles Apache Commons Lang with the following in its NOTICE file:
+| Apache Commons Lang
+| Copyright 2001-2023 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-  * the Apache License, Version 2.0
-    https://www.apache.org/licenses/LICENSE-2.0
-    SPDX-License-Identifier: Apache-2.0
+--------------------------------------------------------------------------------
 
-The following dependencies are EPL.
- * org.eclipse.jetty.orbit:org.eclipse.jdt.core
+This product bundles Apache Commons Configuration with the following in its NOTICE file:
+| Apache Commons Configuration
+| Copyright 2001-2024 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-The following dependencies are EPL and ASL2.
- * org.eclipse.jetty.orbit:javax.security.auth.message
+--------------------------------------------------------------------------------
 
-The following dependencies are EPL and CDDL 1.0.
- * org.eclipse.jetty.orbit:javax.mail.glassfish
+This product bundles Apache HttpClient with the following in its NOTICE file:
+| Apache HttpClient
+| Copyright 1999-2021 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-The following dependencies are CDDL + GPLv2 with classpath exception.
-https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+--------------------------------------------------------------------------------
 
- * jakarta.servlet:jakarta.servlet-api
- * javax.annotation:javax.annotation-api
- * javax.transaction:javax.transaction-api
- * javax.websocket:javax.websocket-api
+This product bundles Apache HttpComponents Core HTTP/1.1 with the following in its NOTICE file:
+| Apache HttpComponents Core HTTP/1.1
+| Copyright 2005-2021 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-The following dependencies are licensed by the OW2 Foundation according to the
-terms of http://asm.ow2.org/license.html
+--------------------------------------------------------------------------------
 
- * org.ow2.asm:asm-commons
- * org.ow2.asm:asm
+This product bundles Apache HttpComponents Core HTTP/2 with the following in its NOTICE file:
+| Apache HttpComponents Core HTTP/2
+| Copyright 2005-2021 The Apache Software Foundation
+|
+| This product includes software developed at
+| The Apache Software Foundation (https://www.apache.org/).
 
-The following dependencies are ASL2 licensed.
+--------------------------------------------------------------------------------
 
- * org.apache.taglibs:taglibs-standard-spec
- * org.apache.taglibs:taglibs-standard-impl
+This product bundles Apache Hadoop with the following in its NOTICE file:
+| Apache Hadoop
+| Copyright 2006 and onwards The Apache Software Foundation.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Export Control Notice
+| ---------------------
+|
+| This distribution includes cryptographic software.  The country in
+| which you currently reside may have restrictions on the import,
+| possession, use, and/or re-export to another country, of
+| encryption software.  BEFORE using any encryption software, please
+| check your country's laws, regulations and policies concerning the
+| import, possession, or use, and re-export of encryption software, to
+| see if this is permitted.  See <http://www.wassenaar.org/> for more
+| information.
+|
+| The U.S. Government Department of Commerce, Bureau of Industry and
+| Security (BIS), has classified this software as Export Commodity
+| Control Number (ECCN) 5D002.C.1, which includes information security
+| software using or performing cryptographic functions with asymmetric
+| algorithms.  The form and manner of this Apache Software Foundation
+| distribution makes it eligible for export under the License Exception
+| ENC Technology Software Unrestricted (TSU) exception (see the BIS
+| Export Administration Regulations, Section 740.13) for both object
+| code and source code.
+|
+| The following provides more details on the included cryptographic software:
+|
+| This software uses the SSL libraries from the Jetty project written
+| by mortbay.org.
+| Hadoop Yarn Server Web Proxy uses the BouncyCastle Java
+| cryptography APIs written by the Legion of the Bouncy Castle Inc.
 
-The following dependencies are ASL2 licensed.  Based on selected classes from
-following Apache Tomcat jars, all ASL2 licensed.
+--------------------------------------------------------------------------------
 
- * org.mortbay.jasper:apache-jsp
- * org.apache.tomcat:tomcat-jasper
- * org.apache.tomcat:tomcat-juli
- * org.apache.tomcat:tomcat-jsp-api
- * org.apache.tomcat:tomcat-el-api
- * org.apache.tomcat:tomcat-jasper-el
- * org.apache.tomcat:tomcat-api
- * org.apache.tomcat:tomcat-util-scan
- * org.apache.tomcat:tomcat-util
- * org.mortbay.jasper:apache-el
- * org.apache.tomcat:tomcat-jasper-el
- * org.apache.tomcat:tomcat-el-api
-
-The following artifacts are CDDL + GPLv2 with classpath exception.
-https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
-
- * org.eclipse.jetty.toolchain:jetty-schemas
-
-Cryptography
-------------
-Content may contain encryption software. The country in which you are currently
-may have restrictions on the import, possession, and use, and/or re-export to
-another country, of encryption software. BEFORE using any encryption software,
-please check the country's laws, regulations and policies concerning the import,
-possession, or use, and re-export of encryption software, to see if this is
-permitted.
-
-The UnixCrypt.java code implements the one way cryptography used by
-Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,
-modified April 2001  by Iris Van den Broeke, Daniel Deville.
-Permission to use, copy, modify and distribute UnixCrypt
-for non-commercial or commercial purposes and without fee is
-granted provided that the copyright notice appears in all copies.
+This product bundles Jetty with the following in its NOTICE file:
+| Notices for Eclipse Jetty
+| =========================
+| This content is produced and maintained by the Eclipse Jetty project.
+|
+| Project home: https://jetty.org/
+|
+| Trademarks
+| ----------
+| Eclipse Jetty, and Jetty are trademarks of the Eclipse Foundation.
+|
+| Copyright
+| ---------
+| All contributions are the property of the respective authors or of
+| entities to which copyright has been assigned by the authors (eg. employer).
+|
+| Declared Project Licenses
+| -------------------------
+| This artifacts of this project are made available under the terms of:
+|
+|   * the Eclipse Public License v2.0
+|     https://www.eclipse.org/legal/epl-2.0
+|     SPDX-License-Identifier: EPL-2.0
+|
+|   or
+|
+|   * the Apache License, Version 2.0
+|     https://www.apache.org/licenses/LICENSE-2.0
+|     SPDX-License-Identifier: Apache-2.0
+|
+| The following dependencies are EPL.
+|  * org.eclipse.jetty.orbit:org.eclipse.jdt.core
+|
+| The following dependencies are EPL and ASL2.
+|  * org.eclipse.jetty.orbit:javax.security.auth.message
+|
+| The following dependencies are EPL and CDDL 1.0.
+|  * org.eclipse.jetty.orbit:javax.mail.glassfish
+|
+| The following dependencies are CDDL + GPLv2 with classpath exception.
+| https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+|
+|  * jakarta.servlet:jakarta.servlet-api
+|  * javax.annotation:javax.annotation-api
+|  * javax.transaction:javax.transaction-api
+|  * javax.websocket:javax.websocket-api
+|
+| The following dependencies are licensed by the OW2 Foundation according to the
+| terms of http://asm.ow2.org/license.html
+|
+|  * org.ow2.asm:asm-commons
+|  * org.ow2.asm:asm
+|
+| The following dependencies are ASL2 licensed.
+|
+|  * org.apache.taglibs:taglibs-standard-spec
+|  * org.apache.taglibs:taglibs-standard-impl
+|
+| The following dependencies are ASL2 licensed.  Based on selected classes from
+| following Apache Tomcat jars, all ASL2 licensed.
+|
+|  * org.mortbay.jasper:apache-jsp
+|  * org.apache.tomcat:tomcat-jasper
+|  * org.apache.tomcat:tomcat-juli
+|  * org.apache.tomcat:tomcat-jsp-api
+|  * org.apache.tomcat:tomcat-el-api
+|  * org.apache.tomcat:tomcat-jasper-el
+|  * org.apache.tomcat:tomcat-api
+|  * org.apache.tomcat:tomcat-util-scan
+|  * org.apache.tomcat:tomcat-util
+|  * org.mortbay.jasper:apache-el
+|  * org.apache.tomcat:tomcat-jasper-el
+|  * org.apache.tomcat:tomcat-el-api
+|
+| The following artifacts are CDDL + GPLv2 with classpath exception.
+| https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html
+|
+|  * org.eclipse.jetty.toolchain:jetty-schemas
+|
+| Cryptography
+| ------------
+| Content may contain encryption software. The country in which you are currently
+| may have restrictions on the import, possession, and use, and/or re-export to
+| another country, of encryption software. BEFORE using any encryption software,
+| please check the country's laws, regulations and policies concerning the import,
+| possession, or use, and re-export of encryption software, to see if this is
+| permitted.
+|
+| The UnixCrypt.java code implements the one way cryptography used by
+| Unix systems for simple password protection.  Copyright 1996 Aki Yoshida,
+| modified April 2001  by Iris Van den Broeke, Daniel Deville.
+| Permission to use, copy, modify and distribute UnixCrypt
+| for non-commercial or commercial purposes and without fee is
+| granted provided that the copyright notice appears in all copies.
 
 --------------------------------------------------------------------------------

--- a/open-api/NOTICE
+++ b/open-api/NOTICE
@@ -7,15 +7,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet Format with the following in its NOTICE file:
-| Apache Parquet Format
-| Copyright 2022 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-
 This product bundles Jakarta Activation API with the following in its NOTICE file:
 | # Notices for Eclipse Project for JAF
 |
@@ -106,88 +97,7 @@ This product bundles Jackson JSON Processor with the following in its NOTICE fil
 | See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
 | and the licenses and copyrights that apply to that code.
 
---------------------------------------------------------------------------------
-
-This product bundles Apache Commons Codec with the following in its NOTICE file:
-| Apache Commons Codec
-| Copyright 2002-2024 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product bundles Apache Commons IO with the following in its NOTICE file:
-| Apache Commons IO
-| Copyright 2002-2024 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product bundles Apache Avro with the following in its NOTICE file:
-| Apache Avro
-| Copyright 2009-2024 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product bundles Apache Commons Compress with the following in its NOTICE file:
-| Apache Commons Compress
-| Copyright 2002-2024 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product bundles Apache Commons Lang with the following in its NOTICE file:
-| Apache Commons Lang
-| Copyright 2001-2023 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product bundles Apache Commons Configuration with the following in its NOTICE file:
-| Apache Commons Configuration
-| Copyright 2001-2024 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product bundles Apache HttpClient with the following in its NOTICE file:
-| Apache HttpClient
-| Copyright 1999-2021 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product bundles Apache HttpComponents Core HTTP/1.1 with the following in its NOTICE file:
-| Apache HttpComponents Core HTTP/1.1
-| Copyright 2005-2021 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product bundles Apache HttpComponents Core HTTP/2 with the following in its NOTICE file:
-| Apache HttpComponents Core HTTP/2
-| Copyright 2005-2021 The Apache Software Foundation
-|
-| This product includes software developed at
-| The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------
 
 This product bundles Apache Hadoop with the following in its NOTICE file:
 | Apache Hadoop


### PR DESCRIPTION
Align LICENSE and NOTICE files with changes in #15449.

@codex also identified some missing licenses and notices.