### PR TITLE
Spark: Restrict view command rewrite to Iceberg catalogs

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.iceberg.spark.source.HasIcebergCatalog
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.View
@@ -36,7 +37,7 @@ object ViewUtil {
   }
 
   def isViewCatalog(catalog: CatalogPlugin): Boolean = {
-    catalog.isInstanceOf[ViewCatalog]
+    catalog.isInstanceOf[ViewCatalog] && catalog.isInstanceOf[HasIcebergCatalog]
   }
 
   implicit class IcebergViewHelper(plugin: CatalogPlugin) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViewUtil.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViewUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.apache.iceberg.spark.source.HasIcebergCatalog;
+import org.apache.spark.sql.catalyst.analysis.ViewUtil;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
+import org.junit.jupiter.api.Test;
+
+public class TestViewUtil {
+
+  @Test
+  public void viewCatalogWithoutIcebergCatalogIsNotRecognized() {
+    ViewCatalog viewCatalog = mock(ViewCatalog.class);
+    assertThat(ViewUtil.isViewCatalog(viewCatalog)).isFalse();
+  }
+
+  @Test
+  public void viewCatalogWithIcebergCatalogIsRecognized() {
+    ViewCatalog viewCatalog =
+        mock(ViewCatalog.class, withSettings().extraInterfaces(HasIcebergCatalog.class));
+    assertThat(ViewUtil.isViewCatalog(viewCatalog)).isTrue();
+  }
+
+  @Test
+  public void nonViewCatalogIsNotRecognized() {
+    CatalogPlugin catalog = mock(CatalogPlugin.class);
+    assertThat(ViewUtil.isViewCatalog(catalog)).isFalse();
+  }
+}

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.iceberg.spark.source.HasIcebergCatalog
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.View
@@ -36,7 +37,7 @@ object ViewUtil {
   }
 
   def isViewCatalog(catalog: CatalogPlugin): Boolean = {
-    catalog.isInstanceOf[ViewCatalog]
+    catalog.isInstanceOf[ViewCatalog] && catalog.isInstanceOf[HasIcebergCatalog]
   }
 
   implicit class IcebergViewHelper(plugin: CatalogPlugin) {

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViewUtil.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViewUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.apache.iceberg.spark.source.HasIcebergCatalog;
+import org.apache.spark.sql.catalyst.analysis.ViewUtil;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
+import org.junit.jupiter.api.Test;
+
+public class TestViewUtil {
+
+  @Test
+  public void viewCatalogWithoutIcebergCatalogIsNotRecognized() {
+    ViewCatalog viewCatalog = mock(ViewCatalog.class);
+    assertThat(ViewUtil.isViewCatalog(viewCatalog)).isFalse();
+  }
+
+  @Test
+  public void viewCatalogWithIcebergCatalogIsRecognized() {
+    ViewCatalog viewCatalog =
+        mock(ViewCatalog.class, withSettings().extraInterfaces(HasIcebergCatalog.class));
+    assertThat(ViewUtil.isViewCatalog(viewCatalog)).isTrue();
+  }
+
+  @Test
+  public void nonViewCatalogIsNotRecognized() {
+    CatalogPlugin catalog = mock(CatalogPlugin.class);
+    assertThat(ViewUtil.isViewCatalog(catalog)).isFalse();
+  }
+}

--- a/spark/v4.0/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
+++ b/spark/v4.0/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.iceberg.spark.source.HasIcebergCatalog
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.View
@@ -36,7 +37,7 @@ object ViewUtil {
   }
 
   def isViewCatalog(catalog: CatalogPlugin): Boolean = {
-    catalog.isInstanceOf[ViewCatalog]
+    catalog.isInstanceOf[ViewCatalog] && catalog.isInstanceOf[HasIcebergCatalog]
   }
 
   implicit class IcebergViewHelper(plugin: CatalogPlugin) {

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViewUtil.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViewUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.apache.iceberg.spark.source.HasIcebergCatalog;
+import org.apache.spark.sql.catalyst.analysis.ViewUtil;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
+import org.junit.jupiter.api.Test;
+
+public class TestViewUtil {
+
+  @Test
+  public void viewCatalogWithoutIcebergCatalogIsNotRecognized() {
+    ViewCatalog viewCatalog = mock(ViewCatalog.class);
+    assertThat(ViewUtil.isViewCatalog(viewCatalog)).isFalse();
+  }
+
+  @Test
+  public void viewCatalogWithIcebergCatalogIsRecognized() {
+    ViewCatalog viewCatalog =
+        mock(ViewCatalog.class, withSettings().extraInterfaces(HasIcebergCatalog.class));
+    assertThat(ViewUtil.isViewCatalog(viewCatalog)).isTrue();
+  }
+
+  @Test
+  public void nonViewCatalogIsNotRecognized() {
+    CatalogPlugin catalog = mock(CatalogPlugin.class);
+    assertThat(ViewUtil.isViewCatalog(catalog)).isFalse();
+  }
+}

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ViewUtil.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.iceberg.spark.source.HasIcebergCatalog
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.View
@@ -36,7 +37,7 @@ object ViewUtil {
   }
 
   def isViewCatalog(catalog: CatalogPlugin): Boolean = {
-    catalog.isInstanceOf[ViewCatalog]
+    catalog.isInstanceOf[ViewCatalog] && catalog.isInstanceOf[HasIcebergCatalog]
   }
 
   implicit class IcebergViewHelper(plugin: CatalogPlugin) {

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViewUtil.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViewUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.apache.iceberg.spark.source.HasIcebergCatalog;
+import org.apache.spark.sql.catalyst.analysis.ViewUtil;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
+import org.junit.jupiter.api.Test;
+
+public class TestViewUtil {
+
+  @Test
+  public void viewCatalogWithoutIcebergCatalogIsNotRecognized() {
+    ViewCatalog viewCatalog = mock(ViewCatalog.class);
+    assertThat(ViewUtil.isViewCatalog(viewCatalog)).isFalse();
+  }
+
+  @Test
+  public void viewCatalogWithIcebergCatalogIsRecognized() {
+    ViewCatalog viewCatalog =
+        mock(ViewCatalog.class, withSettings().extraInterfaces(HasIcebergCatalog.class));
+    assertThat(ViewUtil.isViewCatalog(viewCatalog)).isTrue();
+  }
+
+  @Test
+  public void nonViewCatalogIsNotRecognized() {
+    CatalogPlugin catalog = mock(CatalogPlugin.class);
+    assertThat(ViewUtil.isViewCatalog(catalog)).isFalse();
+  }
+}


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                            
  - `RewriteViewCommands` only checked `catalog.isInstanceOf[ViewCatalog]` before rewriting `SHOW VIEWS` / `CREATE VIEW` / `DROP VIEW` into Iceberg-specific plans (`ShowIcebergViews`, `CreateIcebergView`, `DropIcebergView`). Any non-Iceberg catalog that also implements Spark's `ViewCatalog` interface — for example,
   a subclass of Spark's `JDBCTableCatalog` that additionally implements `ViewCatalog` to provide JDBC-backed views — was therefore incorrectly intercepted once `IcebergSparkSessionExtensions` was loaded, and the rewritten plan failed because the catalog isn't backed by an Iceberg view implementation.              
  - `ViewUtil.isViewCatalog` now also requires `HasIcebergCatalog`. All Iceberg-provided Spark catalogs (`SparkCatalog`, `SparkSessionCatalog`) already implement it via `BaseCatalog`, so there's no behavior change for them. Non-Iceberg `ViewCatalog`s now fall through to Spark's default view handling.               
  - Applied to `spark-extensions` for v3.4, v3.5, v4.0, and v4.1.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  Example that triggered the bug:                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
```scala                                                                                                                                                                                                                                                                                                                  
  class IometeJDBCTableCatalog extends JDBCTableCatalog with ViewCatalog  
```
### Test plan
                                                                                                                                                                                                                                                                                                                            
  - New TestViewUtil (one per Spark version) asserts:
    - ViewCatalog without HasIcebergCatalog → isViewCatalog is false                                                                                                                                                                                                                                                        
    - ViewCatalog with HasIcebergCatalog → isViewCatalog is true                                                                                                                                                                                                                                                            
    - non-ViewCatalog CatalogPlugin → isViewCatalog is false
  - Existing TestViews continues to pass — Iceberg view catalogs are still detected.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
### AI disclosure   
                                                                                                                                                                                                                                                                                                                            
  Per the contribution guide, AI was used to draft the fix, tests, and this description. I verified the change end-to-end against my own reproduction (a custom JDBCTableCatalog subclass that also implements ViewCatalog, which was being incorrectly rewritten to ShowIcebergViews by IcebergSparkSessionExtensions).    
  