### PR TITLE
API: Fix FileRange validation to reject negative offset/length

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileRange.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileRange.java
@@ -31,10 +31,8 @@ public class FileRange {
   public FileRange(CompletableFuture<ByteBuffer> byteBuffer, long offset, int length)
       throws EOFException {
     Preconditions.checkNotNull(byteBuffer, "byteBuffer can't be null");
-    Preconditions.checkArgument(
-        length() >= 0, "Invalid length: %s in range (must be >= 0)", length);
-    Preconditions.checkArgument(
-        offset() >= 0, "Invalid offset: %s in range (must be >= 0)", offset);
+    Preconditions.checkArgument(length >= 0, "Invalid length: %s in range (must be >= 0)", length);
+    Preconditions.checkArgument(offset >= 0, "Invalid offset: %s in range (must be >= 0)", offset);
 
     this.byteBuffer = byteBuffer;
     this.offset = offset;

--- a/api/src/test/java/org/apache/iceberg/io/TestFileRange.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestFileRange.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+public class TestFileRange {
+
+  @Test
+  public void validRange() throws EOFException {
+    CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
+    FileRange range = new FileRange(future, 10L, 100);
+    assertThat(range.offset()).isEqualTo(10L);
+    assertThat(range.length()).isEqualTo(100);
+    assertThat(range.byteBuffer()).isSameAs(future);
+  }
+
+  @Test
+  public void negativeLength() {
+    CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
+    assertThatThrownBy(() -> new FileRange(future, 0L, -1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid length");
+  }
+
+  @Test
+  public void negativeOffset() {
+    CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
+    assertThatThrownBy(() -> new FileRange(future, -1L, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid offset");
+  }
+
+  @Test
+  public void nullByteBuffer() {
+    assertThatThrownBy(() -> new FileRange(null, 0L, 0))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("byteBuffer");
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/io/TestFileRange.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestFileRange.java
@@ -42,7 +42,7 @@ public class TestFileRange {
     CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
     assertThatThrownBy(() -> new FileRange(future, 0L, -1))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid length");
+        .hasMessage("Invalid length: -1 in range (must be >= 0)");
   }
 
   @Test
@@ -50,13 +50,13 @@ public class TestFileRange {
     CompletableFuture<ByteBuffer> future = new CompletableFuture<>();
     assertThatThrownBy(() -> new FileRange(future, -1L, 0))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid offset");
+        .hasMessage("Invalid offset: -1 in range (must be >= 0)");
   }
 
   @Test
   public void nullByteBuffer() {
     assertThatThrownBy(() -> new FileRange(null, 0L, 0))
         .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("byteBuffer");
+        .hasMessage("byteBuffer can't be null");
   }
 }


### PR DESCRIPTION
## Summary

- `FileRange` constructor validates `length()` and `offset()` (getters) before assigning fields, so negative inputs bypass validation silently since field defaults are 0
- Changed to validate constructor parameters directly instead of getters
- Added `TestFileRange.java` with test cases for negative offset, negative length, null byteBuffer, and valid construction

## Root Cause

```java
// BEFORE — length() returns 0 (field default), not the parameter value
Preconditions.checkArgument(
    length() >= 0, "Invalid length: %s in range (must be >= 0)", length);

// AFTER — validates the actual parameter
Preconditions.checkArgument(
    length >= 0, "Invalid length: %s in range (must be >= 0)", length);
```

## Test Plan

- [x] Added `TestFileRange.java` covering negative offset, negative length, null byteBuffer, and valid range
- [ ] Existing CI tests should pass

Fixes #15922