### PR TITLE
Core: Set scan planning mode when initializing client

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -72,6 +72,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTCatalogProperties.ScanPlanningMode;
 import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
 import org.apache.iceberg.rest.RESTTableCache.TableWithETag;
 import org.apache.iceberg.rest.auth.AuthManager;
@@ -174,6 +175,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private Set<Endpoint> endpoints;
   private Supplier<Map<String, String>> mutationHeaders = Map::of;
   private String namespaceSeparator = null;
+  private ScanPlanningMode clientScanPlanningMode = null;
 
   private RESTTableCache tableCache;
 
@@ -290,6 +292,10 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             mergedProps,
             RESTCatalogProperties.NAMESPACE_SEPARATOR,
             RESTCatalogProperties.NAMESPACE_SEPARATOR_DEFAULT);
+
+    String scanPlanningModeConfig = mergedProps.get(RESTCatalogProperties.SCAN_PLANNING_MODE);
+    this.clientScanPlanningMode =
+        scanPlanningModeConfig == null ? null : ScanPlanningMode.fromString(scanPlanningModeConfig);
 
     this.tableCache = createTableCache(mergedProps);
     this.closeables.addCloseable(this.tableCache);
@@ -603,31 +609,34 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       TableIdentifier finalIdentifier,
       RESTClient restClient,
       Map<String, String> tableConf) {
-    // Get client-side and server-side scan planning modes
-    String planningModeClientConfig = properties().get(RESTCatalogProperties.SCAN_PLANNING_MODE);
     String planningModeServerConfig = tableConf.get(RESTCatalogProperties.SCAN_PLANNING_MODE);
+    ScanPlanningMode serverScanPlanningMode =
+        planningModeServerConfig == null
+            ? null
+            : ScanPlanningMode.fromString(planningModeServerConfig);
 
-    // Warn if client and server configs conflict; server config takes precedence
-    if (planningModeClientConfig != null
-        && planningModeServerConfig != null
-        && !planningModeClientConfig.equalsIgnoreCase(planningModeServerConfig)) {
+    // Warn if client and server configs conflict
+    if (clientScanPlanningMode != null
+        && serverScanPlanningMode != null
+        && clientScanPlanningMode != serverScanPlanningMode) {
       LOG.warn(
           "Scan planning mode mismatch for table {}: client config={}, server config={}. "
               + "Server config will take precedence.",
           finalIdentifier,
-          planningModeClientConfig,
+          clientScanPlanningMode.modeName(),
           planningModeServerConfig);
     }
 
-    // Determine effective mode: prefer server config if present, otherwise use client config
-    String effectiveModeConfig =
-        planningModeServerConfig != null ? planningModeServerConfig : planningModeClientConfig;
-    RESTCatalogProperties.ScanPlanningMode effectiveMode =
-        effectiveModeConfig != null
-            ? RESTCatalogProperties.ScanPlanningMode.fromString(effectiveModeConfig)
-            : RESTCatalogProperties.SCAN_PLANNING_MODE_DEFAULT;
+    // Determine effective mode: prefer server config if present, otherwise use client config,
+    // fall back to default if both are null
+    ScanPlanningMode effectiveMode = RESTCatalogProperties.SCAN_PLANNING_MODE_DEFAULT;
+    if (serverScanPlanningMode != null) {
+      effectiveMode = serverScanPlanningMode;
+    } else if (clientScanPlanningMode != null) {
+      effectiveMode = clientScanPlanningMode;
+    }
 
-    if (effectiveMode == RESTCatalogProperties.ScanPlanningMode.SERVER) {
+    if (effectiveMode == ScanPlanningMode.SERVER) {
       Preconditions.checkState(
           endpoints.contains(Endpoint.V1_SUBMIT_TABLE_SCAN_PLAN),
           "Server requires server-side scan planning for table %s but does not support endpoint %s",

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -75,6 +75,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -1575,5 +1576,85 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
 
     assertThat(table).isNotInstanceOf(RESTTable.class);
     assertThat(table).isInstanceOf(BaseTable.class);
+  }
+
+  @Test
+  public void defaultPlanningModeWhenNoneSpecified() {
+    CatalogWithAdapter catalogWithAdapter = catalogWithModes(null, null);
+    catalogWithAdapter.catalog.createNamespace(NS);
+
+    Table table =
+        catalogWithAdapter
+            .catalog
+            .buildTable(TableIdentifier.of(NS, "default_mode_test"), SCHEMA)
+            .create();
+
+    assertThat(table).isNotInstanceOf(RESTTable.class).isInstanceOf(BaseTable.class);
+  }
+
+  @Test
+  public void invalidPlanningModeConfiguredForClient() {
+    assertThatThrownBy(
+            () ->
+                catalogWithModes(
+                    "invalid_mode", RESTCatalogProperties.ScanPlanningMode.CLIENT.modeName()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid scan planning mode: invalid_mode");
+  }
+
+  @Test
+  public void invalidPlanningModeConfiguredForServer() {
+    CatalogWithAdapter catalogWithAdapter =
+        catalogWithModes(RESTCatalogProperties.ScanPlanningMode.CLIENT.modeName(), "invalid_mode");
+    catalogWithAdapter.catalog.createNamespace(NS);
+
+    assertThatThrownBy(
+            () ->
+                catalogWithAdapter
+                    .catalog
+                    .buildTable(TableIdentifier.of(NS, "invalid_server_mode_test"), SCHEMA)
+                    .create())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid scan planning mode: invalid_mode");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"client", "CLIENT", "Client", "cLiEnT", "server", "SERVER", "Server", "sErVeR"})
+  public void planningModeWithDifferentCasesOnClient(String planningMode) {
+    CatalogWithAdapter catalogWithAdapter = catalogWithModes(planningMode, null);
+    catalogWithAdapter.catalog.createNamespace(NS);
+
+    Table table =
+        catalogWithAdapter
+            .catalog
+            .buildTable(TableIdentifier.of(NS, "client_case_test_" + planningMode), SCHEMA)
+            .create();
+
+    verifyTableTypeForPlanningMode(planningMode, table);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"client", "CLIENT", "Client", "cLiEnT", "server", "SERVER", "Server", "sErVeR"})
+  public void planningModeWithDifferentCasesOnServer(String serverMode) {
+    CatalogWithAdapter catalogWithAdapter = catalogWithModes(null, serverMode);
+    catalogWithAdapter.catalog.createNamespace(NS);
+
+    Table table =
+        catalogWithAdapter
+            .catalog
+            .buildTable(TableIdentifier.of(NS, "server_case_test_" + serverMode), SCHEMA)
+            .create();
+
+    verifyTableTypeForPlanningMode(serverMode, table);
+  }
+
+  private void verifyTableTypeForPlanningMode(String planingMode, Table table) {
+    if (planingMode.equalsIgnoreCase("client")) {
+      assertThat(table).isNotInstanceOf(RESTTable.class).isInstanceOf(BaseTable.class);
+    } else {
+      assertThat(table).isInstanceOf(RESTTable.class);
+    }
   }
 }


### PR DESCRIPTION
Since it's a startup parameter for RESTSessionCatalog, setting client-side scan planning mode is move to the initialize() function. With this we can throw an exception right away when an invalid value is set, not just when we try to load a table.