### PR TITLE
Core: Fix StructLikeWrapper.equals exception with comparator failure

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/StructLikeWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeWrapper.java
@@ -88,7 +88,13 @@ public class StructLikeWrapper {
       return false;
     }
 
-    return comparator.compare(this.struct, that.struct) == 0;
+    try {
+      return comparator.compare(this.struct, that.struct) == 0;
+    } catch (RuntimeException e) {
+      // An exception may occur, for example, when struct is PartitionData and its type does not
+      // match its data.
+      return false;
+    }
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/util/TestStructLikeWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestStructLikeWrapper.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestStructLikeWrapper {
+  @Test
+  public void equalsTypeAndDataMismatch() {
+    Types.StructType intType =
+        Types.StructType.of(Types.NestedField.required(1, "a", Types.IntegerType.get()));
+    Types.StructType stringType =
+        Types.StructType.of(Types.NestedField.required(1, "a", Types.StringType.get()));
+
+    PartitionData intData = new PartitionData(intType);
+    intData.set(0, 1);
+
+    PartitionData stringData = new PartitionData(stringType);
+    stringData.set(0, "test");
+
+    StructLikeWrapper integerStruct = StructLikeWrapper.forType(intType).set(intData);
+    StructLikeWrapper stringStruct = StructLikeWrapper.forType(stringType).set(stringData);
+
+    // StructLikeWrapper.equals previously threw an exception when the type and data mismatch
+    assertThat(integerStruct).isNotEqualTo(stringStruct);
+  }
+}


### PR DESCRIPTION
StructLikeWrapper.equals threw an exception when the comparator threw an exception. This PR wraps the comparator.compare call in a try-catch so that type mismatches return false instead of propagating the exception. 

The newly added test fails if we revert the StructLikeWrapper.equals change: 
```sh
Wrong class, expected java.lang.Integer, but was java.lang.String, for object: test
java.lang.IllegalArgumentException: Wrong class, expected java.lang.Integer, but was java.lang.String, for object: test
	at org.apache.iceberg.PartitionData.get(PartitionData.java:126)
	at org.apache.iceberg.types.Comparators$StructLikeComparator.compare(Comparators.java:122)
	at org.apache.iceberg.types.Comparators$StructLikeComparator.compare(Comparators.java:95)
	at org.apache.iceberg.util.StructLikeWrapper.equals(StructLikeWrapper.java:91)
	at org.assertj.core.internal.StandardComparisonStrategy.areEqual(StandardComparisonStrategy.java:111)
	at org.assertj.core.internal.Objects.areEqual(Objects.java:231)
	at org.assertj.core.internal.Objects.assertNotEqual(Objects.java:227)
	at org.assertj.core.api.AbstractAssert.isNotEqualTo(AbstractAssert.java:394)
	at org.apache.iceberg.util.TestStructLikeWrapper.equalsTypeAndDataMismatch(TestStructLikeWrapper.java:45)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```