### PR TITLE
Revert "Gradle: bump shadow-gradle-plugin to 9.4.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.gradleup.shadow:shadow-gradle-plugin:9.4.1'
+    classpath 'com.gradleup.shadow:shadow-gradle-plugin:8.3.10'
     classpath 'com.palantir.baseline:gradle-baseline-java:6.90.0'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:8.4.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -80,7 +80,7 @@ subprojects {
             if (tasks.matching({task -> task.name == 'shadowJar'}).isEmpty()) {
               from components.java
             } else {
-              from components.shadow
+              project.shadow.component(it)
             }
 
             artifact sourceJar


### PR DESCRIPTION
Reverts apache/iceberg#15835

I think we should revert this version bump for now because it spams the build output due to duplicates in the uber jar. This is because 9.3.2 of the plugin fixed how duplicates are reported in https://github.com/GradleUp/shadow/pull/1931. Once we have a proper way of dealing with the duplicates and defining a way to deal with them, we can re-introduce the change