### PR TITLE
Build: Pass docker token using --password-stdin

### DIFF
--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -56,7 +56,7 @@ jobs:
         DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       run: |
-        docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_TOKEN"
+        echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USER" --password-stdin
     - name: Set the tagged version
       # for tag 'apache-iceberg-1.7.1', publish image 'apache/iceberg-rest-fixture:1.7.1'
       if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')


### PR DESCRIPTION
The way DockerHub token is passed for logging in while publishing the rest-fixture image is not safe. See https://www.codegenes.net/blog/docker-using-password-via-the-cli-is-insecure-use-password-stdin/ . Command-line arguments like -p can be visible to other processes, increasing the risk of exposure. 

Instead of using -p, we use echo <token> | docker login ... --password-stdin for authentication now. This is the recommended way of doing it as per the official docker docs: https://docs.docker.com/reference/cli/docker/login/#password-stdin.