### PR TITLE
Flink: Add ConvertEqualityDeletes maintenance task

### DIFF
--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -68,6 +68,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     }
 
     implementation libs.datasketches
+    implementation libs.roaringbitmap
 
     testImplementation libs.flink21.connector.test.utils
     testImplementation libs.flink21.core

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ConvertEqualityDeletes.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ConvertEqualityDeletes.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.BroadcastStream;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableUtil;
+import org.apache.iceberg.flink.maintenance.operator.DVPosition;
+import org.apache.iceberg.flink.maintenance.operator.DVWriteResult;
+import org.apache.iceberg.flink.maintenance.operator.EqualityConvertCommitter;
+import org.apache.iceberg.flink.maintenance.operator.EqualityConvertDVWriter;
+import org.apache.iceberg.flink.maintenance.operator.EqualityConvertPKIndex;
+import org.apache.iceberg.flink.maintenance.operator.EqualityConvertPlan;
+import org.apache.iceberg.flink.maintenance.operator.EqualityConvertPlanner;
+import org.apache.iceberg.flink.maintenance.operator.EqualityConvertReader;
+import org.apache.iceberg.flink.maintenance.operator.IndexCommand;
+import org.apache.iceberg.flink.maintenance.operator.ReadCommand;
+import org.apache.iceberg.flink.maintenance.operator.SerializedEqualityValues;
+import org.apache.iceberg.flink.maintenance.operator.TaskResultAggregator;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types.NestedField;
+
+/**
+ * Creates the equality delete to DV conversion data stream. Runs a single iteration of the
+ * conversion for every {@link Trigger} event.
+ *
+ * <p>The pipeline reads equality delete files from a staging branch, converts them to deletion
+ * vectors (DVs) using a primary key index stored in Flink state, and commits the data files and DVs
+ * to the main branch.
+ *
+ * <p>The conversion is split into parallel stages:
+ *
+ * <ol>
+ *   <li>Planner (p=1): scans staging branch, emits file-level ReadCommands with phase timestamps
+ *   <li>Reader (p=N): reads files, emits row-level IndexCommands
+ *   <li>PKIndex (p=N): maintains PK index shards, resolves equality deletes to DV positions
+ *   <li>DVWriter (p=N, keyed by data file path): buffers positions per file, writes Puffin DVs
+ *       inline
+ *   <li>Committer (p=1): commits data files and DVs to main branch
+ * </ol>
+ *
+ * <p>Mutual exclusion with concurrent maintenance tasks (e.g. compaction) is enforced by the Flink
+ * maintenance framework lock.
+ */
+@Experimental
+public class ConvertEqualityDeletes {
+  static final String PLANNER_TASK_NAME = "EqConvert Planner";
+  static final String READER_TASK_NAME = "EqConvert Reader";
+  static final String PK_INDEX_TASK_NAME = "EqConvert PKIndex";
+  static final String DV_WRITER_TASK_NAME = "EqConvert DVWriter";
+  static final String UPSTREAM_ABORT_TASK_NAME = "EqConvert UpstreamAbort";
+  static final String COMMIT_TASK_NAME = "EqConvert Commit";
+  static final String AGGREGATOR_TASK_NAME = "EqConvert Aggregator";
+
+  private ConvertEqualityDeletes() {}
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder extends MaintenanceTaskBuilder<Builder> {
+    private String stagingBranch;
+    private String targetBranch = SnapshotRef.MAIN_BRANCH;
+    private List<String> equalityFieldColumns = Collections.emptyList();
+
+    @Override
+    String maintenanceTaskName() {
+      return "ConvertEqualityDeletes";
+    }
+
+    /** Sets the staging branch name that holds the equality delete files and data files. */
+    public Builder stagingBranch(String newStagingBranch) {
+      this.stagingBranch = newStagingBranch;
+      return this;
+    }
+
+    /**
+     * Sets the target branch where converted data files and DVs are committed. Defaults to the main
+     * branch.
+     */
+    public Builder targetBranch(String newTargetBranch) {
+      this.targetBranch = newTargetBranch;
+      return this;
+    }
+
+    /**
+     * Sets the equality field columns used by the worker index. Required. Must match the equality
+     * field columns the writer uses for staging eq-delete files; mismatched eq-deletes fail the
+     * cycle. Mirrors {@link
+     * org.apache.iceberg.flink.sink.IcebergSink.Builder#equalityFieldColumns}.
+     *
+     * <p>Partition source columns of every spec on the table must be a subset of these columns
+     * (FlinkSink / IcebergSink contract). The converter keys data rows by {@code (specId, equality
+     * values)} and assumes the partition contains the equality values.
+     */
+    public Builder equalityFieldColumns(List<String> columns) {
+      Preconditions.checkNotNull(columns, "equalityFieldColumns must not be null");
+      Preconditions.checkArgument(!columns.isEmpty(), "equalityFieldColumns must not be empty");
+      this.equalityFieldColumns = ImmutableList.copyOf(columns);
+      return this;
+    }
+
+    @Override
+    DataStream<TaskResult> append(DataStream<Trigger> trigger) {
+      Preconditions.checkNotNull(stagingBranch, "stagingBranch must be set");
+      Preconditions.checkArgument(
+          !equalityFieldColumns.isEmpty(), "equalityFieldColumns must be set on the builder");
+      Set<Integer> eqFieldIds = resolveEqualityFieldIds();
+
+      // Planner (p=1): emits ReadCommands with phase timestamps and watermarks
+      SingleOutputStreamOperator<ReadCommand> planned =
+          setSlotSharingGroup(
+              trigger
+                  .transform(
+                      operatorName(PLANNER_TASK_NAME),
+                      TypeInformation.of(ReadCommand.class),
+                      new EqualityConvertPlanner(
+                          tableName(),
+                          taskName(),
+                          tableLoader(),
+                          stagingBranch,
+                          targetBranch,
+                          eqFieldIds))
+                  .uid(PLANNER_TASK_NAME + uidSuffix())
+                  .forceNonParallel());
+
+      // Reader (p=N): reads files, emits IndexCommands
+      SingleOutputStreamOperator<IndexCommand> index =
+          setSlotSharingGroup(
+              planned
+                  .rebalance()
+                  .process(
+                      new EqualityConvertReader(
+                          tableLoader(), eqFieldIds, stagingBranch.equals(targetBranch)))
+                  .name(operatorName(READER_TASK_NAME))
+                  .uid(READER_TASK_NAME + uidSuffix())
+                  .setParallelism(parallelism()));
+
+      // Broadcast from the planner to the PKIndex to clear the entire index
+      BroadcastStream<IndexCommand> clearIndexBroadcast =
+          planned
+              .getSideOutput(EqualityConvertPlanner.CLEAR_BROADCAST_STREAM)
+              .broadcast(EqualityConvertPKIndex.CLEAR_BROADCAST_DESCRIPTOR);
+
+      // PKIndex (p=N): keyed by full PK, phase-aware buffering.
+      SingleOutputStreamOperator<DVPosition> dvPositions =
+          setSlotSharingGroup(
+              index
+                  .keyBy(IndexCommand::key, TypeInformation.of(SerializedEqualityValues.class))
+                  .connect(clearIndexBroadcast)
+                  .process(new EqualityConvertPKIndex(stagingBranch.equals(targetBranch)))
+                  .name(operatorName(PK_INDEX_TASK_NAME))
+                  .uid(PK_INDEX_TASK_NAME + uidSuffix())
+                  .setParallelism(parallelism()));
+
+      // Reader-side abort signals bypass the PKIndex and feed the DVWriter directly, so a reader
+      // failure can short-circuit the cycle without waiting on a keyed shuffle. This is not a full
+      // short-circuit: the abort is keyed by data file path (empty for ABORT), so only one resolver
+      // subtask observes it; the others still write their buffered DVs, which the committer then
+      // drops.
+      DataStream<DVPosition> readerAborts =
+          index.getSideOutput(EqualityConvertReader.READER_ABORT_STREAM);
+      DataStream<DVPosition> dvPositionsWithAborts = dvPositions.union(readerAborts);
+
+      // Metadata side output from planner
+      DataStream<EqualityConvertPlan> metadata =
+          planned.getSideOutput(EqualityConvertPlanner.METADATA_STREAM);
+
+      // DVWriter (p=N, keyed by data file path): groups positions per file, writes Puffin DV
+      // files inline, emits DVMergeResult per task. Plan metadata broadcast so every subtask sees
+      // it.
+      SingleOutputStreamOperator<DVWriteResult> resolved =
+          setSlotSharingGroup(
+              dvPositionsWithAborts
+                  .keyBy(DVPosition::dataFilePath)
+                  .connect(metadata.broadcast())
+                  .transform(
+                      operatorName(DV_WRITER_TASK_NAME),
+                      TypeInformation.of(DVWriteResult.class),
+                      new EqualityConvertDVWriter(
+                          tableName(), taskName(), tableLoader(), targetBranch))
+                  .uid(DV_WRITER_TASK_NAME + uidSuffix())
+                  .setParallelism(parallelism()));
+
+      // Upstream errors become abort signals so a partial read never commits. The same error side
+      // outputs also feed the aggregator below to surface the exception in TaskResult; the two
+      // consumers serve different purposes and must both exist.
+      DataStream<DVWriteResult> upstreamAborts =
+          setSlotSharingGroup(
+              index
+                  .getSideOutput(TaskResultAggregator.ERROR_STREAM)
+                  .union(dvPositions.getSideOutput(TaskResultAggregator.ERROR_STREAM))
+                  .map(e -> DVWriteResult.ABORT)
+                  .returns(TypeInformation.of(DVWriteResult.class))
+                  .name(operatorName(UPSTREAM_ABORT_TASK_NAME))
+                  .uid(UPSTREAM_ABORT_TASK_NAME + uidSuffix())
+                  .forceNonParallel());
+
+      // Committer (p=1): commits data files + DVs to main.
+      SingleOutputStreamOperator<Trigger> committed =
+          setSlotSharingGroup(
+              resolved
+                  .union(upstreamAborts)
+                  .connect(metadata)
+                  .transform(
+                      operatorName(COMMIT_TASK_NAME),
+                      TypeInformation.of(Trigger.class),
+                      new EqualityConvertCommitter(
+                          tableName(), taskName(), tableLoader(), stagingBranch, targetBranch))
+                  .uid(COMMIT_TASK_NAME + uidSuffix())
+                  .forceNonParallel());
+
+      // Aggregator (p=1): collects errors and emits TaskResult.
+      return setSlotSharingGroup(
+          committed
+              .connect(
+                  planned
+                      .getSideOutput(TaskResultAggregator.ERROR_STREAM)
+                      .union(index.getSideOutput(TaskResultAggregator.ERROR_STREAM))
+                      .union(dvPositions.getSideOutput(TaskResultAggregator.ERROR_STREAM))
+                      .union(resolved.getSideOutput(TaskResultAggregator.ERROR_STREAM))
+                      .union(committed.getSideOutput(TaskResultAggregator.ERROR_STREAM)))
+              .transform(
+                  operatorName(AGGREGATOR_TASK_NAME),
+                  TypeInformation.of(TaskResult.class),
+                  new TaskResultAggregator(tableName(), taskName(), index()))
+              .uid(AGGREGATOR_TASK_NAME + uidSuffix())
+              .forceNonParallel());
+    }
+
+    private Set<Integer> resolveEqualityFieldIds() {
+      if (!tableLoader().isOpen()) {
+        tableLoader().open();
+      }
+
+      Table table = tableLoader().loadTable();
+      int formatVersion = TableUtil.formatVersion(table);
+      Preconditions.checkArgument(
+          formatVersion >= 3,
+          "ConvertEqualityDeletes requires table format version >= 3 (DVs), "
+              + "but table '%s' is version %s",
+          tableName(),
+          formatVersion);
+
+      Schema schema = table.schema();
+      List<Integer> fieldIds = Lists.newArrayListWithCapacity(equalityFieldColumns.size());
+      for (String column : equalityFieldColumns) {
+        NestedField field = schema.findField(column);
+        Preconditions.checkArgument(
+            field != null,
+            "Equality field column '%s' not found in table schema %s",
+            column,
+            schema);
+        fieldIds.add(field.fieldId());
+      }
+
+      Set<Integer> resolved = ImmutableSet.copyOf(fieldIds);
+      validateCurrentSpecPartitionColumns(table, resolved);
+      return resolved;
+    }
+
+    /**
+     * Checks that the current spec's partition source columns are a subset of the equality fields.
+     * The converter keys rows by {@code (specId, equality values)} and drops partition values from
+     * the key, so a partition column outside the equality set would make cross-partition resolution
+     * wrong. Only the current spec is checked; older specs from partition evolution may differ.
+     */
+    private static void validateCurrentSpecPartitionColumns(Table table, Set<Integer> eqFieldIds) {
+      for (PartitionField field : table.spec().fields()) {
+        Preconditions.checkArgument(
+            eqFieldIds.contains(field.sourceId()),
+            "Partition field '%s' (source id %s) of the current spec is not an equality field %s; "
+                + "partition columns must be a subset of the equality fields.",
+            field.name(),
+            field.sourceId(),
+            eqFieldIds);
+      }
+    }
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVPosition.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVPosition.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A deletion vector position emitted by {@link EqualityConvertPKIndex} when resolving an equality
+ * delete. Identifies a specific row (by file path and position) to be marked as deleted, and
+ * carries the data file's {@code specId} + encoded partition so the downstream resolver can write
+ * the DV without re-reading data manifests.
+ *
+ * <p>{@code dataSequenceNumber} is the data file's sequence number. The worker keeps it in its
+ * index so a resolving equality delete only deletes rows older than itself (only applies an
+ * equality delete with sequence {@code S} to data with sequence {@code < S}).
+ *
+ * <p>{@code partition} is a {@code byte[]} (see {@link StructLikeSerializer#encodePartition}) so
+ * Flink serializes it natively rather than falling back to Kryo, including in the worker's keyed
+ * state.
+ */
+@Internal
+public record DVPosition(
+    String dataFilePath, long position, int specId, byte[] partition, long dataSequenceNumber)
+    implements Serializable {
+
+  /**
+   * Sentinel filePath for the {@link #ABORT} record so {@code keyBy(dataFilePath)} can route it.
+   */
+  private static final String ABORT_FILE_PATH = "";
+
+  public static final DVPosition ABORT =
+      new DVPosition(ABORT_FILE_PATH, -1, -1, StructLikeSerializer.EMPTY_PARTITION, -1);
+
+  public boolean isAbort() {
+    return ABORT_FILE_PATH.equals(dataFilePath);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVWriteResult.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVWriteResult.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.DeleteFile;
+
+/**
+ * Result from the {@link EqualityConvertDVWriter} containing new and rewritten DV files written by
+ * a single resolver task. A result with {@link #hasError()} signals that the writer failed; the
+ * committer must not commit data files in that case.
+ */
+@Internal
+public record DVWriteResult(
+    List<DeleteFile> dvFiles, List<DeleteFile> rewrittenDvFiles, boolean hasError)
+    implements Serializable {
+
+  public DVWriteResult(List<DeleteFile> dvFiles, List<DeleteFile> rewrittenDvFiles) {
+    this(dvFiles, rewrittenDvFiles, false);
+  }
+
+  /** Sentinel result that tells the committer to abort the current cycle. */
+  public static final DVWriteResult ABORT = new DVWriteResult(null, null, true);
+
+  public boolean isAbort() {
+    return hasError;
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertCommitter.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Commits data files and DVs to the target branch. Receives {@link DVWriteResult}s from parallel
+ * {@link EqualityConvertDVWriter} instances (input 1) and an {@link EqualityConvertPlan} from the
+ * planner (input 2). Assembles the final file lists and commits using a {@link RowDelta} operation
+ * once the plan result and done-timestamp watermark have both arrived.
+ *
+ * <p>Watermarks are absorbed while a cycle is active.
+ *
+ * <p>Emits a {@link Trigger} after each cycle (commit, no-op, or error) so the downstream {@link
+ * TaskResultAggregator} can track task completion. This is the sole source of Trigger records for
+ * the Aggregator.
+ *
+ * <p>No-op vs error: a no-op cycle (empty plan result from {@code
+ * EqualityConvertPlanner.emitNoOpResult}) returns early in {@code commitIfNeeded} without writing
+ * anything; the Trigger emit in {@code processWatermark} still happens, so the maintenance task
+ * completes cleanly. Errors are reported via {@link TaskResultAggregator#ERROR_STREAM} side output;
+ * the Aggregator collects them and surfaces failure on its own watermark.
+ *
+ * <p>The committer is intentionally stateless: {@code bufferedResults} and {@code planResult} are
+ * not checkpointed. The maintenance framework ensures mutual exclusive tasks, and on restart the
+ * planner re-derives its position from {@link #COMMITTED_STAGING_SNAPSHOT_PROPERTY} on main, so the
+ * committer never receives a plan for an already-committed staging snapshot.
+ */
+@Internal
+public class EqualityConvertCommitter extends AbstractStreamOperator<Trigger>
+    implements TwoInputStreamOperator<DVWriteResult, EqualityConvertPlan, Trigger> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertCommitter.class);
+
+  static final String COMMITTED_STAGING_SNAPSHOT_PROPERTY = "equality-convert-staging-snapshot";
+
+  private static final String ADDED_DV_NUM_METRIC = "addedDvNum";
+  private static final String COMMIT_DURATION_MS_METRIC = "commitDurationMs";
+
+  private final String tableName;
+  private final String taskName;
+  private final TableLoader tableLoader;
+  private final String targetBranch;
+  private final boolean stagingOnTargetBranch;
+
+  private transient Table table;
+  private transient List<DVWriteResult> bufferedResults;
+  private transient EqualityConvertPlan planResult;
+
+  private transient Counter errorCounter;
+  private transient Counter addedDataFileNumCounter;
+  private transient Counter addedDataFileSizeCounter;
+  private transient Counter addedDvNumCounter;
+  private transient Counter commitDurationMsCounter;
+
+  public EqualityConvertCommitter(
+      String tableName,
+      String taskName,
+      TableLoader tableLoader,
+      String stagingBranch,
+      String targetBranch) {
+    this.tableName = tableName;
+    this.taskName = taskName;
+    this.tableLoader = tableLoader;
+    this.targetBranch = targetBranch;
+    this.stagingOnTargetBranch = stagingBranch.equals(targetBranch);
+  }
+
+  @Override
+  public void open() throws Exception {
+    super.open();
+    if (!tableLoader.isOpen()) {
+      tableLoader.open();
+    }
+
+    this.table = tableLoader.loadTable();
+    this.bufferedResults = Lists.newArrayList();
+
+    MetricGroup taskMetricGroup =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), tableName, taskName, 0);
+    this.errorCounter = taskMetricGroup.counter(TableMaintenanceMetrics.ERROR_COUNTER);
+    this.addedDataFileNumCounter =
+        taskMetricGroup.counter(TableMaintenanceMetrics.ADDED_DATA_FILE_NUM_METRIC);
+    this.addedDataFileSizeCounter =
+        taskMetricGroup.counter(TableMaintenanceMetrics.ADDED_DATA_FILE_SIZE_METRIC);
+    this.addedDvNumCounter = taskMetricGroup.counter(ADDED_DV_NUM_METRIC);
+    this.commitDurationMsCounter = taskMetricGroup.counter(COMMIT_DURATION_MS_METRIC);
+  }
+
+  @Override
+  public void processElement1(StreamRecord<DVWriteResult> record) {
+    bufferedResults.add(record.getValue());
+  }
+
+  @Override
+  public void processElement2(StreamRecord<EqualityConvertPlan> record) {
+    planResult = record.getValue();
+  }
+
+  @Override
+  public void processWatermark(Watermark mark) throws Exception {
+    if (planResult != null && mark.getTimestamp() >= planResult.doneTimestamp()) {
+      try {
+        commitIfNeeded();
+      } catch (Exception e) {
+        LOG.error(
+            "Failed to commit equality convert result for table {} task {}",
+            tableName,
+            taskName,
+            e);
+        output.collect(TaskResultAggregator.ERROR_STREAM, new StreamRecord<>(e));
+        errorCounter.inc();
+      }
+
+      // Emit Trigger for the Aggregator (even on error or no-op).
+      output.collect(new StreamRecord<>(Trigger.create(planResult.triggerTimestamp(), 0)));
+
+      bufferedResults.clear();
+      planResult = null;
+    }
+
+    // Always forward watermarks to prevent stalling downstream.
+    super.processWatermark(mark);
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  private void commitIfNeeded() {
+    for (DVWriteResult result : bufferedResults) {
+      if (result.isAbort()) {
+        LOG.warn(
+            "Skipping commit for table {} task {}: a DV resolver reported an error.",
+            tableName,
+            taskName);
+        deleteUncommittedDVs();
+        return;
+      }
+    }
+
+    // No-op cycle: the planner emitted an empty plan result (see
+    // EqualityConvertPlanner.emitNoOpResult) because the next staging snapshot was filtered by
+    // shouldSkip or there was nothing new on staging. processWatermark still forwards a Trigger to
+    // TaskResultAggregator, so the maintenance task completes cleanly.
+    if (planResult.noOp()) {
+      return;
+    }
+
+    table.refresh();
+
+    List<DeleteFile> allDvFiles = Lists.newArrayList();
+    List<DeleteFile> allRewrittenDvFiles = Lists.newArrayList();
+    for (DVWriteResult result : bufferedResults) {
+      allDvFiles.addAll(result.dvFiles());
+      allRewrittenDvFiles.addAll(result.rewrittenDvFiles());
+    }
+
+    RowDelta rowDelta = buildRowDelta(planResult.dataFiles(), allDvFiles, allRewrittenDvFiles);
+
+    long startNano = System.nanoTime();
+    try {
+      commit(rowDelta);
+    } catch (CommitStateUnknownException e) {
+      // Commit outcome unknown: the DVs may already be referenced by a committed snapshot. Leave
+      // them for Remove Orphan Files rather than risk deleting live data.
+      throw e;
+    } catch (Exception e) {
+      // Commit definitively failed: the DVs this cycle wrote are unreferenced. Delete them so a
+      // failed cycle does not leak Puffin files. Rewritten DVs stay (still live on the target).
+      deleteUncommittedDVs();
+      throw e;
+    }
+
+    long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
+    commitDurationMsCounter.inc(durationMs);
+
+    LOG.info(
+        "Committed {} data files and {} DV files to branch '{}' for table {} in {} ms. "
+            + "Processed staging snapshot {}.",
+        planResult.dataFiles().size(),
+        allDvFiles.size(),
+        targetBranch,
+        tableName,
+        durationMs,
+        planResult.stagingSnapshotId());
+
+    // Only count files actually added by this commit. When sameBranch, the writer already
+    // committed the data files to target and buildRowDelta does not re-add them.
+    if (!stagingOnTargetBranch) {
+      for (DataFile dataFile : planResult.dataFiles()) {
+        addedDataFileNumCounter.inc();
+        addedDataFileSizeCounter.inc(dataFile.fileSizeInBytes());
+      }
+    }
+
+    addedDvNumCounter.inc(allDvFiles.size());
+  }
+
+  @VisibleForTesting
+  void commit(RowDelta rowDelta) {
+    rowDelta.commit();
+  }
+
+  /**
+   * Deletes the DVs this cycle wrote but did not commit (abort or definite commit failure). Only
+   * the newly written DVs are removed; rewritten DVs remain referenced on the target branch. Best
+   * effort: a delete failure is logged, not propagated, so it never masks the original error.
+   */
+  private void deleteUncommittedDVs() {
+    for (DVWriteResult result : bufferedResults) {
+      if (result.isAbort()) {
+        continue;
+      }
+
+      for (DeleteFile dvFile : result.dvFiles()) {
+        try {
+          table.io().deleteFile(dvFile.location());
+        } catch (RuntimeException e) {
+          LOG.warn(
+              "Failed to delete uncommitted DV {} for table {} task {}",
+              dvFile.location(),
+              tableName,
+              taskName,
+              e);
+        }
+      }
+    }
+  }
+
+  private RowDelta buildRowDelta(
+      List<DataFile> dataFiles, List<DeleteFile> allDvFiles, List<DeleteFile> allRewrittenDvFiles) {
+    RowDelta rowDelta = table.newRowDelta();
+
+    // Fail the commit on external target-branch activity since the planner's snapshot. The next
+    // trigger detects the change and reindexes.
+    if (planResult.mainSnapshotId() != null) {
+      rowDelta.validateFromSnapshot(planResult.mainSnapshotId());
+    }
+
+    rowDelta.validateNoConflictingDataFiles();
+    rowDelta.validateNoConflictingDeleteFiles();
+
+    Set<String> referencedDataFiles = Sets.newHashSet();
+    for (DeleteFile dvFile : allDvFiles) {
+      if (dvFile.referencedDataFile() != null) {
+        referencedDataFiles.add(dvFile.referencedDataFile());
+      }
+    }
+
+    if (!referencedDataFiles.isEmpty()) {
+      rowDelta.validateDataFilesExist(referencedDataFiles);
+    }
+
+    // When stagingBranch == targetBranch, the writer already committed data files and DVs to the
+    // target branch. Re-adding them here would produce duplicate manifest entries. Skip those
+    // paths; only the new DVs from the resolver need to be added.
+    if (!stagingOnTargetBranch) {
+      for (DataFile dataFile : dataFiles) {
+        rowDelta.addRows(dataFile);
+      }
+    }
+
+    for (DeleteFile dvFile : allDvFiles) {
+      rowDelta.addDeletes(dvFile);
+    }
+
+    if (!stagingOnTargetBranch) {
+      addStagingDeletes(rowDelta, referencedDataFiles, planResult.stagingDVFiles());
+    }
+
+    removeRewrittenDVs(
+        rowDelta, allRewrittenDvFiles, planResult.stagingDVFiles(), stagingOnTargetBranch);
+
+    rowDelta.toBranch(targetBranch);
+    rowDelta.set(
+        COMMITTED_STAGING_SNAPSHOT_PROPERTY, String.valueOf(planResult.stagingSnapshotId()));
+    return rowDelta;
+  }
+
+  /** Adds staging delete files, skipping DVs that overlap with conversion DVs (V3 rule). */
+  private static void addStagingDeletes(
+      RowDelta rowDelta, Set<String> dvCoveredDataFiles, List<DeleteFile> stagingDVFiles) {
+    for (DeleteFile stagingDelete : stagingDVFiles) {
+      // V3 allows one DV per data file. When a staging snapshot contains both a writer-committed
+      // DV and an eq-delete that resolves to additional positions in the same data file, the
+      // resolver folds the staging DV into a new merged DV (via
+      // EqualityConvertDVWriter.collectExistingDVs). Skip the superseded staging DV; adding both
+      // would commit two DVs for the same data file.
+      if (ContentFileUtil.isDV(stagingDelete)
+          && stagingDelete.referencedDataFile() != null
+          && dvCoveredDataFiles.contains(stagingDelete.referencedDataFile())) {
+        continue;
+      }
+
+      rowDelta.addDeletes(stagingDelete);
+    }
+  }
+
+  /**
+   * Removes rewritten DVs. On a separate target branch, staging DVs are not yet on target, so they
+   * are skipped: removeDeletes would fail. On a shared branch they are already on target and must
+   * be removed like any other rewritten DV; the merged DV that supersedes them would otherwise be a
+   * second DV for the same data file (V3 allows one).
+   */
+  private static void removeRewrittenDVs(
+      RowDelta rowDelta,
+      List<DeleteFile> allRewrittenDvFiles,
+      List<DeleteFile> stagingDVFiles,
+      boolean stagingOnTargetBranch) {
+    Set<String> stagingDeleteLocations = Sets.newHashSet();
+    for (DeleteFile sd : stagingDVFiles) {
+      stagingDeleteLocations.add(sd.location());
+    }
+
+    for (DeleteFile rewrittenDv : allRewrittenDvFiles) {
+      if (stagingOnTargetBranch || !stagingDeleteLocations.contains(rewrittenDv.location())) {
+        rowDelta.removeDeletes(rewrittenDv);
+      }
+    }
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertDVWriter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertDVWriter.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.deletes.BaseDVFileWriter;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.io.DeleteWriteResult;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Keyed parallel resolver that buffers {@link DVPosition}s per data-file path, then writes Puffin
+ * DV files directly via {@link BaseDVFileWriter}. Plan metadata arrives broadcast on input 2, so
+ * every parallel task sees the cycle's metadata and can validate against the main snapshot.
+ *
+ * <p>Each buffered {@link DVPosition} carries the data file's {@code specId} + encoded partition,
+ * so writing DVs needs no data-manifest scan. Existing DVs are folded into the rewrite (V3 allows
+ * one DV per data file): delete manifests are pruned by partition summary to the cycle's affected
+ * partitions, then filtered to entries referencing the affected data files. No cross-cycle state is
+ * kept; reads are bounded by the pruned manifest set, not the table's full DV history.
+ *
+ * <p>Buffered positions are transient per-task. On failure recovery, upstream replay rebuilds them.
+ */
+@Internal
+public class EqualityConvertDVWriter extends AbstractStreamOperator<DVWriteResult>
+    implements TwoInputStreamOperator<DVPosition, EqualityConvertPlan, DVWriteResult> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertDVWriter.class);
+
+  private final String tableName;
+  private final String taskName;
+  private final TableLoader tableLoader;
+  private final String targetBranch;
+
+  private transient Table table;
+  private transient OutputFileFactory fileFactory;
+  private transient DeleteLoader deleteLoader;
+  private transient Map<String, FilePositions> positionsByFile;
+  private transient EqualityConvertPlan planResult;
+  private transient boolean hasUpstreamError;
+  private transient int manifestsRead;
+
+  public EqualityConvertDVWriter(
+      String tableName, String taskName, TableLoader tableLoader, String targetBranch) {
+    this.tableName = tableName;
+    this.taskName = taskName;
+    this.tableLoader = tableLoader;
+    this.targetBranch = targetBranch;
+  }
+
+  @Override
+  public void open() throws Exception {
+    super.open();
+    if (!tableLoader.isOpen()) {
+      tableLoader.open();
+    }
+
+    table = tableLoader.loadTable();
+    int subtaskIndex = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
+    fileFactory =
+        OutputFileFactory.builderFor(table, subtaskIndex, 0L).format(FileFormat.PUFFIN).build();
+    deleteLoader = new BaseDeleteLoader(deleteFile -> table.io().newInputFile(deleteFile));
+    positionsByFile = Maps.newHashMap();
+  }
+
+  @Override
+  public void processElement1(StreamRecord<DVPosition> record) {
+    DVPosition pos = record.getValue();
+    if (pos.isAbort()) {
+      hasUpstreamError = true;
+    }
+
+    if (!hasUpstreamError) {
+      positionsByFile
+          .computeIfAbsent(
+              pos.dataFilePath(), k -> new FilePositions(pos.specId(), pos.partition()))
+          .positions
+          .addLong(pos.position());
+    }
+  }
+
+  @Override
+  public void processElement2(StreamRecord<EqualityConvertPlan> record) {
+    planResult = record.getValue();
+  }
+
+  @Override
+  public void processWatermark(Watermark mark) throws Exception {
+    if (planResult != null && mark.getTimestamp() >= planResult.doneTimestamp()) {
+      if (hasUpstreamError) {
+        output.collect(new StreamRecord<>(DVWriteResult.ABORT));
+      } else {
+        try {
+          resolveAndWrite();
+        } catch (Exception e) {
+          LOG.error("Error writing DVs for table {} task {}", tableName, taskName, e);
+          output.collect(TaskResultAggregator.ERROR_STREAM, new StreamRecord<>(e));
+          output.collect(new StreamRecord<>(DVWriteResult.ABORT));
+        }
+      }
+
+      positionsByFile.clear();
+      hasUpstreamError = false;
+      planResult = null;
+    }
+
+    super.processWatermark(mark);
+  }
+
+  private void resolveAndWrite() throws IOException {
+    if (positionsByFile.isEmpty()) {
+      return;
+    }
+
+    table.refresh();
+
+    Snapshot mainSnapshot = table.snapshot(targetBranch);
+
+    // Fail fast if the main branch changed since planning, to avoid writing DV files that the
+    // committer would reject via validateFromSnapshot. The next cycle will reindex.
+    if (mainSnapshot != null
+        && planResult.mainSnapshotId() != null
+        && mainSnapshot.snapshotId() != planResult.mainSnapshotId()) {
+      throw new IllegalStateException(
+          "Main branch snapshot changed since planning: expected "
+              + planResult.mainSnapshotId()
+              + " but found: "
+              + mainSnapshot.snapshotId());
+    }
+
+    Map<String, DeleteFile> dvs = collectExistingDVs(mainSnapshot, positionsByFile.keySet());
+
+    // Fold staging DVs into the rewrite so the writer emits one DV per data file (V3 rule). Flink
+    // writes a staging DV only for a newly added data file, so it never collides with a distinct
+    // existing DV: on a separate target branch collectExistingDVs has not seen it yet; on a shared
+    // branch it IS that existing DV, so the put is idempotent.
+    for (DeleteFile sd : planResult.stagingDVFiles()) {
+      if (ContentFileUtil.isDV(sd) && sd.referencedDataFile() != null) {
+        dvs.put(sd.referencedDataFile(), sd);
+      }
+    }
+
+    BaseDVFileWriter dvWriter =
+        new BaseDVFileWriter(fileFactory, path -> loadPreviousDV(path, dvs));
+    try (dvWriter) {
+      for (Map.Entry<String, FilePositions> entry : positionsByFile.entrySet()) {
+        String dataFilePath = entry.getKey();
+        FilePositions filePositions = entry.getValue();
+        PartitionSpec spec = table.specs().get(filePositions.specId);
+        StructLike partition = filePositions.partition(spec.partitionType());
+
+        filePositions.positions.forEach(
+            (long pos) -> dvWriter.delete(dataFilePath, pos, spec, partition));
+      }
+    }
+
+    DeleteWriteResult result = dvWriter.result();
+    LOG.info(
+        "Wrote {} DV files (rewriting {}) for {} data files in table {} task {}.",
+        result.deleteFiles().size(),
+        result.rewrittenDeleteFiles().size(),
+        positionsByFile.size(),
+        tableName,
+        taskName);
+
+    output.collect(
+        new StreamRecord<>(
+            new DVWriteResult(
+                Lists.newArrayList(result.deleteFiles()),
+                Lists.newArrayList(result.rewrittenDeleteFiles()))));
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  private Map<String, DeleteFile> collectExistingDVs(
+      Snapshot mainSnapshot, Set<String> affectedPaths) {
+    manifestsRead = 0;
+    Map<String, DeleteFile> dvs = Maps.newHashMap();
+    if (mainSnapshot == null) {
+      return dvs;
+    }
+
+    // Prune delete manifests whose partition summaries cannot cover the cycle's affected
+    // partitions. A DV inherits its referenced data file's spec and partition, so partition pruning
+    // works for DV manifests.
+    Map<Integer, ManifestEvaluator> evaluators = partitionEvaluators(positionsByFile);
+    for (ManifestFile manifest : mainSnapshot.deleteManifests(table.io())) {
+      ManifestEvaluator evaluator = evaluators.get(manifest.partitionSpecId());
+      if (evaluator == null || !evaluator.eval(manifest)) {
+        continue;
+      }
+
+      readDVEntries(manifest, affectedPaths, dvs);
+    }
+
+    return dvs;
+  }
+
+  private Map<Integer, ManifestEvaluator> partitionEvaluators(
+      Map<String, FilePositions> positions) {
+    Map<Integer, StructLikeWrapper> templatesBySpec = Maps.newHashMap();
+    Map<Integer, Set<StructLikeWrapper>> partitionsBySpec = Maps.newHashMap();
+    for (FilePositions filePositions : positions.values()) {
+      PartitionSpec spec = table.specs().get(filePositions.specId);
+      StructLikeWrapper template =
+          templatesBySpec.computeIfAbsent(
+              filePositions.specId, id -> StructLikeWrapper.forType(spec.partitionType()));
+      partitionsBySpec
+          .computeIfAbsent(filePositions.specId, k -> Sets.newHashSet())
+          .add(template.copyFor(filePositions.partition(spec.partitionType())));
+    }
+
+    Map<Integer, ManifestEvaluator> evaluators = Maps.newHashMap();
+    for (Map.Entry<Integer, Set<StructLikeWrapper>> entry : partitionsBySpec.entrySet()) {
+      PartitionSpec spec = table.specs().get(entry.getKey());
+      Expression filter = partitionFilter(spec, entry.getValue());
+      evaluators.put(entry.getKey(), ManifestEvaluator.forPartitionFilter(filter, spec, false));
+    }
+
+    return evaluators;
+  }
+
+  private static Expression partitionFilter(PartitionSpec spec, Set<StructLikeWrapper> partitions) {
+    List<PartitionField> fields = spec.fields();
+    Expression anyPartition = Expressions.alwaysFalse();
+    for (StructLikeWrapper wrapper : partitions) {
+      StructLike partition = wrapper.get();
+      Expression onePartition = Expressions.alwaysTrue();
+      for (int i = 0; i < fields.size(); i++) {
+        String name = fields.get(i).name();
+        Object value = partition.get(i, Object.class);
+        Expression predicate =
+            value == null ? Expressions.isNull(name) : Expressions.equal(name, value);
+        onePartition = Expressions.and(onePartition, predicate);
+      }
+
+      anyPartition = Expressions.or(anyPartition, onePartition);
+    }
+
+    return anyPartition;
+  }
+
+  private void readDVEntries(
+      ManifestFile manifest, Set<String> filterPaths, Map<String, DeleteFile> out) {
+    manifestsRead++;
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
+      for (DeleteFile deleteFile : reader) {
+        if (ContentFileUtil.isDV(deleteFile)
+            && deleteFile.referencedDataFile() != null
+            && filterPaths.contains(deleteFile.referencedDataFile())) {
+          out.put(deleteFile.referencedDataFile(), deleteFile);
+        }
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read manifest: " + manifest.path(), e);
+    }
+  }
+
+  @VisibleForTesting
+  int manifestsReadLastCycle() {
+    return manifestsRead;
+  }
+
+  @VisibleForTesting
+  int retainedStateSize() {
+    return positionsByFile.size();
+  }
+
+  private PositionDeleteIndex loadPreviousDV(String dataFilePath, Map<String, DeleteFile> dvs) {
+    DeleteFile existingDV = dvs.get(dataFilePath);
+    if (existingDV == null) {
+      return null;
+    }
+
+    return deleteLoader.loadPositionDeletes(ImmutableList.of(existingDV), dataFilePath);
+  }
+
+  private static final class FilePositions {
+    private final int specId;
+    private final byte[] encodedPartition;
+    private final Roaring64Bitmap positions = new Roaring64Bitmap();
+    private StructLike decodedPartition;
+
+    FilePositions(int specId, byte[] encodedPartition) {
+      this.specId = specId;
+      this.encodedPartition = encodedPartition;
+    }
+
+    StructLike partition(Types.StructType partitionType) {
+      if (decodedPartition == null) {
+        decodedPartition = StructLikeSerializer.decodePartition(encodedPartition, partitionType);
+      }
+
+      return decodedPartition;
+    }
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parallel operator that maintains a shard of the primary key index. Keyed by the full serialized
+ * primary key ({@link SerializedEqualityValues}), each instance handles a subset of PK values.
+ *
+ * <p>Existing main data is indexed immediately on arrival. A staging snapshot's new data rows
+ * ({@link IndexCommand.Type#ADD_STAGING_DATA_ROW}) and every RESOLVE_DELETE instead register an
+ * event-time timer at their phase timestamp and act only when the watermark reaches it. Flink fires
+ * timers in timestamp order, so a delete resolves before the cycle's own new staging rows (a
+ * strictly later phase) join the index: a re-inserted key survives a same-cycle delete regardless
+ * of the order the parallel readers deliver records. Main data is safe to apply eagerly because its
+ * phase precedes the delete, so the delete's watermark only advances once every main row has
+ * arrived.
+ *
+ * <p>On a shared staging/target branch, resolution is sequence-number aware: an equality delete
+ * deletes an indexed row only when the row's data sequence number is below the delete's. A
+ * re-insert of the same key with a higher sequence survives and stays indexed for a later delete.
+ * On a separate target branch the committer reassigns data sequence numbers, so every match is
+ * deleted; event-time ordering prevents over-deletion.
+ *
+ * <p>Stale-index protection runs on two levels. Each key tracks the main sequence number its stored
+ * positions were indexed against. The sequence number is unique and monotonic per snapshot, so it
+ * serves both the equality test below and the ordering test:
+ *
+ * <ul>
+ *   <li><b>Lazy (per-key)</b>: any keyed command at the top of {@link #processElement} whose {@link
+ *       IndexCommand#mainSequenceNumber()} differs from the stored one clears stale state and
+ *       adopts the command's sequence number. Equality suffices here. Required because the
+ *       broadcast and keyed inputs are independent streams with no ordering guarantee; without it,
+ *       an ADD_DATA_ROW that arrived before the broadcast would be wrongly evicted.
+ *   <li><b>Eager (all keys)</b>: a CLEAR_INDEX broadcast iterates all keys on the subtask via
+ *       {@link KeyedBroadcastProcessFunction.Context#applyToKeyedState} and clears any whose stored
+ *       sequence number is older than the broadcast's. Staleness is ordered by sequence number.
+ *       Bounds state size for PKs that were removed from main by an external CoW commit and won't
+ *       receive any keyed command next cycle.
+ * </ul>
+ */
+@Internal
+public class EqualityConvertPKIndex
+    extends KeyedBroadcastProcessFunction<
+        SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertPKIndex.class);
+
+  private static final String RESOLVED_DELETE_NUM_METRIC = "resolvedDeleteNum";
+  private static final String INDEXED_KEY_NUM_METRIC = "indexedKeyNum";
+  private static final String EAGERLY_EVICTED_KEY_NUM_METRIC = "eagerlyEvictedKeyNum";
+
+  public static final MapStateDescriptor<Void, Void> CLEAR_BROADCAST_DESCRIPTOR =
+      new MapStateDescriptor<>("eq-convert-clear-broadcast", Types.VOID, Types.VOID);
+
+  private static final ValueStateDescriptor<Long> MAIN_SEQUENCE_VERSION_DESCRIPTOR =
+      new ValueStateDescriptor<>("mainSequenceVersion", Types.LONG);
+  private static final ListStateDescriptor<DVPosition> DATA_ROW_POSITIONS_DESCRIPTOR =
+      new ListStateDescriptor<>("filePositions", TypeInformation.of(DVPosition.class));
+  private static final ListStateDescriptor<DVPosition> BUFFERED_ROWS_DESCRIPTOR =
+      new ListStateDescriptor<>("bufferedRows", TypeInformation.of(DVPosition.class));
+  private static final ValueStateDescriptor<Long> RESOLVE_TIMESTAMP_DESCRIPTOR =
+      new ValueStateDescriptor<>("resolveTimestamp", Types.LONG);
+  private static final ValueStateDescriptor<Long> RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR =
+      new ValueStateDescriptor<>("resolveSequenceNumber", Types.LONG);
+
+  private transient ValueState<Long> mainSequenceVersion;
+  // Resolvable rows for this key. Populated immediately for main data, or from onTimer for
+  // staging rows once their phase watermark passes, so a delete never resolves against a row from a
+  // later phase.
+  private transient ListState<DVPosition> dataRowPositions;
+  // Deferred staging-snapshot rows awaiting their event-time timer. onTimer moves them into
+  // dataRowPositions after this cycle's delete has resolved.
+  private transient ListState<DVPosition> bufferedRows;
+  // Phase timestamp of the pending RESOLVE_DELETE; onTimer resolves when the firing timer matches.
+  private transient ValueState<Long> resolveTimestamp;
+  // Maximum sequence number among the cycle's RESOLVE_DELETEs for this key. Deletes a
+  // data row only when the row's sequence number is below it.
+  private transient ValueState<Long> resolveSequenceNumber;
+
+  private transient Counter resolvedDeleteNumCounter;
+  private transient Counter indexedKeyNumCounter;
+  private transient Counter eagerlyEvictedKeyNumCounter;
+
+  private final boolean stagingOnTargetBranch;
+
+  public EqualityConvertPKIndex(boolean stagingOnTargetBranch) {
+    this.stagingOnTargetBranch = stagingOnTargetBranch;
+  }
+
+  @Override
+  public void open(OpenContext context) throws Exception {
+    super.open(context);
+    mainSequenceVersion = getRuntimeContext().getState(MAIN_SEQUENCE_VERSION_DESCRIPTOR);
+    dataRowPositions = getRuntimeContext().getListState(DATA_ROW_POSITIONS_DESCRIPTOR);
+    bufferedRows = getRuntimeContext().getListState(BUFFERED_ROWS_DESCRIPTOR);
+    resolveTimestamp = getRuntimeContext().getState(RESOLVE_TIMESTAMP_DESCRIPTOR);
+    resolveSequenceNumber = getRuntimeContext().getState(RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR);
+    resolvedDeleteNumCounter =
+        getRuntimeContext().getMetricGroup().counter(RESOLVED_DELETE_NUM_METRIC);
+    indexedKeyNumCounter = getRuntimeContext().getMetricGroup().counter(INDEXED_KEY_NUM_METRIC);
+    eagerlyEvictedKeyNumCounter =
+        getRuntimeContext().getMetricGroup().counter(EAGERLY_EVICTED_KEY_NUM_METRIC);
+  }
+
+  @Override
+  public void processElement(IndexCommand cmd, ReadOnlyContext ctx, Collector<DVPosition> out)
+      throws Exception {
+    try {
+      Long storedSequence = mainSequenceVersion.value();
+      if (!Objects.equals(storedSequence, cmd.mainSequenceNumber())) {
+        LOG.info(
+            "Main sequence changed from {} to {} (snapshot {}), clearing state",
+            storedSequence,
+            cmd.mainSequenceNumber(),
+            cmd.mainSnapshotId());
+        clearKeyState();
+        mainSequenceVersion.update(cmd.mainSequenceNumber());
+      }
+
+      long ts = ctx.timestamp();
+
+      if (cmd.type() == IndexCommand.Type.ADD_DATA_ROW) {
+        // Existing main data: index immediately so this cycle's delete can remove it.
+        dataRowPositions.add(cmd.rowPosition());
+        indexedKeyNumCounter.inc();
+      } else if (cmd.type() == IndexCommand.Type.ADD_STAGING_DATA_ROW) {
+        // Staging snapshot's new data: defer until after this cycle's delete resolves so a
+        // re-inserted key survives. Applied by the event-time timer at this phase.
+        bufferedRows.add(cmd.rowPosition());
+        ctx.timerService().registerEventTimeTimer(ts);
+      } else if (cmd.type() == IndexCommand.Type.RESOLVE_DELETE) {
+        Long resolveTs = resolveTimestamp.value();
+        if (resolveTs == null || ts > resolveTs) {
+          resolveTimestamp.update(ts);
+        }
+
+        Long currentSeq = resolveSequenceNumber.value();
+        if (currentSeq == null || cmd.deleteSequenceNumber() > currentSeq) {
+          resolveSequenceNumber.update(cmd.deleteSequenceNumber());
+        }
+
+        ctx.timerService().registerEventTimeTimer(ts);
+      } else {
+        throw new IllegalStateException("Unexpected command type in keyed stream: " + cmd.type());
+      }
+    } catch (Exception e) {
+      LOG.error("PKIndex failed to process command of type {}", cmd.type(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  @Override
+  public void processBroadcastElement(IndexCommand cmd, Context ctx, Collector<DVPosition> out) {
+    Preconditions.checkArgument(
+        cmd.type() == IndexCommand.Type.CLEAR_INDEX,
+        "Broadcast element must be %s",
+        IndexCommand.Type.CLEAR_INDEX);
+
+    final long broadcastSequenceNumber = cmd.mainSequenceNumber();
+    try {
+      ctx.applyToKeyedState(
+          MAIN_SEQUENCE_VERSION_DESCRIPTOR,
+          (key, sequenceState) -> {
+            Long storedSequenceNumber = sequenceState.value();
+            if (storedSequenceNumber != null && storedSequenceNumber < broadcastSequenceNumber) {
+              clearKeyState();
+              sequenceState.update(broadcastSequenceNumber);
+              eagerlyEvictedKeyNumCounter.inc();
+            }
+          });
+    } catch (Exception e) {
+      LOG.error("PKIndex failed to apply CLEAR_INDEX for snapshot {}", cmd.mainSnapshotId(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  @Override
+  public void onTimer(long timestamp, OnTimerContext ctx, Collector<DVPosition> out) {
+    try {
+      // Timers fire in ascending timestamp order. The delete-phase timer resolves against the
+      // index; any other timer is a staging phase whose buffered rows now join the index.
+      // The delete fires before the (strictly later) staging phase, so the cycle's own new rows are
+      // applied only after the delete and survive it.
+      Long resolveTs = resolveTimestamp.value();
+      if (resolveTs != null && timestamp == resolveTs) {
+        resolveDeletes(out);
+        resolveTimestamp.clear();
+        resolveSequenceNumber.clear();
+      } else {
+        applyBufferedRows();
+      }
+    } catch (Exception e) {
+      LOG.error("PKIndex failed in onTimer at ts={}", timestamp, e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  private void applyBufferedRows() throws Exception {
+    for (DVPosition position : bufferedRows.get()) {
+      dataRowPositions.add(position);
+      indexedKeyNumCounter.inc();
+    }
+
+    bufferedRows.clear();
+  }
+
+  private void resolveDeletes(Collector<DVPosition> out) throws Exception {
+    // An equality delete with sequence S deletes only data rows with sequence < S. Rows at or
+    // above S are re-inserts the delete does not affect; keep them indexed for a later delete.
+    // Only valid on a shared staging/target branch, where data and deletes share one sequence
+    // space. On a separate target branch the committer reassigns data sequence numbers, so the
+    // indexed sequence is not comparable to the staging delete's; event-time ordering already
+    // prevents false deletion.
+    Long deleteSeq = resolveSequenceNumber.value();
+    List<DVPosition> nonEligible = Lists.newArrayList();
+    int count = 0;
+    for (DVPosition pos : dataRowPositions.get()) {
+      if (stagingOnTargetBranch && deleteSeq != null && pos.dataSequenceNumber() >= deleteSeq) {
+        nonEligible.add(pos);
+      } else {
+        out.collect(pos);
+        count++;
+      }
+    }
+
+    resolvedDeleteNumCounter.inc(count);
+    dataRowPositions.update(nonEligible);
+  }
+
+  private void clearKeyState() {
+    dataRowPositions.clear();
+    bufferedRows.clear();
+    resolveTimestamp.clear();
+    resolveSequenceNumber.clear();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlan.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlan.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+/**
+ * Result of equality convert planning. Produced by {@link EqualityConvertPlanner} and consumed by
+ * both {@link EqualityConvertDVWriter} (for partition info and DV merge gating) and {@link
+ * EqualityConvertCommitter} (for data files and staging deletes to commit).
+ *
+ * <p>A no-op cycle is encoded by {@link #stagingSnapshotId()} == {@link
+ * #NO_OP_STAGING_SNAPSHOT_ID}. Use {@link #noOp(Long, long, long)} to construct one and {@link
+ * #noOp()} to check.
+ *
+ * @param dataFiles new staging data files committed in the cycle
+ * @param stagingDVFiles staging DVs passed through to main, used by DVWriter to merge with
+ *     newly-created DVs
+ * @param stagingSnapshotId staging snapshot the cycle resolved against, or {@link
+ *     #NO_OP_STAGING_SNAPSHOT_ID} for a no-op cycle
+ * @param mainSnapshotId main branch snapshot ID the index was resolved against, used for commit
+ *     validation
+ * @param triggerTimestamp original trigger timestamp, forwarded by the Committer to the Aggregator
+ * @param doneTimestamp timestamp after which all phase watermarks have been emitted; the DVWriter
+ *     should only process the result when the watermark reaches or exceeds this value
+ */
+@Internal
+public record EqualityConvertPlan(
+    List<DataFile> dataFiles,
+    List<DeleteFile> stagingDVFiles,
+    long stagingSnapshotId,
+    Long mainSnapshotId,
+    long triggerTimestamp,
+    long doneTimestamp)
+    implements Serializable {
+
+  public static final long NO_OP_STAGING_SNAPSHOT_ID = -1L;
+
+  /** Returns {@code true} if this cycle has nothing to commit. */
+  public boolean noOp() {
+    return stagingSnapshotId == NO_OP_STAGING_SNAPSHOT_ID;
+  }
+
+  /** No-op cycle: empty file lists, sentinel staging snapshot id. */
+  public static EqualityConvertPlan noOp(
+      Long mainSnapshotId, long triggerTimestamp, long doneTimestamp) {
+    return new EqualityConvertPlan(
+        ImmutableList.of(),
+        ImmutableList.of(),
+        NO_OP_STAGING_SNAPSHOT_ID,
+        mainSnapshotId,
+        triggerTimestamp,
+        doneTimestamp);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
@@ -1,0 +1,741 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotChanges;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Planner for the equality delete conversion pipeline. For each trigger, it picks the oldest
+ * staging snapshot that hasn't been converted yet and emits {@link ReadCommand}s describing the
+ * files its downstream readers and workers must process.
+ *
+ * <p>Each trigger runs two steps in order:
+ *
+ * <ol>
+ *   <li>{@link #ensureIndexCurrent}: updates {@link #lastStagingSnapshotId} from main's history,
+ *       bootstraps the worker index from main on first run, and reindexes when external commits
+ *       (e.g. compaction) have advanced main past the currently-indexed snapshot.
+ *   <li>{@link #processStagingSnapshot}: resolve the chosen staging snapshot's eq deletes against
+ *       the (now-current) index, pass through any DV files, and index the snapshot's new data files
+ *       for the next cycle.
+ * </ol>
+ *
+ * Watermarks separate phases that gate the worker's keyed state. The contract is documented on
+ * {@link #advancePhase()}.
+ *
+ * <p>An {@link EqualityConvertPlan} with the current cycle's metadata is emitted via the {@link
+ * #METADATA_STREAM} side output after the read commands.
+ *
+ * <p>Assumes a single equality-field set supplied via the builder; staging eq-deletes with a
+ * different {@code equalityFieldIds} fail fast in {@link #retrieveStagingFiles}. Concurrent writes
+ * on the target branch are handled by {@link #ensureIndexCurrent} reindexing from the new main
+ * snapshot; commit-time conflicts are caught by {@code RowDelta.validateFromSnapshot}.
+ */
+@Internal
+public class EqualityConvertPlanner extends AbstractStreamOperator<ReadCommand>
+    implements OneInputStreamOperator<Trigger, ReadCommand> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertPlanner.class);
+
+  public static final OutputTag<EqualityConvertPlan> METADATA_STREAM =
+      new OutputTag<>("metadata-stream") {};
+
+  public static final OutputTag<IndexCommand> CLEAR_BROADCAST_STREAM =
+      new OutputTag<>("clear-broadcast-stream") {};
+
+  private static final String PROCESSED_EQ_DELETE_FILE_NUM_METRIC = "processedEqDeleteFileNum";
+  private static final String PROCESSED_STAGING_SNAPSHOT_NUM_METRIC = "processedStagingSnapshotNum";
+  private static final String SKIPPED_NO_OP_CYCLES_METRIC = "skippedNoOpCycles";
+  private static final String REINDEX_COUNT_METRIC = "reindexCount";
+
+  private final String tableName;
+  private final String taskName;
+  private final TableLoader tableLoader;
+  private final String stagingBranch;
+  private final String targetBranch;
+  private final boolean stagingOnTargetBranch;
+  // Equality-field-id set the worker keys on. Supplied via the builder; every staging
+  // eq-delete's equalityFieldIds() must match exactly.
+  private final Set<Integer> eqFieldIds;
+
+  // Main snapshot id the worker's index reflects.
+  private transient ListState<Long> indexSnapshotState;
+  // Main sequence number the worker's index reflects.
+  private transient ListState<Long> indexedSequenceNumberState;
+  // Equality field IDs the index was built with, allows to detect reconfiguration.
+  private transient ListState<Integer> eqFieldIdsState;
+
+  private transient Table table;
+
+  private transient Long lastMainSnapshotId;
+  private transient Long lastStagingSnapshotId;
+  private transient Long indexSnapshotId;
+  private transient Long indexedSequenceNumber;
+
+  private transient long nextPhaseTs;
+
+  private transient Counter processedEqDeleteFileNumCounter;
+  private transient Counter processedStagingSnapshotNumCounter;
+  private transient Counter skippedNoOpCyclesCounter;
+  private transient Counter reindexCounter;
+  private transient Counter errorCounter;
+
+  public EqualityConvertPlanner(
+      String tableName,
+      String taskName,
+      TableLoader tableLoader,
+      String stagingBranch,
+      String targetBranch,
+      Set<Integer> eqFieldIds) {
+    this.tableName = tableName;
+    this.taskName = taskName;
+    this.tableLoader = tableLoader;
+    this.stagingBranch = stagingBranch;
+    this.targetBranch = targetBranch;
+    this.stagingOnTargetBranch = stagingBranch.equals(targetBranch);
+    Preconditions.checkArgument(
+        eqFieldIds != null && !eqFieldIds.isEmpty(), "eqFieldIds must not be null or empty");
+    this.eqFieldIds = ImmutableSet.copyOf(eqFieldIds);
+  }
+
+  @Override
+  public void open() throws Exception {
+    super.open();
+    if (!tableLoader.isOpen()) {
+      tableLoader.open();
+    }
+
+    table = tableLoader.loadTable();
+
+    MetricGroup taskMetricGroup =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), tableName, taskName, 0);
+    this.processedEqDeleteFileNumCounter =
+        taskMetricGroup.counter(PROCESSED_EQ_DELETE_FILE_NUM_METRIC);
+    this.processedStagingSnapshotNumCounter =
+        taskMetricGroup.counter(PROCESSED_STAGING_SNAPSHOT_NUM_METRIC);
+    this.skippedNoOpCyclesCounter = taskMetricGroup.counter(SKIPPED_NO_OP_CYCLES_METRIC);
+    this.reindexCounter = taskMetricGroup.counter(REINDEX_COUNT_METRIC);
+    this.errorCounter = taskMetricGroup.counter(TableMaintenanceMetrics.ERROR_COUNTER);
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    indexSnapshotState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("indexSnapshotId", Types.LONG));
+
+    indexSnapshotId = null;
+    for (Long stateValue : indexSnapshotState.get()) {
+      Preconditions.checkState(
+          indexSnapshotId == null, "indexSnapshotId state should hold at most one value");
+      indexSnapshotId = stateValue;
+    }
+
+    indexedSequenceNumberState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("indexedSequenceNumber", Types.LONG));
+
+    indexedSequenceNumber = null;
+    for (Long stateValue : indexedSequenceNumberState.get()) {
+      Preconditions.checkState(
+          indexedSequenceNumber == null,
+          "indexedSequenceNumber state should hold at most one value");
+      indexedSequenceNumber = stateValue;
+    }
+
+    eqFieldIdsState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("eqFieldIds", Types.INT));
+    Set<Integer> restoredEqFieldIds = Sets.newHashSet(eqFieldIdsState.get());
+    Preconditions.checkState(
+        restoredEqFieldIds.isEmpty() || restoredEqFieldIds.equals(eqFieldIds),
+        "Equality field IDs changed across restart: restored=%s, configured=%s. "
+            + "Reconfiguring equality-field columns is not supported; "
+            + "restart from a clean state (no savepoint).",
+        restoredEqFieldIds,
+        eqFieldIds);
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    indexSnapshotState.clear();
+    if (indexSnapshotId != null) {
+      indexSnapshotState.add(indexSnapshotId);
+    }
+
+    indexedSequenceNumberState.clear();
+    if (indexedSequenceNumber != null) {
+      indexedSequenceNumberState.add(indexedSequenceNumber);
+    }
+
+    eqFieldIdsState.clear();
+    for (int id : eqFieldIds) {
+      eqFieldIdsState.add(id);
+    }
+  }
+
+  @Override
+  public void processElement(StreamRecord<Trigger> element) throws Exception {
+    long triggerTs = element.getTimestamp();
+    nextPhaseTs = Math.max(triggerTs, nextPhaseTs + 1);
+
+    Long currentMainSnapshotId = lastMainSnapshotId;
+    try {
+      table.refresh();
+      Snapshot mainSnapshot = table.snapshot(targetBranch);
+      currentMainSnapshotId = mainSnapshot != null ? mainSnapshot.snapshotId() : null;
+
+      ensureIndexCurrent(mainSnapshot);
+
+      Snapshot nextToProcess =
+          nextUnprocessedStagingSnapshot(table.snapshot(stagingBranch), mainSnapshot);
+
+      if (nextToProcess == null) {
+        LOG.info("Nothing new to convert on staging branch '{}'.", stagingBranch);
+        emitNoOpResult(triggerTs, currentMainSnapshotId);
+        return;
+      }
+
+      processStagingSnapshot(nextToProcess, triggerTs, currentMainSnapshotId);
+    } catch (Exception e) {
+      LOG.error("Error processing equality deletes for table {} task {}", tableName, taskName, e);
+      output.collect(TaskResultAggregator.ERROR_STREAM, new StreamRecord<>(e));
+      errorCounter.inc();
+      emitDrainResult(triggerTs, currentMainSnapshotId);
+    }
+  }
+
+  /**
+   * Brings the worker's index up to date with the current state of the target branch:
+   *
+   * <ul>
+   *   <li>Updates {@link #lastStagingSnapshotId} from the most recent committer marker on main.
+   *   <li>Bootstraps the index from main on the first trigger with a non-null main snapshot.
+   *   <li>Reindexes from main when external commits (e.g. compaction or direct writes) have
+   *       advanced main past the currently-indexed snapshot.
+   * </ul>
+   *
+   * <p>No-op when main hasn't moved since the last trigger. Otherwise the history walk is bounded
+   * to commits added since {@link #lastMainSnapshotId}.
+   */
+  private void ensureIndexCurrent(Snapshot mainSnapshot) {
+    Long currentMainSnapshotId = mainSnapshot != null ? mainSnapshot.snapshotId() : null;
+
+    if (Objects.equals(lastMainSnapshotId, currentMainSnapshotId)) {
+      return;
+    }
+
+    LastCommittedWork info = discoverLastCommittedWork(mainSnapshot);
+    updateLastStagingSnapshotId(info);
+
+    boolean bootstrap = mainSnapshot != null && indexSnapshotId == null;
+    boolean reindex = indexSnapshotId != null && info.externalCommitCount() > 0;
+    if (bootstrap || reindex) {
+      LOG.info(
+          "{} worker index from main snapshot {} for field IDs {}.",
+          bootstrap ? "Bootstrapping" : "Reindexing",
+          currentMainSnapshotId,
+          eqFieldIds);
+      if (reindex) {
+        // Evict keyed entries the reindex will not re-add (e.g. data file removed by CoW).
+        output.collect(
+            CLEAR_BROADCAST_STREAM,
+            new StreamRecord<>(
+                IndexCommand.clearBeforeReindex(
+                    currentMainSnapshotId, mainSnapshot.sequenceNumber())));
+        reindexCounter.inc();
+      }
+
+      indexSnapshotId = currentMainSnapshotId;
+      indexedSequenceNumber = mainSnapshot.sequenceNumber();
+      emitMainDataReadCommands(mainSnapshot);
+    }
+
+    lastMainSnapshotId = currentMainSnapshotId;
+  }
+
+  private void updateLastStagingSnapshotId(LastCommittedWork info) {
+    if (info.lastCommittedStaging() != null) {
+      lastStagingSnapshotId = info.lastCommittedStaging();
+      return;
+    }
+
+    Preconditions.checkState(
+        lastMainSnapshotId == null || lastStagingSnapshotId == null || info.reachedLastInspected(),
+        "No COMMITTED_STAGING_SNAPSHOT marker reachable on target branch '%s' for table %s, "
+            + "but a prior marker was seen (lastStagingSnapshotId=%s). Target may have been "
+            + "rewritten (rollback, replace_main, or snapshot expiration). "
+            + "Manual intervention required.",
+        targetBranch,
+        tableName,
+        lastStagingSnapshotId);
+  }
+
+  /**
+   * Walks main back from head looking for the most recent snapshot tagged with {@link
+   * EqualityConvertCommitter#COMMITTED_STAGING_SNAPSHOT_PROPERTY}. Returns the staging snapshot id
+   * recorded there (or {@code null} if not reached) and the count of intervening external commits.
+   *
+   * <p>The walk stops at whichever comes first:
+   *
+   * <ul>
+   *   <li>The first snapshot carrying the committer marker.
+   *   <li>{@link #lastMainSnapshotId} — anything older was inspected on a previous trigger.
+   * </ul>
+   */
+  private LastCommittedWork discoverLastCommittedWork(Snapshot mainSnapshot) {
+    Long lastCommittedStaging = null;
+    int externalCount = 0;
+    boolean reachedLastInspected = false;
+    Snapshot current = mainSnapshot;
+    while (current != null) {
+      if (lastMainSnapshotId != null && current.snapshotId() == lastMainSnapshotId) {
+        reachedLastInspected = true;
+        break;
+      }
+
+      String prop =
+          current.summary().get(EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY);
+      if (prop != null) {
+        lastCommittedStaging = Long.parseLong(prop);
+        break;
+      }
+
+      externalCount++;
+      current = parentOf(current);
+    }
+
+    return new LastCommittedWork(lastCommittedStaging, externalCount, reachedLastInspected);
+  }
+
+  private record LastCommittedWork(
+      Long lastCommittedStaging, int externalCommitCount, boolean reachedLastInspected) {}
+
+  /**
+   * Walks staging history from head back to the stop point and returns the oldest unprocessed
+   * snapshot to convert this cycle, or {@code null} if there's nothing new.
+   *
+   * <p>The stop point is:
+   *
+   * <ul>
+   *   <li>the last-processed staging snapshot, if known;
+   *   <li>otherwise, on cold start with {@code stagingBranch != targetBranch}, the common ancestor
+   *       with target;
+   *   <li>otherwise, on cold start with {@code stagingBranch == targetBranch}, the root of history
+   *       ({@code null}). {@link #shouldSkip} filters already-converted snapshots in O(1) via the
+   *       {@code COMMITTED_STAGING_SNAPSHOT_PROPERTY} marker, and pure-insert snapshots via the
+   *       same-branch eq-delete predicate.
+   * </ul>
+   *
+   * <p>When {@code stagingBranch == targetBranch}, the writer commits eq-deletes and data files
+   * directly to target; the converter performs in-place eq-delete-to-DV compaction. On cold start
+   * we walk the full history so eq-deletes committed before the converter started are still picked
+   * up.
+   */
+  private Snapshot nextUnprocessedStagingSnapshot(Snapshot stagingHead, Snapshot mainSnapshot) {
+    if (stagingHead == null) {
+      return null;
+    }
+
+    Long stopAt;
+    if (lastStagingSnapshotId != null) {
+      stopAt = lastStagingSnapshotId;
+    } else if (stagingOnTargetBranch) {
+      stopAt = null;
+    } else {
+      stopAt = findCommonAncestor(stagingHead, mainSnapshot);
+    }
+
+    Snapshot current = stagingHead;
+    Snapshot oldestUnprocessed = null;
+    while (current != null) {
+      if (stopAt != null && current.snapshotId() == stopAt) {
+        break;
+      }
+
+      if (!shouldSkip(current)) {
+        oldestUnprocessed = current;
+      }
+
+      current = parentOf(current);
+    }
+
+    return oldestUnprocessed;
+  }
+
+  /**
+   * Resolves the eq deletes in {@code stagingSnapshot} against the current index and emits the
+   * cycle's metadata. Phase ordering (separated by watermarks):
+   *
+   * <ol>
+   *   <li>Eq delete read commands. Eq deletes resolve in the worker.
+   *   <li>Staging data files. Indexed for the NEXT cycle's eq-delete resolution.
+   * </ol>
+   *
+   * Cold-start bootstrap of the index from main data is handled separately in {@link
+   * #processElement}, which runs once before the first cycle.
+   */
+  private void processStagingSnapshot(
+      Snapshot stagingSnapshot, long triggerTs, Long currentMainSnapshotId) {
+
+    StagingInputs inputs = retrieveStagingFiles(stagingSnapshot);
+    Preconditions.checkState(
+        !inputs.isEmpty(),
+        "Staging snapshot %s has no convertible inputs; shouldSkip should have filtered it.",
+        stagingSnapshot.snapshotId());
+
+    emitDeletePhase(inputs.eqDeleteFiles());
+    emitSnapshotDataPhase(inputs.newDataFiles());
+
+    LOG.info(
+        "Emitted read commands for {} new data files from staging branch '{}'.",
+        inputs.newDataFiles().size(),
+        stagingBranch);
+
+    processedStagingSnapshotNumCounter.inc();
+
+    output.collect(
+        METADATA_STREAM,
+        new StreamRecord<>(
+            new EqualityConvertPlan(
+                inputs.newDataFiles(),
+                inputs.stagingDVFiles(),
+                stagingSnapshot.snapshotId(),
+                currentMainSnapshotId,
+                triggerTs,
+                nextPhaseTs)));
+
+    advancePhase();
+  }
+
+  /**
+   * Classifies the files added by {@code stagingSnapshot} into data files, eq delete files, and DV
+   * files. Throws if the snapshot:
+   *
+   * <ul>
+   *   <li>Removes data files (rewrites on the staging branch aren't supported).
+   *   <li>Contains V2 positional delete files (the converter expects a V3 staging branch written by
+   *       Flink, which produces only deletion vectors for deletes).
+   *   <li>Contains an eq-delete file whose {@code equalityFieldIds()} doesn't match the
+   *       builder-configured set (silent wrong-key serialization otherwise).
+   * </ul>
+   */
+  private StagingInputs retrieveStagingFiles(Snapshot stagingSnapshot) {
+    SnapshotChanges changes = SnapshotChanges.builderFor(table).snapshot(stagingSnapshot).build();
+
+    // Rewrites on the staging branch would require rewriting the corresponding DVs against new
+    // data files on target. Not implemented; fail fast instead of silently dropping work.
+    if (changes.removedDataFiles().iterator().hasNext()) {
+      throw new IllegalStateException(
+          String.format(
+              "Staging snapshot %s on branch '%s' removes data files; "
+                  + "equality delete conversion does not support rewrites on the staging branch. "
+                  + "Run compaction on the target branch instead.",
+              stagingSnapshot.snapshotId(), stagingBranch));
+    }
+
+    List<DataFile> newDataFiles = Lists.newArrayList();
+    List<DeleteFile> stagingDVFiles = Lists.newArrayList();
+    List<DeleteFile> eqDeleteFiles = Lists.newArrayList();
+
+    for (DataFile dataFile : changes.addedDataFiles()) {
+      newDataFiles.add(dataFile);
+    }
+
+    for (DeleteFile deleteFile : changes.addedDeleteFiles()) {
+      if (deleteFile.content() == FileContent.EQUALITY_DELETES) {
+        Set<Integer> deleteFieldIds = Sets.newHashSet(deleteFile.equalityFieldIds());
+        Preconditions.checkState(
+            deleteFieldIds.equals(eqFieldIds),
+            "Staging snapshot %s on branch '%s' contains an equality delete file %s with "
+                + "equalityFieldIds=%s, which does not match the configured eqFieldIds=%s. "
+                + "The writer must use the same equality field IDs as the converter.",
+            stagingSnapshot.snapshotId(),
+            stagingBranch,
+            deleteFile.location(),
+            deleteFieldIds,
+            eqFieldIds);
+        eqDeleteFiles.add(deleteFile);
+      } else if (ContentFileUtil.isDV(deleteFile)) {
+        stagingDVFiles.add(deleteFile);
+      } else {
+        throw new IllegalStateException(
+            String.format(
+                "Staging snapshot %s on branch '%s' contains a V2 positional delete file (%s); "
+                    + "equality delete conversion expects a V3 staging branch written by Flink, "
+                    + "which produces only deletion vectors for deletes.",
+                stagingSnapshot.snapshotId(), stagingBranch, deleteFile.location()));
+      }
+    }
+
+    return new StagingInputs(newDataFiles, stagingDVFiles, eqDeleteFiles);
+  }
+
+  /** Files added by one staging snapshot, classified for cycle emission. */
+  private record StagingInputs(
+      List<DataFile> newDataFiles,
+      List<DeleteFile> stagingDVFiles,
+      List<DeleteFile> eqDeleteFiles) {
+
+    boolean isEmpty() {
+      return newDataFiles.isEmpty() && eqDeleteFiles.isEmpty() && stagingDVFiles.isEmpty();
+    }
+  }
+
+  private void emitDeletePhase(List<DeleteFile> eqDeleteFiles) {
+    for (DeleteFile deleteFile : eqDeleteFiles) {
+      PartitionSpec spec = table.specs().get(deleteFile.specId());
+      output.collect(
+          new StreamRecord<>(
+              ReadCommand.eqDeleteFile(
+                  deleteFile,
+                  spec,
+                  indexSnapshotId,
+                  indexedSequenceNumber,
+                  dataSequenceNumber(deleteFile)),
+              nextPhaseTs));
+      processedEqDeleteFileNumCounter.inc();
+    }
+
+    advancePhase();
+  }
+
+  private void emitSnapshotDataPhase(List<DataFile> snapshotDataFiles) {
+    // Shared-branch skip: when stagingBranch == targetBranch, these files are already on target
+    // and were indexed by bootstrap/reindex. Re-emitting would duplicate entries in
+    // dataRowPositions.
+    if (!stagingOnTargetBranch) {
+      for (DataFile dataFile : snapshotDataFiles) {
+        PartitionSpec spec = table.specs().get(dataFile.specId());
+        output.collect(
+            new StreamRecord<>(
+                ReadCommand.stagingDataFile(
+                    new FlinkAddedRowsScanTask(dataFile, spec),
+                    indexSnapshotId,
+                    indexedSequenceNumber,
+                    dataSequenceNumber(dataFile)),
+                nextPhaseTs));
+      }
+    }
+
+    advancePhase();
+  }
+
+  private void emitNoOpResult(long triggerTimestamp, Long currentMainSnapshotId) {
+    skippedNoOpCyclesCounter.inc();
+    emitDrainResult(triggerTimestamp, currentMainSnapshotId);
+  }
+
+  /** Emits an empty plan result and advances the phase so the pipeline drains. */
+  private void emitDrainResult(long triggerTimestamp, Long currentMainSnapshotId) {
+    output.collect(
+        METADATA_STREAM,
+        new StreamRecord<>(
+            EqualityConvertPlan.noOp(currentMainSnapshotId, triggerTimestamp, nextPhaseTs)));
+    advancePhase();
+  }
+
+  /**
+   * Emits {@link ReadCommand}s for every data file on {@code mainSnapshot} so the worker indexes
+   * them for the configured equality-field set. Existing DVs attached to a data file are loaded by
+   * the reader and their positions are skipped. V2 positional deletes are not expected on main; the
+   * reader throws if it encounters one. Equality deletes attached to the scan task are skipped
+   * during indexing (they are processed via the planner's eq-delete read commands).
+   */
+  private void emitMainDataReadCommands(Snapshot mainSnapshot) {
+    long commitSnapshotId = mainSnapshot.snapshotId();
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(commitSnapshotId).planFiles()) {
+      for (FileScanTask task : tasks) {
+        output.collect(
+            new StreamRecord<>(
+                ReadCommand.dataFile(
+                    task, indexSnapshotId, indexedSequenceNumber, dataSequenceNumber(task.file())),
+                nextPhaseTs));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to plan files for main index", e);
+    }
+
+    LOG.info(
+        "Emitted main data read commands for field IDs {} from snapshot {}.",
+        eqFieldIds,
+        commitSnapshotId);
+
+    advancePhase();
+  }
+
+  /**
+   * Emits a phase-end watermark and bumps the phase timestamp. Every phase-emitting method must
+   * call this exactly once after its records; the worker uses these watermarks to gate keyed-state
+   * transitions. Missing or extra calls silently break ordering.
+   */
+  private void advancePhase() {
+    output.emitWatermark(new Watermark(nextPhaseTs));
+    nextPhaseTs++;
+  }
+
+  /**
+   * Returns {@code true} if {@code snapshot} can be skipped:
+   *
+   * <ul>
+   *   <li>It was already committed by us (carries {@link
+   *       EqualityConvertCommitter#COMMITTED_STAGING_SNAPSHOT_PROPERTY}), OR
+   *   <li>it adds no data or delete files (e.g. delete-file-only removals), OR
+   *   <li>{@code stagingBranch == targetBranch} and the snapshot adds no equality-delete files.
+   *       Pure-insert (and data-file-only) commits on the shared branch don't need a conversion
+   *       cycle: their data is already on target, and the worker's index stays fresh via {@link
+   *       #ensureIndexCurrent} when the next eq-delete arrives.
+   * </ul>
+   *
+   * <p>Filter checks read per-snapshot counts from {@link Snapshot#summary()}; we don't parse
+   * manifests here. Manifest parsing happens later in {@link #retrieveStagingFiles} only for the
+   * chosen snapshot.
+   */
+  private boolean shouldSkip(Snapshot snapshot) {
+    Map<String, String> summary = snapshot.summary();
+    if (summary.containsKey(EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY)) {
+      return true;
+    }
+
+    long addedDataFiles = summaryCount(summary, SnapshotSummary.ADDED_FILES_PROP);
+    long addedDeleteFiles = summaryCount(summary, SnapshotSummary.ADDED_DELETE_FILES_PROP);
+    if (addedDataFiles == 0 && addedDeleteFiles == 0) {
+      LOG.info(
+          "Skipping staging snapshot {}: no added data or delete files.", snapshot.snapshotId());
+      return true;
+    }
+
+    if (stagingOnTargetBranch
+        && summaryCount(summary, SnapshotSummary.ADD_EQ_DELETE_FILES_PROP) == 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private static long summaryCount(Map<String, String> summary, String key) {
+    String value = summary.get(key);
+    return value == null ? 0L : Long.parseLong(value);
+  }
+
+  /**
+   * Returns the id of the newest snapshot that is reachable from both the staging and target branch
+   * heads (i.e. the most recent common ancestor where the two branches last matched), or {@code
+   * null} if they share no history. Used on cold start to know where staging diverged from target
+   * so we can skip converting snapshots that already exist on target.
+   */
+  private Long findCommonAncestor(Snapshot stagingHead, Snapshot mainHead) {
+    if (mainHead == null) {
+      return null;
+    }
+
+    Set<Long> stagingSeen = Sets.newHashSet();
+    Set<Long> mainSeen = Sets.newHashSet();
+    Snapshot stagingCurrent = stagingHead;
+    Snapshot mainCurrent = mainHead;
+
+    while (stagingCurrent != null || mainCurrent != null) {
+      if (stagingCurrent != null) {
+        long id = stagingCurrent.snapshotId();
+        if (mainSeen.contains(id)) {
+          return id;
+        }
+
+        stagingSeen.add(id);
+        stagingCurrent = parentOf(stagingCurrent);
+      }
+
+      if (mainCurrent != null) {
+        long id = mainCurrent.snapshotId();
+        if (stagingSeen.contains(id)) {
+          return id;
+        }
+
+        mainSeen.add(id);
+        mainCurrent = parentOf(mainCurrent);
+      }
+    }
+
+    return null;
+  }
+
+  /** Returns the parent snapshot, or {@code null} if {@code snapshot} has no parent. */
+  private Snapshot parentOf(Snapshot snapshot) {
+    Long parentId = snapshot.parentId();
+    return parentId != null ? table.snapshot(parentId) : null;
+  }
+
+  private static long dataSequenceNumber(ContentFile<?> file) {
+    Long sequenceNumber = file.dataSequenceNumber();
+    Preconditions.checkNotNull(
+        sequenceNumber, "Missing data sequence number for committed file %s", file.location());
+    return sequenceNumber;
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.Accessor;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.formats.FormatModelRegistry;
+import org.apache.iceberg.formats.ReadBuilder;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parallel reader that processes {@link ReadCommand}s from the planner and emits {@link
+ * IndexCommand}s. Dispatches on the wrapped {@link ContentScanTask} subtype: {@link FileScanTask}
+ * (data file) emits {@code ADD_DATA_ROW} per row, our equality-delete task emits {@code
+ * RESOLVE_DELETE} per row.
+ */
+@Internal
+public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCommand> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertReader.class);
+
+  public static final OutputTag<DVPosition> READER_ABORT_STREAM =
+      new OutputTag<>("reader-abort-stream") {};
+
+  private final TableLoader tableLoader;
+  private final Set<Integer> eqFieldIds;
+  private final boolean stagingOnTargetBranch;
+
+  private transient Table table;
+  private transient Schema keySchema;
+  private transient StructLikeSerializer fieldSerializer;
+  private transient DeleteLoader deleteLoader;
+
+  public EqualityConvertReader(
+      TableLoader tableLoader, Set<Integer> eqFieldIds, boolean stagingOnTargetBranch) {
+    Preconditions.checkArgument(
+        eqFieldIds != null && !eqFieldIds.isEmpty(), "eqFieldIds must not be null or empty");
+    this.tableLoader = tableLoader;
+    this.eqFieldIds = ImmutableSet.copyOf(eqFieldIds);
+    this.stagingOnTargetBranch = stagingOnTargetBranch;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    if (!tableLoader.isOpen()) {
+      tableLoader.open();
+    }
+
+    table = tableLoader.loadTable();
+    // Equality fields resolve against the current schema at build time, so it covers all ids.
+    // Fail fast on a missing id rather than silently widening the key.
+    keySchema = TypeUtil.select(table.schema(), eqFieldIds);
+    Preconditions.checkArgument(
+        TypeUtil.getProjectedIds(keySchema).containsAll(eqFieldIds),
+        "Equality field IDs %s not present in table schema",
+        eqFieldIds);
+    fieldSerializer = new StructLikeSerializer();
+    deleteLoader = new BaseDeleteLoader(deleteFile -> table.io().newInputFile(deleteFile));
+  }
+
+  @Override
+  public void processElement(ReadCommand cmd, Context ctx, Collector<IndexCommand> out)
+      throws Exception {
+    ContentScanTask<?> task = cmd.task();
+    ContentFile<?> file = task.file();
+    try {
+      if (task instanceof FileScanTask dataTask) {
+        processDataFile(
+            dataTask,
+            cmd.mainSnapshotId(),
+            cmd.mainSequenceNumber(),
+            cmd.dataSequenceNumber(),
+            cmd.staging(),
+            out);
+      } else if (task instanceof EqualityDeleteFileScanTask deleteTask) {
+        processDeleteFile(
+            deleteTask,
+            cmd.mainSnapshotId(),
+            cmd.mainSequenceNumber(),
+            cmd.dataSequenceNumber(),
+            out);
+      } else {
+        throw new IllegalStateException(
+            "Unexpected ContentScanTask type: " + task.getClass().getName());
+      }
+    } catch (Exception e) {
+      LOG.error("Reader failed to process command for file={}", file.location(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      ctx.output(READER_ABORT_STREAM, DVPosition.ABORT);
+    }
+  }
+
+  private void processDataFile(
+      FileScanTask task,
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      long dataSequenceNumber,
+      boolean staging,
+      Collector<IndexCommand> out)
+      throws IOException {
+    ContentFile<?> file = task.file();
+    Schema readSchema = appendRowPosition(keySchema);
+    PositionDeleteIndex existingDeletes = loadExistingDVs(task, file.location());
+
+    int specId = file.specId();
+    StructLike partition = file.partition();
+    Types.StructType partitionType = table.specs().get(specId).partitionType();
+    byte[] partitionBytes = fieldSerializer.encodePartition(partition, partitionType);
+
+    InputFile input = table.io().newInputFile(file.location());
+    ReadBuilder<Record, Schema> builder =
+        FormatModelRegistry.readBuilder(file.format(), Record.class, input);
+    try (CloseableIterable<Record> records =
+        builder.project(readSchema).reuseContainers().build()) {
+      Accessor<StructLike> posAccessor =
+          readSchema.accessorForField(MetadataColumns.ROW_POSITION.fieldId());
+      for (Record record : records) {
+        long position = (long) posAccessor.get(record);
+        if (existingDeletes != null && existingDeletes.isDeleted(position)) {
+          continue;
+        }
+
+        SerializedEqualityValues key =
+            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        out.collect(
+            IndexCommand.addDataRow(
+                mainSnapshotId,
+                mainSequenceNumber,
+                key,
+                file.location(),
+                position,
+                specId,
+                partitionBytes,
+                dataSequenceNumber,
+                staging));
+      }
+    }
+  }
+
+  private void processDeleteFile(
+      EqualityDeleteFileScanTask task,
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      long dataSequenceNumber,
+      Collector<IndexCommand> out)
+      throws IOException {
+    ContentFile<?> file = task.file();
+
+    int specId = file.specId();
+
+    InputFile input = table.io().newInputFile(file.location());
+    ReadBuilder<Record, Schema> builder =
+        FormatModelRegistry.readBuilder(file.format(), Record.class, input);
+    try (CloseableIterable<Record> records = builder.project(keySchema).reuseContainers().build()) {
+      for (Record record : records) {
+        SerializedEqualityValues key =
+            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        out.collect(
+            IndexCommand.resolveDelete(
+                mainSnapshotId, mainSequenceNumber, key, dataSequenceNumber));
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  private Schema appendRowPosition(Schema schema) {
+    List<Types.NestedField> columns = Lists.newArrayList(schema.columns());
+    columns.add(MetadataColumns.ROW_POSITION);
+    return new Schema(columns);
+  }
+
+  private PositionDeleteIndex loadExistingDVs(FileScanTask task, String dataFilePath) {
+    List<DeleteFile> dvs = Lists.newArrayList();
+    for (DeleteFile deleteFile : task.deletes()) {
+      if (ContentFileUtil.isDV(deleteFile)) {
+        dvs.add(deleteFile);
+      } else if (deleteFile.content() == FileContent.POSITION_DELETES) {
+        throw new IllegalStateException(
+            String.format(
+                "V2 positional delete file %s attached to main data file %s; "
+                    + "the converter expects a V3 target with deletion vectors only.",
+                deleteFile.location(), dataFilePath));
+      } else if (deleteFile.content() == FileContent.EQUALITY_DELETES && !stagingOnTargetBranch) {
+        // When stagingBranch == targetBranch the target carries unconverted equality deletes; they
+        // are indexed as rows here and converted via the planner's RESOLVE_DELETE commands. On a
+        // separate target branch an attached equality delete means an unconverted delete leaked
+        // onto the target, which the converter cannot reason about.
+        throw new IllegalStateException(
+            String.format(
+                "Equality delete file %s attached to main data file %s; the converter expects "
+                    + "equality deletes only on the staging branch, converted to DVs on the target.",
+                deleteFile.location(), dataFilePath));
+      }
+    }
+
+    if (dvs.isEmpty()) {
+      return null;
+    }
+
+    return deleteLoader.loadPositionDeletes(dvs, dataFilePath);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityDeleteFileScanTask.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityDeleteFileScanTask.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+
+/**
+ * {@link ContentScanTask} for reading a single equality delete file standalone. The {@link
+ * DeleteFile#equalityFieldIds()} on {@link #file()} carries the PK field IDs the worker resolves
+ * against.
+ */
+@Internal
+record EqualityDeleteFileScanTask(DeleteFile file, PartitionSpec spec)
+    implements ContentScanTask<DeleteFile> {
+
+  @Override
+  public long start() {
+    return 0L;
+  }
+
+  @Override
+  public long length() {
+    return file.fileSizeInBytes();
+  }
+
+  @Override
+  public Expression residual() {
+    return Expressions.alwaysTrue();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FlinkAddedRowsScanTask.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FlinkAddedRowsScanTask.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * Minimal {@link FileScanTask} wrapper used when we have a bare {@link DataFile} (e.g. a new
+ * staging data file from {@code SnapshotChanges#addedDataFiles}) and need to feed it into the
+ * reader. For data files that already come from a planned scan, we pass the native {@link
+ * FileScanTask} through directly.
+ */
+@Internal
+record FlinkAddedRowsScanTask(DataFile file, PartitionSpec spec, List<DeleteFile> deletes)
+    implements FileScanTask {
+
+  FlinkAddedRowsScanTask {
+    // Iceberg's scan APIs return Guava ImmutableList (see BaseAddedRowsScanTask#deletes), which
+    // does not round-trip through Flink's Kryo fallback. Copy into a plain ArrayList so the record
+    // serializes cleanly regardless of what the caller passes.
+    deletes = Lists.newArrayList(deletes);
+  }
+
+  FlinkAddedRowsScanTask(DataFile file, PartitionSpec spec) {
+    this(file, spec, Collections.emptyList());
+  }
+
+  @Override
+  public long start() {
+    return 0L;
+  }
+
+  @Override
+  public long length() {
+    return file.fileSizeInBytes();
+  }
+
+  @Override
+  public Expression residual() {
+    return Expressions.alwaysTrue();
+  }
+
+  @Override
+  public Iterable<FileScanTask> split(long targetSplitSize) {
+    return Collections.singletonList(this);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Command from the {@link EqualityConvertPlanner} to the {@link EqualityConvertPKIndex}.
+ *
+ * <p>{@link Type#ADD_DATA_ROW} adds an existing main-data row to the worker's PK index shard
+ * immediately, so this cycle's delete can remove it. {@link Type#ADD_STAGING_DATA_ROW} adds a
+ * staging snapshot's new data row; the index applies it only after this cycle's delete resolves, so
+ * a re-inserted key survives a same-cycle delete. Both carry the row location as {@link
+ * #rowPosition}. {@link Type#RESOLVE_DELETE} resolves an equality delete key against the index and
+ * emits {@link DVPosition}s for all matching rows. All three flow through the keyed stream and
+ * route via {@link #key}.
+ *
+ * <p>{@link Type#CLEAR_INDEX} is emitted on the broadcast side when an external commit has advanced
+ * the main branch and the worker must evict keyed entries that won't be re-added by the upcoming
+ * reindex (e.g. PKs whose data file was removed by CoW). Has no {@link #key} or row position.
+ * Carries the new {@link #mainSequenceNumber} as the staleness threshold.
+ *
+ * <p>{@link #rowPosition} is the data row's location, set for the two add types and null otherwise;
+ * the data sequence number it carries lets the worker apply a delete only to older rows. {@code
+ * deleteSequenceNumber} is the equality delete's sequence number, set for {@link
+ * Type#RESOLVE_DELETE} and unused (-1) otherwise.
+ */
+@Internal
+public record IndexCommand(
+    Type type,
+    Long mainSnapshotId,
+    Long mainSequenceNumber,
+    SerializedEqualityValues key,
+    DVPosition rowPosition,
+    long deleteSequenceNumber)
+    implements Serializable {
+
+  public enum Type {
+    ADD_DATA_ROW,
+    ADD_STAGING_DATA_ROW,
+    RESOLVE_DELETE,
+    CLEAR_INDEX
+  }
+
+  public static IndexCommand addDataRow(
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      SerializedEqualityValues key,
+      String filePath,
+      long position,
+      int specId,
+      byte[] partition,
+      long dataSequenceNumber,
+      boolean staging) {
+    return new IndexCommand(
+        staging ? Type.ADD_STAGING_DATA_ROW : Type.ADD_DATA_ROW,
+        mainSnapshotId,
+        mainSequenceNumber,
+        key,
+        new DVPosition(filePath, position, specId, partition, dataSequenceNumber),
+        -1);
+  }
+
+  public static IndexCommand resolveDelete(
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      SerializedEqualityValues key,
+      long deleteSequenceNumber) {
+    return new IndexCommand(
+        Type.RESOLVE_DELETE, mainSnapshotId, mainSequenceNumber, key, null, deleteSequenceNumber);
+  }
+
+  public static IndexCommand clearBeforeReindex(long mainSnapshotId, long mainSequenceNumber) {
+    return new IndexCommand(Type.CLEAR_INDEX, mainSnapshotId, mainSequenceNumber, null, null, -1);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ReadCommand.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ReadCommand.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+
+/**
+ * Envelope from the {@link EqualityConvertPlanner} to the {@link EqualityConvertReader}, wrapping
+ * an Iceberg {@link ContentScanTask} plus the metadata the reader needs to process it.
+ *
+ * <p>The wrapped task is either:
+ *
+ * <ul>
+ *   <li>A {@link FileScanTask} for data files: native tasks from {@code table.newScan()} for main
+ *       reindex, or a {@link FlinkAddedRowsScanTask} wrapper for bare {@link
+ *       org.apache.iceberg.DataFile}s from {@code SnapshotChanges#addedDataFiles}.
+ *   <li>An {@link EqualityDeleteFileScanTask} for equality delete files.
+ * </ul>
+ *
+ * <p>The equality field IDs are static for the lifetime of the job and carried on the reader
+ * itself, not per-record.
+ *
+ * <p>{@code mainSnapshotId} is sent for diagnostic output.
+ *
+ * <p>{@code mainSequenceNumber} is used by the index to order eager evictions by.
+ *
+ * <p>{@code dataSequenceNumber} is the wrapped file's sequence number (data file or equality
+ * delete), propagated to the worker so a delete only deletes rows older than itself.
+ *
+ * <p>{@code staging} is true for a staging snapshot's new data rows, which the index defers until
+ * after this cycle's delete resolves; false for main reindex data and equality deletes.
+ */
+@Internal
+public record ReadCommand(
+    ContentScanTask<?> task,
+    Long mainSnapshotId,
+    Long mainSequenceNumber,
+    long dataSequenceNumber,
+    boolean staging)
+    implements Serializable {
+
+  public static ReadCommand dataFile(
+      FileScanTask task, Long mainSnapshotId, Long mainSequenceNumber, long dataSequenceNumber) {
+    return new ReadCommand(task, mainSnapshotId, mainSequenceNumber, dataSequenceNumber, false);
+  }
+
+  public static ReadCommand stagingDataFile(
+      FileScanTask task, Long mainSnapshotId, Long mainSequenceNumber, long dataSequenceNumber) {
+    return new ReadCommand(task, mainSnapshotId, mainSequenceNumber, dataSequenceNumber, true);
+  }
+
+  public static ReadCommand eqDeleteFile(
+      DeleteFile file,
+      PartitionSpec spec,
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      long dataSequenceNumber) {
+    return new ReadCommand(
+        new EqualityDeleteFileScanTask(file, spec),
+        mainSnapshotId,
+        mainSequenceNumber,
+        dataSequenceNumber,
+        false);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SerializedEqualityValues.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SerializedEqualityValues.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Arrays;
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Serialized primary key used as a Flink keyed state key. Wraps the raw bytes with content-based
+ * {@code equals}/{@code hashCode} so that Flink's keyBy partitions by key value, not by reference.
+ *
+ * <p>Using the full serialized key (instead of a hash) eliminates hash collisions: two distinct
+ * primary keys always map to separate Flink state entries.
+ */
+@Internal
+public record SerializedEqualityValues(byte[] data) {
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof SerializedEqualityValues other)) {
+      return false;
+    }
+
+    return Arrays.equals(data, other.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(data);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/StructLikeSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/StructLikeSerializer.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Serializer for {@link StructLike} tuples. Two entry points:
+ *
+ * <ul>
+ *   <li>{@link #serializeKey} builds a Flink keyed-state key ({@link SerializedEqualityValues}),
+ *       prefixed with the partition spec id so partition evolution keeps specs disjoint.
+ *   <li>{@link #encodePartition} / {@link #decodePartition} serialize partition tuples into bytes.
+ * </ul>
+ */
+class StructLikeSerializer {
+
+  static final byte[] EMPTY_PARTITION = new byte[0];
+
+  private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+  private final DataOutputStream dos = new DataOutputStream(baos);
+
+  public SerializedEqualityValues serializeKey(
+      StructLike key, Types.StructType keyType, int specId) {
+    baos.reset();
+    try {
+      dos.writeInt(specId);
+
+      List<Types.NestedField> fields = keyType.fields();
+      dos.writeInt(fields.size());
+      for (Types.NestedField field : fields) {
+        dos.writeInt(field.fieldId());
+      }
+
+      for (int i = 0; i < fields.size(); i++) {
+        writeField(key, i, fields.get(i).type());
+      }
+
+      dos.flush();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to serialize PK index key", e);
+    }
+
+    return new SerializedEqualityValues(baos.toByteArray());
+  }
+
+  public byte[] encodePartition(StructLike partition, Types.StructType partitionType) {
+    List<Types.NestedField> fields = partitionType.fields();
+    if (fields.isEmpty()) {
+      return EMPTY_PARTITION;
+    }
+
+    baos.reset();
+    try {
+      for (int i = 0; i < fields.size(); i++) {
+        writeField(partition, i, fields.get(i).type());
+      }
+
+      dos.flush();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to encode partition", e);
+    }
+
+    return baos.toByteArray();
+  }
+
+  public static StructLike decodePartition(byte[] encoded, Types.StructType partitionType) {
+    PartitionData partition = new PartitionData(partitionType);
+    List<Types.NestedField> fields = partitionType.fields();
+    if (fields.isEmpty()) {
+      return partition;
+    }
+
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(encoded))) {
+      for (int i = 0; i < fields.size(); i++) {
+        boolean isNull = dis.readBoolean();
+        if (isNull) {
+          partition.set(i, null);
+        } else {
+          int length = dis.readInt();
+          byte[] bytes = new byte[length];
+          dis.readFully(bytes);
+          Object value = Conversions.fromByteBuffer(fields.get(i).type(), ByteBuffer.wrap(bytes));
+          // Conversions returns CharBuffer for STRING; PartitionData (and the manifest writer)
+          // expects String.
+          if (value instanceof CharSequence cs && !(value instanceof String)) {
+            value = cs.toString();
+          }
+
+          partition.set(i, value);
+        }
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to decode partition", e);
+    }
+
+    return partition;
+  }
+
+  private void writeField(StructLike struct, int pos, Type fieldType) throws IOException {
+    Object value = struct.get(pos, Object.class);
+    if (value == null) {
+      dos.writeBoolean(true);
+      return;
+    }
+
+    dos.writeBoolean(false);
+    ByteBuffer buf = Conversions.toByteBuffer(fieldType, value);
+    dos.writeInt(buf.remaining());
+    dos.write(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletes.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletes.java
@@ -1,0 +1,1312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestConvertEqualityDeletes extends MaintenanceTaskTestBase {
+
+  private static final String STAGING_BRANCH = "__flink_staging_test";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void testRejectsFormatVersion2() {
+    createTableWithDelete(2);
+
+    assertThatThrownBy(
+            () ->
+                ConvertEqualityDeletes.builder()
+                    .stagingBranch(STAGING_BRANCH)
+                    .equalityFieldColumns(ImmutableList.of("id", "data"))
+                    .append(
+                        infra.triggerStream(),
+                        DUMMY_TABLE_NAME,
+                        DUMMY_TASK_NAME,
+                        0,
+                        tableLoader(),
+                        UID_SUFFIX,
+                        StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+                        1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("format version >= 3");
+  }
+
+  @Test
+  void testRejectsPartitionColumnNotInEqualityFields() {
+    // Current spec partitions by identity("data"); equality fields are just "id". The converter
+    // drops partition from the key, so a partition column outside the equality set is rejected.
+    createPartitionedTableWithDelete(3);
+
+    assertThatThrownBy(
+            () ->
+                ConvertEqualityDeletes.builder()
+                    .stagingBranch(STAGING_BRANCH)
+                    .equalityFieldColumns(ImmutableList.of("id"))
+                    .append(
+                        infra.triggerStream(),
+                        DUMMY_TABLE_NAME,
+                        DUMMY_TASK_NAME,
+                        0,
+                        tableLoader(),
+                        UID_SUFFIX,
+                        StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+                        1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not an equality field");
+  }
+
+  @Test
+  void testConvertEqualityDeletesToDVs() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    // Insert initial data to main
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+
+    assertThat(dataFileCount(table)).isEqualTo(3);
+
+    // Create staging branch from current main state
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Write a new data file (simulating insert of id=4)
+    DataFile newDataFile = writeDataFile(table, createRecord(4, "d"));
+
+    // Write an equality delete for id=2 (simulating delete of row "b")
+    DeleteFile eqDelete = writeEqualityDelete(table, 2, "b");
+
+    // Commit both to the staging branch
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Verify staging branch has the eq delete
+    long stagingEqDeleteCount =
+        table.snapshot(STAGING_BRANCH).deleteManifests(table.io()).stream()
+            .flatMap(
+                m ->
+                    StreamSupport.stream(
+                        ManifestFiles.readDeleteManifest(m, table.io(), table.specs())
+                            .spliterator(),
+                        false))
+            .filter(f -> f.content() == FileContent.EQUALITY_DELETES)
+            .count();
+    assertThat(stagingEqDeleteCount).isEqualTo(1);
+
+    // Wire the ConvertEqualityDeletes maintenance task
+    ConvertEqualityDeletes.builder()
+        .stagingBranch(STAGING_BRANCH)
+        .equalityFieldColumns(ImmutableList.of("id", "data"))
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    // Run the maintenance task
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    // Verify main branch now has 4 data files (3 original + 1 new)
+    table.refresh();
+    assertThat(dataFileCount(table)).isEqualTo(4);
+
+    // Verify main branch has DV delete files (not equality deletes)
+    long mainDvCount =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .flatMap(
+                m ->
+                    StreamSupport.stream(
+                        ManifestFiles.readDeleteManifest(m, table.io(), table.specs())
+                            .spliterator(),
+                        false))
+            .filter(f -> f.content() == FileContent.POSITION_DELETES)
+            .count();
+    assertThat(mainDvCount).isGreaterThanOrEqualTo(1);
+
+    // Verify no equality deletes on main
+    long mainEqDeleteCount =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .flatMap(
+                m ->
+                    StreamSupport.stream(
+                        ManifestFiles.readDeleteManifest(m, table.io(), table.specs())
+                            .spliterator(),
+                        false))
+            .filter(f -> f.content() == FileContent.EQUALITY_DELETES)
+            .count();
+    assertThat(mainEqDeleteCount).isEqualTo(0);
+
+    // Verify data correctness: id=2 should be deleted, id=4 should be added
+    SimpleDataUtil.assertTableRecords(
+        table, ImmutableList.of(createRecord(1, "a"), createRecord(3, "c"), createRecord(4, "d")));
+  }
+
+  @Test
+  void testNoOpWhenStagingBranchEmpty() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    // Create staging branch with no new files
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    ConvertEqualityDeletes.builder()
+        .stagingBranch(STAGING_BRANCH)
+        .equalityFieldColumns(ImmutableList.of("id", "data"))
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    // Should complete successfully with no changes
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    assertThat(dataFileCount(table)).isEqualTo(1);
+    SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(1, "a")));
+  }
+
+  @Test
+  void testMultipleEqualityDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+    insert(table, 5, "e");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Delete id=1 and id=4 via equality deletes on staging
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    DeleteFile eqDelete2 = writeEqualityDelete(table, 4, "d");
+
+    table
+        .newRowDelta()
+        .addDeletes(eqDelete1)
+        .addDeletes(eqDelete2)
+        .toBranch(STAGING_BRANCH)
+        .commit();
+    table.refresh();
+
+    ConvertEqualityDeletes.builder()
+        .stagingBranch(STAGING_BRANCH)
+        .equalityFieldColumns(ImmutableList.of("id", "data"))
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    SimpleDataUtil.assertTableRecords(
+        table, ImmutableList.of(createRecord(2, "b"), createRecord(3, "c"), createRecord(5, "e")));
+  }
+
+  @Test
+  void testDuplicateKeyAcrossDataFiles() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    // Two data files with the same key (id=1, data="a")
+    insert(table, 1, "a");
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Eq delete for id=1 should produce DVs for both data files containing id=1
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    ConvertEqualityDeletes.builder()
+        .stagingBranch(STAGING_BRANCH)
+        .equalityFieldColumns(ImmutableList.of("id", "data"))
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    // Only id=2 should remain
+    SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(2, "b")));
+  }
+
+  @Test
+  void testMultiSnapshotStagingWithPerSnapshotScoping() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging snapshot 1: delete id=1 from main
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging snapshot 2: re-insert id=1 (new data file)
+    DataFile newDataFile = writeDataFile(table, createRecord(1, "a"));
+    table.newAppend().appendFile(newDataFile).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      // Cycle 1: processes S1 (delete id=1)
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.success()).isTrue();
+
+      // Cycle 2: processes S2 (re-insert id=1)
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      // id=1 should still exist: the delete from S1 removed the original,
+      // but S2 re-inserted it. Per-snapshot scoping ensures S1's delete
+      // doesn't affect S2's data.
+      assertRecords(table, ImmutableList.of(createRecord(1, "a")));
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  @Test
+  void testInsertThenDeleteAcrossCycles() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging snapshot 1: insert id=1 (data-only, no eq deletes)
+    DataFile insertS1 = writeDataFile(table, createRecord(1, "a"));
+    table.newAppend().appendFile(insertS1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging snapshot 2: eq delete the row written in S1
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      // Cycle 1: processes S1 (insert id=1), commits data file to main
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.exceptions()).isEmpty();
+      assertThat(result1.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(1, "a")));
+
+      // Cycle 2: processes S2 (eq delete id=1), must find id=1 on main
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.exceptions()).isEmpty();
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of());
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  @Test
+  void testInsertUpdateDeleteInsertUpdateChain() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S1: insert K=1, V=A
+    DataFile s1 = writeDataFile(table, createRecord(1, "a"));
+    table.newAppend().appendFile(s1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S2: update K=1 to V=B (eq delete + insert in same commit)
+    DataFile s2 = writeDataFile(table, createRecord(1, "b"));
+    DeleteFile e2 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(s2).addDeletes(e2).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S3: delete K=1
+    DeleteFile e3 = writeEqualityDelete(table, 1, "b");
+    table.newRowDelta().addDeletes(e3).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S4: insert K=1, V=C
+    DataFile s4 = writeDataFile(table, createRecord(1, "c"));
+    table.newAppend().appendFile(s4).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S5: update K=1 to V=D (eq delete + insert in same commit)
+    DataFile s5 = writeDataFile(table, createRecord(1, "d"));
+    DeleteFile e5 = writeEqualityDelete(table, 1, "c");
+    table.newRowDelta().addRows(s5).addDeletes(e5).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      long time = System.currentTimeMillis();
+
+      // Cycle 1: S1 inserts K=1, V=A
+      long time1 = time;
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.exceptions()).isEmpty();
+      assertThat(result1.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(1, "a")));
+
+      // Cycle 2: S2 updates K=1 from V=A to V=B (eq delete + insert)
+      long time2 = time + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.exceptions()).isEmpty();
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(1, "b")));
+
+      // Cycle 3: S3 deletes K=1
+      long time3 = time + 2;
+      infra.source().sendRecord(Trigger.create(time3, 0), time3);
+      TaskResult result3 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result3.exceptions()).isEmpty();
+      assertThat(result3.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of());
+
+      // Cycle 4: S4 inserts K=1, V=C
+      long time4 = time + 3;
+      infra.source().sendRecord(Trigger.create(time4, 0), time4);
+      TaskResult result4 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result4.exceptions()).isEmpty();
+      assertThat(result4.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(1, "c")));
+
+      // Cycle 5: S5 updates K=1 from V=C to V=D (eq delete + insert)
+      long time5 = time + 4;
+      infra.source().sendRecord(Trigger.create(time5, 0), time5);
+      TaskResult result5 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result5.exceptions()).isEmpty();
+      assertThat(result5.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(1, "d")));
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  @Test
+  void testDVMergeAcrossConversionCycles() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    // Single data file with 3 rows so DV merge applies to the same file
+    insert(
+        table, ImmutableList.of(createRecord(1, "a"), createRecord(2, "b"), createRecord(3, "c")));
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Cycle 1 setup: eq delete for id=1
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      // Cycle 1: convert eq delete for id=1
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(2, "b"), createRecord(3, "c")));
+
+      // Cycle 2 setup: eq delete for id=2 (committed while job is running)
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      // Cycle 2: convert eq delete for id=2, should merge DV with existing
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.exceptions()).isEmpty();
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(3, "c")));
+
+      // Verify: main has DVs, no equality deletes
+      assertNoEqualityDeletesOnMain(table, 0);
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  @Test
+  void testConversionCorrectAfterCompaction() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    // Three separate data files
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Cycle 1: delete id=1
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(2, "b"), createRecord(3, "c")));
+
+      // Compact file2 and file3 on main into one file (leave file1 + its DV untouched)
+      Set<DataFile> allDataFiles = Sets.newHashSet();
+      for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+        try (ManifestReader<DataFile> reader =
+            ManifestFiles.read(manifest, table.io(), table.specs())) {
+          for (DataFile df : reader) {
+            allDataFiles.add(df.copy());
+          }
+        }
+      }
+
+      // Find file1 (contains id=1) by checking which file has a DV against it
+      Set<String> dvReferencedFiles = Sets.newHashSet();
+      for (ManifestFile manifest : table.currentSnapshot().deleteManifests(table.io())) {
+        try (ManifestReader<DeleteFile> reader =
+            ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
+          for (DeleteFile df : reader) {
+            if (df.referencedDataFile() != null) {
+              dvReferencedFiles.add(df.referencedDataFile());
+            }
+          }
+        }
+      }
+
+      Set<DataFile> filesToCompact = Sets.newHashSet();
+      for (DataFile df : allDataFiles) {
+        if (!dvReferencedFiles.contains(df.location())) {
+          filesToCompact.add(df);
+        }
+      }
+
+      assertThat(filesToCompact).hasSize(2);
+
+      DataFile compactedFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(ImmutableList.of(createRecord(2, "b"), createRecord(3, "c")));
+      RewriteFiles rewrite = table.newRewrite();
+      for (DataFile old : filesToCompact) {
+        rewrite.deleteFile(old);
+      }
+
+      rewrite.addFile(compactedFile);
+      rewrite.commit();
+      table.refresh();
+
+      assertRecords(table, ImmutableList.of(createRecord(2, "b"), createRecord(3, "c")));
+
+      // Cycle 2: delete id=2 (should target the compacted file)
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.exceptions()).isEmpty();
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(3, "c")));
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  @Test
+  void testConvertEqualityDeletesPartitionedTable() throws Exception {
+    Table table = createPartitionedTableWithDelete(3);
+
+    // Insert data into two partitions
+    insertPartitioned(table, 1, "a");
+    insertPartitioned(table, 2, "b");
+    insertPartitioned(table, 3, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Partition-scoped equality delete for id=1 in partition data="a"
+    DeleteFile eqDelete = writePartitionedEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    // id=1 deleted from partition "a", id=2 in partition "b" and id=3 in partition "a" remain
+    assertRecords(table, ImmutableList.of(createRecord(2, "b"), createRecord(3, "a")));
+  }
+
+  @Test
+  void testEqualityDeleteIsScopedToItsPartition() throws Exception {
+    Table table = createPartitionedTableWithDelete(3);
+
+    // Same PK (id=1) exists in two partitions. An eq delete in one partition must not delete
+    // rows in the other.
+    insertPartitioned(table, 1, "a");
+    insertPartitioned(table, 1, "b");
+    insertPartitioned(table, 2, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writePartitionedEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    // Only (1, "a") is deleted; (1, "b") remains because the eq delete was scoped to partition
+    // "a", and (2, "a") remains because its equality field values don't match.
+    assertRecords(table, ImmutableList.of(createRecord(1, "b"), createRecord(2, "a")));
+  }
+
+  @Test
+  void testStagingPositionDeleteMergedIntoConversionDV() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S1: write a data file with two rows (id=1 at pos 0, id=2 at pos 1).
+    DataFile data =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+    table.newAppend().appendFile(data).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S2: eq delete matches row 0 (will produce a conversion DV at pos 0) + a position
+    // delete DV referencing the same data file at pos 1. Both DVs target the same data
+    // file and must be merged into a single DV (V3 invariant).
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    DeleteFile stagingDV = writeStagingDV(table, data.location(), 1L);
+    table
+        .newRowDelta()
+        .addDeletes(eqDelete)
+        .addDeletes(stagingDV)
+        .toBranch(STAGING_BRANCH)
+        .commit();
+    table.refresh();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      // Cycle 1: commits S1's data file to main
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.success()).isTrue();
+
+      // Cycle 2: converts S2's eq delete to DV, merges with staging DV
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.exceptions()).isEmpty();
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      // Both rows from S1 must be masked: pos 0 by the conversion DV, pos 1 by the staging DV.
+      assertRecords(table, ImmutableList.of());
+
+      // Exactly one DV per data file (V3 invariant): the resolver must have folded the
+      // staging DV's positions into the conversion DV.
+      long dvCount =
+          table.currentSnapshot().deleteManifests(table.io()).stream()
+              .flatMap(
+                  m ->
+                      StreamSupport.stream(
+                          ManifestFiles.readDeleteManifest(m, table.io(), table.specs())
+                              .spliterator(),
+                          false))
+              .filter(f -> f.content() == FileContent.POSITION_DELETES)
+              .filter(f -> data.location().equals(f.referencedDataFile()))
+              .count();
+      assertThat(dvCount).isEqualTo(1);
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  @Test
+  void testStagingDataFilesOnlyNoEqDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging has only a new data file, no equality deletes
+    DataFile newDataFile = writeDataFile(table, createRecord(2, "b"));
+    table.newAppend().appendFile(newDataFile).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    assertThat(dataFileCount(table)).isEqualTo(2);
+    SimpleDataUtil.assertTableRecords(
+        table, ImmutableList.of(createRecord(1, "a"), createRecord(2, "b")));
+  }
+
+  @Test
+  void testReindexAfterExternalCommit() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Cycle 1: delete id=1
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(2, "b")));
+
+      // External commit: insert id=3 directly to main (not via staging)
+      insert(table, 3, "c");
+
+      // Cycle 2: delete id=2 (should reindex because of external commit)
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.exceptions()).isEmpty();
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(3, "c")));
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  @Test
+  void testReindexEvictsGhostKeyAfterExternalDataFileRemoval() throws Exception {
+    // CoW removal case: an external commit removes a data file, leaving a stale
+    // PK in the worker's index. A later staging eq-delete for that PK must NOT produce a DV
+    // referencing the removed file. The external commit advances main, so the next cycle reindexes
+    // and the worker clears the ghost key before resolving the delete.
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    table.refresh();
+    DataFile file1 = table.currentSnapshot().addedDataFiles(table.io()).iterator().next().copy();
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Cycle 1: delete id=2. Bootstraps the worker index from main (id=1 -> file1, id=2 -> file2).
+    DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+    table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(1, "a")));
+
+      // External CoW-style removal: drop file1 (id=1) from main without re-adding the row. The
+      // worker's index still holds the ghost id=1 -> file1 until the next reindex clears it.
+      table.newDelete().deleteFile(file1).commit();
+      table.refresh();
+      assertRecords(table, ImmutableList.of());
+
+      // Cycle 2: stage an eq-delete for the removed key id=1. Without ghost eviction the worker
+      // would emit a DV position against the now-absent file1.
+      DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+      table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.exceptions()).isEmpty();
+      assertThat(result2.success()).isTrue();
+
+      // No deletion vector may reference the removed file1.
+      table.refresh();
+      assertThat(dvReferencedDataFiles(table)).doesNotContain(file1.location());
+      assertRecords(table, ImmutableList.of());
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  private static Set<String> dvReferencedDataFiles(Table table) {
+    Set<String> referenced = Sets.newHashSet();
+    for (ManifestFile manifest : table.currentSnapshot().deleteManifests(table.io())) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
+        for (DeleteFile df : reader) {
+          if (df.referencedDataFile() != null) {
+            referenced.add(df.referencedDataFile());
+          }
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    return referenced;
+  }
+
+  private DataFile writeDataFile(Table table, Record record) throws IOException {
+    return new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+        .writeFile(Lists.newArrayList(record));
+  }
+
+  private DeleteFile writeStagingDV(Table table, String dataFilePath, long position)
+      throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+
+    PositionDelete<Record> delete = PositionDelete.create();
+    delete.set(dataFilePath, position, null);
+    return FileHelpers.writePosDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(delete),
+        3);
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+
+    Schema eqDeleteSchema = table.schema();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(createRecord(id, data)),
+        eqDeleteSchema);
+  }
+
+  private DeleteFile writePartitionedEqualityDelete(Table table, Integer id, String data)
+      throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+
+    PartitionData partition = new PartitionData(table.spec().partitionType());
+    partition.set(0, data);
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        partition,
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private static long dataFileCount(Table table) {
+    table.refresh();
+    long count = 0;
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile ignored : reader) {
+          count++;
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    return count;
+  }
+
+  @Test
+  void testStagingEqualsTargetBranch() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Write eq delete directly to main (no separate staging branch)
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    DataFile newData = writeDataFile(table, createRecord(3, "c"));
+    table.newRowDelta().addRows(newData).addDeletes(eqDelete).commit();
+    table.refresh();
+
+    appendConvertTask(SnapshotRef.MAIN_BRANCH);
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      // Cycle 1: process the eq delete for id=1
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result1.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(2, "b"), createRecord(3, "c")));
+      long dataFilesAfterCycle1 = dataFileCount(table);
+      // Expect 3: two from insert() + one from the writer's rowDelta.addRows(newData).
+      // When stagingBranch == targetBranch, the committer must NOT re-add newData via
+      // rowDelta.addRows(...) — that would duplicate (count=4).
+      assertThat(dataFilesAfterCycle1).isEqualTo(3);
+
+      // Cycle 2: no-op (converter's own commit must be skipped)
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(2, "b"), createRecord(3, "c")));
+      assertThat(dataFileCount(table)).isEqualTo(dataFilesAfterCycle1);
+
+      // New eq delete for id=2 committed directly to main between cycles
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      DataFile newData2 = writeDataFile(table, createRecord(4, "d"));
+      table.newRowDelta().addRows(newData2).addDeletes(eqDelete2).commit();
+      table.refresh();
+
+      // Cycle 3: process the new eq delete
+      long time3 = time2 + 1;
+      infra.source().sendRecord(Trigger.create(time3, 0), time3);
+      TaskResult result3 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result3.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(3, "c"), createRecord(4, "d")));
+      long dataFilesAfterCycle3 = dataFileCount(table);
+
+      // Cycle 4: no-op again
+      long time4 = time3 + 1;
+      infra.source().sendRecord(Trigger.create(time4, 0), time4);
+      TaskResult result4 = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result4.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(3, "c"), createRecord(4, "d")));
+      assertThat(dataFileCount(table)).isEqualTo(dataFilesAfterCycle3);
+    } finally {
+      if (jobClient != null) {
+        jobClient.cancel().get();
+      }
+    }
+  }
+
+  @Test
+  void testStagingEqualsTargetBranchColdStartCatchUp() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+
+    // Writer commits three eq-deletes to main BEFORE the converter starts.
+    // Cold start must pick up the unconverted history, not just the head snapshot.
+    table.newRowDelta().addDeletes(writeEqualityDelete(table, 1, "a")).commit();
+    table.newRowDelta().addDeletes(writeEqualityDelete(table, 2, "b")).commit();
+    table.newRowDelta().addDeletes(writeEqualityDelete(table, 3, "c")).commit();
+    table.refresh();
+
+    appendConvertTask(SnapshotRef.MAIN_BRANCH);
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      // One unconverted snapshot per cycle, oldest first. After three cycles every eq-delete
+      // commit has its own committer commit carrying the marker.
+      for (int cycle = 1; cycle <= 3; cycle++) {
+        long ts = System.currentTimeMillis() + cycle;
+        infra.source().sendRecord(Trigger.create(ts, 0), ts);
+        TaskResult result = infra.sink().poll(Duration.ofSeconds(10));
+        assertThat(result.success()).isTrue();
+      }
+
+      table.refresh();
+      long convertedCount =
+          StreamSupport.stream(table.snapshots().spliterator(), false)
+              .filter(s -> s.summary().containsKey("equality-convert-staging-snapshot"))
+              .count();
+      assertThat(convertedCount).isEqualTo(3);
+      assertRecords(table, ImmutableList.of());
+    } finally {
+      if (jobClient != null) {
+        jobClient.cancel().get();
+      }
+    }
+  }
+
+  @Test
+  void testStagingEqualsTargetBranchReinsertAfterDeleteSurvives() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    // Shared branch: insert id=1, eq-delete id=1, then re-insert id=1. The re-insert has a higher
+    // sequence than the delete and must survive the conversion (sequence-aware resolution).
+    insert(table, 1, "a");
+    table.newRowDelta().addDeletes(writeEqualityDelete(table, 1, "a")).commit();
+    table.newAppend().appendFile(writeDataFile(table, createRecord(1, "a"))).commit();
+    table.refresh();
+
+    appendConvertTask(SnapshotRef.MAIN_BRANCH);
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      // One cycle converts the eq-delete: the original row is deleted, the newer re-insert is
+      // not (its sequence is at or above the delete's).
+      long ts = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(ts, 0), ts);
+      TaskResult result = infra.sink().poll(Duration.ofSeconds(10));
+      assertThat(result.exceptions()).isEmpty();
+      assertThat(result.success()).isTrue();
+
+      table.refresh();
+      assertRecords(table, ImmutableList.of(createRecord(1, "a")));
+    } finally {
+      if (jobClient != null) {
+        jobClient.cancel().get();
+      }
+    }
+  }
+
+  @Test
+  void testStagingEqualsTargetBranchMergesStagingDvIntoSingleDv() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    // One data file with two rows: id=1 at pos 0, id=2 at pos 1, committed to main.
+    DataFile data =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+    table.newAppend().appendFile(data).commit();
+    table.refresh();
+
+    // Same-branch commit: an eq-delete for id=1 (resolves to a conversion DV at pos 0) plus a
+    // writer DV at pos 1 on the same data file. The resolver folds the staging DV into the
+    // conversion DV; on a shared branch the committer must remove the superseded staging DV.
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    DeleteFile stagingDV = writeStagingDV(table, data.location(), 1L);
+    table.newRowDelta().addDeletes(eqDelete).addDeletes(stagingDV).commit();
+    table.refresh();
+
+    appendConvertTask(SnapshotRef.MAIN_BRANCH);
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    // Both rows masked: pos 0 by the conversion DV, pos 1 by the merged-in staging DV.
+    assertRecords(table, ImmutableList.of());
+
+    // Exactly one DV per data file (V3 invariant). Without removing the rewritten staging DV on a
+    // shared branch, the data file would carry two DVs.
+    long dvCount =
+        table.currentSnapshot().deleteManifests(table.io()).stream()
+            .flatMap(
+                m ->
+                    StreamSupport.stream(
+                        ManifestFiles.readDeleteManifest(m, table.io(), table.specs())
+                            .spliterator(),
+                        false))
+            .filter(f -> f.content() == FileContent.POSITION_DELETES)
+            .filter(f -> data.location().equals(f.referencedDataFile()))
+            .count();
+    assertThat(dvCount).isEqualTo(1);
+  }
+
+  @Test
+  void testReaderErrorSkipsCommit() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    long mainSnapshotBeforeStaging = table.currentSnapshot().snapshotId();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging data file + eq delete file, both referenced by the staging commit.
+    DataFile newDataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    File eqDeleteLocalFile = new File(eqDelete.location().replace("file:", ""));
+
+    // Delete the eq delete file; the committer must abort rather than committing data without its
+    // DV.
+    assertThat(eqDeleteLocalFile.delete()).isTrue();
+
+    appendConvertTask();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = infra.env().executeAsync();
+
+      long time1 = System.currentTimeMillis();
+      infra.source().sendRecord(Trigger.create(time1, 0), time1);
+      TaskResult result1 = infra.sink().poll(Duration.ofSeconds(10));
+
+      assertThat(result1.success()).isFalse();
+      assertThat(result1.exceptions()).isNotEmpty();
+
+      table.refresh();
+      // Main must not have advanced (no commit happened).
+      assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotBeforeStaging);
+      SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(1, "a")));
+
+      // Restore the eq delete file content by rewriting an identical delete, and retry:
+      // the planner must re-process the same staging snapshot (cursor didn't advance on failure).
+      DeleteFile recreated =
+          FileHelpers.writeDeleteFile(
+              table,
+              Files.localOutput(eqDeleteLocalFile),
+              new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+              Lists.newArrayList(createRecord(1, "a")),
+              table.schema());
+      assertThat(recreated.location()).isEqualTo(eqDelete.location());
+
+      long time2 = time1 + 1;
+      infra.source().sendRecord(Trigger.create(time2, 0), time2);
+      TaskResult result2 = infra.sink().poll(Duration.ofSeconds(10));
+
+      assertThat(result2.exceptions()).isEmpty();
+      assertThat(result2.success()).isTrue();
+
+      table.refresh();
+      // Staging data file committed with DV for id=1: should see id=2 only.
+      SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(2, "b")));
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  private void appendConvertTask() {
+    appendConvertTask(STAGING_BRANCH);
+  }
+
+  private void appendConvertTask(String stagingBranch) {
+    ConvertEqualityDeletes.builder()
+        .stagingBranch(stagingBranch)
+        .equalityFieldColumns(ImmutableList.of("id", "data"))
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+  }
+
+  private static void assertRecords(Table table, List<Record> expected) throws IOException {
+    table.refresh();
+    Types.StructType type = SimpleDataUtil.SCHEMA.asStruct();
+
+    StructLikeSet expectedSet = StructLikeSet.create(type);
+    expectedSet.addAll(expected);
+
+    try (CloseableIterable<Record> iterable =
+        IcebergGenerics.read(table)
+            .useSnapshot(table.currentSnapshot().snapshotId())
+            .project(SimpleDataUtil.SCHEMA)
+            .build()) {
+      StructLikeSet actualSet = StructLikeSet.create(type);
+      for (Record record : iterable) {
+        actualSet.add(record);
+      }
+
+      assertThat(actualSet).isEqualTo(expectedSet);
+    }
+  }
+
+  private static void assertNoEqualityDeletesOnMain(Table table, long expectedEqDeleteCount) {
+    long mainEqDeleteCount = 0;
+    for (ManifestFile manifest : table.currentSnapshot().deleteManifests(table.io())) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
+        for (DeleteFile f : reader) {
+          if (f.content() == FileContent.EQUALITY_DELETES) {
+            mainEqDeleteCount++;
+          }
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    assertThat(mainEqDeleteCount).isEqualTo(expectedEqDeleteCount);
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletesE2E.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletesE2E.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.maintenance.operator.OperatorTestBase;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * End-to-end test for {@link ConvertEqualityDeletes} wired through the {@link TableMaintenance}
+ * framework. Verifies that the converter actually runs and commits a DV when the framework triggers
+ * it, exercising the full operator graph including the framework's monitor source, trigger manager,
+ * and lock remover.
+ */
+class TestConvertEqualityDeletesE2E extends OperatorTestBase {
+  private static final String STAGING_BRANCH = "staging";
+
+  @TempDir private Path tempDir;
+  private StreamExecutionEnvironment env;
+
+  @BeforeEach
+  public void beforeEach() {
+    this.env = StreamExecutionEnvironment.getExecutionEnvironment();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {STAGING_BRANCH, SnapshotRef.MAIN_BRANCH})
+  void testConvertEqualityDeletesE2E(String stagingBranch) throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // When staging is a separate branch, fork it from main first.
+    if (!stagingBranch.equals(SnapshotRef.MAIN_BRANCH)) {
+      table.manageSnapshots().createBranch(stagingBranch).commit();
+      table.refresh();
+    }
+
+    // Commit a new data file + eq delete to staging. This pre-job snapshot exercises both the
+    // "new data file" and "eq delete" paths in one cycle.
+    DataFile newData = writeDataFile(table, 3, "c");
+    DeleteFile firstDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newData).addDeletes(firstDelete).toBranch(stagingBranch).commit();
+    table.refresh();
+    assertThat(dvCountOnMain(table)).isZero();
+
+    TableMaintenance.forTable(env, tableLoader(), LOCK_FACTORY)
+        .uidSuffix("ConvertEqualityDeletesE2EUID-" + stagingBranch)
+        .rateLimit(Duration.ofMillis(50))
+        .lockCheckDelay(Duration.ofMillis(50))
+        .add(
+            ConvertEqualityDeletes.builder()
+                .scheduleOnInterval(Duration.ofMillis(100))
+                .stagingBranch(stagingBranch)
+                .targetBranch(SnapshotRef.MAIN_BRANCH)
+                .equalityFieldColumns(ImmutableList.of("id", "data"))
+                .parallelism(2))
+        .append();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = env.executeAsync();
+
+      // Cycle 1: row 1 deleted by the converted DV; row 3 added on staging and committed to main.
+      Awaitility.await()
+          .atMost(Duration.ofMinutes(2))
+          .pollInterval(Duration.ofMillis(200))
+          .untilAsserted(() -> assertThat(dvCountOnMain(table)).isEqualTo(1));
+      SimpleDataUtil.assertTableRecords(
+          table, ImmutableList.of(createRecord(2, "b"), createRecord(3, "c")));
+
+      // Cycle 2: commit a second staging snapshot while the job is still running. The framework's
+      // next interval-trigger should pick it up and produce a second DV against the data file
+      // holding id=2.
+      table.refresh();
+      DeleteFile secondDelete = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(secondDelete).toBranch(stagingBranch).commit();
+
+      Awaitility.await()
+          .atMost(Duration.ofMinutes(2))
+          .pollInterval(Duration.ofMillis(200))
+          .untilAsserted(() -> assertThat(dvCountOnMain(table)).isEqualTo(2));
+      SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(3, "c")));
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  private DataFile writeDataFile(Table table, Integer id, String data) throws IOException {
+    return new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+        .writeFile(Lists.newArrayList(SimpleDataUtil.createRecord(id, data)));
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(SimpleDataUtil.createRecord(id, data)),
+        table.schema());
+  }
+
+  private static long dvCountOnMain(Table table) throws IOException {
+    table.refresh();
+    if (table.currentSnapshot() == null) {
+      return 0;
+    }
+
+    long count = 0;
+    for (ManifestFile manifest : table.currentSnapshot().deleteManifests(table.io())) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
+        for (DeleteFile file : reader) {
+          if (ContentFileUtil.isDV(file)) {
+            count++;
+          }
+        }
+      }
+    }
+
+    return count;
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestMaintenanceE2E.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestMaintenanceE2E.java
@@ -24,8 +24,11 @@ import java.io.IOException;
 import java.time.Duration;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.maintenance.operator.OperatorTestBase;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -104,6 +107,36 @@ class TestMaintenanceE2E extends OperatorTestBase {
                 .deleteFileThreshold(10)
                 .rewriteAll(false)
                 .maxFileGroupSizeBytes(1000L))
