### PR TITLE
Core: Propagate iceberg.hadoop.conf. properties to Hadoop Configuration

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.apache.iceberg.util.Tasks;
@@ -52,6 +53,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
   private static final String DELETE_FILE_POOL_NAME = "iceberg-hadoopfileio-delete";
   private static final int DELETE_RETRY_ATTEMPTS = 3;
   private static final int DEFAULT_DELETE_CORE_MULTIPLE = 4;
+  private static final String HADOOP_CONF_PREFIX = "iceberg.hadoop.conf.";
   private static volatile ExecutorService executorService;
 
   private volatile SerializableSupplier<Configuration> hadoopConf;
@@ -85,6 +87,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
   @Override
   public void initialize(Map<String, String> props) {
     this.properties = SerializableMap.copyOf(props);
+    rebuildConfWithProperties(getConf());
   }
 
   @Override
@@ -120,7 +123,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
 
   @Override
   public void setConf(Configuration conf) {
-    this.hadoopConf = new SerializableConfiguration(conf);
+    rebuildConfWithProperties(conf);
   }
 
   @Override
@@ -200,6 +203,12 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
     if (failureCount.get() != 0) {
       throw new BulkDeletionFailureException(failureCount.get());
     }
+  }
+
+  private void rebuildConfWithProperties(Configuration baseConf) {
+    Configuration conf = new Configuration(baseConf);
+    PropertyUtil.propertiesWithPrefix(properties, HADOOP_CONF_PREFIX).forEach(conf::set);
+    this.hadoopConf = new SerializableConfiguration(conf);
   }
 
   private int deleteThreads() {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopFileIO.java
@@ -145,6 +145,38 @@ public class TestHadoopFileIO {
         .hasMessage("Failed to delete 2 files");
   }
 
+  @Test
+  public void testHadoopConfPrefixedPropertiesApplied() {
+    Configuration baseConf = new Configuration();
+    baseConf.set("fs.s3a.endpoint", "original");
+    HadoopFileIO io = new HadoopFileIO(baseConf);
+    io.initialize(
+        ImmutableMap.of(
+            "iceberg.hadoop.conf.fs.s3a.endpoint", "https://s3.example.com",
+            "iceberg.hadoop.conf.fs.s3a.path.style.access", "true",
+            "unrelated.property", "ignored"));
+
+    assertThat(io.conf().get("fs.s3a.endpoint")).isEqualTo("https://s3.example.com");
+    assertThat(io.conf().get("fs.s3a.path.style.access")).isEqualTo("true");
+    assertThat(io.conf().get("unrelated.property")).isNull();
+    assertThat(io.conf().get("iceberg.hadoop.conf.fs.s3a.endpoint")).isNull();
+    assertThat(baseConf.get("fs.s3a.endpoint")).isEqualTo("original");
+  }
+
+  @Test
+  public void testHadoopConfPrefixedPropertiesAppliedOnSetConf() {
+    HadoopFileIO io = new HadoopFileIO();
+    io.initialize(ImmutableMap.of("iceberg.hadoop.conf.fs.s3a.endpoint", "https://s3.example.com"));
+
+    Configuration otherBase = new Configuration();
+    otherBase.set("fs.s3a.access.key", "AKIA");
+    io.setConf(otherBase);
+
+    assertThat(io.conf().get("fs.s3a.endpoint")).isEqualTo("https://s3.example.com");
+    assertThat(io.conf().get("fs.s3a.access.key")).isEqualTo("AKIA");
+    assertThat(otherBase.get("fs.s3a.endpoint")).isNull();
+  }
+
   @ParameterizedTest
   @MethodSource("org.apache.iceberg.TestHelpers#serializers")
   public void testHadoopFileIOSerialization(


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/16017

HadoopFileIO accepts catalog properties through FileIO.initialize, but there is currently no way to push Hadoop-level settings (fs.s3a.*, fs.defaultFS, etc.) through the catalog properties. Callers who want to parameterize those values per catalog end up having to mutate the shared Hadoop Configuration out-of-band, which is awkward and leaks settings between catalogs that share a Configuration instance.

Copy the base Configuration and overlay any property whose key starts with "iceberg.hadoop.conf." (prefix stripped). Both initialize and setConf delegate to the same helper, so the feature works for both the REST-catalog-driven and Hadoop-aware (`HadoopConfigurable#setConf`) paths. The original base Configuration is never mutated.

Unrelated catalog properties are not copied to the Hadoop Configuration.