### PR TITLE
API: Implement startsWith bounds check in StrictMetricsEvaluator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -464,6 +464,42 @@ public class StrictMetricsEvaluator {
 
     @Override
     public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+      if (isNestedColumn(id)) {
+        return ROWS_MIGHT_NOT_MATCH;
+      }
+
+      if (canContainNulls(id)) {
+        return ROWS_MIGHT_NOT_MATCH;
+      }
+
+      if (lowerBounds != null
+          && lowerBounds.containsKey(id)
+          && upperBounds != null
+          && upperBounds.containsKey(id)) {
+        String prefix = (String) lit.value();
+        Comparator<CharSequence> comparator = Comparators.charSequences();
+        CharSequence lower = Conversions.fromByteBuffer(ref.type(), lowerBounds.get(id));
+        CharSequence upper = Conversions.fromByteBuffer(ref.type(), upperBounds.get(id));
+
+        // if lower is shorter than the prefix then lower doesn't start with the prefix
+        if (lower.length() < prefix.length()) {
+          return ROWS_MIGHT_NOT_MATCH;
+        }
+
+        if (comparator.compare(lower.subSequence(0, prefix.length()), prefix) == 0) {
+          // if upper is shorter than the prefix then upper can't start with the prefix
+          if (upper.length() < prefix.length()) {
+            return ROWS_MIGHT_NOT_MATCH;
+          }
+
+          if (comparator.compare(upper.subSequence(0, prefix.length()), prefix) == 0) {
+            // both bounds start with the prefix, so all rows must start with the prefix
+            return ROWS_MUST_MATCH;
+          }
+        }
+      }
+
       return ROWS_MIGHT_NOT_MATCH;
     }
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -34,6 +34,7 @@ import static org.apache.iceberg.expressions.Expressions.notNaN;
 import static org.apache.iceberg.expressions.Expressions.notNull;
 import static org.apache.iceberg.expressions.Expressions.notStartsWith;
 import static org.apache.iceberg.expressions.Expressions.or;
+import static org.apache.iceberg.expressions.Expressions.startsWith;
 import static org.apache.iceberg.types.Conversions.toByteBuffer;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
@@ -775,6 +776,57 @@ public class TestStrictMetricsEvaluator {
   }
 
   @Test
+  void testStartsWithBothBoundsMatchPrefix() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "ab")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should match: both bounds start with the prefix").isTrue();
+  }
+
+  @Test
+  void testStartsWithSingleCharPrefixBothBoundsMatch() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "a")).eval(STRING_FILE);
+    assertThat(shouldRead)
+        .as("Should match: both bounds start with the single char prefix")
+        .isTrue();
+  }
+
+  @Test
+  void testStartsWithOnlyLowerBoundMatchesPrefix() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "abc")).eval(STRING_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: upper bound does not start with the prefix")
+        .isFalse();
+  }
+
+  @Test
+  void testStartsWithBoundsDoNotMatchPrefix() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "zzz")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: no bounds start with the prefix").isFalse();
+  }
+
+  @Test
+  void testStartsWithWiderRange() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "a")).eval(STRING_FILE_2);
+    assertThat(shouldRead)
+        .as("Should not match: upper bound does not start with the prefix")
+        .isFalse();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "e")).eval(STRING_FILE_2);
+    assertThat(shouldRead).as("Should not match: no bounds start with the prefix").isFalse();
+  }
+
+  @Test
+  void testStartsWithNoStats() {
+    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, startsWith("required", "a")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: no bounds available for column").isFalse();
+  }
+
+  @Test
   public void testNotStartsWithSomeNullsBoundsOutsidePrefix() {
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "zzz")).eval(FILE_2);
@@ -829,5 +881,44 @@ public class TestStrictMetricsEvaluator {
         new StrictMetricsEvaluator(SCHEMA, notStartsWith("struct.nested_string_col", "a"))
             .eval(FILE);
     assertThat(shouldRead).as("notStartsWith nested column should not match").isFalse();
+  }
+
+  @Test
+  void testStartsWithAllNulls() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("all_nulls", "a")).eval(FILE);
+    assertThat(shouldRead)
+        .as("Should not match: all null values do not satisfy startsWith")
+        .isFalse();
+  }
+
+  @Test
+  void testStartsWithSomeNulls() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("some_nulls", "b")).eval(FILE_2);
+    assertThat(shouldRead)
+        .as("Should not match: some nulls means not all rows can satisfy startsWith")
+        .isFalse();
+  }
+
+  @Test
+  void testStartsWithPrefixLongerThanBounds() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "abcdef")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should not match: prefix is longer than the bounds").isFalse();
+  }
+
+  @Test
+  void testStartsWithEmptyPrefix() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "")).eval(STRING_FILE);
+    assertThat(shouldRead).as("Should match: all strings start with empty prefix").isTrue();
+  }
+
+  @Test
+  void testStartsWithNestedColumn() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, startsWith("struct.nested_string_col", "a")).eval(FILE);
+    assertThat(shouldRead).as("Should not match: nested column is not supported").isFalse();
   }
 }


### PR DESCRIPTION
### What

Implements bounds-based evaluation for `startsWith` in
`StrictMetricsEvaluator`, replacing the unconditional
`ROWS_MIGHT_NOT_MATCH` return with actual logic.

Previously, `startsWith` always returned `ROWS_MIGHT_NOT_MATCH`,
which prevented the engine from eliminating the residual predicate even
when file-level column bounds made it provable that every value started
with the given prefix.

### Changes

- **`StrictMetricsEvaluator.startsWith`**: Added checks for nested
  columns, null-containing columns, and lower/upper bound comparisons
  against the prefix. Returns `ROWS_MUST_MATCH` when both bounds start
  with the prefix.
- **`TestStrictMetricsEvaluator`**: Added 9 test methods covering:
  both bounds match prefix, single-char prefix match, only lower bound
  matches, bounds outside prefix range, wider range, missing stats,
  all-nulls, some-nulls, and prefix longer than bounds.

### How it works

For `STARTS WITH <prefix>`:
- If the column can contain nulls → `ROWS_MIGHT_NOT_MATCH` (conservative)
- If the lower bound is shorter than the prefix → `ROWS_MIGHT_NOT_MATCH`
- If the lower bound (truncated to prefix length) equals the prefix **and**
  the upper bound (truncated to prefix length) equals the prefix →
  `ROWS_MUST_MATCH` (all values in the file start with the prefix)
- Otherwise → `ROWS_MIGHT_NOT_MATCH` (conservative)

This follows the same pattern used by `eq` and the PR for
`notStartsWith` bounds (https://github.com/apache/iceberg/pull/15883) check in this class.

Closes #15901