### PR TITLE
Core: Fix silent DV conflict when conflictDetectionFilter doesn't cover all touched partitions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -38,8 +38,6 @@ import org.apache.iceberg.events.CreateSnapshotEvent;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.expressions.ManifestEvaluator;
-import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
@@ -838,23 +836,31 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     List<ManifestFile> newDeleteManifests = history.first();
     Set<Long> newSnapshotIds = history.second();
 
+    // Scan every concurrent delete manifest that has added files. Pruning by
+    // conflictDetectionFilter is unsafe here: a commit may write DVs in partitions that are not
+    // covered by the caller-supplied filter (the filter is typically derived from the query's
+    // WHERE clause and only describes the user's scope of interest, not every partition the
+    // commit is touching). Skipping a manifest because the filter doesn't overlap it can miss
+    // a concurrent DV for a data file we are also DV-ing, which would allow two DVs to reference
+    // the same data file and poison every subsequent scan with "Can't index multiple DVs".
     Iterable<ManifestFile> matchingManifests =
-        Iterables.filter(
-            filterManifestsByPartition(base, conflictDetectionFilter, newDeleteManifests),
-            ManifestFile::hasAddedFiles);
+        Iterables.filter(newDeleteManifests, ManifestFile::hasAddedFiles);
 
     Tasks.foreach(matchingManifests)
         .stopOnFailure()
         .throwFailureWhenFinished()
         .executeWith(workerPool())
-        .run(manifest -> validateAddedDVs(manifest, conflictDetectionFilter, newSnapshotIds));
+        .run(manifest -> validateAddedDVs(manifest, newSnapshotIds));
   }
 
