### PR TITLE
API, Core: Support explicit null default values

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -251,6 +251,9 @@ public class Expressions {
         "Cannot create %s predicate inclusive a value",
         op);
     Preconditions.checkArgument(
+        !(lit instanceof Literals.NullLiteral),
+        "Invalid expression literal: null, use isNull or notNull instead");
+    Preconditions.checkArgument(
         !NaNUtil.isNaN(lit.value()),
         "Invalid expression literal: NaN, use isNaN or notNaN instead");
     return new UnboundPredicate<T>(op, ref(name), lit);

--- a/api/src/main/java/org/apache/iceberg/expressions/Literal.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literal.java
@@ -71,6 +71,18 @@ public interface Literal<T> extends Serializable {
     return new Literals.DecimalLiteral(value);
   }
 
+  /**
+   * Returns a sentinel literal representing an explicit null default value.
+   *
+   * <p>This is distinct from a Java {@code null} literal reference, which means "not set." When
+   * used as a field default, this literal indicates that the default is explicitly null rather than
+   * absent. Engines use this distinction to avoid falling back to initial-default when
+   * write-default is explicitly set to null.
+   */
+  static Literal<?> ofNull() {
+    return Literals.nullLiteral();
+  }
+
   /** Returns the value wrapped by this literal. */
   T value();
 

