### PR TITLE
API: Relax partition name check when source column is dropped

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -402,21 +402,22 @@ public class PartitionSpec implements Serializable {
       Types.NestedField schemaField =
           this.caseSensitive ? schema.findField(name) : schema.caseInsensitiveFindField(name);
       if (checkConflicts) {
-        if (sourceColumnId != null) {
-          // for identity transform case we allow conflicts between partition and schema field name
-          // as
-          //   long as they are sourced from the same schema field
-          Preconditions.checkArgument(
-              schemaField == null || schemaField.fieldId() == sourceColumnId,
-              "Cannot create identity partition sourced from different field in schema: %s",
-              name);
-        } else {
-          // for all other transforms we don't allow conflicts between partition name and schema
-          // field name
+        if (sourceColumnId == null) {
           Preconditions.checkArgument(
               schemaField == null,
               "Cannot create partition from name that exists in schema: %s",
               name);
+        } else {
+          boolean sourceFieldExists = schema.findField(sourceColumnId) != null;
+          // For identity transforms, require the partition name to match the source column when it
+          // still exists in the schema. When the source was dropped, the spec may be historical;
+          // skip the identity name check in that case.
+          if (sourceFieldExists) {
+            Preconditions.checkArgument(
+                schemaField == null || schemaField.fieldId() == sourceColumnId,
+                "Cannot create identity partition sourced from different field in schema: %s",
+                name);
+          }
         }
       }
       Preconditions.checkArgument(!name.isEmpty(), "Cannot use empty partition name: %s", name);

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -243,6 +243,22 @@ public class TestPartitionSpecValidation {
   }
 
   @Test
+  public void testStalePartitionSourceIdWithReusedColumnName() {
+    int newFieldId = 2;
+    int droppedFieldId = 1;
+    Schema schema =
+        new Schema(NestedField.required(newFieldId, "category", Types.StringType.get()));
+    PartitionSpec spec =
+        PartitionSpec.builderFor(schema)
+            .withSpecId(0)
+            .add(droppedFieldId, 1000, "category", Transforms.alwaysNull())
+            .build();
+    assertThat(spec.fields()).hasSize(1);
+    assertThat(spec.fields().get(0).sourceId()).isEqualTo(droppedFieldId);
+    assertThat(spec.fields().get(0).name()).isEqualTo("category");
+  }
+
+  @Test
   public void testMissingSourceColumn() {
     assertThatThrownBy(() -> PartitionSpec.builderFor(SCHEMA).year("missing").build())
         .isInstanceOf(IllegalArgumentException.class)

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -647,4 +647,17 @@ public class TestAlterTablePartitionFields extends ExtensionsTestBase {
     sql("DELETE FROM %s WHERE id >= 1", tableName);
     assertThat(sql("SELECT * FROM %s WHERE id >= 1", tableName)).isEmpty();
   }
+
+  @TestTemplate
+  public void testReaddColumnAfterIdentityPartitionDrop() {
+    createTable("id bigint NOT NULL, category string, data string", "category");
+
+    sql("ALTER TABLE %s DROP PARTITION FIELD category", tableName);
+    sql("ALTER TABLE %s DROP COLUMN category", tableName);
+    sql("ALTER TABLE %s ADD COLUMN category string", tableName);
+
+    sql("INSERT INTO %s (id, category, data) VALUES (1, 'books', 'a')", tableName);
+    assertThat(sql("SELECT id, category, data FROM %s ORDER BY id", tableName))
+        .containsExactly(row(1L, "books", "a"));
+  }
 }


### PR DESCRIPTION
Skip the identity name pairing when the partition source id no longer resolves in the schema, so historical specs do not block re-adding a column with the same name. Add API and Spark extension tests.


Used Cursor - Claude-4.6-opus-high