### PR TITLE
Flink: FlinkSink data loss with unaligned checkpoints

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -423,19 +423,51 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   }
 
   private void writeToManifestUptoLatestCheckpoint(long checkpointId) throws IOException {
-    if (!writeResultsSinceLastSnapshot.containsKey(checkpointId)) {
+
+    if (!dataFilesPerCheckpoint.containsKey(checkpointId)) {
       dataFilesPerCheckpoint.put(checkpointId, EMPTY_MANIFEST_DATA);
     }
 
-    for (Map.Entry<Long, List<WriteResult>> writeResultsOfCheckpoint :
-        writeResultsSinceLastSnapshot.entrySet()) {
-      dataFilesPerCheckpoint.put(
-          writeResultsOfCheckpoint.getKey(),
-          writeToManifest(writeResultsOfCheckpoint.getKey(), writeResultsOfCheckpoint.getValue()));
+    Map<Long, List<WriteResult>> pendingWriteResults = Maps.newHashMap();
+    for (Map.Entry<Long, List<WriteResult>> entry : writeResultsSinceLastSnapshot.entrySet()) {
+      long assignedCheckpointId = computeCheckpointId(checkpointId, entry);
+      pendingWriteResults
+          .computeIfAbsent(assignedCheckpointId, k -> Lists.newArrayList())
+          .addAll(entry.getValue());
+    }
+
+    for (Map.Entry<Long, List<WriteResult>> entry : pendingWriteResults.entrySet()) {
+      dataFilesPerCheckpoint.put(entry.getKey(), writeToManifest(entry.getKey(), entry.getValue()));
     }
 
     // Clear the local buffer for current checkpoint.
     writeResultsSinceLastSnapshot.clear();
+  }
+
+  /**
+   * in case of unaligned checkpoints, data files that were part of checkpoint N in the writer may
+   * have to become part of a later checkpoint in the committer if:
+   *
+   * <ul>
+   *   <li>previous files were already committed for checkpoint N. We have to keep the manifests for
+   *       new files under a later key, otherwise they are discarded during recovery after a crash
+   *   <li>we already have a manifest of files to be committed for checkpoint N, even though it
+   *       might not have been committed yet. In this case, we must not overwrite the manifests we
+   *       already have, and we must keep them consistent with our checkpoint
+   * </ul>
+   */
+  private long computeCheckpointId(long checkpointId, Map.Entry<Long, List<WriteResult>> entry) {
+    long sourceCheckpointId = entry.getKey();
+
+    boolean sourceCheckpointIdAlreadyCommitted = sourceCheckpointId <= maxCommittedCheckpointId;
+    boolean sourceCheckpointIdHasDataInSnapshot =
+        dataFilesPerCheckpoint.containsKey(sourceCheckpointId);
+    // for aligned checkpoints, both conditions will be false and the upstream operator's checkpoint
+    // ID
+    // will be chosen.
+    return sourceCheckpointIdAlreadyCommitted || sourceCheckpointIdHasDataInSnapshot
+        ? checkpointId
+        : sourceCheckpointId;
   }
 
   /**

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -445,7 +445,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   }
 
   /**
-   * in case of unaligned checkpoints, data files that were part of checkpoint N in the writer may
+   * In case of unaligned checkpoints, data files that were part of checkpoint N in the writer may
    * have to become part of a later checkpoint in the committer if:
    *
    * <ul>
@@ -463,8 +463,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     boolean sourceCheckpointIdHasDataInSnapshot =
         dataFilesPerCheckpoint.containsKey(sourceCheckpointId);
     // for aligned checkpoints, both conditions will be false and the upstream operator's checkpoint
-    // ID
-    // will be chosen.
+    // ID will be chosen.
     return sourceCheckpointIdAlreadyCommitted || sourceCheckpointIdHasDataInSnapshot
         ? checkpointId
         : sourceCheckpointId;

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -1076,6 +1076,220 @@ public class TestIcebergFilesCommitter extends TestBase {
     }
   }
 
+  /**
+   * (unaligned checkpoints) With unaligned checkpoints a writer subtask may deliver its write
+   * result after {@code snapshotState(N)} has already fired. ("post-barrier data"). This test
+   * verifies that post-barrier data for a checkpoint that never completes is not lost, it must be
+   * committed together with the next successful checkpoint. Also covers the case where the
+   * successful checkpoint itself has post-barrier data, which must then wait for the checkpoint
+   * after that.
+   *
+   * <pre>
+   *   processElement(dataA, checkpointId=1)
+   *   snapshotState(1)
+   *   processElement(dataB, checkpointId=1)
+   *   // checkpoint 1 never completes
+   *   processElement(dataC, checkpointId=2)
+   *   snapshotState(2)
+   *   processElement(dataD, checkpointId=2)
+   *   notifyCheckpointComplete(2)   // commits dataA, dataB, dataC
+   *   snapshotState(3)
+   *   notifyCheckpointComplete(3)   // commits dataD
+   * </pre>
+   */
+  @TestTemplate
+  public void testPostBarrierDataSurvivesFailedCheckpoint() throws Exception {
+    long timestamp = 0;
+    JobID jobId = new JobID();
+    OperatorID operatorId;
+    try (OneInputStreamOperatorTestHarness<FlinkWriteResult, Void> harness =
+        createStreamSink(jobId)) {
+      harness.setup();
+      harness.open();
+      operatorId = harness.getOperator().getOperatorID();
+
+      assertSnapshotSize(0);
+      assertMaxCommittedCheckpointId(jobId, operatorId, -1L);
+
+      RowData rowA = SimpleDataUtil.createRowData(1, "early-checkpoint1");
+      DataFile dataFileA = writeDataFile("data-A", ImmutableList.of(rowA));
+      RowData rowB = SimpleDataUtil.createRowData(2, "post-barrier-checkpoint1");
+      DataFile dataFileB = writeDataFile("data-B", ImmutableList.of(rowB));
+      RowData rowC = SimpleDataUtil.createRowData(3, "early-checkpoint2");
+      DataFile dataFileC = writeDataFile("data-C", ImmutableList.of(rowC));
+      RowData rowD = SimpleDataUtil.createRowData(4, "post-barrier-checkpoint2");
+      DataFile dataFileD = writeDataFile("data-D", ImmutableList.of(rowD));
+
+      long checkpoint1 = 1;
+      long checkpoint2 = 2;
+      long checkpoint3 = 3;
+
+      harness.processElement(of(checkpoint1, dataFileA), ++timestamp);
+      harness.snapshot(checkpoint1, ++timestamp);
+      assertFlinkManifests(1);
+
+      // post-barrier, arrives after snapshotState(1); checkpoint1 then FAILS (no notify)
+      harness.processElement(of(checkpoint1, dataFileB), ++timestamp);
+
+      harness.processElement(of(checkpoint2, dataFileC), ++timestamp);
+      harness.snapshot(checkpoint2, ++timestamp);
+
+      // post-barrier, arrives after snapshotState(2), before notify(2)
+      harness.processElement(of(checkpoint2, dataFileD), ++timestamp);
+
+      harness.notifyOfCompletedCheckpoint(checkpoint2);
+      SimpleDataUtil.assertTableRows(table, ImmutableList.of(rowA, rowB, rowC), branch);
+      assertMaxCommittedCheckpointId(jobId, operatorId, checkpoint2);
+
+      harness.snapshot(checkpoint3, ++timestamp);
+      harness.notifyOfCompletedCheckpoint(checkpoint3);
+      SimpleDataUtil.assertTableRows(table, ImmutableList.of(rowA, rowB, rowC, rowD), branch);
+      assertMaxCommittedCheckpointId(jobId, operatorId, checkpoint3);
+    }
+  }
+
+  /**
+   * (unaligned checkpoints) Post-barrier data for checkpoint N arrives after {@code
+   * snapshotState(N)} but before {@code notifyCheckpointComplete(N)}, so it is not included in the
+   * Iceberg commit for checkpoint N. This test verifies that such data survives a crash/recovery:
+   * after notify(N) commits the pre-barrier data for N and the job crashes before notify(N+1),
+   * recovery from checkpoint N+1 must still commit the post-barrier data for N and any data
+   * snapshotted before the crash for N+1.
+   *
+   * <pre>
+   *   processElement(dataA, checkpointId=1)
+   *   snapshotState(1)
+   *   processElement(dataB, checkpointId=1)
+   *   notifyCheckpointComplete(1)           // commits dataA only
+   *   processElement(dataC, checkpointId=2)
+   *   snapshotState(2)
+   *   // crash, no notifyCheckpointComplete(2)
+   *   recover from checkpoint2              // dataB and dataC committed on initializeState
+   * </pre>
+   */
+  @TestTemplate
+  public void testPostBarrierDataMergedWithEarlyDataOnRecovery() throws Exception {
+    long timestamp = 0;
+    JobID jobId = new JobID();
+    OperatorID operatorId;
+    OperatorSubtaskState snapshot;
+
+    RowData rowA = SimpleDataUtil.createRowData(1, "pre-barrier-checkpoint1");
+    DataFile dataFileA = writeDataFile("data-A", ImmutableList.of(rowA));
+    RowData rowB = SimpleDataUtil.createRowData(2, "post-barrier-checkpoint1");
+    DataFile dataFileB = writeDataFile("data-B", ImmutableList.of(rowB));
+    RowData rowC = SimpleDataUtil.createRowData(3, "pre-barrier-checkpoint2");
+    DataFile dataFileC = writeDataFile("data-C", ImmutableList.of(rowC));
+
+    long checkpoint1 = 1;
+    long checkpoint2 = 2;
+
+    try (OneInputStreamOperatorTestHarness<FlinkWriteResult, Void> harness =
+        createStreamSink(jobId)) {
+      harness.setup();
+      harness.open();
+      operatorId = harness.getOperator().getOperatorID();
+
+      assertSnapshotSize(0);
+      assertMaxCommittedCheckpointId(jobId, operatorId, -1L);
+
+      harness.processElement(of(checkpoint1, dataFileA), ++timestamp);
+      harness.snapshot(checkpoint1, ++timestamp);
+      assertFlinkManifests(1);
+
+      // post-barrier, arrives after snapshotState(1), before notify(1)
+      harness.processElement(of(checkpoint1, dataFileB), ++timestamp);
+
+      harness.notifyOfCompletedCheckpoint(checkpoint1);
+      SimpleDataUtil.assertTableRows(table, ImmutableList.of(rowA), branch);
+      assertMaxCommittedCheckpointId(jobId, operatorId, checkpoint1);
+      assertFlinkManifests(0);
+
+      harness.processElement(of(checkpoint2, dataFileC), ++timestamp);
+      snapshot = harness.snapshot(checkpoint2, ++timestamp);
+      // crash, notifyCheckpointComplete(2) never fires
+    }
+
+    try (OneInputStreamOperatorTestHarness<FlinkWriteResult, Void> harness =
+        createStreamSink(jobId)) {
+      harness.getStreamConfig().setOperatorID(operatorId);
+      harness.setup();
+      harness.initializeState(snapshot);
+      harness.open();
+
+      SimpleDataUtil.assertTableRows(table, ImmutableList.of(rowA, rowB, rowC), branch);
+      assertMaxCommittedCheckpointId(jobId, operatorId, checkpoint2);
+    }
+  }
+
+  /**
+   * (unaligned checkpoints) Combines the failed-checkpoint scenario from {@link
+   * #testPostBarrierDataSurvivesFailedCheckpoint} with crash+recovery: checkpoint N fails and
+   * checkpoint N+1 also never completes (crash before notify). Recovery from checkpoint N+1 must
+   * commit both the pre-barrier data from the failed checkpoint N and the post-barrier data that
+   * arrived after snapshotState(N).
+   *
+   * <pre>
+   *   processElement(dataA, checkpointId=1)
+   *   snapshotState(1)
+   *   processElement(dataB, checkpointId=1)
+   *   // checkpoint 1 never completes
+   *   processElement(dataC, checkpointId=2)
+   *   snapshotState(2)
+   *   // crash, no notifyCheckpointComplete(2)
+   *   recover from checkpoint2    // all three files committed on initializeState
+   * </pre>
+   */
+  @TestTemplate
+  public void testPostBarrierDataForFailedCheckpointSurvivesRecovery() throws Exception {
+    long timestamp = 0;
+    JobID jobId = new JobID();
+    OperatorID operatorId;
+    OperatorSubtaskState snapshot;
+
+    RowData rowA = SimpleDataUtil.createRowData(1, "pre-barrier-checkpoint1");
+    DataFile dataFileA = writeDataFile("data-A", ImmutableList.of(rowA));
+    RowData rowB = SimpleDataUtil.createRowData(2, "post-barrier-checkpoint1");
+    DataFile dataFileB = writeDataFile("data-B", ImmutableList.of(rowB));
+    RowData rowC = SimpleDataUtil.createRowData(3, "pre-barrier-checkpoint2");
+    DataFile dataFileC = writeDataFile("data-C", ImmutableList.of(rowC));
+
+    long checkpoint1 = 1;
+    long checkpoint2 = 2;
+
+    try (OneInputStreamOperatorTestHarness<FlinkWriteResult, Void> harness =
+        createStreamSink(jobId)) {
+      harness.setup();
+      harness.open();
+      operatorId = harness.getOperator().getOperatorID();
+
+      assertSnapshotSize(0);
+      assertMaxCommittedCheckpointId(jobId, operatorId, -1L);
+
+      harness.processElement(of(checkpoint1, dataFileA), ++timestamp);
+      harness.snapshot(checkpoint1, ++timestamp);
+      assertFlinkManifests(1);
+
+      // post-barrier, arrives after snapshotState(1); checkpoint1 then fails (no notify)
+      harness.processElement(of(checkpoint1, dataFileB), ++timestamp);
+
+      harness.processElement(of(checkpoint2, dataFileC), ++timestamp);
+      snapshot = harness.snapshot(checkpoint2, ++timestamp);
+      // crash, notifyCheckpointComplete(2) never fires
+    }
+
+    try (OneInputStreamOperatorTestHarness<FlinkWriteResult, Void> harness =
+        createStreamSink(jobId)) {
+      harness.getStreamConfig().setOperatorID(operatorId);
+      harness.setup();
+      harness.initializeState(snapshot);
+      harness.open();
+
+      SimpleDataUtil.assertTableRows(table, ImmutableList.of(rowA, rowB, rowC), branch);
+      assertMaxCommittedCheckpointId(jobId, operatorId, checkpoint2);
+    }
+  }
+
   private int getStagingManifestSpecId(OperatorStateStore operatorStateStore, long checkPointId)
       throws Exception {
     ListState<SortedMap<Long, byte[]>> checkpointsState =


### PR DESCRIPTION
Closes #15846

### Quick Summary

When running with unaligned checkpoints, data files may reach IcebergFilesCommitter after the associated checkpoint's first barrier.
We then need to account for these files in the state for the 'next' checkpoint to avoid discarding them during recovery or failed checkpoints.

### Details

We have recently encountered a case of data loss in an application using FlinkSink (v1), running on Flink 2.x with unaligned checkpoints.

What we saw:

One commit to the Iceberg table was missing approximately half of the data files that were written by the writer during this checkpoint.
Around this time, one checkpoint was started and Flink snapshots were triggered, but this checkpoint timed out before completing.
Based on our research, we believe that the culprit might be the internal state tracking in `IcebergFilesCommitter`. Here's our current theory:

For unaligned checkpoints, the order of operations happening on `IcebergFilesCommitter` can change subtly since `processElement` can be called for a `FlinkWriteResult` that is part of checkpoint N even _after_ `snapshotState` was called for checkpoint N:
- `processElement(FlinkWriteResult1[part of checkpoint N])`, recorded in `writeResultsSinceLastSnapshot`
- `snapshotState(checkpoint N)`
- `writeToManifestUptoLatestCheckpoint(N)` is called, putting the contents of `writeResultsSinceLastSnapshot` to `dataFilesPerCheckpoint(N)` and clearing `writeResultsSinceLastSnapshot`
- `processElement(FlinkWriteResult2[part of checkpoint N])`, recorded in `writeResultsSinceLastSnapshot` (now the single element there)
- checkpoint N times out, so `notifyCheckpointComplete(N)` is never called
- `processElement(FlinkWriteResult3[part of checkpoint N+1])`
- `snapshotState(checkpoint N+1)`
- `writeToManifestUptoLatestCheckpoint(N+1)` is called, putting the contents of `writeResultsSinceLastSnapshot` to `dataFilesPerCheckpoint(N)` and `dataFilesPerCheckpoint(N+1)` and clearing `writeResultsSinceLastSnapshot`. `dataFilesPerCheckpoint(N)` now loses `FlinkWriteResult1` even though it was never committed and contains only `FlinkWriteResult2`
- `notifyCheckpointComplete(checkpoint N+1)`
- Iceberg commit is started, but contains only `FlinkWriteResult2` and `FlinkWriteResult3`, not `FlinkWriteResult1`.
This sequence, or equivalently one where checkpoint N does not time out, but completes after checkpoint N+1, therefore leads to data loss.

This explanation aligns with the effects that we're seeing. The root cause seems to be that `snapshotState->writeToManifestUpToLatestCheckpoint->writeResultsSinceLastSnapshot` seems to implicitly assume that all records for the checkpoints have already been processed when `snapshotState()` is called - i.e. it assumes aligned checkpoints. If this assumption breaks, AND in addition a later checkpoint is snapshotted before an earlier one was notified complete, the issue described above is observed.

Additionally, we suspect there's a second failure mode with unaligned checkpoints that loses data on job recovery: If our above theory is correct, then `IcebergFilesCommitter` has an issue with elements for checkpoint N being processed after `snapshotState(N)`. But the iceberg commit triggered during `notifyComplete(N)` only commits the records from the snapshot. On recovery, this means one of two things: Either `initializeState()->.tailMap(N)` loses information about not-yet-committed records; or even if it remembered to do so, it would think that these records should be committed as part of Flink checkpoint N.  It feels like there's a problem when a checkpoint ID can appear in `dataFilesPerCheckpoint` after it has already been used as `maxCommittedCheckpointId`, and the strict tailMap exclusion has no way to distinguish "already committed" from "deferred post-barrier" data.


### Contents of this PR

This PR contains three test cases that trigger the test harness in ways that are only possible when using unaligned checkpoints. Without the associated code change in prod code, these test cases fail.

### Disclaimer / disclosure as per contributing guidelines

AI tools were used to initially pinpoint the possible issue and draft test cases. The code was subsequently rewritten condensed and clarified by hand. To the best of my knowledge, I believe that the way in which the reproduction test cases trigger the harness are all cases that DO happen with unaligned checkpoints, and the data loss that we had encountered at runtime aligns with the one that happens in these reproduction test cases.

### Caveats

The logic that I'm changing here was last changed by https://github.com/apache/iceberg/pull/10526 while fixing a data duplication bug. The test cases that were added for that bug are still green with the changes that I'm proposing here. I would still like to tag @pvary and @zhongqishang and kindly ask them for advice on this issue here and this associated PR, as I'm sure they have a much deeper understanding of the inner workings of `IcebergFileCommitter` than  I do.