### PR TITLE
Core, API, Spark: Add FileContent.fromId

### DIFF
--- a/api/src/main/java/org/apache/iceberg/FileContent.java
+++ b/api/src/main/java/org/apache/iceberg/FileContent.java
@@ -41,8 +41,7 @@ public enum FileContent {
   }
 
   public static FileContent fromContentTypeId(int id) {
-    Preconditions.checkArgument(
-        id >= 0 && id < VALUES.length, "Invalid content type id: %s", id);
+    Preconditions.checkArgument(id >= 0 && id < VALUES.length, "Invalid content type id: %s", id);
     return VALUES[id];
   }
 }

--- a/api/src/main/java/org/apache/iceberg/FileContent.java
+++ b/api/src/main/java/org/apache/iceberg/FileContent.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
 /** Content type stored in a file. */
 public enum FileContent {
   DATA(0),
@@ -40,8 +38,7 @@ public enum FileContent {
     return id;
   }
 
-  public static FileContent fromContentTypeId(int id) {
-    Preconditions.checkArgument(id >= 0 && id < VALUES.length, "Invalid content type id: %s", id);
+  public static FileContent fromId(int id) {
     return VALUES[id];
   }
 }

--- a/api/src/main/java/org/apache/iceberg/FileContent.java
+++ b/api/src/main/java/org/apache/iceberg/FileContent.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
 /** Content type stored in a file. */
 public enum FileContent {
   DATA(0),
@@ -39,6 +41,8 @@ public enum FileContent {
   }
 
   public static FileContent fromContentTypeId(int id) {
+    Preconditions.checkArgument(
+        id >= 0 && id < VALUES.length, "Invalid content type id: %s", id);
     return VALUES[id];
   }
 }

--- a/api/src/test/java/org/apache/iceberg/TestFileContent.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileContent.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class TestFileContent {
 
@@ -32,14 +34,11 @@ class TestFileContent {
     }
   }
 
-  @Test
-  void fromContentTypeIdInvalid() {
-    assertThatThrownBy(() -> FileContent.fromContentTypeId(-1))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining("-1");
-
-    assertThatThrownBy(() -> FileContent.fromContentTypeId(FileContent.values().length))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
-        .hasMessageContaining(String.valueOf(FileContent.values().length));
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 5, 100})
+  void fromContentTypeIdInvalid(int id) {
+    assertThatThrownBy(() -> FileContent.fromContentTypeId(id))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(String.valueOf(id));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/TestFileContent.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileContent.java
@@ -21,9 +21,10 @@ package org.apache.iceberg;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TestFileContent {
 
@@ -34,8 +35,12 @@ class TestFileContent {
     }
   }
 
+  static IntStream invalidContentTypeIds() {
+    return IntStream.of(-1, FileContent.values().length);
+  }
+
   @ParameterizedTest
-  @ValueSource(ints = {-1, 5, 100})
+  @MethodSource("invalidContentTypeIds")
   void fromContentTypeIdInvalid(int id) {
     assertThatThrownBy(() -> FileContent.fromContentTypeId(id))
         .isInstanceOf(IllegalArgumentException.class)

--- a/api/src/test/java/org/apache/iceberg/TestFileContent.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileContent.java
@@ -35,9 +35,11 @@ class TestFileContent {
   @Test
   void fromContentTypeIdInvalid() {
     assertThatThrownBy(() -> FileContent.fromContentTypeId(-1))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining("-1");
 
     assertThatThrownBy(() -> FileContent.fromContentTypeId(FileContent.values().length))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining(String.valueOf(FileContent.values().length));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/TestFileContent.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileContent.java
@@ -30,8 +30,8 @@ class TestFileContent {
 
   @ParameterizedTest
   @EnumSource(FileContent.class)
-  void fromContentTypeId(FileContent content) {
-    assertThat(FileContent.fromContentTypeId(content.id())).isEqualTo(content);
+  void fromId(FileContent content) {
+    assertThat(FileContent.fromId(content.id())).isEqualTo(content);
   }
 
   static IntStream invalidContentTypeIds() {
@@ -40,9 +40,8 @@ class TestFileContent {
 
   @ParameterizedTest
   @MethodSource("invalidContentTypeIds")
-  void fromContentTypeIdInvalid(int id) {
-    assertThatThrownBy(() -> FileContent.fromContentTypeId(id))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid content type id: %d", id);
+  void fromIdInvalid(int id) {
+    assertThatThrownBy(() -> FileContent.fromId(id))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/TestFileContent.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileContent.java
@@ -22,17 +22,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class TestFileContent {
 
-  @Test
-  void fromContentTypeId() {
-    for (FileContent content : FileContent.values()) {
-      assertThat(FileContent.fromContentTypeId(content.id())).isEqualTo(content);
-    }
+  @ParameterizedTest
+  @EnumSource(FileContent.class)
+  void fromContentTypeId(FileContent content) {
+    assertThat(FileContent.fromContentTypeId(content.id())).isEqualTo(content);
   }
 
   static IntStream invalidContentTypeIds() {
@@ -44,6 +43,6 @@ class TestFileContent {
   void fromContentTypeIdInvalid(int id) {
     assertThatThrownBy(() -> FileContent.fromContentTypeId(id))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(String.valueOf(id));
+        .hasMessage("Invalid content type id: %d", id);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/TestFileContent.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileContent.java
@@ -42,6 +42,7 @@ class TestFileContent {
   @MethodSource("invalidContentTypeIds")
   void fromIdInvalid(int id) {
     assertThatThrownBy(() -> FileContent.fromId(id))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining(String.valueOf(id));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/TestFileContent.java
+++ b/api/src/test/java/org/apache/iceberg/TestFileContent.java
@@ -18,27 +18,26 @@
  */
 package org.apache.iceberg;
 
-/** Content type stored in a file. */
-public enum FileContent {
-  DATA(0),
-  POSITION_DELETES(1),
-  EQUALITY_DELETES(2),
-  DATA_MANIFEST(3),
-  DELETE_MANIFEST(4);
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-  private static final FileContent[] VALUES = FileContent.values();
+import org.junit.jupiter.api.Test;
 
-  private final int id;
+class TestFileContent {
 
-  FileContent(int id) {
-    this.id = id;
+  @Test
+  void fromContentTypeId() {
+    for (FileContent content : FileContent.values()) {
+      assertThat(FileContent.fromContentTypeId(content.id())).isEqualTo(content);
+    }
   }
 
-  public int id() {
-    return id;
-  }
+  @Test
+  void fromContentTypeIdInvalid() {
+    assertThatThrownBy(() -> FileContent.fromContentTypeId(-1))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
 
-  public static FileContent fromContentTypeId(int id) {
-    return VALUES[id];
+    assertThatThrownBy(() -> FileContent.fromContentTypeId(FileContent.values().length))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -316,7 +316,8 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
-        this.content = value != null ? FileContent.fromContentTypeId((Integer) value) : FileContent.DATA;
+        this.content =
+            value != null ? FileContent.fromContentTypeId((Integer) value) : FileContent.DATA;
         return;
       case 1:
         // always coerce to String for Serializable

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -45,7 +45,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
         StructLike,
         SpecificData.SchemaConstructable,
         Serializable {
-  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
+
   static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
   static final PartitionData EMPTY_PARTITION_DATA =
       new PartitionData(EMPTY_STRUCT_TYPE) {
@@ -316,7 +316,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
-        this.content = value != null ? FILE_CONTENT_VALUES[(Integer) value] : FileContent.DATA;
+        this.content = value != null ? FileContent.fromContentTypeId((Integer) value) : FileContent.DATA;
         return;
       case 1:
         // always coerce to String for Serializable

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -317,7 +317,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
     switch (pos) {
       case 0:
         this.content =
-            value != null ? FileContent.fromContentTypeId((Integer) value) : FileContent.DATA;
+            value != null ? FileContent.fromId((Integer) value) : FileContent.DATA;
         return;
       case 1:
         // always coerce to String for Serializable

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -316,8 +316,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
       case 0:
-        this.content =
-            value != null ? FileContent.fromId((Integer) value) : FileContent.DATA;
+        this.content = value != null ? FileContent.fromId((Integer) value) : FileContent.DATA;
         return;
       case 1:
         // always coerce to String for Serializable

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
-  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
 
   private final int fileContentPosition;
   private final int filePathPosition;
@@ -139,7 +138,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FILE_CONTENT_VALUES[wrapped.getInt(fileContentPosition)];
+    return FileContent.fromContentTypeId(wrapped.getInt(fileContentPosition));
   }
 
   @Override

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
-
   private final int fileContentPosition;
   private final int filePathPosition;
   private final int fileFormatPosition;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -137,7 +137,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FileContent.fromContentTypeId(wrapped.getInt(fileContentPosition));
+    return FileContent.fromId(wrapped.getInt(fileContentPosition));
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
-  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
 
   private final int fileContentPosition;
   private final int filePathPosition;
@@ -139,7 +138,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FILE_CONTENT_VALUES[wrapped.getInt(fileContentPosition)];
+    return FileContent.fromContentTypeId(wrapped.getInt(fileContentPosition));
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
-
   private final int fileContentPosition;
   private final int filePathPosition;
   private final int fileFormatPosition;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -137,7 +137,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FileContent.fromContentTypeId(wrapped.getInt(fileContentPosition));
+    return FileContent.fromId(wrapped.getInt(fileContentPosition));
   }
 
   @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
-  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
 
   private final int fileContentPosition;
   private final int filePathPosition;
@@ -139,7 +138,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FILE_CONTENT_VALUES[wrapped.getInt(fileContentPosition)];
+    return FileContent.fromContentTypeId(wrapped.getInt(fileContentPosition));
   }
 
   @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
-
   private final int fileContentPosition;
   private final int filePathPosition;
   private final int fileFormatPosition;

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -137,7 +137,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FileContent.fromContentTypeId(wrapped.getInt(fileContentPosition));
+    return FileContent.fromId(wrapped.getInt(fileContentPosition));
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
-  private static final FileContent[] FILE_CONTENT_VALUES = FileContent.values();
 
   private final int fileContentPosition;
   private final int filePathPosition;
@@ -139,7 +138,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FILE_CONTENT_VALUES[wrapped.getInt(fileContentPosition)];
+    return FileContent.fromContentTypeId(wrapped.getInt(fileContentPosition));
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.types.StructType;
 
 public abstract class SparkContentFile<F> implements ContentFile<F> {
 
-
   private final int fileContentPosition;
   private final int filePathPosition;
   private final int fileFormatPosition;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -137,7 +137,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     if (wrapped.isNullAt(fileContentPosition)) {
       return null;
     }
-    return FileContent.fromContentTypeId(wrapped.getInt(fileContentPosition));
+    return FileContent.fromId(wrapped.getInt(fileContentPosition));
   }
 
   @Override


### PR DESCRIPTION
Added this API to centralize ID-to-enum lookup. 

This was a [suggestion](https://github.com/apache/iceberg/pull/15854#discussion_r3041794617) from @stevenzwu 