### PR TITLE
Flink: Fix duplicate commits in DynamicCommitter when Flink jobId changes on restart

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CommitGroupKey.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CommitGroupKey.java
@@ -18,19 +18,19 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
-import java.io.IOException;
 import java.util.Objects;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputView;
-import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
-class TableKey {
+class CommitGroupKey {
   private final String tableName;
   private final String branch;
+  private final String jobId;
+  private final String operatorId;
 
-  TableKey(String tableName, String branch) {
-    this.tableName = tableName;
-    this.branch = branch;
+  CommitGroupKey(DynamicCommittable committable) {
+    this.tableName = committable.key().tableName();
+    this.branch = committable.key().branch();
+    this.jobId = committable.jobId();
+    this.operatorId = committable.operatorId();
   }
 
   String tableName() {
@@ -41,13 +41,12 @@ class TableKey {
     return branch;
   }
 
-  void serializeTo(DataOutputView view) throws IOException {
-    view.writeUTF(tableName);
-    view.writeUTF(branch);
+  String jobId() {
+    return jobId;
   }
 
-  static TableKey deserializeFrom(DataInputView view) throws IOException {
-    return new TableKey(view.readUTF(), view.readUTF());
+  String operatorId() {
+    return operatorId;
   }
 
   @Override
@@ -55,25 +54,17 @@ class TableKey {
     if (this == other) {
       return true;
     }
-
-    if (other == null || getClass() != other.getClass()) {
+    if (!(other instanceof CommitGroupKey that)) {
       return false;
     }
-
-    TableKey that = (TableKey) other;
-    return tableName.equals(that.tableName) && branch.equals(that.branch);
+    return tableName.equals(that.tableName)
+        && branch.equals(that.branch)
+        && Objects.equals(jobId, that.jobId)
+        && Objects.equals(operatorId, that.operatorId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tableName, branch);
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("tableName", tableName)
-        .add("branch", branch)
-        .toString();
+    return Objects.hash(tableName, branch, jobId, operatorId);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -119,28 +119,28 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       DynamicWriteResultAggregator. Iceberg 1.12 will remove this, and users should upgrade to the 1.11 release first
       to migrate their state to a single commit request per checkpoint.
     */
-    Map<TableKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>> commitRequestMap =
-        Maps.newHashMap();
+    Map<CommitGroupKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>
+        commitRequestMap = Maps.newHashMap();
     for (CommitRequest<DynamicCommittable> request : commitRequests) {
       NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> committables =
           commitRequestMap.computeIfAbsent(
-              new TableKey(request.getCommittable()), unused -> Maps.newTreeMap());
+              new CommitGroupKey(request.getCommittable()), unused -> Maps.newTreeMap());
       committables
           .computeIfAbsent(request.getCommittable().checkpointId(), unused -> Lists.newArrayList())
           .add(request);
     }
 
-    for (Map.Entry<TableKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>> entry :
-        commitRequestMap.entrySet()) {
-      Table table = catalog.loadTable(TableIdentifier.parse(entry.getKey().tableName()));
-      DynamicCommittable last = entry.getValue().lastEntry().getValue().get(0).getCommittable();
-      Snapshot latestSnapshot = table.snapshot(entry.getKey().branch());
+    for (Map.Entry<CommitGroupKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>
+        entry : commitRequestMap.entrySet()) {
+      CommitGroupKey groupKey = entry.getKey();
+      Table table = catalog.loadTable(TableIdentifier.parse(groupKey.tableName()));
+      Snapshot latestSnapshot = table.snapshot(groupKey.branch());
       Iterable<Snapshot> ancestors =
           latestSnapshot != null
               ? SnapshotUtil.ancestorsOf(latestSnapshot.snapshotId(), table::snapshot)
               : List.of();
       long maxCommittedCheckpointId =
-          getMaxCommittedCheckpointId(ancestors, last.jobId(), last.operatorId());
+          getMaxCommittedCheckpointId(ancestors, groupKey.jobId(), groupKey.operatorId());
 
       NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> skippedCommitRequests =
           entry.getValue().headMap(maxCommittedCheckpointId, true);
@@ -155,7 +155,7 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
           entry.getValue().tailMap(maxCommittedCheckpointId, false);
       if (!uncommitted.isEmpty()) {
         commitPendingRequests(
-            table, entry.getKey().branch(), uncommitted, last.jobId(), last.operatorId());
+            table, groupKey.branch(), uncommitted, groupKey.jobId(), groupKey.operatorId());
       }
     }
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -137,14 +138,21 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       TableKey tableKey = tableEntry.getKey();
       Table table = catalog.loadTable(TableIdentifier.parse(tableKey.tableName()));
       Snapshot latestSnapshot = table.snapshot(tableKey.branch());
-      List<Snapshot> ancestors =
+      Iterable<Snapshot> ancestors =
           latestSnapshot != null
-              ? Lists.newArrayList(
-                  SnapshotUtil.ancestorsOf(latestSnapshot.snapshotId(), table::snapshot))
+              ? SnapshotUtil.ancestorsOf(latestSnapshot.snapshotId(), table::snapshot)
               : List.of();
 
+      List<Map.Entry<JobOperatorKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>>
+          jobEntries = Lists.newArrayList(tableEntry.getValue().entrySet());
+      // Preserve checkpoint order across groups so that older-jobId commits land before newer-jobId
+      // ones when the batch mixes committables from different jobIds (e.g. state replay after a
+      // restart). Within a (jobId, operatorId) group, checkpoint order is already guaranteed by
+      // the inner NavigableMap.
+      jobEntries.sort(Comparator.comparingLong(entry -> entry.getValue().firstKey()));
+
       for (Map.Entry<JobOperatorKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>
-          jobEntry : tableEntry.getValue().entrySet()) {
+          jobEntry : jobEntries) {
         JobOperatorKey jobKey = jobEntry.getKey();
         long maxCommittedCheckpointId =
             getMaxCommittedCheckpointId(ancestors, jobKey.jobId(), jobKey.operatorId());

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -119,43 +119,51 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
       DynamicWriteResultAggregator. Iceberg 1.12 will remove this, and users should upgrade to the 1.11 release first
       to migrate their state to a single commit request per checkpoint.
     */
-    Map<CommitGroupKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>
+    Map<TableKey, Map<JobOperatorKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>>
         commitRequestMap = Maps.newHashMap();
     for (CommitRequest<DynamicCommittable> request : commitRequests) {
-      NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> committables =
-          commitRequestMap.computeIfAbsent(
-              new CommitGroupKey(request.getCommittable()), unused -> Maps.newTreeMap());
-      committables
-          .computeIfAbsent(request.getCommittable().checkpointId(), unused -> Lists.newArrayList())
+      DynamicCommittable committable = request.getCommittable();
+      commitRequestMap
+          .computeIfAbsent(committable.key(), unused -> Maps.newHashMap())
+          .computeIfAbsent(new JobOperatorKey(committable), unused -> Maps.newTreeMap())
+          .computeIfAbsent(committable.checkpointId(), unused -> Lists.newArrayList())
           .add(request);
     }
 
-    for (Map.Entry<CommitGroupKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>
-        entry : commitRequestMap.entrySet()) {
-      CommitGroupKey groupKey = entry.getKey();
-      Table table = catalog.loadTable(TableIdentifier.parse(groupKey.tableName()));
-      Snapshot latestSnapshot = table.snapshot(groupKey.branch());
-      Iterable<Snapshot> ancestors =
+    for (Map.Entry<
+            TableKey,
+            Map<JobOperatorKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>>
+        tableEntry : commitRequestMap.entrySet()) {
+      TableKey tableKey = tableEntry.getKey();
+      Table table = catalog.loadTable(TableIdentifier.parse(tableKey.tableName()));
+      Snapshot latestSnapshot = table.snapshot(tableKey.branch());
+      List<Snapshot> ancestors =
           latestSnapshot != null
-              ? SnapshotUtil.ancestorsOf(latestSnapshot.snapshotId(), table::snapshot)
+              ? Lists.newArrayList(
+                  SnapshotUtil.ancestorsOf(latestSnapshot.snapshotId(), table::snapshot))
               : List.of();
-      long maxCommittedCheckpointId =
-          getMaxCommittedCheckpointId(ancestors, groupKey.jobId(), groupKey.operatorId());
 
-      NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> skippedCommitRequests =
-          entry.getValue().headMap(maxCommittedCheckpointId, true);
-      LOG.debug(
-          "Skipping {} commit requests: {}", skippedCommitRequests.size(), skippedCommitRequests);
-      // Mark the already committed FilesCommittable(s) as finished
-      skippedCommitRequests
-          .values()
-          .forEach(list -> list.forEach(CommitRequest::signalAlreadyCommitted));
+      for (Map.Entry<JobOperatorKey, NavigableMap<Long, List<CommitRequest<DynamicCommittable>>>>
+          jobEntry : tableEntry.getValue().entrySet()) {
+        JobOperatorKey jobKey = jobEntry.getKey();
+        long maxCommittedCheckpointId =
+            getMaxCommittedCheckpointId(ancestors, jobKey.jobId(), jobKey.operatorId());
 
-      NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> uncommitted =
-          entry.getValue().tailMap(maxCommittedCheckpointId, false);
-      if (!uncommitted.isEmpty()) {
-        commitPendingRequests(
-            table, groupKey.branch(), uncommitted, groupKey.jobId(), groupKey.operatorId());
+        NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> skippedCommitRequests =
+            jobEntry.getValue().headMap(maxCommittedCheckpointId, true);
+        LOG.debug(
+            "Skipping {} commit requests: {}", skippedCommitRequests.size(), skippedCommitRequests);
+        // Mark the already committed FilesCommittable(s) as finished
+        skippedCommitRequests
+            .values()
+            .forEach(list -> list.forEach(CommitRequest::signalAlreadyCommitted));
+
+        NavigableMap<Long, List<CommitRequest<DynamicCommittable>>> uncommitted =
+            jobEntry.getValue().tailMap(maxCommittedCheckpointId, false);
+        if (!uncommitted.isEmpty()) {
+          commitPendingRequests(
+              table, tableKey.branch(), uncommitted, jobKey.jobId(), jobKey.operatorId());
+        }
       }
     }
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicCommitter.java
@@ -112,6 +112,17 @@ class DynamicCommitter implements Committer<DynamicCommittable> {
     }
 
     /*
+      Group the incoming commit requests into a three-level structure before committing:
+
+        Map<TableKey, Map<JobOperatorKey, NavigableMap<Long, List<CommitRequest>>>>
+              |              |                  |              |
+              |              |                  |              +-- commit requests at that checkpoint
+              |              |                  +-- checkpointId, sorted ascending so older commits go first
+              |              +-- (jobId, operatorId) of the producing aggregator; deduplication against the
+              |                  table's snapshot summaries is per (jobId, operatorId), so each group is
+              |                  walked against the ancestor chain independently
+              +-- (tableName, branch); we load the table and its ancestor chain once per TableKey
+
       Each (table, branch, checkpoint) triplet must have only one commit request.
       There may be commit requests from previous checkpoints which have not been committed yet.
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/JobOperatorKey.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/JobOperatorKey.java
@@ -20,25 +20,13 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.Objects;
 
-class CommitGroupKey {
-  private final String tableName;
-  private final String branch;
+class JobOperatorKey {
   private final String jobId;
   private final String operatorId;
 
-  CommitGroupKey(DynamicCommittable committable) {
-    this.tableName = committable.key().tableName();
-    this.branch = committable.key().branch();
+  JobOperatorKey(DynamicCommittable committable) {
     this.jobId = committable.jobId();
     this.operatorId = committable.operatorId();
-  }
-
-  String tableName() {
-    return tableName;
-  }
-
-  String branch() {
-    return branch;
   }
 
   String jobId() {
@@ -54,17 +42,16 @@ class CommitGroupKey {
     if (this == other) {
       return true;
     }
-    if (!(other instanceof CommitGroupKey that)) {
+
+    if (!(other instanceof JobOperatorKey that)) {
       return false;
     }
-    return tableName.equals(that.tableName)
-        && branch.equals(that.branch)
-        && Objects.equals(jobId, that.jobId)
-        && Objects.equals(operatorId, that.operatorId);
+
+    return jobId.equals(that.jobId) && operatorId.equals(that.operatorId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tableName, branch, jobId, operatorId);
+    return Objects.hash(jobId, operatorId);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/JobOperatorKey.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/JobOperatorKey.java
@@ -47,7 +47,7 @@ class JobOperatorKey {
       return false;
     }
 
-    return jobId.equals(that.jobId) && operatorId.equals(that.operatorId);
+    return Objects.equals(jobId, that.jobId) && Objects.equals(operatorId, that.operatorId);
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -618,8 +618,7 @@ class TestDynamicCommitter {
     // Two committables, one for each snapshot / table / branch.
     assertThat(table.snapshots()).hasSize(2);
 
-    Snapshot snapshot1 = Iterables.getFirst(table.snapshots(), null);
-    assertThat(snapshot1.snapshotId()).isEqualTo(table.refs().get("branch1").snapshotId());
+    Snapshot snapshot1 = table.snapshot(table.refs().get("branch1").snapshotId());
     assertThat(snapshot1.summary())
         .containsAllEntriesOf(
             ImmutableMap.<String, String>builder()
@@ -637,8 +636,7 @@ class TestDynamicCommitter {
                 .put("total-records", "66")
                 .build());
 
-    Snapshot snapshot2 = Iterables.get(table.snapshots(), 1);
-    assertThat(snapshot2.snapshotId()).isEqualTo(table.refs().get("branch2").snapshotId());
+    Snapshot snapshot2 = table.snapshot(table.refs().get("branch2").snapshotId());
     assertThat(snapshot2.summary())
         .containsAllEntriesOf(
             ImmutableMap.<String, String>builder()

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -422,6 +422,71 @@ class TestDynamicCommitter {
   }
 
   @Test
+  void testCommitsLandInCheckpointOrderAcrossJobIds() throws Exception {
+    Table table = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table.snapshots()).isEmpty();
+
+    boolean overwriteMode = false;
+    int workerPoolSize = 1;
+    String sinkId = "sinkId";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    DynamicCommitterMetrics committerMetrics = new DynamicCommitterMetrics(metricGroup);
+    DynamicCommitter committer =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            sinkId,
+            committerMetrics);
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    TableKey tableKey = new TableKey(TABLE1, "branch");
+    final String oldJobId = JobID.generate().toHexString();
+    final String newJobId = JobID.generate().toHexString();
+    final String operatorId = new OperatorID().toHexString();
+    final int oldCheckpointId = 1;
+    final int newCheckpointId = 2;
+
+    byte[][] oldManifests =
+        aggregator.writeToManifests(tableKey.tableName(), WRITE_RESULT_BY_SPEC, oldCheckpointId);
+    byte[][] newManifests =
+        aggregator.writeToManifests(tableKey.tableName(), WRITE_RESULT_BY_SPEC_2, newCheckpointId);
+
+    CommitRequest<DynamicCommittable> oldRequest =
+        new MockCommitRequest<>(
+            new DynamicCommittable(tableKey, oldManifests, oldJobId, operatorId, oldCheckpointId));
+    CommitRequest<DynamicCommittable> newRequest =
+        new MockCommitRequest<>(
+            new DynamicCommittable(tableKey, newManifests, newJobId, operatorId, newCheckpointId));
+
+    // Hand the requests in reversed order; the committer must still land them in checkpointId
+    // order on the snapshot chain.
+    committer.commit(Lists.newArrayList(newRequest, oldRequest));
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(2);
+
+    Snapshot first = Iterables.get(table.snapshots(), 0);
+    assertThat(first.summary())
+        .containsEntry("flink.job-id", oldJobId)
+        .containsEntry("flink.max-committed-checkpoint-id", String.valueOf(oldCheckpointId))
+        .containsEntry("flink.operator-id", operatorId);
+
+    Snapshot second = Iterables.get(table.snapshots(), 1);
+    assertThat(second.summary())
+        .containsEntry("flink.job-id", newJobId)
+        .containsEntry("flink.max-committed-checkpoint-id", String.valueOf(newCheckpointId))
+        .containsEntry("flink.operator-id", operatorId);
+    assertThat(second.parentId()).isEqualTo(first.snapshotId());
+  }
+
+  @Test
   void testCommitDeleteInDifferentFormatVersion() throws Exception {
     Table table1 = catalog.loadTable(TableIdentifier.of(TABLE1));
     assertThat(table1.snapshots()).isEmpty();

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -327,6 +327,112 @@ class TestDynamicCommitter {
   }
 
   @Test
+  void testDedupsCommittablesTaggedWithPreviousJobIdAfterRestart() throws Exception {
+    // Reproduces duplication bug: after a stop-with-savepoint rescale, the committer's state
+    // contains a committable tagged with the previous Flink jobId alongside fresh committables
+    // tagged with the new jobId. Dedup must recognise that the previous-jobId committable's
+    // data is already present in the ancestor chain (stamped with the previous jobId) and skip it,
+    // otherwise the underlying data files are committed twice and rows are duplicated.
+    Table table = catalog.loadTable(TableIdentifier.of(TABLE1));
+    assertThat(table.snapshots()).isEmpty();
+
+    boolean overwriteMode = false;
+    int workerPoolSize = 1;
+    String uidPrefix = "uidPrefix";
+    UnregisteredMetricsGroup metricGroup = new UnregisteredMetricsGroup();
+    JobID previousJobId = JobID.generate();
+    DynamicCommitterMetrics previousCommitterMetrics = new DynamicCommitterMetrics(metricGroup);
+    DynamicCommitter previousCommitter =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            uidPrefix,
+            previousCommitterMetrics);
+
+    DynamicWriteResultAggregator aggregator =
+        new DynamicWriteResultAggregator(CATALOG_EXTENSION.catalogLoader(), cacheMaximumSize);
+    OneInputStreamOperatorTestHarness aggregatorHarness =
+        new OneInputStreamOperatorTestHarness(aggregator);
+    aggregatorHarness.open();
+
+    TableKey tableKey = new TableKey(TABLE1, "branch");
+    // Operator id is stable across Flink job restarts, jobId is not.
+    final String operatorId = new OperatorID().toHexString();
+    final String previousJobIdStr = previousJobId.toHexString();
+    final int previousCheckpointId = 10;
+
+    byte[][] previousManifests =
+        aggregator.writeToManifests(
+            tableKey.tableName(), WRITE_RESULT_BY_SPEC, previousCheckpointId);
+
+    DynamicCommittable previousCommittable =
+        new DynamicCommittable(
+            tableKey, previousManifests, previousJobIdStr, operatorId, previousCheckpointId);
+    previousCommitter.commit(Sets.newHashSet(new MockCommitRequest<>(previousCommittable)));
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+
+    // Simulate the savepoint-driven restart: a new Flink jobId is assigned, yet the committer
+    // state replays the previous committable tagged with previousJobIdStr and adds a fresh
+    // committable for the next checkpoint tagged with newJobIdStr.
+    JobID newJobId = JobID.generate();
+    DynamicCommitterMetrics newCommitterMetrics = new DynamicCommitterMetrics(metricGroup);
+    DynamicCommitter newCommitter =
+        new DynamicCommitter(
+            CATALOG_EXTENSION.catalog(),
+            Maps.newHashMap(),
+            overwriteMode,
+            workerPoolSize,
+            uidPrefix,
+            newCommitterMetrics);
+
+    final String newJobIdStr = newJobId.toHexString();
+    final int newCheckpointId = previousCheckpointId + 1;
+
+    byte[][] previousManifestsNew =
+        aggregator.writeToManifests(
+            tableKey.tableName(), WRITE_RESULT_BY_SPEC, previousCheckpointId);
+    byte[][] newManifests =
+        aggregator.writeToManifests(tableKey.tableName(), WRITE_RESULT_BY_SPEC_2, newCheckpointId);
+
+    CommitRequest<DynamicCommittable> replayedPreviousCommitRequest =
+        new MockCommitRequest<>(
+            new DynamicCommittable(
+                tableKey,
+                previousManifestsNew,
+                previousJobIdStr,
+                operatorId,
+                previousCheckpointId));
+    CommitRequest<DynamicCommittable> newCommitRequest =
+        new MockCommitRequest<>(
+            new DynamicCommittable(
+                tableKey, newManifests, newJobIdStr, operatorId, newCheckpointId));
+
+    newCommitter.commit(Sets.newHashSet(replayedPreviousCommitRequest, newCommitRequest));
+
+    table.refresh();
+    // Exactly two snapshots: the original one stamped with previousJobIdStr and the one added
+    // under newJobIdStr. Without the dedup fix the replayed committable would produce a third
+    // snapshot that re-adds the same data files, yielding duplicate rows.
+    assertThat(table.snapshots()).hasSize(2);
+
+    Snapshot first = Iterables.get(table.snapshots(), 0);
+    assertThat(first.summary())
+        .containsEntry("flink.job-id", previousJobIdStr)
+        .containsEntry("flink.max-committed-checkpoint-id", String.valueOf(previousCheckpointId))
+        .containsEntry("flink.operator-id", operatorId);
+
+    Snapshot second = Iterables.get(table.snapshots(), 1);
+    assertThat(second.summary())
+        .containsEntry("flink.job-id", newJobIdStr)
+        .containsEntry("flink.max-committed-checkpoint-id", String.valueOf(newCheckpointId))
+        .containsEntry("flink.operator-id", operatorId);
+  }
+
+  @Test
   void testCommitDeleteInDifferentFormatVersion() throws Exception {
     Table table1 = catalog.loadTable(TableIdentifier.of(TABLE1));
     assertThat(table1.snapshots()).isEmpty();

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.connector.sink2.Committer.CommitRequest;
@@ -327,12 +328,7 @@ class TestDynamicCommitter {
   }
 
   @Test
-  void testDedupsCommittablesTaggedWithPreviousJobIdAfterRestart() throws Exception {
-    // Reproduces duplication bug: after a stop-with-savepoint rescale, the committer's state
-    // contains a committable tagged with the previous Flink jobId alongside fresh committables
-    // tagged with the new jobId. Dedup must recognise that the previous-jobId committable's
-    // data is already present in the ancestor chain (stamped with the previous jobId) and skip it,
-    // otherwise the underlying data files are committed twice and rows are duplicated.
+  void testSkipsAlreadyCommittedDataAfterJobIdChanges() throws Exception {
     Table table = catalog.loadTable(TableIdentifier.of(TABLE1));
     assertThat(table.snapshots()).isEmpty();
 
@@ -375,9 +371,6 @@ class TestDynamicCommitter {
     table.refresh();
     assertThat(table.snapshots()).hasSize(1);
 
-    // Simulate the savepoint-driven restart: a new Flink jobId is assigned, yet the committer
-    // state replays the previous committable tagged with previousJobIdStr and adds a fresh
-    // committable for the next checkpoint tagged with newJobIdStr.
     JobID newJobId = JobID.generate();
     DynamicCommitterMetrics newCommitterMetrics = new DynamicCommitterMetrics(metricGroup);
     DynamicCommitter newCommitter =
@@ -414,9 +407,6 @@ class TestDynamicCommitter {
     newCommitter.commit(Sets.newHashSet(replayedPreviousCommitRequest, newCommitRequest));
 
     table.refresh();
-    // Exactly two snapshots: the original one stamped with previousJobIdStr and the one added
-    // under newJobIdStr. Without the dedup fix the replayed committable would produce a third
-    // snapshot that re-adds the same data files, yielding duplicate rows.
     assertThat(table.snapshots()).hasSize(2);
 
     Snapshot first = Iterables.get(table.snapshots(), 0);
@@ -1081,8 +1071,9 @@ class TestDynamicCommitter {
     @Override
     public void commit(Collection<CommitRequest<DynamicCommittable>> commitRequests)
         throws IOException, InterruptedException {
-      commitHook.beforeCommit(commitRequests);
-      super.commit(commitRequests);
+      List<CommitRequest<DynamicCommittable>> mutableRequests = Lists.newArrayList(commitRequests);
+      commitHook.beforeCommit(mutableRequests);
+      super.commit(mutableRequests);
       commitHook.afterCommit();
     }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicCommitter.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.connector.sink2.Committer.CommitRequest;
@@ -992,7 +991,10 @@ class TestDynamicCommitter {
   }
 
   interface CommitHook extends Serializable {
-    default void beforeCommit(Collection<CommitRequest<DynamicCommittable>> commitRequests) {}
+    default Collection<CommitRequest<DynamicCommittable>> beforeCommit(
+        Collection<CommitRequest<DynamicCommittable>> commitRequests) {
+      return commitRequests;
+    }
 
     default void beforeCommitOperation() {}
 
@@ -1013,11 +1015,14 @@ class TestDynamicCommitter {
     }
 
     @Override
-    public void beforeCommit(Collection<CommitRequest<DynamicCommittable>> ignored) {
+    public Collection<CommitRequest<DynamicCommittable>> beforeCommit(
+        Collection<CommitRequest<DynamicCommittable>> requests) {
       if (!failedBeforeCommit) {
         failedBeforeCommit = true;
         throw new RuntimeException("Failing before commit");
       }
+
+      return requests;
     }
 
     @Override
@@ -1071,9 +1076,7 @@ class TestDynamicCommitter {
     @Override
     public void commit(Collection<CommitRequest<DynamicCommittable>> commitRequests)
         throws IOException, InterruptedException {
-      List<CommitRequest<DynamicCommittable>> mutableRequests = Lists.newArrayList(commitRequests);
-      commitHook.beforeCommit(mutableRequests);
-      super.commit(mutableRequests);
+      super.commit(commitHook.beforeCommit(commitRequests));
       commitHook.afterCommit();
     }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -1213,6 +1213,10 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     assertThat(mainSnapshot.summary())
         .containsEntry("added-data-files", "1")
         .containsEntry("added-records", String.valueOf(records.size()));
+
+    long expectedTotalRecords = overwriteMode ? records.size() : records.size() + 1L;
+    assertThat(Long.parseLong(mainSnapshot.summary().get("total-records")))
+        .isEqualTo(expectedTotalRecords);
   }
 
   @Test
@@ -1566,10 +1570,13 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     }
 
     @Override
-    public void beforeCommit(Collection<Committer.CommitRequest<DynamicCommittable>> requests) {
+    public Collection<Committer.CommitRequest<DynamicCommittable>> beforeCommit(
+        Collection<Committer.CommitRequest<DynamicCommittable>> requests) {
       if (!hasTriggered) {
         this.commitRequests.addAll(requests);
       }
+
+      return requests;
     }
 
     @Override
@@ -1588,9 +1595,10 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
   }
 
   /**
-   * Seeds an ancestor snapshot under a synthetic previous jobId and injects a replay committable
-   * tagged with that jobId into the main batch. The seed uses {@code table.newAppend()} directly
-   * rather than a side committer so the real committable's manifest stays intact.
+   * Seeds an ancestor snapshot under a synthetic previous jobId and prepends a replay committable
+   * tagged with that jobId (at an earlier checkpoint, as would happen on restart-replay) to the
+   * batch. The seed uses {@code table.newAppend()} directly rather than a side committer so the
+   * real committable's manifest stays intact.
    */
   static class ReplayPreviousJobIdCommittableHook implements CommitHook {
     static final String PREVIOUS_JOB_ID = JobID.generate().toHexString();
@@ -1610,13 +1618,15 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     }
 
     @Override
-    public void beforeCommit(Collection<Committer.CommitRequest<DynamicCommittable>> requests) {
+    public Collection<Committer.CommitRequest<DynamicCommittable>> beforeCommit(
+        Collection<Committer.CommitRequest<DynamicCommittable>> requests) {
       if (hasTriggered || requests.isEmpty()) {
-        return;
+        return requests;
       }
 
       hasTriggered = true;
       DynamicCommittable original = requests.iterator().next().getCommittable();
+      long replayedCheckpointId = original.checkpointId() - 1;
 
       Table table =
           CATALOG_EXTENSION.catalog().loadTable(TableIdentifier.parse(original.key().tableName()));
@@ -1625,7 +1635,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           .appendFile(seedDataFile)
           .set(FLINK_JOB_ID, PREVIOUS_JOB_ID)
           .set(OPERATOR_ID, original.operatorId())
-          .set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(original.checkpointId()))
+          .set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(replayedCheckpointId))
           .toBranch(original.key().branch())
           .commit();
 
@@ -1635,8 +1645,12 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
               original.manifests(),
               PREVIOUS_JOB_ID,
               original.operatorId(),
-              original.checkpointId());
-      requests.add(new MockCommitRequest<>(replayed));
+              replayedCheckpointId);
+      List<Committer.CommitRequest<DynamicCommittable>> enriched =
+          Lists.newArrayListWithCapacity(requests.size() + 1);
+      enriched.add(new MockCommitRequest<>(replayed));
+      enriched.addAll(requests);
+      return enriched;
     }
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -35,11 +35,13 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.api.connector.sink2.mocks.MockCommitRequest;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
@@ -1175,6 +1177,44 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     assertThat(totalAddedRecords).isEqualTo(records.size());
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void testSkipsAlreadyCommittedDataAfterJobIdChanges(boolean overwriteMode) throws Exception {
+    TableIdentifier tableId = TableIdentifier.of(DATABASE, "t1");
+    List<DynamicIcebergDataImpl> records =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                tableId.name(),
+                SnapshotRef.MAIN_BRANCH,
+                PartitionSpec.unpartitioned()));
+
+    DataFile seedDataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("/path/to/seed-data-1.parquet")
+            .withFileSizeInBytes(0)
+            .withRecordCount(1)
+            .build();
+
+    executeDynamicSink(
+        records, env, true, 1, new ReplayPreviousJobIdCommittableHook(seedDataFile), overwriteMode);
+
+    Table table = CATALOG_EXTENSION.catalog().loadTable(tableId);
+
+    Snapshot mainSnapshot =
+        StreamSupport.stream(table.snapshots().spliterator(), false)
+            .filter(
+                s ->
+                    !ReplayPreviousJobIdCommittableHook.PREVIOUS_JOB_ID.equals(
+                        s.summary().get("flink.job-id")))
+            .filter(s -> s.summary().get("flink.job-id") != null)
+            .reduce((first, second) -> second)
+            .orElseThrow();
+    assertThat(mainSnapshot.summary())
+        .containsEntry("added-data-files", "1")
+        .containsEntry("added-records", String.valueOf(records.size()));
+  }
+
   @Test
   void testCommitsOncePerTableBranchAndCheckpoint() throws Exception {
     String tableName = "t1";
@@ -1544,6 +1584,59 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
         commitRequests.clear();
         hasTriggered = true;
       }
+    }
+  }
+
+  /**
+   * Seeds an ancestor snapshot under a synthetic previous jobId and injects a replay committable
+   * tagged with that jobId into the main batch. The seed uses {@code table.newAppend()} directly
+   * rather than a side committer so the real committable's manifest stays intact.
+   */
+  static class ReplayPreviousJobIdCommittableHook implements CommitHook {
+    static final String PREVIOUS_JOB_ID = JobID.generate().toHexString();
+
+    private static final String MAX_COMMITTED_CHECKPOINT_ID = "flink.max-committed-checkpoint-id";
+    private static final String FLINK_JOB_ID = "flink.job-id";
+    private static final String OPERATOR_ID = "flink.operator-id";
+
+    // Static to survive Flink operator serialization.
+    private static boolean hasTriggered = false;
+
+    private final DataFile seedDataFile;
+
+    ReplayPreviousJobIdCommittableHook(DataFile seedDataFile) {
+      this.seedDataFile = seedDataFile;
+      hasTriggered = false;
+    }
+
+    @Override
+    public void beforeCommit(Collection<Committer.CommitRequest<DynamicCommittable>> requests) {
+      if (hasTriggered || requests.isEmpty()) {
+        return;
+      }
+
+      hasTriggered = true;
+      DynamicCommittable original = requests.iterator().next().getCommittable();
+
+      Table table =
+          CATALOG_EXTENSION.catalog().loadTable(TableIdentifier.parse(original.key().tableName()));
+      table
+          .newAppend()
+          .appendFile(seedDataFile)
+          .set(FLINK_JOB_ID, PREVIOUS_JOB_ID)
+          .set(OPERATOR_ID, original.operatorId())
+          .set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(original.checkpointId()))
+          .toBranch(original.key().branch())
+          .commit();
+
+      DynamicCommittable replayed =
+          new DynamicCommittable(
+              original.key(),
+              original.manifests(),
+              PREVIOUS_JOB_ID,
+              original.operatorId(),
+              original.checkpointId());
+      requests.add(new MockCommitRequest<>(replayed));
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/16008

The DynamicCommitter deduplicates commits on the triplet (flink.job-id, flink.operator-id, max-committed-checkpoint-id) stored in each snapshot summary. The aggregator previously sampled the job id from the runtime environment on every operator open(), so a restart or rescale with a fresh Flink JobID would stamp restored write results with the new id. The committer's ancestor walk then could not find the snapshot committed under the old id, and silently re-committed the data, producing duplicate rows in the target table.

Persist the aggregator's job id as operator state and reuse it on restore, so committables keep the job id under which their data was originally produced. This restores the dedup invariant across job restarts, autoscaler savepoint+resubmit cycles, and session-cluster resubmissions, which was broken under sustained catalog-side latency where commit responses were lost client-side.