### PR TITLE
API, Spark: Add branch support to RemoveDanglingDeleteFiles

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RemoveDanglingDeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RemoveDanglingDeleteFiles.java
@@ -27,6 +27,17 @@ import org.apache.iceberg.DeleteFile;
 public interface RemoveDanglingDeleteFiles
     extends Action<RemoveDanglingDeleteFiles, RemoveDanglingDeleteFiles.Result> {
 
+  /**
+   * Set the branch to remove dangling delete files from.
+   *
+   * @param branch the branch name
+   * @return this for method chaining
+   */
+  default RemoveDanglingDeleteFiles toBranch(String branch) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement toBranch(String)");
+  }
+
   /** An action that remove dangling deletes. */
   interface Result {
     /** Return removed deletes. */

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
@@ -23,6 +23,7 @@ import static org.apache.spark.sql.functions.min;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -30,13 +31,19 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ImmutableRemoveDanglingDeleteFiles;
 import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.SparkDeleteFile;
+import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DeleteFileSet;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -64,6 +71,7 @@ class RemoveDanglingDeletesSparkAction
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoveDanglingDeletesSparkAction.class);
   private final Table table;
+  private String branch = SnapshotRef.MAIN_BRANCH;
 
   protected RemoveDanglingDeletesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -76,7 +84,21 @@ class RemoveDanglingDeletesSparkAction
   }
 
   @Override
