### PR TITLE
Core: Fix child AuthSession inheriting parent's expiresAtMillis

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -529,6 +529,7 @@ public class OAuth2Util {
                 .from(config())
                 .token(response.token())
                 .tokenType(response.issuedTokenType())
+                .expiresAtMillis(OAuth2Util.expiresAtMillis(response.token()))
                 .build();
         Map<String, String> currentHeaders = this.headers;
         this.headers = RESTUtil.merge(currentHeaders, authHeaders(config.token()));
@@ -618,6 +619,7 @@ public class OAuth2Util {
                   .from(parent.config())
                   .token(token)
                   .tokenType(OAuth2Properties.ACCESS_TOKEN_TYPE)
+                  .expiresAtMillis(OAuth2Util.expiresAtMillis(token))
                   .build());
 
       long startTimeMillis = System.currentTimeMillis();
@@ -699,6 +701,7 @@ public class OAuth2Util {
                   .token(response.token())
                   .tokenType(issuedTokenType)
                   .credential(credential)
+                  .expiresAtMillis(OAuth2Util.expiresAtMillis(response.token()))
                   .build());
 
       Long expiresAtMillis = session.expiresAtMillis();

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -26,9 +26,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.auth.OAuth2Util.AuthSession;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -134,5 +138,98 @@ public class TestOAuth2Util {
               anyMap(),
               any());
     }
+  }
+
+  @Test
+  void fromTokenResponseUsesChildTokenExpiry() {
+    AuthSession parent = parentSession(7200);
+    OAuthTokenResponse response = childTokenResponse(tokenWithExp(300), 300);
+
+    AuthSession child =
+        AuthSession.fromTokenResponse(null, null, response, System.currentTimeMillis(), parent);
+    assertThat(child.expiresAtMillis())
+        .as("Child session should use the child token's exp, not the parent's")
+        .isEqualTo(TimeUnit.SECONDS.toMillis(300));
+  }
+
+  @Test
+  void fromTokenResponseOpaqueTokenDoesNotInheritParentExpiry() {
+    AuthSession parent = parentSession(7200);
+    OAuthTokenResponse response = childTokenResponse("opaque-access-token", 600);
+
+    AuthSession child =
+        AuthSession.fromTokenResponse(null, null, response, System.currentTimeMillis(), parent);
+
+    assertThat(child.expiresAtMillis())
+        .as("Child session with opaque token should not inherit parent's expiresAtMillis")
+        .isNull();
+  }
+
+  @Test
+  void fromAccessTokenUsesChildTokenExpiry() {
+    AuthSession parent = parentSession(7200);
+    String childToken = tokenWithExp(300);
+
+    AuthSession child = AuthSession.fromAccessToken(null, null, childToken, null, parent);
+    assertThat(child.expiresAtMillis())
+        .as("Child session should use the child token's exp, not the parent's")
+        .isEqualTo(TimeUnit.SECONDS.toMillis(300));
+  }
+
+  @Test
+  void refreshUsesRefreshedTokenExpiry() throws IOException {
+    String parentToken = tokenWithExp(7200);
+    String refreshedToken = tokenWithExp(500);
+
+    AuthConfig authConfig =
+        AuthConfig.builder()
+            .token(parentToken)
+            .tokenType(OAuth2Properties.ACCESS_TOKEN_TYPE)
+            .keepRefreshed(true)
+            .credential("testClientId:testClientSecret")
+            .oauth2ServerUri("/v1/token")
+            .expiresAtMillis(OAuth2Util.expiresAtMillis(parentToken))
+            .build();
+
+    OAuthTokenResponse response = childTokenResponse(refreshedToken, 500);
+
+    try (RESTClient client = Mockito.mock(RESTClient.class);
+        AuthSession session = new AuthSession(Map.of(), authConfig)) {
+      Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any())).thenReturn(response);
+
+      session.refresh(client);
+
+      assertThat(session.expiresAtMillis())
+          .as("After refresh, session should use the refreshed token's exp")
+          .isEqualTo(TimeUnit.SECONDS.toMillis(500));
+    }
+  }
+
+  private static AuthSession parentSession(long expSeconds) {
+    String parentToken = tokenWithExp(expSeconds);
+    AuthConfig parentConfig =
+        AuthConfig.builder()
+            .token(parentToken)
+            .tokenType(OAuth2Properties.ACCESS_TOKEN_TYPE)
+            .keepRefreshed(false)
+            .build();
+    AuthSession parent = new AuthSession(Map.of(), parentConfig);
+    assertThat(parent.expiresAtMillis()).isEqualTo(TimeUnit.SECONDS.toMillis(expSeconds));
+    return parent;
+  }
+
+  private static OAuthTokenResponse childTokenResponse(String token, int expiresInSeconds) {
+    return OAuthTokenResponse.builder()
+        .withToken(token)
+        .withTokenType(BEARER)
+        .withIssuedTokenType(OAuth2Properties.ACCESS_TOKEN_TYPE)
+        .setExpirationInSeconds(expiresInSeconds)
+        .build();
+  }
+
+  private static String tokenWithExp(long expSeconds) {
+    JWTClaimsSet claimsSet =
+        new JWTClaimsSet.Builder().subject("test").claim("exp", expSeconds).build();
+    return new PlainJWT(claimsSet).serialize();
   }
 }


### PR DESCRIPTION
### What

Fix child `AuthSession` inheriting the parent session's `expiresAtMillis` instead of computing it from its own token.

### Why

When creating a child `AuthSession` via `fromTokenResponse()` or `fromAccessToken()`, the `AuthConfig` builder calls `.from(parent.config())` to inherit configuration (scope, credential, oauth2ServerUri, etc.). However, Immutables' `from()` copies **all** values from the parent, including `expiresAtMillis`. This overrides the `@Value.Default` method that would otherwise recompute the expiry from the child's own JWT `exp` claim.

**Impact**: The child session schedules its first token refresh based on the **parent's** token expiry, not its own. In token exchange flows where:
- Catalog session holds a long-lived token (e.g., 1-hour Azure AD token)
- Exchanged per-user token is short-lived (e.g., 5-minute token)

...the refresh is scheduled ~54 minutes out instead of ~4.5 minutes, causing the short-lived token to expire without being refreshed.

### How

Explicitly set `expiresAtMillis` from the child token in both `fromTokenResponse()` and `fromAccessToken()` builders:

```java
.expiresAtMillis(OAuth2Util.expiresAtMillis(response.token()))
```

This ensures the child session's expiry is always derived from its own token's JWT `exp` claim (or `null` for opaque tokens, falling back to `response.expiresInSeconds()` for scheduling).

Fixes #16002 

### Testing

Added 3 tests to `TestOAuth2Util`:
- `fromTokenResponseUsesChildTokenExpiry` — verifies child JWT token's exp is used, not parent's
- `fromTokenResponseOpaqueTokenDoesNotInheritParentExpiry` — verifies opaque child tokens don't inherit parent's exp
- `fromAccessTokenUsesChildTokenExpiry` — verifies the same fix for `fromAccessToken()`
