### PR TITLE
Core: Add branch support for RewriteManifests operation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -178,8 +178,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
         snapshot != null ? snapshot.allManifests(ops().io()) : Collections.emptyList();
     Set<ManifestFile> currentManifestSet = ImmutableSet.copyOf(currentManifests);
 
-    validateDeletedManifests(
-        currentManifestSet, snapshot != null ? snapshot.snapshotId() : -1L);
+    validateDeletedManifests(currentManifestSet, snapshot != null ? snapshot.snapshotId() : -1L);
 
     if (requiresRewrite(currentManifestSet)) {
       performRewrite(currentManifests);

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -84,6 +84,12 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
   }
 
   @Override
+  public RewriteManifests toBranch(String branch) {
+    targetBranch(branch);
+    return this;
+  }
+
+  @Override
   protected String operation() {
     return DataOperations.REPLACE;
   }
@@ -168,10 +174,12 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
 
   @Override
   public List<ManifestFile> apply(TableMetadata base, Snapshot snapshot) {
-    List<ManifestFile> currentManifests = base.currentSnapshot().allManifests(ops().io());
+    List<ManifestFile> currentManifests =
+        snapshot != null ? snapshot.allManifests(ops().io()) : Collections.emptyList();
     Set<ManifestFile> currentManifestSet = ImmutableSet.copyOf(currentManifests);
 
-    validateDeletedManifests(currentManifestSet, base.currentSnapshot().snapshotId());
+    validateDeletedManifests(
+        currentManifestSet, snapshot != null ? snapshot.snapshotId() : -1L);
 
     if (requiresRewrite(currentManifestSet)) {
       performRewrite(currentManifests);

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -1085,8 +1085,7 @@ public class TestRewriteManifests extends TestBase {
     assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotId);
 
     // branch snapshot must reflect the rewrite
-    Snapshot branchSnapshot =
-        table.snapshot(table.ops().current().ref("branch").snapshotId());
+    Snapshot branchSnapshot = table.snapshot(table.ops().current().ref("branch").snapshotId());
     assertThat(branchSnapshot.allManifests(table.io())).hasSize(1);
     validateManifestEntries(
         branchSnapshot.allManifests(table.io()).get(0),

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -1072,16 +1072,27 @@ public class TestRewriteManifests extends TestBase {
   }
 
   @TestTemplate
-  public void testRewriteManifestsOnBranchUnsupported() {
-
+  public void testRewriteManifestsOnBranch() {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    long mainSnapshotId = table.currentSnapshot().snapshotId();
+    table.manageSnapshots().createBranch("branch", mainSnapshotId).commit();
 
     assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
-    assertThatThrownBy(() -> table.rewriteManifests().toBranch("someBranch").commit())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage(
-            "Cannot commit to branch someBranch: org.apache.iceberg.BaseRewriteManifests does not support branch commits");
+    table.rewriteManifests().clusterBy(file -> "").toBranch("branch").commit();
+
+    // main snapshot must not have changed
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotId);
+
+    // branch snapshot must reflect the rewrite
+    Snapshot branchSnapshot =
+        table.snapshot(table.ops().current().ref("branch").snapshotId());
+    assertThat(branchSnapshot.allManifests(table.io())).hasSize(1);
+    validateManifestEntries(
+        branchSnapshot.allManifests(table.io()).get(0),
+        ids(mainSnapshotId, mainSnapshotId),
+        files(FILE_A, FILE_B),
+        statuses(ManifestEntry.Status.EXISTING, ManifestEntry.Status.EXISTING));
   }
 
   @TestTemplate


### PR DESCRIPTION
### What

Add support for committing a `rewriteManifests` operation to a named branch via `toBranch(String branch)`.

### Why

**Manifest clustering for scan performance**

In tables with many partitions, manifest files that span multiple partitions cannot be pruned during planning even after the manifest list has been read. Rewriting manifests clustered by partition (`.clusterBy(DataFile::partition)`) significantly reduces the metadata read overhead for single-partition scans.

**Write-Audit-Publish (WAP) workflow**

Our ingestion pipeline follows a WAP pattern: data is written to a branch, verified, and then merged into `main`. Before merging, we want to compact and cluster the branch's manifests so that `main` remains efficient after the merge. Without branch support in `rewriteManifests`, this step is not possible without merging unoptimised metadata first.