### PR TITLE
Spark4.1: Add changelog tests for table v3

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -58,6 +58,12 @@ public class TestChangelogTable extends ExtensionsTestBase {
         SparkCatalogConfig.HIVE.implementation(),
         SparkCatalogConfig.HIVE.properties(),
         2
+      },
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties(),
+        3
       }
     };
   }

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
@@ -91,7 +91,7 @@ public class TestCreateChangelogViewProcedure extends ExtensionsTestBase {
         snap2.snapshotId(),
         "cdc_view");
 
-    long rowCount = sql("select * from %s", "cdc_view").stream().count();
+    long rowCount = sql("select * from %s", "cdc_view").size();
     assertThat(rowCount).isEqualTo(2);
   }
 
@@ -476,6 +476,37 @@ public class TestCreateChangelogViewProcedure extends ExtensionsTestBase {
     assertEquals(
         "Rows should match",
         ImmutableList.of(
+            row(2, "b", INSERT, 0, snap1.snapshotId()),
+            row(2, "b", UPDATE_BEFORE, 1, snap2.snapshotId()),
+            row(2, "d", UPDATE_AFTER, 1, snap2.snapshotId()),
+            row(3, "c", INSERT, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id, data", viewName));
+  }
+
+  @TestTemplate
+  public void testUpdateWithIdentifierFieldAfterUpgradeToV3() {
+    createTableWithIdentifierField();
+
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('format-version' = '3')", tableName);
+    sql("INSERT OVERWRITE %s VALUES (1, 'a'), (2, 'd'), (3, 'c')", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view(table => '%s', compute_updates => true)",
+            catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", INSERT, 0, snap1.snapshotId()),
             row(2, "b", INSERT, 0, snap1.snapshotId()),
             row(2, "b", UPDATE_BEFORE, 1, snap2.snapshotId()),
             row(2, "d", UPDATE_AFTER, 1, snap2.snapshotId()),

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseSparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseSparkTable.java
@@ -23,7 +23,6 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.BaseTable;
@@ -31,10 +30,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.spark.sql.SparkSession;
@@ -133,20 +130,7 @@ abstract class BaseSparkTable
 
   @Override
   public MetadataColumn[] metadataColumns() {
-    List<SparkMetadataColumn> cols = Lists.newArrayList();
-
-    cols.add(SparkMetadataColumns.SPEC_ID);
-    cols.add(SparkMetadataColumns.partition(table));
-    cols.add(SparkMetadataColumns.FILE_PATH);
-    cols.add(SparkMetadataColumns.ROW_POSITION);
-    cols.add(SparkMetadataColumns.IS_DELETED);
-
-    if (TableUtil.supportsRowLineage(table)) {
-      cols.add(SparkMetadataColumns.ROW_ID);
-      cols.add(SparkMetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER);
-    }
-
-    return cols.toArray(SparkMetadataColumn[]::new);
+    return SparkMetadataColumns.metadataColumnArray(table);
   }
 
   private String fileFormat() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogTable.java
@@ -86,12 +86,6 @@ public class SparkChangelogTable
 
   @Override
   public MetadataColumn[] metadataColumns() {
-    return new MetadataColumn[] {
-      SparkMetadataColumns.SPEC_ID,
-      SparkMetadataColumns.partition(table),
-      SparkMetadataColumns.FILE_PATH,
-      SparkMetadataColumns.ROW_POSITION,
-      SparkMetadataColumns.IS_DELETED,
-    };
+    return SparkMetadataColumns.metadataColumnArray(table);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMetadataColumns.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMetadataColumns.java
@@ -18,10 +18,14 @@
  */
 package org.apache.iceberg.spark.source;
 
+import java.util.List;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.spark.sql.connector.catalog.MetadataColumn;
 import org.apache.spark.sql.types.DataTypes;
 
 public class SparkMetadataColumns {
@@ -82,5 +86,22 @@ public class SparkMetadataColumns {
         .dataType(SparkSchemaUtil.convert(Partitioning.partitionType(table)))
         .withNullability(true)
         .build();
+  }
+
+  public static MetadataColumn[] metadataColumnArray(Table table) {
+    List<SparkMetadataColumn> cols = Lists.newArrayList();
+
+    cols.add(SPEC_ID);
+    cols.add(partition(table));
+    cols.add(FILE_PATH);
+    cols.add(ROW_POSITION);
+    cols.add(IS_DELETED);
+
+    if (TableUtil.supportsRowLineage(table)) {
+      cols.add(ROW_ID);
+      cols.add(LAST_UPDATED_SEQUENCE_NUMBER);
+    }
+
+    return cols.toArray(SparkMetadataColumn[]::new);
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestChangelogReader.java
@@ -32,6 +32,9 @@ import org.apache.iceberg.ChangelogScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.IncrementalChangelogScan;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
@@ -42,22 +45,33 @@ import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
+@ExtendWith(ParameterizedTestExtension.class)
 public class TestChangelogReader extends TestBase {
+  private static final TableIdentifier TABLE_IDENT = TableIdentifier.of("default", "test");
   private static final Schema SCHEMA =
       new Schema(
           required(1, "id", Types.IntegerType.get()), optional(2, "data", Types.StringType.get()));
   private static final PartitionSpec SPEC =
       PartitionSpec.builderFor(SCHEMA).bucket("data", 16).build();
+
+  @Parameters(name = "formatVersion = {0}")
+  public static Object[][] parameters() {
+    return new Object[][] {{2}, {3}};
+  }
+
+  @Parameter(index = 0)
+  private int formatVersion;
+
   private final List<Record> records1 = Lists.newArrayList();
   private final List<Record> records2 = Lists.newArrayList();
 
@@ -69,9 +83,9 @@ public class TestChangelogReader extends TestBase {
 
   @BeforeEach
   public void before() throws IOException {
-    table = catalog.createTable(TableIdentifier.of("default", "test"), SCHEMA, SPEC);
+    table = catalog.createTable(TABLE_IDENT, SCHEMA, SPEC);
     // create some data
-    GenericRecord record = GenericRecord.create(table.schema());
+    GenericRecord record = GenericRecord.create(SCHEMA);
     records1.add(record.copy("id", 29, "data", "a"));
     records1.add(record.copy("id", 43, "data", "b"));
     records1.add(record.copy("id", 61, "data", "c"));
@@ -88,10 +102,12 @@ public class TestChangelogReader extends TestBase {
 
   @AfterEach
   public void after() {
-    catalog.dropTable(TableIdentifier.of("default", "test"));
+    records1.clear();
+    records2.clear();
+    catalog.dropTable(TABLE_IDENT);
   }
 
-  @Test
+  @TestTemplate
   public void testInsert() throws IOException {
     table.newAppend().appendFile(dataFile1).commit();
     long snapshotId1 = table.currentSnapshot().snapshotId();
@@ -121,7 +137,7 @@ public class TestChangelogReader extends TestBase {
     assertEquals("Should have expected rows", expectedRows, internalRowsToJava(rows));
   }
 
-  @Test
+  @TestTemplate
   public void testDelete() throws IOException {
     table.newAppend().appendFile(dataFile1).commit();
     long snapshotId1 = table.currentSnapshot().snapshotId();
@@ -151,16 +167,13 @@ public class TestChangelogReader extends TestBase {
     assertEquals("Should have expected rows", expectedRows, internalRowsToJava(rows));
   }
 
-  @Test
+  @TestTemplate
   public void testDataFileRewrite() throws IOException {
     table.newAppend().appendFile(dataFile1).commit();
     table.newAppend().appendFile(dataFile2).commit();
     long snapshotId2 = table.currentSnapshot().snapshotId();
 
-    table
-        .newRewrite()
-        .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2))
-        .commit();
+    table.newRewrite().deleteFile(dataFile1).addFile(dataFile2).commit();
 
     // the rewrite operation should generate no Changelog rows
     CloseableIterable<ScanTaskGroup<ChangelogScanTask>> taskGroups =
@@ -180,7 +193,7 @@ public class TestChangelogReader extends TestBase {
     assertThat(rows).as("Should have no rows").isEmpty();
   }
 
-  @Test
+  @TestTemplate
   public void testMixDeleteAndInsert() throws IOException {
     table.newAppend().appendFile(dataFile1).commit();
     long snapshotId1 = table.currentSnapshot().snapshotId();
@@ -226,7 +239,7 @@ public class TestChangelogReader extends TestBase {
     return table.newIncrementalChangelogScan();
   }
 
-  private List<Object[]> addExpectedRows(
+  private void addExpectedRows(
       List<Object[]> expectedRows,
       ChangelogOperation operation,
       long snapshotId,
@@ -235,7 +248,6 @@ public class TestChangelogReader extends TestBase {
     records.forEach(
         r ->
             expectedRows.add(row(r.get(0), r.get(1), operation.name(), changeOrdinal, snapshotId)));
-    return expectedRows;
   }
 
   protected List<Object[]> internalRowsToJava(List<InternalRow> rows) {


### PR DESCRIPTION
This PR also adds row-lineage metadata columns to `SparkChangelogTable`.

---

Co-authored-by: @codex 