### PR TITLE
Arrow: Align vectorized reader handling of unsigned Parquet integers with BaseParquetReaders

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -590,7 +590,8 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
                 java.util.Locale.ROOT,
                 "Cannot read unsigned integer column '%s' (uint%d): "
                     + "Iceberg does not support unsigned integer types",
-                primitive.getName(), intLogicalType.getBitWidth()));
+                primitive.getName(),
+                intLogicalType.getBitWidth()));
       }
       FieldVector vector = arrowField.createVector(rootAlloc);
       int bitWidth = intLogicalType.getBitWidth();

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -584,6 +584,14 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     @Override
     public Optional<LogicalTypeVisitorResult> visit(
         LogicalTypeAnnotation.IntLogicalTypeAnnotation intLogicalType) {
+      if (!intLogicalType.isSigned()) {
+        throw new UnsupportedOperationException(
+            String.format(
+                java.util.Locale.ROOT,
+                "Cannot read unsigned integer column '%s' (uint%d): "
+                    + "Iceberg does not support unsigned integer types",
+                primitive.getName(), intLogicalType.getBitWidth()));
+      }
       FieldVector vector = arrowField.createVector(rootAlloc);
       int bitWidth = intLogicalType.getBitWidth();
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -584,23 +584,22 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     @Override
     public Optional<LogicalTypeVisitorResult> visit(
         LogicalTypeAnnotation.IntLogicalTypeAnnotation intLogicalType) {
-      if (!intLogicalType.isSigned()) {
-        throw new UnsupportedOperationException(
-            String.format(
-                java.util.Locale.ROOT,
-                "Cannot read unsigned integer column '%s' (uint%d): "
-                    + "Iceberg does not support unsigned integer types",
-                primitive.getName(),
-                intLogicalType.getBitWidth()));
-      }
       FieldVector vector = arrowField.createVector(rootAlloc);
       int bitWidth = intLogicalType.getBitWidth();
 
       if (bitWidth == 8 || bitWidth == 16 || bitWidth == 32) {
+        // Iceberg has no unsigned integer type. Reading UINT32 into a 32-bit signed value would
+        // silently produce negative results for inputs above Integer.MAX_VALUE. UINT8 and UINT16
+        // both fit losslessly in a signed int32 and are allowed, matching the policy in
+        // BaseParquetReaders for the non-vectorized path.
+        Preconditions.checkArgument(
+            intLogicalType.isSigned() || bitWidth < 32, "Cannot read UINT32 as an int value");
         ((IntVector) vector).allocateNew(batchSize);
         return Optional.of(
             new LogicalTypeVisitorResult(vector, ReadType.INT, (int) IntVector.TYPE_WIDTH));
       } else if (bitWidth == 64) {
+        Preconditions.checkArgument(
+            intLogicalType.isSigned(), "Cannot read UINT64 as a long value");
         ((BigIntVector) vector).allocateNew(batchSize);
         return Optional.of(
             new LogicalTypeVisitorResult(vector, ReadType.LONG, (int) BigIntVector.TYPE_WIDTH));

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -396,8 +396,7 @@ public class TestArrowReader {
               ? PrimitiveType.PrimitiveTypeName.INT32
               : PrimitiveType.PrimitiveTypeName.INT64;
 
-      Schema schema =
-          new Schema(Types.NestedField.optional(1, "col", Types.IntegerType.get()));
+      Schema schema = new Schema(Types.NestedField.optional(1, "col", Types.IntegerType.get()));
       Table table = tables.create(schema, tempDir.toURI() + "/uint" + unsignedBitWidth);
 
       MessageType parquetSchema =

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.arrow.vectorized;
 import static org.apache.iceberg.Files.localInput;
 import static org.apache.parquet.schema.Types.primitive;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -381,6 +382,69 @@ public class TestArrowReader {
     }
 
     assertThat(totalRowsRead).as("Should read all rows").isEqualTo(millisValues.size());
+  }
+
+  @Test
+  public void testUnsignedIntegerColumnThrowsException() throws Exception {
+    tables = new HadoopTables();
+
+    for (int[] spec : new int[][] {{8, 32}, {16, 32}, {32, 32}, {64, 64}}) {
+      int unsignedBitWidth = spec[0];
+      int physicalBitWidth = spec[1];
+      PrimitiveType.PrimitiveTypeName physicalType =
+          physicalBitWidth == 32
+              ? PrimitiveType.PrimitiveTypeName.INT32
+              : PrimitiveType.PrimitiveTypeName.INT64;
+
+      Schema schema =
+          new Schema(Types.NestedField.optional(1, "col", Types.IntegerType.get()));
+      Table table = tables.create(schema, tempDir.toURI() + "/uint" + unsignedBitWidth);
+
+      MessageType parquetSchema =
+          new MessageType(
+              "test",
+              primitive(physicalType, Type.Repetition.OPTIONAL)
+                  .as(LogicalTypeAnnotation.intType(unsignedBitWidth, false))
+                  .id(1)
+                  .named("col"));
+
+      File testFile = new File(tempDir, "unsigned-int" + unsignedBitWidth + ".parquet");
+      try (ParquetWriter<Group> writer =
+          ExampleParquetWriter.builder(new Path(testFile.toURI()))
+              .withType(parquetSchema)
+              .build()) {
+        SimpleGroupFactory factory = new SimpleGroupFactory(parquetSchema);
+        Group group = factory.newGroup();
+        if (physicalBitWidth == 32) {
+          group.add("col", 100);
+        } else {
+          group.add("col", 100L);
+        }
+        writer.write(group);
+      }
+
+      DataFile dataFile =
+          DataFiles.builder(PartitionSpec.unpartitioned())
+              .withPath(testFile.getAbsolutePath())
+              .withFileSizeInBytes(testFile.length())
+              .withFormat(FileFormat.PARQUET)
+              .withRecordCount(1)
+              .build();
+      table.newAppend().appendFile(dataFile).commit();
+
+      assertThatThrownBy(
+              () -> {
+                try (VectorizedTableScanIterable vectorizedReader =
+                    new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+                  for (ColumnarBatch batch : vectorizedReader) {
+                    batch.createVectorSchemaRootFromVectors().close();
+                  }
+                }
+              })
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("unsigned integer")
+          .hasMessageContaining("col");
+    }
   }
 
   /**

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -42,6 +42,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -102,6 +103,9 @@ import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test cases for {@link ArrowReader}.
@@ -384,17 +388,82 @@ public class TestArrowReader {
     assertThat(totalRowsRead).as("Should read all rows").isEqualTo(millisValues.size());
   }
 
+  private static Stream<Arguments> rejectedUnsignedIntegerCases() {
+    return Stream.of(
+        Arguments.of(
+            32,
+            PrimitiveType.PrimitiveTypeName.INT32,
+            new Schema(Types.NestedField.optional(1, "col", Types.IntegerType.get())),
+            "Cannot read UINT32 as an int value"),
+        Arguments.of(
+            64,
+            PrimitiveType.PrimitiveTypeName.INT64,
+            new Schema(Types.NestedField.optional(1, "col", Types.LongType.get())),
+            "Cannot read UINT64 as a long value"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("rejectedUnsignedIntegerCases")
+  public void testUnsignedIntegerColumnThrowsException(
+      int unsignedBitWidth,
+      PrimitiveType.PrimitiveTypeName physicalType,
+      Schema schema,
+      String expectedMessage)
+      throws Exception {
+    tables = new HadoopTables();
+    Table table = tables.create(schema, tempDir.toURI() + "/uint" + unsignedBitWidth);
+
+    MessageType parquetSchema =
+        new MessageType(
+            "test",
+            primitive(physicalType, Type.Repetition.OPTIONAL)
+                .as(LogicalTypeAnnotation.intType(unsignedBitWidth, false))
+                .id(1)
+                .named("col"));
+
+    File testFile =
+        new File(tempDir, "unsigned-int" + unsignedBitWidth + "-" + System.nanoTime() + ".parquet");
+    try (ParquetWriter<Group> writer =
+        ExampleParquetWriter.builder(new Path(testFile.toURI())).withType(parquetSchema).build()) {
+      SimpleGroupFactory factory = new SimpleGroupFactory(parquetSchema);
+      Group group = factory.newGroup();
+      if (unsignedBitWidth == 64) {
+        group.add("col", 100L);
+      } else {
+        group.add("col", 100);
+      }
+      writer.write(group);
+    }
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath(testFile.getAbsolutePath())
+            .withFileSizeInBytes(testFile.length())
+            .withFormat(FileFormat.PARQUET)
+            .withRecordCount(1)
+            .build();
+    table.newAppend().appendFile(dataFile).commit();
+
+    assertThatThrownBy(
+            () -> {
+              try (VectorizedTableScanIterable vectorizedReader =
+                  new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+                for (ColumnarBatch batch : vectorizedReader) {
+                  batch.createVectorSchemaRootFromVectors().close();
+                }
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(expectedMessage);
+  }
+
   @Test
-  public void testUnsignedIntegerColumnThrowsException() throws Exception {
+  public void testUnsignedSmallIntegerColumnRoundtrips() throws Exception {
     tables = new HadoopTables();
 
-    for (int[] spec : new int[][] {{8, 32}, {16, 32}, {32, 32}, {64, 64}}) {
+    for (int[] spec : new int[][] {{8, 250}, {16, 50000}}) {
       int unsignedBitWidth = spec[0];
-      int physicalBitWidth = spec[1];
-      PrimitiveType.PrimitiveTypeName physicalType =
-          physicalBitWidth == 32
-              ? PrimitiveType.PrimitiveTypeName.INT32
-              : PrimitiveType.PrimitiveTypeName.INT64;
+      int value = spec[1];
 
       Schema schema = new Schema(Types.NestedField.optional(1, "col", Types.IntegerType.get()));
       Table table = tables.create(schema, tempDir.toURI() + "/uint" + unsignedBitWidth);
@@ -402,23 +471,21 @@ public class TestArrowReader {
       MessageType parquetSchema =
           new MessageType(
               "test",
-              primitive(physicalType, Type.Repetition.OPTIONAL)
+              primitive(PrimitiveType.PrimitiveTypeName.INT32, Type.Repetition.OPTIONAL)
                   .as(LogicalTypeAnnotation.intType(unsignedBitWidth, false))
                   .id(1)
                   .named("col"));
 
-      File testFile = new File(tempDir, "unsigned-int" + unsignedBitWidth + ".parquet");
+      File testFile =
+          new File(
+              tempDir, "unsigned-int" + unsignedBitWidth + "-" + System.nanoTime() + ".parquet");
       try (ParquetWriter<Group> writer =
           ExampleParquetWriter.builder(new Path(testFile.toURI()))
               .withType(parquetSchema)
               .build()) {
         SimpleGroupFactory factory = new SimpleGroupFactory(parquetSchema);
         Group group = factory.newGroup();
-        if (physicalBitWidth == 32) {
-          group.add("col", 100);
-        } else {
-          group.add("col", 100L);
-        }
+        group.add("col", value);
         writer.write(group);
       }
 
@@ -431,18 +498,20 @@ public class TestArrowReader {
               .build();
       table.newAppend().appendFile(dataFile).commit();
 
-      assertThatThrownBy(
-              () -> {
-                try (VectorizedTableScanIterable vectorizedReader =
-                    new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
-                  for (ColumnarBatch batch : vectorizedReader) {
-                    batch.createVectorSchemaRootFromVectors().close();
-                  }
-                }
-              })
-          .isInstanceOf(UnsupportedOperationException.class)
-          .hasMessageContaining("unsigned integer")
-          .hasMessageContaining("col");
+      int totalRows = 0;
+      try (VectorizedTableScanIterable vectorizedReader =
+          new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+        for (ColumnarBatch batch : vectorizedReader) {
+          VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+          assertThat(((IntVector) root.getVector("col")).get(0))
+              .as("UINT%d value should round-trip through int", unsignedBitWidth)
+              .isEqualTo(value);
+          totalRows += root.getRowCount();
+          root.close();
+        }
+      }
+
+      assertThat(totalRows).isEqualTo(1);
     }
   }
 

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -388,6 +388,54 @@ public class TestArrowReader {
     assertThat(totalRowsRead).as("Should read all rows").isEqualTo(millisValues.size());
   }
 
+  @ParameterizedTest
+  @MethodSource("rejectedUnsignedIntegerCases")
+  public void testUnsignedIntegerColumnThrowsException(
+      int unsignedBitWidth,
+      PrimitiveType.PrimitiveTypeName physicalType,
+      Schema schema,
+      String expectedMessage)
+      throws Exception {
+    Table table = createSingleRowUnsignedIntTable(schema, physicalType, unsignedBitWidth, 100L);
+
+    assertThatThrownBy(
+            () -> {
+              try (VectorizedTableScanIterable vectorizedReader =
+                  new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+                for (ColumnarBatch batch : vectorizedReader) {
+                  batch.createVectorSchemaRootFromVectors().close();
+                }
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(expectedMessage);
+  }
+
+  @ParameterizedTest
+  @MethodSource("acceptedUnsignedSmallIntegerCases")
+  public void testUnsignedSmallIntegerColumnRoundtrips(int unsignedBitWidth, int value)
+      throws Exception {
+    Schema schema = new Schema(Types.NestedField.optional(1, "col", Types.IntegerType.get()));
+    Table table =
+        createSingleRowUnsignedIntTable(
+            schema, PrimitiveType.PrimitiveTypeName.INT32, unsignedBitWidth, value);
+
+    int totalRows = 0;
+    try (VectorizedTableScanIterable vectorizedReader =
+        new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+      for (ColumnarBatch batch : vectorizedReader) {
+        VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+        assertThat(((IntVector) root.getVector("col")).get(0))
+            .as("UINT%d value should round-trip through int", unsignedBitWidth)
+            .isEqualTo(value);
+        totalRows += root.getRowCount();
+        root.close();
+      }
+    }
+
+    assertThat(totalRows).isEqualTo(1);
+  }
+
   private static Stream<Arguments> rejectedUnsignedIntegerCases() {
     return Stream.of(
         Arguments.of(
@@ -402,14 +450,13 @@ public class TestArrowReader {
             "Cannot read UINT64 as a long value"));
   }
 
-  @ParameterizedTest
-  @MethodSource("rejectedUnsignedIntegerCases")
-  public void testUnsignedIntegerColumnThrowsException(
-      int unsignedBitWidth,
-      PrimitiveType.PrimitiveTypeName physicalType,
-      Schema schema,
-      String expectedMessage)
-      throws Exception {
+  private static Stream<Arguments> acceptedUnsignedSmallIntegerCases() {
+    return Stream.of(Arguments.of(8, 250), Arguments.of(16, 50000));
+  }
+
+  private Table createSingleRowUnsignedIntTable(
+      Schema schema, PrimitiveType.PrimitiveTypeName physicalType, int unsignedBitWidth, long value)
+      throws IOException {
     tables = new HadoopTables();
     Table table = tables.create(schema, tempDir.toURI() + "/uint" + unsignedBitWidth);
 
@@ -427,10 +474,10 @@ public class TestArrowReader {
         ExampleParquetWriter.builder(new Path(testFile.toURI())).withType(parquetSchema).build()) {
       SimpleGroupFactory factory = new SimpleGroupFactory(parquetSchema);
       Group group = factory.newGroup();
-      if (unsignedBitWidth == 64) {
-        group.add("col", 100L);
+      if (physicalType == PrimitiveType.PrimitiveTypeName.INT64) {
+        group.add("col", value);
       } else {
-        group.add("col", 100);
+        group.add("col", (int) value);
       }
       writer.write(group);
     }
@@ -443,76 +490,7 @@ public class TestArrowReader {
             .withRecordCount(1)
             .build();
     table.newAppend().appendFile(dataFile).commit();
-
-    assertThatThrownBy(
-            () -> {
-              try (VectorizedTableScanIterable vectorizedReader =
-                  new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
-                for (ColumnarBatch batch : vectorizedReader) {
-                  batch.createVectorSchemaRootFromVectors().close();
-                }
-              }
-            })
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(expectedMessage);
-  }
-
-  @Test
-  public void testUnsignedSmallIntegerColumnRoundtrips() throws Exception {
-    tables = new HadoopTables();
-
-    for (int[] spec : new int[][] {{8, 250}, {16, 50000}}) {
-      int unsignedBitWidth = spec[0];
-      int value = spec[1];
-
-      Schema schema = new Schema(Types.NestedField.optional(1, "col", Types.IntegerType.get()));
-      Table table = tables.create(schema, tempDir.toURI() + "/uint" + unsignedBitWidth);
-
-      MessageType parquetSchema =
-          new MessageType(
-              "test",
-              primitive(PrimitiveType.PrimitiveTypeName.INT32, Type.Repetition.OPTIONAL)
-                  .as(LogicalTypeAnnotation.intType(unsignedBitWidth, false))
-                  .id(1)
-                  .named("col"));
-
-      File testFile =
-          new File(
-              tempDir, "unsigned-int" + unsignedBitWidth + "-" + System.nanoTime() + ".parquet");
-      try (ParquetWriter<Group> writer =
-          ExampleParquetWriter.builder(new Path(testFile.toURI()))
-              .withType(parquetSchema)
-              .build()) {
-        SimpleGroupFactory factory = new SimpleGroupFactory(parquetSchema);
-        Group group = factory.newGroup();
-        group.add("col", value);
-        writer.write(group);
-      }
-
-      DataFile dataFile =
-          DataFiles.builder(PartitionSpec.unpartitioned())
-              .withPath(testFile.getAbsolutePath())
-              .withFileSizeInBytes(testFile.length())
-              .withFormat(FileFormat.PARQUET)
-              .withRecordCount(1)
-              .build();
-      table.newAppend().appendFile(dataFile).commit();
-
-      int totalRows = 0;
-      try (VectorizedTableScanIterable vectorizedReader =
-          new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
-        for (ColumnarBatch batch : vectorizedReader) {
-          VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
-          assertThat(((IntVector) root.getVector("col")).get(0))
-              .as("UINT%d value should round-trip through int", unsignedBitWidth)
-              .isEqualTo(value);
-          totalRows += root.getRowCount();
-          root.close();
-        }
-      }
-
-      assertThat(totalRows).isEqualTo(1);
-    }
+    return table;
   }
 
   /**


### PR DESCRIPTION
The vectorized Arrow reader was silently reading unsigned Parquet integer columns (uint8, uint16, uint32, uint64) as signed, producing incorrect values for any value exceeding the signed maximum for that bit width.

Since Iceberg has no unsigned integer type, throw UnsupportedOperationException when the Arrow reader encounters an unsigned integer logical type annotation, consistent with how the schema conversion layer already rejects uint64.

Fixes #14547