### PR TITLE
Fix duplicate commits in DynamicCommitter after Flink restart

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -162,23 +162,29 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
 
   private static long getMaxCommittedCheckpointId(
       Iterable<Snapshot> ancestors, String flinkJobId, String operatorId) {
-    long lastCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+    long fallbackCheckpointId = INITIAL_CHECKPOINT_ID;
 
     for (Snapshot ancestor : ancestors) {
       Map<String, String> summary = ancestor.summary();
       String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
       String snapshotOperatorId = summary.get(OPERATOR_ID);
-      if (flinkJobId.equals(snapshotFlinkJobId)
-          && (snapshotOperatorId == null || snapshotOperatorId.equals(operatorId))) {
-        String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
-        if (value != null) {
-          lastCommittedCheckpointId = Long.parseLong(value);
-          break;
+      String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
+
+      if (value != null) {
+        if (flinkJobId.equals(snapshotFlinkJobId)
+            && (snapshotOperatorId == null || snapshotOperatorId.equals(operatorId))) {
+          return Long.parseLong(value);
+        }
+
+        if (fallbackCheckpointId == INITIAL_CHECKPOINT_ID
+            && snapshotOperatorId != null
+            && snapshotOperatorId.equals(operatorId)) {
+          fallbackCheckpointId = Long.parseLong(value);
         }
       }
     }
 
-    return lastCommittedCheckpointId;
+    return fallbackCheckpointId;
   }
 
   /**

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -162,23 +162,29 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
 
   private static long getMaxCommittedCheckpointId(
       Iterable<Snapshot> ancestors, String flinkJobId, String operatorId) {
-    long lastCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+    long fallbackCheckpointId = INITIAL_CHECKPOINT_ID;
 
     for (Snapshot ancestor : ancestors) {
       Map<String, String> summary = ancestor.summary();
       String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
       String snapshotOperatorId = summary.get(OPERATOR_ID);
-      if (flinkJobId.equals(snapshotFlinkJobId)
-          && (snapshotOperatorId == null || snapshotOperatorId.equals(operatorId))) {
-        String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
-        if (value != null) {
-          lastCommittedCheckpointId = Long.parseLong(value);
-          break;
+      String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
+
+      if (value != null) {
+        if (flinkJobId.equals(snapshotFlinkJobId)
+            && (snapshotOperatorId == null || snapshotOperatorId.equals(operatorId))) {
+          return Long.parseLong(value);
+        }
+
+        if (fallbackCheckpointId == INITIAL_CHECKPOINT_ID
+            && snapshotOperatorId != null
+            && snapshotOperatorId.equals(operatorId)) {
+          fallbackCheckpointId = Long.parseLong(value);
         }
       }
     }
 
-    return lastCommittedCheckpointId;
+    return fallbackCheckpointId;
   }
 
   /**

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -327,6 +327,69 @@ class TestDynamicCommitter {
   }
 
   @Test
+  void testSkipsAlreadyCommittedCheckpointAfterJobRestart() throws Exception {
+    Table table = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table.snapshots()).isEmpty();
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    final String jobId1 = JobID.generate().toHexString();
+    final String jobId2 = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int checkpointId = 5;
+    final String branch = SnapshotRef.MAIN_BRANCH;
+
+    TableKey tableKey = new TableKey(TABLE1, branch);
+    byte[][] manifests =
+        aggregator.writeToManifests(tableKey.tableName(), WRITE_RESULT_BY_SPEC, checkpointId);
+
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+
+    DynamicCommitter committer1 =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            false,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    CommitRequest<DynamicCommittable> request1 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(tableKey, manifests, jobId1, operatorId, checkpointId));
+    committer1.commit(Sets.newHashSet(request1));
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+    assertThat(table.currentSnapshot().summary()).containsEntry("flink.job-id", jobId1);
+
+    // Simulate restart with new job ID and same operator ID
+    DynamicCommitter committer2 =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            false,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    CommitRequest<DynamicCommittable> request2 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(tableKey, new byte[0][], jobId2, operatorId, checkpointId));
+    committer2.commit(Sets.newHashSet(request2));
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+  }
+
+  @Test
   void testCommitDeleteInDifferentFormatVersion() throws Exception {
     Table table1 = catalog.loadTable(TableIdentifier.of(TABLE1));
     assertThat(table1.snapshots()).isEmpty();

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -162,23 +162,29 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
 
   private static long getMaxCommittedCheckpointId(
       Iterable<Snapshot> ancestors, String flinkJobId, String operatorId) {
-    long lastCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+    long fallbackCheckpointId = INITIAL_CHECKPOINT_ID;
 
     for (Snapshot ancestor : ancestors) {
       Map<String, String> summary = ancestor.summary();
       String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
       String snapshotOperatorId = summary.get(OPERATOR_ID);
-      if (flinkJobId.equals(snapshotFlinkJobId)
-          && (snapshotOperatorId == null || snapshotOperatorId.equals(operatorId))) {
-        String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
-        if (value != null) {
-          lastCommittedCheckpointId = Long.parseLong(value);
-          break;
+      String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
+
+      if (value != null) {
+        if (flinkJobId.equals(snapshotFlinkJobId)
+            && (snapshotOperatorId == null || snapshotOperatorId.equals(operatorId))) {
+          return Long.parseLong(value);
+        }
+
+        if (fallbackCheckpointId == INITIAL_CHECKPOINT_ID
+            && snapshotOperatorId != null
+            && snapshotOperatorId.equals(operatorId)) {
+          fallbackCheckpointId = Long.parseLong(value);
         }
       }
     }
 
-    return lastCommittedCheckpointId;
+    return fallbackCheckpointId;
   }
 
   /**

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -327,6 +327,69 @@ class TestDynamicCommitter {
   }
 
   @Test
+  void testSkipsAlreadyCommittedCheckpointAfterJobRestart() throws Exception {
+    Table table = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table.snapshots()).isEmpty();
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    final String jobId1 = JobID.generate().toHexString();
+    final String jobId2 = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int checkpointId = 5;
+    final String branch = SnapshotRef.MAIN_BRANCH;
+
+    TableKey tableKey = new TableKey(TABLE1, branch);
+    byte[][] manifests =
+        aggregator.writeToManifests(tableKey.tableName(), WRITE_RESULT_BY_SPEC, checkpointId);
+
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+
+    DynamicCommitter committer1 =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            false,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    CommitRequest<DynamicCommittable> request1 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(tableKey, manifests, jobId1, operatorId, checkpointId));
+    committer1.commit(Sets.newHashSet(request1));
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+    assertThat(table.currentSnapshot().summary()).containsEntry("flink.job-id", jobId1);
+
+    // Simulate restart with new job ID and same operator ID
+    DynamicCommitter committer2 =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            false,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    CommitRequest<DynamicCommittable> request2 =
+        new MockCommitRequest<>(
+            new DynamicCommittable(tableKey, new byte[0][], jobId2, operatorId, checkpointId));
+    committer2.commit(Sets.newHashSet(request2));
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+  }
+
+  @Test
   void testCommitDeleteInDifferentFormatVersion() throws Exception {
     Table table1 = catalog.loadTable(TableIdentifier.of(TABLE1));
     assertThat(table1.snapshots()).isEmpty();


### PR DESCRIPTION
Fixes #16008

After a Flink restart, the job gets a new ID but keeps the same operator. The dedup logic was only matching on job ID, so we'd try to commit again if the response got lost. Fixed getMaxCommittedCheckpointId to also check operator ID as a fallback, with tests for the restart case.