### PR TITLE
Build: Ban toLowerCase/toUpperCase without locale

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -450,6 +450,11 @@
             <property name="format" value="^\s*(public\s+)?(abstract\s+)?class\s+[A-Za-z0-9]*Test(\s|&lt;)"/>
             <property name="message" value="Test class names should start with 'Test' prefix, not end with 'Test' suffix. Example: 'TestNewFeature' instead of 'NewFeatureTest'"/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="ignoreComments" value="true"/>
+            <property name="format" value="String::to(Lower|Upper)Case"/>
+            <property name="message" value="Use toLowerCase(Locale)/toUpperCase(Locale) instead of no-arg versions or method references. Prefer Locale.ROOT for locale-insensitive operations."/>
+        </module>
         <module name="IllegalToken">
             <property name="tokens" value="LITERAL_ASSERT"/>
         </module>

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -157,6 +157,8 @@ subprojects {
           '-Xep:Slf4jThrowable:ERROR',
           // Added because it errors out compile, but we need to figure out if we want it
           '-Xep:StrictUnusedVariable:OFF',
+          // This rule doesn't enforce the use of method references. That's handled by checkstyle.
+          '-Xep:StringCaseLocaleUsage:ERROR',
           // Enforce safe string splitting
           '-Xep:StringSplitter:ERROR',
           '-Xep:TypeParameterShadowing:OFF',


### PR DESCRIPTION
Using both errorprone and checkstyle. 

* The errorprone [StringCaseLocaleUsage](https://errorprone.info/bugpattern/StringCaseLocaleUsage) doesn't throw an error in case of method reference, `String::toLowerCase` / `String::toUpperCase`

* The checkstyle with regexp fails with false-positive because `TableIdentifier` has `toLowerCase()` method. 

The example failures by introducing wrong code: 
```
/Users/yuya.ebihara/iceberg/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java:86: error: [StringCaseLocaleUsage] Specify a `Locale` when calling `String#to{Lower,Upper}Case`. (Note: there are multiple suggested fixes; the third may be most appropriate if you're dealing with ASCII Strings.)
    String newName = name().toLowerCase();
```

```
[ant:checkstyle] [ERROR] /Users/yuya.ebihara/iceberg/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java:84: Use toLowerCase(Locale)/toUpperCase(Locale) instead of no-arg versions or method references. Prefer Locale.ROOT for locale-insensitive operations. [RegexpSinglelineJava]
```

- Relates to #15958
