### PR TITLE
Open-API: Align requiresNamespaceCreate default with README documentation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -407,6 +407,13 @@ public class CatalogHandlers {
       Catalog catalog, Namespace namespace, CreateTableRequest request) {
     request.validate();
 
+    if (catalog instanceof SupportsNamespaces) {
+      SupportsNamespaces nsCatalog = (SupportsNamespaces) catalog;
+      if (!nsCatalog.namespaceExists(namespace)) {
+        throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+      }
+    }
+
     TableIdentifier ident = TableIdentifier.of(namespace, request.name());
     if (catalog.tableExists(ident)) {
       throw new AlreadyExistsException("Table already exists: %s", ident);
@@ -445,6 +452,13 @@ public class CatalogHandlers {
   public static LoadTableResponse createTable(
       Catalog catalog, Namespace namespace, CreateTableRequest request) {
     request.validate();
+
+    if (catalog instanceof SupportsNamespaces) {
+      SupportsNamespaces nsCatalog = (SupportsNamespaces) catalog;
+      if (!nsCatalog.namespaceExists(namespace)) {
+        throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+      }
+    }
 
     TableIdentifier ident = TableIdentifier.of(namespace, request.name());
     Table table =

--- a/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java
@@ -72,9 +72,7 @@ public class RESTCompatibilityKitCatalogTests extends CatalogTests<RESTCatalog> 
   @Override
   protected boolean requiresNamespaceCreate() {
     return PropertyUtil.propertyAsBoolean(
-        restCatalog.properties(),
-        RESTCompatibilityKitSuite.RCK_REQUIRES_NAMESPACE_CREATE,
-        super.requiresNamespaceCreate());
+        restCatalog.properties(), RESTCompatibilityKitSuite.RCK_REQUIRES_NAMESPACE_CREATE, true);
   }
 
   @Override

--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
@@ -25,6 +25,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
@@ -102,9 +105,19 @@ public class RESTCatalogServer {
         PropertyUtil.propertyAsString(catalogProperties, CATALOG_NAME, CATALOG_NAME_DEFAULT);
 
     LOG.info("Creating {} catalog with properties: {}", catalogName, catalogProperties);
-    return new CatalogContext(
-        CatalogUtil.buildIcebergCatalog(catalogName, catalogProperties, new Configuration()),
-        catalogProperties);
+    Catalog catalog =
+        CatalogUtil.buildIcebergCatalog(catalogName, catalogProperties, new Configuration());
+
+    if (catalog instanceof SupportsNamespaces nsCatalog) {
+      try {
+        nsCatalog.createNamespace(Namespace.of("default"));
+        LOG.info("Created default namespace in backend catalog");
+      } catch (AlreadyExistsException ignored) {
+        LOG.info("Default namespace already exists in backend catalog", ignored);
+      }
+    }
+
+    return new CatalogContext(catalog, catalogProperties);
   }
 
   public void start(boolean join) throws Exception {


### PR DESCRIPTION
The README.md documents that rck.requires-namespace-create defaults to true, but the code was using super.requiresNamespaceCreate() as fallback which returns false from CatalogTests. This change makes the default value consistent with the documented behavior.