### PR TITLE
Fix typos in javadoc/comment: 'intialize', 'seperated'

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/S3FileIOAwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/S3FileIOAwsClientFactories.java
@@ -32,7 +32,7 @@ public class S3FileIOAwsClientFactories {
   /**
    * Attempts to load an AWS client factory class for S3 file IO defined in the catalog property
    * {@link S3FileIOProperties#CLIENT_FACTORY}. If the property wasn't set, fallback to {@link
-   * AwsClientFactories#from(Map) to intialize an AWS client factory class}
+   * AwsClientFactories#from(Map) to initialize an AWS client factory class}
    *
    * @param properties catalog properties
    * @return an instance of a factory class

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -295,7 +295,7 @@ public class TestLocationProvider extends TestBase {
     String fileLocation =
         table.locationProvider().newDataLocation(table.spec(), partitionData, "test.parquet");
 
-    // no partition values included in the path and last part of entropy is seperated with "-"
+    // no partition values included in the path and last part of entropy is separated with "-"
     assertThat(fileLocation).endsWith("/data/0110/1010/0011/11101000-test.parquet");
   }
 


### PR DESCRIPTION
- `S3FileIOAwsClientFactories.java`: javadoc `to intialize` -> `to initialize`
- `TestLocationProvider.java`: comment `is seperated with` -> `is separated with`

No behavior changes.