### PR TITLE
OpenAPI: Add Basic Auth to the REST spec

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -5265,3 +5265,6 @@ components:
     BearerAuth:
       type: http
       scheme: bearer
+    BasicAuth:
+      type: http
+      scheme: basic

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -60,6 +60,7 @@ servers:
 security:
   - OAuth2: [catalog]
   - BearerAuth: []
+  - BasicAuth: []
 
 paths:
   /v1/config:


### PR DESCRIPTION
Updated the OpenAPI specification to include Basic Authentication, reflecting the support already present in the Iceberg `RESTCatalog`. I'm uncertain if we need to initiate a discussion on the dev mailing list for this.