### PR TITLE
API: Implement notStartsWith bounds check in StrictMetricsEvaluator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.expressions.Expressions.rewriteNot;
 
 import java.nio.ByteBuffer;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
+import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.NaNUtil;
@@ -467,8 +469,38 @@ public class StrictMetricsEvaluator {
 
     @Override
     public <T> Boolean notStartsWith(BoundReference<T> ref, Literal<T> lit) {
-      // TODO: Handle cases that definitely cannot match, such as notStartsWith("x") when the bounds
-      // are ["a", "b"].
+      int id = ref.fieldId();
+      if (isNestedColumn(id)) {
+        return ROWS_MIGHT_NOT_MATCH;
+      }
+
+      if (containsNullsOnly(id)) {
+        return ROWS_MUST_MATCH;
+      }
+
+      String prefix = (String) lit.value();
+      Comparator<CharSequence> comparator = Comparators.charSequences();
+
+      if (lowerBounds != null && lowerBounds.containsKey(id)) {
+        CharSequence lower = Conversions.fromByteBuffer(ref.type(), lowerBounds.get(id));
+        // if the lower bound, truncated to the prefix length, is strictly greater than the prefix,
+        // then all values are above the prefix range and none can start with it
+        int length = Math.min(prefix.length(), lower.length());
+        if (comparator.compare(lower.subSequence(0, length), prefix) > 0) {
+          return ROWS_MUST_MATCH;
+        }
+      }
+
+      if (upperBounds != null && upperBounds.containsKey(id)) {
+        CharSequence upper = Conversions.fromByteBuffer(ref.type(), upperBounds.get(id));
+        // if the upper bound, truncated to the prefix length, is strictly less than the prefix,
+        // then all values are below the prefix range and none can start with it
+        int length = Math.min(prefix.length(), upper.length());
+        if (comparator.compare(upper.subSequence(0, length), prefix) < 0) {
+          return ROWS_MUST_MATCH;
+        }
+      }
+
       return ROWS_MIGHT_NOT_MATCH;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -483,8 +483,7 @@ public class StrictMetricsEvaluator {
 
       if (lowerBounds != null && lowerBounds.containsKey(id)) {
         CharSequence lower = Conversions.fromByteBuffer(ref.type(), lowerBounds.get(id));
-        // if the lower bound, truncated to the prefix length, is strictly greater than the prefix,
-        // then all values are above the prefix range and none can start with it
+        // truncate lower bound so that its length is not greater than the length of prefix
         int length = Math.min(prefix.length(), lower.length());
         if (comparator.compare(lower.subSequence(0, length), prefix) > 0) {
           return ROWS_MUST_MATCH;
@@ -493,8 +492,7 @@ public class StrictMetricsEvaluator {
 
       if (upperBounds != null && upperBounds.containsKey(id)) {
         CharSequence upper = Conversions.fromByteBuffer(ref.type(), upperBounds.get(id));
-        // if the upper bound, truncated to the prefix length, is strictly less than the prefix,
-        // then all values are below the prefix range and none can start with it
+        // truncate upper bound so that its length is not greater than the length of prefix
         int length = Math.min(prefix.length(), upper.length());
         if (comparator.compare(upper.subSequence(0, length), prefix) < 0) {
           return ROWS_MUST_MATCH;

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -32,6 +32,7 @@ import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
 import static org.apache.iceberg.expressions.Expressions.notNull;
+import static org.apache.iceberg.expressions.Expressions.notStartsWith;
 import static org.apache.iceberg.expressions.Expressions.or;
 import static org.apache.iceberg.types.Conversions.toByteBuffer;
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -171,6 +172,40 @@ public class TestStrictMetricsEvaluator {
           ImmutableMap.of(5, toByteBuffer(StringType.get(), "bbb")),
           // upper bounds
           ImmutableMap.of(5, toByteBuffer(StringType.get(), "bbb")));
+
+  // String-focused file: required column 3 has no nulls and string bounds ["abc", "abd"]
+  private static final DataFile STRING_FILE =
+      new TestDataFile(
+          "string_file.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(3, 50L),
+          // null value counts
+          ImmutableMap.of(),
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(3, toByteBuffer(StringType.get(), "abc")),
+          // upper bounds
+          ImmutableMap.of(3, toByteBuffer(StringType.get(), "abd")));
+
+  // String file with wider range: required column 3 has no nulls and bounds ["aa", "dC"]
+  private static final DataFile STRING_FILE_2 =
+      new TestDataFile(
+          "string_file_2.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(3, 50L),
+          // null value counts
+          ImmutableMap.of(),
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(3, toByteBuffer(StringType.get(), "aa")),
+          // upper bounds
+          ImmutableMap.of(3, toByteBuffer(StringType.get(), "dC")));
 
   @Test
   public void testAllNulls() {
@@ -683,5 +718,86 @@ public class TestStrictMetricsEvaluator {
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notNull("struct.nested_col_with_stats")).eval(FILE);
     assertThat(shouldRead).as("notNull nested column should not match").isFalse();
+  }
+
+  @Test
+  public void testNotStartsWithAllNulls() {
+    // all_nulls column (col 4) has all null values; no value can start with any prefix
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("all_nulls", "a")).eval(FILE);
+    assertThat(shouldRead).as("Should match: all null values satisfy notStartsWith").isTrue();
+  }
+
+  @Test
+  public void testNotStartsWithBoundsAbovePrefix() {
+    // STRING_FILE: required column 3 has bounds ["abc", "abd"]
+    // prefix "aaa" is below the lower bound truncated to 3 chars ("abc" > "aaa")
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "aaa")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should match: all values are above the prefix range").isTrue();
+  }
+
+  @Test
+  public void testNotStartsWithBoundsBelowPrefix() {
+    // STRING_FILE: required column 3 has bounds ["abc", "abd"]
+    // prefix "zzz" is above the upper bound truncated to 3 chars ("abd" < "zzz")
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "zzz")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should match: all values are below the prefix range").isTrue();
+  }
+
+  @Test
+  public void testNotStartsWithBoundsOverlapPrefix() {
+    // STRING_FILE: required column 3 has bounds ["abc", "abd"]
+    // prefix "ab" overlaps the bounds — some values could start with "ab"
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "ab")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: bounds overlap the prefix range").isFalse();
+
+    // prefix "abc" overlaps the lower bound of ["abc", "abd"]
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "abc")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: lower bound starts with the prefix").isFalse();
+  }
+
+  @Test
+  public void testNotStartsWithWiderRange() {
+    // STRING_FILE_2: required column 3 has bounds ["aa", "dC"]
+    // prefix "e" is above the upper bound truncated to 1 char ("d" < "e")
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "e")).eval(STRING_FILE_2);
+    assertThat(shouldRead).as("Should match: all values are below the prefix").isTrue();
+
+    // prefix "a" overlaps the bounds — some values start with "a"
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "a")).eval(STRING_FILE_2);
+    assertThat(shouldRead).as("Should not match: lower bound starts with the prefix").isFalse();
+
+    // prefix "c" is within the range ["aa", "dC"]
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "c")).eval(STRING_FILE_2);
+    assertThat(shouldRead).as("Should not match: prefix is within the bounds range").isFalse();
+  }
+
+  @Test
+  public void testNotStartsWithNoStats() {
+    // FILE has no string bounds for column 3 ("required")
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "a")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: no bounds available for column").isFalse();
+  }
+
+  @Test
+  public void testNotStartsWithSomeNullsBoundsOutsidePrefix() {
+    // FILE_2: column 5 (some_nulls) has 10 nulls, bounds ["bbb", "eee"]
+    // prefix "zzz" is above the upper bound
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "zzz")).eval(FILE_2);
+    assertThat(shouldRead).as("Should match: all values are below the prefix").isTrue();
+
+    // prefix "aaa" is below the lower bound
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "aaa")).eval(FILE_2);
+    assertThat(shouldRead).as("Should match: all values are above the prefix").isTrue();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -801,6 +801,29 @@ public class TestStrictMetricsEvaluator {
   }
 
   @Test
