### PR TITLE
Spec: Clarify record-related snapshot summaries refer to physical layout

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -1794,9 +1794,9 @@ Snapshot summary can include metrics fields to track numeric stats of the snapsh
 | **`removed-dvs`**                   | Number of deletion vectors removed in the snapshot                                               |
 | **`removed-delete-files`**          | Number of positional/equality delete files and deletion vectors removed in the snapshot          |
 | **`total-delete-files`**            | Total number of live positional/equality delete files and deletion vectors in the snapshot       |
-| **`added-records`**                 | Number of records added in the snapshot                                                          |
-| **`deleted-records`**               | Number of records deleted in the snapshot                                                        |
-| **`total-records`**                 | Total number of records in the snapshot                                                          |
+| **`added-records`**                 | Number of physical records added by data files added in the snapshot                             |
+| **`deleted-records`**               | Number of physical records removed by data files removed in the snapshot                         |
+| **`total-records`**                 | Total number of physical records present in data files in the snapshot                           |
 | **`added-files-size`**              | The size of files added in the snapshot                                                          |
 | **`removed-files-size`**            | The size of files removed in the snapshot                                                        |
 | **`total-files-size`**              | Total size of live files in the snapshot                                                         |


### PR DESCRIPTION
This is a minor clarification to be clear that the following fields in snapshot summaries refer to the physical layout (i.e. records in data and delete files) rather than logical records (i.e. active records, that should be considered to be valid to return in queries).

It was unclear to me when implementing a compaction algorithm what the values referred to. I have reviewed the Java implementation to confirm that these fields - at least in Java - refer to the physical layout: https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/SnapshotSummary.java#L322-L325.

I acknowledge this is changing the specification (`format/` dir) - please let me know if there is a good way to proceed. I'm hoping this is a simple clarification.