### PR TITLE
Core: Allow missing source fields when binding specs in time-travel scan

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -95,7 +95,11 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
     ImmutableMap.Builder<Integer, PartitionSpec> newSpecs =
         ImmutableMap.builderWithExpectedSize(specs.size());
     for (Map.Entry<Integer, PartitionSpec> entry : specs.entrySet()) {
-      newSpecs.put(entry.getKey(), entry.getValue().toUnbound().bind(snapshotSchema));
+      // Allow missing source fields: historical specs may reference columns that did not yet
+      // exist in the time-travel snapshot's schema. Files written with those specs cannot be
+      // present in the target snapshot, so the spec is not used during planning. Binding must
+      // still succeed so the specs-by-id map can be built for the specs that are used.
+      newSpecs.put(entry.getKey(), entry.getValue().toUnbound().bind(snapshotSchema, true));
     }
 
     return newSpecs.build();

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -248,6 +248,36 @@ public class TestScansAndSchemaEvolution {
   }
 
   @TestTemplate
+  public void testTimeTravelAfterAddingPartitionFieldOnNewColumn() throws IOException {
+    Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);
+
+    DataFile fileOne = createDataFile("one");
+    DataFile fileTwo = createDataFile("two");
+
+    table.newAppend().appendFile(fileOne).appendFile(fileTwo).commit();
+    long firstSnapshotId = table.currentSnapshot().snapshotId();
+
+    // Add a new column that did not exist at firstSnapshotId
+    table.updateSchema().addColumn("extra", Types.StringType.get()).commit();
+
+    // Add a partition field on the newly added column, creating a new spec that references a
+    // source column that does not exist in the schema of firstSnapshotId
+    table.updateSpec().addField("extra").commit();
+
+    // Create a new snapshot so the current snapshot differs from firstSnapshotId and the scan
+    // actually exercises the time-travel path that re-binds specs to the snapshot schema
+    DataFile fileThree = createDataFile("three", table.schema(), table.spec());
+    table.newAppend().appendFile(fileThree).commit();
+
+    // Time-travel to the first snapshot; planning must succeed even though one of the historical
+    // specs references a column that is missing from the time-travel schema
+    List<FileScanTask> tasks =
+        Lists.newArrayList(table.newScan().useSnapshot(firstSnapshotId).planFiles());
+
+    assertThat(tasks).hasSize(2);
+  }
+
+  @TestTemplate
   public void testAddColumnWithDefaultValueAndQuery() throws IOException {
     assumeThat(V3_AND_ABOVE).as("Default values require v3+").contains(formatVersion);
     Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);


### PR DESCRIPTION
## Summary

#13301 made `SnapshotScan.specs()` re-bind every historical partition spec to the time-travel snapshot's schema using strict `bind()`. If a later partition spec references a column that was added *after* the target snapshot, this throws `ValidationException` at plan time and the scan fails.

Repro:

1. Create a table, write data -- snapshot `S1`.
2. `ALTER TABLE ... ADD COLUMN extra STRING`.
3. `ALTER TABLE ... ADD PARTITION FIELD extra`.
4. Write data -- snapshot `S2`.
5. `table.newScan().useSnapshot(S1).planFiles()` -- fails with:

```
org.apache.iceberg.exceptions.ValidationException: Cannot find source column for partition field: 1001: extra: identity(4)
    at org.apache.iceberg.PartitionSpec.checkCompatibility(PartitionSpec.java:656)
    at org.apache.iceberg.PartitionSpec$Builder.build(PartitionSpec.java:628)
    at org.apache.iceberg.UnboundPartitionSpec.bind(UnboundPartitionSpec.java:46)
    at org.apache.iceberg.SnapshotScan.specs(SnapshotScan.java:98)
    at org.apache.iceberg.DataTableScan.doPlanFiles(DataTableScan.java:77)
```

Reproduces on format versions 1-4. It affects all `DataTableScan` consumers (Spark, Flink, Trino, core API) on any table that evolves its spec to include a column added after the target snapshot -- for example, disaster-recovery reads after a bad DDL.

## Fix

Use `bind(snapshotSchema, true)` so missing source fields are tolerated during the re-bind. Files written with a spec that references a not-yet-existing column cannot appear in the target snapshot, so that spec is never actually used during planning -- it only needs to be constructible so the specs-by-id map can be built for the specs that *are* used. This matches the precedent already set by `BaseMetadataTable.build(true)` from #14089.

## Test plan

- [x] New test `testTimeTravelAfterAddingPartitionFieldOnNewColumn` in `TestScansAndSchemaEvolution` -- fails on current `main`, passes with the fix, all 4 format versions.
- [x] Existing `TestScansAndSchemaEvolution` suite still green.
- [ ] Still validating the fix -- leaving as draft until I've thought through edge cases around transforms that depend on source type (bucket, truncate) when the source type is missing, and whether any downstream code assumes `specs()` returns fully-bound specs.