### PR TITLE
Core: Close FileIO on cache eviction to prevent thread leaks

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -98,13 +98,6 @@ public class CachingCatalog implements Catalog {
       if (cause.wasEvicted()) {
         if (!MetadataTableUtils.hasMetadataTableName(tableIdentifier)) {
           tableCache.invalidateAll(metadataTableIdentifiers(tableIdentifier));
-          if (table != null) {
-            try {
-              table.io().close();
-            } catch (Exception e) {
-              LOG.warn("Failed to close FileIO for evicted table {}", tableIdentifier, e);
-            }
-          }
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -95,7 +95,7 @@ public class CachingCatalog implements Catalog {
     @Override
     public void onRemoval(TableIdentifier tableIdentifier, Table table, RemovalCause cause) {
       LOG.debug("Evicted {} from the table cache ({})", tableIdentifier, cause);
-      if (RemovalCause.EXPIRED.equals(cause)) {
+      if (cause.wasEvicted()) {
         if (!MetadataTableUtils.hasMetadataTableName(tableIdentifier)) {
           tableCache.invalidateAll(metadataTableIdentifiers(tableIdentifier));
           if (table != null) {

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -98,6 +98,13 @@ public class CachingCatalog implements Catalog {
       if (RemovalCause.EXPIRED.equals(cause)) {
         if (!MetadataTableUtils.hasMetadataTableName(tableIdentifier)) {
           tableCache.invalidateAll(metadataTableIdentifiers(tableIdentifier));
+          if (table != null) {
+            try {
+              table.io().close();
+            } catch (Exception e) {
+              LOG.warn("Failed to close FileIO for evicted table {}", tableIdentifier, e);
+            }
+          }
         }
       }
     }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -20,6 +20,9 @@ package org.apache.iceberg.hadoop;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import java.io.IOException;
@@ -43,6 +46,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.FakeTicker;
@@ -434,6 +438,29 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
     // cache should have been invalidated by registerTable
     assertThat(catalog.cache().asMap()).doesNotContainKey(targetIdent);
+  }
+
+  @Test
+  public void testFileIOClosedOnCacheEviction() throws IOException {
+    FileIO mockIO = mock(FileIO.class);
+    Table mockTable = mock(Table.class);
+    TableIdentifier tableIdent = TableIdentifier.of("db", "tbl");
+
+    Catalog mockCatalog = mock(Catalog.class);
+    when(mockCatalog.loadTable(tableIdent)).thenReturn(mockTable);
+    when(mockTable.io()).thenReturn(mockIO);
+
+    TestableCachingCatalog catalog =
+        TestableCachingCatalog.wrap(mockCatalog, EXPIRATION_TTL, ticker);
+
+    catalog.loadTable(tableIdent);
+    assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+
+    ticker.advance(EXPIRATION_TTL.plus(Duration.ofSeconds(1)));
+    catalog.cache().cleanUp();
+
+    assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+    verify(mockIO).close();
   }
 
   public static TableIdentifier[] metadataTables(TableIdentifier tableIdent) {


### PR DESCRIPTION
Fixes #15898

When tables get evicted from the cache, the FileIO wasn't being closed. This leaves S3FileIO with open thread pools that never get cleaned up, which is a problem in long-running applications. Added a try-catch around the close call since FileIO implementations can throw exceptions, and added a test to verify it gets called.