### PR TITLE
Flink: Fix JdbcLockFactory to allow ClientPoolImpl connection retry

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -260,10 +260,6 @@ public class JdbcLockFactory implements TriggerLockFactory {
                       this,
                       instanceId,
                       count);
-                } catch (SQLException e) {
-                  // SQL exception happened when deleting lock information
-                  throw new UncheckedSQLException(
-                      e, "Failed to delete %s lock with instanceId %s", this, instanceId);
                 }
 
                 return null;
@@ -298,9 +294,6 @@ public class JdbcLockFactory implements TriggerLockFactory {
                     return null;
                   }
                 }
-              } catch (SQLException e) {
-                // SQL exception happened when getting lock information
-                throw new UncheckedSQLException(e, "Failed to get lock information for %s", type);
               }
             });
       } catch (InterruptedException e) {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestJdbcLockFactory.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestJdbcLockFactory.java
@@ -19,11 +19,18 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import static org.apache.iceberg.flink.maintenance.api.JdbcLockFactory.INIT_LOCK_TABLES_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.sql.SQLTransientConnectionException;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.jdbc.JdbcClientPool;
+import org.apache.iceberg.jdbc.UncheckedSQLException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
 
 class TestJdbcLockFactory extends TestLockFactoryBase {
   @Override
@@ -37,5 +44,63 @@ class TestJdbcLockFactory extends TestLockFactoryBase {
         "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", ""),
         tableName,
         properties);
+  }
+
+  @Test
+  void testSQLExceptionEnablesRetryInClientPool() throws Exception {
+    // Regression test for #15759: verify that removing the inner try-catch allows
+    // ClientPoolImpl to retry on transient connection failures.
+    //
+    // Before the fix: inner catch converted SQLException -> UncheckedSQLException
+    // (RuntimeException) inside the lambda. ClientPoolImpl only catches the declared
+    // exception type (SQLException), so RuntimeException bypasses retry entirely.
+    // After the fix: SQLException propagates naturally, ClientPoolImpl catches it,
+    // and retries on transient connection exceptions.
+    Map<String, String> props = Maps.newHashMap();
+    props.put("username", "user");
+    props.put("password", "password");
+    String uri = "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", "");
+
+    try (JdbcClientPool pool = new JdbcClientPool(1, uri, props)) {
+      AtomicInteger attempts = new AtomicInteger(0);
+
+      String result =
+          pool.run(
+              conn -> {
+                if (attempts.incrementAndGet() == 1) {
+                  throw new SQLTransientConnectionException("transient failure");
+                }
+
+                return "success";
+              });
+
+      assertThat(result).isEqualTo("success");
+      assertThat(attempts.get()).isGreaterThan(1);
+    }
+  }
+
+  @Test
+  void testUncheckedSQLExceptionBypassesRetry() throws Exception {
+    // Companion test: demonstrates that wrapping SQLException as UncheckedSQLException
+    // (the OLD behavior before the fix) prevents ClientPoolImpl from retrying.
+    Map<String, String> props = Maps.newHashMap();
+    props.put("username", "user");
+    props.put("password", "password");
+    String uri = "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", "");
+
+    try (JdbcClientPool pool = new JdbcClientPool(1, uri, props)) {
+      assertThatThrownBy(
+              () ->
+                  pool.run(
+                      conn -> {
+                        try {
+                          throw new SQLTransientConnectionException("transient failure");
+                        } catch (java.sql.SQLException e) {
+                          throw new UncheckedSQLException(e, "wrapped");
+                        }
+                      }))
+          .isInstanceOf(UncheckedSQLException.class)
+          .hasMessageContaining("wrapped");
+    }
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -260,10 +260,6 @@ public class JdbcLockFactory implements TriggerLockFactory {
                       this,
                       instanceId,
                       count);
-                } catch (SQLException e) {
-                  // SQL exception happened when deleting lock information
-                  throw new UncheckedSQLException(
-                      e, "Failed to delete %s lock with instanceId %s", this, instanceId);
                 }
 
                 return null;
