### PR TITLE
Core: Pass optionalOAuthParams during non-exchange token refresh

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -190,7 +190,7 @@ public class OAuth2Util {
           config.credential(),
           config.scope(),
           config.oauth2ServerUri(),
-          ImmutableMap.of());
+          optionalOAuthParams);
     }
   }
 
@@ -563,7 +563,7 @@ public class OAuth2Util {
             client, config, basicHeaders, token(), tokenType(), optionalOAuthParams());
       } else {
         return fetchToken(
-            client, Map.of(), credential(), scope(), oauth2ServerUri(), ImmutableMap.of());
+            client, Map.of(), credential(), scope(), oauth2ServerUri(), optionalOAuthParams());
       }
     }
 

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 
 import java.io.IOException;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.junit.jupiter.api.Test;
@@ -130,6 +131,82 @@ public class TestOAuth2Util {
                   formData ->
                       formData.containsKey(GRANT_TYPE)
                           && formData.get(GRANT_TYPE).equals(CLIENT_CREDENTIALS)),
+              Mockito.eq(OAuthTokenResponse.class),
+              anyMap(),
+              any());
+    }
+  }
+
+  @Test
+  public void testRefreshExpiredTokenIncludesOptionalOAuthParams() throws IOException {
+    String audience = "https://my-catalog.example.com";
+    String resource = "https://my-resource.example.com";
+    AuthConfig authConfig =
+        ImmutableAuthConfig.builder()
+            .keepRefreshed(true)
+            .exchangeEnabled(false)
+            .token("expired_token")
+            .credential("testClientId:testClientSecret")
+            .oauth2ServerUri("/v1/token")
+            .expiresAtMillis(System.currentTimeMillis() - 10_000)
+            .optionalOAuthParams(ImmutableMap.of("audience", audience, "resource", resource))
+            .build();
+
+    OAuthTokenResponse response =
+        OAuthTokenResponse.builder().withToken("refreshed_token").withTokenType(BEARER).build();
+
+    try (RESTClient client = Mockito.mock(RESTClient.class);
+        OAuth2Util.AuthSession session = new OAuth2Util.AuthSession(Map.of(), authConfig)) {
+      Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any())).thenReturn(response);
+
+      session.refresh(client);
+
+      Mockito.verify(client)
+          .postForm(
+              any(),
+              argThat(
+                  formData ->
+                      CLIENT_CREDENTIALS.equals(formData.get(GRANT_TYPE))
+                          && audience.equals(formData.get("audience"))
+                          && resource.equals(formData.get("resource"))),
+              Mockito.eq(OAuthTokenResponse.class),
+              anyMap(),
+              any());
+    }
+  }
+
+  @Test
+  public void testRefreshCurrentTokenIncludesOptionalOAuthParams() throws IOException {
+    String audience = "https://my-catalog.example.com";
+    String resource = "https://my-resource.example.com";
+    AuthConfig authConfig =
+        ImmutableAuthConfig.builder()
+            .keepRefreshed(true)
+            .exchangeEnabled(false)
+            .token("valid_token")
+            .credential("testClientId:testClientSecret")
+            .oauth2ServerUri("/v1/token")
+            .expiresAtMillis(System.currentTimeMillis() + 300_000)
+            .optionalOAuthParams(ImmutableMap.of("audience", audience, "resource", resource))
+            .build();
+
+    OAuthTokenResponse response =
+        OAuthTokenResponse.builder().withToken("refreshed_token").withTokenType(BEARER).build();
+
+    try (RESTClient client = Mockito.mock(RESTClient.class);
+        OAuth2Util.AuthSession session = new OAuth2Util.AuthSession(Map.of(), authConfig)) {
+      Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any())).thenReturn(response);
+
+      session.refresh(client);
+
+      Mockito.verify(client)
+          .postForm(
+              any(),
+              argThat(
+                  formData ->
+                      CLIENT_CREDENTIALS.equals(formData.get(GRANT_TYPE))
+                          && audience.equals(formData.get("audience"))
+                          && resource.equals(formData.get("resource"))),
               Mockito.eq(OAuthTokenResponse.class),
               anyMap(),
               any());


### PR DESCRIPTION
## Summary
- When `token-exchange-enabled=false`, both `refreshToken()` and `refreshExpiredToken()` passed `ImmutableMap.of()` to `fetchToken()` instead of the stored `optionalOAuthParams` (audience, resource). This caused refreshed tokens to silently lose audience/resource scoping, leading to 401/403 errors or overly broad permissions.
- Fixed by passing `optionalOAuthParams` in both non-exchange code paths (lines 193 and 566 of `OAuth2Util.java`).
- Added tests for both the expired-token and current-token refresh paths verifying that audience and resource are included in the token request form data.

Closes #16022

## Test plan
- [x] `./gradlew :iceberg-core:test --tests TestOAuth2Util` passes
- [ ] CI passes