### PR TITLE
Core, Spark: Fix copy plan to include live files with expired snapshot IDs in RewriteTablePath

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -432,6 +432,9 @@ public class RewriteTablePathUtil {
     DataFile newDataFile =
         DataFiles.builder(spec).copy(entry.file()).withPath(targetDataFilePath).build();
     appendEntryWithFile(entry, writer, newDataFile);
+    // keep the following entries in metadata but exclude them from copyPlan
+    // 1) deleted data files
+    // 2) entries not changed by snapshotIds (incremental copy only)
     if (entry.isLive() && (snapshotIds == null || snapshotIds.contains(entry.snapshotId()))) {
       result.copyPlan().add(Pair.of(sourceDataFilePath, newDataFile.location()));
     }
@@ -454,6 +457,9 @@ public class RewriteTablePathUtil {
       case POSITION_DELETES:
         DeleteFile posDeleteFile = newPositionDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, posDeleteFile);
+        // keep the following entries in metadata but exclude them from copyPlan
+        // 1) deleted position delete files
+        // 2) entries not changed by snapshotIds (incremental copy only)
         if (entry.isLive() && (snapshotIds == null || snapshotIds.contains(entry.snapshotId()))) {
           result
               .copyPlan()
@@ -467,6 +473,9 @@ public class RewriteTablePathUtil {
       case EQUALITY_DELETES:
         DeleteFile eqDeleteFile = newEqualityDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, eqDeleteFile);
+        // keep the following entries in metadata but exclude them from copyPlan
+        // 1) deleted equality delete files
+        // 2) entries not changed by snapshotIds (incremental copy only)
         if (entry.isLive() && (snapshotIds == null || snapshotIds.contains(entry.snapshotId()))) {
           // No need to rewrite equality delete files as they do not contain absolute file paths.
           result.copyPlan().add(Pair.of(file.location(), eqDeleteFile.location()));

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -331,7 +331,9 @@ public class RewriteTablePathUtil {
    * Rewrite a data manifest, replacing path references.
    *
    * @param manifestFile source manifest file to rewrite
-   * @param snapshotIds snapshot ids for filtering returned data manifest entries
+   * @param snapshotIds snapshot ids for filtering returned data manifest entries. When null, all
+   *     live entries are included in the copy plan regardless of their snapshot id. This is used
+   *     for full table copies where expired snapshot ids should not exclude live files.
    * @param outputFile output file to rewrite manifest file to
    * @param io file io
    * @param format format of the manifest file
@@ -367,7 +369,8 @@ public class RewriteTablePathUtil {
    * Rewrite a delete manifest, replacing path references.
    *
    * @param manifestFile source delete manifest to rewrite
-   * @param snapshotIds snapshot ids for filtering returned delete manifest entries
+   * @param snapshotIds snapshot ids for filtering returned delete manifest entries. When null, all
+   *     live entries are included in the copy plan regardless of their snapshot id.
    * @param outputFile output file to rewrite manifest file to
    * @param io file io
    * @param format format of the manifest file
@@ -429,10 +432,7 @@ public class RewriteTablePathUtil {
     DataFile newDataFile =
         DataFiles.builder(spec).copy(entry.file()).withPath(targetDataFilePath).build();
     appendEntryWithFile(entry, writer, newDataFile);
-    // keep the following entries in metadata but exclude them from copyPlan
-    // 1) deleted data files
-    // 2) entries not changed by snapshotIds
-    if (entry.isLive() && snapshotIds.contains(entry.snapshotId())) {
+    if (entry.isLive() && (snapshotIds == null || snapshotIds.contains(entry.snapshotId()))) {
       result.copyPlan().add(Pair.of(sourceDataFilePath, newDataFile.location()));
     }
     return result;
@@ -454,10 +454,7 @@ public class RewriteTablePathUtil {
       case POSITION_DELETES:
         DeleteFile posDeleteFile = newPositionDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, posDeleteFile);
-        // keep the following entries in metadata but exclude them from copyPlan
-        // 1) deleted position delete files
-        // 2) entries not changed by snapshotIds
-        if (entry.isLive() && snapshotIds.contains(entry.snapshotId())) {
+        if (entry.isLive() && (snapshotIds == null || snapshotIds.contains(entry.snapshotId()))) {
           result
               .copyPlan()
               .add(
@@ -470,10 +467,7 @@ public class RewriteTablePathUtil {
       case EQUALITY_DELETES:
         DeleteFile eqDeleteFile = newEqualityDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, eqDeleteFile);
-        // keep the following entries in metadata but exclude them from copyPlan
-        // 1) deleted equality delete files
-        // 2) entries not changed by snapshotIds
-        if (entry.isLive() && snapshotIds.contains(entry.snapshotId())) {
+        if (entry.isLive() && (snapshotIds == null || snapshotIds.contains(entry.snapshotId()))) {
           // No need to rewrite equality delete files as they do not contain absolute file paths.
           result.copyPlan().add(Pair.of(file.location(), eqDeleteFile.location()));
         }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -253,6 +253,77 @@ public class TestRewriteTablePathUtil extends TestBase {
   }
 
   @TestTemplate
+  public void testRewriteDataManifestWithExpiredSnapshotId() throws IOException {
+    String sourcePrefix = "/path/to/";
+    String targetPrefix = "/path/new/";
+
+    long expiredSnapshotId = 999L;
+    ManifestFile manifest = writeManifest(expiredSnapshotId, FILE_A, FILE_B);
+
+    // When snapshotIds does not contain the expired snapshot, live entries are excluded
+    RewriteTablePathUtil.RewriteResult<DataFile> filtered =
+        RewriteTablePathUtil.rewriteDataManifest(
+            manifest,
+            Set.of(1L),
+            Files.localOutput(
+                FileFormat.AVRO.addExtension(
+                    temp.resolve("junit" + System.nanoTime()).toFile().toString())),
+            table.io(),
+            formatVersion,
+            table.specs(),
+            sourcePrefix,
+            targetPrefix);
+    assertThat(filtered.copyPlan()).isEmpty();
+
+    // When snapshotIds is null, all live entries are included in the copy plan
+    RewriteTablePathUtil.RewriteResult<DataFile> unfiltered =
+        RewriteTablePathUtil.rewriteDataManifest(
+            manifest,
+            null,
+            Files.localOutput(
+                FileFormat.AVRO.addExtension(
+                    temp.resolve("junit" + System.nanoTime()).toFile().toString())),
+            table.io(),
+            formatVersion,
+            table.specs(),
+            sourcePrefix,
+            targetPrefix);
+    assertThat(unfiltered.copyPlan()).hasSize(2);
+  }
+
+  @TestTemplate
+  public void testRewriteDeleteManifestWithExpiredSnapshotId() throws IOException {
+    assumeThat(formatVersion)
+        .as("Delete files only work for format version 2")
+        .isGreaterThanOrEqualTo(2);
+
+    String sourcePrefix = "/path/to/";
+    String stagingDir = "/staging/";
+    String targetPrefix = "/path/new/";
+
+    long expiredSnapshotId = 999L;
+    ManifestFile manifest =
+        writeDeleteManifest(formatVersion, expiredSnapshotId, FILE_A_DELETES, FILE_B_DELETES);
+
+    // When snapshotIds is null, all live entries are included in the copy plan
+    RewriteTablePathUtil.RewriteResult<DeleteFile> result =
+        RewriteTablePathUtil.rewriteDeleteManifest(
+            manifest,
+            null,
+            Files.localOutput(
+                FileFormat.AVRO.addExtension(
+                    temp.resolve("junit" + System.nanoTime()).toFile().toString())),
+            table.io(),
+            formatVersion,
+            table.specs(),
+            sourcePrefix,
+            targetPrefix,
+            stagingDir);
+    assertThat(result.copyPlan()).hasSize(2);
+    assertThat(result.toRewrite()).hasSize(2);
+  }
+
+  @TestTemplate
   public void testRewritingMultiplePositionDeleteEntriesWithinManifestFile() throws IOException {
     assumeThat(formatVersion)
         .as("Delete files only work for format version 2")

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -313,9 +313,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     // For full copy (no start version), pass null so all live entries are included
     // in the copy plan. Current snapshot IDs may not cover entries whose original
     // adding snapshot has been expired, but those files can still be live.
-    Set<Snapshot> snapshotFilter = startMetadata == null ? null : deltaSnapshots;
+    Set<Snapshot> deltaSnapshotIds = startMetadata == null ? null : deltaSnapshots;
     RewriteContentFileResult rewriteManifestResult =
-        rewriteManifests(snapshotFilter, endMetadata, metaFiles);
+        rewriteManifests(deltaSnapshotIds, endMetadata, metaFiles);
 
     // rebuild position delete files
     Set<DeleteFile> deleteFiles =

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -310,8 +310,12 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
     // rebuild manifest files
     Set<ManifestFile> metaFiles = rewriteManifestListResult.toRewrite();
+    // For full copy (no start version), pass null so all live entries are included
+    // in the copy plan. Current snapshot IDs may not cover entries whose original
+    // adding snapshot has been expired, but those files can still be live.
+    Set<Snapshot> snapshotFilter = startMetadata == null ? null : deltaSnapshots;
     RewriteContentFileResult rewriteManifestResult =
-        rewriteManifests(deltaSnapshots, endMetadata, metaFiles);
+        rewriteManifests(snapshotFilter, endMetadata, metaFiles);
 
     // rebuild position delete files
     Set<DeleteFile> deleteFiles =
@@ -569,15 +573,22 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Encoder<ManifestFile> manifestFileEncoder = Encoders.javaSerialization(ManifestFile.class);
     Dataset<ManifestFile> manifestDS =
         spark().createDataset(Lists.newArrayList(toRewrite), manifestFileEncoder);
-    Set<Long> deltaSnapshotIds =
-        deltaSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+
+    Broadcast<Set<Long>> snapshotIdsBroadcast;
+    if (deltaSnapshots == null) {
+      snapshotIdsBroadcast = null;
+    } else {
+      Set<Long> deltaSnapshotIds =
+          deltaSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+      snapshotIdsBroadcast = sparkContext().broadcast(deltaSnapshotIds);
+    }
 
     return manifestDS
         .repartition(toRewrite.size())
         .map(
             toManifests(
                 tableBroadcast(),
-                sparkContext().broadcast(deltaSnapshotIds),
+                snapshotIdsBroadcast,
                 stagingDir,
                 tableMetadata.formatVersion(),
                 sourcePrefix,
@@ -643,7 +654,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       FileIO io = table.getValue().io();
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
-      Set<Long> deltaSnapshotIds = snapshotIds.value();
+      Set<Long> deltaSnapshotIds = snapshotIds == null ? null : snapshotIds.value();
       return RewriteTablePathUtil.rewriteDataManifest(
           manifestFile,
           deltaSnapshotIds,
@@ -672,7 +683,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       FileIO io = table.getValue().io();
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
-      Set<Long> deltaSnapshotIds = snapshotIds.value();
+      Set<Long> deltaSnapshotIds = snapshotIds == null ? null : snapshotIds.value();
       return RewriteTablePathUtil.rewriteDeleteManifest(
           manifestFile,
           deltaSnapshotIds,

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -733,8 +733,8 @@ public class TestRewriteTablePathsAction extends TestBase {
     // the first snapshot
     // from the version file history
     int missingVersionFile = 1;
-    // since first snapshot cannot be found, first data files will also be skipped
-    int missingDataFile = 1;
+    // the first snapshot was expired, but its data file is still live and included in the copy plan
+    int missingDataFile = 0;
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(sourceTable)


### PR DESCRIPTION
Fixes #14458

During a full table copy, RewriteTablePathSparkAction builds deltaSnapshotIds from endMetadata.snapshots(), which excludes expired snapshots. Since entry.snapshotId() records the adding snapshot, live files whose adding snapshot was expired are excluded from the copy plan, resulting in a broken table at the target location.

This fix makes the snapshotIds filter nullable in RewriteTablePathUtil. For full copies (startMetadata == null), null is passed to skip the filter and include all live entries in the copy plan.