--- a/api/src/main/java/org/apache/iceberg/expressions/Literal.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literal.java
@@ -74,7 +74,7 @@ public interface Literal<T> extends Serializable {
   /**
    * Returns a sentinel literal representing an explicit null default value.
    *
-   * <p>This is distinct from a Java {@code null} literal reference, which means "not set." When
+   * <p>This is distinct from a Java {@code null} literal reference, which means "not set". When
    * used as a field default, this literal indicates that the default is explicitly null rather than
    * absent. Engines use this distinction to avoid falling back to initial-default when
    * write-default is explicitly set to null.

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -755,10 +755,10 @@ class Literals {
 
   /**
    * A sentinel literal representing an explicit null default value. This is distinct from a Java
-   * {@code null} literal reference, which means "not set." Engines use this distinction to decide
+   * {@code null} literal reference, which means "not set". Engines use this distinction to decide
    * whether to fall back to initial-default when write-default is not set.
    */
-  static class NullLiteral<T> implements Literal<T> {
+  static final class NullLiteral<T> implements Literal<T> {
     private static final NullLiteral<?> INSTANCE = new NullLiteral<>();
 
     private NullLiteral() {}

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -104,6 +104,11 @@ class Literals {
     return BelowMin.INSTANCE;
   }
 
+  @SuppressWarnings("unchecked")
+  static <T> Literal<T> nullLiteral() {
+    return (Literal<T>) NullLiteral.INSTANCE;
+  }
+
   private abstract static class BaseLiteral<T> implements Literal<T> {
     private final T value;
     private transient volatile ByteBuffer byteBuffer = null;
@@ -745,6 +750,52 @@ class Literals {
     public String toString() {
       byte[] bytes = ByteBuffers.toByteArray(value());
       return "X'" + BASE16_ENCODING.encode(bytes) + "'";
+    }
+  }
+
+  /**
+   * A sentinel literal representing an explicit null default value. This is distinct from a Java
+   * {@code null} literal reference, which means "not set." Engines use this distinction to decide
+   * whether to fall back to initial-default when write-default is not set.
+   */
+  static class NullLiteral<T> implements Literal<T> {
+    private static final NullLiteral<?> INSTANCE = new NullLiteral<>();
+
+    private NullLiteral() {}
+
+    @Override
+    public T value() {
+      return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <X> Literal<X> to(Type type) {
+      return (Literal<X>) this;
+    }
+
+    @Override
+    public Comparator<T> comparator() {
+      throw new UnsupportedOperationException("NullLiteral has no comparator");
+    }
+
+    @Override
+    public String toString() {
+      return "null";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof NullLiteral;
+    }
+
+    @Override
+    public int hashCode() {
+      return NullLiteral.class.hashCode();
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+      return INSTANCE;
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -878,32 +878,25 @@ public class Types {
       this.name = name;
       this.type = type;
       this.doc = doc;
-      this.initialDefault = castDefault(initialDefault, type);
-      this.writeDefault = castDefault(writeDefault, type);
-      Preconditions.checkArgument(
-          isOptional || this.initialDefault != Literal.ofNull(),
-          "Cannot use null initial default for required field: %s",
-          name);
-      Preconditions.checkArgument(
-          isOptional || this.writeDefault != Literal.ofNull(),
-          "Cannot use null write default for required field: %s",
-          name);
+      this.initialDefault = initDefault(isOptional, initialDefault, type);
+      this.writeDefault = initDefault(isOptional, writeDefault, type);
     }
 
-    private static Literal<?> castDefault(Literal<?> defaultValue, Type type) {
-      if (type.isNestedType() && defaultValue != null) {
+    private static Literal<?> initDefault(boolean isOptional, Literal<?> defaultValue, Type type) {
+      if (defaultValue == null) {
+        return null;
+      } else if (defaultValue.equals(Literal.ofNull())) {
+        Preconditions.checkArgument(isOptional, "Cannot use null default for required field");
+        return defaultValue;
+      } else if (type.isNestedType()) {
         throw new IllegalArgumentException(
             String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
-      } else if (defaultValue == Literal.ofNull()) {
-        return defaultValue;
-      } else if (defaultValue != null) {
+      } else {
         Literal<?> typedDefault = defaultValue.to(type);
         Preconditions.checkArgument(
             typedDefault != null, "Cannot cast default value to %s: %s", type, defaultValue);
         return typedDefault;
       }
-
-      return null;
     }
 
     public boolean isOptional() {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -886,7 +886,8 @@ public class Types {
       if (defaultValue == null) {
         return null;
       } else if (defaultValue.equals(Literal.ofNull())) {
-        Preconditions.checkArgument(isOptional, "Cannot use null default for required field");
+        Preconditions.checkArgument(
+            isOptional, "Cannot use null default for required field (%s)", type);
         return defaultValue;
       } else if (type.isNestedType()) {
         throw new IllegalArgumentException(

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -880,12 +880,22 @@ public class Types {
       this.doc = doc;
       this.initialDefault = castDefault(initialDefault, type);
       this.writeDefault = castDefault(writeDefault, type);
+      Preconditions.checkArgument(
+          isOptional || this.initialDefault != Literal.ofNull(),
+          "Cannot use null initial default for required field: %s",
+          name);
+      Preconditions.checkArgument(
+          isOptional || this.writeDefault != Literal.ofNull(),
+          "Cannot use null write default for required field: %s",
+          name);
     }
 
     private static Literal<?> castDefault(Literal<?> defaultValue, Type type) {
       if (type.isNestedType() && defaultValue != null) {
         throw new IllegalArgumentException(
             String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
+      } else if (defaultValue == Literal.ofNull()) {
+        return defaultValue;
       } else if (defaultValue != null) {
         Literal<?> typedDefault = defaultValue.to(type);
         Preconditions.checkArgument(

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -273,6 +273,15 @@ public class TestExpressionHelpers {
     assertInvalidateNaNThrows(() -> predicate(Expression.Operation.EQ, "a", Double.NaN));
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testInvalidateNullLiteralInPredicate() {
+    Literal<Object> nullLit = (Literal<Object>) Literal.ofNull();
+    assertThatThrownBy(() -> predicate(Expression.Operation.EQ, "a", nullLit))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid expression literal: null, use isNull or notNull instead");
+  }
+
   private void assertInvalidateNaNThrows(Callable<UnboundPredicate<Double>> callable) {
     assertThatThrownBy(callable::call)
         .isInstanceOf(IllegalArgumentException.class)

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -93,12 +93,12 @@ public class SchemaParser {
         generator.writeStringField(DOC, field.doc());
       }
 
-      if (field.initialDefault() != null) {
+      if (field.initialDefaultLiteral() != null) {
         generator.writeFieldName(INITIAL_DEFAULT);
         SingleValueParser.toJson(field.type(), field.initialDefault(), generator);
       }
 
-      if (field.writeDefault() != null) {
+      if (field.writeDefaultLiteral() != null) {
         generator.writeFieldName(WRITE_DEFAULT);
         SingleValueParser.toJson(field.type(), field.writeDefault(), generator);
       }
@@ -198,6 +198,10 @@ public class SchemaParser {
   private static Literal<?> defaultFromJson(String defaultField, Type type, JsonNode json) {
     if (json.has(defaultField)) {
       Object value = SingleValueParser.fromJson(type, json.get(defaultField));
+      if (value == null) {
+        return Literal.ofNull();
+      }
+
       if (type instanceof Types.TimestampNanoType) {
         // Call Expressions.nanos instead of Expressions.lit to prevent overflow
         // https://github.com/apache/iceberg/issues/13160

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -330,7 +330,7 @@ class SchemaUpdate implements UpdateSchema {
     // if the value can be converted to the expected type, check if it is already set
     // if it can't be converted, the builder will throw an exception
     Literal<?> converted = newDefault != null ? newDefault.to(field.type()) : null;
-    if (converted != null && Objects.equals(field.writeDefault(), converted.value())) {
+    if (converted != null && Objects.equals(field.writeDefaultLiteral(), converted)) {
       return this;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -270,4 +270,42 @@ public class TestSchemaParser extends DataTestBase {
     assertThat(explicitNull.writeDefaultLiteral()).isEqualTo(Literal.ofNull());
     assertThat(absent).isNotEqualTo(explicitNull);
   }
+
+  @Test
+  void testNullDefaultOnNestedTypes() {
+    Types.NestedField listField =
+        Types.NestedField.optional("list_col")
+            .withId(1)
+            .ofType(Types.ListType.ofOptional(2, Types.StringType.get()))
+            .withWriteDefault(Literal.ofNull())
+            .build();
+    assertThat(listField.writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+
+    Types.NestedField mapField =
+        Types.NestedField.optional("map_col")
+            .withId(3)
+            .ofType(Types.MapType.ofOptional(4, 5, Types.StringType.get(), Types.IntegerType.get()))
+            .withWriteDefault(Literal.ofNull())
+            .build();
+    assertThat(mapField.writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+
+    Types.NestedField structField =
+        Types.NestedField.optional("struct_col")
+            .withId(6)
+            .ofType(
+                Types.StructType.of(Types.NestedField.required(7, "id", Types.IntegerType.get())))
+            .withWriteDefault(Literal.ofNull())
+            .build();
+    assertThat(structField.writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+
+    Schema schema = new Schema(listField, mapField, structField);
+    String json = SchemaParser.toJson(schema);
+    Schema deserialized = SchemaParser.fromJson(json);
+
+    assertThat(deserialized.findField("list_col").writeDefaultLiteral())
+        .isEqualTo(Literal.ofNull());
+    assertThat(deserialized.findField("map_col").writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+    assertThat(deserialized.findField("struct_col").writeDefaultLiteral())
+        .isEqualTo(Literal.ofNull());
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -154,5 +155,119 @@ public class TestSchemaParser extends DataTestBase {
         .isEqualTo(defaultValue.value());
     assertThat(serialized.findField("col_with_default").writeDefault())
         .isEqualTo(defaultValue.value());
+  }
+
+  @Test
+  void testExplicitNullWriteDefault() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("data")
+                .withId(2)
+                .ofType(Types.IntegerType.get())
+                .withInitialDefault(Literal.of(5))
+                .withWriteDefault(Literal.ofNull())
+                .build());
+
+    String json = SchemaParser.toJson(schema);
+    assertThat(json).contains("\"write-default\":null");
+    assertThat(json).contains("\"initial-default\":5");
+
+    Schema deserialized = SchemaParser.fromJson(json);
+    Types.NestedField field = deserialized.findField("data");
+    assertThat(field.initialDefault()).isEqualTo(5);
+    assertThat(field.initialDefaultLiteral()).isEqualTo(Literal.of(5));
+    assertThat(field.writeDefault()).isNull();
+    assertThat(field.writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+  }
+
+  @Test
+  void testExplicitNullInitialDefault() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("data")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Literal.ofNull())
+                .withWriteDefault(Literal.of("hello"))
+                .build());
+
+    String json = SchemaParser.toJson(schema);
+    assertThat(json).contains("\"initial-default\":null");
+    assertThat(json).contains("\"write-default\":\"hello\"");
+
+    Schema deserialized = SchemaParser.fromJson(json);
+    Types.NestedField field = deserialized.findField("data");
+    assertThat(field.initialDefault()).isNull();
+    assertThat(field.initialDefaultLiteral()).isEqualTo(Literal.ofNull());
+    assertThat(field.writeDefault()).isEqualTo("hello");
+  }
+
+  @Test
+  void testBothDefaultsExplicitlyNull() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("data")
+                .withId(2)
+                .ofType(Types.IntegerType.get())
+                .withInitialDefault(Literal.ofNull())
+                .withWriteDefault(Literal.ofNull())
+                .build());
+
+    String json = SchemaParser.toJson(schema);
+    assertThat(json).contains("\"initial-default\":null");
+    assertThat(json).contains("\"write-default\":null");
+
+    Schema deserialized = SchemaParser.fromJson(json);
+    Types.NestedField field = deserialized.findField("data");
+    assertThat(field.initialDefaultLiteral()).isEqualTo(Literal.ofNull());
+    assertThat(field.writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+  }
+
+  @Test
+  void testNullDefaultOnRequiredFieldThrows() {
+    assertThatThrownBy(
+            () ->
+                Types.NestedField.required("data")
+                    .withId(1)
+                    .ofType(Types.IntegerType.get())
+                    .withWriteDefault(Literal.ofNull())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot use null write default for required field");
+  }
+
+  @Test
+  void testParseJsonWithNullWriteDefault() {
+    String json =
+        "{\"type\":\"struct\",\"schema-id\":0,\"fields\":["
+            + "{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"long\"},"
+            + "{\"id\":2,\"name\":\"data\",\"required\":false,\"type\":\"int\","
+            + "\"initial-default\":5,\"write-default\":null}]}";
+
+    Schema deserialized = SchemaParser.fromJson(json);
+    Types.NestedField field = deserialized.findField("data");
+    assertThat(field.initialDefault()).isEqualTo(5);
+    assertThat(field.writeDefault()).isNull();
+    assertThat(field.writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+  }
+
+  @Test
+  void testAbsentVsExplicitNullDefault() {
+    Types.NestedField absent =
+        Types.NestedField.optional("data").withId(1).ofType(Types.IntegerType.get()).build();
+
+    Types.NestedField explicitNull =
+        Types.NestedField.optional("data")
+            .withId(1)
+            .ofType(Types.IntegerType.get())
+            .withWriteDefault(Literal.ofNull())
+            .build();
+
+    assertThat(absent.writeDefaultLiteral()).isNull();
+    assertThat(explicitNull.writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+    assertThat(absent).isNotEqualTo(explicitNull);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -236,7 +236,7 @@ public class TestSchemaParser extends DataTestBase {
                     .withWriteDefault(Literal.ofNull())
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Cannot use null write default for required field");
+        .hasMessageContaining("Cannot use null default for required field");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -285,6 +285,34 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testUpdateColumnDefaultToNull() {
+    Schema schema =
+        new Schema(
+            optional("data")
+                .withId(1)
+                .ofType(Types.IntegerType.get())
+                .withInitialDefault(Literal.of(5))
+                .withWriteDefault(Literal.of(5))
+                .build());
+
+    Schema expected =
+        new Schema(
+            optional("data")
+                .withId(1)
+                .ofType(Types.IntegerType.get())
+                .withInitialDefault(Literal.of(5))
+                .withWriteDefault(Literal.ofNull())
+                .build());
+
+    Schema updated =
+        new SchemaUpdate(schema, 1).updateColumnDefault("data", Literal.ofNull()).apply();
+
+    assertThat(updated.asStruct()).isEqualTo(expected.asStruct());
+    assertThat(updated.findField("data").writeDefaultLiteral()).isEqualTo(Literal.ofNull());
+    assertThat(updated.findField("data").initialDefault()).isEqualTo(5);
+  }
+
+  @Test
   public void testUpdateTypesCaseInsensitive() {
     Types.StructType expected =
         Types.StructType.of(

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -313,6 +313,23 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testUpdateRequiredColumnDefaultToNullThrows() {
+    Schema schema =
+        new Schema(
+            required("data")
+                .withId(1)
+                .ofType(Types.IntegerType.get())
+                .withInitialDefault(Literal.of(5))
+                .withWriteDefault(Literal.of(5))
+                .build());
+
+    assertThatThrownBy(
+            () -> new SchemaUpdate(schema, 1).updateColumnDefault("data", Literal.ofNull()).apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot use null default for required field");
+  }
+
+  @Test
   public void testUpdateTypesCaseInsensitive() {
     Types.StructType expected =
         Types.StructType.of(


### PR DESCRIPTION
Fixes #15932.

Parsing "write-default": null in JSON crashes because Expressions.lit(null) rejects null. This makes it impossible to set write-default to null when initial-default is non-null — the fallback always wins.
This PR adds a NullLiteral sentinel (Literal.ofNull()) to distinguish "not set" from "explicitly null," and fixes the parser, serializer, and SchemaUpdate to handle it correctly.

Used Cursor - Claude-4.6-opus-high