### PR TITLE
Core: Propagate server error message in failed remote scan planning responses

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -219,8 +219,7 @@ class RESTTableScan extends DataTableScan {
         Endpoint.check(supportedEndpoints, Endpoint.V1_FETCH_TABLE_SCAN_PLAN);
         return fetchPlanningResult();
       case FAILED:
-        throw new IllegalStateException(
-            failureMessage(planStatus, planId, response.errorResponse()));
+        throw new IllegalStateException(failureMessage(planId, response.errorResponse()));
       default:
         throw new IllegalStateException(
             String.format("Invalid planStatus: %s for planId: %s", planStatus, planId));
@@ -289,10 +288,18 @@ class RESTTableScan extends DataTableScan {
                   case SUBMITTED:
                     throw new NotCompleteException();
                   case FAILED:
+                    throw new IllegalStateException(failureMessage(id, response.errorResponse()));
                   case CANCELLED:
+                    throw new IllegalStateException(
+                        String.format(
+                            Locale.ROOT, "Remote scan planning cancelled for planId: %s", id));
                   default:
                     throw new IllegalStateException(
-                        failureMessage(response.planStatus(), id, response.errorResponse()));
+                        String.format(
+                            Locale.ROOT,
+                            "Invalid planStatus: %s for planId: %s",
+                            response.planStatus(),
+                            id));
                 }
               });
     } catch (NotCompleteException e) {
@@ -315,15 +322,11 @@ class RESTTableScan extends DataTableScan {
     return scanTasksIterable(response.planTasks(), response.fileScanTasks());
   }
 
-  private static String failureMessage(PlanStatus status, String planId, ErrorResponse error) {
-    if (error == null) {
-      return String.format(
-          Locale.ROOT, "Remote scan planning %s for planId: %s", status.status(), planId);
-    }
+  private static String failureMessage(String planId, ErrorResponse error) {
+    Preconditions.checkArgument(error != null, "Error must be present for failed status");
     return String.format(
         Locale.ROOT,
-        "Remote scan planning %s for planId: %s: %s (code=%d): %s",
-        status.status(),
+        "Remote scan planning failed for planId: %s: %s (code=%d): %s",
         planId,
         error.type(),
         error.code(),

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -218,13 +218,9 @@ class RESTTableScan extends DataTableScan {
         Endpoint.check(supportedEndpoints, Endpoint.V1_FETCH_TABLE_SCAN_PLAN);
         return fetchPlanningResult();
       case FAILED:
-        throw new IllegalStateException(
-            String.format(
-                "Received status: %s for planId: %s. Server error: %s",
-                PlanStatus.FAILED, planId, response.errorMessage()));
       case CANCELLED:
         throw new IllegalStateException(
-            String.format("Received status: %s for planId: %s", PlanStatus.CANCELLED, planId));
+            failureMessage(planStatus, planId, response.errorMessage()));
       default:
         throw new IllegalStateException(
             String.format("Invalid planStatus: %s for planId: %s", planStatus, planId));
@@ -286,16 +282,18 @@ class RESTTableScan extends DataTableScan {
                         ErrorHandlers.planErrorHandler(),
                         parserContext);
 
-                if (response.planStatus() == PlanStatus.SUBMITTED) {
-                  throw new NotCompleteException();
-                } else if (response.planStatus() != PlanStatus.COMPLETED) {
-                  throw new IllegalStateException(
-                      String.format(
-                          "Invalid planStatus: %s for planId: %s. Server error: %s",
-                          response.planStatus(), id, response.errorMessage()));
+                switch (response.planStatus()) {
+                  case COMPLETED:
+                    result.set(response);
+                    break;
+                  case SUBMITTED:
+                    throw new NotCompleteException();
+                  case FAILED:
+                  case CANCELLED:
+                  default:
+                    throw new IllegalStateException(
+                        failureMessage(response.planStatus(), id, response.errorMessage()));
                 }
-
-                result.set(response);
               });
     } catch (NotCompleteException e) {
       throw new RemotePlanTimeoutException(
@@ -315,6 +313,14 @@ class RESTTableScan extends DataTableScan {
         !response.credentials().isEmpty() ? scanFileIO(response.credentials()) : table().io();
 
     return scanTasksIterable(response.planTasks(), response.fileScanTasks());
+  }
+
+  private static String failureMessage(PlanStatus status, String planId, String errorMessage) {
+    if (errorMessage == null) {
+      return String.format("Received status: %s for planId: %s", status, planId);
+    }
+    return String.format(
+        "Received status: %s for planId: %s. Server error: %s", status, planId, errorMessage);
   }
 
   private CloseableIterable<FileScanTask> scanTasksIterable(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -219,7 +219,9 @@ class RESTTableScan extends DataTableScan {
         return fetchPlanningResult();
       case FAILED:
         throw new IllegalStateException(
-            String.format("Received status: %s for planId: %s", PlanStatus.FAILED, planId));
+            String.format(
+                "Received status: %s for planId: %s. Server error: %s",
+                PlanStatus.FAILED, planId, response.errorMessage()));
       case CANCELLED:
         throw new IllegalStateException(
             String.format("Received status: %s for planId: %s", PlanStatus.CANCELLED, planId));
@@ -289,7 +291,8 @@ class RESTTableScan extends DataTableScan {
                 } else if (response.planStatus() != PlanStatus.COMPLETED) {
                   throw new IllegalStateException(
                       String.format(
-                          "Invalid planStatus: %s for planId: %s", response.planStatus(), id));
+                          "Invalid planStatus: %s for planId: %s. Server error: %s",
+                          response.planStatus(), id, response.errorMessage()));
                 }
 
                 result.set(response);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.requests.PlanTableScanRequest;
+import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.types.TypeUtil;
@@ -218,9 +219,8 @@ class RESTTableScan extends DataTableScan {
         Endpoint.check(supportedEndpoints, Endpoint.V1_FETCH_TABLE_SCAN_PLAN);
         return fetchPlanningResult();
       case FAILED:
-      case CANCELLED:
         throw new IllegalStateException(
-            failureMessage(planStatus, planId, response.errorMessage()));
+            failureMessage(planStatus, planId, response.errorResponse()));
       default:
         throw new IllegalStateException(
             String.format("Invalid planStatus: %s for planId: %s", planStatus, planId));
@@ -292,7 +292,7 @@ class RESTTableScan extends DataTableScan {
                   case CANCELLED:
                   default:
                     throw new IllegalStateException(
-                        failureMessage(response.planStatus(), id, response.errorMessage()));
+                        failureMessage(response.planStatus(), id, response.errorResponse()));
                 }
               });
     } catch (NotCompleteException e) {
@@ -315,12 +315,19 @@ class RESTTableScan extends DataTableScan {
     return scanTasksIterable(response.planTasks(), response.fileScanTasks());
   }
 
-  private static String failureMessage(PlanStatus status, String planId, String errorMessage) {
-    if (errorMessage == null) {
-      return String.format("Received status: %s for planId: %s", status, planId);
+  private static String failureMessage(PlanStatus status, String planId, ErrorResponse error) {
+    if (error == null) {
+      return String.format(
+          Locale.ROOT, "Remote scan planning %s for planId: %s", status.status(), planId);
     }
     return String.format(
-        "Received status: %s for planId: %s. Server error: %s", status, planId, errorMessage);
+        Locale.ROOT,
+        "Remote scan planning %s for planId: %s: %s (code=%d): %s",
+        status.status(),
+        planId,
+        error.type(),
+        error.code(),
+        error.message());
   }
 
   private CloseableIterable<FileScanTask> scanTasksIterable(

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
@@ -46,12 +46,11 @@ public class ErrorResponseParser {
   public static void toJson(ErrorResponse errorResponse, JsonGenerator generator)
       throws IOException {
     generator.writeStartObject();
-    writeErrorField(errorResponse, generator);
+    writeError(errorResponse, generator);
     generator.writeEndObject();
   }
 
-  public static void writeErrorField(ErrorResponse errorResponse, JsonGenerator generator)
-      throws IOException {
+  static void writeError(ErrorResponse errorResponse, JsonGenerator generator) throws IOException {
     generator.writeObjectFieldStart(ERROR);
     generator.writeStringField(MESSAGE, errorResponse.message());
     generator.writeStringField(TYPE, errorResponse.type());

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
@@ -46,17 +46,19 @@ public class ErrorResponseParser {
   public static void toJson(ErrorResponse errorResponse, JsonGenerator generator)
       throws IOException {
     generator.writeStartObject();
+    writeErrorField(errorResponse, generator);
+    generator.writeEndObject();
+  }
 
+  public static void writeErrorField(ErrorResponse errorResponse, JsonGenerator generator)
+      throws IOException {
     generator.writeObjectFieldStart(ERROR);
-
     generator.writeStringField(MESSAGE, errorResponse.message());
     generator.writeStringField(TYPE, errorResponse.type());
     generator.writeNumberField(CODE, errorResponse.code());
     if (errorResponse.stack() != null) {
       JsonUtil.writeStringArray(STACK, errorResponse.stack(), generator);
     }
-
-    generator.writeEndObject();
 
     generator.writeEndObject();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
@@ -31,10 +31,12 @@ import org.apache.iceberg.rest.credentials.Credential;
 
 public class FetchPlanningResultResponse extends BaseScanTaskResponse {
   private final PlanStatus planStatus;
+  private final ErrorResponse errorResponse;
   private final List<Credential> credentials;
 
   private FetchPlanningResultResponse(
       PlanStatus planStatus,
+      ErrorResponse errorResponse,
       List<String> planTasks,
       List<FileScanTask> fileScanTasks,
       List<DeleteFile> deleteFiles,
@@ -42,12 +44,21 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
       List<Credential> credentials) {
     super(planTasks, fileScanTasks, deleteFiles, specsById);
     this.planStatus = planStatus;
+    this.errorResponse = errorResponse;
     this.credentials = credentials;
     validate();
   }
 
   public PlanStatus planStatus() {
     return planStatus;
+  }
+
+  public ErrorResponse errorResponse() {
+    return errorResponse;
+  }
+
+  public String errorMessage() {
+    return errorResponse != null ? errorResponse.message() : null;
   }
 
   public List<Credential> credentials() {
@@ -76,10 +87,16 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
     private Builder() {}
 
     private PlanStatus planStatus;
+    private ErrorResponse errorResponse;
     private final List<Credential> credentials = Lists.newArrayList();
 
     public Builder withPlanStatus(PlanStatus status) {
       this.planStatus = status;
+      return this;
+    }
+
+    public Builder withErrorResponse(ErrorResponse response) {
+      this.errorResponse = response;
       return this;
     }
 
@@ -91,7 +108,13 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
     @Override
     public FetchPlanningResultResponse build() {
       return new FetchPlanningResultResponse(
-          planStatus, planTasks(), fileScanTasks(), deleteFiles(), specsById(), credentials);
+          planStatus,
+          errorResponse,
+          planTasks(),
+          fileScanTasks(),
+          deleteFiles(),
+          specsById(),
+          credentials);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.rest.responses;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
@@ -54,20 +53,8 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
     return planStatus;
   }
 
-  ErrorResponse errorResponse() {
+  public ErrorResponse errorResponse() {
     return errorResponse;
-  }
-
-  public String errorMessage() {
-    if (errorResponse == null) {
-      return null;
-    }
-    return String.format(
-        Locale.ROOT,
-        "%s (code=%d): %s",
-        errorResponse.type(),
-        errorResponse.code(),
-        errorResponse.message());
   }
 
   public List<Credential> credentials() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
@@ -53,7 +53,7 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
     return planStatus;
   }
 
-  public ErrorResponse errorResponse() {
+  ErrorResponse errorResponse() {
     return errorResponse;
   }
 
@@ -75,6 +75,9 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
     Preconditions.checkArgument(
         planStatus() == PlanStatus.COMPLETED || (planTasks() == null && fileScanTasks() == null),
         "Invalid response: tasks can only be returned in a 'completed' status");
+    Preconditions.checkArgument(
+        planStatus() == PlanStatus.FAILED || errorResponse() == null,
+        "Invalid response: error can only be defined when status is 'failed'");
     if (fileScanTasks() == null || fileScanTasks().isEmpty()) {
       Preconditions.checkArgument(
           (deleteFiles() == null || deleteFiles().isEmpty()),

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest.responses;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
@@ -58,7 +59,15 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
   }
 
   public String errorMessage() {
-    return errorResponse != null ? errorResponse.message() : null;
+    if (errorResponse == null) {
+      return null;
+    }
+    return String.format(
+        Locale.ROOT,
+        "%s (code=%d): %s",
+        errorResponse.type(),
+        errorResponse.code(),
+        errorResponse.message());
   }
 
   public List<Credential> credentials() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponse.java
@@ -73,7 +73,7 @@ public class FetchPlanningResultResponse extends BaseScanTaskResponse {
         "Invalid response: tasks can only be returned in a 'completed' status");
     Preconditions.checkArgument(
         planStatus() == PlanStatus.FAILED || errorResponse() == null,
-        "Invalid response: error can only be defined when status is 'failed'");
+        "Invalid response: error can only be returned in a 'failed' status");
     if (fileScanTasks() == null || fileScanTasks().isEmpty()) {
       Preconditions.checkArgument(
           (deleteFiles() == null || deleteFiles().isEmpty()),

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponseParser.java
@@ -61,7 +61,7 @@ public class FetchPlanningResultResponseParser {
     gen.writeStringField(STATUS, response.planStatus().status());
 
     if (response.errorResponse() != null) {
-      ErrorResponseParser.writeErrorField(response.errorResponse(), gen);
+      ErrorResponseParser.writeError(response.errorResponse(), gen);
     }
 
     if (response.planTasks() != null) {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/FetchPlanningResultResponseParser.java
@@ -38,6 +38,7 @@ public class FetchPlanningResultResponseParser {
   private static final String STATUS = "status";
   private static final String PLAN_TASKS = "plan-tasks";
   private static final String STORAGE_CREDENTIALS = "storage-credentials";
+  private static final String ERROR = "error";
 
   private FetchPlanningResultResponseParser() {}
 
@@ -58,6 +59,11 @@ public class FetchPlanningResultResponseParser {
         "Cannot serialize fileScanTasks in fetchingPlanningResultResponse without specsById");
     gen.writeStartObject();
     gen.writeStringField(STATUS, response.planStatus().status());
+
+    if (response.errorResponse() != null) {
+      ErrorResponseParser.writeErrorField(response.errorResponse(), gen);
+    }
+
     if (response.planTasks() != null) {
       JsonUtil.writeStringArray(PLAN_TASKS, response.planTasks(), gen);
     }
@@ -90,6 +96,11 @@ public class FetchPlanningResultResponseParser {
         json != null && !json.isEmpty(), "Invalid fetchPlanningResult response: null or empty");
 
     PlanStatus planStatus = PlanStatus.fromName(JsonUtil.getString(STATUS, json));
+    ErrorResponse errorResponse = null;
+    if (json.has(ERROR) && json.get(ERROR).isObject()) {
+      errorResponse = ErrorResponseParser.fromJson(json);
+    }
+
     List<String> planTasks = JsonUtil.getStringListOrNull(PLAN_TASKS, json);
     List<DeleteFile> deleteFiles = TableScanResponseParser.parseDeleteFiles(json, specsById);
     List<FileScanTask> fileScanTasks =
@@ -98,6 +109,7 @@ public class FetchPlanningResultResponseParser {
     FetchPlanningResultResponse.Builder builder =
         FetchPlanningResultResponse.builder()
             .withPlanStatus(planStatus)
+            .withErrorResponse(errorResponse)
             .withPlanTasks(planTasks)
             .withFileScanTasks(fileScanTasks)
             .withSpecsById(specsById);

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
@@ -61,7 +61,7 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
     return planId;
   }
 
-  public ErrorResponse errorResponse() {
+  ErrorResponse errorResponse() {
     return errorResponse;
   }
 
@@ -97,6 +97,10 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
         planStatus() == PlanStatus.COMPLETED || (planTasks() == null && fileScanTasks() == null),
         "Invalid response: tasks can only be defined when status is '%s'",
         PlanStatus.COMPLETED.status());
+    Preconditions.checkArgument(
+        planStatus() == PlanStatus.FAILED || errorResponse() == null,
+        "Invalid response: error can only be defined when status is '%s'",
+        PlanStatus.FAILED.status());
     if (null != planId()) {
       Preconditions.checkArgument(
           planStatus() == PlanStatus.SUBMITTED || planStatus() == PlanStatus.COMPLETED,

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.rest.responses;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
@@ -62,20 +61,8 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
     return planId;
   }
 
-  ErrorResponse errorResponse() {
+  public ErrorResponse errorResponse() {
     return errorResponse;
-  }
-
-  public String errorMessage() {
-    if (errorResponse == null) {
-      return null;
-    }
-    return String.format(
-        Locale.ROOT,
-        "%s (code=%d): %s",
-        errorResponse.type(),
-        errorResponse.code(),
-        errorResponse.message());
   }
 
   public List<Credential> credentials() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
@@ -33,11 +33,13 @@ import org.apache.iceberg.rest.credentials.Credential;
 public class PlanTableScanResponse extends BaseScanTaskResponse {
   private final PlanStatus planStatus;
   private final String planId;
+  private final ErrorResponse errorResponse;
   private final List<Credential> credentials;
 
   private PlanTableScanResponse(
       PlanStatus planStatus,
       String planId,
+      ErrorResponse errorResponse,
       List<String> planTasks,
       List<FileScanTask> fileScanTasks,
       List<DeleteFile> deleteFiles,
@@ -46,6 +48,7 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
     super(planTasks, fileScanTasks, deleteFiles, specsById);
     this.planStatus = planStatus;
     this.planId = planId;
+    this.errorResponse = errorResponse;
     this.credentials = credentials;
     validate();
   }
@@ -56,6 +59,14 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
 
   public String planId() {
     return planId;
+  }
+
+  public ErrorResponse errorResponse() {
+    return errorResponse;
+  }
+
+  public String errorMessage() {
+    return errorResponse != null ? errorResponse.message() : null;
   }
 
   public List<Credential> credentials() {
@@ -108,6 +119,7 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
   public static class Builder extends BaseScanTaskResponse.Builder<Builder, PlanTableScanResponse> {
     private PlanStatus planStatus;
     private String planId;
+    private ErrorResponse errorResponse;
     private final List<Credential> credentials = Lists.newArrayList();
 
     /**
@@ -127,6 +139,11 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
       return this;
     }
 
+    public Builder withErrorResponse(ErrorResponse response) {
+      this.errorResponse = response;
+      return this;
+    }
+
     public Builder withCredentials(List<Credential> credentialsToAdd) {
       credentials.addAll(credentialsToAdd);
       return this;
@@ -137,6 +154,7 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
       return new PlanTableScanResponse(
           planStatus,
           planId,
+          errorResponse,
           planTasks(),
           fileScanTasks(),
           deleteFiles(),

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponse.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest.responses;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
@@ -66,7 +67,15 @@ public class PlanTableScanResponse extends BaseScanTaskResponse {
   }
 
   public String errorMessage() {
-    return errorResponse != null ? errorResponse.message() : null;
+    if (errorResponse == null) {
+      return null;
+    }
+    return String.format(
+        Locale.ROOT,
+        "%s (code=%d): %s",
+        errorResponse.type(),
+        errorResponse.code(),
+        errorResponse.message());
   }
 
   public List<Credential> credentials() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponseParser.java
@@ -62,7 +62,7 @@ public class PlanTableScanResponseParser {
     gen.writeStringField(STATUS, response.planStatus().status());
 
     if (response.errorResponse() != null) {
-      ErrorResponseParser.writeErrorField(response.errorResponse(), gen);
+      ErrorResponseParser.writeError(response.errorResponse(), gen);
     }
 
     if (response.planId() != null) {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/PlanTableScanResponseParser.java
@@ -39,6 +39,7 @@ public class PlanTableScanResponseParser {
   private static final String PLAN_ID = "plan-id";
   private static final String PLAN_TASKS = "plan-tasks";
   private static final String STORAGE_CREDENTIALS = "storage-credentials";
+  private static final String ERROR = "error";
 
   private PlanTableScanResponseParser() {}
 
@@ -59,6 +60,10 @@ public class PlanTableScanResponseParser {
 
     gen.writeStartObject();
     gen.writeStringField(STATUS, response.planStatus().status());
+
+    if (response.errorResponse() != null) {
+      ErrorResponseParser.writeErrorField(response.errorResponse(), gen);
+    }
 
     if (response.planId() != null) {
       gen.writeStringField(PLAN_ID, response.planId());
@@ -98,6 +103,11 @@ public class PlanTableScanResponseParser {
         "Cannot parse planTableScan response from empty or null object");
 
     PlanStatus planStatus = PlanStatus.fromName(JsonUtil.getString(STATUS, json));
+    ErrorResponse errorResponse = null;
+    if (json.has(ERROR) && json.get(ERROR).isObject()) {
+      errorResponse = ErrorResponseParser.fromJson(json);
+    }
+
     String planId = JsonUtil.getStringOrNull(PLAN_ID, json);
     List<String> planTasks = JsonUtil.getStringListOrNull(PLAN_TASKS, json);
     List<DeleteFile> deleteFiles = TableScanResponseParser.parseDeleteFiles(json, specsById);
@@ -108,6 +118,7 @@ public class PlanTableScanResponseParser {
         PlanTableScanResponse.builder()
             .withPlanId(planId)
             .withPlanStatus(planStatus)
+            .withErrorResponse(errorResponse)
             .withPlanTasks(planTasks)
             .withFileScanTasks(fileScanTasks)
             .withSpecsById(specsById);

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -1284,15 +1284,10 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
         .hasMessageContaining("must be positive");
   }
 
-  @Test
-  public void syncPlanningFailsWithServerError() {
-    List<Endpoint> endpoints =
-        endpointsWithPlanning(
-            Endpoint.V1_SUBMIT_TABLE_SCAN_PLAN,
-            Endpoint.V1_FETCH_TABLE_SCAN_PLAN,
-            Endpoint.V1_CANCEL_TABLE_SCAN_PLAN,
-            Endpoint.V1_FETCH_TABLE_SCAN_PLAN_TASKS);
-
+  @ParameterizedTest
+  @EnumSource(PlanningMode.class)
+  public void planningFailsWithServerError(
+      Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> planMode) {
     ErrorResponse serverError =
         ErrorResponse.builder()
             .withMessage("table too large to plan")
@@ -1300,69 +1295,24 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
             .responseCode(500)
             .build();
 
-    RESTCatalogAdapter adapter =
-        Mockito.spy(
-            new RESTCatalogAdapter(backendCatalog) {
-              @Override
-              public <T extends RESTResponse> T execute(
-                  HTTPRequest request,
-                  Class<T> responseType,
-                  Consumer<ErrorResponse> errorHandler,
-                  Consumer<Map<String, String>> responseHeaders,
-                  ParserContext parserContext) {
-                if (ResourcePaths.config().equals(request.path())) {
-                  return castResponse(
-                      responseType, ConfigResponse.builder().withEndpoints(endpoints).build());
-                }
-                T response =
-                    super.execute(
-                        request, responseType, errorHandler, responseHeaders, parserContext);
-                if (response instanceof LoadTableResponse) {
-                  return castResponse(
-                      responseType,
-                      withPlanningMode(
-                          (LoadTableResponse) response,
-                          RESTCatalogProperties.ScanPlanningMode.SERVER.modeName()));
-                }
-                if (response instanceof PlanTableScanResponse) {
-                  return castResponse(
-                      responseType,
-                      PlanTableScanResponse.builder()
-                          .withPlanStatus(PlanStatus.FAILED)
-                          .withErrorResponse(serverError)
-                          .withSpecsById(((PlanTableScanResponse) response).specsById())
-                          .build());
-                }
-                return response;
-              }
-            });
+    TestPlanningBehavior behavior = planMode.apply(TestPlanningBehavior.builder()).build();
+    CatalogWithAdapter catalogWithAdapter =
+        catalogThatFailsPlanning(serverError, behavior, "test-planning-failed");
 
-    adapter.setPlanningBehavior(TestPlanningBehavior.builder().synchronous().build());
-
-    RESTCatalog catalog =
-        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
-    catalog.initialize(
-        "test-sync-failed",
-        ImmutableMap.of(
-            CatalogProperties.FILE_IO_IMPL,
-            "org.apache.iceberg.inmemory.InMemoryFileIO",
-            RESTCatalogProperties.SCAN_PLANNING_MODE,
-            RESTCatalogProperties.ScanPlanningMode.SERVER.modeName()));
-
-    RESTTable table = restTableFor(catalog, "sync_failed_test");
+    RESTTable table = restTableFor(catalogWithAdapter.catalog, "planning_failed_test");
     setParserContext(table);
     RESTTableScan scan = restTableScanFor(table);
 
     assertThatThrownBy(scan::planFiles)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Remote scan planning failed")
-        .hasMessageContaining("IllegalStateException")
-        .hasMessageContaining("code=500")
-        .hasMessageContaining("table too large to plan");
+        .hasMessageContaining(serverError.type())
+        .hasMessageContaining("code=" + serverError.code())
+        .hasMessageContaining(serverError.message());
   }
 
-  @Test
-  public void asyncPlanningFailsWithServerError() {
+  private CatalogWithAdapter catalogThatFailsPlanning(
+      ErrorResponse serverError, TestPlanningBehavior behavior, String catalogName) {
     List<Endpoint> endpoints =
         endpointsWithPlanning(
             Endpoint.V1_SUBMIT_TABLE_SCAN_PLAN,
@@ -1370,13 +1320,6 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
             Endpoint.V1_CANCEL_TABLE_SCAN_PLAN,
             Endpoint.V1_FETCH_TABLE_SCAN_PLAN_TASKS);
 
-    ErrorResponse serverError =
-        ErrorResponse.builder()
-            .withMessage("backend planner crashed")
-            .withType("RuntimeException")
-            .responseCode(500)
-            .build();
-
     RESTCatalogAdapter adapter =
         Mockito.spy(
             new RESTCatalogAdapter(backendCatalog) {
@@ -1401,7 +1344,17 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
                           (LoadTableResponse) response,
                           RESTCatalogProperties.ScanPlanningMode.SERVER.modeName()));
                 }
-                // Server-side planning returns FAILED only on the fetch call in async mode
+                // Leave SUBMITTED untouched so async mode polls and hits the fetch below.
+                if (response instanceof PlanTableScanResponse planResp
+                    && planResp.planStatus() == PlanStatus.COMPLETED) {
+                  return castResponse(
+                      responseType,
+                      PlanTableScanResponse.builder()
+                          .withPlanStatus(PlanStatus.FAILED)
+                          .withErrorResponse(serverError)
+                          .withSpecsById(planResp.specsById())
+                          .build());
+                }
                 if (response instanceof FetchPlanningResultResponse) {
                   return castResponse(
                       responseType,
@@ -1414,28 +1367,18 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
               }
             });
 
-    adapter.setPlanningBehavior(TestPlanningBehavior.builder().asynchronous().build());
+    adapter.setPlanningBehavior(behavior);
 
     RESTCatalog catalog =
         new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
     catalog.initialize(
-        "test-async-failed",
+        catalogName,
         ImmutableMap.of(
             CatalogProperties.FILE_IO_IMPL,
             "org.apache.iceberg.inmemory.InMemoryFileIO",
             RESTCatalogProperties.SCAN_PLANNING_MODE,
             RESTCatalogProperties.ScanPlanningMode.SERVER.modeName()));
-
-    RESTTable table = restTableFor(catalog, "async_failed_test");
-    setParserContext(table);
-    RESTTableScan scan = restTableScanFor(table);
-
-    assertThatThrownBy(scan::planFiles)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Remote scan planning failed")
-        .hasMessageContaining("RuntimeException")
-        .hasMessageContaining("code=500")
-        .hasMessageContaining("backend planner crashed");
+    return new CatalogWithAdapter(catalog, adapter);
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -1284,6 +1284,160 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
         .hasMessageContaining("must be positive");
   }
 
+  @Test
+  public void syncPlanningFailsWithServerError() {
+    List<Endpoint> endpoints =
+        endpointsWithPlanning(
+            Endpoint.V1_SUBMIT_TABLE_SCAN_PLAN,
+            Endpoint.V1_FETCH_TABLE_SCAN_PLAN,
+            Endpoint.V1_CANCEL_TABLE_SCAN_PLAN,
+            Endpoint.V1_FETCH_TABLE_SCAN_PLAN_TASKS);
+
+    ErrorResponse serverError =
+        ErrorResponse.builder()
+            .withMessage("table too large to plan")
+            .withType("IllegalStateException")
+            .responseCode(500)
+            .build();
+
+    RESTCatalogAdapter adapter =
+        Mockito.spy(
+            new RESTCatalogAdapter(backendCatalog) {
+              @Override
+              public <T extends RESTResponse> T execute(
+                  HTTPRequest request,
+                  Class<T> responseType,
+                  Consumer<ErrorResponse> errorHandler,
+                  Consumer<Map<String, String>> responseHeaders,
+                  ParserContext parserContext) {
+                if (ResourcePaths.config().equals(request.path())) {
+                  return castResponse(
+                      responseType, ConfigResponse.builder().withEndpoints(endpoints).build());
+                }
+                T response =
+                    super.execute(
+                        request, responseType, errorHandler, responseHeaders, parserContext);
+                if (response instanceof LoadTableResponse) {
+                  return castResponse(
+                      responseType,
+                      withPlanningMode(
+                          (LoadTableResponse) response,
+                          RESTCatalogProperties.ScanPlanningMode.SERVER.modeName()));
+                }
+                if (response instanceof PlanTableScanResponse) {
+                  return castResponse(
+                      responseType,
+                      PlanTableScanResponse.builder()
+                          .withPlanStatus(PlanStatus.FAILED)
+                          .withErrorResponse(serverError)
+                          .withSpecsById(((PlanTableScanResponse) response).specsById())
+                          .build());
+                }
+                return response;
+              }
+            });
+
+    adapter.setPlanningBehavior(TestPlanningBehavior.builder().synchronous().build());
+
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize(
+        "test-sync-failed",
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            RESTCatalogProperties.SCAN_PLANNING_MODE,
+            RESTCatalogProperties.ScanPlanningMode.SERVER.modeName()));
+
+    RESTTable table = restTableFor(catalog, "sync_failed_test");
+    setParserContext(table);
+    RESTTableScan scan = restTableScanFor(table);
+
+    assertThatThrownBy(scan::planFiles)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Remote scan planning failed")
+        .hasMessageContaining("IllegalStateException")
+        .hasMessageContaining("code=500")
+        .hasMessageContaining("table too large to plan");
+  }
+
+  @Test
+  public void asyncPlanningFailsWithServerError() {
+    List<Endpoint> endpoints =
+        endpointsWithPlanning(
+            Endpoint.V1_SUBMIT_TABLE_SCAN_PLAN,
+            Endpoint.V1_FETCH_TABLE_SCAN_PLAN,
+            Endpoint.V1_CANCEL_TABLE_SCAN_PLAN,
+            Endpoint.V1_FETCH_TABLE_SCAN_PLAN_TASKS);
+
+    ErrorResponse serverError =
+        ErrorResponse.builder()
+            .withMessage("backend planner crashed")
+            .withType("RuntimeException")
+            .responseCode(500)
+            .build();
+
+    RESTCatalogAdapter adapter =
+        Mockito.spy(
+            new RESTCatalogAdapter(backendCatalog) {
+              @Override
+              public <T extends RESTResponse> T execute(
+                  HTTPRequest request,
+                  Class<T> responseType,
+                  Consumer<ErrorResponse> errorHandler,
+                  Consumer<Map<String, String>> responseHeaders,
+                  ParserContext parserContext) {
+                if (ResourcePaths.config().equals(request.path())) {
+                  return castResponse(
+                      responseType, ConfigResponse.builder().withEndpoints(endpoints).build());
+                }
+                T response =
+                    super.execute(
+                        request, responseType, errorHandler, responseHeaders, parserContext);
+                if (response instanceof LoadTableResponse) {
+                  return castResponse(
+                      responseType,
+                      withPlanningMode(
+                          (LoadTableResponse) response,
+                          RESTCatalogProperties.ScanPlanningMode.SERVER.modeName()));
+                }
+                // Server-side planning returns FAILED only on the fetch call in async mode
+                if (response instanceof FetchPlanningResultResponse) {
+                  return castResponse(
+                      responseType,
+                      FetchPlanningResultResponse.builder()
+                          .withPlanStatus(PlanStatus.FAILED)
+                          .withErrorResponse(serverError)
+                          .build());
+                }
+                return response;
+              }
+            });
+
+    adapter.setPlanningBehavior(TestPlanningBehavior.builder().asynchronous().build());
+
+    RESTCatalog catalog =
+        new RESTCatalog(SessionCatalog.SessionContext.createEmpty(), (config) -> adapter);
+    catalog.initialize(
+        "test-async-failed",
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL,
+            "org.apache.iceberg.inmemory.InMemoryFileIO",
+            RESTCatalogProperties.SCAN_PLANNING_MODE,
+            RESTCatalogProperties.ScanPlanningMode.SERVER.modeName()));
+
+    RESTTable table = restTableFor(catalog, "async_failed_test");
+    setParserContext(table);
+    RESTTableScan scan = restTableScanFor(table);
+
+    assertThatThrownBy(scan::planFiles)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Remote scan planning failed")
+        .hasMessageContaining("RuntimeException")
+        .hasMessageContaining("code=500")
+        .hasMessageContaining("backend planner crashed");
+  }
+
   @ParameterizedTest
   @EnumSource(PlanningMode.class)
   void fileIOForRemotePlanningIsPropagated(

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
@@ -361,6 +361,9 @@ public class TestFetchPlanningResultResponseParser {
         .isEqualTo("Scan planning failed: table too large to plan");
     assertThat(fromResponse.errorResponse().type()).isEqualTo("IllegalStateException");
     assertThat(fromResponse.errorResponse().code()).isEqualTo(500);
+    assertThat(fromResponse.errorMessage())
+        .isEqualTo(
+            "IllegalStateException (code=500): Scan planning failed: table too large to plan");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
@@ -330,4 +330,45 @@ public class TestFetchPlanningResultResponseParser {
     assertThat(FetchPlanningResultResponseParser.toJson(copyResponse, true))
         .isEqualTo(expectedJson);
   }
+
+  @Test
+  public void roundTripSerdeWithFailedStatusAndErrorResponse() {
+    ErrorResponse errorResponse =
+        ErrorResponse.builder()
+            .withMessage("Scan planning failed: table too large to plan")
+            .withType("IllegalStateException")
+            .responseCode(500)
+            .build();
+
+    FetchPlanningResultResponse response =
+        FetchPlanningResultResponse.builder()
+            .withPlanStatus(PlanStatus.FAILED)
+            .withErrorResponse(errorResponse)
+            .build();
+
+    String expectedJson =
+        "{\"status\":\"failed\","
+            + "\"error\":{\"message\":\"Scan planning failed: table too large to plan\","
+            + "\"type\":\"IllegalStateException\",\"code\":500}}";
+    String json = FetchPlanningResultResponseParser.toJson(response);
+    assertThat(json).isEqualTo(expectedJson);
+
+    FetchPlanningResultResponse fromResponse =
+        FetchPlanningResultResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+    assertThat(fromResponse.planStatus()).isEqualTo(PlanStatus.FAILED);
+    assertThat(fromResponse.errorResponse()).isNotNull();
+    assertThat(fromResponse.errorResponse().message())
+        .isEqualTo("Scan planning failed: table too large to plan");
+    assertThat(fromResponse.errorResponse().type()).isEqualTo("IllegalStateException");
+    assertThat(fromResponse.errorResponse().code()).isEqualTo(500);
+  }
+
+  @Test
+  public void parseFailedStatusWithoutErrorObject() {
+    String json = "{\"status\":\"failed\"}";
+    FetchPlanningResultResponse response =
+        FetchPlanningResultResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+    assertThat(response.planStatus()).isEqualTo(PlanStatus.FAILED);
+    assertThat(response.errorResponse()).isNull();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
@@ -376,8 +376,6 @@ public class TestFetchPlanningResultResponseParser {
 
   @Test
   public void parseFailedStatusWithPrimitiveErrorField() {
-    // Spec requires `error` to be an ErrorModel object. A primitive is non-compliant;
-    // parse leniently and skip the malformed field rather than failing the whole response.
     String json = "{\"status\":\"failed\",\"error\":\"oops\"}";
     FetchPlanningResultResponse response =
         FetchPlanningResultResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
@@ -396,6 +394,6 @@ public class TestFetchPlanningResultResponseParser {
                     .withErrorResponse(errorResponse)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid response: error can only be defined when status is 'failed'");
+        .hasMessage("Invalid response: error can only be returned in a 'failed' status");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
@@ -365,10 +365,37 @@ public class TestFetchPlanningResultResponseParser {
 
   @Test
   public void parseFailedStatusWithoutErrorObject() {
+    // Spec requires an `error` object on failed responses, but parse leniently so
+    // a non-compliant server still surfaces the failure to the client.
     String json = "{\"status\":\"failed\"}";
     FetchPlanningResultResponse response =
         FetchPlanningResultResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
     assertThat(response.planStatus()).isEqualTo(PlanStatus.FAILED);
     assertThat(response.errorResponse()).isNull();
+  }
+
+  @Test
+  public void parseFailedStatusWithPrimitiveErrorField() {
+    // Spec requires `error` to be an ErrorModel object. A primitive is non-compliant;
+    // parse leniently and skip the malformed field rather than failing the whole response.
+    String json = "{\"status\":\"failed\",\"error\":\"oops\"}";
+    FetchPlanningResultResponse response =
+        FetchPlanningResultResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+    assertThat(response.planStatus()).isEqualTo(PlanStatus.FAILED);
+    assertThat(response.errorResponse()).isNull();
+  }
+
+  @Test
+  public void cannotBuildWithErrorResponseWhenStatusIsNotFailed() {
+    ErrorResponse errorResponse =
+        ErrorResponse.builder().withMessage("boom").withType("X").responseCode(500).build();
+    assertThatThrownBy(
+            () ->
+                FetchPlanningResultResponse.builder()
+                    .withPlanStatus(PlanStatus.COMPLETED)
+                    .withErrorResponse(errorResponse)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid response: error can only be defined when status is 'failed'");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
@@ -361,9 +361,6 @@ public class TestFetchPlanningResultResponseParser {
         .isEqualTo("Scan planning failed: table too large to plan");
     assertThat(fromResponse.errorResponse().type()).isEqualTo("IllegalStateException");
     assertThat(fromResponse.errorResponse().code()).isEqualTo(500);
-    assertThat(fromResponse.errorMessage())
-        .isEqualTo(
-            "IllegalStateException (code=500): Scan planning failed: table too large to plan");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -680,6 +680,9 @@ public class TestPlanTableScanResponseParser {
         .isEqualTo("Scan planning failed: table too large to plan");
     assertThat(fromResponse.errorResponse().type()).isEqualTo("IllegalStateException");
     assertThat(fromResponse.errorResponse().code()).isEqualTo(500);
+    assertThat(fromResponse.errorMessage())
+        .isEqualTo(
+            "IllegalStateException (code=500): Scan planning failed: table too large to plan");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -695,8 +695,6 @@ public class TestPlanTableScanResponseParser {
 
   @Test
   public void parseFailedStatusWithPrimitiveErrorField() {
-    // Spec requires `error` to be an ErrorModel object. A primitive is non-compliant;
-    // parse leniently and skip the malformed field rather than failing the whole response.
     String json = "{\"status\":\"failed\",\"error\":\"oops\"}";
     PlanTableScanResponse response =
         PlanTableScanResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -648,4 +648,46 @@ public class TestPlanTableScanResponseParser {
 
     assertThat(PlanTableScanResponseParser.toJson(copyResponse, true)).isEqualTo(expectedJson);
   }
+
+  @Test
+  public void roundTripSerdeWithFailedStatusAndErrorResponse() {
+    ErrorResponse errorResponse =
+        ErrorResponse.builder()
+            .withMessage("Scan planning failed: table too large to plan")
+            .withType("IllegalStateException")
+            .responseCode(500)
+            .build();
+
+    PlanTableScanResponse response =
+        PlanTableScanResponse.builder()
+            .withPlanStatus(PlanStatus.FAILED)
+            .withErrorResponse(errorResponse)
+            .withSpecsById(PARTITION_SPECS_BY_ID)
+            .build();
+
+    String expectedJson =
+        "{\"status\":\"failed\","
+            + "\"error\":{\"message\":\"Scan planning failed: table too large to plan\","
+            + "\"type\":\"IllegalStateException\",\"code\":500}}";
+    String json = PlanTableScanResponseParser.toJson(response);
+    assertThat(json).isEqualTo(expectedJson);
+
+    PlanTableScanResponse fromResponse =
+        PlanTableScanResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+    assertThat(fromResponse.planStatus()).isEqualTo(PlanStatus.FAILED);
+    assertThat(fromResponse.errorResponse()).isNotNull();
+    assertThat(fromResponse.errorResponse().message())
+        .isEqualTo("Scan planning failed: table too large to plan");
+    assertThat(fromResponse.errorResponse().type()).isEqualTo("IllegalStateException");
+    assertThat(fromResponse.errorResponse().code()).isEqualTo(500);
+  }
+
+  @Test
+  public void parseFailedStatusWithoutErrorObject() {
+    String json = "{\"status\":\"failed\"}";
+    PlanTableScanResponse response =
+        PlanTableScanResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+    assertThat(response.planStatus()).isEqualTo(PlanStatus.FAILED);
+    assertThat(response.errorResponse()).isNull();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -680,9 +680,6 @@ public class TestPlanTableScanResponseParser {
         .isEqualTo("Scan planning failed: table too large to plan");
     assertThat(fromResponse.errorResponse().type()).isEqualTo("IllegalStateException");
     assertThat(fromResponse.errorResponse().code()).isEqualTo(500);
-    assertThat(fromResponse.errorMessage())
-        .isEqualTo(
-            "IllegalStateException (code=500): Scan planning failed: table too large to plan");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -684,10 +684,38 @@ public class TestPlanTableScanResponseParser {
 
   @Test
   public void parseFailedStatusWithoutErrorObject() {
+    // Spec requires an `error` object on failed responses, but parse leniently so
+    // a non-compliant server still surfaces the failure to the client.
     String json = "{\"status\":\"failed\"}";
     PlanTableScanResponse response =
         PlanTableScanResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
     assertThat(response.planStatus()).isEqualTo(PlanStatus.FAILED);
     assertThat(response.errorResponse()).isNull();
+  }
+
+  @Test
+  public void parseFailedStatusWithPrimitiveErrorField() {
+    // Spec requires `error` to be an ErrorModel object. A primitive is non-compliant;
+    // parse leniently and skip the malformed field rather than failing the whole response.
+    String json = "{\"status\":\"failed\",\"error\":\"oops\"}";
+    PlanTableScanResponse response =
+        PlanTableScanResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+    assertThat(response.planStatus()).isEqualTo(PlanStatus.FAILED);
+    assertThat(response.errorResponse()).isNull();
+  }
+
+  @Test
+  public void cannotBuildWithErrorResponseWhenStatusIsNotFailed() {
+    ErrorResponse errorResponse =
+        ErrorResponse.builder().withMessage("boom").withType("X").responseCode(500).build();
+    assertThatThrownBy(
+            () ->
+                PlanTableScanResponse.builder()
+                    .withPlanStatus(PlanStatus.COMPLETED)
+                    .withErrorResponse(errorResponse)
+                    .withSpecsById(PARTITION_SPECS_BY_ID)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid response: error can only be defined when status is 'failed'");
   }
 }


### PR DESCRIPTION
  Per the OpenAPI spec, FailedPlanningResult extends IcebergErrorResponse via allOf — when server-side scan planning fails, the response is an HTTP 200 with status: "failed" and a full ErrorModel (message, type, code) in the body:

  https://github.com/apache/iceberg/blob/8f1f483985bfbef3c19472b9e2ec474593fee219/open-api/rest-catalog-open-api.yaml#L3622-L3633

```
  {
    "status": "failed",
    "error": {
      "message": "I am on fire",
      "type": "IllegalStateException",
      "code": 500
    }
  }
```

  Today the SDK discards this error entirely. RESTTableScan throws a generic IllegalStateException like:

  ▎ Invalid planStatus: failed for planId: 6594660417062534

  After this change, the server's error is surfaced:

  ▎ Remote scan planning failed for planId: 6594660417062534: IllegalStateException (code=500): I am on fire

  Changes

  - Add ErrorResponse errorResponse() accessor to PlanTableScanResponse and FetchPlanningResultResponse. Callers get the full ErrorModel and can branch on code / type (e.g. retry on 503 but not 400) rather than parse a formatted string.
  - Parse the spec-compliant ErrorModel (message, type, code) in PlanTableScanResponseParser and FetchPlanningResultResponseParser. Non-object error values are parsed leniently so a non-compliant server still surfaces the failure.
  - Serialize the error as a spec-compliant ErrorModel in toJson; extract ErrorResponseParser.writeError (package-private) to share the serialization across parsers.
  - Tighten validate() on both response classes: error is only allowed when status is failed (produce-strict, parse-lenient).
  - In RESTTableScan, surface the server error in both failure paths (sync planTableScan and async fetchPlanningResult) via a null-safe failureMessage(PlanStatus, planId, ErrorResponse) helper.
  - Drop the unreachable case CANCELLED: from the outer planTableScan switch — PlanTableScanResponse.validate() already rejects it.

  Known out-of-scope

  PlanTableScanResponse.validate() rejects status=cancelled, but the OpenAPI spec maps cancelled → EmptyPlanningResult for PlanTableScanResult. Filed separately; not addressed here.