### PR TITLE
Core: Add fromId to EntryStatus and ManifestEntry.Status

### DIFF
--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -26,7 +26,6 @@ import org.apache.iceberg.types.Types;
 
 class GenericManifestEntry<F extends ContentFile<F>>
     implements ManifestEntry<F>, IndexedRecord, SpecificData.SchemaConstructable, StructLike {
-  private static final Status[] STATUS_VALUES = Status.values();
   private final org.apache.avro.Schema schema;
   private Status status = Status.EXISTING;
   private Long snapshotId = null;
@@ -159,7 +158,7 @@ class GenericManifestEntry<F extends ContentFile<F>>
   public void put(int i, Object v) {
     switch (i) {
       case 0:
-        this.status = STATUS_VALUES[(Integer) v];
+        this.status = Status.fromId((Integer) v);
         return;
       case 1:
         this.snapshotId = (Long) v;

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -40,8 +40,6 @@ public class GenericManifestFile extends SupportsIndexProjection
     implements ManifestFile, StructLike, IndexedRecord, SchemaConstructable, Serializable {
   private static final Schema AVRO_SCHEMA =
       AvroSchemaUtil.convert(ManifestFile.schema(), "manifest_file");
-  private static final ManifestContent[] MANIFEST_CONTENT_VALUES = ManifestContent.values();
-
   private transient Schema avroSchema; // not final for Java serialization
 
   // data fields
@@ -343,7 +341,7 @@ public class GenericManifestFile extends SupportsIndexProjection
         return;
       case 3:
         this.content =
-            value != null ? MANIFEST_CONTENT_VALUES[(Integer) value] : ManifestContent.DATA;
+            value != null ? ManifestContent.fromId((Integer) value) : ManifestContent.DATA;
         return;
       case 4:
         this.sequenceNumber = value != null ? (Long) value : 0;

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -30,6 +30,8 @@ interface ManifestEntry<F extends ContentFile<F>> {
     ADDED(1),
     DELETED(2);
 
+    private static final Status[] VALUES = Status.values();
+
     private final int id;
 
     Status(int id) {
@@ -38,6 +40,10 @@ interface ManifestEntry<F extends ContentFile<F>> {
 
     public int id() {
       return id;
+    }
+
+    static Status fromId(int id) {
+      return VALUES[id];
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestEntryStatus.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntryStatus.java
@@ -18,27 +18,31 @@
  */
 package org.apache.iceberg;
 
-/** Status of an entry in a manifest file. */
-enum EntryStatus {
-  EXISTING(0),
-  ADDED(1),
-  DELETED(2),
-  /** Indicates an entry that has been replaced by a column update or DV change. Added in v4. */
-  REPLACED(3);
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-  private static final EntryStatus[] VALUES = EntryStatus.values();
+import java.util.stream.IntStream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
-  private final int id;
+class TestEntryStatus {
 
-  EntryStatus(int id) {
-    this.id = id;
+  @ParameterizedTest
+  @EnumSource(EntryStatus.class)
+  void fromId(EntryStatus status) {
+    assertThat(EntryStatus.fromId(status.id())).isEqualTo(status);
   }
 
-  public int id() {
-    return id;
+  static IntStream invalidIds() {
+    return IntStream.of(-1, EntryStatus.values().length);
   }
 
-  static EntryStatus fromId(int id) {
-    return VALUES[id];
+  @ParameterizedTest
+  @MethodSource("invalidIds")
+  void fromIdInvalid(int id) {
+    assertThatThrownBy(() -> EntryStatus.fromId(id))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining(String.valueOf(id));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestEntryStatus.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestEntryStatus.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.IntStream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TestManifestEntryStatus {
+
+  @ParameterizedTest
+  @EnumSource(ManifestEntry.Status.class)
+  void fromId(ManifestEntry.Status status) {
+    assertThat(ManifestEntry.Status.fromId(status.id())).isEqualTo(status);
+  }
+
+  static IntStream invalidIds() {
+    return IntStream.of(-1, ManifestEntry.Status.values().length);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidIds")
+  void fromIdInvalid(int id) {
+    assertThatThrownBy(() -> ManifestEntry.Status.fromId(id))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessageContaining(String.valueOf(id));
+  }
+}


### PR DESCRIPTION
Move the cached values() array lookup into the enums themselves and update callers.

This is a code cleanup similar to https://github.com/apache/iceberg/pull/15953