### PR TITLE
Core: Fix namespace URL encoding to use %20 instead of + for spaces

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -293,7 +293,7 @@ public class RESTUtil {
     String[] encodedLevels = new String[levels.length];
 
     for (int i = 0; i < levels.length; i++) {
-      encodedLevels[i] = encodeString(levels[i]);
+      encodedLevels[i] = encodeString(levels[i]).replace("+", "%20");
     }
 
     return Joiner.on(separator).join(encodedLevels);

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -171,6 +171,32 @@ public class TestRESTUtil {
   }
 
   @Test
+  public void testEncodeNamespaceSpacesUsePercentEncoding() {
+    // Spaces in namespace levels must be encoded as %20 (URL path encoding),
+    // not + (application/x-www-form-urlencoded). A server receiving /v1/namespaces/a+b
+    // treats '+' as a literal character, not a space, causing namespace lookup failures.
+    String separator = "%2E";
+
+    // single-level namespace with a space
+    Namespace singleLevel = Namespace.of("a b");
+    String encoded = RESTUtil.encodeNamespace(singleLevel, separator);
+    assertThat(encoded)
+        .as("space must be encoded as %%20, not +")
+        .isEqualTo("a%20b")
+        .doesNotContain("+");
+    assertThat(RESTUtil.decodeNamespace(encoded, separator)).isEqualTo(singleLevel);
+
+    // multi-level namespace where each level contains spaces
+    Namespace multiLevel = Namespace.of("my namespace", "my schema");
+    String encodedMulti = RESTUtil.encodeNamespace(multiLevel, separator);
+    assertThat(encodedMulti)
+        .as("spaces in every level must be encoded as %%20, not +")
+        .isEqualTo("my%20namespace%2Emy%20schema")
+        .doesNotContain("+");
+    assertThat(RESTUtil.decodeNamespace(encodedMulti, separator)).isEqualTo(multiLevel);
+  }
+
+  @Test
   public void testNullEndpointPath() {
     assertThat(RESTUtil.resolveEndpoint("http://catalog-uri", null)).isNull();
   }


### PR DESCRIPTION
`RESTUtil.encodeNamespace()` called `encodeString()` which uses Java URLEncoder. 

This follows `application/x-www-form-urlencoded` rules and encodes spaces as `+`. 
While correct for form data and OAuth2, URL path segments require RFC 3986 percent-encoding where spaces must be `%20`. Servers receiving` /v1/namespaces/a+b` treat `+` as a literal character, not a space, causing namespace lookup failures in catalogs such as Polaris.

Fix by replacing `+` with `%20` in encodeNamespace() only, leaving encodeString() unchanged so form data and OAuth2 encoding is unaffected. URLDecoder.decode() already handles both `+` and `%20` as spaces, so decoding remains backward compatible.

Fixes https://github.com/apache/iceberg/issues/14263