### PR TITLE
API: Fix AllowMissing bug and Add Unit tests for StructProjection class

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -123,7 +123,9 @@ public class StructProjection implements StructLike {
             case STRUCT:
               nestedProjections[pos] =
                   new StructProjection(
-                      dataField.type().asStructType(), projectedField.type().asStructType(), allowMissing);
+                      dataField.type().asStructType(),
+                      projectedField.type().asStructType(),
+                      allowMissing);
               break;
             case MAP:
               MapType projectedMap = projectedField.type().asMapType();

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -123,7 +123,7 @@ public class StructProjection implements StructLike {
             case STRUCT:
               nestedProjections[pos] =
                   new StructProjection(
-                      dataField.type().asStructType(), projectedField.type().asStructType());
+                      dataField.type().asStructType(), projectedField.type().asStructType(), allowMissing);
               break;
             case MAP:
               MapType projectedMap = projectedField.type().asMapType();

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -28,7 +28,13 @@ import java.util.Set;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers;
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.DoubleType;
+import org.apache.iceberg.types.Types.IntegerType;
+import org.apache.iceberg.types.Types.ListType;
+import org.apache.iceberg.types.Types.LongType;
+import org.apache.iceberg.types.Types.MapType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.Test;
 
@@ -37,11 +43,11 @@ public class TestStructProjection {
   public void projectSubsetOfSchemaFields() {
     Schema dataSchema =
         new Schema(
-            required(10, "id", Types.LongType.get()),
-            required(20, "name", Types.StringType.get()),
-            required(30, "value", Types.IntegerType.get()));
+            required(10, "id", LongType.get()),
+            required(20, "name", StringType.get()),
+            required(30, "value", IntegerType.get()));
 
-    Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
+    Schema projectedSchema = new Schema(required(30, "value", IntegerType.get()));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
@@ -59,11 +65,11 @@ public class TestStructProjection {
   public void getThrowsClassCastExceptionForWrongType() {
     Schema dataSchema =
         new Schema(
-            required(10, "id", Types.LongType.get()),
-            required(20, "name", Types.StringType.get()),
-            required(30, "value", Types.IntegerType.get()));
+            required(10, "id", LongType.get()),
+            required(20, "name", StringType.get()),
+            required(30, "value", IntegerType.get()));
 
-    Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
+    Schema projectedSchema = new Schema(required(30, "value", IntegerType.get()));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
@@ -81,11 +87,11 @@ public class TestStructProjection {
   public void getThrowsForOutOfBoundsIndex() {
     Schema dataSchema =
         new Schema(
-            required(10, "id", Types.LongType.get()),
-            required(20, "name", Types.StringType.get()),
-            required(30, "value", Types.IntegerType.get()));
+            required(10, "id", LongType.get()),
+            required(20, "name", StringType.get()),
+            required(30, "value", IntegerType.get()));
 
-    Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
+    Schema projectedSchema = new Schema(required(30, "value", IntegerType.get()));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
@@ -101,11 +107,11 @@ public class TestStructProjection {
   public void setOnProjectionThrows() {
     Schema dataSchema =
         new Schema(
-            required(10, "id", Types.LongType.get()),
-            required(20, "name", Types.StringType.get()),
-            required(30, "value", Types.IntegerType.get()));
+            required(10, "id", LongType.get()),
+            required(20, "name", StringType.get()),
+            required(30, "value", IntegerType.get()));
 
-    Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
+    Schema projectedSchema = new Schema(required(30, "value", IntegerType.get()));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
@@ -123,18 +129,18 @@ public class TestStructProjection {
   public void projectNestedStructSubfields() {
     Schema dataSchema =
         new Schema(
-            required(1, "id", Types.LongType.get()),
+            required(1, "id", LongType.get()),
             required(
                 2,
                 "address",
                 StructType.of(
-                    required(10, "street", Types.StringType.get()),
+                    required(10, "street", StringType.get()),
                     required(
                         20,
                         "coordinates",
                         StructType.of(
-                            required(100, "latitude", Types.DoubleType.get()),
-                            required(200, "longitude", Types.DoubleType.get()))))));
+                            required(100, "latitude", DoubleType.get()),
+                            required(200, "longitude", DoubleType.get()))))));
 
     Schema projectedSchema =
         new Schema(
@@ -145,7 +151,7 @@ public class TestStructProjection {
                     required(
                         20,
                         "coordinates",
-                        StructType.of(required(200, "longitude", Types.DoubleType.get()))))));
+                        StructType.of(required(200, "longitude", DoubleType.get()))))));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
@@ -168,12 +174,11 @@ public class TestStructProjection {
 
   @Test
   public void createAllowMissingWithAbsentOptionalFieldReturnsNull() {
-    Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
+    Schema dataSchema = new Schema(required(10, "id", LongType.get()));
 
     StructType projectedStructType =
         StructType.of(
-            required(10, "id", Types.LongType.get()),
-            Types.NestedField.optional(20, "name", Types.StringType.get()));
+            required(10, "id", LongType.get()), NestedField.optional(20, "name", StringType.get()));
 
     StructProjection projection =
         StructProjection.createAllowMissing(dataSchema.asStruct(), projectedStructType);
@@ -189,12 +194,11 @@ public class TestStructProjection {
 
   @Test
   public void createThrowsWhenOptionalFieldAbsent() {
-    Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
+    Schema dataSchema = new Schema(required(10, "id", LongType.get()));
 
     StructType projectedStructType =
         StructType.of(
-            required(10, "id", Types.LongType.get()),
-            Types.NestedField.optional(20, "name", Types.StringType.get()));
+            required(10, "id", LongType.get()), NestedField.optional(20, "name", StringType.get()));
 
     assertThatThrownBy(() -> StructProjection.create(dataSchema.asStruct(), projectedStructType))
         .isInstanceOf(IllegalArgumentException.class)
@@ -203,11 +207,10 @@ public class TestStructProjection {
 
   @Test
   public void createAllowMissingThrowsWhenRequiredFieldAbsent() {
-    Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
+    Schema dataSchema = new Schema(required(10, "id", LongType.get()));
 
     StructType projectedStructType =
-        StructType.of(
-            required(10, "id", Types.LongType.get()), required(20, "name", Types.StringType.get()));
+        StructType.of(required(10, "id", LongType.get()), required(20, "name", StringType.get()));
 
     assertThatThrownBy(
             () -> StructProjection.createAllowMissing(dataSchema.asStruct(), projectedStructType))
@@ -217,11 +220,10 @@ public class TestStructProjection {
 
   @Test
   public void createThrowsWhenRequiredFieldAbsent() {
-    Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
+    Schema dataSchema = new Schema(required(10, "id", LongType.get()));
 
     StructType projectedStructType =
-        StructType.of(
-            required(10, "id", Types.LongType.get()), required(20, "name", Types.StringType.get()));
+        StructType.of(required(10, "id", LongType.get()), required(20, "name", StringType.get()));
 
     assertThatThrownBy(() -> StructProjection.create(dataSchema.asStruct(), projectedStructType))
         .isInstanceOf(IllegalArgumentException.class)
@@ -233,30 +235,18 @@ public class TestStructProjection {
   public void projectMapWithNestedStructAndPrimitiveValues() {
     StructType coordinatesStruct =
         StructType.of(
-            required(100, "latitude", Types.DoubleType.get()),
-            required(200, "longitude", Types.DoubleType.get()));
+            required(100, "latitude", DoubleType.get()),
+            required(200, "longitude", DoubleType.get()));
 
     Schema dataSchema =
         new Schema(
-            required(1, "id", Types.LongType.get()),
-            required(
-                2,
-                "address",
-                Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinatesStruct)),
-            required(
-                5,
-                "metadata",
-                Types.MapType.ofRequired(6, 7, Types.StringType.get(), Types.StringType.get())));
+            required(1, "id", LongType.get()),
+            required(2, "address", MapType.ofRequired(3, 4, StringType.get(), coordinatesStruct)),
+            required(5, "metadata", MapType.ofRequired(6, 7, StringType.get(), StringType.get())));
     Schema projectedSchema =
         new Schema(
-            required(
-                2,
-                "address",
-                Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinatesStruct)),
-            required(
-                5,
-                "metadata",
-                Types.MapType.ofRequired(6, 7, Types.StringType.get(), Types.StringType.get())));
+            required(2, "address", MapType.ofRequired(3, 4, StringType.get(), coordinatesStruct)),
+            required(5, "metadata", MapType.ofRequired(6, 7, StringType.get(), StringType.get())));
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
     TestHelpers.Row coordinates = TestHelpers.Row.of(42.00, 24.00);
@@ -282,16 +272,16 @@ public class TestStructProjection {
   @Test
   @SuppressWarnings("unchecked")
   public void projectListWithPrimitiveAndStructElements() {
-    StructType elementStruct = StructType.of(required(200, "point", Types.DoubleType.get()));
+    StructType elementStruct = StructType.of(required(200, "point", DoubleType.get()));
     Schema dataSchema =
         new Schema(
-            required(1, "id", Types.LongType.get()),
-            required(2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())),
-            required(4, "points", Types.ListType.ofRequired(5, elementStruct)));
+            required(1, "id", LongType.get()),
+            required(2, "numbers", ListType.ofRequired(3, StringType.get())),
+            required(4, "points", ListType.ofRequired(5, elementStruct)));
     Schema projectedSchema =
         new Schema(
-            required(2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())),
-            required(4, "points", Types.ListType.ofRequired(5, elementStruct)));
+            required(2, "numbers", ListType.ofRequired(3, StringType.get())),
+            required(4, "points", ListType.ofRequired(5, elementStruct)));
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
     TestHelpers.Row points = TestHelpers.Row.of(1.0, 2.0);
@@ -308,9 +298,9 @@ public class TestStructProjection {
   public void createProjectionFromFieldIds() {
     Schema dataSchema =
         new Schema(
-            required(10, "id", Types.LongType.get()),
-            required(20, "name", Types.StringType.get()),
-            required(30, "value", Types.IntegerType.get()));
+            required(10, "id", LongType.get()),
+            required(20, "name", StringType.get()),
+            required(30, "value", IntegerType.get()));
 
     StructProjection projection = StructProjection.create(dataSchema, Set.of(30, 20));
 
@@ -327,11 +317,11 @@ public class TestStructProjection {
   public void copyForCreatesIndependentProjection() {
     StructType dataSchema =
         StructType.of(
-            required(10, "id", Types.LongType.get()),
-            required(20, "name", Types.StringType.get()),
-            required(30, "value", Types.IntegerType.get()));
+            required(10, "id", LongType.get()),
+            required(20, "name", StringType.get()),
+            required(30, "value", IntegerType.get()));
 
-    StructType projectedSchema = StructType.of(required(30, "value", Types.IntegerType.get()));
+    StructType projectedSchema = StructType.of(required(30, "value", IntegerType.get()));
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
     TestHelpers.Row row1 = TestHelpers.Row.of(1L, "Batman", 42);
@@ -351,27 +341,27 @@ public class TestStructProjection {
   public void createThrowsForPartialMapValueStructProjection() {
     Schema dataSchema =
         new Schema(
-            required(1, "id", Types.LongType.get()),
+            required(1, "id", LongType.get()),
             required(
                 2,
                 "address",
-                Types.MapType.ofRequired(
+                MapType.ofRequired(
                     3,
                     4,
-                    Types.StringType.get(),
+                    StringType.get(),
                     StructType.of(
-                        required(100, "latitude", Types.DoubleType.get()),
-                        required(200, "longitude", Types.DoubleType.get())))));
+                        required(100, "latitude", DoubleType.get()),
+                        required(200, "longitude", DoubleType.get())))));
     Schema projectedSchema =
         new Schema(
             required(
                 2,
                 "address",
-                Types.MapType.ofRequired(
+                MapType.ofRequired(
                     3,
                     4,
-                    Types.StringType.get(),
-                    StructType.of(required(200, "longitude", Types.DoubleType.get())))));
+                    StringType.get(),
+                    StructType.of(required(200, "longitude", DoubleType.get())))));
 
     assertThatThrownBy(() -> StructProjection.create(dataSchema, projectedSchema))
         .isInstanceOf(IllegalArgumentException.class)
