### PR TITLE
Spark 4.1: Focus Coverage of async planner stream tests 

### DIFF
--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DataOperations;
@@ -39,9 +38,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
-import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
-import org.apache.iceberg.Parameters;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -60,7 +57,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.CatalogTestBase;
-import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -85,72 +81,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ParameterizedTestExtension.class)
 public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
-  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, async = {3}")
-  public static Object[][] parameters() {
-    return new Object[][] {
-      {
-        SparkCatalogConfig.HIVE.catalogName(),
-        SparkCatalogConfig.HIVE.implementation(),
-        SparkCatalogConfig.HIVE.properties(),
-        false
-      },
-      {
-        SparkCatalogConfig.HIVE.catalogName(),
-        SparkCatalogConfig.HIVE.implementation(),
-        SparkCatalogConfig.HIVE.properties(),
-        true
-      },
-      {
-        SparkCatalogConfig.HADOOP.catalogName(),
-        SparkCatalogConfig.HADOOP.implementation(),
-        SparkCatalogConfig.HADOOP.properties(),
-        false
-      },
-      {
-        SparkCatalogConfig.HADOOP.catalogName(),
-        SparkCatalogConfig.HADOOP.implementation(),
-        SparkCatalogConfig.HADOOP.properties(),
-        true
-      },
-      {
-        SparkCatalogConfig.REST.catalogName(),
-        SparkCatalogConfig.REST.implementation(),
-        ImmutableMap.builder()
-            .putAll(SparkCatalogConfig.REST.properties())
-            .put(CatalogProperties.URI, restCatalog.properties().get(CatalogProperties.URI))
-            .build(),
-        false
-      },
-      {
-        SparkCatalogConfig.REST.catalogName(),
-        SparkCatalogConfig.REST.implementation(),
-        ImmutableMap.builder()
-            .putAll(SparkCatalogConfig.REST.properties())
-            .put(CatalogProperties.URI, restCatalog.properties().get(CatalogProperties.URI))
-            .build(),
-        true
-      },
-      {
-        SparkCatalogConfig.SPARK_SESSION.catalogName(),
-        SparkCatalogConfig.SPARK_SESSION.implementation(),
-        SparkCatalogConfig.SPARK_SESSION.properties(),
-        false
-      },
-      {
-        SparkCatalogConfig.SPARK_SESSION.catalogName(),
-        SparkCatalogConfig.SPARK_SESSION.implementation(),
-        SparkCatalogConfig.SPARK_SESSION.properties(),
-        true
-      }
-    };
-  }
-
   private Table table;
 
   private final AtomicInteger microBatches = new AtomicInteger();
