### PR TITLE
Docker: Add logging configuration to iceberg-rest-fixture image

### DIFF
--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -33,6 +33,9 @@ WORKDIR /usr/lib/iceberg-rest
 # Copy the JAR file directly to the target location
 COPY --chown=iceberg:iceberg open-api/build/libs/iceberg-open-api-test-fixtures-runtime-*.jar /usr/lib/iceberg-rest/iceberg-rest-adapter.jar
 
+# Copy logging configuration (slf4j-simple reads this from the classpath)
+COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/simplelogger.properties /usr/lib/iceberg-rest/simplelogger.properties
+
 ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
 ENV CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db
 ENV CATALOG_JDBC_USER=user

--- a/docker/iceberg-rest-fixture/simplelogger.properties
+++ b/docker/iceberg-rest-fixture/simplelogger.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Default log level for the REST catalog fixture.
+# Override at runtime via: -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
+org.slf4j.simpleLogger.defaultLogLevel=WARN
+
+# Show the date/time in log messages
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss
+
+# Show short logger names for readability
+org.slf4j.simpleLogger.showShortLogName=true


### PR DESCRIPTION
The `iceberg-rest-fixture` Docker image runs with no logging configuration, so slf4j-simple defaults to INFO level. This causes container logs to be flooded with messages like:

```
[qtp...] INFO org.apache.iceberg.BaseMetastoreCatalog - Table loaded by catalog: ...
[qtp...] INFO org.apache.iceberg.BaseMetastoreTableOperations - Successfully committed to table ...
```

These fire on every REST API call, making it hard to spot actual warnings and errors.

**Fix:**
- Add a `simplelogger.properties` file with `WARN` as the default log level
- Copy it into the Docker image alongside the JAR (slf4j-simple auto-discovers it on the classpath)

Users can override the log level at runtime:
```bash
docker run apache/iceberg-rest-fixture java -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG -jar iceberg-rest-adapter.jar
```

**Testing:**
```bash
# Build the shadow JAR
./gradlew :iceberg-open-api:shadowJar

# Build the Docker image
docker build -t apache/iceberg-rest-fixture -f docker/iceberg-rest-fixture/Dockerfile .

# Run the container
docker run -d --name iceberg-rest-test -p 8181:8181 apache/iceberg-rest-fixture

# Hit the API to generate log activity
curl http://localhost:8181/v1/config
curl http://localhost:8181/v1/namespaces

# Verify logs — should NOT contain INFO-level spam from BaseMetastoreCatalog
docker logs iceberg-rest-test
# Expected: only WARN/ERROR messages

# Verify users can override to DEBUG
docker rm -f iceberg-rest-test
docker run -d --name iceberg-rest-test -p 8181:8181 \
  apache/iceberg-rest-fixture \
  java -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG -jar iceberg-rest-adapter.jar
curl http://localhost:8181/v1/config
docker logs iceberg-rest-test
# Expected: DEBUG-level messages now visible

docker rm -f iceberg-rest-test
```

Closes #14227