@@ -381,14 +371,12 @@ public class TestStructProjection {
   @Test
   @SuppressWarnings("unchecked")
   public void projectMapWithNestedStructKey() {
-    StructType keyStruct = StructType.of(required(100, "region", Types.StringType.get()));
+    StructType keyStruct = StructType.of(required(100, "region", StringType.get()));
 
     Schema dataSchema =
-        new Schema(
-            required(2, "data", Types.MapType.ofRequired(3, 4, keyStruct, Types.StringType.get())));
+        new Schema(required(2, "data", MapType.ofRequired(3, 4, keyStruct, StringType.get())));
     Schema projectedSchema =
-        new Schema(
-            required(2, "data", Types.MapType.ofRequired(3, 4, keyStruct, Types.StringType.get())));
+        new Schema(required(2, "data", MapType.ofRequired(3, 4, keyStruct, StringType.get())));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
     TestHelpers.Row key = TestHelpers.Row.of("US");
@@ -406,24 +394,24 @@ public class TestStructProjection {
             required(
                 1,
                 "delivery_map",
-                Types.MapType.ofRequired(
+                MapType.ofRequired(
                     2,
                     3,
                     StructType.of(
-                        required(100, "city", Types.StringType.get()),
-                        required(101, "zip", Types.IntegerType.get())),
-                    Types.StringType.get())));
+                        required(100, "city", StringType.get()),
+                        required(101, "zip", IntegerType.get())),
+                    StringType.get())));
 
     Schema projectedSchema =
         new Schema(
             required(
                 1,
                 "delivery_map",
-                Types.MapType.ofRequired(
+                MapType.ofRequired(
                     2,
                     3,
-                    StructType.of(required(100, "city", Types.StringType.get())),
-                    Types.StringType.get())));
+                    StructType.of(required(100, "city", StringType.get())),
+                    StringType.get())));
 
     assertThatThrownBy(() -> StructProjection.create(dataSchema, projectedSchema))
         .isInstanceOf(IllegalArgumentException.class)
