### PR TITLE
Fix zombie coordinator thread when S3 writes fail

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkTask.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkTask.java
@@ -61,20 +61,22 @@ public class IcebergSinkTask extends SinkTask {
   }
 
   private void close() {
-    if (committer != null) {
-      committer.close(List.of());
-      committer = null;
-    }
-
-    if (catalog != null) {
-      if (catalog instanceof AutoCloseable) {
-        try {
-          ((AutoCloseable) catalog).close();
-        } catch (Exception e) {
-          LOG.warn("An error occurred closing catalog instance, ignoring...", e);
-        }
+    try {
+      if (committer != null) {
+        committer.close(List.of());
+        committer = null;
       }
-      catalog = null;
+    } finally {
+      if (catalog != null) {
+        if (catalog instanceof AutoCloseable) {
+          try {
+            ((AutoCloseable) catalog).close();
+          } catch (Exception e) {
+            LOG.warn("An error occurred closing catalog instance, ignoring...", e);
+          }
+        }
+        catalog = null;
+      }
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -221,7 +221,16 @@ public class CommitterImpl implements Committer {
 
   private void stopCoordinator() {
     if (coordinatorThread != null) {
-      coordinatorThread.terminate();
+      try {
+        coordinatorThread.terminate();
+      } finally {
+        try {
+          coordinatorThread.join(30_000L);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          LOG.warn("Interrupted waiting for coordinator thread to stop", e);
+        }
+      }
       coordinatorThread = null;
     }
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -149,6 +149,9 @@ class Coordinator extends Channel {
     try {
       doCommit(partialCommit);
     } catch (Exception e) {
+      if (terminated) {
+        throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
+      }
       LOG.warn("Commit failed, will try again next cycle", e);
     } finally {
       commitState.endCurrentCommit();

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkTask.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkTask.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergSinkTask {
+
+  interface CloseableCatalog extends Catalog, AutoCloseable {}
+
+  @Test
+  public void testStopClosesCatalogEvenIfCommitterThrows() throws Exception {
+    IcebergSinkTask task = new IcebergSinkTask();
+
+    Committer committer = mock(Committer.class);
+    doThrow(new ConnectException("coordinator shutdown timeout")).when(committer).close(any());
+
+    CloseableCatalog catalog = mock(CloseableCatalog.class);
+
+    Field committerField = IcebergSinkTask.class.getDeclaredField("committer");
+    Field catalogField = IcebergSinkTask.class.getDeclaredField("catalog");
+    committerField.setAccessible(true);
+    catalogField.setAccessible(true);
+    committerField.set(task, committer);
+    catalogField.set(task, catalog);
+
+    assertThatThrownBy(task::stop)
+        .isInstanceOf(ConnectException.class)
+        .hasMessageContaining("timeout");
+    verify(catalog).close();
+  }
+}

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorThread.java
@@ -19,11 +19,14 @@
 package org.apache.iceberg.connect.channel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.concurrent.CountDownLatch;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
 
 public class TestCoordinatorThread {
@@ -44,5 +47,50 @@ public class TestCoordinatorThread {
 
     verify(coordinator, timeout(1000)).stop();
     assertThat(coordinatorThread.isTerminated()).isTrue();
+  }
+
+  @Test
+  public void testTerminateDuringProcess() throws InterruptedException {
+    Coordinator coordinator = mock(Coordinator.class);
+    CountDownLatch processStarted = new CountDownLatch(1);
+    CountDownLatch processUnblock = new CountDownLatch(1);
+    doAnswer(
+            inv -> {
+              processStarted.countDown();
+              processUnblock.await();
+              return null;
+            })
+        .when(coordinator)
+        .process();
+
+    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
+    coordinatorThread.start();
+
+    processStarted.await();
+    coordinatorThread.terminate();
+    processUnblock.countDown();
+
+    coordinatorThread.join(2000);
+    assertThat(coordinatorThread.isAlive()).isFalse();
+    assertThat(coordinatorThread.isTerminated()).isTrue();
+  }
+
+  @Test
+  public void testProcessExceptionExitsThread() throws InterruptedException {
+    Coordinator coordinator = mock(Coordinator.class);
+    doAnswer(
+            inv -> {
+              throw new ConnectException("simulated failure");
+            })
+        .when(coordinator)
+        .process();
+
+    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
+    coordinatorThread.start();
+
+    coordinatorThread.join(2000);
+    assertThat(coordinatorThread.isAlive()).isFalse();
+    assertThat(coordinatorThread.isTerminated()).isTrue();
+    verify(coordinator, timeout(1000)).stop();
   }
 }


### PR DESCRIPTION
Fixes #16016

When S3 writes failed, the coordinator thread wouldn't properly terminate because nothing was waiting for it, leaving a zombie. Fixed by joining the thread after calling terminate() and wrapping the cleanup in try-finally so the catalog gets closed even if the committer shutdown fails.