@@ -298,9 +294,6 @@ public class JdbcLockFactory implements TriggerLockFactory {
                     return null;
                   }
                 }
-              } catch (SQLException e) {
-                // SQL exception happened when getting lock information
-                throw new UncheckedSQLException(e, "Failed to get lock information for %s", type);
               }
             });
       } catch (InterruptedException e) {

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestJdbcLockFactory.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestJdbcLockFactory.java
@@ -19,11 +19,18 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import static org.apache.iceberg.flink.maintenance.api.JdbcLockFactory.INIT_LOCK_TABLES_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.sql.SQLTransientConnectionException;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.jdbc.JdbcClientPool;
+import org.apache.iceberg.jdbc.UncheckedSQLException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
 
 class TestJdbcLockFactory extends TestLockFactoryBase {
   @Override
@@ -37,5 +44,63 @@ class TestJdbcLockFactory extends TestLockFactoryBase {
         "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", ""),
         tableName,
         properties);
+  }
+
+  @Test
+  void testSQLExceptionEnablesRetryInClientPool() throws Exception {
+    // Regression test for #15759: verify that removing the inner try-catch allows
+    // ClientPoolImpl to retry on transient connection failures.
+    //
+    // Before the fix: inner catch converted SQLException -> UncheckedSQLException
+    // (RuntimeException) inside the lambda. ClientPoolImpl only catches the declared
+    // exception type (SQLException), so RuntimeException bypasses retry entirely.
+    // After the fix: SQLException propagates naturally, ClientPoolImpl catches it,
+    // and retries on transient connection exceptions.
+    Map<String, String> props = Maps.newHashMap();
+    props.put("username", "user");
+    props.put("password", "password");
+    String uri = "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", "");
+
+    try (JdbcClientPool pool = new JdbcClientPool(1, uri, props)) {
+      AtomicInteger attempts = new AtomicInteger(0);
+
+      String result =
+          pool.run(
+              conn -> {
+                if (attempts.incrementAndGet() == 1) {
+                  throw new SQLTransientConnectionException("transient failure");
+                }
+
+                return "success";
+              });
+
+      assertThat(result).isEqualTo("success");
+      assertThat(attempts.get()).isGreaterThan(1);
+    }
+  }
+
+  @Test
+  void testUncheckedSQLExceptionBypassesRetry() throws Exception {
+    // Companion test: demonstrates that wrapping SQLException as UncheckedSQLException
+    // (the OLD behavior before the fix) prevents ClientPoolImpl from retrying.
+    Map<String, String> props = Maps.newHashMap();
+    props.put("username", "user");
+    props.put("password", "password");
+    String uri = "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", "");
+
+    try (JdbcClientPool pool = new JdbcClientPool(1, uri, props)) {
+      assertThatThrownBy(
+              () ->
+                  pool.run(
+                      conn -> {
+                        try {
+                          throw new SQLTransientConnectionException("transient failure");
+                        } catch (java.sql.SQLException e) {
+                          throw new UncheckedSQLException(e, "wrapped");
+                        }
+                      }))
+          .isInstanceOf(UncheckedSQLException.class)
+          .hasMessageContaining("wrapped");
+    }
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/JdbcLockFactory.java
@@ -260,10 +260,6 @@ public class JdbcLockFactory implements TriggerLockFactory {
                       this,
                       instanceId,
                       count);
-                } catch (SQLException e) {
-                  // SQL exception happened when deleting lock information
-                  throw new UncheckedSQLException(
-                      e, "Failed to delete %s lock with instanceId %s", this, instanceId);
                 }
 
                 return null;
@@ -298,9 +294,6 @@ public class JdbcLockFactory implements TriggerLockFactory {
                     return null;
                   }
                 }
