### PR TITLE
Core: Make util test classes and methods package-private

### DIFF
--- a/core/src/test/java/org/apache/iceberg/util/TestArrayUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestArrayUtil.java
@@ -22,10 +22,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-public class TestArrayUtil {
+class TestArrayUtil {
 
   @Test
-  public void testStrictlyAscendingLongArrays() {
+  void testStrictlyAscendingLongArrays() {
     long[] emptyArray = new long[0];
     assertThat(ArrayUtil.isStrictlyAscending(emptyArray)).isTrue();
 
@@ -43,7 +43,7 @@ public class TestArrayUtil {
   }
 
   @Test
-  public void testConcatWithDifferentLengthArrays() {
+  void testConcatWithDifferentLengthArrays() {
     Integer[] array1 = {1, 2, 3};
     Integer[] array2 = {4, 5};
     Integer[] array3 = {6, 7, 8, 9};
@@ -53,7 +53,7 @@ public class TestArrayUtil {
   }
 
   @Test
-  public void testConcatWithEmptyArrays() {
+  void testConcatWithEmptyArrays() {
     String[] array1 = {};
     String[] array2 = {"a", "b"};
 
@@ -62,14 +62,14 @@ public class TestArrayUtil {
   }
 
   @Test
-  public void testConcatWithSingleArray() {
+  void testConcatWithSingleArray() {
     Boolean[] array = {true, false};
     Boolean[] result = ArrayUtil.concat(Boolean.class, array);
     assertThat(result).isEqualTo(new Boolean[] {true, false});
   }
 
   @Test
-  public void testConcatWithNoArray() {
+  void testConcatWithNoArray() {
     Character[] result = ArrayUtil.concat(Character.class);
     assertThat(result).isEqualTo(new Character[] {});
   }

--- a/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestBinPacking.java
@@ -25,9 +25,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.BinPacking.ListPacker;
 import org.junit.jupiter.api.Test;
 
-public class TestBinPacking {
+class TestBinPacking {
   @Test
-  public void testBasicBinPacking() {
+  void testBasicBinPacking() {
     assertThat(pack(list(1, 2, 3, 4, 5), 3))
         .as("Should pack the first 2 values")
         .isEqualTo(list(list(1, 2), list(3), list(4), list(5)));
@@ -62,7 +62,7 @@ public class TestBinPacking {
   }
 
   @Test
-  public void testBasicBinPackingTargetSize() {
+  void testBasicBinPackingTargetSize() {
     assertThat(pack(list(1, 2, 3, 4, 5), 3, Integer.MAX_VALUE, 2))
         .as("Should pack the first 2 values")
         .isEqualTo(list(list(1, 2), list(3), list(4), list(5)));
@@ -93,7 +93,7 @@ public class TestBinPacking {
   }
 
   @Test
-  public void testReverseBinPackingSingleLookback() {
+  void testReverseBinPackingSingleLookback() {
     assertThat(packEnd(list(1, 2, 3, 4, 5), 3, 1))
         .as("Should pack the first 2 values")
         .isEqualTo(list(list(1, 2), list(3), list(4), list(5)));
@@ -140,7 +140,7 @@ public class TestBinPacking {
   }
 
   @Test
-  public void testReverseBinPackingUnlimitedLookback() {
+  void testReverseBinPackingUnlimitedLookback() {
     assertThat(packEnd(list(1, 2, 3, 4, 5), 3))
         .as("Should pack the first 2 values")
         .isEqualTo(list(list(1, 2), list(3), list(4), list(5)));
@@ -195,7 +195,7 @@ public class TestBinPacking {
   }
 
   @Test
-  public void testBinPackingLookBack() {
+  void testBinPackingLookBack() {
     // lookback state:
     // 1. [5]
     // 2. [5, 1]

--- a/core/src/test/java/org/apache/iceberg/util/TestDataFileSet.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestDataFileSet.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Testing {@link DataFileSet} is easier in iceberg-core since the data file builders are located
  * here
  */
-public class TestDataFileSet {
+class TestDataFileSet {
 
   private static final DataFile FILE_A =
       DataFiles.builder(PartitionSpec.unpartitioned())
@@ -66,13 +66,13 @@ public class TestDataFileSet {
           .build();
 
   @Test
-  public void emptySet() {
+  void emptySet() {
     assertThat(DataFileSet.create()).isEmpty();
     assertThat(DataFileSet.create()).doesNotContain(FILE_A, FILE_B, FILE_C);
   }
 
   @Test
-  public void insertionOrderIsMaintained() {
+  void insertionOrderIsMaintained() {
     DataFileSet set = DataFileSet.create();
     set.addAll(ImmutableList.of(FILE_D, FILE_A, FILE_C));
     set.add(FILE_B);
@@ -82,14 +82,14 @@ public class TestDataFileSet {
   }
 
   @Test
-  public void clear() {
+  void clear() {
     DataFileSet set = DataFileSet.of(ImmutableList.of(FILE_A, FILE_B));
     set.clear();
     assertThat(set).isEmpty();
   }
 
   @Test
-  public void addAll() {
+  void addAll() {
     DataFileSet empty = DataFileSet.create();
     assertThatThrownBy(() -> empty.add(null))
         .isInstanceOf(NullPointerException.class)
@@ -113,7 +113,7 @@ public class TestDataFileSet {
   }
 
   @Test
-  public void contains() {
+  void contains() {
     DataFileSet set = DataFileSet.of(ImmutableList.of(FILE_A, FILE_B));
     assertThatThrownBy(() -> set.contains(null))
         .isInstanceOf(NullPointerException.class)
@@ -131,7 +131,7 @@ public class TestDataFileSet {
   }
 
   @Test
-  public void containsAll() {
+  void containsAll() {
     DataFileSet set = DataFileSet.of(ImmutableList.of(FILE_A, FILE_B));
     assertThatThrownBy(() -> set.containsAll(null))
         .isInstanceOf(NullPointerException.class)
@@ -151,7 +151,7 @@ public class TestDataFileSet {
   }
 
   @Test
-  public void toArray() {
+  void toArray() {
     DataFileSet set = DataFileSet.of(ImmutableList.of(FILE_B, FILE_A));
     assertThat(set.toArray()).hasSize(2).containsExactly(FILE_B, FILE_A);
 
@@ -169,7 +169,7 @@ public class TestDataFileSet {
   }
 
   @Test
-  public void retainAll() {
+  void retainAll() {
     DataFileSet empty = DataFileSet.create();
     assertThatThrownBy(() -> empty.retainAll(null))
         .isInstanceOf(NullPointerException.class)
@@ -204,7 +204,7 @@ public class TestDataFileSet {
   }
 
   @Test
-  public void remove() {
+  void remove() {
     DataFileSet set = DataFileSet.of(ImmutableList.of(FILE_A, FILE_B));
     assertThatThrownBy(() -> set.remove(null))
         .isInstanceOf(NullPointerException.class)
@@ -219,7 +219,7 @@ public class TestDataFileSet {
   }
 
   @Test
-  public void removeAll() {
+  void removeAll() {
     DataFileSet empty = DataFileSet.create();
     assertThatThrownBy(() -> empty.removeAll(null))
         .isInstanceOf(NullPointerException.class)
@@ -254,7 +254,7 @@ public class TestDataFileSet {
   }
 
   @Test
-  public void equalsAndHashCode() {
+  void equalsAndHashCode() {
     DataFileSet set1 = DataFileSet.create();
     DataFileSet set2 = DataFileSet.create();
 
@@ -293,7 +293,7 @@ public class TestDataFileSet {
 
   @ParameterizedTest
   @MethodSource("org.apache.iceberg.TestHelpers#serializers")
-  public void serialization(TestHelpers.RoundTripSerializer<DataFileSet> roundTripSerializer)
+  void serialization(TestHelpers.RoundTripSerializer<DataFileSet> roundTripSerializer)
       throws IOException, ClassNotFoundException {
     DataFileSet dataFiles = DataFileSet.of(ImmutableList.of(FILE_C, FILE_B, FILE_A));
     assertThat(roundTripSerializer.apply(dataFiles)).isEqualTo(dataFiles);

--- a/core/src/test/java/org/apache/iceberg/util/TestDeleteFileSet.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestDeleteFileSet.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Testing {@link DeleteFileSet} is easier in iceberg-core since the delete file builders are
  * located here
  */
-public class TestDeleteFileSet {
+class TestDeleteFileSet {
 
   private static final DeleteFile FILE_A_DELETES =
       FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
@@ -70,14 +70,14 @@ public class TestDeleteFileSet {
           .build();
 
   @Test
-  public void emptySet() {
+  void emptySet() {
     assertThat(DeleteFileSet.create()).isEmpty();
     assertThat(DeleteFileSet.create())
         .doesNotContain(FILE_A_DELETES, FILE_B_DELETES, FILE_C_DELETES);
   }
 
   @Test
-  public void insertionOrderIsMaintained() {
+  void insertionOrderIsMaintained() {
     DeleteFileSet set = DeleteFileSet.create();
     set.addAll(ImmutableList.of(FILE_D_DELETES, FILE_A_DELETES, FILE_C_DELETES));
     set.add(FILE_B_DELETES);
@@ -89,14 +89,14 @@ public class TestDeleteFileSet {
   }
 
   @Test
-  public void clear() {
+  void clear() {
     DeleteFileSet set = DeleteFileSet.of(ImmutableList.of(FILE_A_DELETES, FILE_B_DELETES));
     set.clear();
     assertThat(set).isEmpty();
   }
 
   @Test
-  public void addAll() {
+  void addAll() {
     DeleteFileSet empty = DeleteFileSet.create();
     assertThatThrownBy(() -> empty.add(null))
         .isInstanceOf(NullPointerException.class)
@@ -120,7 +120,7 @@ public class TestDeleteFileSet {
   }
 
   @Test
-  public void contains() {
+  void contains() {
     DeleteFileSet set = DeleteFileSet.of(ImmutableList.of(FILE_A_DELETES, FILE_B_DELETES));
     assertThatThrownBy(() -> set.contains(null))
         .isInstanceOf(NullPointerException.class)
@@ -141,7 +141,7 @@ public class TestDeleteFileSet {
   }
 
   @Test
-  public void containsAll() {
+  void containsAll() {
     DeleteFileSet set = DeleteFileSet.of(ImmutableList.of(FILE_A_DELETES, FILE_B_DELETES));
     assertThatThrownBy(() -> set.containsAll(null))
         .isInstanceOf(NullPointerException.class)
@@ -162,7 +162,7 @@ public class TestDeleteFileSet {
   }
 
   @Test
-  public void toArray() {
+  void toArray() {
     DeleteFileSet set = DeleteFileSet.of(ImmutableList.of(FILE_B_DELETES, FILE_A_DELETES));
     assertThat(set.toArray()).hasSize(2).containsExactly(FILE_B_DELETES, FILE_A_DELETES);
 
@@ -182,7 +182,7 @@ public class TestDeleteFileSet {
   }
 
   @Test
-  public void retainAll() {
+  void retainAll() {
     DeleteFileSet empty = DeleteFileSet.create();
     assertThatThrownBy(() -> empty.retainAll(null))
         .isInstanceOf(NullPointerException.class)
@@ -217,7 +217,7 @@ public class TestDeleteFileSet {
   }
 
   @Test
-  public void remove() {
+  void remove() {
     DeleteFileSet set = DeleteFileSet.of(ImmutableList.of(FILE_A_DELETES, FILE_B_DELETES));
     assertThatThrownBy(() -> set.remove(null))
         .isInstanceOf(NullPointerException.class)
@@ -233,7 +233,7 @@ public class TestDeleteFileSet {
   }
 
   @Test
-  public void removeAll() {
+  void removeAll() {
     DeleteFileSet empty = DeleteFileSet.create();
     assertThatThrownBy(() -> empty.removeAll(null))
         .isInstanceOf(NullPointerException.class)
@@ -267,7 +267,7 @@ public class TestDeleteFileSet {
   }
 
   @Test
-  public void equalsAndHashCode() {
+  void equalsAndHashCode() {
     DeleteFileSet set1 = DeleteFileSet.create();
     DeleteFileSet set2 = DeleteFileSet.create();
 
@@ -309,7 +309,7 @@ public class TestDeleteFileSet {
 
   @ParameterizedTest
   @MethodSource("org.apache.iceberg.TestHelpers#serializers")
-  public void serialization(TestHelpers.RoundTripSerializer<DeleteFileSet> roundTripSerializer)
+  void serialization(TestHelpers.RoundTripSerializer<DeleteFileSet> roundTripSerializer)
       throws IOException, ClassNotFoundException {
     DeleteFileSet deleteFiles =
         DeleteFileSet.of(ImmutableList.of(FILE_C_DELETES, FILE_B_DELETES, FILE_A_DELETES));

--- a/core/src/test/java/org/apache/iceberg/util/TestEnvironmentUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestEnvironmentUtil.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 class TestEnvironmentUtil {
   @Test
-  public void testEnvironmentSubstitution() {
+  void testEnvironmentSubstitution() {
     Optional<Map.Entry<String, String>> envEntry = System.getenv().entrySet().stream().findFirst();
     assumeThat(envEntry).as("Expecting at least one env. variable to be present").isPresent();
     Map<String, String> resolvedProps =
@@ -39,7 +39,7 @@ class TestEnvironmentUtil {
   }
 
   @Test
-  public void testMultipleEnvironmentSubstitutions() {
+  void testMultipleEnvironmentSubstitutions() {
     Map<String, String> result =
         EnvironmentUtil.resolveAll(
             ImmutableMap.of("USER", "u", "VAR", "value"),
@@ -51,7 +51,7 @@ class TestEnvironmentUtil {
   }
 
   @Test
-  public void testEnvironmentSubstitutionWithMissingVar() {
+  void testEnvironmentSubstitutionWithMissingVar() {
     Map<String, String> result =
         EnvironmentUtil.resolveAll(ImmutableMap.of(), ImmutableMap.of("user-test", "env:USER"));
 

--- a/core/src/test/java/org/apache/iceberg/util/TestFileSystemWalker.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestFileSystemWalker.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class TestFileSystemWalker {
+class TestFileSystemWalker {
 
   @TempDir private Path tempDir;
   private String basePath;
@@ -51,7 +51,7 @@ public class TestFileSystemWalker {
   private HadoopFileIO fileIO;
 
   @BeforeEach
-  public void before() throws IOException {
+  void before() throws IOException {
     this.basePath = tempDir.toAbsolutePath().toString();
     this.hadoopConf = new Configuration();
     this.fileIO = new HadoopFileIO(hadoopConf);
@@ -76,7 +76,7 @@ public class TestFileSystemWalker {
   }
 
   @Test
-  public void testListDirRecursivelyWithHadoop() {
+  void testListDirRecursivelyWithHadoop() {
     List<String> foundFiles = Lists.newArrayList();
     List<String> remainingDirs = Lists.newArrayList();
     Predicate<FileStatus> fileFilter =
@@ -103,7 +103,7 @@ public class TestFileSystemWalker {
   }
 
   @Test
-  public void testListDirRecursivelyWithHadoopMaxDepth() {
+  void testListDirRecursivelyWithHadoopMaxDepth() {
     List<String> foundFiles = Lists.newArrayList();
     List<String> remainingDirs = Lists.newArrayList();
     Predicate<FileStatus> fileFilter =
@@ -130,7 +130,7 @@ public class TestFileSystemWalker {
   }
 
   @Test
-  public void testListDirRecursivelyWithHadoopMaxDirectSubDirs() {
+  void testListDirRecursivelyWithHadoopMaxDirectSubDirs() {
     List<String> foundFiles = Lists.newArrayList();
     List<String> remainingDirs = Lists.newArrayList();
     Predicate<FileStatus> fileFilter =
@@ -154,7 +154,7 @@ public class TestFileSystemWalker {
   }
 
   @Test
-  public void testListDirRecursivelyWithFileIO() {
+  void testListDirRecursivelyWithFileIO() {
     List<String> foundFiles = Lists.newArrayList();
     Predicate<FileInfo> fileFilter = fileInfo -> fileInfo.location().endsWith(".txt");
     FileSystemWalker.listDirRecursivelyWithFileIO(
@@ -172,7 +172,7 @@ public class TestFileSystemWalker {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void testListDirRecursivelyNotInclude(boolean useHadoop) {
+  void testListDirRecursivelyNotInclude(boolean useHadoop) {
     List<String> foundFiles = Lists.newArrayList();
     String path = basePath + "/normal_dir";
 
@@ -189,7 +189,7 @@ public class TestFileSystemWalker {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void testPartitionAwareHiddenPathFilter(boolean useHadoop) throws IOException {
+  void testPartitionAwareHiddenPathFilter(boolean useHadoop) throws IOException {
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.IntegerType.get()),

--- a/core/src/test/java/org/apache/iceberg/util/TestHashWriter.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestHashWriter.java
@@ -38,10 +38,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestHashWriter {
+class TestHashWriter {
 
   @Test
-  public void testIncrementalHashCalculation() throws Exception {
+  void testIncrementalHashCalculation() throws Exception {
     HashWriter hashWriter = spy(new HashWriter("SHA-256", StandardCharsets.UTF_8));
 
     // Create large enough TableMetadata which will be serialized into JSON in multiple chunks by

--- a/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
@@ -35,26 +35,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 @Timeout(value = 5)
-public class TestInMemoryLockManager {
+class TestInMemoryLockManager {
 
   private LockManagers.InMemoryLockManager lockManager;
   private String lockEntityId;
   private String ownerId;
 
   @BeforeEach
-  public void before() {
+  void before() {
     lockEntityId = UUID.randomUUID().toString();
     ownerId = UUID.randomUUID().toString();
     lockManager = new LockManagers.InMemoryLockManager(Maps.newHashMap());
   }
 
   @AfterEach
-  public void after() throws Exception {
+  void after() throws Exception {
     lockManager.close();
   }
 
   @Test
-  public void testAcquireOnceSingleProcess() {
+  void testAcquireOnceSingleProcess() {
     lockManager.acquireOnce(lockEntityId, ownerId);
     assertThatThrownBy(() -> lockManager.acquireOnce(lockEntityId, ownerId))
         .isInstanceOf(IllegalStateException.class)
@@ -64,7 +64,7 @@ public class TestInMemoryLockManager {
   }
 
   @Test
-  public void testAcquireOnceMultiProcesses() {
+  void testAcquireOnceMultiProcesses() {
     List<Boolean> results =
         IntStream.range(0, 10)
             .parallel()
@@ -84,7 +84,7 @@ public class TestInMemoryLockManager {
   }
 
   @Test
-  public void testReleaseAndAcquire() {
+  void testReleaseAndAcquire() {
     assertThat(lockManager.acquire(lockEntityId, ownerId)).isTrue();
     assertThat(lockManager.release(lockEntityId, ownerId)).isTrue();
     assertThat(lockManager.acquire(lockEntityId, ownerId))
@@ -93,7 +93,7 @@ public class TestInMemoryLockManager {
   }
 
   @Test
-  public void testReleaseWithWrongOwner() {
+  void testReleaseWithWrongOwner() {
     assertThat(lockManager.acquire(lockEntityId, ownerId)).isTrue();
     assertThat(lockManager.release(lockEntityId, UUID.randomUUID().toString()))
         .as("should return false if ownerId is wrong")
@@ -101,7 +101,7 @@ public class TestInMemoryLockManager {
   }
 
   @Test
-  public void testAcquireSingleProcess() throws Exception {
+  void testAcquireSingleProcess() throws Exception {
     lockManager.initialize(
         ImmutableMap.of(
             CatalogProperties.LOCK_ACQUIRE_INTERVAL_MS, "500",
@@ -129,7 +129,7 @@ public class TestInMemoryLockManager {
   }
 
   @Test
-  public void testAcquireMultiProcessAllSucceed() {
+  void testAcquireMultiProcessAllSucceed() {
     lockManager.initialize(ImmutableMap.of(CatalogProperties.LOCK_ACQUIRE_INTERVAL_MS, "500"));
     long start = System.currentTimeMillis();
     List<Boolean> results =
@@ -159,7 +159,7 @@ public class TestInMemoryLockManager {
   }
 
   @Test
-  public void testAcquireMultiProcessOnlyOneSucceed() {
+  void testAcquireMultiProcessOnlyOneSucceed() {
     lockManager.initialize(
         ImmutableMap.of(
             CatalogProperties.LOCK_HEARTBEAT_INTERVAL_MS, "100",

--- a/core/src/test/java/org/apache/iceberg/util/TestJsonUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestJsonUtil.java
@@ -32,10 +32,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.junit.jupiter.api.Test;
 
-public class TestJsonUtil {
+class TestJsonUtil {
 
   @Test
-  public void get() throws JsonProcessingException {
+  void get() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.get("x", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing field: x");
@@ -49,7 +49,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getInt() throws JsonProcessingException {
+  void getInt() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getInt("x", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing int: x");
@@ -70,7 +70,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getIntOrNull() throws JsonProcessingException {
+  void getIntOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getIntOrNull("x", JsonUtil.mapper().readTree("{}"))).isNull();
     assertThat(JsonUtil.getIntOrNull("x", JsonUtil.mapper().readTree("{\"x\": 23}"))).isEqualTo(23);
     assertThat(JsonUtil.getIntOrNull("x", JsonUtil.mapper().readTree("{\"x\": null}"))).isNull();
@@ -87,7 +87,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getLong() throws JsonProcessingException {
+  void getLong() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getLong("x", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing long: x");
@@ -108,7 +108,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getLongOrNull() throws JsonProcessingException {
+  void getLongOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getLongOrNull("x", JsonUtil.mapper().readTree("{}"))).isNull();
     assertThat(JsonUtil.getLongOrNull("x", JsonUtil.mapper().readTree("{\"x\": 23}")))
         .isEqualTo(23);
@@ -126,7 +126,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getString() throws JsonProcessingException {
+  void getString() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getString("x", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing string: x");
@@ -144,7 +144,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getStringOrNull() throws JsonProcessingException {
+  void getStringOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getStringOrNull("x", JsonUtil.mapper().readTree("{}"))).isNull();
     assertThat(JsonUtil.getStringOrNull("x", JsonUtil.mapper().readTree("{\"x\": \"23\"}")))
         .isEqualTo("23");
@@ -157,7 +157,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getDurationStringOrNull() throws JsonProcessingException {
+  void getDurationStringOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getDurationStringOrNull("x", JsonUtil.mapper().readTree("{}"))).isNull();
     assertThat(JsonUtil.getDurationStringOrNull("x", JsonUtil.mapper().readTree("{\"x\": null}")))
         .isNull();
@@ -180,7 +180,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getByteBufferOrNull() throws JsonProcessingException {
+  void getByteBufferOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getByteBufferOrNull("x", JsonUtil.mapper().readTree("{}"))).isNull();
     assertThat(JsonUtil.getByteBufferOrNull("x", JsonUtil.mapper().readTree("{\"x\": null}")))
         .isNull();
@@ -198,7 +198,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getBool() throws JsonProcessingException {
+  void getBool() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getBool("x", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing boolean: x");
@@ -220,7 +220,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getBoolOrNull() throws JsonProcessingException {
+  void getBoolOrNull() throws JsonProcessingException {
     assertThatThrownBy(
             () -> JsonUtil.getBoolOrNull("x", JsonUtil.mapper().readTree("{\"x\": \"23\"}")))
         .isInstanceOf(IllegalArgumentException.class)
@@ -240,7 +240,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getIntArrayOrNull() throws JsonProcessingException {
+  void getIntArrayOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getIntArrayOrNull("items", JsonUtil.mapper().readTree("{}"))).isNull();
 
     assertThat(JsonUtil.getIntArrayOrNull("items", JsonUtil.mapper().readTree("{\"items\": null}")))
@@ -260,7 +260,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getIntegerList() throws JsonProcessingException {
+  void getIntegerList() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getIntegerList("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing list: items");
@@ -294,7 +294,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getIntegerSet() throws JsonProcessingException {
+  void getIntegerSet() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getIntegerSet("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing set: items");
@@ -316,7 +316,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getIntegerSetOrNull() throws JsonProcessingException {
+  void getIntegerSetOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getIntegerSetOrNull("items", JsonUtil.mapper().readTree("{}"))).isNull();
 
     assertThat(
@@ -337,7 +337,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getLongList() throws JsonProcessingException {
+  void getLongList() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getLongList("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing list: items");
@@ -370,7 +370,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getLongListOrNull() throws JsonProcessingException {
+  void getLongListOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getLongListOrNull("items", JsonUtil.mapper().readTree("{}"))).isNull();
 
     assertThat(JsonUtil.getLongListOrNull("items", JsonUtil.mapper().readTree("{\"items\": null}")))
@@ -390,7 +390,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getLongSet() throws JsonProcessingException {
+  void getLongSet() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getLongSet("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing set: items");
@@ -412,7 +412,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getLongSetOrNull() throws JsonProcessingException {
+  void getLongSetOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getLongSetOrNull("items", JsonUtil.mapper().readTree("{}"))).isNull();
 
     assertThat(JsonUtil.getLongSetOrNull("items", JsonUtil.mapper().readTree("{\"items\": null}")))
@@ -431,7 +431,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getStringList() throws JsonProcessingException {
+  void getStringList() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getStringList("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing list: items");
@@ -466,7 +466,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getStringListOrNull() throws JsonProcessingException {
+  void getStringListOrNull() throws JsonProcessingException {
     assertThat(JsonUtil.getStringListOrNull("items", JsonUtil.mapper().readTree("{}"))).isNull();
 
     assertThat(
@@ -487,7 +487,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getStringSet() throws JsonProcessingException {
+  void getStringSet() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getStringSet("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing set: items");
@@ -511,7 +511,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getStringMap() throws JsonProcessingException {
+  void getStringMap() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getStringMap("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing map: items");
@@ -546,7 +546,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void getStringMapNullableValues() throws JsonProcessingException {
+  void getStringMapNullableValues() throws JsonProcessingException {
     assertThatThrownBy(
             () -> JsonUtil.getStringMapNullableValues("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)
@@ -591,7 +591,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void testGetStringMapOrNull() throws JsonProcessingException {
+  void testGetStringMapOrNull() throws JsonProcessingException {
     String json = "{\"test\": {\"property\": \"value\"}}";
     Map<String, String> map = JsonUtil.getStringMapOrNull("test", JsonUtil.mapper().readTree(json));
     assertThat(map).isEqualTo(Map.of("property", "value"));
@@ -600,7 +600,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void testGetObjectList() throws JsonProcessingException {
+  void testGetObjectList() throws JsonProcessingException {
     String json = "{\"test\": [{\"id\": 1}, {\"id\": 2}], \"not-a-list\": \"value\"}";
     List<Long> list =
         JsonUtil.getObjectList(
@@ -628,7 +628,7 @@ public class TestJsonUtil {
   }
 
   @Test
-  public void testGetObjectListOrNull() throws JsonProcessingException {
+  void testGetObjectListOrNull() throws JsonProcessingException {
     String json = "{\"test\": [{\"id\": 1}, {\"id\": 2}], \"not-a-list\": \"value\"}";
     List<Long> list =
         JsonUtil.getObjectListOrNull(

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
-public class TestLocationUtil {
+class TestLocationUtil {
 
   @Test
-  public void testStripTrailingSlash() {
+  void testStripTrailingSlash() {
     String pathWithoutTrailingSlash = "s3://bucket/db/tbl";
     assertThat(LocationUtil.stripTrailingSlash(pathWithoutTrailingSlash))
         .as("Should have no trailing slashes")
@@ -49,7 +49,7 @@ public class TestLocationUtil {
   }
 
   @Test
-  public void testStripTrailingSlashWithInvalidPath() {
+  void testStripTrailingSlashWithInvalidPath() {
     String[] invalidPaths = new String[] {null, ""};
 
     for (String invalidPath : invalidPaths) {

--- a/core/src/test/java/org/apache/iceberg/util/TestLockManagers.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLockManagers.java
@@ -26,16 +26,16 @@ import org.apache.iceberg.LockManager;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.Test;
 
-public class TestLockManagers {
+class TestLockManagers {
 
   @Test
-  public void testLoadDefaultLockManager() {
+  void testLoadDefaultLockManager() {
     assertThat(LockManagers.defaultLockManager())
         .isInstanceOf(LockManagers.InMemoryLockManager.class);
   }
 
   @Test
-  public void testLoadCustomLockManager() {
+  void testLoadCustomLockManager() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(CatalogProperties.LOCK_IMPL, CustomLockManager.class.getName());
     assertThat(LockManagers.from(properties)).isInstanceOf(CustomLockManager.class);

--- a/core/src/test/java/org/apache/iceberg/util/TestManifestFileUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestManifestFileUtil.java
@@ -38,7 +38,7 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class TestManifestFileUtil {
+class TestManifestFileUtil {
   private static final Schema SCHEMA =
       new Schema(
           optional(1, "id", Types.IntegerType.get()),
@@ -48,7 +48,7 @@ public class TestManifestFileUtil {
   @TempDir private Path temp;
 
   @Test
-  public void canContainWithUnknownTypeOnly() throws IOException {
+  void canContainWithUnknownTypeOnly() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("unknown").build();
     PartitionData partition = new PartitionData(spec.partitionType());
     partition.set(0, "someValue");
@@ -63,7 +63,7 @@ public class TestManifestFileUtil {
   }
 
   @Test
-  public void canContainWithNaNValueOnly() throws IOException {
+  void canContainWithNaNValueOnly() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("floats").build();
     PartitionData partition = new PartitionData(spec.partitionType());
     partition.set(0, Float.NaN);
@@ -78,7 +78,7 @@ public class TestManifestFileUtil {
   }
 
   @Test
-  public void canContainWithNullValueOnly() throws IOException {
+  void canContainWithNullValueOnly() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("floats").build();
     PartitionData partition = new PartitionData(spec.partitionType());
     partition.set(0, null);
@@ -93,7 +93,7 @@ public class TestManifestFileUtil {
   }
 
   @Test
-  public void canContainWithUnknownType() throws IOException {
+  void canContainWithUnknownType() throws IOException {
     PartitionSpec spec =
         PartitionSpec.builderFor(SCHEMA).identity("floats").identity("unknown").build();
     PartitionData partition = new PartitionData(spec.partitionType());

--- a/core/src/test/java/org/apache/iceberg/util/TestParallelIterable.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestParallelIterable.java
@@ -42,9 +42,9 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-public class TestParallelIterable {
+class TestParallelIterable {
   @Test
-  public void closeParallelIteratorWithoutCompleteIteration() {
+  void closeParallelIteratorWithoutCompleteIteration() {
     ExecutorService executor = Executors.newFixedThreadPool(1);
     try {
       Iterable<CloseableIterable<Integer>> transform =
@@ -80,7 +80,7 @@ public class TestParallelIterable {
   }
 
   @Test
-  public void closeMoreDataParallelIteratorWithoutCompleteIteration() {
+  void closeMoreDataParallelIteratorWithoutCompleteIteration() {
     ExecutorService executor = Executors.newFixedThreadPool(1);
     try {
       Iterator<Integer> integerIterator =
@@ -144,7 +144,7 @@ public class TestParallelIterable {
   }
 
   @Test
-  public void limitQueueSize() {
+  void limitQueueSize() {
     ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
       List<Iterable<Integer>> iterables =
@@ -185,7 +185,7 @@ public class TestParallelIterable {
 
   @Test
   @Timeout(10)
-  public void noDeadlock() {
+  void noDeadlock() {
     // This test simulates a scenario where iterators use a constrained resource
     // (e.g. an S3 connection pool that has a limit on the number of connections).
     // In this case, the constrained resource shouldn't cause a deadlock when queue

--- a/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPartitionMap.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestPartitionMap {
+class TestPartitionMap {
 
   private static final Schema SCHEMA =
       new Schema(
@@ -59,7 +59,7 @@ public class TestPartitionMap {
           BY_DATA_CATEGORY_BUCKET_SPEC);
 
   @Test
-  public void testEmptyMap() {
+  void testEmptyMap() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     assertThat(map).isEmpty();
     assertThat(map).hasSize(0);
@@ -70,7 +70,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testSize() {
+  void testSize() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(UNPARTITIONED_SPEC.specId(), null, "v1");
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v2");
@@ -81,7 +81,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testDifferentStructLikeImplementations() {
+  void testDifferentStructLikeImplementations() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(BY_DATA_SPEC.specId(), CustomRow.of("aaa"), "value");
     map.put(UNPARTITIONED_SPEC.specId(), null, "value");
@@ -92,7 +92,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testPutAndGet() {
+  void testPutAndGet() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(UNPARTITIONED_SPEC.specId(), null, "v1");
     map.put(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("aaa", 1), "v2");
@@ -101,7 +101,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testRemove() {
+  void testRemove() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
 
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
@@ -116,7 +116,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void putAll() {
+  void putAll() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
 
     Map<Pair<Integer, StructLike>, String> otherMap = Maps.newHashMap();
@@ -130,7 +130,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testClear() {
+  void testClear() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(UNPARTITIONED_SPEC.specId(), null, "v1");
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v2");
@@ -140,7 +140,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testValues() {
+  void testValues() {
     PartitionMap<Integer> map = PartitionMap.create(SPECS);
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), 1);
     map.put(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("aaa", 2), 2);
@@ -149,7 +149,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testEntrySet() {
+  void testEntrySet() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
     map.put(BY_DATA_CATEGORY_BUCKET_SPEC.specId(), Row.of("bbb", 2), "v2");
@@ -158,7 +158,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testKeySet() {
+  void testKeySet() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
     map.put(BY_DATA_SPEC.specId(), CustomRow.of("ccc"), "v2");
@@ -167,7 +167,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testEqualsAndHashCode() {
+  void testEqualsAndHashCode() {
     PartitionMap<String> map1 = PartitionMap.create(SPECS);
     PartitionMap<String> map2 = PartitionMap.create(SPECS);
 
@@ -185,7 +185,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testToString() {
+  void testToString() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
 
     // empty map
@@ -205,7 +205,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testConcurrentReadAccess() throws InterruptedException {
+  void testConcurrentReadAccess() throws InterruptedException {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
     map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
@@ -232,7 +232,7 @@ public class TestPartitionMap {
 
   @Test
   @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
-  public void testNullKey() {
+  void testNullKey() {
     // no check on the underlying error msg as it might be missing based on the JDK version
     PartitionMap<String> map = PartitionMap.create(SPECS);
     assertThatThrownBy(() -> map.put(null, "value")).isInstanceOf(NullPointerException.class);
@@ -241,7 +241,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testUnknownSpecId() {
+  void testUnknownSpecId() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     assertThatThrownBy(() -> map.put(Integer.MAX_VALUE, null, "value"))
         .isInstanceOf(NullPointerException.class)
@@ -249,7 +249,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testUnmodifiableViews() {
+  void testUnmodifiableViews() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
     map.put(BY_DATA_SPEC.specId(), Row.of("bbb"), "v2");
@@ -272,7 +272,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testKeyAndEntrySetEquality() {
+  void testKeyAndEntrySetEquality() {
     PartitionMap<String> map1 = PartitionMap.create(SPECS);
     PartitionMap<String> map2 = PartitionMap.create(SPECS);
 
@@ -292,7 +292,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testLookupArbitraryKeyTypes() {
+  void testLookupArbitraryKeyTypes() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
     map.put(BY_DATA_SPEC.specId(), Row.of("aaa"), "v1");
     map.put(UNPARTITIONED_SPEC.specId(), null, "v2");
@@ -302,7 +302,7 @@ public class TestPartitionMap {
   }
 
   @Test
-  public void testComputeIfAbsent() {
+  void testComputeIfAbsent() {
     PartitionMap<String> map = PartitionMap.create(SPECS);
 
     String result1 = map.computeIfAbsent(BY_DATA_SPEC.specId(), Row.of("a"), () -> "v1");

--- a/core/src/test/java/org/apache/iceberg/util/TestPartitionSet.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPartitionSet.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestPartitionSet {
+class TestPartitionSet {
   private static final Schema SCHEMA =
       new Schema(
           required(1, "id", Types.IntegerType.get()),
@@ -51,7 +51,7 @@ public class TestPartitionSet {
           BY_DATA_CATEGORY_BUCKET_SPEC);
 
   @Test
-  public void testGet() {
+  void testGet() {
     PartitionSet set = PartitionSet.create(SPECS);
     set.add(BY_DATA_SPEC.specId(), Row.of("a"));
     set.add(UNPARTITIONED_SPEC.specId(), null);
@@ -66,7 +66,7 @@ public class TestPartitionSet {
   }
 
   @Test
-  public void testRemove() {
+  void testRemove() {
     PartitionSet set = PartitionSet.create(SPECS);
     set.add(BY_DATA_SPEC.specId(), Row.of("a"));
     set.add(UNPARTITIONED_SPEC.specId(), null);

--- a/core/src/test/java/org/apache/iceberg/util/TestPropertyUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPropertyUtil.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-public class TestPropertyUtil {
+class TestPropertyUtil {
 
   @Test
   void propertiesWithPrefixHandlesRegexSpecialChars() {

--- a/core/src/test/java/org/apache/iceberg/util/TestReachableFileUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestReachableFileUtil.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class TestReachableFileUtil {
+class TestReachableFileUtil {
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
       new Schema(
@@ -71,13 +71,13 @@ public class TestReachableFileUtil {
   private Table table;
 
   @BeforeEach
-  public void setupTableLocation() throws Exception {
+  void setupTableLocation() throws Exception {
     String tableLocation = tableDir.toURI().toString();
     this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
   }
 
   @Test
-  public void testManifestListLocations() {
+  void testManifestListLocations() {
     table.newAppend().appendFile(FILE_A).commit();
 
     table.newAppend().appendFile(FILE_B).commit();
@@ -87,7 +87,7 @@ public class TestReachableFileUtil {
   }
 
   @Test
-  public void testMetadataFileLocations() {
+  void testMetadataFileLocations() {
     table.updateProperties().set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "1").commit();
 
     table.newAppend().appendFile(FILE_A).commit();
@@ -102,7 +102,7 @@ public class TestReachableFileUtil {
   }
 
   @Test
-  public void testMetadataFileLocationsWithMissingFiles() {
+  void testMetadataFileLocationsWithMissingFiles() {
     table.updateProperties().set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "1").commit();
 
     table.newAppend().appendFile(FILE_A).commit();
@@ -119,7 +119,7 @@ public class TestReachableFileUtil {
   }
 
   @Test
-  public void testVersionHintWithStaticTables() {
+  void testVersionHintWithStaticTables() {
     TableOperations ops = ((HasTableOperations) table).operations();
     TableMetadata metadata = ops.current();
     String metadataFileLocation = metadata.metadataFileLocation();
@@ -133,7 +133,7 @@ public class TestReachableFileUtil {
   }
 
   @Test
-  public void testVersionHintWithBucketNameAsLocation() {
+  void testVersionHintWithBucketNameAsLocation() {
     Table mockTable = mock(Table.class);
     when(mockTable.location()).thenReturn("s3://bucket1");
     String reportedVersionHintLocation = ReachableFileUtil.versionHintLocation(mockTable);

--- a/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class TestSnapshotUtil {
+class TestSnapshotUtil {
   @TempDir private File tableDir;
   // Schema passed to create tables
   public static final Schema SCHEMA =
@@ -82,7 +82,7 @@ public class TestSnapshotUtil {
   }
 
   @BeforeEach
-  public void before() throws Exception {
+  void before() throws Exception {
     new File(tableDir, "metadata");
 
     this.table = TestTables.create(tableDir, "test", SCHEMA, SPEC, 2);
@@ -108,19 +108,19 @@ public class TestSnapshotUtil {
   }
 
   @AfterEach
-  public void cleanupTables() {
+  void cleanupTables() {
     TestTables.clearTables();
   }
 
   @Test
-  public void isParentAncestorOf() {
+  void isParentAncestorOf() {
     assertThat(SnapshotUtil.isParentAncestorOf(table, snapshotMain1Id, snapshotBaseId)).isTrue();
     assertThat(SnapshotUtil.isParentAncestorOf(table, snapshotBranchId, snapshotMain1Id)).isFalse();
     assertThat(SnapshotUtil.isParentAncestorOf(table, snapshotFork2Id, snapshotFork0Id)).isTrue();
   }
 
   @Test
-  public void isAncestorOf() {
+  void isAncestorOf() {
     assertThat(SnapshotUtil.isAncestorOf(table, snapshotMain1Id, snapshotBaseId)).isTrue();
     assertThat(SnapshotUtil.isAncestorOf(table, snapshotBranchId, snapshotMain1Id)).isFalse();
     assertThat(SnapshotUtil.isAncestorOf(table, snapshotFork2Id, snapshotFork0Id)).isFalse();
@@ -130,7 +130,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void currentAncestors() {
+  void currentAncestors() {
     Iterable<Snapshot> snapshots = SnapshotUtil.currentAncestors(table);
     expectedSnapshots(new long[] {snapshotMain2Id, snapshotMain1Id, snapshotBaseId}, snapshots);
 
@@ -140,7 +140,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void oldestAncestor() {
+  void oldestAncestor() {
     Snapshot snapshot = SnapshotUtil.oldestAncestor(table);
     assertThat(snapshot.snapshotId()).isEqualTo(snapshotBaseId);
 
@@ -152,7 +152,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void snapshotsBetween() {
+  void snapshotsBetween() {
     List<Long> snapshotIdsBetween =
         SnapshotUtil.snapshotIdsBetween(table, snapshotBaseId, snapshotMain2Id);
     assertThat(snapshotIdsBetween.toArray(new Long[0]))
@@ -168,7 +168,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void ancestorsOf() {
+  void ancestorsOf() {
     Iterable<Snapshot> snapshots = SnapshotUtil.ancestorsOf(snapshotFork2Id, table::snapshot);
     expectedSnapshots(new long[] {snapshotFork2Id, snapshotFork1Id}, snapshots);
 
@@ -190,7 +190,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void schemaForRef() {
+  void schemaForRef() {
     Schema initialSchema =
         new Schema(
             required(1, "id", Types.IntegerType.get()),
@@ -205,7 +205,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void schemaForBranch() {
+  void schemaForBranch() {
     Schema initialSchema =
         new Schema(
             required(1, "id", Types.IntegerType.get()),
@@ -230,7 +230,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void schemaForTag() {
+  void schemaForTag() {
     Schema initialSchema =
         new Schema(
             required(1, "id", Types.IntegerType.get()),
@@ -254,7 +254,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void schemaForSnapshotId() {
+  void schemaForSnapshotId() {
     Schema initialSchema =
         new Schema(
             required(1, "id", Types.IntegerType.get()),
@@ -283,7 +283,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void schemaForSnapshotIdInvalidSnapshot() {
+  void schemaForSnapshotIdInvalidSnapshot() {
     long invalidSnapshotId = 999999L;
     assertThat(table.snapshot(invalidSnapshotId)).isNull();
 
@@ -293,7 +293,7 @@ public class TestSnapshotUtil {
   }
 
   @Test
-  public void schemaForSnapshotIdMetadataTable() {
+  void schemaForSnapshotIdMetadataTable() {
     long firstSnapshotId = table.currentSnapshot().snapshotId();
 
     table.updateSchema().addColumn("zip", Types.IntegerType.get()).commit();

--- a/core/src/test/java/org/apache/iceberg/util/TestSortOrderUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSortOrderUtil.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class TestSortOrderUtil {
+class TestSortOrderUtil {
 
   // column ids will be reassigned during table creation
   private static final Schema SCHEMA =
@@ -47,12 +47,12 @@ public class TestSortOrderUtil {
   @TempDir private File tableDir;
 
   @AfterEach
-  public void cleanupTables() {
+  void cleanupTables() {
     TestTables.clearTables();
   }
 
   @Test
-  public void testEmptySpecsV1() {
+  void testEmptySpecsV1() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     SortOrder order = SortOrder.builderFor(SCHEMA).withOrderId(1).asc("id", NULLS_LAST).build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, 1);
@@ -70,7 +70,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testEmptySpecsV2() {
+  void testEmptySpecsV2() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     SortOrder order = SortOrder.builderFor(SCHEMA).withOrderId(1).asc("id", NULLS_LAST).build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, 2);
@@ -88,7 +88,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringNoPartitionFields() {
+  void testSortOrderClusteringNoPartitionFields() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("ts").identity("category").build();
     SortOrder order = SortOrder.builderFor(SCHEMA).withOrderId(1).desc("id").build();
 
@@ -106,7 +106,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringAllPartitionFields() {
+  void testSortOrderClusteringAllPartitionFields() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("ts").identity("category").build();
     SortOrder order =
         SortOrder.builderFor(SCHEMA)
@@ -122,7 +122,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringAllPartitionFieldsReordered() {
+  void testSortOrderClusteringAllPartitionFieldsReordered() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("category").day("ts").build();
     SortOrder order =
         SortOrder.builderFor(SCHEMA)
@@ -138,7 +138,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringSomePartitionFields() {
+  void testSortOrderClusteringSomePartitionFields() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("category").day("ts").build();
     SortOrder order =
         SortOrder.builderFor(SCHEMA).withOrderId(1).asc("category").desc("id").build();
@@ -157,7 +157,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringSatisfiedPartitionLast() {
+  void testSortOrderClusteringSatisfiedPartitionLast() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("category").day("ts").build();
     SortOrder order =
         SortOrder.builderFor(SCHEMA)
@@ -176,7 +176,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringSatisfiedPartitionFirst() {
+  void testSortOrderClusteringSatisfiedPartitionFirst() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("ts").identity("category").build();
     SortOrder order =
         SortOrder.builderFor(SCHEMA)
@@ -201,7 +201,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringSatisfiedPartitionFields() {
+  void testSortOrderClusteringSatisfiedPartitionFields() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("ts").identity("category").build();
 
     SortOrder order =
@@ -227,7 +227,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringWithRedundantPartitionFields() {
+  void testSortOrderClusteringWithRedundantPartitionFields() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("ts").identity("category").build();
 
     // Specs with redundant time fields can't be constructed directly and have to use
@@ -259,7 +259,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testSortOrderClusteringWithRedundantPartitionFieldsMissing() {
+  void testSortOrderClusteringWithRedundantPartitionFieldsMissing() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("ts").identity("category").build();
 
     // Specs with redundant time fields can't be constructed directly and have to use
@@ -289,7 +289,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testFindSortOrderForTable() {
+  void testFindSortOrderForTable() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     SortOrder order = SortOrder.builderFor(SCHEMA).withOrderId(1).asc("id", NULLS_LAST).build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, 2);
@@ -302,7 +302,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testFindSortOrderForTableWithoutFieldId() {
+  void testFindSortOrderForTableWithoutFieldId() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     SortOrder order = SortOrder.builderFor(SCHEMA).withOrderId(1).asc("id", NULLS_LAST).build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, 2);
@@ -316,7 +316,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testFindSortOrderForTableThatIsNotCurrentOrder() {
+  void testFindSortOrderForTableThatIsNotCurrentOrder() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     SortOrder order = SortOrder.builderFor(SCHEMA).withOrderId(1).asc("id", NULLS_LAST).build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, 2);
@@ -334,7 +334,7 @@ public class TestSortOrderUtil {
   }
 
   @Test
-  public void testReturnsUnsortedForMissingSortOrder() {
+  void testReturnsUnsortedForMissingSortOrder() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     SortOrder order = SortOrder.builderFor(SCHEMA).withOrderId(1).asc("id", NULLS_LAST).build();
     TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, 2);

--- a/core/src/test/java/org/apache/iceberg/util/TestStructLikeMap.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestStructLikeMap.java
@@ -33,14 +33,14 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestStructLikeMap {
+class TestStructLikeMap {
   private static final Types.StructType STRUCT_TYPE =
       Types.StructType.of(
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.optional(2, "data", Types.LongType.get()));
 
   @Test
-  public void testSingleRecord() {
+  void testSingleRecord() {
     Record gRecord = GenericRecord.create(STRUCT_TYPE);
     Record record1 = gRecord.copy(ImmutableMap.of("id", 1, "data", "aaa"));
 
@@ -66,7 +66,7 @@ public class TestStructLikeMap {
   }
 
   @Test
-  public void testMultipleRecord() {
+  void testMultipleRecord() {
     Record gRecord = GenericRecord.create(STRUCT_TYPE);
     Record record1 = gRecord.copy(ImmutableMap.of("id", 1, "data", "aaa"));
     Record record2 = gRecord.copy(ImmutableMap.of("id", 2, "data", "bbb"));
@@ -103,7 +103,7 @@ public class TestStructLikeMap {
   }
 
   @Test
-  public void testRemove() {
+  void testRemove() {
     Record gRecord = GenericRecord.create(STRUCT_TYPE);
     Record record = gRecord.copy(ImmutableMap.of("id", 1, "data", "aaa"));
 
@@ -118,7 +118,7 @@ public class TestStructLikeMap {
   }
 
   @Test
-  public void testNullKeys() {
+  void testNullKeys() {
     Map<StructLike, String> map = StructLikeMap.create(STRUCT_TYPE);
     assertThat(map).doesNotContainKey(null);
 
@@ -133,7 +133,7 @@ public class TestStructLikeMap {
   }
 
   @Test
-  public void testKeysWithNulls() {
+  void testKeysWithNulls() {
     Record recordTemplate = GenericRecord.create(STRUCT_TYPE);
     Record record1 = recordTemplate.copy("id", 1, "data", null);
     Record record2 = recordTemplate.copy("id", 2, "data", null);
@@ -151,7 +151,7 @@ public class TestStructLikeMap {
   }
 
   @Test
-  public void testEqualsAndHashCode() {
+  void testEqualsAndHashCode() {
     Map<StructLike, String> map1 = StructLikeMap.create(STRUCT_TYPE);
     Map<StructLike, String> map2 = StructLikeMap.create(STRUCT_TYPE);
 
@@ -169,7 +169,7 @@ public class TestStructLikeMap {
   }
 
   @Test
-  public void testKeyAndEntrySetEquality() {
+  void testKeyAndEntrySetEquality() {
     Map<StructLike, String> map1 = StructLikeMap.create(STRUCT_TYPE);
     Map<StructLike, String> map2 = StructLikeMap.create(STRUCT_TYPE);
 

--- a/core/src/test/java/org/apache/iceberg/util/TestStructLikeSet.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestStructLikeSet.java
@@ -27,14 +27,14 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestStructLikeSet {
+class TestStructLikeSet {
   private static final Types.StructType STRUCT_TYPE =
       Types.StructType.of(
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.optional(2, "data", Types.LongType.get()));
 
   @Test
-  public void testNullElements() {
+  void testNullElements() {
     Set<StructLike> set = StructLikeSet.create(STRUCT_TYPE);
     assertThat(set).doesNotContain((StructLike) null);
 
@@ -50,7 +50,7 @@ public class TestStructLikeSet {
   }
 
   @Test
-  public void testElementsWithNulls() {
+  void testElementsWithNulls() {
     Record recordTemplate = GenericRecord.create(STRUCT_TYPE);
     Record record1 = recordTemplate.copy("id", 1, "data", null);
     Record record2 = recordTemplate.copy("id", 2, "data", null);

--- a/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
@@ -54,7 +54,7 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TestTableScanUtil {
+class TestTableScanUtil {
 
   private List<FileScanTask> tasksWithDataAndDeleteSizes(List<Pair<Long, Long[]>> sizePairs) {
     return sizePairs.stream()
@@ -94,7 +94,7 @@ public class TestTableScanUtil {
   }
 
   @Test
-  public void testFileScanTaskSizeEstimation() {
+  void testFileScanTaskSizeEstimation() {
     DataFile dataFile = dataFileWithSize(100L);
     DeleteFile dv = dvWithSize(20L);
     MockFileScanTask task = new MockFileScanTask(dataFile, new DeleteFile[] {dv});
@@ -102,7 +102,7 @@ public class TestTableScanUtil {
   }
 
   @Test
-  public void testPlanTaskWithDeleteFiles() {
+  void testPlanTaskWithDeleteFiles() {
     List<FileScanTask> testFiles =
         tasksWithDataAndDeleteSizes(
             Arrays.asList(
@@ -133,7 +133,7 @@ public class TestTableScanUtil {
   }
 
   @Test
-  public void testTaskGroupPlanning() {
+  void testTaskGroupPlanning() {
     List<ParentTask> tasks =
         ImmutableList.of(
             new ChildTask1(64),
@@ -150,7 +150,7 @@ public class TestTableScanUtil {
   }
 
   @Test
-  public void testTaskGroupPlanningCorruptedOffset() {
+  void testTaskGroupPlanningCorruptedOffset() {
     DataFile dataFile =
         DataFiles.builder(TestBase.SPEC)
             .withPath("/path/to/data-a.parquet")
@@ -189,7 +189,7 @@ public class TestTableScanUtil {
   }
 
   @Test
-  public void testTaskMerging() {
+  void testTaskMerging() {
     List<ParentTask> tasks =
         ImmutableList.of(
             new ChildTask1(64),
@@ -218,7 +218,7 @@ public class TestTableScanUtil {
   private static final StructLike PARTITION2 = new TestStructLike(200, "b");
 
   @Test
-  public void testTaskGroupPlanningByPartition() {
+  void testTaskGroupPlanningByPartition() {
     // When all files belong to the same partition, we should combine them together as long as the
     // total file size is <= split size
     List<PartitionScanTask> tasks =
@@ -303,7 +303,7 @@ public class TestTableScanUtil {
   }
 
   @Test
-  public void testAdaptiveSplitSize() {
+  void testAdaptiveSplitSize() {
     long scanSize = 500L * 1024 * 1024 * 1024; // 500 GB
     int parallelism = 500;
     long smallDefaultSplitSize = 128 * 1024 * 1024; // 128 MB

--- a/core/src/test/java/org/apache/iceberg/util/TestTasks.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTasks.java
@@ -25,10 +25,10 @@ import org.apache.iceberg.metrics.Counter;
 import org.apache.iceberg.metrics.DefaultMetricsContext;
 import org.junit.jupiter.api.Test;
 
-public class TestTasks {
+class TestTasks {
 
   @Test
-  public void attemptCounterIsIncreasedOnRetries() {
+  void attemptCounterIsIncreasedOnRetries() {
     Counter counter = new DefaultMetricsContext().counter("counter");
 
     final int retries = 10;
@@ -50,7 +50,7 @@ public class TestTasks {
   }
 
   @Test
-  public void attemptCounterIsIncreasedWithoutRetries() {
+  void attemptCounterIsIncreasedWithoutRetries() {
     Counter counter = new DefaultMetricsContext().counter("counter");
 
     Tasks.foreach(IntStream.range(0, 10)).countAttempts(counter).run(x -> {});

--- a/core/src/test/java/org/apache/iceberg/util/TestTruncateUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTruncateUtil.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 class TestTruncateUtil {
   @Test
-  public void testInvalidInputWidthBehavior() {
+  void testInvalidInputWidthBehavior() {
     assertThatNoException()
         .as("Invalid width input shouldn't necessarily throw an exception as it's not validated")
         .isThrownBy(() -> TruncateUtil.truncateInt(-1, 100));

--- a/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
@@ -29,7 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.primitives.UnsignedBytes;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestZOrderByteUtil {
+class TestZOrderByteUtil {
   private static final byte IIIIIIII = (byte) 255;
   private static final byte IOIOIOIO = (byte) 170;
   private static final byte OIOIOIOI = (byte) 85;
@@ -87,7 +87,7 @@ public class TestZOrderByteUtil {
    * wrong or are both identically correct.
    */
   @Test
-  public void testInterleaveRandomExamples() {
+  void testInterleaveRandomExamples() {
     for (int test = 0; test < NUM_INTERLEAVE_TESTS; test++) {
       int numByteArrays = Math.abs(random.nextInt(6)) + 1;
       byte[][] testBytes = new byte[numByteArrays][];
@@ -110,7 +110,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testReuseInterleaveBuffer() {
+  void testReuseInterleaveBuffer() {
     int numByteArrays = 2;
     int colLength = 16;
     ByteBuffer interleaveBuffer = ByteBuffer.allocate(numByteArrays * colLength);
@@ -135,7 +135,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testInterleaveEmptyBits() {
+  void testInterleaveEmptyBits() {
     byte[][] test = new byte[4][10];
     byte[] expected = new byte[40];
 
@@ -145,7 +145,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testInterleaveFullBits() {
+  void testInterleaveFullBits() {
     byte[][] test = new byte[4][];
     test[0] = new byte[] {IIIIIIII, IIIIIIII};
     test[1] = new byte[] {IIIIIIII};
@@ -159,7 +159,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testInterleaveMixedBits() {
+  void testInterleaveMixedBits() {
     byte[][] test = new byte[4][];
     test[0] = new byte[] {OOOOOOOI, IIIIIIII, OOOOOOOO, OOOOIIII};
     test[1] = new byte[] {OOOOOOOI, OOOOOOOO, IIIIIIII};
@@ -175,7 +175,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testIntOrdering() {
+  void testIntOrdering() {
     ByteBuffer aBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     ByteBuffer bBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     for (int i = 0; i < NUM_TESTS; i++) {
@@ -196,7 +196,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testLongOrdering() {
+  void testLongOrdering() {
     ByteBuffer aBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     ByteBuffer bBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     for (int i = 0; i < NUM_TESTS; i++) {
@@ -222,7 +222,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testShortOrdering() {
+  void testShortOrdering() {
     ByteBuffer aBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     ByteBuffer bBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     for (int i = 0; i < NUM_TESTS; i++) {
@@ -248,7 +248,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testTinyOrdering() {
+  void testTinyOrdering() {
     ByteBuffer aBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     ByteBuffer bBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     for (int i = 0; i < NUM_TESTS; i++) {
@@ -274,7 +274,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testFloatOrdering() {
+  void testFloatOrdering() {
     ByteBuffer aBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     ByteBuffer bBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     for (int i = 0; i < NUM_TESTS; i++) {
@@ -300,7 +300,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testDoubleOrdering() {
+  void testDoubleOrdering() {
     ByteBuffer aBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     ByteBuffer bBuffer = ZOrderByteUtils.allocatePrimitiveBuffer();
     for (int i = 0; i < NUM_TESTS; i++) {
@@ -326,7 +326,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testStringOrdering() {
+  void testStringOrdering() {
     CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
     ByteBuffer aBuffer = ByteBuffer.allocate(128);
     ByteBuffer bBuffer = ByteBuffer.allocate(128);
@@ -353,7 +353,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testByteTruncateOrFill() {
+  void testByteTruncateOrFill() {
     ByteBuffer aBuffer = ByteBuffer.allocate(128);
     ByteBuffer bBuffer = ByteBuffer.allocate(128);
     for (int i = 0; i < NUM_TESTS; i++) {
@@ -380,7 +380,7 @@ public class TestZOrderByteUtil {
   }
 
   @Test
-  public void testByteTruncatedOrFillNullIsZeroArray() {
+  void testByteTruncatedOrFillNullIsZeroArray() {
     ByteBuffer buffer = ByteBuffer.allocate(128);
     byte[] actualBytes = ZOrderByteUtils.byteTruncateOrFill(null, 128, buffer).array();
     ByteBuffer expected = ByteBuffer.allocate(128);


### PR DESCRIPTION
### What
Update test classes and methods under `core/src/test/.../util/` to use package-private visibility by removing unnecessary `public` modifiers.

### Why
JUnit 5 does not require test classes or methods to be public, and the project convention recommends package-private visibility unless broader access is required. These 25 test files in the core util package still used `public` visibility and were updated to align with the convention.

### Notes
- `FakeTicker` remains public because it is referenced by test classes in other packages (`hadoop`, `rest`).
- Methods in inner classes implementing interfaces (e.g., in `TestLockManagers`) remain public as required by the interface contract.