+  void testNotStartsWithEmptyPrefix() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: all strings start with empty prefix").isFalse();
+  }
+
+  @Test
+  void testNotStartsWithExactBoundMatch() {
+    // FILE_3 has column 5 (some_nulls) with exact bounds ["bbb", "bbb"]
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "bbb")).eval(FILE_3);
+    assertThat(shouldRead).as("Should not match: bounds exactly equal the prefix").isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "zzz")).eval(FILE_3);
+    assertThat(shouldRead).as("Should match: all values are below the prefix").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "aaa")).eval(FILE_3);
+    assertThat(shouldRead).as("Should match: all values are above the prefix").isTrue();
+  }
+
+  @Test
   public void testNotStartsWithNestedColumn() {
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("struct.nested_string_col", "a"))

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -722,7 +722,6 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   public void testNotStartsWithAllNulls() {
-    // all_nulls column (col 4) has all null values; no value can start with any prefix
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("all_nulls", "a")).eval(FILE);
     assertThat(shouldRead).as("Should match: all null values satisfy notStartsWith").isTrue();
@@ -730,8 +729,6 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   public void testNotStartsWithBoundsAbovePrefix() {
-    // STRING_FILE: required column 3 has bounds ["abc", "abd"]
-    // prefix "aaa" is below the lower bound truncated to 3 chars ("abc" > "aaa")
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "aaa")).eval(STRING_FILE);
     assertThat(shouldRead).as("Should match: all values are above the prefix range").isTrue();
@@ -739,8 +736,6 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   public void testNotStartsWithBoundsBelowPrefix() {
-    // STRING_FILE: required column 3 has bounds ["abc", "abd"]
-    // prefix "zzz" is above the upper bound truncated to 3 chars ("abd" < "zzz")
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "zzz")).eval(STRING_FILE);
     assertThat(shouldRead).as("Should match: all values are below the prefix range").isTrue();
