### PR TITLE
Build: Add Java 25 support by adding arrow-memory-unsafe to dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -948,12 +948,15 @@ project(':iceberg-arrow') {
       exclude group: 'io.netty', module: 'netty-common'
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
-    implementation(libs.arrow.memory.netty) {
-      exclude group: 'com.google.code.findbugs', module: 'jsr305'
-      exclude group: 'io.netty', module: 'netty-common'
+    implementation(libs.arrow.memory.unsafe) {
       exclude group: 'io.netty', module: 'netty-buffer'
+      exclude group: 'io.netty', module: 'netty-common'
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
-
+    // netty-buffer is not a transitive dep of arrow-vector or arrow-memory-unsafe;
+    // it must be declared explicitly so downstream modules (e.g. Spark) that
+    // exclude netty from their own deps and rely on iceberg-arrow to supply it
+    // continue to find it on the runtime classpath.
     runtimeOnly libs.netty.buffer
 
     implementation(libs.parquet.avro) {
@@ -964,10 +967,9 @@ project(':iceberg-arrow') {
     }
 
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
-    // To run ArrowReaderTest test cases, :netty-common is needed.
-    // We import :netty-common through :arrow-memory-netty
-    // so that the same version as used by the :arrow-memory-netty module is picked.
-    testImplementation libs.arrow.memory.netty
+    // ArrowReaderTest requires netty-common; pull it in directly without
+    // bringing in arrow-memory-netty's broken allocator (fails on Java 25).
+    testImplementation libs.netty.common
     testImplementation libs.hadoop3.common
     testImplementation libs.hadoop3.mapreduce.client.core
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,7 +103,7 @@ antlr-antlr4 = { module = "org.antlr:antlr4", version.ref = "antlr" }
 antlr-runtime = { module = "org.antlr:antlr4-runtime", version.ref = "antlr" }
 antlr-antlr413 = { module = "org.antlr:antlr4", version.ref = "antlr413" }
 antlr-runtime413 = { module = "org.antlr:antlr4-runtime", version.ref = "antlr413" }
-arrow-memory-netty = { module = "org.apache.arrow:arrow-memory-netty", version.ref = "arrow" }
+arrow-memory-unsafe = { module = "org.apache.arrow:arrow-memory-unsafe", version.ref = "arrow" }
 arrow-vector = { module = "org.apache.arrow:arrow-vector", version.ref = "arrow" }
 avro-avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 awssdk-bom = { module = "software.amazon.awssdk:bom", version.ref = "awssdk-bom" }
@@ -165,6 +165,7 @@ lz4Java = { module = "at.yawk.lz4:lz4-java", version.ref = "lz4Java" }
 microprofile-openapi-api = { module = "org.eclipse.microprofile.openapi:microprofile-openapi-api", version.ref = "microprofile-openapi-api" }
 nessie-client = { module = "org.projectnessie.nessie:nessie-client", version.ref = "nessie" }
 netty-buffer = { module = "io.netty:netty-buffer", version.ref = "netty-buffer" }
+netty-common = { module = "io.netty:netty-common", version.ref = "netty-buffer" }
 object-client-bundle = { module = "com.emc.ecs:object-client-bundle", version.ref = "object-client-bundle" }
 orc-core = { module = "org.apache.orc:orc-core", version.ref = "orc" }
 parquet-avro = { module = "org.apache.parquet:parquet-avro", version.ref = "parquet" }


### PR DESCRIPTION
## Background

**The Problem: Default Netty Allocator Fails on Java 25**
When running Apache Iceberg / Spark with Apache Arrow on Java 25, the default memory allocator (`arrow.allocation.manager.type=Netty`) will crash our jobs with an `ExceptionInInitializerError` and `UnsupportedOperationException`. 

This happens because the older version of Netty bundled inside Iceberg relies heavily on deep JVM internals to access memory. Specifically, Java 25 completely removed the SecurityManager (JEP 486) and changed internal memory structures (JEP 471) that Netty was looking for. Because these internal classes and fields no longer exist, no amount of --add-opens flags will fix the crash.

**The Solution: Use the Unsafe Allocator**
To avoid this issue on Java 25, we must bypass Netty entirely by adding the following to our Spark configuration:
```
spark.executor.extraJavaOptions=-Darrow.allocation.manager.type=Unsafe
spark.driver.extraJavaOptions=-Darrow.allocation.manager.type=Unsafe
```
But it will throw `java.lang.ClassNotFoundException: org.apache.arrow.memory.UnsafeAllocationManager`.  So we need to add arrow-memory-unsafe to dependencies.

Closes #15930

## How to test

1. Download [iceberg-java25.tgz](https://github.com/user-attachments/files/26623832/iceberg-java25.tgz)
2. tar -zxf iceberg-java25.tgz && cd iceberg-java25
3. Build with Java 17: `/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home/bin/javac  -cp ".:*" Reproducer.java`
4. Run with Java 25: `/Library/Java/JavaVirtualMachines/zulu-25.jdk/Contents/Home/bin/java  -cp ".:*" --add-opens=java.base/java.nio=ALL-UNNAMED Reproducer`, it will throw exception. We should add `-Darrow.allocation.manager.type=Unsafe ` to run it: `/Library/Java/JavaVirtualMachines/zulu-25.jdk/Contents/Home/bin/java  -cp ".:*" --add-opens=java.base/java.nio=ALL-UNNAMED -Darrow.allocation.manager.type=Unsafe  Reproducer`