### PR TITLE
Parquet: Fix ParquetWriteAdapter NPE when accessing length/splitOffsets after close

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
@@ -42,6 +42,7 @@ public class ParquetWriteAdapter<D> implements FileAppender<D> {
   private ParquetWriter<D> writer;
   private final MetricsConfig metricsConfig;
   private ParquetMetadata footer;
+  private long length = 0L;
 
   public ParquetWriteAdapter(ParquetWriter<D> writer, MetricsConfig metricsConfig) {
     this.writer = writer;
@@ -69,17 +70,26 @@ public class ParquetWriteAdapter<D> implements FileAppender<D> {
 
   @Override
   public long length() {
-    return writer.getDataSize();
+    if (writer != null) {
+      return writer.getDataSize();
+    }
+
+    return length;
   }
 
   @Override
   public List<Long> splitOffsets() {
-    return ParquetUtil.getSplitOffsets(writer.getFooter());
+    if (footer != null) {
+      return ParquetUtil.getSplitOffsets(footer);
+    }
+
+    return null;
   }
 
   @Override
   public void close() throws IOException {
     if (writer != null) {
+      this.length = writer.getDataSize();
       writer.close();
       this.footer = writer.getFooter();
       this.writer = null;

--- a/parquet/src/test/java/org/apache/iceberg/parquet/ParquetWritingTestUtils.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/ParquetWritingTestUtils.java
@@ -47,8 +47,6 @@ class ParquetWritingTestUtils {
       GenericData.Record... records)
       throws IOException {
 
-    long len;
-
     FileAppender<GenericData.Record> writer =
         Parquet.write(localOutput(file))
             .schema(schema)
@@ -58,16 +56,9 @@ class ParquetWritingTestUtils {
 
     try (Closeable toClose = writer) {
       writer.addAll(Lists.newArrayList(records));
-      len =
-          writer
-              .length(); // in deprecated adapter we need to get the length first and then close the
-      // writer
     }
 
-    if (writer instanceof ParquetWriter) {
-      len = writer.length();
-    }
-    return len;
+    return writer.length();
   }
 
   static File createTempFile(Path temp) throws IOException {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetWriteAdapter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetWriteAdapter.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.apache.iceberg.parquet.ParquetWritingTestUtils.createTempFile;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestParquetWriteAdapter {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+  @TempDir private Path temp;
+
+  @Test
+  void postCloseAccessors() throws IOException {
+    OutputFile file = Files.localOutput(createTempFile(temp));
+
+    // Parquet.write() without .createWriterFunc() produces a ParquetWriteAdapter
+    FileAppender<GenericData.Record> appender =
+        Parquet.write(file).schema(SCHEMA).overwrite().build();
+
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(SCHEMA, "table");
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("id", 1L);
+    record.put("data", "a");
+    appender.add(record);
+
+    // close the appender — this nulls writer in ParquetWriteAdapter
+    appender.close();
+
+    // all three accessors must work after close without NPE
+    assertThatNoException().isThrownBy(appender::length);
+    assertThat(appender.length()).isGreaterThan(0L);
+
+    assertThatNoException().isThrownBy(appender::metrics);
+    assertThat(appender.metrics()).isNotNull();
+    assertThat(appender.metrics().recordCount()).isEqualTo(1L);
+
+    assertThatNoException().isThrownBy(appender::splitOffsets);
+  }
+
+  @Test
+  void dataWriterCloseWithDeprecatedAdapter() throws IOException {
+    OutputFile file = Files.localOutput(createTempFile(temp));
+
+    // Parquet.writeData() without .createWriterFunc() uses ParquetWriteAdapter
+    DataWriter<GenericData.Record> dataWriter =
+        Parquet.writeData(file)
+            .schema(SCHEMA)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(SCHEMA, "table");
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("id", 1L);
+    record.put("data", "a");
+    dataWriter.write(record);
+
+    // DataWriter.close() calls appender.close() then appender.length()/splitOffsets()/metrics()
+    // This previously threw NPE with ParquetWriteAdapter
+    dataWriter.close();
+
+    DataFile dataFile = dataWriter.toDataFile();
+    assertThat(dataFile).isNotNull();
+    assertThat(dataFile.recordCount()).isEqualTo(1L);
+    assertThat(dataFile.fileSizeInBytes()).isGreaterThan(0L);
+    assertThat(dataFile.format()).isEqualTo(FileFormat.PARQUET);
+  }
+}


### PR DESCRIPTION
## Summary

  - Fix NPE in `ParquetWriteAdapter.length()` and `splitOffsets()` when called after `close()` by caching data size and reusing cached footer before nullifying the internal writer
  - Add regression tests verifying the `FileAppender` post-close contract for the deprecated adapter
  - Clean up the pre-close `length()` workaround in `ParquetWritingTestUtils` that was needed because of this bug

  Fixes #14310

  ## Test Plan

  - [x] `TestParquetWriteAdapter.postCloseAccessors` — verifies `length()`, `metrics()`, `splitOffsets()` work after close
  - [x] `TestParquetWriteAdapter.dataWriterCloseWithDeprecatedAdapter` — end-to-end `DataWriter.close()` path
  - [x] Full `:iceberg-parquet:test` suite — 642 tests pass, 0 failures