### PR TITLE
Core: Rebuild REST cached tables with current context

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -531,6 +531,11 @@ public class TableMetadata implements Serializable {
     return snapshots;
   }
 
+  /** Returns true if all snapshots have been fully loaded (no pending lazy supplier). */
+  public boolean snapshotsLoaded() {
+    return snapshotsLoaded;
+  }
+
   private synchronized void ensureSnapshotsLoaded() {
     if (!snapshotsLoaded) {
       List<Snapshot> loadedSnapshots = Lists.newArrayList(snapshotsSupplier.get());

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -474,7 +474,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       if (response == null) {
         Preconditions.checkNotNull(cachedTable, "Invalid load table response: null");
 
-        return cachedTable.supplier().get();
+        return tableWithCurrentContext(context, identifier, cachedTable);
       }
 
       loadedIdent = identifier;
@@ -501,7 +501,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             Preconditions.checkNotNull(cachedTable, "Invalid load table response: null");
 
             return MetadataTableUtils.createMetadataTableInstance(
-                cachedTable.supplier().get(), metadataType);
+                tableWithCurrentContext(context, baseIdent, cachedTable), metadataType);
           }
 
           loadedIdent = baseIdent;
@@ -522,11 +522,14 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
     AuthSession tableSession =
         authManager.tableSession(finalIdentifier, tableConf, contextualSession);