@@ -434,22 +422,22 @@ public class TestStructProjection {
   public void createThrowsForPartialListElementStructProjection() {
     Schema dataSchema =
         new Schema(
-            required(1, "id", Types.LongType.get()),
+            required(1, "id", LongType.get()),
             required(
                 2,
                 "address",
-                Types.ListType.ofRequired(
+                ListType.ofRequired(
                     3,
                     StructType.of(
-                        required(100, "latitude", Types.DoubleType.get()),
-                        required(200, "longitude", Types.DoubleType.get())))));
+                        required(100, "latitude", DoubleType.get()),
+                        required(200, "longitude", DoubleType.get())))));
     Schema projectedSchema =
         new Schema(
             required(
                 2,
                 "address",
-                Types.ListType.ofRequired(
-                    3, StructType.of(required(200, "longitude", Types.DoubleType.get())))));
+                ListType.ofRequired(
+                    3, StructType.of(required(200, "longitude", DoubleType.get())))));
 
     assertThatThrownBy(() -> StructProjection.create(dataSchema, projectedSchema))
         .isInstanceOf(IllegalArgumentException.class)
@@ -460,11 +448,10 @@ public class TestStructProjection {
   public void getReturnsNullForNullNestedStruct() {
     Schema dataSchema =
         new Schema(
-            required(1, "id", Types.LongType.get()),
-            required(2, "address", StructType.of(required(10, "street", Types.StringType.get()))));
+            required(1, "id", LongType.get()),
+            required(2, "address", StructType.of(required(10, "street", StringType.get()))));
     Schema projectedSchema =
-        new Schema(
-            required(2, "address", StructType.of(required(10, "street", Types.StringType.get()))));
+        new Schema(required(2, "address", StructType.of(required(10, "street", StringType.get()))));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
     TestHelpers.Row row = TestHelpers.Row.of(1L, null);
@@ -475,20 +462,19 @@ public class TestStructProjection {
 
   @Test
   public void createAllowMissingPropagatesAllowMissingToNestedStructs() {
-    StructType dataAddressType = StructType.of(required(10, "street", Types.StringType.get()));
+    StructType dataAddressType = StructType.of(required(10, "street", StringType.get()));
 
     StructType projectedAddressType =
         StructType.of(
-            required(10, "street", Types.StringType.get()),
-            Types.NestedField.optional(20, "city", Types.StringType.get()));
+            required(10, "street", StringType.get()),
+            NestedField.optional(20, "city", StringType.get()));
 
     StructType dataStructType =
-        StructType.of(
-            required(1, "id", Types.LongType.get()), required(2, "address", dataAddressType));
+        StructType.of(required(1, "id", LongType.get()), required(2, "address", dataAddressType));
 
     StructType projectedStructType =
         StructType.of(
-            required(1, "id", Types.LongType.get()), required(2, "address", projectedAddressType));
+            required(1, "id", LongType.get()), required(2, "address", projectedAddressType));
 
     StructProjection projection =
         StructProjection.createAllowMissing(dataStructType, projectedStructType);

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -55,10 +55,12 @@ public class TestStructProjection {
     assertThat(projection.get(0, Integer.class)).isEqualTo(42);
 
     assertThatThrownBy(() -> projection.get(0, String.class))
-        .isInstanceOf(ClassCastException.class);
+        .isInstanceOf(ClassCastException.class)
+        .hasMessage("Cannot cast java.lang.Integer to java.lang.String");
 
     assertThatThrownBy(() -> projection.get(1, Integer.class))
-        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class)
+        .hasMessage("Index 1 out of bounds for length 1");
 
     assertThatThrownBy(() -> projection.set(0, 5))
         .isInstanceOf(UnsupportedOperationException.class)
@@ -144,8 +146,7 @@ public class TestStructProjection {
 
     assertThatThrownBy(() -> StructProjection.create(dataSchema.asStruct(), projectedStructType))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "Cannot find field 20: name: optional string in struct<10: id: required long>");
+        .hasMessage("Cannot find field 20: name: optional string in struct<10: id: required long>");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.util;
 
+import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.Test;
 
 public class TestStructProjection {
@@ -33,12 +35,11 @@ public class TestStructProjection {
   public void testSubsetProjection() {
     Schema dataSchema =
         new Schema(
-            Types.NestedField.required(10, "id", Types.LongType.get()),
-            Types.NestedField.required(20, "name", Types.StringType.get()),
-            Types.NestedField.required(30, "value", Types.IntegerType.get()));
+            required(10, "id", Types.LongType.get()),
+            required(20, "name", Types.StringType.get()),
+            required(30, "value", Types.IntegerType.get()));
 
-    Schema projectedSchema =
-        new Schema(Types.NestedField.required(30, "value", Types.IntegerType.get()));
+    Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
 
     StructProjection projectedStructure = StructProjection.create(dataSchema, projectedSchema);
 
@@ -52,30 +53,28 @@ public class TestStructProjection {
 
   @Test
   public void testNestedProjection() {
-    Types.StructType dataCoordinateStruct =
-        Types.StructType.of(
-            Types.NestedField.required(100, "latitude", Types.DoubleType.get()),
-            Types.NestedField.required(200, "longitude", Types.DoubleType.get()));
-
-    Types.StructType dataAddressStruct =
-        Types.StructType.of(
-            Types.NestedField.required(10, "street", Types.StringType.get()),
-            Types.NestedField.required(20, "coordinates", dataCoordinateStruct));
-
     Schema dataSchema =
         new Schema(
-            Types.NestedField.required(1, "id", Types.LongType.get()),
-            Types.NestedField.required(2, "address", dataAddressStruct));
+            required(1, "id", Types.LongType.get()),
+            required(
+                2,
+                "address",
+                StructType.of(
+                    required(10, "street", Types.StringType.get()),
+                    required(
+                        20,
+                        "coordinates",
+                        StructType.of(
+                            required(100, "latitude", Types.DoubleType.get()),
+                            required(200, "longitude", Types.DoubleType.get()))))));
 
-    Types.StructType projectedCoordinateStruct =
-        Types.StructType.of(Types.NestedField.required(200, "longitude", Types.DoubleType.get()));
+    StructType projectedCoordinateStruct =
+        StructType.of(required(200, "longitude", Types.DoubleType.get()));
 
-    Types.StructType projectedAddressStruct =
-        Types.StructType.of(
-            Types.NestedField.required(20, "coordinates", projectedCoordinateStruct));
+    StructType projectedAddressStruct =
+        StructType.of(required(20, "coordinates", projectedCoordinateStruct));
 
-    Schema projectedSchema =
-        new Schema(Types.NestedField.required(2, "address", projectedAddressStruct));
+    Schema projectedSchema = new Schema(required(2, "address", projectedAddressStruct));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
@@ -97,11 +96,11 @@ public class TestStructProjection {
 
   @Test
   public void testAllowMissingOptionalField() {
-    Schema dataSchema = new Schema(Types.NestedField.required(10, "id", Types.LongType.get()));
+    Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
 
-    Types.StructType projectedStructType =
-        Types.StructType.of(
-            Types.NestedField.required(10, "id", Types.LongType.get()),
+    StructType projectedStructType =
+        StructType.of(
+            required(10, "id", Types.LongType.get()),
             Types.NestedField.optional(20, "name", Types.StringType.get()));
 
     StructProjection projection =
@@ -116,21 +115,21 @@ public class TestStructProjection {
 
   @Test
   public void testMapWithNestedValueFullMatch() {
-    Types.StructType coordinateStruct =
-        Types.StructType.of(
-            Types.NestedField.required(100, "latitude", Types.DoubleType.get()),
-            Types.NestedField.required(200, "longitude", Types.DoubleType.get()));
+    StructType coordinateStruct =
+        StructType.of(
+            required(100, "latitude", Types.DoubleType.get()),
+            required(200, "longitude", Types.DoubleType.get()));
 
     Schema dataSchema =
         new Schema(
-            Types.NestedField.required(1, "id", Types.LongType.get()),
-            Types.NestedField.required(
+            required(1, "id", Types.LongType.get()),
+            required(
                 2,
                 "address",
                 Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinateStruct)));
     Schema projectedSchema =
         new Schema(
-            Types.NestedField.required(
+            required(
                 2,
                 "address",
                 Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinateStruct)));
@@ -154,13 +153,10 @@ public class TestStructProjection {
   public void testListWithFullMatch() {
     Schema dataSchema =
         new Schema(
-            Types.NestedField.required(1, "id", Types.LongType.get()),
-            Types.NestedField.required(
-                2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())));
+            required(1, "id", Types.LongType.get()),
+            required(2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())));
     Schema projectedSchema =
-        new Schema(
-            Types.NestedField.required(
-                2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())));
+        new Schema(required(2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())));
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
     TestHelpers.Row row = TestHelpers.Row.of(1L, List.of("a", "b", "c"));

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -20,9 +20,11 @@ package org.apache.iceberg.util;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers;
@@ -32,7 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public class TestStructProjection {
   @Test
-  public void testSubsetProjection() {
+  public void testProjectSubsetOfSchemaFields() {
     Schema dataSchema =
         new Schema(
             required(10, "id", Types.LongType.get()),
@@ -41,18 +43,30 @@ public class TestStructProjection {
 
     Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
 
-    StructProjection projectedStructure = StructProjection.create(dataSchema, projectedSchema);
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+
+    assertThat(projection.get(0, Integer.class)).isNull();
 
     TestHelpers.Row row = TestHelpers.Row.of(1L, "Batman", 42);
+    projection.wrap(row);
 
-    projectedStructure.wrap(row);
+    assertThat(projection.size()).isEqualTo(1);
+    assertThat(projection.projectedFields()).isEqualTo(1);
+    assertThat(projection.get(0, Integer.class)).isEqualTo(42);
 
-    assertThat(projectedStructure.size()).isEqualTo(1);
-    assertThat(projectedStructure.get(0, Integer.class)).isEqualTo(42);
+    assertThatThrownBy(() -> projection.get(0, String.class))
+        .isInstanceOf(ClassCastException.class);
+
+    assertThatThrownBy(() -> projection.get(1, Integer.class))
+        .isInstanceOf(ArrayIndexOutOfBoundsException.class);
+
+    assertThatThrownBy(() -> projection.set(0, 5))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot set fields in a TypeProjection");
   }
 
   @Test
-  public void testNestedProjection() {
+  public void testProjectNestedStructSubfields() {
     Schema dataSchema =
         new Schema(
             required(1, "id", Types.LongType.get()),
@@ -94,11 +108,12 @@ public class TestStructProjection {
     StructLike coordinatesProjection = addressProjection.get(0, StructLike.class);
     assertThat(coordinatesProjection).isNotNull();
     assertThat(coordinatesProjection.size()).isEqualTo(1);
+    assertThat(projection.projectedFields()).isEqualTo(1);
     assertThat(coordinatesProjection.get(0, Double.class)).isEqualTo(24.00);
   }
 
   @Test
-  public void testAllowMissingOptionalField() {
+  public void testCreateAllowMissingWithAbsentOptionalFieldReturnsNull() {
     Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
 
     StructType projectedStructType =
@@ -112,13 +127,58 @@ public class TestStructProjection {
     TestHelpers.Row row = TestHelpers.Row.of(1L);
     projection.wrap(row);
 
+    assertThat(projection.size()).isEqualTo(2);
+    assertThat(projection.projectedFields()).isEqualTo(1);
     assertThat(projection.get(0, Long.class)).isEqualTo(1L);
     assertThat(projection.get(1, String.class)).isNull();
   }
 
   @Test
-  public void testMapWithNestedValueFullMatch() {
-    StructType coordinateStruct =
+  public void testCreateThrowsWhenOptionalFieldAbsent() {
+    Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
+
+    StructType projectedStructType =
+        StructType.of(
+            required(10, "id", Types.LongType.get()),
+            Types.NestedField.optional(20, "name", Types.StringType.get()));
+
+    assertThatThrownBy(() -> StructProjection.create(dataSchema.asStruct(), projectedStructType))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot find field 20: name: optional string in struct<10: id: required long>");
+  }
+
+  @Test
+  public void testCreateAllowMissingThrowsWhenRequiredFieldAbsent() {
+    Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
+
+    StructType projectedStructType =
+        StructType.of(
+            required(10, "id", Types.LongType.get()), required(20, "name", Types.StringType.get()));
+
+    assertThatThrownBy(
+            () -> StructProjection.createAllowMissing(dataSchema.asStruct(), projectedStructType))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot find field 20: name: required string in struct<10: id: required long>");
+  }
+
+  @Test
+  public void testCreateThrowsWhenRequiredFieldAbsent() {
+    Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
+
+    StructType projectedStructType =
+        StructType.of(
+            required(10, "id", Types.LongType.get()), required(20, "name", Types.StringType.get()));
+
+    assertThatThrownBy(() -> StructProjection.create(dataSchema.asStruct(), projectedStructType))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot find field 20: name: required string in struct<10: id: required long>");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testProjectMapWithNestedStructAndPrimitiveValues() {
+    StructType coordinatesStruct =
         StructType.of(
             required(100, "latitude", Types.DoubleType.get()),
             required(200, "longitude", Types.DoubleType.get()));
@@ -129,20 +189,34 @@ public class TestStructProjection {
             required(
                 2,
                 "address",
-                Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinateStruct)));
+                Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinatesStruct)),
+            required(
+                5,
+                "metadata",
+                Types.MapType.ofRequired(6, 7, Types.StringType.get(), Types.StringType.get())));
     Schema projectedSchema =
         new Schema(
             required(
                 2,
                 "address",
-                Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinateStruct)));
+                Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinatesStruct)),
+            required(
+                5,
+                "metadata",
+                Types.MapType.ofRequired(6, 7, Types.StringType.get(), Types.StringType.get())));
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
     TestHelpers.Row coordinates = TestHelpers.Row.of(42.00, 24.00);
     Map<String, TestHelpers.Row> location = Map.of("home", coordinates);
-    TestHelpers.Row row = TestHelpers.Row.of(1L, location);
+    Map<String, String> userDetail = Map.of("type", "administrator");
+    TestHelpers.Row row = TestHelpers.Row.of(1L, location, userDetail);
 
     projection.wrap(row);
+
+    assertThat(projection.size()).isEqualTo(2);
+    assertThat(projection.projectedFields()).isEqualTo(2);
+
+    assertThat(projection.get(1, Map.class)).isEqualTo(Map.of("type", "administrator"));
 
     Map<String, TestHelpers.Row> projectedLocations = projection.get(0, Map.class);
     assertThat(projectedLocations).isNotNull().containsKey("home");
@@ -153,18 +227,144 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testListWithFullMatch() {
+  @SuppressWarnings("unchecked")
+  public void testProjectListWithPrimitiveAndStructElements() {
+    StructType elementStruct = StructType.of(required(200, "point", Types.DoubleType.get()));
     Schema dataSchema =
         new Schema(
             required(1, "id", Types.LongType.get()),
-            required(2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())));
+            required(2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())),
+            required(4, "points", Types.ListType.ofRequired(5, elementStruct)));
     Schema projectedSchema =
-        new Schema(required(2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())));
+        new Schema(
+            required(2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())),
+            required(4, "points", Types.ListType.ofRequired(5, elementStruct)));
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 
-    TestHelpers.Row row = TestHelpers.Row.of(1L, List.of("a", "b", "c"));
+    TestHelpers.Row points = TestHelpers.Row.of(1.0, 2.0);
+    TestHelpers.Row row = TestHelpers.Row.of(1L, List.of("a", "b", "c"), List.of(points));
     projection.wrap(row);
 
+    assertThat(projection.size()).isEqualTo(2);
+    assertThat(projection.projectedFields()).isEqualTo(2);
     assertThat(projection.get(0, List.class)).containsExactly("a", "b", "c");
+    assertThat(projection.get(1, List.class)).containsExactly(points);
+  }
+
+  @Test
+  public void testCreateProjectionFromFieldIds() {
+    Schema dataSchema =
+        new Schema(
+            required(10, "id", Types.LongType.get()),
+            required(20, "name", Types.StringType.get()),
+            required(30, "value", Types.IntegerType.get()));
+
+    StructProjection projection = StructProjection.create(dataSchema, Set.of(30, 20));
+
+    TestHelpers.Row row = TestHelpers.Row.of(1L, "Batman", 42);
+    projection.wrap(row);
+
+    assertThat(projection.size()).isEqualTo(2);
+    assertThat(projection.projectedFields()).isEqualTo(2);
+    assertThat(projection.get(0, String.class)).isEqualTo("Batman");
+    assertThat(projection.get(1, Integer.class)).isEqualTo(42);
+  }
+
+  @Test
+  public void testCopyForCreatesIndependentProjection() {
+    StructType dataSchema =
+        StructType.of(
+            required(10, "id", Types.LongType.get()),
+            required(20, "name", Types.StringType.get()),
+            required(30, "value", Types.IntegerType.get()));
+
+    StructType projectedSchema = StructType.of(required(30, "value", Types.IntegerType.get()));
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+
+    TestHelpers.Row row1 = TestHelpers.Row.of(1L, "Batman", 42);
+    TestHelpers.Row row2 = TestHelpers.Row.of(1L, "Ironman", 3000);
+    TestHelpers.Row row3 = TestHelpers.Row.of(1L, "Spiderman", 8);
+
+    projection.wrap(row1);
+    StructProjection copyProjection = projection.copyFor(row2);
+    projection.wrap(row3);
+
+    assertThat(projection.size()).isEqualTo(1);
+    assertThat(projection.projectedFields()).isEqualTo(1);
+    assertThat(copyProjection.get(0, Integer.class)).isEqualTo(3000);
+  }
+
+  @Test
+  public void testCreateThrowsForPartialMapValueStructProjection() {
+    Schema dataSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(
+                2,
+                "address",
+                Types.MapType.ofRequired(
+                    3,
+                    4,
+                    Types.StringType.get(),
+                    StructType.of(
+                        required(100, "latitude", Types.DoubleType.get()),
+                        required(200, "longitude", Types.DoubleType.get())))));
+    Schema projectedSchema =
+        new Schema(
+            required(
+                2,
+                "address",
+                Types.MapType.ofRequired(
+                    3,
+                    4,
+                    Types.StringType.get(),
+                    StructType.of(required(200, "longitude", Types.DoubleType.get())))));
+
+    assertThatThrownBy(() -> StructProjection.create(dataSchema, projectedSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot project a partial map key or value struct");
+  }
+
+  @Test
+  public void testCreateThrowsForPartialListElementStructProjection() {
+    Schema dataSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(
+                2,
+                "address",
+                Types.ListType.ofRequired(
+                    3,
+                    StructType.of(
+                        required(100, "latitude", Types.DoubleType.get()),
+                        required(200, "longitude", Types.DoubleType.get())))));
+    Schema projectedSchema =
+        new Schema(
+            required(
+                2,
+                "address",
+                Types.ListType.ofRequired(
+                    3, StructType.of(required(200, "longitude", Types.DoubleType.get())))));
+
+    assertThatThrownBy(() -> StructProjection.create(dataSchema, projectedSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot project a partial list element struct");
+  }
+
+  @Test
+  public void testGetReturnsNullForNullNestedStruct() {
+    Schema dataSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "address", StructType.of(required(10, "street", Types.StringType.get()))));
+    Schema projectedSchema =
+        new Schema(
+            required(2, "address", StructType.of(required(10, "street", Types.StringType.get()))));
+
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+    TestHelpers.Row row = TestHelpers.Row.of(1L, null);
+    projection.wrap(row);
+
+    assertThat(projection.get(0, StructLike.class)).isNull();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -343,6 +343,7 @@ public class TestStructProjection {
     projection.wrap(TestHelpers.Row.of(Map.of(key, "A Country")));
 
     assertThat(projection.size()).isEqualTo(1);
+    assertThat(projection.projectedFields()).isEqualTo(1);
     assertThat(projection.get(0, Map.class)).isEqualTo(Map.of(key, "A Country"));
   }
 
@@ -418,5 +419,38 @@ public class TestStructProjection {
     projection.wrap(row);
 
     assertThat(projection.get(0, StructLike.class)).isNull();
+  }
+
+  @Test
+  public void testCreateAllowMissingPropagatesAllowMissingToNestedStructs() {
+    StructType dataAddressType =
+            StructType.of(required(10, "street", Types.StringType.get()));
+
+    StructType projectedAddressType =
+            StructType.of(
+                    required(10, "street", Types.StringType.get()),
+                    Types.NestedField.optional(20, "city", Types.StringType.get()));
+
+    StructType dataStructType =
+            StructType.of(
+                    required(1, "id", Types.LongType.get()),
+                    required(2, "address", dataAddressType));
+
+    StructType projectedStructType =
+            StructType.of(
+                    required(1, "id", Types.LongType.get()),
+                    required(2, "address", projectedAddressType));
+
+    StructProjection projection =
+            StructProjection.createAllowMissing(dataStructType, projectedStructType);
+
+    TestHelpers.Row nestedRow = TestHelpers.Row.of("123 Main St");
+    TestHelpers.Row row = TestHelpers.Row.of(42L, nestedRow);
+    projection.wrap(row);
+
+    assertThat(projection.get(0, Long.class)).isEqualTo(42L);
+    StructLike addressProjection = projection.get(1, StructLike.class);
+    assertThat(addressProjection.get(0, String.class)).isEqualTo("123 Main St");
+    assertThat(addressProjection.get(1, String.class)).isNull();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -423,26 +423,23 @@ public class TestStructProjection {
 
   @Test
   public void testCreateAllowMissingPropagatesAllowMissingToNestedStructs() {
-    StructType dataAddressType =
-            StructType.of(required(10, "street", Types.StringType.get()));
+    StructType dataAddressType = StructType.of(required(10, "street", Types.StringType.get()));
 
     StructType projectedAddressType =
-            StructType.of(
-                    required(10, "street", Types.StringType.get()),
-                    Types.NestedField.optional(20, "city", Types.StringType.get()));
+        StructType.of(
+            required(10, "street", Types.StringType.get()),
+            Types.NestedField.optional(20, "city", Types.StringType.get()));
 
     StructType dataStructType =
-            StructType.of(
-                    required(1, "id", Types.LongType.get()),
-                    required(2, "address", dataAddressType));
+        StructType.of(
+            required(1, "id", Types.LongType.get()), required(2, "address", dataAddressType));
 
     StructType projectedStructType =
-            StructType.of(
-                    required(1, "id", Types.LongType.get()),
-                    required(2, "address", projectedAddressType));
+        StructType.of(
+            required(1, "id", Types.LongType.get()), required(2, "address", projectedAddressType));
 
     StructProjection projection =
-            StructProjection.createAllowMissing(dataStructType, projectedStructType);
+        StructProjection.createAllowMissing(dataStructType, projectedStructType);
 
     TestHelpers.Row nestedRow = TestHelpers.Row.of("123 Main St");
     TestHelpers.Row row = TestHelpers.Row.of(42L, nestedRow);

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -375,10 +375,8 @@ public class TestStructProjection {
 
     Schema dataSchema =
         new Schema(required(2, "data", MapType.ofRequired(3, 4, keyStruct, StringType.get())));
-    Schema projectedSchema =
-        new Schema(required(2, "data", MapType.ofRequired(3, 4, keyStruct, StringType.get())));
 
-    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+    StructProjection projection = StructProjection.create(dataSchema, dataSchema);
     TestHelpers.Row key = TestHelpers.Row.of("US");
     projection.wrap(TestHelpers.Row.of(Map.of(key, "A Country")));
 

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestStructProjection {
+  @Test
+  public void testSubsetProjection() {
+    Schema dataSchema =
+        new Schema(
+            Types.NestedField.required(10, "id", Types.LongType.get()),
+            Types.NestedField.required(20, "name", Types.StringType.get()),
+            Types.NestedField.required(30, "value", Types.IntegerType.get()));
+
+    Schema projectedSchema =
+        new Schema(Types.NestedField.required(30, "value", Types.IntegerType.get()));
+
+    StructProjection projectedStructure = StructProjection.create(dataSchema, projectedSchema);
+
+    TestHelpers.Row row = TestHelpers.Row.of(1L, "Batman", 42);
+
+    projectedStructure.wrap(row);
+
+    assertThat(projectedStructure.size()).isEqualTo(1);
+    assertThat(projectedStructure.get(0, Integer.class)).isEqualTo(42);
+  }
+
+  @Test
+  public void testNestedProjection() {
+    Types.StructType dataCoordinateStruct =
+        Types.StructType.of(
+            Types.NestedField.required(100, "latitude", Types.DoubleType.get()),
+            Types.NestedField.required(200, "longitude", Types.DoubleType.get()));
+
+    Types.StructType dataAddressStruct =
+        Types.StructType.of(
+            Types.NestedField.required(10, "street", Types.StringType.get()),
+            Types.NestedField.required(20, "coordinates", dataCoordinateStruct));
+
+    Schema dataSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "address", dataAddressStruct));
+
+    Types.StructType projectedCoordinateStruct =
+        Types.StructType.of(Types.NestedField.required(200, "longitude", Types.DoubleType.get()));
+
+    Types.StructType projectedAddressStruct =
+        Types.StructType.of(
+            Types.NestedField.required(20, "coordinates", projectedCoordinateStruct));
+
+    Schema projectedSchema =
+        new Schema(Types.NestedField.required(2, "address", projectedAddressStruct));
+
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+
+    TestHelpers.Row coordinates = TestHelpers.Row.of(42.00, 24.00);
+    TestHelpers.Row address = TestHelpers.Row.of("221B Baker Street", coordinates);
+    TestHelpers.Row row = TestHelpers.Row.of(1L, address);
+
+    projection.wrap(row);
+
+    StructLike addressProjection = projection.get(0, StructLike.class);
+    assertThat(addressProjection).isNotNull();
+    assertThat(addressProjection.size()).isEqualTo(1);
+
+    StructLike coordinatesProjection = addressProjection.get(0, StructLike.class);
+    assertThat(coordinatesProjection).isNotNull();
+    assertThat(coordinatesProjection.size()).isEqualTo(1);
+    assertThat(coordinatesProjection.get(0, Double.class)).isEqualTo(24.00);
+  }
+
+  @Test
+  public void testAllowMissingOptionalField() {
+    Schema dataSchema = new Schema(Types.NestedField.required(10, "id", Types.LongType.get()));
+
+    Types.StructType projectedStructType =
+        Types.StructType.of(
+            Types.NestedField.required(10, "id", Types.LongType.get()),
+            Types.NestedField.optional(20, "name", Types.StringType.get()));
+
+    StructProjection projection =
+        StructProjection.createAllowMissing(dataSchema.asStruct(), projectedStructType);
+
+    TestHelpers.Row row = TestHelpers.Row.of(1L);
+    projection.wrap(row);
+
+    assertThat(projection.get(0, Long.class)).isEqualTo(1L);
+    assertThat(projection.get(1, String.class)).isNull();
+  }
+
+  @Test
+  public void testMapWithNestedValueFullMatch() {
+    Types.StructType coordinateStruct =
+        Types.StructType.of(
+            Types.NestedField.required(100, "latitude", Types.DoubleType.get()),
+            Types.NestedField.required(200, "longitude", Types.DoubleType.get()));
+
+    Schema dataSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(
+                2,
+                "address",
+                Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinateStruct)));
+    Schema projectedSchema =
+        new Schema(
+            Types.NestedField.required(
+                2,
+                "address",
+                Types.MapType.ofRequired(3, 4, Types.StringType.get(), coordinateStruct)));
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+
+    TestHelpers.Row coordinates = TestHelpers.Row.of(42.00, 24.00);
+    Map<String, TestHelpers.Row> location = Map.of("home", coordinates);
+    TestHelpers.Row row = TestHelpers.Row.of(1L, location);
+
+    projection.wrap(row);
+
+    Map<String, TestHelpers.Row> projectedLocations = projection.get(0, Map.class);
+    assertThat(projectedLocations).isNotNull().containsKey("home");
+
+    TestHelpers.Row projectedCoordinatesRow = projectedLocations.get("home");
+    assertThat(projectedCoordinatesRow.get(0, Double.class)).isNotNull().isEqualTo(42.00);
+    assertThat(projectedCoordinatesRow.get(1, Double.class)).isNotNull().isEqualTo(24.00);
+  }
+
+  @Test
+  public void testListWithFullMatch() {
+    Schema dataSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(
+                2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())));
+    Schema projectedSchema =
+        new Schema(
+            Types.NestedField.required(
+                2, "numbers", Types.ListType.ofRequired(3, Types.StringType.get())));
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+
+    TestHelpers.Row row = TestHelpers.Row.of(1L, List.of("a", "b", "c"));
+    projection.wrap(row);
+
+    assertThat(projection.get(0, List.class)).containsExactly("a", "b", "c");
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 
 public class TestStructProjection {
   @Test
-  public void testProjectSubsetOfSchemaFields() {
+  public void projectSubsetOfSchemaFields() {
     Schema dataSchema =
         new Schema(
             required(10, "id", Types.LongType.get()),
@@ -68,7 +68,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testProjectNestedStructSubfields() {
+  public void projectNestedStructSubfields() {
     Schema dataSchema =
         new Schema(
             required(1, "id", Types.LongType.get()),
@@ -115,7 +115,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateAllowMissingWithAbsentOptionalFieldReturnsNull() {
+  public void createAllowMissingWithAbsentOptionalFieldReturnsNull() {
     Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
 
     StructType projectedStructType =
@@ -136,7 +136,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateThrowsWhenOptionalFieldAbsent() {
+  public void createThrowsWhenOptionalFieldAbsent() {
     Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
 
     StructType projectedStructType =
@@ -150,7 +150,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateAllowMissingThrowsWhenRequiredFieldAbsent() {
+  public void createAllowMissingThrowsWhenRequiredFieldAbsent() {
     Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
 
     StructType projectedStructType =
@@ -164,7 +164,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateThrowsWhenRequiredFieldAbsent() {
+  public void createThrowsWhenRequiredFieldAbsent() {
     Schema dataSchema = new Schema(required(10, "id", Types.LongType.get()));
 
     StructType projectedStructType =
@@ -178,7 +178,7 @@ public class TestStructProjection {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testProjectMapWithNestedStructAndPrimitiveValues() {
+  public void projectMapWithNestedStructAndPrimitiveValues() {
     StructType coordinatesStruct =
         StructType.of(
             required(100, "latitude", Types.DoubleType.get()),
@@ -229,7 +229,7 @@ public class TestStructProjection {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testProjectListWithPrimitiveAndStructElements() {
+  public void projectListWithPrimitiveAndStructElements() {
     StructType elementStruct = StructType.of(required(200, "point", Types.DoubleType.get()));
     Schema dataSchema =
         new Schema(
@@ -253,7 +253,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateProjectionFromFieldIds() {
+  public void createProjectionFromFieldIds() {
     Schema dataSchema =
         new Schema(
             required(10, "id", Types.LongType.get()),
@@ -272,7 +272,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCopyForCreatesIndependentProjection() {
+  public void copyForCreatesIndependentProjection() {
     StructType dataSchema =
         StructType.of(
             required(10, "id", Types.LongType.get()),
@@ -296,7 +296,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateThrowsForPartialMapValueStructProjection() {
+  public void createThrowsForPartialMapValueStructProjection() {
     Schema dataSchema =
         new Schema(
             required(1, "id", Types.LongType.get()),
@@ -328,7 +328,7 @@ public class TestStructProjection {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testProjectMapWithNestedStructKey() {
+  public void projectMapWithNestedStructKey() {
     StructType keyStruct = StructType.of(required(100, "region", Types.StringType.get()));
 
     Schema dataSchema =
@@ -348,7 +348,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateThrowsForPartialMapKeyStructProjection() {
+  public void createThrowsForPartialMapKeyStructProjection() {
     Schema dataSchema =
         new Schema(
             required(
@@ -379,7 +379,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateThrowsForPartialListElementStructProjection() {
+  public void createThrowsForPartialListElementStructProjection() {
     Schema dataSchema =
         new Schema(
             required(1, "id", Types.LongType.get()),
@@ -405,7 +405,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testGetReturnsNullForNullNestedStruct() {
+  public void getReturnsNullForNullNestedStruct() {
     Schema dataSchema =
         new Schema(
             required(1, "id", Types.LongType.get()),
@@ -422,7 +422,7 @@ public class TestStructProjection {
   }
 
   @Test
-  public void testCreateAllowMissingPropagatesAllowMissingToNestedStructs() {
+  public void createAllowMissingPropagatesAllowMissingToNestedStructs() {
     StructType dataAddressType = StructType.of(required(10, "street", Types.StringType.get()));
 
     StructType projectedAddressType =

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -68,13 +68,16 @@ public class TestStructProjection {
                             required(100, "latitude", Types.DoubleType.get()),
                             required(200, "longitude", Types.DoubleType.get()))))));
 
-    StructType projectedCoordinateStruct =
-        StructType.of(required(200, "longitude", Types.DoubleType.get()));
-
-    StructType projectedAddressStruct =
-        StructType.of(required(20, "coordinates", projectedCoordinateStruct));
-
-    Schema projectedSchema = new Schema(required(2, "address", projectedAddressStruct));
+    Schema projectedSchema =
+        new Schema(
+            required(
+                2,
+                "address",
+                StructType.of(
+                    required(
+                        20,
+                        "coordinates",
+                        StructType.of(required(200, "longitude", Types.DoubleType.get()))))));
 
     StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
 

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -326,6 +326,57 @@ public class TestStructProjection {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  public void testProjectMapWithNestedStructKey() {
+    StructType keyStruct = StructType.of(required(100, "region", Types.StringType.get()));
+
+    Schema dataSchema =
+        new Schema(
+            required(2, "data", Types.MapType.ofRequired(3, 4, keyStruct, Types.StringType.get())));
+    Schema projectedSchema =
+        new Schema(
+            required(2, "data", Types.MapType.ofRequired(3, 4, keyStruct, Types.StringType.get())));
+
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+    TestHelpers.Row key = TestHelpers.Row.of("US");
+    projection.wrap(TestHelpers.Row.of(Map.of(key, "A Country")));
+
+    assertThat(projection.size()).isEqualTo(1);
+    assertThat(projection.get(0, Map.class)).isEqualTo(Map.of(key, "A Country"));
+  }
+
+  @Test
+  public void testCreateThrowsForPartialMapKeyStructProjection() {
+    Schema dataSchema =
+        new Schema(
+            required(
+                1,
+                "delivery_map",
+                Types.MapType.ofRequired(
+                    2,
+                    3,
+                    StructType.of(
+                        required(100, "city", Types.StringType.get()),
+                        required(101, "zip", Types.IntegerType.get())),
+                    Types.StringType.get())));
+
+    Schema projectedSchema =
+        new Schema(
+            required(
+                1,
+                "delivery_map",
+                Types.MapType.ofRequired(
+                    2,
+                    3,
+                    StructType.of(required(100, "city", Types.StringType.get())),
+                    Types.StringType.get())));
+
+    assertThatThrownBy(() -> StructProjection.create(dataSchema, projectedSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot project a partial map key or value struct");
+  }
+
+  @Test
   public void testCreateThrowsForPartialListElementStructProjection() {
     Schema dataSchema =
         new Schema(

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -53,14 +53,66 @@ public class TestStructProjection {
     assertThat(projection.size()).isEqualTo(1);
     assertThat(projection.projectedFields()).isEqualTo(1);
     assertThat(projection.get(0, Integer.class)).isEqualTo(42);
+  }
+
+  @Test
+  public void getThrowsClassCastExceptionForWrongType() {
+    Schema dataSchema =
+        new Schema(
+            required(10, "id", Types.LongType.get()),
+            required(20, "name", Types.StringType.get()),
+            required(30, "value", Types.IntegerType.get()));
+
+    Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
+
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+
+    assertThat(projection.get(0, Integer.class)).isNull();
+
+    TestHelpers.Row row = TestHelpers.Row.of(1L, "Batman", 42);
+    projection.wrap(row);
 
     assertThatThrownBy(() -> projection.get(0, String.class))
         .isInstanceOf(ClassCastException.class)
         .hasMessage("Cannot cast java.lang.Integer to java.lang.String");
+  }
+
+  @Test
+  public void getThrowsForOutOfBoundsIndex() {
+    Schema dataSchema =
+        new Schema(
+            required(10, "id", Types.LongType.get()),
+            required(20, "name", Types.StringType.get()),
+            required(30, "value", Types.IntegerType.get()));
+
+    Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
+
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+
+    TestHelpers.Row row = TestHelpers.Row.of(1L, "Batman", 42);
+    projection.wrap(row);
 
     assertThatThrownBy(() -> projection.get(1, Integer.class))
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)
         .hasMessage("Index 1 out of bounds for length 1");
+  }
+
+  @Test
+  public void setOnProjectionThrows() {
+    Schema dataSchema =
+        new Schema(
+            required(10, "id", Types.LongType.get()),
+            required(20, "name", Types.StringType.get()),
+            required(30, "value", Types.IntegerType.get()));
+
+    Schema projectedSchema = new Schema(required(30, "value", Types.IntegerType.get()));
+
+    StructProjection projection = StructProjection.create(dataSchema, projectedSchema);
+
+    assertThat(projection.get(0, Integer.class)).isNull();
+
+    TestHelpers.Row row = TestHelpers.Row.of(1L, "Batman", 42);
+    projection.wrap(row);
 
     assertThatThrownBy(() -> projection.set(0, 5))
         .isInstanceOf(UnsupportedOperationException.class)


### PR DESCRIPTION
Added Unit tests that improves the reliability of StructProjection class.

1. Subset projection from a flat schema
2. Nested projection across multiple levels
3. Optional field projection (schema evolution)
4. Map projection with nested value and Primitive Types
5. List projection with nested value and Primitive Types
6. Map and List Partial Projection
7. And other small functions

Code coverage from 0% to 100% (Based on Jacoco report)

Fixes #16123 