### PR TITLE
Build, Docs: Add a sample pre-commit hook and instructions on how to enable it

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Pre-commit hook that runs spotlessApply on staged files and re-stages
+# any formatting changes so the commit contains properly formatted code.
+# Unstaged changes are stashed and restored to avoid accidentally committing
+# work-in-progress edits.
+#
+# To install, run from the repository root:
+#   ln -s ../../.githooks/pre-commit .git/hooks/pre-commit
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+  exit 0
+fi
+
+# Stash unstaged changes (including untracked files) so spotless only
+# sees what is being committed. The stash is restored on exit.
+STASH_NAME="pre-commit-$$"
+STASHED=false
+
+restore_stash() {
+  if [ "$STASHED" = true ]; then
+    git stash pop >/dev/null 2>&1 || true
+  fi
+}
+trap restore_stash EXIT
+
+if ! git diff --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+  git stash push --keep-index --include-untracked -m "$STASH_NAME" >/dev/null 2>&1
+  STASHED=true
+fi
+
+echo "Running spotlessApply..."
+if ! "$REPO_ROOT/gradlew" -p "$REPO_ROOT" spotlessApply 2>&1; then
+  echo "spotlessApply failed — commit aborted."
+  exit 1
+fi
+
+# Re-stage any files that spotless reformatted
+echo "$STAGED_FILES" | while IFS= read -r file; do
+  if [ -f "$REPO_ROOT/$file" ]; then
+    git add "$REPO_ROOT/$file"
+  fi
+done
+
+echo "spotlessApply complete — formatted files re-staged."

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -113,6 +113,18 @@ Iceberg is built using Gradle with Java 17 or 21.
 * To fix code style: `./gradlew spotlessApply`
 * To build particular Spark/Flink Versions: `./gradlew build -DsparkVersions=3.5,4.0 -DflinkVersions=1.20,2.0`
 
+### Pre-commit Hook
+
+This project includes a pre-commit hook that runs `spotlessApply` and re-stages formatted files
+before each commit. To enable it, symlink the hook into your local hooks directory:
+
+```bash
+ln -s ../../.githooks/pre-commit .git/hooks/pre-commit
+```
+
+If you already have a `.git/hooks/pre-commit`, the command will fail rather than overwrite it.
+You can chain the hooks together by calling the existing hook from within the new one.
+
 Iceberg table support is organized in library modules:
 
 * `iceberg-common` contains utility classes used in other modules


### PR DESCRIPTION
Provides an example pre-commit hook that users can apply so 
that they will never have to manually run spotlessApply again


I'm not sure folks will actually want this in the project itself and I can always put it 
in a blog or something instead. I think it is generally useful though and I hate when
I forget to run spotless apply.