### PR TITLE
ci: remove zizmor ignore for `allowlist-check`, pin to main

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -43,5 +43,4 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
-    # Intentionally unpinned to always use the latest allowlist from the ASF.
-    - uses: apache/infrastructure-actions/allowlist-check@main # zizmor: ignore[unpinned-uses]
+    - uses: apache/infrastructure-actions/allowlist-check@4e9c961f587f72b170874b6f5cd4ac15f7f26eb8  # main


### PR DESCRIPTION
`apache/infrastructure-actions/allowlist-check` was improved so we can now pin to a commit hash instead of main

using latest commit hash [`4e9c961f587f72b170874b6f5cd4ac15f7f26eb8`](https://github.com/apache/infrastructure-actions/commit/4e9c961f587f72b170874b6f5cd4ac15f7f26eb8)

Same as used by airflow 
https://github.com/apache/airflow/blob/206d9ac9ec7974cec96dd53754eb677ff599bec2/.github/workflows/asf-allowlist-check.yml#L34