-
-  @Parameter(index = 3)
-  private Boolean async;
 
   /**
    * test data to be used by multiple writes each write creates a snapshot and writes a list of
@@ -338,7 +271,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     // Set low preload limits to test async queue behavior - background thread should load
     // remaining data
     StreamingQuery query =
-        startStream(
+        startAsyncStream(
             ImmutableMap.of(
                 SparkReadOptions.ASYNC_QUEUE_PRELOAD_ROW_LIMIT,
                 "5",
@@ -351,16 +284,13 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testAvailableNowStreamReadShouldNotHangOrReprocessData() throws Exception {
+  public void testAvailableNowStreamReadShouldNotHangOrReprocessDataWithAsyncPlanner()
+      throws Exception {
     File writerCheckpointFolder = temp.resolve("writer-checkpoint-folder").toFile();
     File writerCheckpoint = new File(writerCheckpointFolder, "writer-checkpoint");
     File output = temp.resolve("junit").toFile();
 
-    Map<String, String> options = Maps.newHashMap();
-    options.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, async.toString());
-    if (async) {
-      options.put(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
-    }
+    Map<String, String> options = withAsyncPlanning(Collections.emptyMap());
 
     DataStreamWriter querySource =
         spark
@@ -410,7 +340,8 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testTriggerAvailableNowDoesNotProcessNewDataWhileRunning() throws Exception {
+  public void testTriggerAvailableNowDoesNotProcessNewDataWhileRunningWithAsyncPlanner()
+      throws Exception {
     List<List<SimpleRecord>> expectedData = TEST_DATA_MULTIPLE_SNAPSHOTS;
     appendDataAsMultipleSnapshots(expectedData);
 
@@ -420,12 +351,9 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     long expectedSnapshotId = table.currentSnapshot().snapshotId();
 
     String sinkTable = "availablenow_sink";
-    Map<String, String> options = Maps.newHashMap();
-    options.put(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1");
-    options.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, async.toString());
-    if (async) {
-      options.put(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
-    }
+    Map<String, String> options =
+        withAsyncPlanning(
+            ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"));
 
     StreamingQuery query =
         spark
@@ -490,17 +418,14 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
                 spark,
                 table,
                 new CaseInsensitiveStringMap(
-                    ImmutableMap.of(
-                        SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED,
-                        async.toString(),
-                        SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH,
-                        "1",
-                        SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS,
-                        "1",
-                        SparkReadOptions.ASYNC_QUEUE_PRELOAD_FILE_LIMIT,
-                        "10",
-                        SparkReadOptions.ASYNC_QUEUE_PRELOAD_ROW_LIMIT,
-                        "10"))),
+                    withAsyncPlanning(
+                        ImmutableMap.of(
+                            SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH,
+                            "1",
+                            SparkReadOptions.ASYNC_QUEUE_PRELOAD_FILE_LIMIT,
+                            "10",
+                            SparkReadOptions.ASYNC_QUEUE_PRELOAD_ROW_LIMIT,
+                            "10")))),
             table.schema(),
             temp.resolve("available-now-cap-checkpoint").toString());
 
@@ -526,7 +451,8 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testLatestOffsetReturnsNullAfterFinalBatchIsConsumed() throws Exception {
+  public void testLatestOffsetReturnsNullAfterFinalBatchIsConsumedWithAsyncPlanner()
+      throws Exception {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
 
     table.refresh();
@@ -537,7 +463,8 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
     SparkMicroBatchStream stream =
         newMicroBatchStream(
-            ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"),
+            withAsyncPlanning(
+                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")),
             "drain-to-null-checkpoint");
 
     try {
@@ -560,12 +487,13 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testPlanInputPartitionsIsIdempotentForSameOffsets() {
+  public void testPlanInputPartitionsIsIdempotentForSameOffsetsWithAsyncPlanner() {
     appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
 
     SparkMicroBatchStream stream =
         newMicroBatchStream(
-            ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"),
+            withAsyncPlanning(
+                ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1")),
             "idempotent-plan-files-checkpoint");
 
     try {
@@ -676,8 +604,6 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
     // Data appended after the timestamp should appear
     appendData(data);
-    // Allow async background thread to refresh, else test sometimes fails
-    Thread.sleep(50);
     actual = rowsAvailable(query);
     assertThat(actual).containsExactlyInAnyOrderElementsOf(data);
   }
@@ -1130,18 +1056,13 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   private static final String MEMORY_TABLE = "_stream_view_mem";
 
   private StreamingQuery startStream(Map<String, String> options) throws TimeoutException {
-    Map<String, String> allOptions = Maps.newHashMap(options);
-    allOptions.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, async.toString());
-    if (async) {
-      allOptions.putIfAbsent(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
-    }
     return spark
         .readStream()
-        .options(allOptions)
+        .options(options)
         .format("iceberg")
         .load(tableName)
         .writeStream()
-        .options(allOptions)
+        .options(options)
         .format("memory")
         .queryName(MEMORY_TABLE)
         .outputMode(OutputMode.Append())
@@ -1157,6 +1078,10 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
         ImmutableMap.of(key, value, SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1"));
   }
 
+  private StreamingQuery startAsyncStream(Map<String, String> options) throws TimeoutException {
+    return startStream(withAsyncPlanning(options));
+  }
+
   private void assertMicroBatchRecordSizes(
       Map<String, String> options, List<Long> expectedMicroBatchRecordSize)
       throws TimeoutException {
@@ -1166,17 +1091,11 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   private void assertMicroBatchRecordSizes(
       Map<String, String> options, List<Long> expectedMicroBatchRecordSize, Trigger trigger)
       throws TimeoutException {
-    Map<String, String> allOptions = Maps.newHashMap(options);
-    allOptions.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, async.toString());
-    if (async) {
-      allOptions.putIfAbsent(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
-    }
-
-    Dataset<Row> ds = spark.readStream().options(allOptions).format("iceberg").load(tableName);
+    Dataset<Row> ds = spark.readStream().options(options).format("iceberg").load(tableName);
 
     List<Long> syncList = Collections.synchronizedList(Lists.newArrayList());
     ds.writeStream()
-        .options(allOptions)
+        .options(options)
         .trigger(trigger)
         .foreachBatch(
             (VoidFunction2<Dataset<Row>, Long>)
@@ -1200,18 +1119,19 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
   private SparkMicroBatchStream newMicroBatchStream(
       Map<String, String> options, String checkpointDirName) {
-    Map<String, String> allOptions = Maps.newHashMap(options);
-    allOptions.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, async.toString());
-    if (async) {
-      allOptions.putIfAbsent(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
-    }
-
     return new SparkMicroBatchStream(
         JavaSparkContext.fromSparkContext(spark.sparkContext()),
         table,
         table::io,
-        new SparkReadConf(spark, table, new CaseInsensitiveStringMap(allOptions)),
+        new SparkReadConf(spark, table, new CaseInsensitiveStringMap(options)),
         table.schema(),
         temp.resolve(checkpointDirName).toString());
+  }
+
+  private Map<String, String> withAsyncPlanning(Map<String, String> options) {
+    Map<String, String> allOptions = Maps.newHashMap(options);
+    allOptions.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, "true");
+    allOptions.putIfAbsent(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
+    return allOptions;
   }
 }


### PR DESCRIPTION
To improve performance.

Given merging of https://github.com/apache/iceberg/pull/15670 and https://github.com/apache/iceberg/pull/15299, the test coverage of TestStructuredStreaming3 has expanded, tests in this suite run once for SyncMicroBatchPlanner, once for AsyncMicroBatchPlanner which is multiplied by the number of catalog types to support (8 times for each test). As a side effect, the CI test runtimes based on what I observed grew by 10 minutes. While the initial test implementation was taken as is from Drew's implementation, this PR aims to see if we can reduce test runtime by eliminating tests to run async that don't make a difference and focus on the tests that do test functional behavior.