### PR TITLE
[1.10.x] Backport (#14295) Closes #15908 - Hive : Fixing the trailing slash issue for the database paths in HMS …

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -707,7 +707,8 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
           clients.run(client -> client.getDatabase(tableIdentifier.namespace().levels()[0]));
       if (databaseData.getLocationUri() != null) {
         // If the database location is set use it as a base.
-        return String.format("%s/%s", databaseData.getLocationUri(), tableIdentifier.name());
+        String databaseLocation = LocationUtil.stripTrailingSlash(databaseData.getLocationUri());
+        return String.format("%s/%s", databaseLocation, tableIdentifier.name());
       }
 
     } catch (NoSuchObjectException e) {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
@@ -1207,5 +1208,40 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
     Database database = hiveCatalog.convertToDatabase(Namespace.of("database"), ImmutableMap.of());
 
     assertThat(database.getLocationUri()).isEqualTo("s3://bucket/database.db");
+  }
+
+  @Test
+  public void testTableLocationWithTrailingSlashInDatabaseLocation() throws TException {
+    Schema schema = getTestSchema();
+    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "test_table");
+
+    // Create database with trailing slash in location
+    String dbName = "db_with_trailing_slash";
+    String dbLocationWithSlash = temp.resolve(dbName) + "/";
+    Database db = new Database(dbName, "Description", dbLocationWithSlash, Maps.newHashMap());
+    HIVE_METASTORE_EXTENSION.metastoreClient().createDatabase(db);
+
+    try {
+      TableIdentifier tableInDbWithSlash = TableIdentifier.of(dbName, tableIdent.name());
+      Table table = catalog.createTable(tableInDbWithSlash, schema);
+
+      // Verify table location doesn't have double slashes
+      assertThat(table.location())
+          .as("Table location should not contain multiple slashes")
+          .doesNotContain("//test_table")
+          .endsWith("/test_table");
+
+      // Verify the path is normalized correctly
+      String expectedLocation = temp.resolve(dbName) + "/test_table";
+      assertThat(URI.create(table.location()).getPath())
+          .as("Table location should be properly normalized")
+          .isEqualTo(expectedLocation);
+
+      // Dropping the test table
+      catalog.dropTable(tableInDbWithSlash);
+    } finally {
+      // Dropping the test database
+      HIVE_METASTORE_EXTENSION.metastoreClient().dropDatabase(dbName);
+    }
   }
 }


### PR DESCRIPTION
This is a backport of #14295 to 1.10.x.

The original PR was merged into `main` but is not included in the `1.10.x` branch.

No functional changes beyond the original patch.