### PR TITLE
Docs: Clarify Spark branch write precedence over WAP branch

### DIFF
--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -218,7 +218,7 @@ For more complex row-level updates based on incoming data, see the section on `M
 
 ## Writing to Branches
 
-The branch must exist before performing write. Operations do **not** create the branch if it does not exist.
+The target branch may be created during the write operation if it does not exist.
 A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl).
 
 !!! info
@@ -229,7 +229,16 @@ A branch can be created using [Spark DDL](spark-ddl.md#branching-and-tagging-ddl
 Branch writes can be performed by providing a branch identifier, `branch_yourBranch` in the operation.
 
 Branch writes can also be performed as part of a write-audit-publish (WAP) workflow by specifying the `spark.wap.branch` config.
-Note WAP branch and branch identifier cannot both be specified.
+
+The target branch is resolved with the following precedence (Spark 4.1+):
+
+- The identifier and option branches can't conflict. If both are set, they must match.
+- Identifier and option branches take priority over the session WAP branch.
+- If neither the option nor the identifier branch is set and WAP is enabled for the table,
+  the WAP branch from the session SQL config is used.
+
+!!! note
+    WAP ID and WAP branch cannot be set at the same time.
 
 ```sql
 -- INSERT (1,' a') (2, 'b') into the audit branch.


### PR DESCRIPTION
After #15288, the docs in `spark-writes.md` no longer match the actual behavior for writing to branches.

**Changes:**
- Updated the branch creation note: the target branch may now be created during writes (previously docs said it must exist beforehand)
- Replaced the incorrect statement "WAP branch and branch identifier cannot both be specified" with the actual precedence rules from the code:
  1. Identifier and option branches can't conflict — if both set, they must match
  2. Identifier and option branches take priority over the session WAP branch
  3. If neither is set and WAP is enabled, the WAP branch is used
- Added note that WAP ID and WAP branch cannot be set at the same time

Closes #15916