+        .append();
+
+    JobClient jobClient = null;
+    try {
+      jobClient = env.executeAsync();
+
+      // Just make sure that we are able to instantiate the flow
+      assertThat(jobClient).isNotNull();
+    } finally {
+      closeJobClient(jobClient);
+    }
+  }
+
+  @Test
+  void testE2eConvertEqualityDeletes() throws Exception {
+    // Converter requires V3 (DV support); replace the V2 table created in @BeforeEach.
+    dropTable();
+    createTable(3, FileFormat.PARQUET);
+
+    TableMaintenance.forTable(env, tableLoader(), LOCK_FACTORY)
+        .uidSuffix("E2eConvertEqualityDeletesUID")
+        .rateLimit(Duration.ofMinutes(10))
+        .lockCheckDelay(Duration.ofSeconds(10))
+        .add(
+            ConvertEqualityDeletes.builder()
+                .scheduleOnEqDeleteFileCount(1)
+                .stagingBranch("staging")
+                .targetBranch(SnapshotRef.MAIN_BRANCH)
+                .equalityFieldColumns(ImmutableList.of("id"))
+                .parallelism(2))
         .append();
 
     JobClient jobClient = null;

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -187,6 +187,18 @@ public class OperatorTestBase {
                 "format-version", String.valueOf(formatVersion), "write.upsert.enabled", "true"));
   }
 
