### PR TITLE
Core, Hive: Close FileIO in HadoopCatalog and HiveCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -120,6 +120,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
     this.lockManager = LockManagers.from(properties);
 
     this.closeableGroup = new CloseableGroup();
+    closeableGroup.addCloseable(fileIO);
     closeableGroup.addCloseable(lockManager);
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -55,6 +55,7 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
@@ -91,6 +92,7 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
   private String name;
   private Configuration conf;
   private FileIO fileIO;
+  private CloseableGroup closeableGroup;
   private KeyManagementClient keyManagementClient;
   private ClientPool<IMetaStoreClient, TException> clients;
   private boolean listAllTables = false;
@@ -132,6 +134,12 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
     }
 
     this.clients = new CachedClientPool(conf, properties);
+
+    this.closeableGroup = new CloseableGroup();
+    closeableGroup.addCloseable(fileIO);
+    closeableGroup.addCloseable(keyManagementClient);
+    closeableGroup.addCloseable(metricsReporter());
+    closeableGroup.setSuppressCloseFailure(true);
   }
 
   @Override
@@ -824,11 +832,7 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public void close() throws IOException {
-    super.close();
-
-    if (keyManagementClient != null) {
-      keyManagementClient.close();
-    }
+    closeableGroup.close();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### Summary

- HadoopCatalog: add `fileIO` to existing `closeableGroup`
- HiveCatalog: introduce `CloseableGroup` (replacing manual close calls) and register `fileIO`, `keyManagementClient`, and `metricsReporter`

### Problem

All major Iceberg catalog implementations close their `FileIO` when `catalog.close()` is called — except `HadoopCatalog` and `HiveCatalog`:

For the default `HadoopFileIO` this is harmless — it has no `close()` implementation. But users who configure a non-default `FileIO` via `io-impl` (e.g. `S3FileIO`, `GCSFileIO`) will leak HTTP connection pools since `close()` is never called on the FileIO.

### Impact

- Default config (HadoopFileIO): No behavioral change
- Non-default FileIO (S3FileIO, GCSFileIO): Connection pools are now properly released on catalog close

Discovered while fixing a connection pool crash in Apache Beam's IcebergIO