### PR TITLE
Flink 2.1: Fix forward-writer chaining regression in DynamicIcebergSink

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -443,6 +443,7 @@ public class DynamicIcebergSink
                   operatorName("Forward-Writer"),
                   writeResultTypeInfo,
                   new SinkWriterOperatorFactory<>(forwardWriterSink))
+              .setParallelism(converted.getParallelism())
               .uid(prefixIfNotNull(uidPrefix, "-forward-writer"));
 
       // Inject forward write results into sink — they'll be unioned in addPreCommitTopology


### PR DESCRIPTION
Flink CI failed in the following PRs:
https://github.com/apache/iceberg/pull/16006
https://github.com/apache/iceberg/pull/16023
https://github.com/apache/iceberg/pull/16024

```
TestDynamicIcebergSink > testNoShuffleTopology() FAILED
    org.opentest4j.AssertionFailedError: 
    Expecting value to be true but was false
        at app//org.apache.iceberg.flink.sink.dynamic.TestDynamicIcebergSink.testNoShuffleTopology(TestDynamicIcebergSink.java:330)
```
This PR fixes that failure.