### PR TITLE
Core: Introduce default values in RESTCatalogProperties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
@@ -28,7 +28,7 @@ public final class RESTCatalogProperties {
   private RESTCatalogProperties() {}
 
   public static final String SNAPSHOT_LOADING_MODE = "snapshot-loading-mode";
-  public static final String SNAPSHOT_LOADING_MODE_DEFAULT = SnapshotMode.ALL.name();
+  public static final SnapshotMode SNAPSHOT_LOADING_MODE_DEFAULT = SnapshotMode.ALL;
   public static final String SNAPSHOTS_QUERY_PARAMETER = "snapshots";
 
   public static final String METRICS_REPORTING_ENABLED = "rest-metrics-reporting-enabled";
@@ -42,10 +42,13 @@ public final class RESTCatalogProperties {
   public static final String PAGE_SIZE = "rest-page-size";
 
   public static final String NAMESPACE_SEPARATOR = "namespace-separator";
+  public static final String NAMESPACE_SEPARATOR_DEFAULT =
+      RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8;
 
   // Configure scan planning mode
   // Can be set by server in LoadTableResponse.config() for table-level override
   public static final String SCAN_PLANNING_MODE = "scan-planning-mode";
+  public static final ScanPlanningMode SCAN_PLANNING_MODE_DEFAULT = ScanPlanningMode.CLIENT;
 
   public static final String REST_SCAN_PLAN_ID = "rest-scan-plan-id";
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -265,7 +265,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             PropertyUtil.propertyAsString(
                     mergedProps,
                     RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
-                    RESTCatalogProperties.SNAPSHOT_LOADING_MODE_DEFAULT)
+                    RESTCatalogProperties.SNAPSHOT_LOADING_MODE_DEFAULT.name())
                 .toUpperCase(Locale.US));
 
     this.reporter = CatalogUtil.loadMetricsReporter(mergedProps);
@@ -279,7 +279,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         PropertyUtil.propertyAsString(
             mergedProps,
             RESTCatalogProperties.NAMESPACE_SEPARATOR,
-            RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
+            RESTCatalogProperties.NAMESPACE_SEPARATOR_DEFAULT);
 
     this.tableCache = createTableCache(mergedProps);
     this.closeables.addCloseable(this.tableCache);
@@ -615,7 +615,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     RESTCatalogProperties.ScanPlanningMode effectiveMode =
         effectiveModeConfig != null
             ? RESTCatalogProperties.ScanPlanningMode.fromString(effectiveModeConfig)
-            : RESTCatalogProperties.ScanPlanningMode.CLIENT;
+            : RESTCatalogProperties.SCAN_PLANNING_MODE_DEFAULT;
 
     if (effectiveMode == RESTCatalogProperties.ScanPlanningMode.SERVER) {
       Preconditions.checkState(

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -57,7 +57,7 @@ public class ResourcePaths {
         PropertyUtil.propertyAsString(
             properties,
             RESTCatalogProperties.NAMESPACE_SEPARATOR,
-            RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8));
+            RESTCatalogProperties.NAMESPACE_SEPARATOR_DEFAULT));
   }
 
   public static String config() {

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -746,7 +746,7 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
         queryParams
             .getOrDefault(
                 RESTCatalogProperties.SNAPSHOTS_QUERY_PARAMETER,
-                RESTCatalogProperties.SNAPSHOT_LOADING_MODE_DEFAULT)
+                RESTCatalogProperties.SNAPSHOT_LOADING_MODE_DEFAULT.name())
             .toUpperCase(Locale.US));
   }
 }


### PR DESCRIPTION
NAMESPACE_SEPARATOR and SCAN_PLANNING_MODE doesn't have their default values in RESTCatalogProperties. To improve code readability, this change introduces their default to be at the same place.