-              } catch (SQLException e) {
-                // SQL exception happened when getting lock information
-                throw new UncheckedSQLException(e, "Failed to get lock information for %s", type);
               }
             });
       } catch (InterruptedException e) {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestJdbcLockFactory.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestJdbcLockFactory.java
@@ -19,11 +19,18 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import static org.apache.iceberg.flink.maintenance.api.JdbcLockFactory.INIT_LOCK_TABLES_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.sql.SQLTransientConnectionException;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.jdbc.JdbcClientPool;
+import org.apache.iceberg.jdbc.UncheckedSQLException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
 
 class TestJdbcLockFactory extends TestLockFactoryBase {
   @Override
@@ -37,5 +44,63 @@ class TestJdbcLockFactory extends TestLockFactoryBase {
         "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", ""),
         tableName,
         properties);
+  }
+
+  @Test
+  void testSQLExceptionEnablesRetryInClientPool() throws Exception {
+    // Regression test for #15759: verify that removing the inner try-catch allows
+    // ClientPoolImpl to retry on transient connection failures.
+    //
+    // Before the fix: inner catch converted SQLException -> UncheckedSQLException
+    // (RuntimeException) inside the lambda. ClientPoolImpl only catches the declared
+    // exception type (SQLException), so RuntimeException bypasses retry entirely.
+    // After the fix: SQLException propagates naturally, ClientPoolImpl catches it,
+    // and retries on transient connection exceptions.
+    Map<String, String> props = Maps.newHashMap();
+    props.put("username", "user");
+    props.put("password", "password");
+    String uri = "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", "");
+
+    try (JdbcClientPool pool = new JdbcClientPool(1, uri, props)) {
+      AtomicInteger attempts = new AtomicInteger(0);
+
+      String result =
+          pool.run(
+              conn -> {
+                if (attempts.incrementAndGet() == 1) {
+                  throw new SQLTransientConnectionException("transient failure");
+                }
+
+                return "success";
+              });
+
+      assertThat(result).isEqualTo("success");
+      assertThat(attempts.get()).isGreaterThan(1);
+    }
+  }
+
+  @Test
+  void testUncheckedSQLExceptionBypassesRetry() throws Exception {
+    // Companion test: demonstrates that wrapping SQLException as UncheckedSQLException
+    // (the OLD behavior before the fix) prevents ClientPoolImpl from retrying.
+    Map<String, String> props = Maps.newHashMap();
+    props.put("username", "user");
+    props.put("password", "password");
+    String uri = "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", "");
+
+    try (JdbcClientPool pool = new JdbcClientPool(1, uri, props)) {
+      assertThatThrownBy(
+              () ->
+                  pool.run(
+                      conn -> {
+                        try {
+                          throw new SQLTransientConnectionException("transient failure");
+                        } catch (java.sql.SQLException e) {
+                          throw new UncheckedSQLException(e, "wrapped");
+                        }
+                      }))
+          .isInstanceOf(UncheckedSQLException.class)
+          .hasMessageContaining("wrapped");
+    }
   }
 }


### PR DESCRIPTION
## Summary

In `JdbcLockFactory.JdbcLock`, the `instanceId()` and `unlock()` methods caught `SQLException` inside the lambda passed to `ClientPoolImpl.run()` and wrapped it as `UncheckedSQLException` (a `RuntimeException`). This prevented `ClientPoolImpl`'s retry mechanism from triggering because `isConnectionException()` checks for `SQLException`, not `UncheckedSQLException`.

## Fix

Removed the inner `try-catch` blocks that wrapped `SQLException` as `UncheckedSQLException` inside the lambdas. The lambda signature for `ClientPoolImpl.run()` already declares `throws Exception`, so `SQLException` propagates naturally to `ClientPoolImpl` where the retry logic can detect connection exceptions and retry appropriately.

The outer `catch (SQLException e)` blocks remain to convert to `UncheckedSQLException` after `ClientPoolImpl` has exhausted its retry attempts.

Closes #15759