### PR TITLE
ci: fix zizmor mismatch version tag

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,11 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: actions
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         category: "/language:actions"


### PR DESCRIPTION
Fix failing CI caused by zizmor (https://github.com/apache/iceberg/actions/runs/24457899591/job/71470951262?pr=15980)

[`c10b8064de6f491fea524254123dbe5e09572f13`](https://github.com/github/codeql-action/commit/c10b8064de6f491fea524254123dbe5e09572f13) maps to both `v4` and `v4.35.1`

Zizmor prefers more precised version tag

Previously didnt catch this locally because i only ran `uvx zizmor .github/` which doesnt check for tag mismatch. 
Ran ```GH_TOKEN=`gh auth token` uvx zizmor .github --fix=all``` which found the tag mismatch and applied auto fix
