### PR TITLE
Spark: Fix ThreadLocal leak in CommitMetadata (#15284)

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
@@ -56,7 +56,7 @@ public class CommitMetadata {
       ExceptionUtil.castAndThrow(e, exClass);
       return null;
     } finally {
-      COMMIT_PROPERTIES.set(ImmutableMap.of());
+      COMMIT_PROPERTIES.remove();
     }
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
@@ -56,7 +56,7 @@ public class CommitMetadata {
       ExceptionUtil.castAndThrow(e, exClass);
       return null;
     } finally {
-      COMMIT_PROPERTIES.set(ImmutableMap.of());
+      COMMIT_PROPERTIES.remove();
     }
   }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
@@ -56,7 +56,7 @@ public class CommitMetadata {
       ExceptionUtil.castAndThrow(e, exClass);
       return null;
     } finally {
-      COMMIT_PROPERTIES.set(ImmutableMap.of());
+      COMMIT_PROPERTIES.remove();
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/CommitMetadata.java
@@ -56,7 +56,7 @@ public class CommitMetadata {
       ExceptionUtil.castAndThrow(e, exClass);
       return null;
     } finally {
-      COMMIT_PROPERTIES.set(ImmutableMap.of());
+      COMMIT_PROPERTIES.remove();
     }
   }
 


### PR DESCRIPTION
Fixes #15284

Replace `COMMIT_PROPERTIES.set(ImmutableMap.of())` with `COMMIT_PROPERTIES.remove()` in the `finally` block of `CommitMetadata.withCommitProperties()`.

`ThreadLocal.remove()` properly removes the entry from the thread-local map and is the recommended cleanup pattern per https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/ThreadLocal.html#remove() 