+  public RemoveDanglingDeletesSparkAction toBranch(String targetBranch) {
+    Preconditions.checkArgument(targetBranch != null, "Invalid branch name: null");
+    this.branch = targetBranch;
+    return this;
+  }
+
+  @Override
   public Result execute() {
+    Snapshot branchSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    if (branchSnapshot == null) {
+      return ImmutableRemoveDanglingDeleteFiles.Result.builder()
+          .removedDeleteFiles(Collections.emptyList())
+          .build();
+    }
+
     if (table.specs().size() == 1 && table.spec().isUnpartitioned()) {
       // ManifestFilterManager already performs this table-wide delete on each commit
       return ImmutableRemoveDanglingDeleteFiles.Result.builder()
@@ -91,6 +113,8 @@ class RemoveDanglingDeletesSparkAction
 
   Result doExecute() {
     RewriteFiles rewriteFiles = table.newRewrite();
+    rewriteFiles.toBranch(branch);
+
     DeleteFileSet danglingDeletes = DeleteFileSet.create();
     danglingDeletes.addAll(findDanglingDeletes());
     danglingDeletes.addAll(findDanglingDvs());
@@ -109,6 +133,11 @@ class RemoveDanglingDeletesSparkAction
         .build();
   }
 
+  private Map<String, String> snapshotOptions() {
+    Snapshot branchSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    return ImmutableMap.of("snapshot-id", String.valueOf(branchSnapshot.snapshotId()));
+  }
+
   /**
    * Dangling delete files can be identified with following steps
    *
@@ -123,8 +152,10 @@ class RemoveDanglingDeletesSparkAction
    * </ol>
    */
   private List<DeleteFile> findDanglingDeletes() {
+    Map<String, String> options = snapshotOptions();
+
     Dataset<Row> minSequenceNumberByPartition =
-        loadMetadataTable(table, MetadataTableType.ENTRIES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.ENTRIES, options)
             // find live data files
             .filter("data_file.content == 0 AND status < 2")
             .selectExpr(
@@ -136,7 +167,7 @@ class RemoveDanglingDeletesSparkAction
             .toDF("grouped_partition", "grouped_spec_id", "min_data_sequence_number");
 
     Dataset<Row> deleteEntries =
-        loadMetadataTable(table, MetadataTableType.ENTRIES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.ENTRIES, options)
             // find live delete files
             .filter("data_file.content != 0 AND status < 2");
 
@@ -176,10 +207,13 @@ class RemoveDanglingDeletesSparkAction
   }
 
   private List<DeleteFile> findDanglingDvs() {
+    Map<String, String> options = snapshotOptions();
+
     Dataset<Row> dvs =
-        loadMetadataTable(table, MetadataTableType.DELETE_FILES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.DELETE_FILES, options)
             .where(col("file_format").equalTo(FileFormat.PUFFIN.name()));
-    Dataset<Row> dataFiles = loadMetadataTable(table, MetadataTableType.DATA_FILES);
+    Dataset<Row> dataFiles =
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.DATA_FILES, options);
 
     // a DV not pointing to a valid data file path is implicitly a dangling delete
     List<Row> danglingDvs =

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -195,7 +195,7 @@ public class RewriteDataFilesSparkAction
 
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
-          new RemoveDanglingDeletesSparkAction(spark(), table);
+          new RemoveDanglingDeletesSparkAction(spark(), table).toBranch(branch);
       int removedDeleteFiles = Iterables.size(action.execute().removedDeleteFiles());
       return result.withRemovedDeleteFilesCount(
           result.removedDeleteFilesCount() + removedDeleteFiles);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
@@ -23,6 +23,7 @@ import static org.apache.spark.sql.functions.min;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -30,13 +31,19 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ImmutableRemoveDanglingDeleteFiles;
 import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.SparkDeleteFile;
+import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DeleteFileSet;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -64,6 +71,7 @@ class RemoveDanglingDeletesSparkAction
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoveDanglingDeletesSparkAction.class);
   private final Table table;
+  private String branch = SnapshotRef.MAIN_BRANCH;
 
   protected RemoveDanglingDeletesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -76,7 +84,21 @@ class RemoveDanglingDeletesSparkAction
   }
 
   @Override
+  public RemoveDanglingDeletesSparkAction toBranch(String targetBranch) {
+    Preconditions.checkArgument(targetBranch != null, "Invalid branch name: null");
+    this.branch = targetBranch;
+    return this;
+  }
+
+  @Override
   public Result execute() {
+    Snapshot branchSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    if (branchSnapshot == null) {
+      return ImmutableRemoveDanglingDeleteFiles.Result.builder()
+          .removedDeleteFiles(Collections.emptyList())
+          .build();
+    }
+
     if (table.specs().size() == 1 && table.spec().isUnpartitioned()) {
       // ManifestFilterManager already performs this table-wide delete on each commit
       return ImmutableRemoveDanglingDeleteFiles.Result.builder()
@@ -91,6 +113,8 @@ class RemoveDanglingDeletesSparkAction
 
   Result doExecute() {
     RewriteFiles rewriteFiles = table.newRewrite();
+    rewriteFiles.toBranch(branch);
+
     DeleteFileSet danglingDeletes = DeleteFileSet.create();
     danglingDeletes.addAll(findDanglingDeletes());
     danglingDeletes.addAll(findDanglingDvs());
@@ -109,6 +133,11 @@ class RemoveDanglingDeletesSparkAction
         .build();
   }
 
+  private Map<String, String> snapshotOptions() {
+    Snapshot branchSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    return ImmutableMap.of("snapshot-id", String.valueOf(branchSnapshot.snapshotId()));
+  }
+
   /**
    * Dangling delete files can be identified with following steps
    *
@@ -123,8 +152,10 @@ class RemoveDanglingDeletesSparkAction
    * </ol>
    */
   private List<DeleteFile> findDanglingDeletes() {
+    Map<String, String> options = snapshotOptions();
+
     Dataset<Row> minSequenceNumberByPartition =
-        loadMetadataTable(table, MetadataTableType.ENTRIES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.ENTRIES, options)
             // find live data files
             .filter("data_file.content == 0 AND status < 2")
             .selectExpr(
@@ -136,7 +167,7 @@ class RemoveDanglingDeletesSparkAction
             .toDF("grouped_partition", "grouped_spec_id", "min_data_sequence_number");
 
     Dataset<Row> deleteEntries =
-        loadMetadataTable(table, MetadataTableType.ENTRIES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.ENTRIES, options)
             // find live delete files
             .filter("data_file.content != 0 AND status < 2");
 
@@ -176,10 +207,13 @@ class RemoveDanglingDeletesSparkAction
   }
 
   private List<DeleteFile> findDanglingDvs() {
+    Map<String, String> options = snapshotOptions();
+
     Dataset<Row> dvs =
-        loadMetadataTable(table, MetadataTableType.DELETE_FILES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.DELETE_FILES, options)
             .where(col("file_format").equalTo(FileFormat.PUFFIN.name()));
-    Dataset<Row> dataFiles = loadMetadataTable(table, MetadataTableType.DATA_FILES);
+    Dataset<Row> dataFiles =
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.DATA_FILES, options);
 
     // a DV not pointing to a valid data file path is implicitly a dangling delete
     List<Row> danglingDvs =

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -195,7 +195,7 @@ public class RewriteDataFilesSparkAction
 
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
-          new RemoveDanglingDeletesSparkAction(spark(), table);
+          new RemoveDanglingDeletesSparkAction(spark(), table).toBranch(branch);
       int removedDeleteFiles = Iterables.size(action.execute().removedDeleteFiles());
       return result.withRemovedDeleteFilesCount(
           result.removedDeleteFilesCount() + removedDeleteFiles);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -454,6 +454,93 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   }
 
   @TestTemplate
+  public void testBranchSupport() {
+    setupPartitionedTable();
+
+    // Add data files on main
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    // Create a branch from the current snapshot
+    table.manageSnapshots().createBranch("test-branch").commit();
+
+    // Add delete files on the branch (they are dangling because seq number is after data)
+    DeleteFile fileADeletes = fileADeletes();
+    table.newRowDelta().toBranch("test-branch").addDeletes(fileADeletes).commit();
+
+    // Add more data on the branch so that the delete has a lesser seq number
+    table.newAppend().toBranch("test-branch").appendFile(FILE_A2).commit();
+
+    // Run the action targeting the branch
+    RemoveDanglingDeleteFiles.Result result =
+        SparkActions.get().removeDanglingDeleteFiles(table).toBranch("test-branch").execute();
+
+    // The delete file should not be dangling because its seq number equals the data's
+    // and there are data files in partition A
+    assertThat(result.removedDeleteFiles()).as("No dangling deletes expected on branch").isEmpty();
+  }
+
+  @TestTemplate
+  public void testBranchWithDanglingDeletes() {
+    setupPartitionedTable();
+
+    // Add data files on main in partition B only
+    table.newAppend().appendFile(FILE_B).commit();
+
+    // Create a branch
+    table.manageSnapshots().createBranch("test-branch").commit();
+
+    // Add delete files on the branch in partition A (no data in A -> dangling)
+    DeleteFile fileADeletes = fileADeletes();
+    DeleteFile fileAEqDeletes = FILE_A_EQ_DELETES;
+    table
+        .newRowDelta()
+        .toBranch("test-branch")
+        .addDeletes(fileADeletes)
+        .addDeletes(fileAEqDeletes)
+        .commit();
+
+    // Run the action targeting the branch
+    RemoveDanglingDeleteFiles.Result result =
+        SparkActions.get().removeDanglingDeleteFiles(table).toBranch("test-branch").execute();
+
+    Set<CharSequence> removedDeleteFiles =
+        StreamSupport.stream(result.removedDeleteFiles().spliterator(), false)
+            .map(DeleteFile::location)
+            .collect(Collectors.toSet());
+    assertThat(removedDeleteFiles)
+        .as("Delete files in partition A should be removed as dangling")
+        .hasSize(2)
+        .containsExactlyInAnyOrder(fileADeletes.location(), fileAEqDeletes.location());
+  }
+
+  @TestTemplate
+  public void testBranchDoesNotAffectMain() {
+    setupPartitionedTable();
+
+    // Add data and deletes on main
+    table.newAppend().appendFile(FILE_B).commit();
+    DeleteFile fileADeletes = fileADeletes();
+    table.newRowDelta().addDeletes(fileADeletes).commit();
+
+    // Create a branch
+    table.manageSnapshots().createBranch("test-branch").commit();
+
+    // Run the action on the branch only
+    SparkActions.get().removeDanglingDeleteFiles(table).toBranch("test-branch").execute();
+
+    // Main branch should still have the delete file
+    RemoveDanglingDeleteFiles.Result mainResult =
+        SparkActions.get().removeDanglingDeleteFiles(table).execute();
+    Set<CharSequence> mainRemoved =
+        StreamSupport.stream(mainResult.removedDeleteFiles().spliterator(), false)
+            .map(DeleteFile::location)
+            .collect(Collectors.toSet());
+    assertThat(mainRemoved)
+        .as("Main branch should also have dangling delete removed")
+        .contains(fileADeletes.location());
+  }
+
+  @TestTemplate
   public void testPartitionedDeletesWithDanglingDvs() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     setupPartitionedTable();

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
@@ -23,6 +23,7 @@ import static org.apache.spark.sql.functions.min;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -30,13 +31,19 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ImmutableRemoveDanglingDeleteFiles;
 import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.SparkDeleteFile;
+import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DeleteFileSet;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -64,6 +71,7 @@ class RemoveDanglingDeletesSparkAction
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoveDanglingDeletesSparkAction.class);
   private final Table table;
+  private String branch = SnapshotRef.MAIN_BRANCH;
 
   protected RemoveDanglingDeletesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -76,7 +84,21 @@ class RemoveDanglingDeletesSparkAction
   }
 
   @Override
+  public RemoveDanglingDeletesSparkAction toBranch(String targetBranch) {
+    Preconditions.checkArgument(targetBranch != null, "Invalid branch name: null");
+    this.branch = targetBranch;
+    return this;
+  }
+
+  @Override
   public Result execute() {
+    Snapshot branchSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    if (branchSnapshot == null) {
+      return ImmutableRemoveDanglingDeleteFiles.Result.builder()
+          .removedDeleteFiles(Collections.emptyList())
+          .build();
+    }
+
     if (table.specs().size() == 1 && table.spec().isUnpartitioned()) {
       // ManifestFilterManager already performs this table-wide delete on each commit
       return ImmutableRemoveDanglingDeleteFiles.Result.builder()
@@ -91,6 +113,8 @@ class RemoveDanglingDeletesSparkAction
 
   Result doExecute() {
     RewriteFiles rewriteFiles = table.newRewrite();
+    rewriteFiles.toBranch(branch);
+
     DeleteFileSet danglingDeletes = DeleteFileSet.create();
     danglingDeletes.addAll(findDanglingDeletes());
     danglingDeletes.addAll(findDanglingDvs());
@@ -109,6 +133,11 @@ class RemoveDanglingDeletesSparkAction
         .build();
   }
 
+  private Map<String, String> snapshotOptions() {
+    Snapshot branchSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    return ImmutableMap.of("snapshot-id", String.valueOf(branchSnapshot.snapshotId()));
+  }
+
   /**
    * Dangling delete files can be identified with following steps
    *
@@ -123,8 +152,10 @@ class RemoveDanglingDeletesSparkAction
    * </ol>
    */
   private List<DeleteFile> findDanglingDeletes() {
+    Map<String, String> options = snapshotOptions();
+
     Dataset<Row> minSequenceNumberByPartition =
-        loadMetadataTable(table, MetadataTableType.ENTRIES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.ENTRIES, options)
             // find live data files
             .filter("data_file.content == 0 AND status < 2")
             .selectExpr(
@@ -136,7 +167,7 @@ class RemoveDanglingDeletesSparkAction
             .toDF("grouped_partition", "grouped_spec_id", "min_data_sequence_number");
 
     Dataset<Row> deleteEntries =
-        loadMetadataTable(table, MetadataTableType.ENTRIES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.ENTRIES, options)
             // find live delete files
             .filter("data_file.content != 0 AND status < 2");
 
@@ -176,10 +207,13 @@ class RemoveDanglingDeletesSparkAction
   }
 
   private List<DeleteFile> findDanglingDvs() {
+    Map<String, String> options = snapshotOptions();
+
     Dataset<Row> dvs =
-        loadMetadataTable(table, MetadataTableType.DELETE_FILES)
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.DELETE_FILES, options)
             .where(col("file_format").equalTo(FileFormat.PUFFIN.name()));
-    Dataset<Row> dataFiles = loadMetadataTable(table, MetadataTableType.DATA_FILES);
+    Dataset<Row> dataFiles =
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.DATA_FILES, options);
 
     // a DV not pointing to a valid data file path is implicitly a dangling delete
     List<Row> danglingDvs =

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -195,7 +195,7 @@ public class RewriteDataFilesSparkAction
 
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
-          new RemoveDanglingDeletesSparkAction(spark(), table);
+          new RemoveDanglingDeletesSparkAction(spark(), table).toBranch(branch);
       int removedDeleteFiles = Iterables.size(action.execute().removedDeleteFiles());
       return result.withRemovedDeleteFilesCount(
           result.removedDeleteFilesCount() + removedDeleteFiles);

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -454,6 +454,68 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   }
 
   @TestTemplate
+  public void testBranchSupport() {
+    setupPartitionedTable();
+
+    // Add data files on main
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    // Create a branch from the current snapshot
+    table.manageSnapshots().createBranch("test-branch").commit();
+
+    // Add delete files on the branch (they are dangling because seq number is after data)
+    DeleteFile fileADeletes = fileADeletes();
+    table.newRowDelta().toBranch("test-branch").addDeletes(fileADeletes).commit();
+
+    // Add more data on the branch so that the delete has a lesser seq number
+    table.newAppend().toBranch("test-branch").appendFile(FILE_A2).commit();
+
+    // Run the action targeting the branch
+    RemoveDanglingDeleteFiles.Result branchResult =
+        SparkActions.get().removeDanglingDeleteFiles(table).toBranch("test-branch").execute();
+
+    // The delete file should not be dangling because its seq number equals the data's
+    // and there are data files in partition A
+    assertThat(branchResult.removedDeleteFiles())
+        .as("No dangling deletes expected on branch")
+        .isEmpty();
+  }
+
+  @TestTemplate
+  public void testBranchWithDanglingDeletes() {
+    setupPartitionedTable();
+
+    // Add data files on main in partition B only
+    table.newAppend().appendFile(FILE_B).commit();
+
+    // Create a branch
+    table.manageSnapshots().createBranch("test-branch").commit();
+
+    // Add delete files on the branch in partition A (no data in A -> dangling)
+    DeleteFile fileADeletes = fileADeletes();
+    DeleteFile fileAEqDeletes = FILE_A_EQ_DELETES;
+    table
+        .newRowDelta()
+        .toBranch("test-branch")
+        .addDeletes(fileADeletes)
+        .addDeletes(fileAEqDeletes)
+        .commit();
+
+    // Run the action targeting the branch
+    RemoveDanglingDeleteFiles.Result branchResult =
+        SparkActions.get().removeDanglingDeleteFiles(table).toBranch("test-branch").execute();
+
+    Set<CharSequence> removedDeleteFiles =
+        StreamSupport.stream(branchResult.removedDeleteFiles().spliterator(), false)
+            .map(DeleteFile::location)
+            .collect(Collectors.toSet());
+    assertThat(removedDeleteFiles)
+        .as("Delete files in partition A should be removed as dangling")
+        .hasSize(2)
+        .containsExactlyInAnyOrder(fileADeletes.location(), fileAEqDeletes.location());
+  }
+
+  @TestTemplate
   public void testPartitionedDeletesWithDanglingDvs() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     setupPartitionedTable();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
@@ -28,22 +28,33 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ImmutableRemoveDanglingDeleteFiles;
 import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.SparkDeleteFile;
+import org.apache.iceberg.spark.TimeTravel;
+import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DeleteFileSet;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Option;
 
 /**
  * An action that removes dangling delete files from the current snapshot. A delete file is dangling
@@ -64,6 +75,7 @@ class RemoveDanglingDeletesSparkAction
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoveDanglingDeletesSparkAction.class);
   private final Table table;
+  private String branch = SnapshotRef.MAIN_BRANCH;
 
   protected RemoveDanglingDeletesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -76,7 +88,21 @@ class RemoveDanglingDeletesSparkAction
   }
 
   @Override
+  public RemoveDanglingDeletesSparkAction toBranch(String targetBranch) {
+    Preconditions.checkArgument(targetBranch != null, "Invalid branch name: null");
+    this.branch = targetBranch;
+    return this;
+  }
+
+  @Override
   public Result execute() {
+    Snapshot branchSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    if (branchSnapshot == null) {
+      return ImmutableRemoveDanglingDeleteFiles.Result.builder()
+          .removedDeleteFiles(Collections.emptyList())
+          .build();
+    }
+
     if (table.specs().size() == 1 && table.spec().isUnpartitioned()) {
       // ManifestFilterManager already performs this table-wide delete on each commit
       return ImmutableRemoveDanglingDeleteFiles.Result.builder()
@@ -91,6 +117,8 @@ class RemoveDanglingDeletesSparkAction
 
   Result doExecute() {
     RewriteFiles rewriteFiles = table.newRewrite();
+    rewriteFiles.toBranch(branch);
+
     DeleteFileSet danglingDeletes = DeleteFileSet.create();
     danglingDeletes.addAll(findDanglingDeletes());
     danglingDeletes.addAll(findDanglingDvs());
@@ -109,6 +137,24 @@ class RemoveDanglingDeletesSparkAction
         .build();
   }
 
+  private Dataset<Row> loadBranchMetadataTable(MetadataTableType type) {
+    Snapshot branchSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    Table metadataTable = MetadataTableUtils.createMetadataTableInstance(table, type);
+    TimeTravel timeTravel = TimeTravel.version(String.valueOf(branchSnapshot.snapshotId()));
+    SparkTable sparkMetadataTable = SparkTable.create(metadataTable, timeTravel);
+    CaseInsensitiveStringMap options = new CaseInsensitiveStringMap(ImmutableMap.of());
+    DataSourceV2Relation relation =
+        DataSourceV2Relation.create(
+            sparkMetadataTable, Option.empty(), Option.empty(), options, Option.empty());
+    Preconditions.checkArgument(
+        spark() instanceof org.apache.spark.sql.classic.SparkSession,
+        "Expected instance of org.apache.spark.sql.classic.SparkSession, but got: %s",
+        spark().getClass().getName());
+
+    return org.apache.spark.sql.classic.Dataset.ofRows(
+        (org.apache.spark.sql.classic.SparkSession) spark(), relation);
+  }
+
   /**
    * Dangling delete files can be identified with following steps
    *
@@ -124,7 +170,7 @@ class RemoveDanglingDeletesSparkAction
    */
   private List<DeleteFile> findDanglingDeletes() {
     Dataset<Row> minSequenceNumberByPartition =
-        loadMetadataTable(table, MetadataTableType.ENTRIES)
+        loadBranchMetadataTable(MetadataTableType.ENTRIES)
             // find live data files
             .filter("data_file.content == 0 AND status < 2")
             .selectExpr(
@@ -136,7 +182,7 @@ class RemoveDanglingDeletesSparkAction
             .toDF("grouped_partition", "grouped_spec_id", "min_data_sequence_number");
 
     Dataset<Row> deleteEntries =
-        loadMetadataTable(table, MetadataTableType.ENTRIES)
+        loadBranchMetadataTable(MetadataTableType.ENTRIES)
             // find live delete files
             .filter("data_file.content != 0 AND status < 2");
 
@@ -177,9 +223,9 @@ class RemoveDanglingDeletesSparkAction
 
   private List<DeleteFile> findDanglingDvs() {
     Dataset<Row> dvs =
-        loadMetadataTable(table, MetadataTableType.DELETE_FILES)
+        loadBranchMetadataTable(MetadataTableType.DELETE_FILES)
             .where(col("file_format").equalTo(FileFormat.PUFFIN.name()));
-    Dataset<Row> dataFiles = loadMetadataTable(table, MetadataTableType.DATA_FILES);
+    Dataset<Row> dataFiles = loadBranchMetadataTable(MetadataTableType.DATA_FILES);
 
     // a DV not pointing to a valid data file path is implicitly a dangling delete
     List<Row> danglingDvs =

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -195,7 +195,7 @@ public class RewriteDataFilesSparkAction
 
     if (removeDanglingDeletes) {
       RemoveDanglingDeletesSparkAction action =
-          new RemoveDanglingDeletesSparkAction(spark(), table);
+          new RemoveDanglingDeletesSparkAction(spark(), table).toBranch(branch);
       int removedDeleteFiles = Iterables.size(action.execute().removedDeleteFiles());
       return result.withRemovedDeleteFilesCount(
           result.removedDeleteFilesCount() + removedDeleteFiles);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -454,6 +454,68 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   }
 
   @TestTemplate
+  public void testBranchSupport() {
+    setupPartitionedTable();
+
+    // Add data files on main
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    // Create a branch from the current snapshot
+    table.manageSnapshots().createBranch("test-branch").commit();
+
+    // Add delete files on the branch (they are dangling because seq number is after data)
+    DeleteFile fileADeletes = fileADeletes();
+    table.newRowDelta().toBranch("test-branch").addDeletes(fileADeletes).commit();
+
+    // Add more data on the branch so that the delete has a lesser seq number
+    table.newAppend().toBranch("test-branch").appendFile(FILE_A2).commit();
+
+    // Run the action targeting the branch
+    RemoveDanglingDeleteFiles.Result branchResult =
+        SparkActions.get().removeDanglingDeleteFiles(table).toBranch("test-branch").execute();
+
+    // The delete file should not be dangling because its seq number equals the data's
+    // and there are data files in partition A
+    assertThat(branchResult.removedDeleteFiles())
+        .as("No dangling deletes expected on branch")
+        .isEmpty();
+  }
+
+  @TestTemplate
+  public void testBranchWithDanglingDeletes() {
+    setupPartitionedTable();
+
+    // Add data files on main in partition B only
+    table.newAppend().appendFile(FILE_B).commit();
+
+    // Create a branch
+    table.manageSnapshots().createBranch("test-branch").commit();
+
+    // Add delete files on the branch in partition A (no data in A -> dangling)
+    DeleteFile fileADeletes = fileADeletes();
+    DeleteFile fileAEqDeletes = FILE_A_EQ_DELETES;
+    table
+        .newRowDelta()
+        .toBranch("test-branch")
+        .addDeletes(fileADeletes)
+        .addDeletes(fileAEqDeletes)
+        .commit();
+
+    // Run the action targeting the branch
+    RemoveDanglingDeleteFiles.Result branchResult =
+        SparkActions.get().removeDanglingDeleteFiles(table).toBranch("test-branch").execute();
+
+    Set<CharSequence> removedDeleteFiles =
+        StreamSupport.stream(branchResult.removedDeleteFiles().spliterator(), false)
+            .map(DeleteFile::location)
+            .collect(Collectors.toSet());
+    assertThat(removedDeleteFiles)
+        .as("Delete files in partition A should be removed as dangling")
+        .hasSize(2)
+        .containsExactlyInAnyOrder(fileADeletes.location(), fileAEqDeletes.location());
+  }
+
+  @TestTemplate
   public void testPartitionedDeletesWithDanglingDvs() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     setupPartitionedTable();


### PR DESCRIPTION
## Summary

`RemoveDanglingDeleteFiles` always operated on the main branch. There was no way to target a specific branch, and `RewriteDataFilesSparkAction` did not forward its branch when invoking the action internally.

This PR:
- Adds a `toBranch(String)` default method to the `RemoveDanglingDeleteFiles` API
- Implements branch-aware metadata reads and commits in `RemoveDanglingDeletesSparkAction`
- Forwards the branch from `RewriteDataFilesSparkAction` to the dangling delete removal step

Closes #15369

## Changes

- **API**: Added `toBranch(String)` with a default `UnsupportedOperationException` to avoid breaking changes (revapi passes)
- **Spark (v3.4, v3.5, v4.0)**: Metadata table reads are scoped to the branch snapshot via `snapshot-id` option. Commits are directed to the branch via `RewriteFiles.toBranch(branch)`
- **Spark (v4.1)**: Uses `SparkTable.create(metadataTable, TimeTravel)` instead of `snapshot-id` option, since time travel options were reworked in Spark 4.1
- **RewriteDataFilesSparkAction** (all versions): Now passes its `branch` field to `RemoveDanglingDeletesSparkAction`
- **Tests**: Added `testBranchSupport` and `testBranchWithDanglingDeletes` for v3.5, v4.0, v4.1

## Notes

- Unpartitioned table early return is kept as-is. The `findDanglingDeletes` SQL relies on `data_file.partition` which does not exist for unpartitioned tables. Addressing unpartitioned tables would require a different query strategy and is better handled separately.
- AI tools were used to assist with code exploration and drafting. I reviewed and tested all changes locally.

## Test plan

- [x] `./gradlew :iceberg-api:revapi` passes
- [x] `TestRemoveDanglingDeleteAction` passes (18 tests, 0 failures on Spark 4.1)
- [x] `./gradlew spotlessCheck` passes