### PR TITLE
Core: Fix optionalOAuthParams dropped during non-exchange token refresh

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -190,7 +190,7 @@ public class OAuth2Util {
           config.credential(),
           config.scope(),
           config.oauth2ServerUri(),
-          ImmutableMap.of());
+          optionalOAuthParams);
     }
   }
 
@@ -564,7 +564,7 @@ public class OAuth2Util {
             client, config, basicHeaders, token(), tokenType(), optionalOAuthParams());
       } else {
         return fetchToken(
-            client, Map.of(), credential(), scope(), oauth2ServerUri(), ImmutableMap.of());
+            client, Map.of(), credential(), scope(), oauth2ServerUri(), optionalOAuthParams());
       }
     }
 

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -31,6 +31,7 @@ import com.nimbusds.jwt.PlainJWT;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.auth.OAuth2Util.AuthSession;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
@@ -202,6 +203,53 @@ public class TestOAuth2Util {
       assertThat(session.expiresAtMillis())
           .as("After refresh, session should use the refreshed token's exp")
           .isEqualTo(TimeUnit.SECONDS.toMillis(500));
+    }
+  }
+
+  @Test
+  void refreshExpiredTokenShouldIncludeOptionalOAuthParams() throws IOException {
+    assertRefreshIncludesOptionalOAuthParams(System.currentTimeMillis() - 10_000);
+  }
+
+  @Test
+  void refreshCurrentTokenNonExchangeShouldIncludeOptionalOAuthParams() throws IOException {
+    assertRefreshIncludesOptionalOAuthParams(System.currentTimeMillis() + 300_000);
+  }
+
+  private static void assertRefreshIncludesOptionalOAuthParams(long expiresAtMillis)
+      throws IOException {
+    String audience = "https://my-catalog.example.com";
+    AuthConfig authConfig =
+        ImmutableAuthConfig.builder()
+            .keepRefreshed(true)
+            .exchangeEnabled(false)
+            .token("token")
+            .credential("testClientId:testClientSecret")
+            .oauth2ServerUri("/v1/token")
+            .expiresAtMillis(expiresAtMillis)
+            .optionalOAuthParams(ImmutableMap.of("audience", audience, "scope", "catalog"))
+            .build();
+
+    OAuthTokenResponse response =
+        OAuthTokenResponse.builder().withToken("refreshed_token").withTokenType(BEARER).build();
+
+    try (RESTClient client = Mockito.mock(RESTClient.class);
+        OAuth2Util.AuthSession session = new OAuth2Util.AuthSession(Map.of(), authConfig)) {
+      Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any())).thenReturn(response);
+
+      session.refresh(client);
+
+      Mockito.verify(client)
+          .postForm(
+              any(),
+              argThat(
+                  formData ->
+                      CLIENT_CREDENTIALS.equals(formData.get(GRANT_TYPE))
+                          && audience.equals(formData.get("audience"))
+                          && "catalog".equals(formData.get("scope"))),
+              Mockito.eq(OAuthTokenResponse.class),
+              anyMap(),
+              any());
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/16022

When `exchangeEnabled` is false, both `refreshExpiredToken()` and the static `refreshToken()` were calling `fetchToken()` with an empty map instead of forwarding `optionalOAuthParams` (which carries `audience`, `resource`, `scope`).

This was introduced in #14059 when the deprecated 5-arg `fetchToken()` overloads were removed and the 6-arg calls were inlined with `ImmutableMap.of()` instead of the available `optionalOAuthParams`.

The initial token fetch passes the params correctly, so the first token works. After expiry, the refreshed token is missing the audience/scope, causing 401/403 errors.

**Fix:** Pass `optionalOAuthParams` instead of `ImmutableMap.of()` / `Map.of()` in the two non-exchange branches.

**Tests:** Two new tests in `TestOAuth2Util` verify that `audience` appears in the token request form data for both the expired-token and proactive-refresh paths.