### PR TITLE
Docs: Document CATALOG_* env vars in iceberg-rest-fixture README

### DIFF
--- a/docker/iceberg-rest-fixture/README.md
+++ b/docker/iceberg-rest-fixture/README.md
@@ -23,6 +23,39 @@ For converting different catalog implementations into a rest one.
 Adapter for wrapping the existing catalog backends over REST.
 
 
+## Configuration
+
+All configuration is provided via environment variables.
+
+### Backend catalog properties
+
+Catalog properties can be set via `CATALOG_*` environment variables. The
+`CATALOG_` prefix is stripped; single underscores become dots (`.`); double
+underscores become dashes (`-`). Names are lowercased.
+
+| Env var | Catalog property |
+|---|---|
+| `CATALOG_CATALOG_NAME` | `catalog.name` |
+| `CATALOG_WAREHOUSE` | `warehouse` |
+| `CATALOG_URI` | `uri` |
+| `CATALOG_CATALOG__IMPL` | `catalog-impl` |
+| `CATALOG_IO__IMPL` | `io-impl` |
+| `CATALOG_JDBC_USER` | `jdbc.user` |
+
+If `catalog-impl` and `uri` are unset, the fixture defaults to an in-memory
+SQLite `JdbcCatalog`.
+
+### Catalog name
+
+By default, the fixture serves a catalog named `rest_backend`. To match a
+name expected by a specific engine (for example, a catalog created via Trino
+or PyIceberg), override the `catalog.name` property:
+
+```bash
+docker run -e CATALOG_CATALOG_NAME=mycatalog -p 8181:8181 apache/iceberg-rest-fixture
+```
+
+
 ## Build the Docker Image
 
 When making changes to the local files and test them out, you can build the image locally:


### PR DESCRIPTION
## What changes are included in this PR?

Documents the existing `CATALOG_*` environment-variable convention in
`docker/iceberg-rest-fixture/README.md`. The fixture has long supported
configuration via `CATALOG_*` env vars (prefix stripped, `_` → `.`,
`__` → `-`, lowercased), but this was discoverable only by reading
`RCKUtils.environmentCatalogConfig`.

Adds a `Configuration` section with:
- A small mapping table for the most common variables
  (`CATALOG_CATALOG_NAME`, `CATALOG_WAREHOUSE`, `CATALOG_URI`,
  `CATALOG_CATALOG__IMPL`, `CATALOG_IO__IMPL`, `CATALOG_JDBC_USER`)
- The working form to override the catalog name
  (`CATALOG_CATALOG_NAME=mycatalog`)
- The in-memory SQLite default when `catalog-impl` + `uri` are unset

## Are these changes tested?

Docs-only — no code change. The behavior described already exists.

## Are there any user-facing changes?

Documentation only. No runtime behavior change.

Refs #14972 (closed). Per [Iceberg AI-assisted contribution guidelines](https://iceberg.apache.org/contribute/#guidelines-for-ai-assisted-contributions): this PR was AI-assisted (draft + scaffolding); I reviewed and ran the changes locally, and understand the existing `CATALOG_*` translation path end-to-end.