+  protected static Table createPartitionedTableWithDelete(int formatVersion) {
+    return CATALOG_EXTENSION
+        .catalog()
+        .createTable(
+            TestFixtures.TABLE_IDENTIFIER,
+            SCHEMA_WITH_PRIMARY_KEY,
+            PartitionSpec.builderFor(SCHEMA_WITH_PRIMARY_KEY).identity("data").build(),
+            null,
+            ImmutableMap.of(
+                "format-version", String.valueOf(formatVersion), "write.upsert.enabled", "true"));
+  }
+
   protected static Table createPartitionedTable(int formatVersion, FileFormat fileFormat) {
     return CATALOG_EXTENSION
         .catalog()
@@ -443,6 +455,29 @@ public class OperatorTestBase {
         new PartitionData(PartitionSpec.unpartitioned().partitionType()),
         Lists.newArrayList(SimpleDataUtil.createRecord(id, oldData)),
         SCHEMA_WITH_PRIMARY_KEY);
+  }
+
+  /**
+   * Writes an equality delete file whose schema contains only the {@code id} field. Used by tests
+   * that need a different equality-field-id list than {@link #writeEqualityDelete} (which uses both
+   * {@code id} and {@code data}).
+   */
+  protected DeleteFile writeIdOnlyEqualityDelete(Table table, int id) throws IOException {
+    File file = File.createTempFile("junit", null, warehouseDir.toFile());
+    assertThat(file.delete()).isTrue();
+    Schema idOnly =
+        new Schema(
+            Lists.newArrayList(Types.NestedField.required(1, "id", Types.IntegerType.get())),
+            ImmutableMap.of(),
+            ImmutableSet.of(1));
+    GenericRecord record = GenericRecord.create(idOnly);
+    record.set(0, id);
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(record),
+        idOnly);
   }
 
   protected DeleteFile writePosDeleteFile(Table table, String dataFilePath, long pos)

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -445,6 +445,19 @@ public class OperatorTestBase {
         SCHEMA_WITH_PRIMARY_KEY);
   }
 
