### PR TITLE
Core, Spark: Migrate Spark table properties to Spark module

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -358,33 +358,33 @@ public class TableProperties {
   public static final long DELETE_TARGET_FILE_SIZE_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
 
   /**
-   * @deprecated will be removed in 1.12.0, use
+   * @deprecated will be removed in 1.13.0, use
    *     SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED in iceberg-spark instead.
    */
   @Deprecated
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
 
   /**
-   * @deprecated will be removed in 1.12.0, use
+   * @deprecated will be removed in 1.13.0, use
    *     SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT in iceberg-spark instead.
    */
   @Deprecated public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
 
   /**
-   * @deprecated will be removed in 1.12.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA in
+   * @deprecated will be removed in 1.13.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA in
    *     iceberg-spark instead.
    */
   @Deprecated
   public static final String SPARK_WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
 
   /**
-   * @deprecated will be removed in 1.12.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA_DEFAULT
+   * @deprecated will be removed in 1.13.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA_DEFAULT
    *     in iceberg-spark instead.
    */
   @Deprecated public static final boolean SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
 
   /**
-   * @deprecated will be removed in 1.12.0, use SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION in
+   * @deprecated will be removed in 1.13.0, use SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION in
    *     iceberg-spark instead.
    */
   @Deprecated
@@ -392,13 +392,13 @@ public class TableProperties {
       "write.spark.auto-schema-evolution.enabled";
 
   /**
-   * @deprecated will be removed in 1.12.0, use
+   * @deprecated will be removed in 1.13.0, use
    *     SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT in iceberg-spark instead.
    */
   @Deprecated public static final boolean SPARK_WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT = true;
 
   /**
-   * @deprecated will be removed in 1.12.0, use
+   * @deprecated will be removed in 1.13.0, use
    *     SparkTableProperties.WRITE_ADVISORY_PARTITION_SIZE_BYTES in iceberg-spark instead.
    */
   @Deprecated

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -358,33 +358,33 @@ public class TableProperties {
   public static final long DELETE_TARGET_FILE_SIZE_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
 
   /**
-   * @deprecated will be removed in 1.13.0, use
+   * @deprecated will be removed in 1.14.0, use
    *     SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED in iceberg-spark instead.
    */
   @Deprecated
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
 
   /**
-   * @deprecated will be removed in 1.13.0, use
+   * @deprecated will be removed in 1.14.0, use
    *     SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT in iceberg-spark instead.
    */
   @Deprecated public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
 
   /**
-   * @deprecated will be removed in 1.13.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA in
+   * @deprecated will be removed in 1.14.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA in
    *     iceberg-spark instead.
    */
   @Deprecated
   public static final String SPARK_WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
 
   /**
-   * @deprecated will be removed in 1.13.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA_DEFAULT
+   * @deprecated will be removed in 1.14.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA_DEFAULT
    *     in iceberg-spark instead.
    */
   @Deprecated public static final boolean SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
 
   /**
-   * @deprecated will be removed in 1.13.0, use SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION in
+   * @deprecated will be removed in 1.14.0, use SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION in
    *     iceberg-spark instead.
    */
   @Deprecated
@@ -392,13 +392,13 @@ public class TableProperties {
       "write.spark.auto-schema-evolution.enabled";
 
   /**
-   * @deprecated will be removed in 1.13.0, use
+   * @deprecated will be removed in 1.14.0, use
    *     SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT in iceberg-spark instead.
    */
   @Deprecated public static final boolean SPARK_WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT = true;
 
   /**
-   * @deprecated will be removed in 1.13.0, use
+   * @deprecated will be removed in 1.14.0, use
    *     SparkTableProperties.WRITE_ADVISORY_PARTITION_SIZE_BYTES in iceberg-spark instead.
    */
   @Deprecated

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -357,16 +357,51 @@ public class TableProperties {
   public static final String DELETE_TARGET_FILE_SIZE_BYTES = "write.delete.target-file-size-bytes";
   public static final long DELETE_TARGET_FILE_SIZE_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB
 
+  /**
+   * @deprecated will be removed in 1.12.0, use
+   *     SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED in iceberg-spark instead.
+   */
+  @Deprecated
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
-  public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
 
+  /**
+   * @deprecated will be removed in 1.12.0, use
+   *     SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT in iceberg-spark instead.
+   */
+  @Deprecated public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
+
+  /**
+   * @deprecated will be removed in 1.12.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA in
+   *     iceberg-spark instead.
+   */
+  @Deprecated
   public static final String SPARK_WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
-  public static final boolean SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
 
+  /**
+   * @deprecated will be removed in 1.12.0, use SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA_DEFAULT
+   *     in iceberg-spark instead.
+   */
+  @Deprecated public static final boolean SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
+
+  /**
+   * @deprecated will be removed in 1.12.0, use SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION in
+   *     iceberg-spark instead.
+   */
+  @Deprecated
   public static final String SPARK_WRITE_AUTO_SCHEMA_EVOLUTION =
       "write.spark.auto-schema-evolution.enabled";
-  public static final boolean SPARK_WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT = true;
 
+  /**
+   * @deprecated will be removed in 1.12.0, use
+   *     SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT in iceberg-spark instead.
+   */
+  @Deprecated public static final boolean SPARK_WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT = true;
+
+  /**
+   * @deprecated will be removed in 1.12.0, use
+   *     SparkTableProperties.WRITE_ADVISORY_PARTITION_SIZE_BYTES in iceberg-spark instead.
+   */
+  @Deprecated
   public static final String SPARK_WRITE_ADVISORY_PARTITION_SIZE_BYTES =
       "write.spark.advisory-partition-size-bytes";
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -34,11 +34,11 @@ import static org.apache.iceberg.TableProperties.DELETE_PLANNING_MODE;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.ORC_VECTORIZATION_ENABLED;
 import static org.apache.iceberg.TableProperties.PARQUET_VECTORIZATION_ENABLED;
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -172,7 +172,7 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         fileFormat,
         WRITE_DISTRIBUTION_MODE,
         distributionMode,
-        SPARK_WRITE_PARTITIONED_FANOUT_ENABLED,
+        WRITE_PARTITIONED_FANOUT_ENABLED,
         String.valueOf(fanoutEnabled),
         DATA_PLANNING_MODE,
         planningMode.modeName(),

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkTableProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+/** Spark-specific table properties that control Spark integration behavior. */
+public class SparkTableProperties {
+
+  private SparkTableProperties() {}
+
+  public static final String WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
+  public static final boolean WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
+
+  public static final String WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
+  public static final boolean WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
+
+  public static final String WRITE_AUTO_SCHEMA_EVOLUTION =
+      "write.spark.auto-schema-evolution.enabled";
+  public static final boolean WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT = true;
+
+  public static final String WRITE_ADVISORY_PARTITION_SIZE_BYTES =
+      "write.spark.advisory-partition-size-bytes";
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -228,7 +228,7 @@ public class SparkWriteConf {
     return confParser
         .booleanConf()
         .option(SparkWriteOptions.FANOUT_ENABLED)
-        .tableProperty(TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED)
+        .tableProperty(SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED)
         .defaultValue(defaultValue)
         .parse();
   }
@@ -717,7 +717,7 @@ public class SparkWriteConf {
         .longConf()
         .option(SparkWriteOptions.ADVISORY_PARTITION_SIZE)
         .sessionConf(SparkSQLProperties.ADVISORY_PARTITION_SIZE)
-        .tableProperty(TableProperties.SPARK_WRITE_ADVISORY_PARTITION_SIZE_BYTES)
+        .tableProperty(SparkTableProperties.WRITE_ADVISORY_PARTITION_SIZE_BYTES)
         .defaultValue(defaultValue)
         .parse();
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -59,6 +59,7 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkTableProperties;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
@@ -156,8 +157,8 @@ public class SparkTable
     boolean acceptAnySchema =
         PropertyUtil.propertyAsBoolean(
             icebergTable.properties(),
-            TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA,
-            TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT);
+            SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA,
+            SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA_DEFAULT);
     this.capabilities = acceptAnySchema ? CAPABILITIES_WITH_ACCEPT_ANY_SCHEMA : CAPABILITIES;
     this.isTableRewrite = isTableRewrite;
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -20,12 +20,12 @@ package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.TableProperties.DELETE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.MERGE_DISTRIBUTION_MODE;
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.TableProperties.UPDATE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.DELETE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.UPDATE;
@@ -3020,10 +3020,10 @@ public class TestSparkDistributionAndOrderingUtil extends TestBaseWithCatalog {
   }
 
   private void disableFanoutWriters(Table table) {
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "false").commit();
+    table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "false").commit();
   }
 
   private void enableFanoutWriters(Table table) {
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+    table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -25,9 +25,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkTableProperties;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -60,7 +60,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaFailsWithoutWriterOption() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -119,7 +119,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaSparkProperty() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -153,7 +153,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaIcebergProperty() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -190,7 +190,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
         .sql(
             String.format(
                 "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-                tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA))
+                tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA))
         .collect();
 
     String schema = "ID bigint, DaTa string";
@@ -220,7 +220,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaSparkConfiguration() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
     Dataset<Row> twoColDF =
         jsonToDF(
             "id bigint, data string",
@@ -255,7 +255,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaIgnoreCastingLongToInt() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> bigintDF =
         jsonToDF(
@@ -297,7 +297,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
     sql("CREATE TABLE %s (id double, data string) USING iceberg", tableName);
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> doubleDF =
         jsonToDF(
@@ -339,7 +339,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
     sql("CREATE TABLE %s (id decimal(6,2), data string) USING iceberg", tableName);
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> decimalPrecision6DF =
         jsonToDF(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.spark.source;
 
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -624,7 +624,7 @@ public class TestSparkDataWrite {
             .save(location.toString());
         break;
       case TABLE:
-        table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+        table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
         df.select("id", "data")
             .write()
             .format("iceberg")

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -34,11 +34,11 @@ import static org.apache.iceberg.TableProperties.DELETE_PLANNING_MODE;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.ORC_VECTORIZATION_ENABLED;
 import static org.apache.iceberg.TableProperties.PARQUET_VECTORIZATION_ENABLED;
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -172,7 +172,7 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         fileFormat,
         WRITE_DISTRIBUTION_MODE,
         distributionMode,
-        SPARK_WRITE_PARTITIONED_FANOUT_ENABLED,
+        WRITE_PARTITIONED_FANOUT_ENABLED,
         String.valueOf(fanoutEnabled),
         DATA_PLANNING_MODE,
         planningMode.modeName(),

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkTableProperties.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkTableProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+/** Spark-specific table properties that control Spark integration behavior. */
+public class SparkTableProperties {
+
+  private SparkTableProperties() {}
+
+  public static final String WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
+  public static final boolean WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
+
+  public static final String WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
+  public static final boolean WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
+
+  public static final String WRITE_AUTO_SCHEMA_EVOLUTION =
+      "write.spark.auto-schema-evolution.enabled";
+  public static final boolean WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT = true;
+
+  public static final String WRITE_ADVISORY_PARTITION_SIZE_BYTES =
+      "write.spark.advisory-partition-size-bytes";
+}

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -232,7 +232,7 @@ public class SparkWriteConf {
     return confParser
         .booleanConf()
         .option(SparkWriteOptions.FANOUT_ENABLED)
-        .tableProperty(TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED)
+        .tableProperty(SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED)
         .defaultValue(defaultValue)
         .parse();
   }
@@ -731,7 +731,7 @@ public class SparkWriteConf {
         .longConf()
         .option(SparkWriteOptions.ADVISORY_PARTITION_SIZE)
         .sessionConf(SparkSQLProperties.ADVISORY_PARTITION_SIZE)
-        .tableProperty(TableProperties.SPARK_WRITE_ADVISORY_PARTITION_SIZE_BYTES)
+        .tableProperty(SparkTableProperties.WRITE_ADVISORY_PARTITION_SIZE_BYTES)
         .defaultValue(defaultValue)
         .parse();
   }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -38,7 +38,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -60,6 +59,7 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkTableProperties;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
@@ -157,8 +157,8 @@ public class SparkTable
     boolean acceptAnySchema =
         PropertyUtil.propertyAsBoolean(
             icebergTable.properties(),
-            TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA,
-            TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT);
+            SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA,
+            SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA_DEFAULT);
     this.capabilities = acceptAnySchema ? CAPABILITIES_WITH_ACCEPT_ANY_SCHEMA : CAPABILITIES;
     this.isTableRewrite = isTableRewrite;
   }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.exceptions.ValidationException;

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -20,12 +20,12 @@ package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.TableProperties.DELETE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.MERGE_DISTRIBUTION_MODE;
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.TableProperties.UPDATE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.DELETE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.UPDATE;
@@ -3020,10 +3020,10 @@ public class TestSparkDistributionAndOrderingUtil extends TestBaseWithCatalog {
   }
 
   private void disableFanoutWriters(Table table) {
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "false").commit();
+    table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "false").commit();
   }
 
   private void enableFanoutWriters(Table table) {
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+    table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
   }
 }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -25,10 +25,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkTableProperties;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -61,7 +61,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaFailsWithoutWriterOption() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -120,7 +120,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaSparkProperty() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -154,7 +154,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaIcebergProperty() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -196,7 +196,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
         .sql(
             String.format(
                 "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-                tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA))
+                tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA))
         .collect();
 
     String schema = "ID bigint, DaTa string";
@@ -226,7 +226,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaSparkConfiguration() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
     Dataset<Row> twoColDF =
         jsonToDF(
             "id bigint, data string",
@@ -261,7 +261,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaIgnoreCastingLongToInt() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> bigintDF =
         jsonToDF(
@@ -303,7 +303,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
     sql("CREATE TABLE %s (id double, data string) USING iceberg", tableName);
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> doubleDF =
         jsonToDF(
@@ -345,7 +345,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
     sql("CREATE TABLE %s (id decimal(6,2), data string) USING iceberg", tableName);
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> decimalPrecision6DF =
         jsonToDF(

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.spark.source;
 
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -624,7 +624,7 @@ public class TestSparkDataWrite {
             .save(location.toString());
         break;
       case TABLE:
-        table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+        table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
         df.select("id", "data")
             .write()
             .format("iceberg")

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -34,11 +34,11 @@ import static org.apache.iceberg.TableProperties.DELETE_PLANNING_MODE;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.ORC_VECTORIZATION_ENABLED;
 import static org.apache.iceberg.TableProperties.PARQUET_VECTORIZATION_ENABLED;
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -172,7 +172,7 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         fileFormat,
         WRITE_DISTRIBUTION_MODE,
         distributionMode,
-        SPARK_WRITE_PARTITIONED_FANOUT_ENABLED,
+        WRITE_PARTITIONED_FANOUT_ENABLED,
         String.valueOf(fanoutEnabled),
         DATA_PLANNING_MODE,
         planningMode.modeName(),

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeSchemaEvolution.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeSchemaEvolution.java
@@ -24,9 +24,9 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Map;
 import org.apache.iceberg.ParameterizedTestExtension;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkTableProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
@@ -272,7 +272,7 @@ public class TestMergeSchemaEvolution extends SparkRowLevelOperationsTestBase {
 
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s' = 'false')",
-        tableName, TableProperties.SPARK_WRITE_AUTO_SCHEMA_EVOLUTION);
+        tableName, SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION);
 
     createOrReplaceView(
         "source",

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableProperties.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+/** Spark-specific table properties that control Spark integration behavior. */
+public class SparkTableProperties {
+
+  private SparkTableProperties() {}
+
+  public static final String WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
+  public static final boolean WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
+
+  public static final String WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
+  public static final boolean WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
+
+  public static final String WRITE_AUTO_SCHEMA_EVOLUTION =
+      "write.spark.auto-schema-evolution.enabled";
+  public static final boolean WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT = true;
+
+  public static final String WRITE_ADVISORY_PARTITION_SIZE_BYTES =
+      "write.spark.advisory-partition-size-bytes";
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -239,7 +239,7 @@ public class SparkWriteConf {
     return confParser
         .booleanConf()
         .option(SparkWriteOptions.FANOUT_ENABLED)
-        .tableProperty(TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED)
+        .tableProperty(SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED)
         .defaultValue(defaultValue)
         .parse();
   }
@@ -706,7 +706,7 @@ public class SparkWriteConf {
         .longConf()
         .option(SparkWriteOptions.ADVISORY_PARTITION_SIZE)
         .sessionConf(SparkSQLProperties.ADVISORY_PARTITION_SIZE)
-        .tableProperty(TableProperties.SPARK_WRITE_ADVISORY_PARTITION_SIZE_BYTES)
+        .tableProperty(SparkTableProperties.WRITE_ADVISORY_PARTITION_SIZE_BYTES)
         .defaultValue(defaultValue)
         .parse();
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Evaluator;
@@ -49,6 +48,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.SparkTableProperties;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
@@ -375,15 +375,15 @@ public class SparkTable extends BaseSparkTable
   private static boolean acceptAnySchema(Table table) {
     return PropertyUtil.propertyAsBoolean(
         table.properties(),
-        TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA,
-        TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT);
+        SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA,
+        SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA_DEFAULT);
   }
 
   private static boolean autoSchemaEvolution(Table table) {
     return PropertyUtil.propertyAsBoolean(
         table.properties(),
-        TableProperties.SPARK_WRITE_AUTO_SCHEMA_EVOLUTION,
-        TableProperties.SPARK_WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT);
+        SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION,
+        SparkTableProperties.WRITE_AUTO_SCHEMA_EVOLUTION_DEFAULT);
   }
 
   // returns latest snapshot for branch or current snapshot if branch is yet to be created

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -20,12 +20,12 @@ package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.TableProperties.DELETE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.MERGE_DISTRIBUTION_MODE;
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.TableProperties.UPDATE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.DELETE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE;
 import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.UPDATE;
@@ -3019,10 +3019,10 @@ public class TestSparkDistributionAndOrderingUtil extends TestBaseWithCatalog {
   }
 
   private void disableFanoutWriters(Table table) {
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "false").commit();
+    table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "false").commit();
   }
 
   private void enableFanoutWriters(Table table) {
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+    table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -25,10 +25,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkTableProperties;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -61,7 +61,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaFailsWithoutWriterOption() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -120,7 +120,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaSparkProperty() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -154,7 +154,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaIcebergProperty() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> twoColDF =
         jsonToDF(
@@ -196,7 +196,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
         .sql(
             String.format(
                 "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-                tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA))
+                tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA))
         .collect();
 
     String schema = "ID bigint, DaTa string";
@@ -226,7 +226,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaSparkConfiguration() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
     Dataset<Row> twoColDF =
         jsonToDF(
             "id bigint, data string",
@@ -261,7 +261,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
   public void testMergeSchemaIgnoreCastingLongToInt() throws Exception {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> bigintDF =
         jsonToDF(
@@ -303,7 +303,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
     sql("CREATE TABLE %s (id double, data string) USING iceberg", tableName);
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> doubleDF =
         jsonToDF(
@@ -345,7 +345,7 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
     sql("CREATE TABLE %s (id decimal(6,2), data string) USING iceberg", tableName);
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')",
-        tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+        tableName, SparkTableProperties.WRITE_ACCEPT_ANY_SCHEMA);
 
     Dataset<Row> decimalPrecision6DF =
         jsonToDF(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.spark.source;
 
-import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
+import static org.apache.iceberg.spark.SparkTableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -697,7 +697,7 @@ public class TestSparkDataWrite {
             .save(location.toString());
         break;
       case TABLE:
-        table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+        table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
         df.select("id", "data")
             .write()
             .format("iceberg")


### PR DESCRIPTION
## Summary
- Introduces a new `SparkTableProperties` class in the Spark module (all versions: v3.4, v3.5, v4.0, v4.1) containing Spark-specific table property constants that were previously in core `TableProperties`
- Deprecates the Spark-specific constants in `TableProperties` (for removal in 1.14.0) while keeping them for backward compatibility
- Migrates all Spark module references to use the new `SparkTableProperties` class

The migrated properties are:
- `SPARK_WRITE_PARTITIONED_FANOUT_ENABLED` / `_DEFAULT`
- `SPARK_WRITE_ACCEPT_ANY_SCHEMA` / `_DEFAULT`
- `SPARK_WRITE_AUTO_SCHEMA_EVOLUTION` / `_DEFAULT`
- `SPARK_WRITE_ADVISORY_PARTITION_SIZE_BYTES`

These are Spark-specific and do not belong in the engine-agnostic core module.

## Test plan
- [ ] Verify CI passes across all Spark versions (v3.4, v3.5, v4.0, v4.1)
- [ ] Verify `spotlessCheck` passes
- [ ] Verify `revApiCheck` passes (deprecated constants are retained, no API break)