@@ -748,13 +743,10 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   public void testNotStartsWithBoundsOverlapPrefix() {
-    // STRING_FILE: required column 3 has bounds ["abc", "abd"]
-    // prefix "ab" overlaps the bounds — some values could start with "ab"
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "ab")).eval(STRING_FILE);
     assertThat(shouldRead).as("Should not match: bounds overlap the prefix range").isFalse();
 
-    // prefix "abc" overlaps the lower bound of ["abc", "abd"]
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "abc")).eval(STRING_FILE);
     assertThat(shouldRead).as("Should not match: lower bound starts with the prefix").isFalse();
@@ -762,18 +754,14 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   public void testNotStartsWithWiderRange() {
-    // STRING_FILE_2: required column 3 has bounds ["aa", "dC"]
-    // prefix "e" is above the upper bound truncated to 1 char ("d" < "e")
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "e")).eval(STRING_FILE_2);
     assertThat(shouldRead).as("Should match: all values are below the prefix").isTrue();
 
-    // prefix "a" overlaps the bounds — some values start with "a"
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "a")).eval(STRING_FILE_2);
     assertThat(shouldRead).as("Should not match: lower bound starts with the prefix").isFalse();
 
-    // prefix "c" is within the range ["aa", "dC"]
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "c")).eval(STRING_FILE_2);
     assertThat(shouldRead).as("Should not match: prefix is within the bounds range").isFalse();
@@ -781,7 +769,6 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   public void testNotStartsWithNoStats() {
-    // FILE has no string bounds for column 3 ("required")
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "a")).eval(FILE);
     assertThat(shouldRead).as("Should not match: no bounds available for column").isFalse();
@@ -789,15 +776,27 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   public void testNotStartsWithSomeNullsBoundsOutsidePrefix() {
-    // FILE_2: column 5 (some_nulls) has 10 nulls, bounds ["bbb", "eee"]
-    // prefix "zzz" is above the upper bound
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "zzz")).eval(FILE_2);
     assertThat(shouldRead).as("Should match: all values are below the prefix").isTrue();
 
-    // prefix "aaa" is below the lower bound
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "aaa")).eval(FILE_2);
     assertThat(shouldRead).as("Should match: all values are above the prefix").isTrue();
+  }
+
+  @Test
+  public void testNotStartsWithPrefixLongerThanBounds() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "aaaaaaa")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should match: all values are above the long prefix").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "zzzzzzz")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should match: all values are below the long prefix").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "abcdef")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: prefix overlaps with bound range").isFalse();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -73,8 +73,8 @@ public class TestStrictMetricsEvaluator {
               "struct",
               Types.StructType.of(
                   Types.NestedField.optional(16, "nested_col_no_stats", Types.IntegerType.get()),
-                  Types.NestedField.optional(
-                      17, "nested_col_with_stats", Types.IntegerType.get()))));
+                  Types.NestedField.optional(17, "nested_col_with_stats", Types.IntegerType.get()),
+                  Types.NestedField.optional(18, "nested_string_col", Types.StringType.get()))));
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 79;
@@ -798,5 +798,13 @@ public class TestStrictMetricsEvaluator {
     shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "abcdef")).eval(STRING_FILE);
     assertThat(shouldRead).as("Should not match: prefix overlaps with bound range").isFalse();
+  }
+
+  @Test
+  public void testNotStartsWithNestedColumn() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, notStartsWith("struct.nested_string_col", "a"))
+            .eval(FILE);
+    assertThat(shouldRead).as("notStartsWith nested column should not match").isFalse();
   }
 }


### PR DESCRIPTION


### What

Implements bounds-based evaluation for `notStartsWith` in
`StrictMetricsEvaluator`, replacing the existing TODO with actual logic.

Previously, `notStartsWith` always returned `ROWS_MIGHT_NOT_MATCH`,
which prevented the engine from eliminating the residual predicate even
when file-level column bounds made it provable that no value could start
with the given prefix.

### Changes

- **`StrictMetricsEvaluator.notStartsWith`**: Added checks for nested
  columns, all-nulls columns, and lower/upper bound comparisons against
  the prefix. Returns `ROWS_MUST_MATCH` when bounds prove the prefix is
  entirely outside the value range.
- **`TestStrictMetricsEvaluator`**: Added 8 test methods covering:
  all-nulls, bounds above/below/overlapping the prefix, wider ranges,
  missing stats, some-nulls with bounds outside prefix, and prefix
  longer than bounds.

### How it works

For `NOT STARTS WITH <prefix>`:
- If the lower bound (truncated to `min(prefixLen, boundLen)`) is
  strictly greater than the prefix, all values are above the prefix
  range → `ROWS_MUST_MATCH`
- If the upper bound (truncated to `min(prefixLen, boundLen)`) is
  strictly less than the prefix, all values are below the prefix range
  → `ROWS_MUST_MATCH`
- Otherwise, fall through to `ROWS_MIGHT_NOT_MATCH` (conservative)

This follows the same pattern used by `notEq` and `notIn` in this
class, including the null-handling convention.

Closes #15882 