+  protected DeleteFile writePosDeleteFile(Table table, String dataFilePath, long pos)
+      throws IOException {
+    File file = File.createTempFile("junit", null, warehouseDir.toFile());
+    assertThat(file.delete()).isTrue();
+    PositionDelete<GenericRecord> posDelete = PositionDelete.create();
+    GenericRecord nested = GenericRecord.create(table.schema());
+    nested.set(0, 1);
+    nested.set(1, "a");
+    posDelete.set(dataFilePath, pos, nested);
+    return FileHelpers.writePosDeleteFile(
+        table, Files.localOutput(file), null, Lists.newArrayList(posDelete), 2);
+  }
+
   private DeleteFile writePosDelete(
       Table table, CharSequence path, Integer pos, Integer id, String oldData, int formatVersion)
       throws IOException {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertCommitter.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+class TestEqualityConvertCommitter extends OperatorTestBase {
+
+  @Test
+  void commitsDataFilesToMainBranch() throws Exception {
+    Table table = createTable(3, FileFormat.PARQUET);
+    insert(table, 1, "a");
+
+    DataFile stagingDataFile = getFirstDataFile(table);
+    long snapshotIdBefore = table.currentSnapshot().snapshotId();
+    long stagingSnapshotId = 42L;
+
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        createHarness()) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
+              stagingSnapshotId,
+              snapshotIdBefore,
+              doneTs - 1,
+              doneTs);
+
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+      harness.processBothWatermarks(new Watermark(doneTs));
+
+      assertThat(harness.extractOutputValues()).hasSize(1);
+      table.refresh();
+      assertThat(table.currentSnapshot().snapshotId()).isNotEqualTo(snapshotIdBefore);
+      assertThat(
+              table
+                  .currentSnapshot()
+                  .summary()
+                  .get(EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY))
+          .isEqualTo(String.valueOf(stagingSnapshotId));
+    }
+  }
+
+  @Test
+  void skipsCommitForEmptyCycle() throws Exception {
+    Table table = createTable(3, FileFormat.PARQUET);
+
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        createHarness()) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult = EqualityConvertPlan.noOp(null, doneTs - 1, doneTs);
+
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+      harness.processBothWatermarks(new Watermark(doneTs));
+
+      assertThat(harness.extractOutputValues()).hasSize(1);
+      table.refresh();
+      assertThat(table.currentSnapshot()).isNull();
+    }
+  }
+
+  @Test
+  void abortsCommitWhenDVMergerFailed() throws Exception {
+    Table table = createTable(3, FileFormat.PARQUET);
+    insert(table, 1, "a");
+
+    DataFile stagingDataFile = getFirstDataFile(table);
+    long snapshotIdBefore = table.currentSnapshot().snapshotId();
+
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        createHarness()) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
+              42L,
+              snapshotIdBefore,
+              doneTs - 1,
+              doneTs);
+
+      // Receive an abort signal from the DVWriter followed by the planning planResult.
+      harness.processElement1(new StreamRecord<>(DVWriteResult.ABORT, doneTs));
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+
+      harness.processBothWatermarks(new Watermark(doneTs));
+
+      // The cycle must complete (Trigger emitted) but nothing must be committed to the table.
+      assertThat(harness.extractOutputValues()).hasSize(1);
+      table.refresh();
+      assertThat(table.currentSnapshot().snapshotId()).isEqualTo(snapshotIdBefore);
+    }
+  }
+
+  @Test
+  void failsCommitWhenExternalCommitLandsAfterPlan() throws Exception {
+    Table table = createTable(3, FileFormat.PARQUET);
+    insert(table, 1, "a");
+
+    DataFile stagingDataFile = getFirstDataFile(table);
+    long mainSnapshotIdAtPlan = table.currentSnapshot().snapshotId();
+    long stagingSnapshotId = 555L;
+
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        createHarness()) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
+              stagingSnapshotId,
+              mainSnapshotIdAtPlan,
+              doneTs - 1,
+              doneTs);
+
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+
+      // External writer appends to main between plan and commit.
+      insert(table, 2, "b");
+      table.refresh();
+      long mainSnapshotIdAfterExternal = table.currentSnapshot().snapshotId();
+      assertThat(mainSnapshotIdAfterExternal).isNotEqualTo(mainSnapshotIdAtPlan);
+
+      harness.processBothWatermarks(new Watermark(doneTs));
+
+      // Trigger still fires (so the aggregator records the cycle), but the commit
+      // must have been rejected by validateNoConflictingDataFiles.
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      List<StreamRecord<Exception>> errors =
+          Lists.newArrayList(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM));
+      assertThat(errors).hasSize(1);
+      Exception failure = errors.get(0).getValue();
+      assertThat(failure).isInstanceOf(ValidationException.class);
+      assertThat(failure)
+          .hasMessageContaining("Found conflicting files that can contain records matching");
+
+      // Target head is still the external commit, not our cycle's commit.
+      table.refresh();
+      assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotIdAfterExternal);
+      assertThat(
+              table
+                  .currentSnapshot()
+                  .summary()
+                  .get(EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY))
+          .isNull();
+    }
+  }
+
+  @Test
+  void failsReplayOfCommittedPlanFromOlderState() throws Exception {
+    Table table = createTable(3, FileFormat.PARQUET);
+    insert(table, 1, "a");
+
+    DataFile stagingDataFile = getFirstDataFile(table);
+    long mainSnapshotIdAtPlan = table.currentSnapshot().snapshotId();
+    long stagingSnapshotId = 909L;
+
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        createHarness()) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
+              stagingSnapshotId,
+              mainSnapshotIdAtPlan,
+              doneTs - 1,
+              doneTs);
+
+      // Cycle 1 commits, advancing the target past mainSnapshotIdAtPlan and writing the marker.
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+      harness.processBothWatermarks(new Watermark(doneTs));
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      table.refresh();
+      long committedSnapshotId = table.currentSnapshot().snapshotId();
+      assertThat(committedSnapshotId).isNotEqualTo(mainSnapshotIdAtPlan);
+
+      // Restart from older state: the identical plan with its stale mainSnapshotId is replayed.
+      // The committer is stateless, so validateFromSnapshot is the only guard against a duplicate
+      // commit. It must reject the replay.
+      long doneTs2 = doneTs + 1;
+      EqualityConvertPlan replay =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
+              stagingSnapshotId,
+              mainSnapshotIdAtPlan,
+              doneTs2 - 1,
+              doneTs2);
+
+      harness.processElement2(new StreamRecord<>(replay, doneTs2 - 1));
+      harness.processBothWatermarks(new Watermark(doneTs2));
+
+      // Trigger still fires (so the aggregator records the cycle), but the commit was rejected.
+      assertThat(harness.extractOutputValues()).hasSize(2);
+
+      List<StreamRecord<Exception>> errors =
+          Lists.newArrayList(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM));
+      assertThat(errors).hasSize(1);
+      Exception failure = errors.get(0).getValue();
+      assertThat(failure).isInstanceOf(ValidationException.class);
+      assertThat(failure)
+          .hasMessageContaining("Found conflicting files that can contain records matching");
+
+      // No duplicate commit: target head is still cycle 1's commit.
+      table.refresh();
+      assertThat(table.currentSnapshot().snapshotId()).isEqualTo(committedSnapshotId);
+    }
+  }
+
+  @Test
+  void deletesWrittenDvsWhenCommitFails() throws Exception {
+    Table table = createTable(2, FileFormat.PARQUET);
+    insert(table, 1, "a");
+
+    DataFile stagingDataFile = getFirstDataFile(table);
+    long mainSnapshotIdAtPlan = table.currentSnapshot().snapshotId();
+
+    DeleteFile writtenDv = writePosDeleteFile(table, stagingDataFile.location(), 0L);
+    assertThat(table.io().newInputFile(writtenDv.location()).exists()).isTrue();
+
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        createHarness()) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
+              777L,
+              mainSnapshotIdAtPlan,
+              doneTs - 1,
+              doneTs);
+
+      harness.processElement1(
+          new StreamRecord<>(
+              new DVWriteResult(Lists.newArrayList(writtenDv), Lists.newArrayList()), doneTs));
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+
+      // External writer appends to main between plan and commit, so the commit is rejected.
+      insert(table, 2, "b");
+      table.refresh();
+
+      harness.processBothWatermarks(new Watermark(doneTs));
+
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      List<StreamRecord<Exception>> errors =
+          Lists.newArrayList(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM));
+      assertThat(errors).hasSize(1);
+      assertThat(errors.get(0).getValue()).isInstanceOf(ValidationException.class);
+
+      // The DV written this cycle is unreferenced after the failed commit and must be deleted.
+      assertThat(table.io().newInputFile(writtenDv.location()).exists()).isFalse();
+    }
+  }
+
+  @Test
+  void deletesSiblingDvsOnAbortButKeepsRewrittenDvs() throws Exception {
+    Table table = createTable(2, FileFormat.PARQUET);
+    insert(table, 1, "a");
+
+    DataFile stagingDataFile = getFirstDataFile(table);
+    long snapshotIdBefore = table.currentSnapshot().snapshotId();
+
+    DeleteFile writtenDv = writePosDeleteFile(table, stagingDataFile.location(), 0L);
+    DeleteFile rewrittenDv = writePosDeleteFile(table, stagingDataFile.location(), 1L);
+    assertThat(table.io().newInputFile(writtenDv.location()).exists()).isTrue();
+    assertThat(table.io().newInputFile(rewrittenDv.location()).exists()).isTrue();
+
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        createHarness()) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
+              42L,
+              snapshotIdBefore,
+              doneTs - 1,
+              doneTs);
+
+      // One writer task wrote a DV (rewriting an existing one); a sibling task aborted.
+      harness.processElement1(
+          new StreamRecord<>(
+              new DVWriteResult(Lists.newArrayList(writtenDv), Lists.newArrayList(rewrittenDv)),
+              doneTs));
+      harness.processElement1(new StreamRecord<>(DVWriteResult.ABORT, doneTs));
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+      harness.processBothWatermarks(new Watermark(doneTs));
+
+      assertThat(harness.extractOutputValues()).hasSize(1);
+      table.refresh();
+      assertThat(table.currentSnapshot().snapshotId()).isEqualTo(snapshotIdBefore);
+
+      // The freshly written DV is removed; the rewritten DV is still live on target and stays.
+      assertThat(table.io().newInputFile(writtenDv.location()).exists()).isFalse();
+      assertThat(table.io().newInputFile(rewrittenDv.location()).exists()).isTrue();
+    }
+  }
+
+  @Test
+  void retainsWrittenDvsWhenCommitStateUnknown() throws Exception {
+    Table table = createTable(2, FileFormat.PARQUET);
+    insert(table, 1, "a");
+
+    DataFile stagingDataFile = getFirstDataFile(table);
+    long mainSnapshotIdAtPlan = table.currentSnapshot().snapshotId();
+
+    DeleteFile writtenDv = writePosDeleteFile(table, stagingDataFile.location(), 0L);
+    assertThat(table.io().newInputFile(writtenDv.location()).exists()).isTrue();
+
+    EqualityConvertCommitter committer =
+        new EqualityConvertCommitter(
+            DUMMY_TABLE_NAME, DUMMY_TASK_NAME, tableLoader(), "staging", SnapshotRef.MAIN_BRANCH) {
+          @Override
+          void commit(RowDelta rowDelta) {
+            throw new CommitStateUnknownException(
+                new RuntimeException("simulated unknown commit state"));
+          }
+        };
+
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        new TwoInputStreamOperatorTestHarness<>(committer)) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
+              888L,
+              mainSnapshotIdAtPlan,
+              doneTs - 1,
+              doneTs);
+
+      harness.processElement1(
+          new StreamRecord<>(
+              new DVWriteResult(Lists.newArrayList(writtenDv), Lists.newArrayList()), doneTs));
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+      harness.processBothWatermarks(new Watermark(doneTs));
+
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      List<StreamRecord<Exception>> errors =
+          Lists.newArrayList(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM));
+      assertThat(errors).hasSize(1);
+      assertThat(errors.get(0).getValue()).isInstanceOf(CommitStateUnknownException.class);
+
+      // Commit outcome unknown: the DV may be live, so it must not be deleted.
+      assertThat(table.io().newInputFile(writtenDv.location()).exists()).isTrue();
+    }
+  }
+
+  private TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger>
+      createHarness() throws Exception {
+    return new TwoInputStreamOperatorTestHarness<>(
+        new EqualityConvertCommitter(
+            DUMMY_TABLE_NAME, DUMMY_TASK_NAME, tableLoader(), "staging", SnapshotRef.MAIN_BRANCH));
+  }
+
+  private static DataFile getFirstDataFile(Table table) {
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile file : reader) {
+          return file.copy();
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    throw new IllegalStateException("No data files found");
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertDVWriter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertDVWriter.java
@@ -1,0 +1,431 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+class TestEqualityConvertDVWriter extends OperatorTestBase {
+
+  private static final byte[] EMPTY_PARTITION = new byte[0];
+
+  @Test
+  void writesDVFileForSinglePosition() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    String dataFilePath = getFirstDataFilePath(table);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement1(
+          new StreamRecord<>(new DVPosition(dataFilePath, 0, 0, EMPTY_PARTITION, 0L), time));
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time));
+
+      harness.processBothWatermarks(new Watermark(time));
+
+      List<DVWriteResult> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).hasError()).isFalse();
+      assertThat(output.get(0).dvFiles()).hasSize(1);
+    }
+  }
+
+  @Test
+  void writesSingleDVFileForMultiplePositionsOnSameDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+
+    String dataFilePath = getFirstDataFilePath(table);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement1(
+          new StreamRecord<>(new DVPosition(dataFilePath, 0, 0, EMPTY_PARTITION, 0L), time));
+      harness.processElement1(
+          new StreamRecord<>(new DVPosition(dataFilePath, 1, 0, EMPTY_PARTITION, 0L), time));
+      harness.processElement1(
+          new StreamRecord<>(new DVPosition(dataFilePath, 2, 0, EMPTY_PARTITION, 0L), time));
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time));
+
+      harness.processBothWatermarks(new Watermark(time));
+
+      List<DVWriteResult> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).hasError()).isFalse();
+      assertThat(output.get(0).dvFiles()).hasSize(1);
+      assertThat(output.get(0).dvFiles().get(0).recordCount()).isEqualTo(3);
+      assertThat(output.get(0).rewrittenDvFiles()).isEmpty();
+    }
+  }
+
+  @Test
+  void emptyPositionsProducesNoOutput() throws Exception {
+    createTableWithDelete(3);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time));
+
+      harness.processBothWatermarks(new Watermark(time));
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void noOutputWithoutPlanResult() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    String dataFilePath = getFirstDataFilePath(table);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement1(
+          new StreamRecord<>(new DVPosition(dataFilePath, 0, 0, EMPTY_PARTITION, 0L), time));
+
+      harness.processBothWatermarks(new Watermark(time));
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void writesDVFilesForMultipleDataFiles() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    List<String> dataFilePaths = getDataFilePaths(table);
+    assertThat(dataFilePaths).hasSize(2);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement1(
+          new StreamRecord<>(
+              new DVPosition(dataFilePaths.get(0), 0, 0, EMPTY_PARTITION, 0L), time));
+      harness.processElement1(
+          new StreamRecord<>(
+              new DVPosition(dataFilePaths.get(1), 0, 0, EMPTY_PARTITION, 0L), time));
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time));
+
+      harness.processBothWatermarks(new Watermark(time));
+
+      List<DVWriteResult> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dvFiles()).hasSize(2);
+    }
+  }
+
+  @Test
+  void routesErrorToErrorStream() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    String dataFilePath = getFirstDataFilePath(table);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement1(
+          new StreamRecord<>(new DVPosition(dataFilePath, 0, 0, EMPTY_PARTITION, 0L), time));
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time));
+
+      dropTable();
+
+      harness.processBothWatermarks(new Watermark(time));
+
+      assertThat(harness.extractOutputValues()).hasSize(1);
+      assertThat(harness.extractOutputValues().get(0).hasError()).isTrue();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void writesDVForStagingDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    String dataFilePath = getFirstDataFilePath(table);
+    DataFile stagingDataFile = getFirstDataFile(table);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(stagingDataFile), Lists.newArrayList(), 1L, null, 0L, 0L);
+
+      harness.processElement1(
+          new StreamRecord<>(new DVPosition(dataFilePath, 0, 0, EMPTY_PARTITION, 0L), time));
+      harness.processElement2(new StreamRecord<>(planResult, time));
+
+      harness.processBothWatermarks(new Watermark(time));
+
+      List<DVWriteResult> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).hasError()).isFalse();
+      assertThat(output.get(0).dvFiles()).hasSize(1);
+    }
+  }
+
+  @Test
+  void stateResetBetweenBatches() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    String dataFilePath = getFirstDataFilePath(table);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time1 = System.currentTimeMillis();
+      harness.processElement1(
+          new StreamRecord<>(new DVPosition(dataFilePath, 0, 0, EMPTY_PARTITION, 0L), time1));
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time1));
+      harness.processBothWatermarks(new Watermark(time1));
+
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      // Second batch with no positions, plan only.
+      long time2 = time1 + 1;
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time2));
+      harness.processBothWatermarks(new Watermark(time2));
+
+      // Cumulative output: still hasSize(1) since the empty batch produced nothing.
+      assertThat(harness.extractOutputValues()).hasSize(1);
+    }
+  }
+
+  @Test
+  void abortsOnUpstreamAbortPosition() throws Exception {
+    createTableWithDelete(3);
+
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement1(new StreamRecord<>(DVPosition.ABORT, time));
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time));
+      harness.processBothWatermarks(new Watermark(time));
+
+      List<DVWriteResult> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).hasError()).isTrue();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void doesNotRetainStateAcrossCycles() throws Exception {
+    Table table = createTableWithDelete(3);
+    int cycles = 5;
+    for (int i = 0; i < cycles; i++) {
+      insert(table, i, "v" + i);
+    }
+
+    List<String> dataFilePaths = getDataFilePaths(table);
+    assertThat(dataFilePaths).hasSize(cycles);
+
+    EqualityConvertDVWriter resolver = newResolver();
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        new TwoInputStreamOperatorTestHarness<>(resolver)) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      for (int i = 0; i < cycles; i++) {
+        // Each cycle resolves a position in a distinct data file, growing the set of files seen.
+        harness.processElement1(
+            new StreamRecord<>(
+                new DVPosition(dataFilePaths.get(i), 0, 0, EMPTY_PARTITION, 0L), time + i));
+        harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time + i));
+        harness.processBothWatermarks(new Watermark(time + i));
+
+        // No cross-cycle state: the buffer clears every cycle regardless of how many distinct data
+        // files have been processed.
+        assertThat(resolver.retainedStateSize()).isZero();
+        assertThat(harness.extractOutputValues()).hasSize(i + 1);
+      }
+    }
+  }
+
+  @Test
+  void prunesDeleteManifestsByPartition() throws Exception {
+    Table table = createPartitionedTableWithDelete(3);
+    insertPartitioned(table, Lists.newArrayList(createRecord(1, "a")), "a");
+    DataFile fileA = dataFile(table, "a");
+    insertPartitioned(table, Lists.newArrayList(createRecord(2, "b")), "b");
+    DataFile fileB = dataFile(table, "b");
+
+    // Commit one DV per partition: two separate delete manifests, summaries {a} and {b}.
+    commitDV(table, fileA);
+    commitDV(table, fileB);
+    assertThat(table.currentSnapshot().deleteManifests(table.io())).hasSize(2);
+
+    // A new cycle resolves another position in partition a's file. Only partition a's delete
+    // manifest overlaps; partition b's manifest must be pruned.
+    EqualityConvertDVWriter resolver = newResolver();
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        new TwoInputStreamOperatorTestHarness<>(resolver)) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement1(new StreamRecord<>(dvPosition(table, fileA, 0), time));
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time));
+      harness.processBothWatermarks(new Watermark(time));
+
+      List<DVWriteResult> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      // Folded partition a's existing DV: the matching manifest was read.
+      assertThat(output.get(0).rewrittenDvFiles()).hasSize(1);
+      assertThat(output.get(0).dvFiles()).hasSize(1);
+      // Partition b's manifest was skipped: only one manifest read this cycle.
+      assertThat(resolver.manifestsReadLastCycle()).isEqualTo(1);
+    }
+  }
+
+  private void commitDV(Table table, DataFile dataFile) throws Exception {
+    try (TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult> harness =
+        createHarness()) {
+      harness.open();
+
+      long time = System.currentTimeMillis();
+      harness.processElement1(new StreamRecord<>(dvPosition(table, dataFile, 0), time));
+      harness.processElement2(new StreamRecord<>(emptyEqualityConvertPlan(), time));
+      harness.processBothWatermarks(new Watermark(time));
+
+      RowDelta rowDelta = table.newRowDelta();
+      harness.extractOutputValues().get(0).dvFiles().forEach(rowDelta::addDeletes);
+      rowDelta.commit();
+      table.refresh();
+    }
+  }
+
+  private static DVPosition dvPosition(Table table, DataFile dataFile, long position) {
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    byte[] partition =
+        new StructLikeSerializer().encodePartition(dataFile.partition(), spec.partitionType());
+    return new DVPosition(dataFile.location(), position, dataFile.specId(), partition, 0L);
+  }
+
+  private static DataFile dataFile(Table table, String partitionValue) {
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile file : reader) {
+          if (partitionValue.equals(String.valueOf(file.partition().get(0, Object.class)))) {
+            return file;
+          }
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    throw new IllegalStateException("No data file for partition: " + partitionValue);
+  }
+
+  private EqualityConvertDVWriter newResolver() {
+    return new EqualityConvertDVWriter(
+        DUMMY_TABLE_NAME, DUMMY_TASK_NAME, tableLoader(), SnapshotRef.MAIN_BRANCH);
+  }
+
+  private TwoInputStreamOperatorTestHarness<DVPosition, EqualityConvertPlan, DVWriteResult>
+      createHarness() throws Exception {
+    return new TwoInputStreamOperatorTestHarness<>(newResolver());
+  }
+
+  private static EqualityConvertPlan emptyEqualityConvertPlan() {
+    return new EqualityConvertPlan(Lists.newArrayList(), Lists.newArrayList(), 1L, null, 0L, 0L);
+  }
+
+  private static String getFirstDataFilePath(Table table) {
+    return getDataFilePaths(table).get(0);
+  }
+
+  private static DataFile getFirstDataFile(Table table) {
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile file : reader) {
+          return file.copy();
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    throw new IllegalStateException("No data files found");
+  }
+
+  private static List<String> getDataFilePaths(Table table) {
+    List<String> paths = Lists.newArrayList();
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile file : reader) {
+          paths.add(file.location());
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return paths;
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
@@ -1,0 +1,675 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedBroadcastOperatorTestHarness;
+import org.junit.jupiter.api.Test;
+
+class TestEqualityConvertPKIndex {
+
+  private static final SerializedEqualityValues KEY_1 =
+      new SerializedEqualityValues(new byte[] {1, 2, 3});
+  private static final SerializedEqualityValues KEY_2 =
+      new SerializedEqualityValues(new byte[] {4, 5, 6});
+  private static final Long MAIN_SNAPSHOT = 100L;
+  private static final Long MAIN_SEQ = 10L;
+  private static final Long NEW_MAIN_SNAPSHOT = 200L;
+  private static final Long NEW_MAIN_SEQ = 20L;
+  private static final byte[] EMPTY_PARTITION = new byte[0];
+  // Data-row sequence below the delete sequence, so existing tests still tombstone on resolve.
+  private static final long DATA_SEQ = 1L;
+  private static final long DELETE_SEQ = 2L;
+
+  @Test
+  void addDataRowProducesNoOutput() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsDVPosition() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  5,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(5);
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsMultipleDVPositionsForDuplicateKeys() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file2.parquet",
+                  3,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output)
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(0);
+              })
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file2.parquet");
+                assertThat(pos.position()).isEqualTo(3);
+              });
+    }
+  }
+
+  @Test
+  void resolveDeleteClearsEntries() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+    }
+  }
+
+  @Test
+  void resolveDeleteWithNoMatchEmitsNothing() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void mainSnapshotChangeClearsState() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void clearBeforeReindexEvictsOrphanKeyWithoutKeyedInput() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // KEY_1 indexed against the old main; KEY_2 left untouched.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      // External commit removed KEY_1's data file; planner advances main and broadcasts CLEAR.
+      // No keyed input arrives for KEY_1 in the new cycle.
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+
+      // Resolving KEY_1 against the (now-empty) index emits nothing.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void clearBeforeReindexAfterAddPreservesEntry() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // ADD with the new generation arrives before the broadcast.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  NEW_MAIN_SNAPSHOT,
+                  NEW_MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  7,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(7);
+    }
+  }
+
+  @Test
+  void clearBeforeReindexThenAddIndexesAtNewVersion() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "old.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      // Broadcast arrives before the new ADD (race direction 2): old entry is wiped, then the
+      // reindex re-emits KEY_1 at its new file/position.
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  NEW_MAIN_SNAPSHOT,
+                  NEW_MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  4,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              2));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+      harness.watermark(3);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("new.parquet");
+      assertThat(output.get(0).position()).isEqualTo(4);
+    }
+  }
+
+  @Test
+  void olderBroadcastDoesNotEvictNewerEntry() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // KEY_1 indexed at the newer generation: higher sequence number (20) but a lower snapshot id
+      // (50) than the stale broadcast below.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  50L, 20L, KEY_1, "file1.parquet", 7, 0, EMPTY_PARTITION, DATA_SEQ, false),
+              0));
+
+      // A stale CLEAR_INDEX from an older generation arrives late: higher snapshot id (999) but
+      // lower sequence number (10). Ordering by snapshot id would wrongly evict (50 < 999);
+      // ordering
+      // by sequence number keeps the entry (20 is not < 10).
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(999L, 10L), 1));
+
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(50L, 20L, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(7);
+    }
+  }
+
+  @Test
+  void differentKeysAreIndependent() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_2,
+                  "file2.parquet",
+                  1,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+    }
+  }
+
+  @Test
+  void phaseAwareBufferingProcessesInCorrectOrder() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // A main row (ts 0) is indexed and the cycle's delete (ts 1) removes it. The next cycle's new
+      // row (ts 2) arrives before that delete fires; event-time ordering keeps it out of the index
+      // until after the delete, so it survives.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "main.parquet",
+                  10,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  true),
+              2));
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+
+      harness.watermark(1);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+      assertThat(harness.extractOutputValues().get(0).dataFilePath()).isEqualTo("main.parquet");
+
+      // A later cycle's delete (ts 3) removes the now-indexed new row.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+      harness.watermark(3);
+      assertThat(harness.extractOutputValues()).hasSize(2);
+      assertThat(harness.extractOutputValues().get(1).dataFilePath()).isEqualTo("new.parquet");
+    }
+  }
+
+  @Test
+  void laterPhaseAddArrivingBeforeResolveSurvives() throws Exception {
+    // The next cycle's new row (ts 2) is delivered before the current cycle's
+    // delete (ts 1) is processed; the new row must not be affected by the delete.
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness(false)) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  true),
+              2));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(2);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsDVPositionsForSameFileDifferentPositions() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  5,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  10,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output)
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(5);
+              })
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(10);
+              });
+    }
+  }
+
+  @Test
+  void resolveDeleteSparesReinsertWithHigherSequence() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // Same key indexed twice: an older row (seq 1) and a re-insert (seq 3).
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, "old.parquet", 0, 0, EMPTY_PARTITION, 1L, false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, "new.parquet", 0, 0, EMPTY_PARTITION, 3L, false),
+              0));
+
+      // Delete at seq 2 tombstones only the older row; the re-insert (seq 3) survives.
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("old.parquet");
+
+      // The survivor stays indexed: a later delete with a higher sequence removes it.
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 4L), 2));
+      harness.watermark(2);
+
+      List<DVPosition> afterSecond = harness.extractOutputValues();
+      assertThat(afterSecond).hasSize(2);
+      assertThat(afterSecond.get(1).dataFilePath()).isEqualTo("new.parquet");
+    }
+  }
+
+  @Test
+  void deletesHigherSequenceWhenStagingNotOnTargetBranch() throws Exception {
+    // On a separate target branch the committer reassigns data sequence numbers, so the worker must
+    // not spare rows by sequence: every key match is deleted (phase ordering prevents
+    // over-deletion across cycles).
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness(false)) {
+      harness.open();
+
+      // Row sequence (5) above the delete sequence (2) would survive on a shared branch.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  5L,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+    }
+  }
+
+  private static KeyedBroadcastOperatorTestHarness<
+          SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+      createHarness() throws Exception {
+    return createHarness(true);
+  }
+
+  private static KeyedBroadcastOperatorTestHarness<
+          SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+      createHarness(boolean stagingOnTargetBranch) throws Exception {
+    return new KeyedBroadcastOperatorTestHarness<>(
+        new CoBroadcastWithKeyedOperator<>(
+            new EqualityConvertPKIndex(stagingOnTargetBranch),
+            Collections.singletonList(EqualityConvertPKIndex.CLEAR_BROADCAST_DESCRIPTOR)),
+        IndexCommand::key,
+        TypeInformation.of(SerializedEqualityValues.class),
+        1,
+        1,
+        0);
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
@@ -1,0 +1,1065 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestEqualityConvertPlanner extends OperatorTestBase {
+
+  private static final String STAGING_BRANCH = "__flink_staging_test";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void bootstrapsIndexFromBuilderEqualityFieldIds() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Staging branch exists but contains no eq-delete files yet. The planner still populates the
+    // worker index from main using the builder-configured equality field set so the index is ready
+    // when the first delete arrives.
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+      assertThat(countEqDeleteTasks(commands)).isZero();
+
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsWhenStagingEqDeleteFieldIdsMismatchBuilder() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Builder configured for [1, 2], but writer produces an eq delete with [1] only.
+    DeleteFile mismatched = writeIdOnlyEqualityDelete(table, 1);
+    table.newRowDelta().addDeletes(mismatched).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void doesNotDuplicateNewDataFilesWhenStagingEqualsTarget() throws Exception {
+    // When stagingBranch == targetBranch, the writer commits new data files directly to main.
+    // Bootstrap scans the main snapshot (which already includes those files) and indexes them.
+    // The planner must NOT also emit the staging-data phase for the same files — that would
+    // duplicate ADD_DATA_ROW commands for the same (PK, file, position) in the worker's index.
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Writer commits (new-data id=3) + (eq-delete id=1) in one RowDelta directly to main.
+    DataFile newDataFile = writeDataFile(table, createRecord(3, "c"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(SnapshotRef.MAIN_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+
+      // Bootstrap from main emits one data-file command per file (id=1, id=2, id=3) = 3.
+      // Without the same-branch guard, emitSnapshotDataPhase would also emit newDataFile → 4.
+      assertThat(countDataFileTasks(commands)).isEqualTo(3);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+
+      long newDataFileCount =
+          commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .filter(c -> c.task().file().location().equals(newDataFile.location()))
+              .count();
+      assertThat(newDataFileCount).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void emitsReadCommandsForEqualityDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 2, "b");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      // 3 DATA_FILE (from main) + 1 EQ_DELETE_FILE
+      assertThat(countDataFileTasks(commands)).isEqualTo(3);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      assertThat(metadata.get(0).getValue().dataFiles()).isEmpty();
+    }
+  }
+
+  @Test
+  void emitsDataFileFromInsertOnlySnapshotForActiveFieldSets() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S1: eq delete targeting main data (activates a field set in the worker index)
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long s1SnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    // S2: insert-only (no eq deletes, but its data must be indexed for the active field set)
+    DataFile insertS2 = writeDataFile(table, createRecord(2, "b"));
+    table.newAppend().appendFile(insertS2).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1: processes S1 (eq delete), activates the field set
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isEqualTo(1);
+
+      // Simulate the committer writing the S1 conversion to main so the planner
+      // promotes its pending cursor before processing S2.
+      simulateConvertCommit(table, s1SnapshotId);
+
+      // Trigger 2: processes S2 (insert-only). Must emit its data file for the active field set.
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands = allCommands.subList(afterFirst, allCommands.size());
+
+      Set<String> dataFilePaths =
+          trigger2Commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .map(TestEqualityConvertPlanner::filePath)
+              .collect(Collectors.toSet());
+
+      assertThat(dataFilePaths).contains(insertS2.location());
+    }
+  }
+
+  @Test
+  void includesNewDataFilesFromStaging() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DataFile newDataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      // 1 main data file + 1 eq delete + 1 staging data file
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      assertThat(metadata.get(0).getValue().dataFiles()).hasSize(1);
+    }
+  }
+
+  @Test
+  void findsIntersectionWhenMainAdvancedAfterStagingFork() throws Exception {
+    Table table = createTableWithDelete(3);
+    // Pre-fork main: two snapshots.
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Fork staging from current main head.
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Main advances with two more snapshots after the fork. These are on main's
+    // lineage but not on staging's.
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+
+    // Staging gets one new snapshot containing an equality delete.
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      // Planner identifies the fork point and processes only the staging-only
+      // commit (the eq delete), and emits all four current main data files
+      // for the index refresh.
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+      assertThat(countDataFileTasks(commands)).isEqualTo(4);
+    }
+  }
+
+  @Test
+  void skipsAlreadyProcessedStagingSnapshot() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      assertThat(firstTriggerCount).isGreaterThan(0);
+
+      // Simulate the committer committing to main with the staging snapshot property
+      // (the planner promotes pending only after confirming the commit landed on main).
+      simulateConvertCommit(table, stagingSnapshotId);
+
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).hasSize(firstTriggerCount);
+    }
+  }
+
+  @Test
+  void noOutputWhenStagingBranchEmpty() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      // Bootstrap from main for the configured field set: 1 main DATA_FILE; no-op metadata still
+      // emitted because there's nothing on staging to convert.
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(1);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isZero();
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void propagatesStagingOnlyPositionalDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    DataFile mainData = writeDataFile(table, createRecord(1, "a"));
+    table.newAppend().appendFile(mainData).commit();
+    table.refresh();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging snapshot has only a DV (no eq deletes, no new data files). Without the
+    // planner forwarding stagingDVFiles in this case, the committer would never
+    // see the DV and it would be lost.
+    DeleteFile stagingDV = writeStagingDV(table, mainData.location(), 0L);
+    table.newRowDelta().addDeletes(stagingDV).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countDataFileTasks(commands)).isEqualTo(1);
+      assertThat(countEqDeleteTasks(commands)).isZero();
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      EqualityConvertPlan result = metadata.get(0).getValue();
+      assertThat(result.dataFiles()).isEmpty();
+      assertThat(result.stagingDVFiles()).hasSize(1);
+      assertThat(result.stagingDVFiles().get(0).location()).isEqualTo(stagingDV.location());
+    }
+  }
+
+  @Test
+  void phaseTimestampsAreMonotonicallyIncreasing() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging: eq delete + new data file (triggers 3 phases: main data, eq delete, staging data)
+    DataFile newDataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<StreamRecord<ReadCommand>> records = Lists.newArrayList(harness.getRecordOutput());
+      // Verify timestamps are non-decreasing and phases are distinct
+      long prevTs = Long.MIN_VALUE;
+      for (StreamRecord<ReadCommand> record : records) {
+        assertThat(record.getTimestamp()).isGreaterThanOrEqualTo(prevTs);
+        prevTs = record.getTimestamp();
+      }
+
+      // DATA_FILE commands should have different timestamps than EQ_DELETE_FILE commands
+      Set<Long> dataFileTimestamps =
+          records.stream()
+              .filter(r -> r.getValue().task() instanceof FileScanTask)
+              .map(StreamRecord::getTimestamp)
+              .collect(Collectors.toSet());
+      Set<Long> eqDeleteTimestamps =
+          records.stream()
+              .filter(r -> isEqDelete(r.getValue()))
+              .map(StreamRecord::getTimestamp)
+              .collect(Collectors.toSet());
+
+      // Main data and eq delete should be in different phases
+      for (long eqTs : eqDeleteTimestamps) {
+        boolean hasLowerDataTs = dataFileTimestamps.stream().anyMatch(ts -> ts < eqTs);
+        assertThat(hasLowerDataTs).isTrue();
+      }
+    }
+  }
+
+  @Test
+  void routesExceptionToErrorStream() throws Exception {
+    createTableWithDelete(3);
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      dropTable();
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+      sendTrigger(harness);
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsOnRemovedDataFilesOnStagingBranch() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    Set<DataFile> oldDataFiles = Sets.newHashSet();
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile df : reader) {
+          oldDataFiles.add(df.copy());
+        }
+      }
+    }
+
+    assertThat(oldDataFiles).hasSize(2);
+
+    // Rewrite on the staging branch (not main). Equality delete conversion does not support
+    // rewrites on staging; the planner must fail the cycle instead of silently dropping the
+    // removed files.
+    DataFile compactedFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+    RewriteFiles rewrite = table.newRewrite();
+    for (DataFile old : oldDataFiles) {
+      rewrite.deleteFile(old);
+    }
+
+    rewrite.addFile(compactedFile);
+    rewrite.toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      // Bootstrap runs before processCycle's failure, so the main data commands are already on
+      // the wire. Only the cycle itself fails.
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(2);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isZero();
+    }
+  }
+
+  @Test
+  void reEmitsMainDataAfterCompaction() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 2 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(3);
+
+      // Compact data files on main: rewrite 2 files into 1
+      Set<DataFile> oldDataFiles = Sets.newHashSet();
+      for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+        try (ManifestReader<DataFile> reader =
+            ManifestFiles.read(manifest, table.io(), table.specs())) {
+          for (DataFile df : reader) {
+            oldDataFiles.add(df.copy());
+          }
+        }
+      }
+
+      assertThat(oldDataFiles).hasSize(2);
+
+      DataFile compactedFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+      RewriteFiles rewrite = table.newRewrite();
+      for (DataFile old : oldDataFiles) {
+        rewrite.deleteFile(old);
+      }
+
+      rewrite.addFile(compactedFile);
+      rewrite.commit();
+      table.refresh();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // 1 DATA_FILE (compacted main) + 1 EQ_DELETE_FILE
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(1);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      // DATA_FILE should reference the compacted file
+      List<ReadCommand> dataCmds =
+          trigger2Commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .collect(Collectors.toList());
+      for (ReadCommand cmd : dataCmds) {
+        assertThat(cmd.task().file().location()).isEqualTo(compactedFile.location());
+      }
+    }
+  }
+
+  @Test
+  void refreshesIndexBeforeFirstCycleProcessesEqDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Stage MULTIPLE eq-delete snapshots before the first trigger arrives. Without bootstrap we
+    // would create the index entry lazily over multiple cycles. With bootstrap, the first trigger
+    // discovers every unprocessed schema (just one in this case, since both deletes use the same
+    // schema) and creates it once before any cycle processes.
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+    table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long s2SnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+
+      // First trigger processes the OLDER staging snapshot (eqDelete1). Bootstrap created the
+      // index entry for the eq-delete schema once: 2 main DATA_FILE + 1 EQ_DELETE_FILE = 3
+      // commands.
+      assertThat(afterFirst).isEqualTo(3);
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(2);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isEqualTo(1);
+
+      simulateConvertCommit(table, table.snapshot(STAGING_BRANCH).parentId());
+
+      // Second trigger processes the newer staging snapshot. The index entry already exists — no
+      // main re-emission, just the new eq delete.
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands = allCommands.subList(afterFirst, allCommands.size());
+      assertThat(countDataFileTasks(trigger2Commands)).isZero();
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      simulateConvertCommit(table, s2SnapshotId);
+    }
+  }
+
+  @Test
+  void noMainReEmitWhenUnchanged() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 2 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(3);
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // Only 1 EQ_DELETE_FILE, no main re-emission
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(2);
+    }
+  }
+
+  @Test
+  void noMainReEmitAfterOwnCommit() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long indexedStagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+
+      // Simulate converter's own commit referencing the staging snapshot that the
+      // first trigger processed. The planner promotes pendingStagingSnapshotId on the
+      // next trigger, so this ID is in the index high-water mark when the property
+      // is checked.
+      DataFile dummyFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table
+          .newRowDelta()
+          .addRows(dummyFile)
+          .set(
+              EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY,
+              String.valueOf(indexedStagingSnapshotId))
+          .commit();
+      table.refresh();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // Own commits don't trigger index rebuild.
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void reIndexesAfterExternalCommit() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 1 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(2);
+
+      // External commit: no COMMITTED_STAGING_SNAPSHOT_PROPERTY
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // External commit triggers re-index: main data files are re-emitted
+      assertThat(countDataFileTasks(trigger2Commands)).isGreaterThan(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void emitsClearIndexBroadcastOnReindex() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1 bootstraps the index. Bootstrap does not broadcast CLEAR_INDEX.
+      sendTrigger(harness);
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.CLEAR_BROADCAST_STREAM))
+          .isNullOrEmpty();
+
+      // External commit advances main. The next trigger reindexes and must broadcast CLEAR_INDEX
+      // so workers evict ghost keys (e.g. a PK whose data file was removed by external CoW).
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+      long mainAfterExternal = table.snapshot(SnapshotRef.MAIN_BRANCH).snapshotId();
+      long mainSeqAfterExternal = table.snapshot(SnapshotRef.MAIN_BRANCH).sequenceNumber();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+
+      List<IndexCommand> clears =
+          harness.getSideOutput(EqualityConvertPlanner.CLEAR_BROADCAST_STREAM).stream()
+              .map(StreamRecord::getValue)
+              .collect(Collectors.toList());
+      assertThat(clears).hasSize(1);
+      assertThat(clears.get(0).type()).isEqualTo(IndexCommand.Type.CLEAR_INDEX);
+      assertThat(clears.get(0).mainSnapshotId()).isEqualTo(mainAfterExternal);
+      assertThat(clears.get(0).mainSequenceNumber()).isEqualTo(mainSeqAfterExternal);
+    }
+  }
+
+  @Test
+  void detectsMainBranchChangeWithoutNewStagingSnapshots() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1: build the index and process the existing eq delete.
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+      assertThat(afterFirst).isGreaterThan(0);
+
+      // External commit on main (no COMMITTED_STAGING_SNAPSHOT_PROPERTY).
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+
+      // Trigger 2: nothing new on staging, but the planner must still notice the
+      // external main change and immediately re-emit main data for index rebuild.
+      sendTrigger(harness);
+      List<ReadCommand> allAfterTrigger2 = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allAfterTrigger2.subList(afterFirst, allAfterTrigger2.size());
+      assertThat(countDataFileTasks(trigger2Commands)).isGreaterThan(0);
+
+      // A subsequent staging eq delete should NOT re-emit main data because the index
+      // was already rebuilt in trigger 2.
+      int afterSecond = allAfterTrigger2.size();
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 10, "z");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> all = harness.extractOutputValues();
+      List<ReadCommand> trigger3 = all.subList(afterSecond, all.size());
+      assertThat(countDataFileTasks(trigger3)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger3)).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void stateRestoredAfterCheckpoint() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // First trigger processes the staging snapshot and sets pendingStagingSnapshotId.
+      sendTrigger(harness);
+      int commandCount = harness.extractOutputValues().size();
+      assertThat(commandCount).isGreaterThan(0);
+
+      // Simulate the committer committing S1's conversion to main so the planner promotes
+      // pendingStagingSnapshotId on the second trigger.
+      simulateConvertCommit(table, stagingSnapshotId);
+
+      // Second trigger promotes pendingStagingSnapshotId to lastStagingSnapshotId
+      // (which is the state that gets checkpointed).
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).hasSize(commandCount);
+
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    // Restore from checkpoint: staging snapshot is already in persisted state, should be skipped.
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.initializeState(state);
+      harness.open();
+
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void failsOnV2PosDeleteOnStagingBranch() throws Exception {
+    Table table = createTableWithDelete(2);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Flink-written staging branches are V3 and only produce DVs for deletes. A V2 positional
+    // delete on staging is a writer-side misconfiguration and should fail the cycle rather than
+    // be silently absorbed.
+    DataFile dataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile posDelete = writePosDeleteFile(table, dataFile.location(), 0);
+    table.newRowDelta().addRows(dataFile).addDeletes(posDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void skipsCommittedSnapshotAfterCommitLandsButCheckpointDoesNot() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    // Capture the planner's checkpoint before any cycle has run.
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    // The staging commit landed on main but lastStagingSnapshotId was not checkpointed.
+    simulateConvertCommit(table, stagingSnapshotId);
+
+    // On restore, the planner walks main, finds the COMMITTED_STAGING_SNAPSHOT_PROPERTY,
+    // advances lastStagingSnapshotId, and skips re-emitting the already-committed snapshot.
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.initializeState(state);
+      harness.open();
+
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(0);
+      // Bootstrap from main creates the index from the main data files on the first trigger even
+      // though the staging snapshot itself is already committed and skipped. Main now has the
+      // original insert plus simulateConvertCommit's marker file = 2 data files.
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void failsOnEqFieldIdsChangeAcrossRestart() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1))) {
+      assertThatThrownBy(() -> harness.initializeState(state))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Equality field IDs changed across restart");
+    }
+  }
+
+  private OneInputStreamOperatorTestHarness<Trigger, ReadCommand> createHarness(
+      String stagingBranch) throws Exception {
+    // Default matches the [1, 2] equality-field-id list produced by writeEqualityDelete.
+    return createHarness(stagingBranch, Lists.newArrayList(1, 2));
+  }
+
+  private OneInputStreamOperatorTestHarness<Trigger, ReadCommand> createHarness(
+      String stagingBranch, List<Integer> eqFieldIds) throws Exception {
+    return new OneInputStreamOperatorTestHarness<>(
+        new EqualityConvertPlanner(
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            tableLoader(),
+            stagingBranch,
+            SnapshotRef.MAIN_BRANCH,
+            Sets.newHashSet(eqFieldIds)));
+  }
+
+  private static void sendTrigger(OneInputStreamOperatorTestHarness<Trigger, ?> harness)
+      throws Exception {
+    long time = System.currentTimeMillis();
+    harness.processElement(new StreamRecord<>(Trigger.create(time, 0), time));
+  }
+
+  private DataFile writeDataFile(Table table, Record record) throws IOException {
+    return new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+        .writeFile(Lists.newArrayList(record));
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private DeleteFile writeStagingDV(Table table, String dataFilePath, long position)
+      throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+
+    PositionDelete<Record> delete = PositionDelete.create();
+    delete.set(dataFilePath, position, null);
+    return FileHelpers.writePosDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(delete),
+        3);
+  }
+
+  private static long countDataFileTasks(List<ReadCommand> commands) {
+    return commands.stream().filter(c -> c.task() instanceof FileScanTask).count();
+  }
+
+  private static long countEqDeleteTasks(List<ReadCommand> commands) {
+    return commands.stream().filter(TestEqualityConvertPlanner::isEqDelete).count();
+  }
+
+  private static boolean isEqDelete(ReadCommand cmd) {
+    return !(cmd.task() instanceof FileScanTask);
+  }
+
+  private static String filePath(ReadCommand cmd) {
+    return cmd.task().file().location();
+  }
+
+  private void simulateConvertCommit(Table table, long stagingSnapshotId) throws IOException {
+    DataFile dummy =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(-1, "marker" + stagingSnapshotId)));
+    table
+        .newRowDelta()
+        .addRows(dummy)
+        .set(
+            EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY,
+            String.valueOf(stagingSnapshotId))
+        .commit();
+    table.refresh();
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertReader.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertReader.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestEqualityConvertReader extends OperatorTestBase {
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void emitsAddStagingDataRowForDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      // stagingDataFile marks a staging snapshot's new data, so the reader emits
+      // ADD_STAGING_DATA_ROW.
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_STAGING_DATA_ROW);
+      assertThat(output.get(0).rowPosition().dataFilePath()).isEqualTo(dataFile.location());
+      assertThat(output.get(0).rowPosition().position()).isZero();
+    }
+  }
+
+  @Test
+  void emitsAddDataRowWhenNotStaging() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // Same task type as the staging test: the command's staging flag, not the task type, decides
+      // that main reindex data is indexed immediately as ADD_DATA_ROW.
+      ReadCommand cmd =
+          ReadCommand.dataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_DATA_ROW);
+    }
+  }
+
+  @Test
+  void emitsResolveDeleteForEqDeleteFile() throws Exception {
+    Table table = createTableWithDelete(3);
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec spec = table.specs().get(eqDelete.specId());
+    List<Integer> fieldIds = eqDelete.equalityFieldIds();
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd = ReadCommand.eqDeleteFile(eqDelete, spec, 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.RESOLVE_DELETE);
+      assertThat(output.get(0).rowPosition()).isNull();
+    }
+  }
+
+  @Test
+  void tracksPositionsAcrossRecords() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).rowPosition().position()).isZero();
+      assertThat(output.get(1).rowPosition().position()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void skipsDeletedPositionsWhenCreatingIndexFromMain() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(
+                Lists.newArrayList(
+                    createRecord(1, "a"), createRecord(2, "b"), createRecord(3, "c")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    // DV marks position 1 (id=2) as deleted on main. When the reader creates the worker's index
+    // from this data file, it must skip position 1 and emit rows only for positions 0 and 2.
+    DeleteFile dv = writeDV(table, dataFile.location(), 1L);
+
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec, Lists.newArrayList(dv)), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).rowPosition().position()).isZero();
+      assertThat(output.get(1).rowPosition().position()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void sameKeyFromDataAndDeleteProducesEqualSerializedValues() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec dataSpec = table.specs().get(dataFile.specId());
+    PartitionSpec deleteSpec = table.specs().get(eqDelete.specId());
+    List<Integer> fieldIds = eqDelete.equalityFieldIds();
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      harness.processElement(
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, dataSpec), 0L, 0L, 0L),
+          0);
+      harness.processElement(ReadCommand.eqDeleteFile(eqDelete, deleteSpec, 0L, 0L, 0L), 1);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_STAGING_DATA_ROW);
+      assertThat(output.get(1).type()).isEqualTo(IndexCommand.Type.RESOLVE_DELETE);
+      assertThat(output.get(0).key()).isEqualTo(output.get(1).key());
+    }
+  }
+
+  @Test
+  void propagatesMainSnapshotId() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+    long mainSnapshotId = 42L;
+    long mainSequenceNumber = 7L;
+    long dataSequenceNumber = 9L;
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec),
+              mainSnapshotId,
+              mainSequenceNumber,
+              dataSequenceNumber);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).mainSnapshotId()).isEqualTo(mainSnapshotId);
+      assertThat(output.get(0).mainSequenceNumber()).isEqualTo(mainSequenceNumber);
+      assertThat(output.get(0).rowPosition().dataSequenceNumber()).isEqualTo(dataSequenceNumber);
+    }
+  }
+
+  @Test
+  void routesExceptionToErrorStream() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    DataFile missing =
+        DataFiles.builder(table.spec())
+            .copy(dataFile)
+            .withPath(dataFile.location() + ".missing")
+            .build();
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // Non-existent file path causes the reader to throw.
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(missing, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsWhenEqualityFieldMissingFromCurrentSchema() throws Exception {
+    // Field ids from SimpleDataUtil.SCHEMA: 1=id, 2=data.
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+
+    // Drop `data`. Static equality fields resolve against the current schema at build time, so an
+    // equality field id missing from the current schema is a misconfiguration.
+    table.updateSchema().deleteColumn("data").commit();
+    table.refresh();
+
+    List<Integer> fieldIds = Lists.newArrayList(1, 2);
+
+    assertThatThrownBy(
+            () -> {
+              try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+                  createHarness(fieldIds)) {
+                harness.open();
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not present in table schema");
+  }
+
+  @Test
+  void throwsOnEqualityDeleteAttachedToMainDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // An equality delete attached to a main data file is unexpected on a separate target branch
+      // (stagingOnTargetBranch=false): the reader must route the error rather than silently ignore.
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec, Lists.newArrayList(eqDelete)), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  private OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> createHarness(
+      List<Integer> fieldIds) throws Exception {
+    return ProcessFunctionTestHarnesses.forProcessFunction(
+        new EqualityConvertReader(tableLoader(), Sets.newHashSet(fieldIds), false));
+  }
+
+  private static DataFile getFirstDataFile(Table table) {
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile file : reader) {
+          return file.copy();
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    throw new IllegalStateException("No data files found");
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private static DeleteFile writeDV(Table table, String dataFilePath, long... positions)
+      throws IOException {
+    List<PositionDelete<?>> deletes = Lists.newArrayList();
+    GenericRecord nested = GenericRecord.create(table.schema());
+    for (long pos : positions) {
+      PositionDelete<GenericRecord> delete = PositionDelete.create();
+      delete.set(dataFilePath, pos, nested);
+      deletes.add(delete);
+    }
+
+    return FileHelpers.writePosDeleteFile(table, null, null, deletes, 3);
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestFlinkPojoTypes.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestFlinkPojoTypes.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the hot-path classes used as Flink stream element types are valid POJO types. Flink
+ * POJO serialization requires a public no-arg constructor and public setters for all fields.
+ */
+class TestFlinkPojoTypes {
+
+  @Test
+  void testSerializedEqualityValues() {
+    assertThat(TypeInformation.of(SerializedEqualityValues.class)).isInstanceOf(PojoTypeInfo.class);
+  }
+
+  @Test
+  void testDVPosition() {
+    assertThat(TypeInformation.of(DVPosition.class)).isInstanceOf(PojoTypeInfo.class);
+  }
+
+  @Test
+  void testIndexCommand() {
+    assertThat(TypeInformation.of(IndexCommand.class)).isInstanceOf(PojoTypeInfo.class);
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestStructLikeSerializer.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestStructLikeSerializer.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestStructLikeSerializer {
+
+  private static final Types.StructType KEY_TYPE =
+      Types.StructType.of(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+  private static final int SPEC_0 = PartitionSpec.unpartitioned().specId();
+
+  private final StructLikeSerializer serializer = new StructLikeSerializer();
+
+  @Test
+  void serializeKeyIsDeterministic() {
+    GenericRecord key = GenericRecord.create(KEY_TYPE);
+    key.set(0, 42);
+    key.set(1, "hello");
+
+    SerializedEqualityValues key1 = serializer.serializeKey(key, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(key, KEY_TYPE, SPEC_0);
+    assertThat(key1).isEqualTo(key2);
+  }
+
+  @Test
+  void serializeKeyDiffersForDifferentKeys() {
+    GenericRecord record1 = GenericRecord.create(KEY_TYPE);
+    record1.set(0, 1);
+    record1.set(1, "a");
+
+    GenericRecord record2 = GenericRecord.create(KEY_TYPE);
+    record2.set(0, 2);
+    record2.set(1, "b");
+
+    SerializedEqualityValues key1 = serializer.serializeKey(record1, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(record2, KEY_TYPE, SPEC_0);
+    assertThat(key1).isNotEqualTo(key2);
+  }
+
+  @Test
+  void sameValuesDifferentFieldSetsAreNotEqual() {
+    Types.StructType typeWithField1 =
+        Types.StructType.of(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    Types.StructType typeWithField3 =
+        Types.StructType.of(Types.NestedField.required(3, "other", Types.IntegerType.get()));
+
+    GenericRecord record1 = GenericRecord.create(typeWithField1);
+    record1.set(0, 42);
+
+    GenericRecord record3 = GenericRecord.create(typeWithField3);
+    record3.set(0, 42);
+
+    SerializedEqualityValues key1 = serializer.serializeKey(record1, typeWithField1, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(record3, typeWithField3, SPEC_0);
+    assertThat(key1).isNotEqualTo(key2);
+  }
+
+  @Test
+  void serializeKeyWithDecimal() {
+    Types.StructType decimalKeyType =
+        Types.StructType.of(
+            Types.NestedField.required(1, "id", Types.DecimalType.of(10, 2)),
+            Types.NestedField.required(2, "name", Types.StringType.get()));
+
+    GenericRecord record = GenericRecord.create(decimalKeyType);
+    record.set(0, new BigDecimal("123.45"));
+    record.set(1, "test");
+
+    SerializedEqualityValues key1 = serializer.serializeKey(record, decimalKeyType, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(record, decimalKeyType, SPEC_0);
+    assertThat(key1).isEqualTo(key2);
+  }
+
+  @Test
+  void serializeKeyHandlesNulls() {
+    GenericRecord record = GenericRecord.create(KEY_TYPE);
+    record.set(0, 1);
+    record.set(1, null);
+
+    SerializedEqualityValues key1 = serializer.serializeKey(record, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(record, KEY_TYPE, SPEC_0);
+    assertThat(key1).isEqualTo(key2);
+  }
+
+  @Test
+  void nullDiffersFromNonNull() {
+    GenericRecord withNull = GenericRecord.create(KEY_TYPE);
+    withNull.set(0, 1);
+    withNull.set(1, null);
+
+    GenericRecord withValue = GenericRecord.create(KEY_TYPE);
+    withValue.set(0, 1);
+    withValue.set(1, "");
+
+    assertThat(serializer.serializeKey(withNull, KEY_TYPE, SPEC_0))
+        .isNotEqualTo(serializer.serializeKey(withValue, KEY_TYPE, SPEC_0));
+  }
+
+  @Test
+  void samePkDifferentSpecsAreNotEqual() {
+    GenericRecord pk = GenericRecord.create(KEY_TYPE);
+    pk.set(0, 42);
+    pk.set(1, "x");
+
+    assertThat(serializer.serializeKey(pk, KEY_TYPE, 0))
+        .isNotEqualTo(serializer.serializeKey(pk, KEY_TYPE, 1));
+  }
+
+  @Test
+  void encodeDecodeRoundTripsAcrossTypes() {
+    Types.StructType partitionType =
+        Types.StructType.of(
+            Types.NestedField.required(100, "p_int", Types.IntegerType.get()),
+            Types.NestedField.required(101, "p_str", Types.StringType.get()),
+            Types.NestedField.required(102, "p_dec", Types.DecimalType.of(10, 2)),
+            Types.NestedField.required(103, "p_date", Types.DateType.get()),
+            Types.NestedField.optional(104, "p_null", Types.StringType.get()));
+
+    PartitionData partition = new PartitionData(partitionType);
+    partition.set(0, 7);
+    partition.set(1, "abc");
+    partition.set(2, new BigDecimal("12.34"));
+    partition.set(3, 19000);
+    partition.set(4, null);
+
+    StructLike decoded =
+        StructLikeSerializer.decodePartition(
+            serializer.encodePartition(partition, partitionType), partitionType);
+
+    assertThat(decoded.get(0, Integer.class)).isEqualTo(7);
+    assertThat(decoded.get(1, String.class)).isEqualTo("abc");
+    assertThat(decoded.get(2, BigDecimal.class)).isEqualTo(new BigDecimal("12.34"));
+    assertThat(decoded.get(3, Integer.class)).isEqualTo(19000);
+    assertThat(decoded.get(4, String.class)).isNull();
+  }
+
+  @Test
+  void unpartitionedEncodesToEmpty() {
+    Types.StructType empty = PartitionSpec.unpartitioned().partitionType();
+    PartitionData partition = new PartitionData(empty);
+
+    byte[] encoded = serializer.encodePartition(partition, empty);
+    assertThat(encoded).isEmpty();
+
+    StructLike decoded = StructLikeSerializer.decodePartition(encoded, empty);
+    assertThat(decoded.size()).isZero();
+  }
+}


### PR DESCRIPTION
## Motivation
Equality deletes are cheap to write but expensive to read: resolving an equality delete file potentially means scanning all prior-existing data files of the table to find the corresponding rows for the deleted values contained in the equality delete file.

In order to get rid of equality deletes, we need to be able to resolve existing equality delete files into positional deletes. This PR adds a Flink maintenance conversion task (`ConvertEqualityDeletes`) that converts equality delete files into deletion vectors (DVs), enabling V2 tables and writers that use equality deletes to adopt the V3 DV-based delete format.

## ConvertEqualityDeletes

The conversion task reads from a staging branch where writers commit data with equality deletes. It then writes the converted data files together with DVs to the target branch, where they become visible to downstream readers. At this stage, equality delete files have been removed and readers can read efficiently. The staging/target branch separation keeps the original equality delete files available for transparency.

The conversion task is going to be fully integrated into the existing writers (e.g. `IcebergSink`), allowing them to write equality deletes like they normally do, but they commit to a staging branch first. The conversion task monitors the staging branch, builds an index from the equality fields values of the data files, then converts the equality delete files into DVs, and commits everything back to the main branch, where it can be read efficiently using only positional deletes. 

For complete integration, we will need additional wiring with `IcebergSink`, to allow writing data to a staging branch, instead of the main branch and run the here-added `ConvertEqualityDeletes` maintenance task in-line, via its post commit topology. I was tempted to add this right-away, but decided to keep the scope limited to the maintenance task only.

## Workflow

1. Planner (p=1) — scans the staging branch, picks the oldest unprocessed snapshot, emits file-level ReadCommands grouped into phases with ascending watermark timestamps:
    - Phase 0: main-branch data files: for building the worker PK index, plus reindex when external commits (e.g. compaction) have modified the main branch.
    - Phase 1: staging equality delete files: resolved against the PK index in the worker.
    - Phase 2: staging data files: added to the index for the next cycle.
2. Reader (p=N) — reads each file, emits row-level IndexCommands.
3. Worker (p=N, keyed by serialized PK) — maintains the PK index shard, resolves eq deletes to (filePath, position) pairs.
4. DVResolver (p=1) — groups positions by data file, resolves partition info and any existing DVs to merge.
5. DVMerger (p=N) — writes merged DV files (Puffin format).
6. Committer (p=1) — commits the data files + DVs to the target branch in a single RowDelta, stamping the committed staging snapshot id as a property.

## Features

- V3-format-only target (DVs require format version 3).
- Builder level configurable equality field set (`ConvertEqualityDeletes.Builder.equalityFieldColumns(List<String>)`).
- Idempotent commit: if the staging snapshot's id is already on target, the commit is skipped.
- Reindex on external main commits or when the staging cursor is behind target's most recent own commit.
- Phase-based ordering via watermarks lets the parallel worker stage pending rows for the *next* cycle while resolving the current cycle's deletes.
- Mutual exclusion with other maintenance tasks via the framework's coordination lock.

## Fault-tolerance

The planner's state (lastStagingSnapshotId / pendingStagingSnapshotId) is checkpointed. On a crash where the target receives a commit that the operator state does not capture, the state will continue to point to older commits; the next trigger replays the actions, and the committer's isAlreadyCommitted guard discards the duplicate commit (idempotency is ensured via table property which references the staging branch snapshot id). This only works correctly with synchronous / aligned checkpoints (unaligned not supported).

## Commits

The breakdown is as follows:

1. Data model and key serialization - data exchange types and key serialization
2. Operators - file reader and keyed PK index worker
3. DV resolution and writing - group positions by data file, merge with existing DVs
4. Planner - staging branch scanning, orchestration, reindex detection
5. Committer - RowDelta assembly, idempotency via snapshot properties, V3 enforcement
6. API and integration tests - ConvertEqualityDeletes builder, end-to-end tests

These could be put into separate PRs, if needed.

## Metrics

Under the maintenance metric group:

- Planner: processedEqDeleteFileNum, processedStagingSnapshotNum, skippedNoOpCycles, reindexCount
- Worker: indexedKeyNum, resolvedDeleteNum
- Committer: addedDvNum, commitDurationMs, addedDataFileNum, addedDataFileSize, error

## Limitations

For keeping the scope somewhat limited, I skipped these:

- Row lineage is not preserved (can be handled in a follow-up)
- No staging branch lifecycle management, e.g. create / clean up branch (will be added with the integration into IcebergSink)
- DVResolver does a full manifest scan (no partition pruning)


## Follow-ups

Those, I'm planning to work on next:

- Integrate ConvertEqualityDeletes maintenance task as in-line compaction in IcebergSink
- Clean up processed snapshots on the staging branch
- Add documentation

## References

1. Design document:  https://docs.google.com/document/d/1Jz4Fjt-6jRmwqbgHX_u0ohuyTB9ytDzfslS7lYraIjk/edit?tab=t.5qlfbj9bk8i3 (This PR implements the "use lock to avoid conflicts" solution)
2. Mailing list discussion: https://lists.apache.org/thread/gldqrycmo24r0vo77wzcj9s9b04rtvy7
