### PR TITLE
Data: Add TCK tests for metrics collection in BaseFormatModelTests

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -26,8 +26,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -35,9 +38,11 @@ import java.util.stream.IntStream;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestTables;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
@@ -56,9 +61,13 @@ import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.FieldSource;
@@ -77,6 +86,8 @@ public abstract class BaseFormatModelTests<T> {
     return false;
   }
 
+  @TempDir private File tableDir;
+
   private static final FileFormat[] FILE_FORMATS =
       new FileFormat[] {FileFormat.AVRO, FileFormat.PARQUET, FileFormat.ORC};
 
@@ -92,11 +103,14 @@ public abstract class BaseFormatModelTests<T> {
   static final String FEATURE_CASE_SENSITIVE = "caseSensitive";
   static final String FEATURE_SPLIT = "split";
   static final String FEATURE_REUSE_CONTAINERS = "reuseContainers";
+  static final String FEATURE_METRIC_COLLECT = "metricCollect";
 
   private static final Map<FileFormat, String[]> MISSING_FEATURES =
       Map.of(
           FileFormat.AVRO,
-          new String[] {FEATURE_FILTER, FEATURE_CASE_SENSITIVE, FEATURE_SPLIT},
+          new String[] {
+            FEATURE_FILTER, FEATURE_CASE_SENSITIVE, FEATURE_SPLIT, FEATURE_METRIC_COLLECT
+          },
           FileFormat.ORC,
           new String[] {FEATURE_REUSE_CONTAINERS});
 
@@ -398,9 +412,6 @@ public abstract class BaseFormatModelTests<T> {
     assumeSupports(fileFormat, FEATURE_FILTER);
 
     Schema schema = SCHEMA;
-    new Schema(
-        Types.NestedField.required(1, "id", Types.IntegerType.get()),
-        Types.NestedField.required(2, "data", Types.StringType.get()));
 
     // Generate records with known id values [0, count)
     int count = 10000;
@@ -628,6 +639,326 @@ public abstract class BaseFormatModelTests<T> {
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterMetricsCollection(FileFormat fileFormat) throws IOException {
+    DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
+    Schema schema = dataGenerator.schema();
+    FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
+        FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
+
+    DataWriter<Record> writer =
+        writerBuilder.schema(schema).spec(PartitionSpec.unpartitioned()).build();
+
+    List<Record> genericRecords = dataGenerator.generateRecords();
+
+    try (writer) {
+      genericRecords.forEach(writer::write);
+    }
+
+    DataFile dataFile = writer.toDataFile();
+
+    assertThat(dataFile).isNotNull();
+    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
+
+    // AVRO Only support metric collection with rowCount
+    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
+
+    assertValueAndNullCounts(
+        schema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBounds(schema, genericRecords, dataFile.lowerBounds(), dataFile.upperBounds());
+
+    assertThat(dataFile.columnSizes()).isNotNull().isNotEmpty();
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterMetricsWithNoneMode(FileFormat fileFormat) throws IOException {
+
+    // AVRO Only support metric collection with rowCount
+    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
+
+    DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
+    Schema schema = dataGenerator.schema();
+
+    TestTables.TestTable table =
+        TestTables.create(
+            tableDir,
+            "test",
+            schema,
+            PartitionSpec.unpartitioned(),
+            3,
+            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none"));
+
+    MetricsConfig noneConfig = MetricsConfig.forTable(table);
+
+    FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
+        FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
+
+    DataWriter<Record> writer =
+        writerBuilder
+            .schema(schema)
+            .spec(PartitionSpec.unpartitioned())
+            .metricsConfig(noneConfig)
+            .build();
+
+    List<Record> genericRecords = dataGenerator.generateRecords();
+
+    try (writer) {
+      genericRecords.forEach(writer::write);
+    }
+
+    DataFile dataFile = writer.toDataFile();
+
+    assertThat(dataFile).isNotNull();
+    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
+
+    // In `None` mode, `valueCounts`, `nullValueCounts`, `lowerBounds`, and `upperBounds` should be
+    // empty/null.
+    for (Types.NestedField field : schema.columns()) {
+      if (field.type().isPrimitiveType()) {
+        assertThat(dataFile.valueCounts().get(field.fieldId())).isNull();
+        assertThat(dataFile.nullValueCounts().get(field.fieldId())).isNull();
+        assertThat(dataFile.lowerBounds().get(field.fieldId())).isNull();
+        assertThat(dataFile.upperBounds().get(field.fieldId())).isNull();
+      }
+    }
+
+    TestTables.clearTables();
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterMetricsWithCountsMode(FileFormat fileFormat) throws IOException {
+    // AVRO Only support metric collection with rowCount
+    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
+
+    DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
+    Schema schema = dataGenerator.schema();
+    TestTables.TestTable table =
+        TestTables.create(
+            tableDir,
+            "test",
+            schema,
+            PartitionSpec.unpartitioned(),
+            3,
+            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, "counts"));
+
+    MetricsConfig countsConfig = MetricsConfig.forTable(table);
+
+    FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
+        FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
+
+    DataWriter<Record> writer =
+        writerBuilder
+            .schema(schema)
+            .spec(PartitionSpec.unpartitioned())
+            .metricsConfig(countsConfig)
+            .build();
+
+    List<Record> genericRecords = dataGenerator.generateRecords();
+
+    try (writer) {
+      genericRecords.forEach(writer::write);
+    }
+
+    DataFile dataFile = writer.toDataFile();
+
+    assertThat(dataFile).isNotNull();
+    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
+
+    // In the counts mode, valueCounts and nullValueCounts should be present, while lowerBounds and
+    // upperBounds should be null.
+    assertValueAndNullCounts(
+        schema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBoundsNull(schema, dataFile.lowerBounds(), dataFile.upperBounds());
+
+    TestTables.clearTables();
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testEqualityDeleteWriterMetricsCollection(FileFormat fileFormat) throws IOException {
+
+    // AVRO Only support metric collection with rowCount
+    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
+
+    DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
+    Schema schema = dataGenerator.schema();
+    FileWriterBuilder<EqualityDeleteWriter<Record>, Object> writerBuilder =
+        FormatModelRegistry.equalityDeleteWriteBuilder(fileFormat, Record.class, encryptedFile);
+
+    EqualityDeleteWriter<Record> writer =
+        writerBuilder
+            .schema(schema)
+            .spec(PartitionSpec.unpartitioned())
+            .equalityFieldIds(1)
+            .build();
+
+    List<Record> genericRecords = dataGenerator.generateRecords();
+
+    try (writer) {
+      genericRecords.forEach(writer::write);
+    }
+
+    DeleteFile deleteFile = writer.toDeleteFile();
+
+    assertThat(deleteFile).isNotNull();
+    assertThat(deleteFile.recordCount()).isEqualTo(genericRecords.size());
+
+    assertValueAndNullCounts(
+        schema, genericRecords, deleteFile.valueCounts(), deleteFile.nullValueCounts());
+    assertBounds(schema, genericRecords, deleteFile.lowerBounds(), deleteFile.upperBounds());
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testPositionDeleteWriterMetricsSingleFile(FileFormat fileFormat) throws IOException {
+    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
+
+    FileWriterBuilder<PositionDeleteWriter<T>, ?> writerBuilder =
+        FormatModelRegistry.positionDeleteWriteBuilder(fileFormat, encryptedFile);
+
+    // Only reference a single data file, which takes the copyWithoutFieldCounts branch:
+    // counts are removed but bounds are preserved.
+    List<PositionDelete<T>> deletes =
+        ImmutableList.of(
+            PositionDelete.<T>create().set("d-file-1.parquet", 0L),
+            PositionDelete.<T>create().set("d-file-1.parquet", 5L),
+            PositionDelete.<T>create().set("d-file-1.parquet", 3L));
+
+    List<Record> genericRecords =
+        deletes.stream()
+            .map(
+                d ->
+                    GenericRecord.create(positionDeleteSchema)
+                        .copy(
+                            DELETE_FILE_PATH.name(), d.path(),
+                            DELETE_FILE_POS.name(), d.pos()))
+            .toList();
+
+    PositionDeleteWriter<T> writer = writerBuilder.spec(PartitionSpec.unpartitioned()).build();
+    try (writer) {
+      deletes.forEach(writer::write);
+    }
+
+    DeleteFile deleteFile = writer.toDeleteFile();
+
+    assertThat(deleteFile).isNotNull();
+    assertThat(deleteFile.recordCount()).isEqualTo(deletes.size());
+
+    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
+
+    // Single file reference: valueCounts and nullValueCounts for file_path and pos are removed
+    assertCountsNull(positionDeleteSchema, deleteFile.valueCounts(), deleteFile.nullValueCounts());
+    // Single file reference: bounds are preserved
+    assertBounds(
+        positionDeleteSchema, genericRecords, deleteFile.lowerBounds(), deleteFile.upperBounds());
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testPositionDeleteWriterMetricsMultipleFiles(FileFormat fileFormat) throws IOException {
+    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
+
+    FileWriterBuilder<PositionDeleteWriter<T>, ?> writerBuilder =
+        FormatModelRegistry.positionDeleteWriteBuilder(fileFormat, encryptedFile);
+
+    // Reference multiple data files, which takes the copyWithoutFieldCountsAndBounds branch:
+    // both counts and bounds are removed.
+    List<PositionDelete<T>> deletes =
+        ImmutableList.of(
+            PositionDelete.<T>create().set("d-file-1.parquet", 0L),
+            PositionDelete.<T>create().set("d-file-1.parquet", 5L),
+            PositionDelete.<T>create().set("d-file-2.parquet", 3L));
+
+    PositionDeleteWriter<T> writer = writerBuilder.spec(PartitionSpec.unpartitioned()).build();
+    try (writer) {
+      deletes.forEach(writer::write);
+    }
+
+    DeleteFile deleteFile = writer.toDeleteFile();
+
+    assertThat(deleteFile).isNotNull();
+    assertThat(deleteFile.recordCount()).isEqualTo(deletes.size());
+
+    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
+
+    // Multiple file references: all metrics (counts and bounds) for file_path and pos are removed
+    assertCountsNull(positionDeleteSchema, deleteFile.valueCounts(), deleteFile.nullValueCounts());
+    assertBoundsNull(positionDeleteSchema, deleteFile.lowerBounds(), deleteFile.upperBounds());
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterMetricsWithPerColumnMode(FileFormat fileFormat) throws IOException {
+    // AVRO Only support metric collection with rowCount
+    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
+
+    DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
+    Schema schema = dataGenerator.schema();
+
+    // Default mode is "counts", col_b is overridden to "full", col_a is overridden to "none"
+    TestTables.TestTable table =
+        TestTables.create(
+            tableDir,
+            "test",
+            schema,
+            PartitionSpec.unpartitioned(),
+            3,
+            ImmutableMap.of(
+                TableProperties.DEFAULT_WRITE_METRICS_MODE,
+                "counts",
+                TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col_b",
+                "full",
+                TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col_a",
+                "none"));
+
+    MetricsConfig perColumnConfig = MetricsConfig.forTable(table);
+
+    FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
+        FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
+
+    DataWriter<Record> writer =
+        writerBuilder
+            .schema(schema)
+            .spec(PartitionSpec.unpartitioned())
+            .metricsConfig(perColumnConfig)
+            .build();
+
+    List<Record> genericRecords = dataGenerator.generateRecords();
+
+    try (writer) {
+      genericRecords.forEach(writer::write);
+    }
+
+    DataFile dataFile = writer.toDataFile();
+
+    assertThat(dataFile).isNotNull();
+    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
+
+    // col_a: mode=none -> no valueCounts, nullValueCounts, bounds
+    Schema noneSchema = new Schema(schema.findField("col_a"));
+    assertCountsNull(noneSchema, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBoundsNull(noneSchema, dataFile.lowerBounds(), dataFile.upperBounds());
+
+    // col_b: mode=full -> valueCounts, nullValueCounts, and bounds all present
+    Schema fullSchema = new Schema(schema.findField("col_b"));
+    assertValueAndNullCounts(
+        fullSchema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBounds(fullSchema, genericRecords, dataFile.lowerBounds(), dataFile.upperBounds());
+
+    // col_c, col_d, col_e: mode=counts (default) -> valueCounts and nullValueCounts present,
+    // but no bounds
+    Schema countsSchema =
+        new Schema(schema.findField("col_c"), schema.findField("col_d"), schema.findField("col_e"));
+    assertValueAndNullCounts(
+        countsSchema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBoundsNull(countsSchema, dataFile.lowerBounds(), dataFile.upperBounds());
+
+    TestTables.clearTables();
+  }
+
   private void readAndAssertGenericRecords(
       FileFormat fileFormat, Schema schema, List<Record> expected) throws IOException {
     InputFile inputFile = encryptedFile.encryptingOutputFile().toInputFile();
@@ -638,6 +969,7 @@ public abstract class BaseFormatModelTests<T> {
             .build()) {
       readRecords = ImmutableList.copyOf(reader);
     }
+
     DataTestHelpers.assertEquals(schema.asStruct(), expected, readRecords);
   }
 
@@ -718,5 +1050,109 @@ public abstract class BaseFormatModelTests<T> {
           throw new UnsupportedOperationException(
               "No split size property defined for format: " + fileFormat);
     };
+  }
+
+  private void assertValueAndNullCounts(
+      Schema schema,
+      List<Record> genericRecords,
+      Map<Integer, Long> valueCounts,
+      Map<Integer, Long> nullValueCounts) {
+    for (Types.NestedField field : schema.columns()) {
+      if (field.type().isPrimitiveType()) {
+        assertThat(valueCounts).containsKey(field.fieldId());
+        assertThat(nullValueCounts).containsKey(field.fieldId());
+
+        long nullCount =
+            genericRecords.stream().filter(r -> r.getField(field.name()) == null).count();
+
+        assertThat(valueCounts.get(field.fieldId())).isEqualTo(genericRecords.size());
+        assertThat(nullValueCounts.get(field.fieldId())).isEqualTo(nullCount);
+      }
+    }
+  }
+
+  private void assertBounds(
+      Schema schema,
+      List<Record> genericRecords,
+      Map<Integer, ByteBuffer> lowerBounds,
+      Map<Integer, ByteBuffer> upperBounds) {
+    for (Types.NestedField field : schema.columns()) {
+      if (field.type().isPrimitiveType()) {
+        assertThat(lowerBounds).containsKey(field.fieldId());
+        assertThat(upperBounds).containsKey(field.fieldId());
+
+        ByteBuffer lowerBuffer = lowerBounds.get(field.fieldId());
+        ByteBuffer upperBuffer = upperBounds.get(field.fieldId());
+
+        Comparator<Object> cmp = Comparators.forType(field.type().asPrimitiveType());
+
+        Object[] minMax = computeMinMax(genericRecords, field, cmp);
+        Object expectedMin = minMax[0];
+        Object expectedMax = minMax[1];
+
+        if (expectedMin != null) {
+          assertThat(lowerBuffer).isNotNull();
+          Object actualLower = Conversions.fromByteBuffer(field.type(), lowerBuffer);
+          assertThat(cmp.compare(actualLower, expectedMin)).isEqualTo(0);
+        }
+
+        if (expectedMax != null) {
+          assertThat(upperBuffer).isNotNull();
+          Object actualUpper = Conversions.fromByteBuffer(field.type(), upperBuffer);
+          assertThat(cmp.compare(actualUpper, expectedMax)).isEqualTo(0);
+        }
+      }
+    }
+  }
+
+  private static Object[] computeMinMax(
+      List<Record> records, Types.NestedField field, Comparator<Object> cmp) {
+    Object min = null;
+    Object max = null;
+    for (Record record : records) {
+      Object value = record.getField(field.name());
+      if (value == null) {
+        continue;
+      }
+
+      if (value instanceof Float && ((Float) value).isNaN()) {
+        continue;
+      }
+
+      if (value instanceof Double && ((Double) value).isNaN()) {
+        continue;
+      }
+
+      if (min == null || cmp.compare(value, min) < 0) {
+        min = value;
+      }
+
+      if (max == null || cmp.compare(value, max) > 0) {
+        max = value;
+      }
+    }
+
+    return new Object[] {min, max};
+  }
+
+  private void assertBoundsNull(
+      Schema schema, Map<Integer, ByteBuffer> lowerBounds, Map<Integer, ByteBuffer> upperBounds) {
+    for (Types.NestedField field : schema.columns()) {
+      if (field.type().isPrimitiveType()) {
+        assertThat(lowerBounds == null || lowerBounds.get(field.fieldId()) == null).isTrue();
+        assertThat(upperBounds == null || upperBounds.get(field.fieldId()) == null).isTrue();
+      }
+    }
+  }
+
+  private void assertCountsNull(
+      Schema schema, Map<Integer, Long> valueCounts, Map<Integer, Long> nullValueCounts) {
+    for (Types.NestedField field : schema.columns()) {
+      if (field.type().isPrimitiveType()) {
+        assertThat(valueCounts == null || valueCounts.get(field.fieldId()) == null).isTrue();
+        assertThat(nullValueCounts == null || nullValueCounts.get(field.fieldId()) == null)
+            .isTrue();
+      }
+    }
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -103,13 +103,13 @@ public abstract class BaseFormatModelTests<T> {
   static final String FEATURE_CASE_SENSITIVE = "caseSensitive";
   static final String FEATURE_SPLIT = "split";
   static final String FEATURE_REUSE_CONTAINERS = "reuseContainers";
-  static final String FEATURE_METRIC_COLLECT = "metricCollect";
+  static final String FEATURE_COLUMN_LEVEL_METRICS = "columnLevelMetrics";
 
   private static final Map<FileFormat, String[]> MISSING_FEATURES =
       Map.of(
           FileFormat.AVRO,
           new String[] {
-            FEATURE_FILTER, FEATURE_CASE_SENSITIVE, FEATURE_SPLIT, FEATURE_METRIC_COLLECT
+            FEATURE_FILTER, FEATURE_CASE_SENSITIVE, FEATURE_SPLIT, FEATURE_COLUMN_LEVEL_METRICS
           },
           FileFormat.ORC,
           new String[] {FEATURE_REUSE_CONTAINERS});
@@ -137,6 +137,8 @@ public abstract class BaseFormatModelTests<T> {
     if (fileIO != null) {
       fileIO.close();
     }
+
+    TestTables.clearTables();
   }
 
   /** Write with engine type T, read with Generic Record */
@@ -412,6 +414,9 @@ public abstract class BaseFormatModelTests<T> {
     assumeSupports(fileFormat, FEATURE_FILTER);
 
     Schema schema = SCHEMA;
+    new Schema(
+        Types.NestedField.required(1, "id", Types.IntegerType.get()),
+        Types.NestedField.required(2, "data", Types.StringType.get()));
 
     // Generate records with known id values [0, count)
     int count = 10000;
@@ -644,29 +649,17 @@ public abstract class BaseFormatModelTests<T> {
   void testDataWriterMetricsCollection(FileFormat fileFormat) throws IOException {
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
-    FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
-        FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
-
-    DataWriter<Record> writer =
-        writerBuilder.schema(schema).spec(PartitionSpec.unpartitioned()).build();
 
     List<Record> genericRecords = dataGenerator.generateRecords();
-
-    try (writer) {
-      genericRecords.forEach(writer::write);
-    }
-
-    DataFile dataFile = writer.toDataFile();
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords);
 
     assertThat(dataFile).isNotNull();
     assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
 
-    // AVRO Only support metric collection with rowCount
-    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
-
     assertValueAndNullCounts(
-        schema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBounds(schema, genericRecords, dataFile.lowerBounds(), dataFile.upperBounds());
+        fileFormat, schema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBounds(
+        fileFormat, schema, genericRecords, dataFile.lowerBounds(), dataFile.upperBounds());
 
     assertThat(dataFile.columnSizes()).isNotNull().isNotEmpty();
   }
@@ -674,10 +667,6 @@ public abstract class BaseFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testDataWriterMetricsWithNoneMode(FileFormat fileFormat) throws IOException {
-
-    // AVRO Only support metric collection with rowCount
-    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
-
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
 
@@ -691,48 +680,19 @@ public abstract class BaseFormatModelTests<T> {
             ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none"));
 
     MetricsConfig noneConfig = MetricsConfig.forTable(table);
-
-    FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
-        FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
-
-    DataWriter<Record> writer =
-        writerBuilder
-            .schema(schema)
-            .spec(PartitionSpec.unpartitioned())
-            .metricsConfig(noneConfig)
-            .build();
-
     List<Record> genericRecords = dataGenerator.generateRecords();
-
-    try (writer) {
-      genericRecords.forEach(writer::write);
-    }
-
-    DataFile dataFile = writer.toDataFile();
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, noneConfig);
 
     assertThat(dataFile).isNotNull();
     assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
 
-    // In `None` mode, `valueCounts`, `nullValueCounts`, `lowerBounds`, and `upperBounds` should be
-    // empty/null.
-    for (Types.NestedField field : schema.columns()) {
-      if (field.type().isPrimitiveType()) {
-        assertThat(dataFile.valueCounts().get(field.fieldId())).isNull();
-        assertThat(dataFile.nullValueCounts().get(field.fieldId())).isNull();
-        assertThat(dataFile.lowerBounds().get(field.fieldId())).isNull();
-        assertThat(dataFile.upperBounds().get(field.fieldId())).isNull();
-      }
-    }
-
-    TestTables.clearTables();
+    assertCountsNull(fileFormat, schema, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBoundsNull(fileFormat, schema, dataFile.lowerBounds(), dataFile.upperBounds());
   }
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testDataWriterMetricsWithCountsMode(FileFormat fileFormat) throws IOException {
-    // AVRO Only support metric collection with rowCount
-    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
-
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
     TestTables.TestTable table =
@@ -746,23 +706,8 @@ public abstract class BaseFormatModelTests<T> {
 
     MetricsConfig countsConfig = MetricsConfig.forTable(table);
 
-    FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
-        FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
-
-    DataWriter<Record> writer =
-        writerBuilder
-            .schema(schema)
-            .spec(PartitionSpec.unpartitioned())
-            .metricsConfig(countsConfig)
-            .build();
-
     List<Record> genericRecords = dataGenerator.generateRecords();
-
-    try (writer) {
-      genericRecords.forEach(writer::write);
-    }
-
-    DataFile dataFile = writer.toDataFile();
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, countsConfig);
 
     assertThat(dataFile).isNotNull();
     assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
@@ -770,19 +715,13 @@ public abstract class BaseFormatModelTests<T> {
     // In the counts mode, valueCounts and nullValueCounts should be present, while lowerBounds and
     // upperBounds should be null.
     assertValueAndNullCounts(
-        schema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBoundsNull(schema, dataFile.lowerBounds(), dataFile.upperBounds());
-
-    TestTables.clearTables();
+        fileFormat, schema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBoundsNull(fileFormat, schema, dataFile.lowerBounds(), dataFile.upperBounds());
   }
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testEqualityDeleteWriterMetricsCollection(FileFormat fileFormat) throws IOException {
-
-    // AVRO Only support metric collection with rowCount
-    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
-
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
     FileWriterBuilder<EqualityDeleteWriter<Record>, Object> writerBuilder =
@@ -807,71 +746,45 @@ public abstract class BaseFormatModelTests<T> {
     assertThat(deleteFile.recordCount()).isEqualTo(genericRecords.size());
 
     assertValueAndNullCounts(
-        schema, genericRecords, deleteFile.valueCounts(), deleteFile.nullValueCounts());
-    assertBounds(schema, genericRecords, deleteFile.lowerBounds(), deleteFile.upperBounds());
+        fileFormat, schema, genericRecords, deleteFile.valueCounts(), deleteFile.nullValueCounts());
+    assertBounds(
+        fileFormat, schema, genericRecords, deleteFile.lowerBounds(), deleteFile.upperBounds());
   }
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testPositionDeleteWriterMetricsSingleFile(FileFormat fileFormat) throws IOException {
-    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
-
-    FileWriterBuilder<PositionDeleteWriter<T>, ?> writerBuilder =
-        FormatModelRegistry.positionDeleteWriteBuilder(fileFormat, encryptedFile);
-
-    // Only reference a single data file, which takes the copyWithoutFieldCounts branch:
-    // counts are removed but bounds are preserved.
+    // Single file reference: counts are removed but bounds are preserved.
     List<PositionDelete<T>> deletes =
         ImmutableList.of(
             PositionDelete.<T>create().set("d-file-1.parquet", 0L),
             PositionDelete.<T>create().set("d-file-1.parquet", 5L),
             PositionDelete.<T>create().set("d-file-1.parquet", 3L));
 
-    List<Record> genericRecords =
-        deletes.stream()
-            .map(
-                d ->
-                    GenericRecord.create(positionDeleteSchema)
-                        .copy(
-                            DELETE_FILE_PATH.name(), d.path(),
-                            DELETE_FILE_POS.name(), d.pos()))
-            .toList();
-
-    PositionDeleteWriter<T> writer = writerBuilder.spec(PartitionSpec.unpartitioned()).build();
-    try (writer) {
-      deletes.forEach(writer::write);
-    }
-
-    DeleteFile deleteFile = writer.toDeleteFile();
-
-    assertThat(deleteFile).isNotNull();
-    assertThat(deleteFile.recordCount()).isEqualTo(deletes.size());
-
-    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
-
-    // Single file reference: valueCounts and nullValueCounts for file_path and pos are removed
-    assertCountsNull(positionDeleteSchema, deleteFile.valueCounts(), deleteFile.nullValueCounts());
-    // Single file reference: bounds are preserved
-    assertBounds(
-        positionDeleteSchema, genericRecords, deleteFile.lowerBounds(), deleteFile.upperBounds());
+    writePositionDeletesAndAssertMetrics(fileFormat, deletes, true);
   }
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testPositionDeleteWriterMetricsMultipleFiles(FileFormat fileFormat) throws IOException {
-    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
-
-    FileWriterBuilder<PositionDeleteWriter<T>, ?> writerBuilder =
-        FormatModelRegistry.positionDeleteWriteBuilder(fileFormat, encryptedFile);
-
-    // Reference multiple data files, which takes the copyWithoutFieldCountsAndBounds branch:
-    // both counts and bounds are removed.
+    // Multiple file references: both counts and bounds are removed.
     List<PositionDelete<T>> deletes =
         ImmutableList.of(
             PositionDelete.<T>create().set("d-file-1.parquet", 0L),
             PositionDelete.<T>create().set("d-file-1.parquet", 5L),
             PositionDelete.<T>create().set("d-file-2.parquet", 3L));
 
+    writePositionDeletesAndAssertMetrics(fileFormat, deletes, false);
+  }
+
+  private void writePositionDeletesAndAssertMetrics(
+      FileFormat fileFormat, List<PositionDelete<T>> deletes, boolean singleFileReference)
+      throws IOException {
+    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
+
+    FileWriterBuilder<PositionDeleteWriter<T>, ?> writerBuilder =
+        FormatModelRegistry.positionDeleteWriteBuilder(fileFormat, encryptedFile);
+
     PositionDeleteWriter<T> writer = writerBuilder.spec(PartitionSpec.unpartitioned()).build();
     try (writer) {
       deletes.forEach(writer::write);
@@ -882,19 +795,36 @@ public abstract class BaseFormatModelTests<T> {
     assertThat(deleteFile).isNotNull();
     assertThat(deleteFile.recordCount()).isEqualTo(deletes.size());
 
-    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
+    assertCountsNull(
+        fileFormat, positionDeleteSchema, deleteFile.valueCounts(), deleteFile.nullValueCounts());
 
-    // Multiple file references: all metrics (counts and bounds) for file_path and pos are removed
-    assertCountsNull(positionDeleteSchema, deleteFile.valueCounts(), deleteFile.nullValueCounts());
-    assertBoundsNull(positionDeleteSchema, deleteFile.lowerBounds(), deleteFile.upperBounds());
+    if (singleFileReference) {
+      // Single file reference: bounds are preserved
+      List<Record> genericRecords =
+          deletes.stream()
+              .map(
+                  d ->
+                      GenericRecord.create(positionDeleteSchema)
+                          .copy(
+                              DELETE_FILE_PATH.name(), d.path(),
+                              DELETE_FILE_POS.name(), d.pos()))
+              .toList();
+      assertBounds(
+          fileFormat,
+          positionDeleteSchema,
+          genericRecords,
+          deleteFile.lowerBounds(),
+          deleteFile.upperBounds());
+    } else {
+      // Multiple file references: bounds are also removed
+      assertBoundsNull(
+          fileFormat, positionDeleteSchema, deleteFile.lowerBounds(), deleteFile.upperBounds());
+    }
   }
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testDataWriterMetricsWithPerColumnMode(FileFormat fileFormat) throws IOException {
-    // AVRO Only support metric collection with rowCount
-    assumeSupports(fileFormat, FEATURE_METRIC_COLLECT);
-
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
 
@@ -916,47 +846,35 @@ public abstract class BaseFormatModelTests<T> {
 
     MetricsConfig perColumnConfig = MetricsConfig.forTable(table);
 
-    FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
-        FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
-
-    DataWriter<Record> writer =
-        writerBuilder
-            .schema(schema)
-            .spec(PartitionSpec.unpartitioned())
-            .metricsConfig(perColumnConfig)
-            .build();
-
     List<Record> genericRecords = dataGenerator.generateRecords();
-
-    try (writer) {
-      genericRecords.forEach(writer::write);
-    }
-
-    DataFile dataFile = writer.toDataFile();
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, perColumnConfig);
 
     assertThat(dataFile).isNotNull();
     assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
 
     // col_a: mode=none -> no valueCounts, nullValueCounts, bounds
     Schema noneSchema = new Schema(schema.findField("col_a"));
-    assertCountsNull(noneSchema, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBoundsNull(noneSchema, dataFile.lowerBounds(), dataFile.upperBounds());
+    assertCountsNull(fileFormat, noneSchema, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBoundsNull(fileFormat, noneSchema, dataFile.lowerBounds(), dataFile.upperBounds());
 
     // col_b: mode=full -> valueCounts, nullValueCounts, and bounds all present
     Schema fullSchema = new Schema(schema.findField("col_b"));
     assertValueAndNullCounts(
-        fullSchema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBounds(fullSchema, genericRecords, dataFile.lowerBounds(), dataFile.upperBounds());
+        fileFormat, fullSchema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
+    assertBounds(
+        fileFormat, fullSchema, genericRecords, dataFile.lowerBounds(), dataFile.upperBounds());
 
     // col_c, col_d, col_e: mode=counts (default) -> valueCounts and nullValueCounts present,
     // but no bounds
     Schema countsSchema =
         new Schema(schema.findField("col_c"), schema.findField("col_d"), schema.findField("col_e"));
     assertValueAndNullCounts(
-        countsSchema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBoundsNull(countsSchema, dataFile.lowerBounds(), dataFile.upperBounds());
-
-    TestTables.clearTables();
+        fileFormat,
+        countsSchema,
+        genericRecords,
+        dataFile.valueCounts(),
+        dataFile.nullValueCounts());
+    assertBoundsNull(fileFormat, countsSchema, dataFile.lowerBounds(), dataFile.upperBounds());
   }
 
   private void readAndAssertGenericRecords(
@@ -973,10 +891,20 @@ public abstract class BaseFormatModelTests<T> {
     DataTestHelpers.assertEquals(schema.asStruct(), expected, readRecords);
   }
 
-  private void writeGenericRecords(FileFormat fileFormat, Schema schema, List<Record> records)
+  private DataFile writeGenericRecords(FileFormat fileFormat, Schema schema, List<Record> records)
+      throws IOException {
+    return writeGenericRecords(fileFormat, schema, records, null);
+  }
+
+  private DataFile writeGenericRecords(
+      FileFormat fileFormat, Schema schema, List<Record> records, MetricsConfig metricsConfig)
       throws IOException {
     FileWriterBuilder<DataWriter<Record>, Object> writerBuilder =
         FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile);
+
+    if (metricsConfig != null) {
+      writerBuilder.metricsConfig(metricsConfig);
+    }
 
     DataWriter<Record> writer =
         writerBuilder.schema(schema).spec(PartitionSpec.unpartitioned()).build();
@@ -989,6 +917,8 @@ public abstract class BaseFormatModelTests<T> {
     assertThat(dataFile).isNotNull();
     assertThat(dataFile.recordCount()).isEqualTo(records.size());
     assertThat(dataFile.format()).isEqualTo(fileFormat);
+
+    return dataFile;
   }
 
   private List<Record> projectRecords(List<Record> records, Schema projectedSchema) {
@@ -1053,10 +983,12 @@ public abstract class BaseFormatModelTests<T> {
   }
 
   private void assertValueAndNullCounts(
+      FileFormat fileFormat,
       Schema schema,
       List<Record> genericRecords,
       Map<Integer, Long> valueCounts,
       Map<Integer, Long> nullValueCounts) {
+    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
     for (Types.NestedField field : schema.columns()) {
       if (field.type().isPrimitiveType()) {
         assertThat(valueCounts).containsKey(field.fieldId());
@@ -1072,10 +1004,12 @@ public abstract class BaseFormatModelTests<T> {
   }
 
   private void assertBounds(
+      FileFormat fileFormat,
       Schema schema,
       List<Record> genericRecords,
       Map<Integer, ByteBuffer> lowerBounds,
       Map<Integer, ByteBuffer> upperBounds) {
+    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
     for (Types.NestedField field : schema.columns()) {
       if (field.type().isPrimitiveType()) {
         assertThat(lowerBounds).containsKey(field.fieldId());
@@ -1136,7 +1070,11 @@ public abstract class BaseFormatModelTests<T> {
   }
 
   private void assertBoundsNull(
-      Schema schema, Map<Integer, ByteBuffer> lowerBounds, Map<Integer, ByteBuffer> upperBounds) {
+      FileFormat fileFormat,
+      Schema schema,
+      Map<Integer, ByteBuffer> lowerBounds,
+      Map<Integer, ByteBuffer> upperBounds) {
+    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
     for (Types.NestedField field : schema.columns()) {
       if (field.type().isPrimitiveType()) {
         assertThat(lowerBounds == null || lowerBounds.get(field.fieldId()) == null).isTrue();
@@ -1146,7 +1084,11 @@ public abstract class BaseFormatModelTests<T> {
   }
 
   private void assertCountsNull(
-      Schema schema, Map<Integer, Long> valueCounts, Map<Integer, Long> nullValueCounts) {
+      FileFormat fileFormat,
+      Schema schema,
+      Map<Integer, Long> valueCounts,
+      Map<Integer, Long> nullValueCounts) {
+    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
     for (Types.NestedField field : schema.columns()) {
       if (field.type().isPrimitiveType()) {
         assertThat(valueCounts == null || valueCounts.get(field.fieldId()) == null).isTrue();

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -35,10 +35,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.IntStream;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.MetricsModes;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
@@ -62,8 +64,10 @@ import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -653,15 +657,9 @@ public abstract class BaseFormatModelTests<T> {
     List<Record> genericRecords = dataGenerator.generateRecords();
     DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords);
 
-    assertThat(dataFile).isNotNull();
-    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
-
-    assertValueAndNullCounts(
-        fileFormat, schema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBounds(
-        fileFormat, schema, genericRecords, dataFile.lowerBounds(), dataFile.upperBounds());
-
-    assertThat(dataFile.columnSizes()).isNotNull().isNotEmpty();
+    assertCounts(fileFormat, schema, genericRecords, dataFile);
+    assertBounds(fileFormat, schema, genericRecords, dataFile);
+    assertColumnSize(fileFormat, dataFile);
   }
 
   @ParameterizedTest
@@ -677,17 +675,16 @@ public abstract class BaseFormatModelTests<T> {
             schema,
             PartitionSpec.unpartitioned(),
             3,
-            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, "none"));
+            ImmutableMap.of(
+                TableProperties.DEFAULT_WRITE_METRICS_MODE, MetricsModes.None.get().toString()));
 
     MetricsConfig noneConfig = MetricsConfig.forTable(table);
     List<Record> genericRecords = dataGenerator.generateRecords();
     DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, noneConfig);
 
-    assertThat(dataFile).isNotNull();
-    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
-
-    assertCountsNull(fileFormat, schema, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBoundsNull(fileFormat, schema, dataFile.lowerBounds(), dataFile.upperBounds());
+    assertCountsNull(schema, dataFile);
+    assertBoundsNull(schema, dataFile);
+    assertColumnSizeEmpty(fileFormat, dataFile);
   }
 
   @ParameterizedTest
@@ -702,21 +699,79 @@ public abstract class BaseFormatModelTests<T> {
             schema,
             PartitionSpec.unpartitioned(),
             3,
-            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, "counts"));
+            ImmutableMap.of(
+                TableProperties.DEFAULT_WRITE_METRICS_MODE, MetricsModes.Counts.get().toString()));
 
     MetricsConfig countsConfig = MetricsConfig.forTable(table);
 
     List<Record> genericRecords = dataGenerator.generateRecords();
     DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, countsConfig);
 
-    assertThat(dataFile).isNotNull();
-    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
-
     // In the counts mode, valueCounts and nullValueCounts should be present, while lowerBounds and
     // upperBounds should be null.
-    assertValueAndNullCounts(
-        fileFormat, schema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBoundsNull(fileFormat, schema, dataFile.lowerBounds(), dataFile.upperBounds());
+    assertCounts(fileFormat, schema, genericRecords, dataFile);
+    assertBoundsNull(schema, dataFile);
+    assertColumnSize(fileFormat, dataFile);
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterMetricsWithTruncateMode(FileFormat fileFormat) throws IOException {
+    int truncateLength = 5;
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "col_str", Types.StringType.get()),
+            Types.NestedField.required(2, "col_int", Types.IntegerType.get()));
+
+    TestTables.TestTable table =
+        TestTables.create(
+            tableDir,
+            "test",
+            schema,
+            PartitionSpec.unpartitioned(),
+            3,
+            ImmutableMap.of(
+                TableProperties.DEFAULT_WRITE_METRICS_MODE,
+                MetricsModes.Truncate.withLength(truncateLength).toString()));
+
+    MetricsConfig truncateConfig = MetricsConfig.forTable(table);
+
+    List<Record> records = Lists.newArrayList();
+    records.add(GenericRecord.create(schema).copy("col_str", "abcdefghij", "col_int", 10));
+    records.add(GenericRecord.create(schema).copy("col_str", "abcdezyxwv", "col_int", 20));
+    records.add(GenericRecord.create(schema).copy("col_str", "abcdeAAAAA", "col_int", 5));
+
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, records, truncateConfig);
+
+    assertCounts(fileFormat, schema, records, dataFile);
+
+    if (!supportsFeature(fileFormat, FEATURE_COLUMN_LEVEL_METRICS)) {
+      return;
+    }
+
+    // String column bounds should be truncated
+    Map<Integer, ByteBuffer> lowerBounds = dataFile.lowerBounds();
+    Map<Integer, ByteBuffer> upperBounds = dataFile.upperBounds();
+
+    assertThat(lowerBounds).containsKey(1);
+    assertThat(upperBounds).containsKey(1);
+
+    // Lower bound: "abcdeAAAAA" truncated to "abcde"
+    CharSequence actualLower =
+        Conversions.fromByteBuffer(Types.StringType.get(), lowerBounds.get(1));
+    assertThat(actualLower.toString()).hasSize(truncateLength);
+    assertThat(actualLower.toString()).isEqualTo("abcde");
+
+    // Upper bound: "abcdezyxwv" truncated and incremented to "abcdf"
+    CharSequence actualUpper =
+        Conversions.fromByteBuffer(Types.StringType.get(), upperBounds.get(1));
+    assertThat(actualUpper.toString()).hasSize(truncateLength);
+    assertThat(actualUpper.toString()).isEqualTo("abcdf");
+
+    Schema intSchema = new Schema(schema.findField("col_int"));
+    assertBounds(fileFormat, intSchema, records, dataFile);
+
+    assertThat(dataFile.columnSizes()).isNotNull().isNotEmpty();
   }
 
   @ParameterizedTest
@@ -742,13 +797,9 @@ public abstract class BaseFormatModelTests<T> {
 
     DeleteFile deleteFile = writer.toDeleteFile();
 
-    assertThat(deleteFile).isNotNull();
-    assertThat(deleteFile.recordCount()).isEqualTo(genericRecords.size());
-
-    assertValueAndNullCounts(
-        fileFormat, schema, genericRecords, deleteFile.valueCounts(), deleteFile.nullValueCounts());
-    assertBounds(
-        fileFormat, schema, genericRecords, deleteFile.lowerBounds(), deleteFile.upperBounds());
+    assertCounts(fileFormat, schema, genericRecords, deleteFile);
+    assertBounds(fileFormat, schema, genericRecords, deleteFile);
+    assertColumnSize(fileFormat, deleteFile);
   }
 
   @ParameterizedTest
@@ -761,7 +812,7 @@ public abstract class BaseFormatModelTests<T> {
             PositionDelete.<T>create().set("d-file-1.parquet", 5L),
             PositionDelete.<T>create().set("d-file-1.parquet", 3L));
 
-    writePositionDeletesAndAssertMetrics(fileFormat, deletes, true);
+    writePositionDeletesAndAssertMetrics(fileFormat, deletes, true /* checkBounds */);
   }
 
   @ParameterizedTest
@@ -774,52 +825,7 @@ public abstract class BaseFormatModelTests<T> {
             PositionDelete.<T>create().set("d-file-1.parquet", 5L),
             PositionDelete.<T>create().set("d-file-2.parquet", 3L));
 
-    writePositionDeletesAndAssertMetrics(fileFormat, deletes, false);
-  }
-
-  private void writePositionDeletesAndAssertMetrics(
-      FileFormat fileFormat, List<PositionDelete<T>> deletes, boolean singleFileReference)
-      throws IOException {
-    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
-
-    FileWriterBuilder<PositionDeleteWriter<T>, ?> writerBuilder =
-        FormatModelRegistry.positionDeleteWriteBuilder(fileFormat, encryptedFile);
-
-    PositionDeleteWriter<T> writer = writerBuilder.spec(PartitionSpec.unpartitioned()).build();
-    try (writer) {
-      deletes.forEach(writer::write);
-    }
-
-    DeleteFile deleteFile = writer.toDeleteFile();
-
-    assertThat(deleteFile).isNotNull();
-    assertThat(deleteFile.recordCount()).isEqualTo(deletes.size());
-
-    assertCountsNull(
-        fileFormat, positionDeleteSchema, deleteFile.valueCounts(), deleteFile.nullValueCounts());
-
-    if (singleFileReference) {
-      // Single file reference: bounds are preserved
-      List<Record> genericRecords =
-          deletes.stream()
-              .map(
-                  d ->
-                      GenericRecord.create(positionDeleteSchema)
-                          .copy(
-                              DELETE_FILE_PATH.name(), d.path(),
-                              DELETE_FILE_POS.name(), d.pos()))
-              .toList();
-      assertBounds(
-          fileFormat,
-          positionDeleteSchema,
-          genericRecords,
-          deleteFile.lowerBounds(),
-          deleteFile.upperBounds());
-    } else {
-      // Multiple file references: bounds are also removed
-      assertBoundsNull(
-          fileFormat, positionDeleteSchema, deleteFile.lowerBounds(), deleteFile.upperBounds());
-    }
+    writePositionDeletesAndAssertMetrics(fileFormat, deletes, false /* checkBounds */);
   }
 
   @ParameterizedTest
@@ -838,43 +844,95 @@ public abstract class BaseFormatModelTests<T> {
             3,
             ImmutableMap.of(
                 TableProperties.DEFAULT_WRITE_METRICS_MODE,
-                "counts",
+                MetricsModes.Counts.get().toString(),
                 TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col_b",
-                "full",
+                MetricsModes.Full.get().toString(),
                 TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col_a",
-                "none"));
+                MetricsModes.None.get().toString()));
 
     MetricsConfig perColumnConfig = MetricsConfig.forTable(table);
 
     List<Record> genericRecords = dataGenerator.generateRecords();
     DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, perColumnConfig);
 
-    assertThat(dataFile).isNotNull();
-    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
-
     // col_a: mode=none -> no valueCounts, nullValueCounts, bounds
     Schema noneSchema = new Schema(schema.findField("col_a"));
-    assertCountsNull(fileFormat, noneSchema, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBoundsNull(fileFormat, noneSchema, dataFile.lowerBounds(), dataFile.upperBounds());
+    assertCountsNull(noneSchema, dataFile);
+    assertBoundsNull(noneSchema, dataFile);
 
     // col_b: mode=full -> valueCounts, nullValueCounts, and bounds all present
     Schema fullSchema = new Schema(schema.findField("col_b"));
-    assertValueAndNullCounts(
-        fileFormat, fullSchema, genericRecords, dataFile.valueCounts(), dataFile.nullValueCounts());
-    assertBounds(
-        fileFormat, fullSchema, genericRecords, dataFile.lowerBounds(), dataFile.upperBounds());
+    assertCounts(fileFormat, fullSchema, genericRecords, dataFile);
+    assertBounds(fileFormat, fullSchema, genericRecords, dataFile);
 
     // col_c, col_d, col_e: mode=counts (default) -> valueCounts and nullValueCounts present,
     // but no bounds
     Schema countsSchema =
         new Schema(schema.findField("col_c"), schema.findField("col_d"), schema.findField("col_e"));
-    assertValueAndNullCounts(
-        fileFormat,
-        countsSchema,
-        genericRecords,
-        dataFile.valueCounts(),
-        dataFile.nullValueCounts());
-    assertBoundsNull(fileFormat, countsSchema, dataFile.lowerBounds(), dataFile.upperBounds());
+    assertCounts(fileFormat, countsSchema, genericRecords, dataFile);
+    assertBoundsNull(countsSchema, dataFile);
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterNanMetrics(FileFormat fileFormat) throws IOException {
+    Schema schema = new DataGenerators.FloatDoubleSchema().schema();
+
+    List<Record> records = Lists.newArrayList();
+    records.add(
+        GenericRecord.create(schema).copy("col_float", Float.NaN, "col_double", Double.NaN));
+    records.add(
+        GenericRecord.create(schema).copy("col_float", Float.NaN, "col_double", Double.NaN));
+    records.add(GenericRecord.create(schema).copy("col_float", 1.0F, "col_double", 10.0D));
+    records.add(GenericRecord.create(schema).copy("col_float", 5.0F, "col_double", 50.0D));
+    records.add(GenericRecord.create(schema).copy("col_float", 3.0F, "col_double", 30.0D));
+
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, records);
+
+    assertCounts(fileFormat, schema, records, dataFile);
+    assertBounds(fileFormat, schema, records, dataFile);
+    assertNanCounts(fileFormat, schema, records, dataFile);
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterNanSortingOrder(FileFormat fileFormat) throws IOException {
+    Schema schema = new DataGenerators.FloatDoubleSchema().schema();
+
+    List<Record> records = Lists.newArrayList();
+    records.add(
+        GenericRecord.create(schema).copy("col_float", Float.NaN, "col_double", Double.NaN));
+    records.add(
+        GenericRecord.create(schema)
+            .copy("col_float", Float.NEGATIVE_INFINITY, "col_double", Double.NEGATIVE_INFINITY));
+    records.add(GenericRecord.create(schema).copy("col_float", -1.0F, "col_double", -1.0D));
+    records.add(GenericRecord.create(schema).copy("col_float", -0.0F, "col_double", -0.0D));
+    records.add(GenericRecord.create(schema).copy("col_float", 0.0F, "col_double", 0.0D));
+    records.add(GenericRecord.create(schema).copy("col_float", 1.0F, "col_double", 1.0D));
+    records.add(
+        GenericRecord.create(schema)
+            .copy("col_float", Float.POSITIVE_INFINITY, "col_double", Double.POSITIVE_INFINITY));
+    records.add(
+        GenericRecord.create(schema).copy("col_float", Float.NaN, "col_double", Double.NaN));
+
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, records);
+
+    // Bounds should exclude NaN: float/double lower = -Infinity, upper = +Infinity
+    assertBounds(fileFormat, schema, records, dataFile);
+    assertNanCounts(fileFormat, schema, records, dataFile);
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterNegativeZeroBounds(FileFormat fileFormat) throws IOException {
+    Schema schema = new DataGenerators.FloatDoubleSchema().schema();
+
+    List<Record> records = Lists.newArrayList();
+    records.add(GenericRecord.create(schema).copy("col_float", -0.0F, "col_double", -0.0D));
+    records.add(GenericRecord.create(schema).copy("col_float", 0.0F, "col_double", 0.0D));
+
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, records);
+    assertBounds(fileFormat, schema, records, dataFile);
   }
 
   private void readAndAssertGenericRecords(
@@ -943,6 +1001,11 @@ public abstract class BaseFormatModelTests<T> {
     assumeThat(MISSING_FEATURES.getOrDefault(fileFormat, new String[] {})).doesNotContain(feature);
   }
 
+  private static boolean supportsFeature(FileFormat fileFormat, String feature) {
+    String[] missing = MISSING_FEATURES.getOrDefault(fileFormat, new String[] {});
+    return !Arrays.asList(missing).contains(feature);
+  }
+
   private DataFile writeRecordsForSplit(FileFormat fileFormat, Schema schema, List<Record> records)
       throws IOException {
 
@@ -982,13 +1045,14 @@ public abstract class BaseFormatModelTests<T> {
     };
   }
 
-  private void assertValueAndNullCounts(
-      FileFormat fileFormat,
-      Schema schema,
-      List<Record> genericRecords,
-      Map<Integer, Long> valueCounts,
-      Map<Integer, Long> nullValueCounts) {
-    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
+  private static void assertCounts(
+      FileFormat fileFormat, Schema schema, List<Record> genericRecords, ContentFile<?> file) {
+    if (!supportsFeature(fileFormat, FEATURE_COLUMN_LEVEL_METRICS)) {
+      return;
+    }
+
+    Map<Integer, Long> valueCounts = file.valueCounts();
+    Map<Integer, Long> nullValueCounts = file.nullValueCounts();
     for (Types.NestedField field : schema.columns()) {
       if (field.type().isPrimitiveType()) {
         assertThat(valueCounts).containsKey(field.fieldId());
@@ -1003,13 +1067,14 @@ public abstract class BaseFormatModelTests<T> {
     }
   }
 
-  private void assertBounds(
-      FileFormat fileFormat,
-      Schema schema,
-      List<Record> genericRecords,
-      Map<Integer, ByteBuffer> lowerBounds,
-      Map<Integer, ByteBuffer> upperBounds) {
-    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
+  private static void assertBounds(
+      FileFormat fileFormat, Schema schema, List<Record> genericRecords, ContentFile<?> file) {
+    if (!supportsFeature(fileFormat, FEATURE_COLUMN_LEVEL_METRICS)) {
+      return;
+    }
+
+    Map<Integer, ByteBuffer> lowerBounds = file.lowerBounds();
+    Map<Integer, ByteBuffer> upperBounds = file.upperBounds();
     for (Types.NestedField field : schema.columns()) {
       if (field.type().isPrimitiveType()) {
         assertThat(lowerBounds).containsKey(field.fieldId());
@@ -1069,12 +1134,9 @@ public abstract class BaseFormatModelTests<T> {
     return new Object[] {min, max};
   }
 
-  private void assertBoundsNull(
-      FileFormat fileFormat,
-      Schema schema,
-      Map<Integer, ByteBuffer> lowerBounds,
-      Map<Integer, ByteBuffer> upperBounds) {
-    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
+  private static void assertBoundsNull(Schema schema, ContentFile<?> file) {
+    Map<Integer, ByteBuffer> lowerBounds = file.lowerBounds();
+    Map<Integer, ByteBuffer> upperBounds = file.upperBounds();
     for (Types.NestedField field : schema.columns()) {
       if (field.type().isPrimitiveType()) {
         assertThat(lowerBounds == null || lowerBounds.get(field.fieldId()) == null).isTrue();
@@ -1083,18 +1145,95 @@ public abstract class BaseFormatModelTests<T> {
     }
   }
 
-  private void assertCountsNull(
-      FileFormat fileFormat,
-      Schema schema,
-      Map<Integer, Long> valueCounts,
-      Map<Integer, Long> nullValueCounts) {
-    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
+  private static void assertColumnSize(FileFormat fileFormat, ContentFile<?> file) {
+    if (!supportsFeature(fileFormat, FEATURE_COLUMN_LEVEL_METRICS)) {
+      return;
+    }
+
+    assertThat(file.columnSizes()).isNotNull().isNotEmpty();
+  }
+
+  private static void assertColumnSizeEmpty(FileFormat fileFormat, ContentFile<?> file) {
+    if (!supportsFeature(fileFormat, FEATURE_COLUMN_LEVEL_METRICS)) {
+      return;
+    }
+
+    assertThat(file.columnSizes()).isEmpty();
+  }
+
+  private static void assertCountsNull(Schema schema, ContentFile<?> file) {
+    Map<Integer, Long> valueCounts = file.valueCounts();
+    Map<Integer, Long> nullValueCounts = file.nullValueCounts();
     for (Types.NestedField field : schema.columns()) {
       if (field.type().isPrimitiveType()) {
         assertThat(valueCounts == null || valueCounts.get(field.fieldId()) == null).isTrue();
         assertThat(nullValueCounts == null || nullValueCounts.get(field.fieldId()) == null)
             .isTrue();
       }
+    }
+  }
+
+  private static void assertNanCounts(
+      FileFormat fileFormat, Schema schema, List<Record> records, ContentFile<?> file) {
+    if (!supportsFeature(fileFormat, FEATURE_COLUMN_LEVEL_METRICS)) {
+      return;
+    }
+
+    Map<Integer, Long> nanValueCounts = file.nanValueCounts();
+    assertThat(nanValueCounts).isNotNull();
+
+    for (Types.NestedField field : schema.columns()) {
+      if (field.type().typeId() == Type.TypeID.FLOAT
+          || field.type().typeId() == Type.TypeID.DOUBLE) {
+        long expectedNanCount =
+            records.stream()
+                .map(r -> r.getField(field.name()))
+                .filter(
+                    v ->
+                        (v instanceof Float && ((Float) v).isNaN())
+                            || (v instanceof Double && ((Double) v).isNaN()))
+                .count();
+        assertThat(nanValueCounts.get(field.fieldId())).isEqualTo(expectedNanCount);
+      }
+    }
+  }
+
+  private void writePositionDeletesAndAssertMetrics(
+      FileFormat fileFormat, List<PositionDelete<T>> deletes, boolean checkBounds)
+      throws IOException {
+    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
+
+    FileWriterBuilder<PositionDeleteWriter<T>, ?> writerBuilder =
+        FormatModelRegistry.positionDeleteWriteBuilder(fileFormat, encryptedFile);
+
+    PositionDeleteWriter<T> writer = writerBuilder.spec(PartitionSpec.unpartitioned()).build();
+    try (writer) {
+      deletes.forEach(writer::write);
+    }
+
+    DeleteFile deleteFile = writer.toDeleteFile();
+
+    assertThat(deleteFile).isNotNull();
+    assertThat(deleteFile.recordCount()).isEqualTo(deletes.size());
+    assertCountsNull(positionDeleteSchema, deleteFile);
+
+    assumeSupports(fileFormat, FEATURE_COLUMN_LEVEL_METRICS);
+
+    if (checkBounds) {
+      // Single file reference: bounds are preserved
+      List<Record> genericRecords =
+          deletes.stream()
+              .map(
+                  d ->
+                      GenericRecord.create(positionDeleteSchema)
+                          .copy(
+                              DELETE_FILE_PATH.name(), d.path(),
+                              DELETE_FILE_POS.name(), d.pos()))
+              .toList();
+      assertBounds(fileFormat, positionDeleteSchema, genericRecords, deleteFile);
+    } else {
+      // Multiple file references: bounds are also removed
+      assertBoundsNull(positionDeleteSchema, deleteFile);
     }
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -804,11 +804,12 @@ public abstract class BaseFormatModelTests<T> {
     // Single file reference: counts are removed but bounds are preserved.
     List<PositionDelete<T>> deletes =
         ImmutableList.of(
-            PositionDelete.<T>create().set("d-file-1.parquet", 0L),
-            PositionDelete.<T>create().set("d-file-1.parquet", 5L),
-            PositionDelete.<T>create().set("d-file-1.parquet", 3L));
+            PositionDelete.<T>create().set("d-file-1.file", 0L),
+            PositionDelete.<T>create().set("d-file-1.file", 5L),
+            PositionDelete.<T>create().set("d-file-1.file", 3L));
 
-    writePositionDeletesAndAssertMetrics(fileFormat, deletes, true /* checkBounds */);
+    DeleteFile deleteFile = writePositionDeletes(fileFormat, deletes);
+    assertPositionDeleteMetrics(fileFormat, deletes, deleteFile, true /* checkBounds */);
   }
 
   @ParameterizedTest
@@ -817,11 +818,12 @@ public abstract class BaseFormatModelTests<T> {
     // Multiple file references: both counts and bounds are removed.
     List<PositionDelete<T>> deletes =
         ImmutableList.of(
-            PositionDelete.<T>create().set("d-file-1.parquet", 0L),
-            PositionDelete.<T>create().set("d-file-1.parquet", 5L),
-            PositionDelete.<T>create().set("d-file-2.parquet", 3L));
+            PositionDelete.<T>create().set("d-file-1.file", 0L),
+            PositionDelete.<T>create().set("d-file-1.file", 5L),
+            PositionDelete.<T>create().set("d-file-2.file", 3L));
 
-    writePositionDeletesAndAssertMetrics(fileFormat, deletes, false /* checkBounds */);
+    DeleteFile deleteFile = writePositionDeletes(fileFormat, deletes);
+    assertPositionDeleteMetrics(fileFormat, deletes, deleteFile, false /* checkBounds */);
   }
 
   @ParameterizedTest
@@ -986,6 +988,21 @@ public abstract class BaseFormatModelTests<T> {
     assumeThat(MISSING_FEATURES.getOrDefault(fileFormat, new String[] {})).doesNotContain(feature);
   }
 
+  /**
+   * Returns whether the given file format supports the specified feature.
+   *
+   * <p>The check is based on {@link #MISSING_FEATURES}. Features not listed as missing for a format
+   * are treated as supported.
+   *
+   * <p>Prefer this method over {@link #assumeSupports(FileFormat, String)} when only part of a test
+   * should be skipped conditionally. Unlike {@code assumeSupports}, this method does not abort the
+   * entire test via an assumption failure; it returns {@code false} so callers can skip only
+   * feature-specific assertions while still validating shared behavior.
+   *
+   * @param fileFormat the file format under test
+   * @param feature the feature name
+   * @return {@code true} if the feature is supported by the format; {@code false} otherwise
+   */
   private static boolean supportsFeature(FileFormat fileFormat, String feature) {
     String[] missing = MISSING_FEATURES.getOrDefault(fileFormat, new String[] {});
     return !Arrays.asList(missing).contains(feature);
@@ -1183,11 +1200,8 @@ public abstract class BaseFormatModelTests<T> {
     }
   }
 
-  private void writePositionDeletesAndAssertMetrics(
-      FileFormat fileFormat, List<PositionDelete<T>> deletes, boolean checkBounds)
+  private DeleteFile writePositionDeletes(FileFormat fileFormat, List<PositionDelete<T>> deletes)
       throws IOException {
-    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
-
     FileWriterBuilder<PositionDeleteWriter<T>, ?> writerBuilder =
         FormatModelRegistry.positionDeleteWriteBuilder(fileFormat, encryptedFile);
 
@@ -1196,7 +1210,15 @@ public abstract class BaseFormatModelTests<T> {
       deletes.forEach(writer::write);
     }
 
-    DeleteFile deleteFile = writer.toDeleteFile();
+    return writer.toDeleteFile();
+  }
+
+  private void assertPositionDeleteMetrics(
+      FileFormat fileFormat,
+      List<PositionDelete<T>> deletes,
+      DeleteFile deleteFile,
+      boolean checkBounds) {
+    Schema positionDeleteSchema = DeleteSchemaUtil.pathPosSchema();
 
     assertThat(deleteFile).isNotNull();
     assertThat(deleteFile.recordCount()).isEqualTo(deletes.size());

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -34,6 +34,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -41,6 +42,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.MetricsModes.MetricsMode;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
@@ -108,15 +110,20 @@ public abstract class BaseFormatModelTests<T> {
   static final String FEATURE_SPLIT = "split";
   static final String FEATURE_REUSE_CONTAINERS = "reuseContainers";
   static final String FEATURE_COLUMN_LEVEL_METRICS = "columnLevelMetrics";
+  static final String FEATURE_COLUMN_METRICS_TRUNCATE_BINARY = "columnMetricsTruncateBinary";
 
   private static final Map<FileFormat, String[]> MISSING_FEATURES =
       Map.of(
           FileFormat.AVRO,
           new String[] {
-            FEATURE_FILTER, FEATURE_CASE_SENSITIVE, FEATURE_SPLIT, FEATURE_COLUMN_LEVEL_METRICS
+            FEATURE_FILTER,
+            FEATURE_CASE_SENSITIVE,
+            FEATURE_SPLIT,
+            FEATURE_COLUMN_LEVEL_METRICS,
+            FEATURE_COLUMN_METRICS_TRUNCATE_BINARY
           },
           FileFormat.ORC,
-          new String[] {FEATURE_REUSE_CONTAINERS});
+          new String[] {FEATURE_REUSE_CONTAINERS, FEATURE_COLUMN_METRICS_TRUNCATE_BINARY});
 
   private InMemoryFileIO fileIO;
   private EncryptedOutputFile encryptedFile;
@@ -668,17 +675,7 @@ public abstract class BaseFormatModelTests<T> {
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
 
-    TestTables.TestTable table =
-        TestTables.create(
-            tableDir,
-            "test",
-            schema,
-            PartitionSpec.unpartitioned(),
-            3,
-            ImmutableMap.of(
-                TableProperties.DEFAULT_WRITE_METRICS_MODE, MetricsModes.None.get().toString()));
-
-    MetricsConfig noneConfig = MetricsConfig.forTable(table);
+    MetricsConfig noneConfig = config(schema, MetricsModes.None.get());
     List<Record> genericRecords = dataGenerator.generateRecords();
     DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, noneConfig);
 
@@ -692,18 +689,7 @@ public abstract class BaseFormatModelTests<T> {
   void testDataWriterMetricsWithCountsMode(FileFormat fileFormat) throws IOException {
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
-    TestTables.TestTable table =
-        TestTables.create(
-            tableDir,
-            "test",
-            schema,
-            PartitionSpec.unpartitioned(),
-            3,
-            ImmutableMap.of(
-                TableProperties.DEFAULT_WRITE_METRICS_MODE, MetricsModes.Counts.get().toString()));
-
-    MetricsConfig countsConfig = MetricsConfig.forTable(table);
-
+    MetricsConfig countsConfig = config(schema, MetricsModes.Counts.get());
     List<Record> genericRecords = dataGenerator.generateRecords();
     DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, countsConfig);
 
@@ -723,55 +709,65 @@ public abstract class BaseFormatModelTests<T> {
             Types.NestedField.required(1, "col_str", Types.StringType.get()),
             Types.NestedField.required(2, "col_int", Types.IntegerType.get()));
 
-    TestTables.TestTable table =
-        TestTables.create(
-            tableDir,
-            "test",
-            schema,
-            PartitionSpec.unpartitioned(),
-            3,
-            ImmutableMap.of(
-                TableProperties.DEFAULT_WRITE_METRICS_MODE,
-                MetricsModes.Truncate.withLength(truncateLength).toString()));
-
-    MetricsConfig truncateConfig = MetricsConfig.forTable(table);
-
     List<Record> records = Lists.newArrayList();
     records.add(GenericRecord.create(schema).copy("col_str", "abcdefghij", "col_int", 10));
     records.add(GenericRecord.create(schema).copy("col_str", "abcdezyxwv", "col_int", 20));
     records.add(GenericRecord.create(schema).copy("col_str", "abcdeAAAAA", "col_int", 5));
 
-    DataFile dataFile = writeGenericRecords(fileFormat, schema, records, truncateConfig);
+    assertTruncateBoundsForFirstColumn(
+        fileFormat,
+        schema,
+        records,
+        truncateLength,
+        FEATURE_COLUMN_LEVEL_METRICS,
+        (lower, upper) -> {
+          // Lower bound: "abcdeAAAAA" truncated to "abcde"
+          CharSequence actualLower = Conversions.fromByteBuffer(Types.StringType.get(), lower);
+          assertThat(actualLower.toString()).hasSize(truncateLength);
+          assertThat(actualLower.toString()).isEqualTo("abcde");
 
-    assertCounts(fileFormat, schema, records, dataFile);
+          // Upper bound: "abcdezyxwv" truncated and incremented to "abcdf"
+          CharSequence actualUpper = Conversions.fromByteBuffer(Types.StringType.get(), upper);
+          assertThat(actualUpper.toString()).hasSize(truncateLength);
+          assertThat(actualUpper.toString()).isEqualTo("abcdf");
+        });
+  }
 
-    if (!supportsFeature(fileFormat, FEATURE_COLUMN_LEVEL_METRICS)) {
-      return;
-    }
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterMetricsWithTruncateModeForBinary(FileFormat fileFormat) throws IOException {
+    int truncateLength = 5;
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "col_bin", Types.BinaryType.get()),
+            Types.NestedField.required(2, "col_int", Types.IntegerType.get()));
 
-    // String column bounds should be truncated
-    Map<Integer, ByteBuffer> lowerBounds = dataFile.lowerBounds();
-    Map<Integer, ByteBuffer> upperBounds = dataFile.upperBounds();
+    List<Record> records = Lists.newArrayList();
+    records.add(
+        GenericRecord.create(schema)
+            .copy(
+                "col_bin",
+                ByteBuffer.wrap(
+                    new byte[] {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0xA, 0xB}),
+                "col_int",
+                10));
 
-    assertThat(lowerBounds).containsKey(1);
-    assertThat(upperBounds).containsKey(1);
+    assertTruncateBoundsForFirstColumn(
+        fileFormat,
+        schema,
+        records,
+        truncateLength,
+        FEATURE_COLUMN_METRICS_TRUNCATE_BINARY,
+        (lower, upper) -> {
+          ByteBuffer actualLower = Conversions.fromByteBuffer(Types.BinaryType.get(), lower);
+          ByteBuffer actualUpper = Conversions.fromByteBuffer(Types.BinaryType.get(), upper);
 
-    // Lower bound: "abcdeAAAAA" truncated to "abcde"
-    CharSequence actualLower =
-        Conversions.fromByteBuffer(Types.StringType.get(), lowerBounds.get(1));
-    assertThat(actualLower.toString()).hasSize(truncateLength);
-    assertThat(actualLower.toString()).isEqualTo("abcde");
+          ByteBuffer expectedLower = ByteBuffer.wrap(new byte[] {0x1, 0x2, 0x3, 0x4, 0x5});
+          ByteBuffer expectedUpper = ByteBuffer.wrap(new byte[] {0x1, 0x2, 0x3, 0x4, 0x6});
 
-    // Upper bound: "abcdezyxwv" truncated and incremented to "abcdf"
-    CharSequence actualUpper =
-        Conversions.fromByteBuffer(Types.StringType.get(), upperBounds.get(1));
-    assertThat(actualUpper.toString()).hasSize(truncateLength);
-    assertThat(actualUpper.toString()).isEqualTo("abcdf");
-
-    Schema intSchema = new Schema(schema.findField("col_int"));
-    assertBounds(fileFormat, intSchema, records, dataFile);
-
-    assertThat(dataFile.columnSizes()).isNotNull().isNotEmpty();
+          assertThat(actualLower).isEqualTo(expectedLower);
+          assertThat(actualUpper).isEqualTo(expectedUpper);
+        });
   }
 
   @ParameterizedTest
@@ -835,22 +831,11 @@ public abstract class BaseFormatModelTests<T> {
     Schema schema = dataGenerator.schema();
 
     // Default mode is "counts", col_b is overridden to "full", col_a is overridden to "none"
-    TestTables.TestTable table =
-        TestTables.create(
-            tableDir,
-            "test",
+    MetricsConfig perColumnConfig =
+        config(
             schema,
-            PartitionSpec.unpartitioned(),
-            3,
-            ImmutableMap.of(
-                TableProperties.DEFAULT_WRITE_METRICS_MODE,
-                MetricsModes.Counts.get().toString(),
-                TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col_b",
-                MetricsModes.Full.get().toString(),
-                TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col_a",
-                MetricsModes.None.get().toString()));
-
-    MetricsConfig perColumnConfig = MetricsConfig.forTable(table);
+            MetricsModes.Counts.get(),
+            ImmutableMap.of("col_b", MetricsModes.Full.get(), "col_a", MetricsModes.None.get()));
 
     List<Record> genericRecords = dataGenerator.generateRecords();
     DataFile dataFile = writeGenericRecords(fileFormat, schema, genericRecords, perColumnConfig);
@@ -1235,5 +1220,56 @@ public abstract class BaseFormatModelTests<T> {
       // Multiple file references: bounds are also removed
       assertBoundsNull(positionDeleteSchema, deleteFile);
     }
+  }
+
+  private MetricsConfig config(Schema schema, MetricsMode defaultMode) {
+    return config(schema, defaultMode, ImmutableMap.of());
+  }
+
+  private MetricsConfig config(
+      Schema schema, MetricsMode defaultMode, Map<String, MetricsMode> columnModes) {
+    ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    properties.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, defaultMode.toString());
+    columnModes.forEach(
+        (column, mode) ->
+            properties.put(
+                TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + column, mode.toString()));
+
+    TestTables.TestTable table =
+        TestTables.create(
+            tableDir, "test", schema, PartitionSpec.unpartitioned(), 3, properties.build());
+
+    return MetricsConfig.forTable(table);
+  }
+
+  private void assertTruncateBoundsForFirstColumn(
+      FileFormat fileFormat,
+      Schema schema,
+      List<Record> records,
+      int truncateLength,
+      String requiredFeature,
+      BiConsumer<ByteBuffer, ByteBuffer> boundsAssertion)
+      throws IOException {
+    MetricsConfig truncateConfig = config(schema, MetricsModes.Truncate.withLength(truncateLength));
+
+    DataFile dataFile = writeGenericRecords(fileFormat, schema, records, truncateConfig);
+    assertCounts(fileFormat, schema, records, dataFile);
+
+    if (!supportsFeature(fileFormat, requiredFeature)) {
+      return;
+    }
+
+    Map<Integer, ByteBuffer> lowerBounds = dataFile.lowerBounds();
+    Map<Integer, ByteBuffer> upperBounds = dataFile.upperBounds();
+
+    assertThat(lowerBounds).containsKey(1);
+    assertThat(upperBounds).containsKey(1);
+
+    boundsAssertion.accept(lowerBounds.get(1), upperBounds.get(1));
+
+    Schema intSchema = new Schema(schema.findField("col_int"));
+    assertBounds(fileFormat, intSchema, records, dataFile);
+
+    assertThat(dataFile.columnSizes()).isNotNull().isNotEmpty();
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/DataGenerators.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataGenerators.java
@@ -64,4 +64,16 @@ class DataGenerators {
       return schema;
     }
   }
+
+  static class FloatDoubleSchema implements DataGenerator {
+    private final Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "col_float", Types.FloatType.get()),
+            Types.NestedField.required(2, "col_double", Types.DoubleType.get()));
+
+    @Override
+    public Schema schema() {
+      return schema;
+    }
+  }
 }


### PR DESCRIPTION
This pr add TCK tests for collectionreading in BaseFormatModelTests.

Part of https://github.com/apache/iceberg/issues/15415