### PR TITLE
BigQuery: Add support for historical property names for backward compatibility

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryProperties.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryProperties.java
@@ -101,11 +101,37 @@ class BigQueryProperties implements Serializable {
   BigQueryProperties(Map<String, String> properties) {
     Preconditions.checkNotNull(properties, "Properties cannot be null");
 
-    this.projectId = properties.get(PROJECT_ID);
+    Preconditions.checkArgument(
+        !(properties.containsKey(PROJECT_ID)
+            && properties.containsKey(HistoricalPropertyNames.PROJECT_ID)),
+        "Invalid GCP project configuration. "
+            + "Found both properties '%s' and '%s', only one must be used.",
+        PROJECT_ID,
+        HistoricalPropertyNames.PROJECT_ID);
+    Preconditions.checkArgument(
+        properties.containsKey(PROJECT_ID)
+            || properties.containsKey(HistoricalPropertyNames.PROJECT_ID),
+        "Invalid GCP project: %s must be specified",
+        PROJECT_ID);
+
+    Preconditions.checkArgument(
+        !(properties.containsKey(GCP_LOCATION)
+            && properties.containsKey(HistoricalPropertyNames.GCP_LOCATION)),
+        "Invalid warehouse location configuration. "
+            + "Found both properties '%s' and '%s', only one must be used.",
+        GCP_LOCATION,
+        HistoricalPropertyNames.GCP_LOCATION);
+
+    this.projectId =
+        properties.containsKey(PROJECT_ID)
+            ? properties.get(PROJECT_ID)
+            : properties.get(HistoricalPropertyNames.PROJECT_ID);
     Preconditions.checkArgument(
         projectId != null, "Invalid GCP project: %s must be specified", PROJECT_ID);
 
-    this.location = properties.getOrDefault(GCP_LOCATION, DEFAULT_GCP_LOCATION);
+    String fallbackLocation =
+        properties.getOrDefault(HistoricalPropertyNames.GCP_LOCATION, DEFAULT_GCP_LOCATION);
+    this.location = properties.getOrDefault(GCP_LOCATION, fallbackLocation);
 
     this.listAllTables = Boolean.parseBoolean(properties.getOrDefault(LIST_ALL_TABLES, "true"));
 

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryProperties.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryProperties.java
@@ -126,12 +126,11 @@ class BigQueryProperties implements Serializable {
         properties.containsKey(PROJECT_ID)
             ? properties.get(PROJECT_ID)
             : properties.get(HistoricalPropertyNames.PROJECT_ID);
-    Preconditions.checkArgument(
-        projectId != null, "Invalid GCP project: %s must be specified", PROJECT_ID);
 
-    String fallbackLocation =
-        properties.getOrDefault(HistoricalPropertyNames.GCP_LOCATION, DEFAULT_GCP_LOCATION);
-    this.location = properties.getOrDefault(GCP_LOCATION, fallbackLocation);
+    this.location =
+        properties.containsKey(GCP_LOCATION)
+            ? properties.get(GCP_LOCATION)
+            : properties.getOrDefault(HistoricalPropertyNames.GCP_LOCATION, DEFAULT_GCP_LOCATION);
 
     this.listAllTables = Boolean.parseBoolean(properties.getOrDefault(LIST_ALL_TABLES, "true"));
 

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/HistoricalPropertyNames.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/HistoricalPropertyNames.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.bigquery;
+
+/**
+ * This class contains the initial versions of Google's catalog properties used internally. These
+ * names will be used as fallbacks for backward compatibility from OSS version to Google's internal.
+ */
+public class HistoricalPropertyNames {
+  public static final String PROJECT_ID = "gcp_project";
+  public static final String GCP_LOCATION = "gcp_location";
+
+  private HistoricalPropertyNames() {}
+}

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryProperties.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryProperties.java
@@ -40,19 +40,45 @@ public class TestBigQueryProperties {
   }
 
   @Test
-  public void testInitializeWithDefaultLocation() {
-    Map<String, String> properties = Map.of(BigQueryProperties.PROJECT_ID, "test-project");
-    BigQueryProperties bigQueryProperties = new BigQueryProperties(properties);
-
-    assertThat(bigQueryProperties.projectId()).isEqualTo("test-project");
-    assertThat(bigQueryProperties.location()).isEqualTo("us");
-  }
-
-  @Test
   public void testInitializeWithNullProperties() {
     assertThatThrownBy(() -> new BigQueryProperties(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("Properties cannot be null");
+  }
+
+  @Test
+  public void testInitializeWithHistoricalProperties() {
+    Map<String, String> properties =
+        Map.of(
+            HistoricalPropertyNames.PROJECT_ID, "test-project",
+            HistoricalPropertyNames.GCP_LOCATION, "us-central1");
+    BigQueryProperties bigQueryProperties = new BigQueryProperties(properties);
+
+    assertThat(bigQueryProperties.projectId()).isEqualTo("test-project");
+    assertThat(bigQueryProperties.location()).isEqualTo("us-central1");
+  }
+
+  @Test
+  public void testInitializeWithHistoricalProjectIdAndProjectId() {
+    Map<String, String> properties =
+        Map.of(
+            HistoricalPropertyNames.PROJECT_ID, "hist-test-project",
+            BigQueryProperties.PROJECT_ID, "test-project");
+    assertThatThrownBy(() -> new BigQueryProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Found both properties");
+  }
+
+  @Test
+  public void testInitializeWithHistoricalGcpLocationAndGcpLocation() {
+    Map<String, String> properties =
+        Map.of(
+            HistoricalPropertyNames.GCP_LOCATION, "hist-location",
+            BigQueryProperties.GCP_LOCATION, "new-location",
+            BigQueryProperties.PROJECT_ID, "test-project");
+    assertThatThrownBy(() -> new BigQueryProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Found both properties");
   }
 
   @Test


### PR DESCRIPTION
Add support for historical property names (`gcp_project` and `gcp_location`) in `BigQueryProperties` to maintain backward compatibility with internal configurations.

Fixes https://github.com/apache/iceberg/issues/14422