### PR TITLE
Docs: Replace deprecated 'compile' with 'implementation' in Gradle snippet

### DIFF
--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -45,7 +45,7 @@ To add a dependency on Iceberg in Gradle, add the following to `build.gradle`:
 
 ```
 dependencies {
-  compile 'org.apache.iceberg:iceberg-core:{{ icebergVersion }}'
+  implementation 'org.apache.iceberg:iceberg-core:{{ icebergVersion }}'
 }
 ```
 


### PR DESCRIPTION
The Gradle snippet on the Releases page uses the `compile` configuration, which was [removed in Gradle 7](https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal). Updated to `implementation` to match current Gradle conventions.

**Change:**
`site/docs/releases.md` line 48: `compile` → `implementation`

**Testing:**

1. Verified `mkdocs build` runs successfully from `site/` directory (the monorepo plugin warning about nightly docs is pre-existing and unrelated)

2. Ran `pymarkdownlnt scan site/docs/releases.md` — no lint issues on the changed line

3. Confirmed Iceberg's own `build.gradle` uses `implementation` (68 instances) and zero bare `compile` configurations:
   ```
   $ grep -c "implementation " build.gradle
   68
   $ grep -c "^[[:space:]]*compile " build.gradle
   0
   ```

4. Searched all docs for any other Gradle `compile` references — none found:
   ```
   $ grep -rn "compile '" site/ docs/ --include="*.md"
   (no results)
   ```

5. Verified the rendered markdown context is correct — the Gradle snippet now reads:
   ```
   dependencies {
     implementation 'org.apache.iceberg:iceberg-core:{{ icebergVersion }}'
   }
   ```

Closes #15811
