### PR TITLE
API: Fix TableIdentifier.toLowerCase to use Locale.ROOT for namespace levels (#15956)

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
@@ -80,7 +80,9 @@ public class TableIdentifier {
 
   public TableIdentifier toLowerCase() {
     String[] newLevels =
-        Arrays.stream(namespace().levels()).map(String::toLowerCase).toArray(String[]::new);
+        Arrays.stream(namespace().levels())
+            .map(s -> s.toLowerCase(Locale.ROOT))
+            .toArray(String[]::new);
     String newName = name().toLowerCase(Locale.ROOT);
     return TableIdentifier.of(Namespace.of(newLevels), newName);
   }

--- a/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.catalog;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.jupiter.api.Test;
 import java.util.Locale;
+import org.junit.jupiter.api.Test;
 
 public class TestTableIdentifier {
 

--- a/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import java.util.Locale;
 
 public class TestTableIdentifier {
 
@@ -50,6 +51,18 @@ public class TestTableIdentifier {
         .isEqualTo(TableIdentifier.of("dB", "TBL").toLowerCase());
     assertThat(TableIdentifier.of("catalog", "db", "tbl"))
         .isEqualTo(TableIdentifier.of("Catalog", "dB", "TBL").toLowerCase());
+  }
+
+  @Test
+  public void testToLowerCaseIsLocaleIndependent() {
+    Locale defaultLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      assertThat(TableIdentifier.of("information", "db", "tbl"))
+          .isEqualTo(TableIdentifier.of("INFORMATION", "DB", "TBL").toLowerCase());
+    } finally {
+      Locale.setDefault(defaultLocale);
+    }
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.catalog;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Locale;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 public class TestTableIdentifier {
 
@@ -54,15 +54,10 @@ public class TestTableIdentifier {
   }
 
   @Test
+  @DefaultLocale(language = "tr")
   public void testToLowerCaseIsLocaleIndependent() {
-    Locale defaultLocale = Locale.getDefault();
-    try {
-      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
-      assertThat(TableIdentifier.of("information", "db", "tbl"))
-          .isEqualTo(TableIdentifier.of("INFORMATION", "DB", "TBL").toLowerCase());
-    } finally {
-      Locale.setDefault(defaultLocale);
-    }
+    assertThat(TableIdentifier.of("information", "db", "tbl"))
+        .isEqualTo(TableIdentifier.of("INFORMATION", "DB", "TBL").toLowerCase());
   }
 
   @Test

--- a/build.gradle
+++ b/build.gradle
@@ -334,6 +334,8 @@ project(':iceberg-api') {
     testImplementation libs.avro.avro
     testImplementation libs.esotericsoftware.kryo
     testImplementation libs.awaitility
+    testImplementation libs.junit.pioneer
+
   }
 
   tasks.processTestResources.dependsOn rootProject.tasks.buildInfo

--- a/build.gradle
+++ b/build.gradle
@@ -335,7 +335,6 @@ project(':iceberg-api') {
     testImplementation libs.esotericsoftware.kryo
     testImplementation libs.awaitility
     testImplementation libs.junit.pioneer
-
   }
 
   tasks.processTestResources.dependsOn rootProject.tasks.buildInfo


### PR DESCRIPTION
Fixes #15956

Replaced locale-dependent toLowerCase() calls with toLowerCase(Locale.ROOT) in TableIdentifier. This ensures consistent identifier resolution across different system locales, specifically preventing the 'Turkish I' problem where 'I' maps to 'ı' instead of 'i'