### PR TITLE
API, Core: Move all stats-related classes into core and make them package-private

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseContentStats.java
+++ b/core/src/main/java/org/apache/iceberg/BaseContentStats.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
 import java.io.Serializable;
 import java.util.List;
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -33,14 +32,14 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
-public class BaseContentStats implements ContentStats, Serializable {
+class BaseContentStats implements ContentStats, Serializable {
 
   private final List<FieldStats<?>> fieldStats;
   private final Map<Integer, FieldStats<?>> fieldStatsById;
   private final Types.StructType statsStruct;
 
   /** Used by Avro reflection to instantiate this class when reading manifest files. */
-  public BaseContentStats(Types.StructType projection) {
+  BaseContentStats(Types.StructType projection) {
     this.statsStruct = projection;
     this.fieldStats = Lists.newArrayListWithCapacity(projection.fields().size());
     this.fieldStatsById = Maps.newLinkedHashMapWithExpectedSize(projection.fields().size());

--- a/core/src/main/java/org/apache/iceberg/BaseFieldStats.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFieldStats.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -28,7 +28,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
-public class BaseFieldStats<T> extends SupportsIndexProjection implements FieldStats<T> {
+class BaseFieldStats<T> extends SupportsIndexProjection implements FieldStats<T> {
   private static final int[] IDENTITY_MAPPING = identityMapping();
   private final int fieldId;
   private final Type type;

--- a/core/src/main/java/org/apache/iceberg/ContentStats.java
+++ b/core/src/main/java/org/apache/iceberg/ContentStats.java
@@ -16,13 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
 import java.util.List;
-import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Types;
 
-public interface ContentStats extends StructLike {
+interface ContentStats extends StructLike {
 
   /** A list of all the {@link FieldStats} */
   List<FieldStats<?>> fieldStats();

--- a/core/src/main/java/org/apache/iceberg/FieldStatistic.java
+++ b/core/src/main/java/org/apache/iceberg/FieldStatistic.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
@@ -25,7 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
-public enum FieldStatistic {
+enum FieldStatistic {
   VALUE_COUNT(1, "value_count"),
   NULL_VALUE_COUNT(2, "null_value_count"),
   NAN_VALUE_COUNT(3, "nan_value_count"),

--- a/core/src/main/java/org/apache/iceberg/FieldStats.java
+++ b/core/src/main/java/org/apache/iceberg/FieldStats.java
@@ -16,12 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
-import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Type;
 
-public interface FieldStats<T> extends StructLike {
+interface FieldStats<T> extends StructLike {
   /** The field ID of the statistic */
   int fieldId();
 

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -34,9 +34,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.stats.BaseContentStats;
-import org.apache.iceberg.stats.BaseFieldStats;
-import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
@@ -482,7 +479,7 @@ public class MetricsUtil {
     }
   }
 
-  public static ContentStats fromMetrics(Schema schema, Metrics metrics) {
+  static ContentStats fromMetrics(Schema schema, Metrics metrics) {
     if (null == metrics) {
       return null;
     }

--- a/core/src/main/java/org/apache/iceberg/StatsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/StatsUtil.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
@@ -33,7 +32,7 @@ import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class StatsUtil {
+class StatsUtil {
   private static final Logger LOG = LoggerFactory.getLogger(StatsUtil.class);
   // the number of reserved field IDs from the reserved field ID space as defined in
   // https://iceberg.apache.org/spec/#reserved-field-ids

--- a/core/src/main/java/org/apache/iceberg/TrackedFile.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFile.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.apache.iceberg.stats.ContentStats;
 import org.apache.iceberg.types.Types;
 
 /** A file tracked by a manifest. */

--- a/core/src/test/java/org/apache/iceberg/TestContentStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestContentStats.java
@@ -16,22 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
-import static org.apache.iceberg.stats.FieldStatistic.AVG_VALUE_SIZE;
-import static org.apache.iceberg.stats.FieldStatistic.EXACT_BOUNDS;
-import static org.apache.iceberg.stats.FieldStatistic.LOWER_BOUND;
-import static org.apache.iceberg.stats.FieldStatistic.MAX_VALUE_SIZE;
-import static org.apache.iceberg.stats.FieldStatistic.NAN_VALUE_COUNT;
-import static org.apache.iceberg.stats.FieldStatistic.NULL_VALUE_COUNT;
-import static org.apache.iceberg.stats.FieldStatistic.UPPER_BOUND;
-import static org.apache.iceberg.stats.FieldStatistic.VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.AVG_VALUE_SIZE;
+import static org.apache.iceberg.FieldStatistic.EXACT_BOUNDS;
+import static org.apache.iceberg.FieldStatistic.LOWER_BOUND;
+import static org.apache.iceberg.FieldStatistic.MAX_VALUE_SIZE;
+import static org.apache.iceberg.FieldStatistic.NAN_VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.NULL_VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.UPPER_BOUND;
+import static org.apache.iceberg.FieldStatistic.VALUE_COUNT;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Types;
@@ -154,7 +153,7 @@ public class TestContentStats {
     assertThatThrownBy(() -> stats.get(0, Long.class))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Wrong class, expected java.lang.Long but was org.apache.iceberg.stats.BaseFieldStats for object:");
+            "Wrong class, expected java.lang.Long but was org.apache.iceberg.BaseFieldStats for object:");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestFieldStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestFieldStats.java
@@ -16,16 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
-import static org.apache.iceberg.stats.FieldStatistic.AVG_VALUE_SIZE;
-import static org.apache.iceberg.stats.FieldStatistic.EXACT_BOUNDS;
-import static org.apache.iceberg.stats.FieldStatistic.LOWER_BOUND;
-import static org.apache.iceberg.stats.FieldStatistic.MAX_VALUE_SIZE;
-import static org.apache.iceberg.stats.FieldStatistic.NAN_VALUE_COUNT;
-import static org.apache.iceberg.stats.FieldStatistic.NULL_VALUE_COUNT;
-import static org.apache.iceberg.stats.FieldStatistic.UPPER_BOUND;
-import static org.apache.iceberg.stats.FieldStatistic.VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.AVG_VALUE_SIZE;
+import static org.apache.iceberg.FieldStatistic.EXACT_BOUNDS;
+import static org.apache.iceberg.FieldStatistic.LOWER_BOUND;
+import static org.apache.iceberg.FieldStatistic.MAX_VALUE_SIZE;
+import static org.apache.iceberg.FieldStatistic.NAN_VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.NULL_VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.UPPER_BOUND;
+import static org.apache.iceberg.FieldStatistic.VALUE_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
-import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -41,8 +41,6 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.stats.ContentStats;
-import org.apache.iceberg.stats.FieldStats;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.BinaryType;

--- a/core/src/test/java/org/apache/iceberg/TestStatsUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestStatsUtil.java
@@ -16,23 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.stats;
+package org.apache.iceberg;
 
-import static org.apache.iceberg.stats.FieldStatistic.AVG_VALUE_SIZE;
-import static org.apache.iceberg.stats.FieldStatistic.EXACT_BOUNDS;
-import static org.apache.iceberg.stats.FieldStatistic.LOWER_BOUND;
-import static org.apache.iceberg.stats.FieldStatistic.MAX_VALUE_SIZE;
-import static org.apache.iceberg.stats.FieldStatistic.NAN_VALUE_COUNT;
-import static org.apache.iceberg.stats.FieldStatistic.NULL_VALUE_COUNT;
-import static org.apache.iceberg.stats.FieldStatistic.UPPER_BOUND;
-import static org.apache.iceberg.stats.FieldStatistic.VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.AVG_VALUE_SIZE;
+import static org.apache.iceberg.FieldStatistic.EXACT_BOUNDS;
+import static org.apache.iceberg.FieldStatistic.LOWER_BOUND;
+import static org.apache.iceberg.FieldStatistic.MAX_VALUE_SIZE;
+import static org.apache.iceberg.FieldStatistic.NAN_VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.NULL_VALUE_COUNT;
+import static org.apache.iceberg.FieldStatistic.UPPER_BOUND;
+import static org.apache.iceberg.FieldStatistic.VALUE_COUNT;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFile.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFile.java
@@ -22,7 +22,6 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import org.apache.iceberg.stats.StatsUtil;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
This moves all stats related code into `iceberg-core` to avoid any potential API breakages before the Spec has been finalized. It also moves all classes under the `org.apache.iceberg` package for usability/visibility in other classes v4-related classes.