### PR TITLE
AWS: Apply service configurations to S3AsyncClient

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -138,6 +138,7 @@ public class AwsClientFactories {
           .applyMutation(
               b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyServiceConfigurations)
           .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -1003,10 +1003,11 @@ public class S3FileIOProperties implements Serializable {
    * <p>Sample usage:
    *
    * <pre>
-   *     S3Client.builder().applyMutation(s3FileIOProperties::applyS3ServiceConfigurations)
+   *     S3Client.builder().applyMutation(s3FileIOProperties::applyServiceConfigurations)
+   *     S3AsyncClient.builder().applyMutation(s3FileIOProperties::applyServiceConfigurations)
    * </pre>
    */
-  public <T extends S3ClientBuilder> void applyServiceConfigurations(T builder) {
+  public <T extends S3BaseClientBuilder<T, ?>> void applyServiceConfigurations(T builder) {
     builder
         .dualstackEnabled(isDualStackEnabled)
         .crossRegionAccessEnabled(isCrossRegionAccessEnabled)

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -498,6 +498,44 @@ public class TestS3FileIOProperties {
   }
 
   @Test
+  public void testApplyS3AsyncServiceConfigurations() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.DUALSTACK_ENABLED, "true");
+    properties.put(S3FileIOProperties.CROSS_REGION_ACCESS_ENABLED, "true");
+    properties.put(S3FileIOProperties.PATH_STYLE_ACCESS, "true");
+    properties.put(S3FileIOProperties.USE_ARN_REGION_ENABLED, "true");
+    properties.put(S3FileIOProperties.ACCELERATION_ENABLED, "false");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3AsyncClientBuilder mockBuilder = Mockito.mock(S3AsyncClientBuilder.class);
+
+    ArgumentCaptor<S3Configuration> s3ConfigurationCaptor =
+        ArgumentCaptor.forClass(S3Configuration.class);
+
+    Mockito.doReturn(mockBuilder).when(mockBuilder).dualstackEnabled(Mockito.anyBoolean());
+    Mockito.doReturn(mockBuilder)
+        .when(mockBuilder)
+        .crossRegionAccessEnabled(Mockito.anyBoolean());
+    Mockito.doReturn(mockBuilder)
+        .when(mockBuilder)
+        .serviceConfiguration(Mockito.any(S3Configuration.class));
+
+    s3FileIOProperties.applyServiceConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder).serviceConfiguration(s3ConfigurationCaptor.capture());
+
+    S3Configuration s3Configuration = s3ConfigurationCaptor.getValue();
+    assertThat(s3Configuration.pathStyleAccessEnabled())
+        .as("s3 async path style access enabled parameter should be set to true")
+        .isTrue();
+    assertThat(s3Configuration.useArnRegionEnabled())
+        .as("s3 async use arn region enabled parameter should be set to true")
+        .isTrue();
+    assertThat(s3Configuration.accelerateModeEnabled())
+        .as("s3 async acceleration mode enabled parameter should be set to false")
+        .isFalse();
+  }
+
+  @Test
   public void testApplySignerConfiguration() {
     Map<String, String> properties =
         ImmutableMap.of(


### PR DESCRIPTION
This fixes a bug where `DefaultAwsClientFactory` applies `S3FileIOProperties.applyServiceConfigurations()` to the synchronous `S3Client` but not to the `S3AsyncClient`. This means settings like `s3.path-style-access`, `s3.dualstack-enabled`, `s3.accelerate-enabled`, and `s3.use-arn-region-enabled` silently do not take effect for async S3 operations.

## Changes

1. **Widened type bound** of `S3FileIOProperties.applyServiceConfigurations()` from `S3ClientBuilder` to `S3BaseClientBuilder<T, ?>` so it accepts both sync and async builders.
2. **Added `applyServiceConfigurations` call** to the `S3AsyncClient.builder()` path in `DefaultAwsClientFactory.s3Async()`.
3. **Added test** `testApplyS3AsyncServiceConfigurations` verifying that path-style access, ARN region, and acceleration settings are correctly applied to the async client builder.

Closes #14575