### PR TITLE
Spark: Fix NPE in FastForwardBranchProcedure

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -82,12 +84,18 @@ public class FastForwardBranchProcedure extends BaseProcedure {
     return modifyIcebergTable(
         tableIdent,
         table -> {
-          Long snapshotBefore =
-              table.snapshot(from) != null ? table.snapshot(from).snapshotId() : null;
+          Snapshot snapshotBefore = table.snapshot(from);
           table.manageSnapshots().fastForwardBranch(from, to).commit();
-          long snapshotAfter = table.snapshot(from).snapshotId();
+          Snapshot snapshotAfter = table.snapshot(from);
+          Preconditions.checkState(
+              snapshotAfter != null,
+              "Fast-forward failed: branch %s does not reference a snapshot after update",
+              from);
           InternalRow outputRow =
-              newInternalRow(UTF8String.fromString(from), snapshotBefore, snapshotAfter);
+              newInternalRow(
+                  UTF8String.fromString(from),
+                  snapshotBefore != null ? snapshotBefore.snapshotId() : null,
+                  snapshotAfter.snapshotId());
           return new InternalRow[] {outputRow};
         });
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -82,12 +84,18 @@ public class FastForwardBranchProcedure extends BaseProcedure {
     return modifyIcebergTable(
         tableIdent,
         table -> {
-          Long snapshotBefore =
-              table.snapshot(from) != null ? table.snapshot(from).snapshotId() : null;
+          Snapshot snapshotBefore = table.snapshot(from);
           table.manageSnapshots().fastForwardBranch(from, to).commit();
-          long snapshotAfter = table.snapshot(from).snapshotId();
+          Snapshot snapshotAfter = table.snapshot(from);
+          Preconditions.checkState(
+              snapshotAfter != null,
+              "Fast-forward failed: branch %s does not reference a snapshot after update",
+              from);
           InternalRow outputRow =
-              newInternalRow(UTF8String.fromString(from), snapshotBefore, snapshotAfter);
+              newInternalRow(
+                  UTF8String.fromString(from),
+                  snapshotBefore != null ? snapshotBefore.snapshotId() : null,
+                  snapshotAfter.snapshotId());
           return new InternalRow[] {outputRow};
         });
   }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.Iterator;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -87,12 +89,18 @@ public class FastForwardBranchProcedure extends BaseProcedure {
     return modifyIcebergTable(
         tableIdent,
         table -> {
-          Long snapshotBefore =
-              table.snapshot(from) != null ? table.snapshot(from).snapshotId() : null;
+          Snapshot snapshotBefore = table.snapshot(from);
           table.manageSnapshots().fastForwardBranch(from, to).commit();
-          long snapshotAfter = table.snapshot(from).snapshotId();
+          Snapshot snapshotAfter = table.snapshot(from);
+          Preconditions.checkState(
+              snapshotAfter != null,
+              "Fast-forward failed: branch %s does not reference a snapshot after update",
+              from);
           InternalRow outputRow =
-              newInternalRow(UTF8String.fromString(from), snapshotBefore, snapshotAfter);
+              newInternalRow(
+                  UTF8String.fromString(from),
+                  snapshotBefore != null ? snapshotBefore.snapshotId() : null,
+                  snapshotAfter.snapshotId());
           return asScanIterator(OUTPUT_TYPE, outputRow);
         });
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/FastForwardBranchProcedure.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.Iterator;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -87,12 +89,18 @@ public class FastForwardBranchProcedure extends BaseProcedure {
     return modifyIcebergTable(
         tableIdent,
         table -> {
-          Long snapshotBefore =
-              table.snapshot(from) != null ? table.snapshot(from).snapshotId() : null;
+          Snapshot snapshotBefore = table.snapshot(from);
           table.manageSnapshots().fastForwardBranch(from, to).commit();
-          long snapshotAfter = table.snapshot(from).snapshotId();
+          Snapshot snapshotAfter = table.snapshot(from);
+          Preconditions.checkState(
+              snapshotAfter != null,
+              "Fast-forward failed: branch %s does not reference a snapshot after update",
+              from);
           InternalRow outputRow =
-              newInternalRow(UTF8String.fromString(from), snapshotBefore, snapshotAfter);
+              newInternalRow(
+                  UTF8String.fromString(from),
+                  snapshotBefore != null ? snapshotBefore.snapshotId() : null,
+                  snapshotAfter.snapshotId());
           return asScanIterator(OUTPUT_TYPE, outputRow);
         });
   }


### PR DESCRIPTION
The procedure dereferenced `table.snapshot(from)` without a null check after committing the fast-forward, which could produce a bare NullPointerException with no error msg.

This change replaces the unchecked dereference with a `Preconditions.checkState` guard that surfaces a exception that includes the branch name. Also eliminates the redundant double-lookup of the "before" snapshot by storing it in a local Snapshot variable.