+    // responseTableMetadata is the server's raw response metadata — before any lazy
+    // snapshotsSupplier is attached — used to rebuild the table for new callers on 304.
+    TableMetadata responseTableMetadata = response.tableMetadata();
     TableMetadata tableMetadata;
 
     if (snapshotMode == SnapshotMode.REFS) {
       tableMetadata =
-          TableMetadata.buildFrom(response.tableMetadata())
+          TableMetadata.buildFrom(responseTableMetadata)
               .withMetadataLocation(response.metadataLocation())
               .setPreviousFileLocation(null)
               .setSnapshotsSupplier(
@@ -537,7 +540,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               .discardChanges()
               .build();
     } else {
-      tableMetadata = response.tableMetadata();
+      tableMetadata = responseTableMetadata;
     }
 
     List<Credential> credentials = response.credentials();
@@ -548,12 +551,61 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     String eTag = responseHeaders.getOrDefault(HttpHeaders.ETAG, null);
     if (eTag != null) {
-      tableCache.put(context.sessionId(), finalIdentifier, tableSupplier, eTag);
+      tableCache.put(
+          context.sessionId(),
+          finalIdentifier,
+          tableSupplier,
+          eTag,
+          tableMetadata,
+          responseTableMetadata,
+          tableConf,
+          credentials);
     }
 
     if (metadataType != null) {
       return MetadataTableUtils.createMetadataTableInstance(tableSupplier.get(), metadataType);
     }
+
+    return tableSupplier.get();
+  }
+
+  private BaseTable tableWithCurrentContext(
+      SessionContext context, TableIdentifier identifier, TableWithETag cachedTable) {
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    AuthSession tableSession =
+        authManager.tableSession(identifier, cachedTable.tableConfig(), contextualSession);
+    RESTClient tableClient = client.withAuthSession(tableSession);
+
+    TableMetadata tableMetadata = cachedTable.tableMetadata();
+    if (snapshotMode == SnapshotMode.REFS && !tableMetadata.snapshotsLoaded()) {
+      // Rebuild the TableMetadata with a fresh snapshotsSupplier bound to the current context so
+      // that lazy snapshot loading uses the caller's credentials rather than those of the session
+      // that originally populated the cache. We start from responseTableMetadata (no lazy supplier)
+      // to avoid triggering the original supplier during the buildFrom copy. If the supplier has
+      // already been triggered (snapshotsLoaded() == true), the cached metadata already has the
+      // full snapshot list and can be used safely without any context-bound supplier.
+      TableMetadata responseTableMetadata = cachedTable.responseTableMetadata();
+      tableMetadata =
+          TableMetadata.buildFrom(responseTableMetadata)
+              .withMetadataLocation(responseTableMetadata.metadataFileLocation())
+              .setPreviousFileLocation(null)
+              .setSnapshotsSupplier(
+                  () ->
+                      loadInternal(context, identifier, SnapshotMode.ALL, Map.of(), h -> {})
+                          .tableMetadata()
+                          .snapshots())
+              .discardChanges()
+              .build();
+    }
+
+    Supplier<BaseTable> tableSupplier =
+        createTableSupplier(
+            identifier,
+            tableMetadata,
+            context,
+            tableClient,
+            cachedTable.tableConfig(),
+            cachedTable.credentials());
 
     return tableSupplier.get();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableCache.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableCache.java
@@ -23,12 +23,15 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
 import java.io.Closeable;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.util.PropertyUtil;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -81,9 +84,15 @@ class RESTTableCache implements Closeable {
       String sessionId,
       TableIdentifier identifier,
       Supplier<BaseTable> tableSupplier,
-      String eTag) {
+      String eTag,
+      TableMetadata tableMetadata,
+      TableMetadata responseTableMetadata,
+      Map<String, String> tableConfig,
+      List<Credential> credentials) {
     tableCache.put(
-        SessionIdTableId.of(sessionId, identifier), TableWithETag.of(tableSupplier, eTag));
+        SessionIdTableId.of(sessionId, identifier),
+        TableWithETag.of(
+            tableSupplier, eTag, tableMetadata, responseTableMetadata, tableConfig, credentials));
   }
 
   public void invalidate(String sessionId, TableIdentifier identifier) {
@@ -122,8 +131,35 @@ class RESTTableCache implements Closeable {
 
     String eTag();
 
-    static TableWithETag of(Supplier<BaseTable> tableSupplier, String eTag) {
-      return ImmutableTableWithETag.builder().supplier(tableSupplier).eTag(eTag).build();
+    TableMetadata tableMetadata();
+
+    /**
+     * The table metadata as returned directly by the server response, before any lazy
+     * snapshotsSupplier is attached (i.e. the metadata without a context-bound supplier). Used to
+     * rebuild a fresh table in {@code tableWithCurrentContext} without triggering the original
+     * session's supplier.
+     */
+    TableMetadata responseTableMetadata();
+
+    Map<String, String> tableConfig();
+
+    List<Credential> credentials();
+
+    static TableWithETag of(
+        Supplier<BaseTable> tableSupplier,
+        String eTag,
+        TableMetadata tableMetadata,
+        TableMetadata responseTableMetadata,
+        Map<String, String> tableConfig,
+        List<Credential> credentials) {
+      return ImmutableTableWithETag.builder()
+          .supplier(tableSupplier)
+          .eTag(eTag)
+          .tableMetadata(tableMetadata)
+          .responseTableMetadata(responseTableMetadata)
+          .putAllTableConfig(tableConfig)
+          .addAllCredentials(credentials)
+          .build();
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.RESTException;
@@ -574,6 +575,120 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
         .containsOnlyKeys(
             SessionIdTableId.of(DEFAULT_SESSION_CONTEXT.sessionId(), TABLE),
             SessionIdTableId.of(otherSessionContext.sessionId(), TABLE));
+  }
+
+  @Test
+  public void notModifiedResponseShouldUseCurrentContextForCollidingSessionIds() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    Map<String, FileIO> fileIOByToken = Maps.newHashMap();
+
+    RESTSessionCatalog sessionCatalog =
+        new RESTSessionCatalog(
+            config -> adapter,
+            (context, properties) ->
+                fileIOByToken.computeIfAbsent(
+                    tokenForContext(context),
+                    token -> Mockito.mock(FileIO.class, "io-for-" + token)));
+    sessionCatalog.initialize("test_session_catalog", Map.of());
+
+    SessionContext contextWithOriginalCredentials =
+        new SessionContext("colliding_session_id", "user-a", Map.of("token", "token-a"), Map.of());
+    SessionContext contextWithDifferentCredentials =
+        new SessionContext("colliding_session_id", "user-b", Map.of("token", "token-b"), Map.of());
+
+    sessionCatalog.createNamespace(contextWithOriginalCredentials, TABLE.namespace());
+    sessionCatalog.buildTable(contextWithOriginalCredentials, TABLE, SCHEMA).create();
+
+    expectFullTableLoadForLoadTable(TABLE, adapter);
+    BaseTable tableWithOriginalCredentials =
+        (BaseTable) sessionCatalog.loadTable(contextWithOriginalCredentials, TABLE);
+
+    expectNotModifiedResponseForLoadTable(TABLE, adapter);
+    BaseTable tableWithCollidingSessionId =
+        (BaseTable) sessionCatalog.loadTable(contextWithDifferentCredentials, TABLE);
+
+    assertThat(fileIOByToken).containsKeys("token-a", "token-b");
+    assertThat(tableWithOriginalCredentials.io()).isSameAs(fileIOByToken.get("token-a"));
+    assertThat(tableWithCollidingSessionId.io()).isSameAs(fileIOByToken.get("token-b"));
+  }
+
+  @Test
+  public void refsSnapshotSupplierUsesCurrentContextAfter304() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    Map<String, FileIO> fileIOByToken = Maps.newHashMap();
+
+    RESTSessionCatalog sessionCatalog =
+        new RESTSessionCatalog(
+            config -> adapter,
+            (context, properties) ->
+                fileIOByToken.computeIfAbsent(
+                    tokenForContext(context),
+                    token -> Mockito.mock(FileIO.class, "io-for-" + token)));
+    sessionCatalog.initialize(
+        "test_session_catalog",
+        Map.of(
+            RESTCatalogProperties.SNAPSHOT_LOADING_MODE,
+            RESTCatalogProperties.SnapshotMode.REFS.name()));
+
+    SessionContext contextA =
+        new SessionContext("colliding_session_id", "user-a", Map.of("token", "token-a"), Map.of());
+    SessionContext contextB =
+        new SessionContext("colliding_session_id", "user-b", Map.of("token", "token-b"), Map.of());
+
+    sessionCatalog.createNamespace(contextA, TABLE.namespace());
+    sessionCatalog.buildTable(contextA, TABLE, SCHEMA).create();
+
+    // Context A loads the table — full REFS response, only current snapshot in metadata
+    BaseTable tableA = (BaseTable) sessionCatalog.loadTable(contextA, TABLE);
+    assertThat(tableA.io()).isSameAs(fileIOByToken.get("token-a"));
+
+    // Intercept only the REFS+If-None-Match request to simulate a 304; let snapshots=all through.
+    Mockito.doAnswer(
+            invocation -> {
+              HTTPRequest req = invocation.getArgument(0);
+              boolean isRefsRequest =
+                  "refs".equals(req.queryParameters().get("snapshots"))
+                      && req.headers().entries().stream()
+                          .anyMatch(e -> HttpHeaders.IF_NONE_MATCH.equals(e.name()));
+              return isRefsRequest ? null : invocation.callRealMethod();
+            })
+        .when(adapter)
+        .execute(
+            matches(HTTPRequest.HTTPMethod.GET, RESOURCE_PATHS.table(TABLE)),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+
+    // Context B loads the table — 304, same session ID as context A
+    BaseTable tableB = (BaseTable) sessionCatalog.loadTable(contextB, TABLE);
+
+    // FileIO for context B must be bound to token-b, not token-a
+    assertThat(fileIOByToken).containsKeys("token-a", "token-b");
+    assertThat(tableB.io()).isSameAs(fileIOByToken.get("token-b"));
+
+    // Calling snapshots() on tableB must trigger a fresh snapshots=all request bound to context B.
+    // Verify that the adapter receives a snapshots=all request after the 304 hit (the supplier was
+    // rebound to the current context, not reused from context A's original supplier).
+    tableB.snapshots();
+    verify(adapter, times(1))
+        .execute(
+            matches(
+                HTTPRequest.HTTPMethod.GET,
+                RESOURCE_PATHS.table(TABLE),
+                Map.of(),
+                Map.of("snapshots", "all")),
+            eq(LoadTableResponse.class),
+            any(),
+            any());
+  }
+
+  private String tokenForContext(SessionContext context) {
+    Map<String, String> credentials = context.credentials();
+    if (credentials == null) {
+      return "no-credentials";
+    }
+
+    return credentials.getOrDefault("token", "missing-token");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTTableCache.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTTableCache.java
@@ -28,9 +28,14 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.FakeTicker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -74,7 +79,15 @@ public class TestRESTTableCache {
   @Test
   public void basicPutAndGet() {
     RESTTableCache cache = new RESTTableCache(Map.of());
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     assertThat(cache.cache().asMap()).hasSize(1);
     assertThat(cache.cache().asMap())
@@ -89,7 +102,15 @@ public class TestRESTTableCache {
   @Test
   public void notFoundInCache() {
     RESTTableCache cache = new RESTTableCache(Map.of());
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     assertThat(cache.getIfPresent("some_id", TABLE_IDENTIFIER)).isNull();
     assertThat(cache.getIfPresent(SESSION_ID, TableIdentifier.of("ns", "other_table"))).isNull();
@@ -99,8 +120,24 @@ public class TestRESTTableCache {
   public void tableInMultipleSessions() {
     RESTTableCache cache = new RESTTableCache(Map.of());
     String otherSessionId = "sessionID2";
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
-    cache.put(otherSessionId, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
+    cache.put(
+        otherSessionId,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     assertThat(cache.cache().asMap()).hasSize(2);
 
@@ -119,7 +156,16 @@ public class TestRESTTableCache {
     RESTTableCache cache = new RESTTableCache(Map.of());
     // Add more items than the max limit
     for (int i = 0; i < RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES_DEFAULT + 10; ++i) {
-      cache.put(SESSION_ID, TableIdentifier.of("ns", "tbl" + i), TABLE_SUPPLIER, ETAG);
+      TableIdentifier identifier = TableIdentifier.of("ns", "tbl" + i);
+      cache.put(
+          SESSION_ID,
+          identifier,
+          TABLE_SUPPLIER,
+          ETAG,
+          tableMetadata(identifier.name()),
+          tableMetadata(identifier.name()),
+          Map.of(),
+          ImmutableList.of());
     }
     cache.cache().cleanUp();
 
@@ -132,8 +178,24 @@ public class TestRESTTableCache {
     RESTTableCache cache =
         new RESTTableCache(Map.of(RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES, "1"));
     TableIdentifier otherTableIdentifier = TableIdentifier.of("ns", "other_table");
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
-    cache.put(SESSION_ID, otherTableIdentifier, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
+    cache.put(
+        SESSION_ID,
+        otherTableIdentifier,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(otherTableIdentifier.name()),
+        tableMetadata(otherTableIdentifier.name()),
+        Map.of(),
+        ImmutableList.of());
     cache.cache().cleanUp();
 
     assertThat(cache.cache().asMap()).hasSize(1);
@@ -145,7 +207,15 @@ public class TestRESTTableCache {
   public void cacheTurnedOff() {
     RESTTableCache cache =
         new RESTTableCache(Map.of(RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES, "0"));
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
     cache.cache().cleanUp();
 
     assertThat(cache.cache().asMap()).isEmpty();
@@ -155,7 +225,15 @@ public class TestRESTTableCache {
   public void entryExpires() {
     FakeTicker ticker = new FakeTicker();
     RESTTableCache cache = new RESTTableCache(Map.of(), ticker);
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     SessionIdTableId cacheKey = SessionIdTableId.of(SESSION_ID, TABLE_IDENTIFIER);
     assertThat(cache.cache().policy().expireAfterAccess()).isNotPresent();
@@ -188,7 +266,15 @@ public class TestRESTTableCache {
                 RESTCatalogProperties.TABLE_CACHE_EXPIRE_AFTER_WRITE_MS,
                 String.valueOf(expirationInterval.toMillis())),
             ticker);
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     assertThat(cache.getIfPresent(SESSION_ID, TABLE_IDENTIFIER)).isNotNull();
 
@@ -196,5 +282,14 @@ public class TestRESTTableCache {
     cache.cache().cleanUp();
 
     assertThat(cache.getIfPresent(SESSION_ID, TABLE_IDENTIFIER)).isNull();
+  }
+
+  private TableMetadata tableMetadata(String tableName) {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+    return TableMetadata.newTableMetadata(
+        schema, PartitionSpec.unpartitioned(), "file:/tmp/" + tableName, Map.of());
   }
 }


### PR DESCRIPTION
This PR fixes a context-leak risk in REST table caching: after a 304 response, callers now get tables rebuilt with their own current auth/context rather than reusing potentially stale context captured by the original cached supplier.

---

Co-authored-by: @codex 