### PR TITLE
Fix RCK view tests failing with AlreadyExistsException due to missing ns1/ns2 in cleanup list

### DIFF
--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RCKUtils.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RCKUtils.java
@@ -37,7 +37,13 @@ class RCKUtils {
   static final String RCK_LOCAL = "rck.local";
   static final String RCK_PURGE_TEST_NAMESPACES = "rck.purge-test-namespaces";
 
-  static final List<Namespace> TEST_NAMESPACES = List.of(Namespace.of("ns"), Namespace.of("newdb"));
+  static final List<Namespace> TEST_NAMESPACES =
+      List.of(
+          Namespace.of("ns"),
+          Namespace.of("newdb"),
+          Namespace.of("ns1"),
+          Namespace.of("ns2"),
+          Namespace.of("other_ns"));
 
   private RCKUtils() {}
 


### PR DESCRIPTION
## Problem

`RESTCompatibilityKitViewCatalogTests` fails with `AlreadyExistsException`
on `createNamespace` when view tests run sequentially. The `@BeforeEach`
hook calls `RCKUtils.purgeCatalogTestEntries` to clean up between tests,
but `TEST_NAMESPACES` only listed `ns` and `newdb`.

`ViewCatalogTests.listViews()` creates `ns1` and `ns2` namespaces that were
never included in the purge list, so they accumulate across test methods.

## Fix

Add `ns1` and `ns2` to `RCKUtils.TEST_NAMESPACES`.

## Testing

Run `RESTCompatibilityKitViewCatalogTests` to verify view tests no longer
fail with `AlreadyExistsException` on `createNamespace`.
