### PR TITLE
Repro: Concurrent replace V3 failure

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2711,10 +2711,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     }
 
     Transaction transaction =
-        catalog
-            .buildTable(TABLE, SCHEMA)
-            .withProperty("format-version", "3")
-            .createTransaction();
+        catalog.buildTable(TABLE, SCHEMA).withProperty("format-version", "3").createTransaction();
     transaction.newFastAppend().appendFile(FILE_A).commit();
     transaction.commitTransaction();
 

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2718,7 +2718,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table original = catalog.loadTable(TABLE);
     assertFiles(original, FILE_A);
 
-    // start two concurrent replace transactions while the table is at V3
+    // start two concurrent replace transactions
     Transaction secondReplace = catalog.buildTable(TABLE, SCHEMA).replaceTransaction();
     secondReplace.newFastAppend().appendFile(FILE_C).commit();
 
@@ -2726,13 +2726,10 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.newFastAppend().appendFile(FILE_B).commit();
     firstReplace.commitTransaction();
 
-    // the second replace should also succeed, but it fails because the snapshot's
+    // the second replace should also succeed, but it fails for REST because the snapshot's
     // first-row-id (set from the original base's next-row-id) is now behind the table's
     // next-row-id after the first replace advanced it
     secondReplace.commitTransaction();
-
-    Table afterSecondReplace = catalog.loadTable(TABLE);
-    assertThat(afterSecondReplace.snapshots()).hasSize(3);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2703,6 +2703,42 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void testConcurrentReplaceTransactionsV3() {
+    C catalog = catalog();
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(NS);
+    }
+
+    Transaction transaction =
+        catalog
+            .buildTable(TABLE, SCHEMA)
+            .withProperty("format-version", "3")
+            .createTransaction();
+    transaction.newFastAppend().appendFile(FILE_A).commit();
+    transaction.commitTransaction();
+
+    Table original = catalog.loadTable(TABLE);
+    assertFiles(original, FILE_A);
+
+    // start two concurrent replace transactions while the table is at V3
+    Transaction secondReplace = catalog.buildTable(TABLE, SCHEMA).replaceTransaction();
+    secondReplace.newFastAppend().appendFile(FILE_C).commit();
+
+    Transaction firstReplace = catalog.buildTable(TABLE, SCHEMA).replaceTransaction();
+    firstReplace.newFastAppend().appendFile(FILE_B).commit();
+    firstReplace.commitTransaction();
+
+    // the second replace should also succeed, but it fails because the snapshot's
+    // first-row-id (set from the original base's next-row-id) is now behind the table's
+    // next-row-id after the first replace advanced it
+    secondReplace.commitTransaction();
+
+    Table afterSecondReplace = catalog.loadTable(TABLE);
+    assertThat(afterSecondReplace.snapshots()).hasSize(3);
+  }
+
+  @Test
   public void testConcurrentReplaceTransactionSchema() {
     C catalog = catalog();
 


### PR DESCRIPTION
Addressing https://github.com/apache/iceberg/pull/15092#discussion_r2708701236.

Failure (see CI):

```
CommitFailedException: Commit failed: Validation failed, please retry:
  Cannot add a snapshot, first-row-id is behind table next-row-id: 2 < 4
```

Observed this when writing integration tests for https://github.com/apache/iceberg/pull/13225 - encryption is a V3 feature.

See https://github.com/apache/iceberg/pull/15904 also.