-  private void validateAddedDVs(
-      ManifestFile manifest, Expression conflictDetectionFilter, Set<Long> newSnapshotIds) {
+  private void validateAddedDVs(ManifestFile manifest, Set<Long> newSnapshotIds) {
+    // Read every live entry in the manifest. DV conflicts are detected by referencedDataFile
+    // identity, not by any data-level predicate. Filtering entries with the caller-supplied
+    // conflictDetectionFilter can drop a concurrent DV whose partition is outside the filter
+    // even though it targets a data file we are also DV-ing, which allows two DVs to land on
+    // the same data file and breaks subsequent reads with "Can't index multiple DVs".
     try (CloseableIterable<ManifestEntry<DeleteFile>> entries =
         ManifestFiles.readDeleteManifest(manifest, ops().io(), ops().current().specsById())
-            .filterRows(conflictDetectionFilter)
             .caseSensitive(caseSensitive)
             .liveEntries()) {
 
@@ -871,38 +877,6 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-  }
-
-  private Iterable<ManifestFile> filterManifestsByPartition(
-      TableMetadata base, Expression conflictDetectionFilter, List<ManifestFile> manifests) {
-    if (conflictDetectionFilter == null || conflictDetectionFilter == Expressions.alwaysTrue()) {
-      return manifests;
-    }
-
-    // if any concurrent manifest was written with a different partition spec, skip pruning
-    // to avoid incorrectly excluding manifests when a spec change happened during validation
-    int defaultSpecId = base.defaultSpecId();
-    if (manifests.stream().anyMatch(m -> m.partitionSpecId() != defaultSpecId)) {
-      return manifests;
-    }
-
-    Map<Integer, PartitionSpec> specsById = base.specsById();
-    Map<Integer, ManifestEvaluator> evaluators = Maps.newHashMap();
-    return Iterables.filter(
-        manifests,
-        manifest -> {
-          ManifestEvaluator evaluator =
-              evaluators.computeIfAbsent(
-                  manifest.partitionSpecId(),
-                  specId -> {
-                    PartitionSpec spec = specsById.get(specId);
-                    Expression partitionFilter =
-                        Projections.inclusive(spec, caseSensitive).project(conflictDetectionFilter);
-                    return ManifestEvaluator.forPartitionFilter(
-                        partitionFilter, spec, caseSensitive);
-                  });
-          return evaluator.eval(manifest);
-        });
   }
 
   // returns newly added manifests and snapshot IDs between the starting and parent snapshots

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -2249,6 +2249,61 @@ public class TestRowDelta extends TestBase {
   }
 
   @TestTemplate
+  public void testConcurrentDVsMultiPartitionNarrowFilter() {
+    // Reproducer for a bug introduced by #15653 (79d4fc82c).
+    //
+    // MergingSnapshotProducer.validateAddedDVs() now prunes concurrent delete manifests by
+    // projecting conflictDetectionFilter onto each manifest's partition spec and dropping
+    // manifests whose partition range doesn't match. The filter is supplied by the caller
+    // (e.g. Spark derives it from the query's WHERE clause) and is not required to cover every
+    // partition the current commit writes DVs into.
+    //
+    // When a commit writes DVs across multiple partitions but supplies a filter that only names
+    // a subset of them, pruning can skip a manifest containing a concurrent DV for one of the
+    // un-filtered partitions. validateAddedDVs never sees that manifest, no conflict is raised,
+    // and the commit succeeds. The table ends up with two DVs referencing the same data file,
+    // which subsequently poisons every scan with "Can't index multiple DVs" in
+    // DeleteFileIndex.Builder.add().
+    //
+    // This test is expected to FAIL on current main: commit(writerA) returns normally instead of
+    // throwing "Found concurrently added DV".
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    // Two data files in two different buckets
+    DataFile dataFileInBucket0 = newDataFile("data_bucket=0");
+    DataFile dataFileInBucket2 = newDataFile("data_bucket=2");
+    commit(
+        table, table.newRowDelta().addRows(dataFileInBucket0).addRows(dataFileInBucket2), branch);
+
+    Snapshot base = latestSnapshot(table, branch);
+
+    // Writer A adds DVs for files in BOTH bucket 0 and bucket 2, but supplies a conflict
+    // detection filter scoped to bucket 0 only, mimicking a MERGE whose WHERE clause names
+    // one partition while the matched rows span additional partitions.
+    DeleteFile writerA_dvBucket0 = newDeletes(dataFileInBucket0);
+    DeleteFile writerA_dvBucket2 = newDeletes(dataFileInBucket2);
+    RowDelta writerA =
+        table
+            .newRowDelta()
+            .addDeletes(writerA_dvBucket0)
+            .addDeletes(writerA_dvBucket2)
+            .validateFromSnapshot(base.snapshotId())
+            .validateNoConflictingDeleteFiles()
+            .conflictDetectionFilter(Expressions.equal("data", "u")); // bucket16("u") -> 0
+
+    // Writer B concurrently commits a DV for the bucket 2 file
+    DeleteFile writerB_dvBucket2 = newDeletes(dataFileInBucket2);
+    commit(table, table.newRowDelta().addDeletes(writerB_dvBucket2), branch);
+
+    // Writer A is adding a DV for the same data file that Writer B already committed a DV for.
+    // This must be detected as a conflict even though the conflict detection filter is scoped to
+    // a different partition than where the conflicting file lives.
+    assertThatThrownBy(() -> commit(table, writerA, branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Found concurrently added DV for %s", dataFileInBucket2.location());
+  }
+
+  @TestTemplate
   public void testConcurrentDVsInSamePartitionWithFilter() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -2280,20 +2280,20 @@ public class TestRowDelta extends TestBase {
     // Writer A adds DVs for files in BOTH bucket 0 and bucket 2, but supplies a conflict
     // detection filter scoped to bucket 0 only, mimicking a MERGE whose WHERE clause names
     // one partition while the matched rows span additional partitions.
-    DeleteFile writerA_dvBucket0 = newDeletes(dataFileInBucket0);
-    DeleteFile writerA_dvBucket2 = newDeletes(dataFileInBucket2);
+    DeleteFile dvBucket0ForA = newDeletes(dataFileInBucket0);
+    DeleteFile dvBucket2ForA = newDeletes(dataFileInBucket2);
     RowDelta writerA =
         table
             .newRowDelta()
-            .addDeletes(writerA_dvBucket0)
-            .addDeletes(writerA_dvBucket2)
+            .addDeletes(dvBucket0ForA)
+            .addDeletes(dvBucket2ForA)
             .validateFromSnapshot(base.snapshotId())
             .validateNoConflictingDeleteFiles()
             .conflictDetectionFilter(Expressions.equal("data", "u")); // bucket16("u") -> 0
 
     // Writer B concurrently commits a DV for the bucket 2 file
-    DeleteFile writerB_dvBucket2 = newDeletes(dataFileInBucket2);
-    commit(table, table.newRowDelta().addDeletes(writerB_dvBucket2), branch);
+    DeleteFile dvBucket2ForB = newDeletes(dataFileInBucket2);
+    commit(table, table.newRowDelta().addDeletes(dvBucket2ForB), branch);
 
     // Writer A is adding a DV for the same data file that Writer B already committed a DV for.
     // This must be detected as a conflict even though the conflict detection filter is scoped to


### PR DESCRIPTION
## Summary

Fixes a correctness bug in `MergingSnapshotProducer.validateAddedDVs` that lets two Deletion Vectors land on the same data file when concurrent row-level writers use a `conflictDetectionFilter` narrower than the set of partitions the current commit is writing DVs into. The committed table state ends up with duplicate DVs per data file, which poisons every subsequent scan with `Can't index multiple DVs` in `DeleteFileIndex.Builder.add`.

The bug has two layers:

1. **Manifest-level pruning (introduced in #15653, commit `79d4fc82c`).** `filterManifestsByPartition` projects the user-supplied `conflictDetectionFilter` onto each concurrent delete manifest's partition spec and drops manifests whose partition range doesn't match. That filter comes from the query's WHERE clause (for Spark: `SparkPositionDeltaWrite#conflictDetectionFilter` → `queryScan.filterExpressions()`) and describes the user's scope of interest, not the union of partitions the commit is actually writing DVs into. A MERGE whose matched rows span partitions beyond what the WHERE clause names will drop concurrent manifests that hold a conflicting DV.

2. **Entry-level `filterRows(conflictDetectionFilter)` (in place since the original DV support in #11495).** Even if the manifest is scanned, `ManifestReader#filterRows` builds an `Evaluator` from `Projections.inclusive(spec, caseSensitive).project(rowFilter)` and drops entries whose partition doesn't satisfy the projected filter, so a concurrent DV for a file whose partition is outside the user's filter is still silently ignored. This layer alone is enough to reproduce the bug — removing only the manifest pruning is insufficient.

Both layers misuse the same filter. DV conflicts are detected by `referencedDataFile` identity, not by any data-level predicate, so `conflictDetectionFilter` has no business being applied in this path at all.

This PR:

- Removes the `filterManifestsByPartition` helper and its call site in `validateAddedDVs`.
- Drops the now-unused `ManifestEvaluator` / `Projections` imports.
- Removes `filterRows(conflictDetectionFilter)` from the per-manifest scan.
- Simplifies the private overload to take only the manifest and new-snapshot-ids set.
- Keeps the protected `validateAddedDVs(TableMetadata, Long, Expression, Snapshot)` signature unchanged so existing callers and any subclasses keep compiling.

A fix that adds the missing partition coverage (combining `conflictDetectionFilter` with a projection derived from `dvsByReferencedFile`) is possible as a future optimization, but it's not what this PR does. This PR restores correctness by fully scanning concurrent delete manifests and their live entries, which is what the code did before #11495 + #15653 made both filtering layers wrong.

## Reproducer

The first commit adds `testConcurrentDVsMultiPartitionNarrowFilter` to `TestRowDelta`:

1. Table partitioned by `bucket[16](data)`, seeded with `F_P0` in bucket 0 and `F_P2` in bucket 2.
2. Writer A builds a `RowDelta` that adds DVs for **both** `F_P0` and `F_P2`, with `conflictDetectionFilter = data = 'u'` (which projects to `bucket(data) = 0`).
3. Writer B concurrently commits a DV for `F_P2`.
4. Writer A calls `commit()` and must throw `Found concurrently added DV for .../F_P2`.

On an un-fixed tree, `assertThatThrownBy` fails with `Expecting code to raise a throwable` — the commit returns normally and the table is left with two DVs for `F_P2`.

On this branch, the assertion passes.

## Test results on this branch (JDK 21, rebased on `56092bc8c`)

```
./gradlew :iceberg-core:test --tests 'org.apache.iceberg.TestRowDelta'
BUILD SUCCESSFUL

testsuite name="org.apache.iceberg.TestRowDelta" tests="324" skipped="49" failures="0" errors="0"
```

324 tests, 0 failures. The three DV validation tests added alongside the buggy optimization in #15653 still pass:

- `testConcurrentDVsInDifferentPartitionsWithFilter` — Writer A's DVs live entirely in a partition that overlaps the filter; concurrent DV is elsewhere; correct outcome: A succeeds.
- `testConcurrentDVsInSamePartitionWithFilter` — DVs and concurrent DV share a partition; correct outcome: A fails with conflict.
- `testDVValidationPartitionPruningManifestCount` — micro-test of pruning arithmetic; doesn't call `validateAddedDVs` and is unaffected.

Those tests were testing cases where the filter happens to be aligned with the commit's DV set, so they kept passing despite the bug.

## Test gap in #15653

None of the three DV validation tests in #15653 cross the current commit's `dvsByReferencedFile` partition set against the pruning filter. That's the axis where the bug lives. The reproducer added here is the missing test.

## Follow-on severity

The corruption is committed at row-delta commit time but becomes visible only when a reader tries to build the `DeleteFileIndex`:

```java
// core/src/main/java/org/apache/iceberg/DeleteFileIndex.java:528-536
private void add(Map<String, DeleteFile> dvByPath, DeleteFile dv) {
  String path = dv.referencedDataFile();
  DeleteFile existingDV = dvByPath.putIfAbsent(path, dv);
  if (existingDV != null) {
    throw new ValidationException(
        "Can't index multiple DVs for %s: %s and %s",
        path, ContentFileUtil.dvDesc(dv), ContentFileUtil.dvDesc(existingDV));
  }
}
```

Every read, DML (UPDATE/DELETE/MERGE), and maintenance task touching the affected data file blows up. The table is effectively bricked until the duplicate DVs are manually resolved (rewrite, expire_snapshots on one of the duplicates, etc.).

## Commits

1. `dfcd371db` — `Core: Reproducer for concurrent DV conflict missed by partition pruning`
2. `36266b4c7` — `Core: Don't filter DV validation by conflictDetectionFilter`

## Test plan

- [x] New reproducer test `testConcurrentDVsMultiPartitionNarrowFilter` fails on main (`56092bc8c`) and passes with the fix.
- [x] Full `TestRowDelta` passes on this branch (324 tests, 0 failures).
- [ ] Reviewer to confirm: is the semantic contract of `conflictDetectionFilter` in `RowDelta` documented anywhere that would make removing it from `validateAddedDVs` controversial? Happy to restore a parameter-narrowing optimization in a follow-up if maintainers want to keep the perf win — but correctness first.