### PR TITLE
Core: Coalesce consecutive position deletes into range inserts (Iceberg V2)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -78,7 +78,7 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
     if (that instanceof BitmapPositionDeleteIndex) {
       merge((BitmapPositionDeleteIndex) that);
     } else {
-      that.forEach(this::delete);
+      PositionDeleteRangeConsumer.forEach(that, this);
       deleteFiles.addAll(that.deleteFiles());
     }
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -177,7 +177,7 @@ public class Deletes {
       CloseableIterable<Long> posDeletes, List<DeleteFile> files) {
     try (CloseableIterable<Long> deletes = posDeletes) {
       PositionDeleteIndex positionDeleteIndex = new BitmapPositionDeleteIndex(files);
-      deletes.forEach(positionDeleteIndex::delete);
+      PositionDeleteRangeConsumer.forEach(deletes, positionDeleteIndex);
       return positionDeleteIndex;
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to close position delete source", e);

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.deletes;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -32,10 +33,13 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.PeekingIterator;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceMap;
+import org.apache.iceberg.util.CharSequenceUtil;
 import org.apache.iceberg.util.Filter;
 import org.apache.iceberg.util.SortedMerge;
 import org.apache.iceberg.util.StructLikeSet;
@@ -131,6 +135,8 @@ public class Deletes {
    *
    * <p>This method builds a position delete index for each referenced data file and does not filter
    * deletes. This can be useful when the entire delete file content is needed (e.g. caching).
+   * Adjacent same-path runs are coalesced via {@link PositionDeleteRangeConsumer#forEach(Iterable,
+   * PositionDeleteIndex)}.
    *
    * @param posDeletes position deletes
    * @param file the source delete file for the deletes
@@ -141,18 +147,40 @@ public class Deletes {
     CharSequenceMap<PositionDeleteIndex> indexes = CharSequenceMap.create();
 
     try (CloseableIterable<T> deletes = posDeletes) {
-      for (T delete : deletes) {
-        CharSequence filePath = (CharSequence) FILENAME_ACCESSOR.get(delete);
-        long position = (long) POSITION_ACCESSOR.get(delete);
+      PeekingIterator<T> records = Iterators.peekingIterator(deletes.iterator());
+      while (records.hasNext()) {
+        CharSequence path = (CharSequence) FILENAME_ACCESSOR.get(records.peek());
         PositionDeleteIndex index =
-            indexes.computeIfAbsent(filePath, key -> new BitmapPositionDeleteIndex(file));
-        index.delete(position);
+            indexes.computeIfAbsent(path, key -> new BitmapPositionDeleteIndex(file));
+        PositionDeleteRangeConsumer.forEach(positionsForPath(records, path), index);
       }
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to close position delete source", e);
     }
 
     return indexes;
+  }
+
+  /**
+   * Yields positions from {@code records} while the next record's {@code file_path} matches {@code
+   * path}, advancing the iterator as a side effect.
+   */
+  private static <T extends StructLike> Iterable<Long> positionsForPath(
+      PeekingIterator<T> records, CharSequence path) {
+    return () ->
+        new Iterator<Long>() {
+          @Override
+          public boolean hasNext() {
+            return records.hasNext()
+                && !CharSequenceUtil.unequalPaths(
+                    path, (CharSequence) FILENAME_ACCESSOR.get(records.peek()));
+          }
+
+          @Override
+          public Long next() {
+            return (Long) POSITION_ACCESSOR.get(records.next());
+          }
+        };
   }
 
   public static <T extends StructLike> PositionDeleteIndex toPositionIndex(

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -20,8 +20,8 @@ package org.apache.iceberg.deletes;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Iterator;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -163,25 +163,25 @@ public class Deletes {
 
   /**
    * Drains positions from {@code records} while the next record's {@code file_path} matches {@code
-   * path}. The returned {@code Iterable} consumes {@code records} on iteration and stops as soon as
-   * a record with a different path is peeked; subsequent calls resume from that record.
+   * path}. The returned iterator consumes {@code records} on traversal and stops as soon as a
+   * record with a different path is peeked; subsequent calls resume from that record. Returning a
+   * primitive iterator keeps positions unboxed all the way into the consumer's slice buffer.
    */
-  private static <T extends StructLike> Iterable<Long> drainPositionsForPath(
+  private static <T extends StructLike> PrimitiveIterator.OfLong drainPositionsForPath(
       PeekingIterator<T> records, CharSequence path) {
-    return () ->
-        new Iterator<Long>() {
-          @Override
-          public boolean hasNext() {
-            return records.hasNext()
-                && !CharSequenceUtil.unequalPaths(
-                    path, (CharSequence) FILENAME_ACCESSOR.get(records.peek()));
-          }
+    return new PrimitiveIterator.OfLong() {
+      @Override
+      public boolean hasNext() {
+        return records.hasNext()
+            && !CharSequenceUtil.unequalPaths(
+                path, (CharSequence) FILENAME_ACCESSOR.get(records.peek()));
+      }
 
-          @Override
-          public Long next() {
-            return (Long) POSITION_ACCESSOR.get(records.next());
-          }
-        };
+      @Override
+      public long nextLong() {
+        return (long) POSITION_ACCESSOR.get(records.next());
+      }
+    };
   }
 
   public static <T extends StructLike> PositionDeleteIndex toPositionIndex(

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
@@ -46,8 +47,7 @@ import org.apache.iceberg.util.StructLikeSet;
 
 public class Deletes {
 
-  private static final Schema POSITION_DELETE_SCHEMA =
-      new Schema(MetadataColumns.DELETE_FILE_PATH, MetadataColumns.DELETE_FILE_POS);
+  private static final Schema POSITION_DELETE_SCHEMA = DeleteSchemaUtil.pathPosSchema();
 
   private static final Accessor<StructLike> FILENAME_ACCESSOR =
       POSITION_DELETE_SCHEMA.accessorForField(MetadataColumns.DELETE_FILE_PATH.fieldId());
@@ -152,7 +152,7 @@ public class Deletes {
         CharSequence path = (CharSequence) FILENAME_ACCESSOR.get(records.peek());
         PositionDeleteIndex index =
             indexes.computeIfAbsent(path, key -> new BitmapPositionDeleteIndex(file));
-        PositionDeleteRangeConsumer.forEach(positionsForPath(records, path), index);
+        PositionDeleteRangeConsumer.forEach(drainPositionsForPath(records, path), index);
       }
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to close position delete source", e);
@@ -162,10 +162,11 @@ public class Deletes {
   }
 
   /**
-   * Yields positions from {@code records} while the next record's {@code file_path} matches {@code
-   * path}, advancing the iterator as a side effect.
+   * Drains positions from {@code records} while the next record's {@code file_path} matches {@code
+   * path}. The returned {@code Iterable} consumes {@code records} on iteration and stops as soon as
+   * a record with a different path is peeked; subsequent calls resume from that record.
    */
-  private static <T extends StructLike> Iterable<Long> positionsForPath(
+  private static <T extends StructLike> Iterable<Long> drainPositionsForPath(
       PeekingIterator<T> records, CharSequence path) {
     return () ->
         new Iterator<Long>() {

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -113,8 +113,38 @@ public interface PositionDeleteIndex {
     return BitmapPositionDeleteIndex.deserialize(bytes, deleteFile);
   }
 
-  /** Returns an empty immutable position delete index. */
+  /**
+   * Returns an empty immutable position delete index.
+   *
+   * @see #create()
+   */
   static PositionDeleteIndex empty() {
     return EmptyPositionDeleteIndex.get();
+  }
+
+  /**
+   * Returns an empty mutable position delete index that supports {@link #delete(long)} and {@link
+   * #delete(long, long)}.
+   *
+   * <p>Unlike {@link #empty()}, the returned index is mutable. It is not safe for concurrent
+   * mutation by multiple threads. The index does not record provenance; positions added to it are
+   * not associated with any source delete file.
+   *
+   * @see #empty()
+   * @see #create(DeleteFile)
+   */
+  static PositionDeleteIndex create() {
+    return new BitmapPositionDeleteIndex();
+  }
+
+  /**
+   * Returns an empty mutable position delete index that records the given delete file as its
+   * source. The returned index is not safe for concurrent mutation by multiple threads.
+   *
+   * @param deleteFile the delete file the index is created for, may be {@code null}
+   * @see #create()
+   */
+  static PositionDeleteIndex create(DeleteFile deleteFile) {
+    return new BitmapPositionDeleteIndex(deleteFile);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -49,7 +49,7 @@ public interface PositionDeleteIndex {
     if (!that.deleteFiles().isEmpty()) {
       throw new UnsupportedOperationException(getClass().getName() + " does not support merge");
     }
-    that.forEach(this::delete);
+    PositionDeleteRangeConsumer.forEach(that, this);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Coalesces consecutive position deletes into range inserts on a {@link PositionDeleteIndex}.
+ *
+ * <p>The consumer is agnostic to input sortedness: callers can stream any {@code Iterable} or
+ * {@code long[]} of positions and the API flushes them onto the target {@link PositionDeleteIndex}
+ * without requiring a sorted contract. Monotone runs become a single range insert, which touches
+ * fewer bitmap pages than a per-position {@code target.delete(pos)} loop; non-monotone input still
+ * produces a correct index via an internal per-position fallback.
+ *
+ * <p>External callers see three operations: construct with a target index, feed positions via
+ * {@link #acceptAll(long[], int, int)} (one or more calls), and {@link #flush()} when done. The
+ * sniff/escape state and the buffering policy used by the package-private {@code forEach} helpers
+ * are internal and may change.
+ *
+ * <p><b>Note:</b> this class is tied to the V2 position delete file lifecycle. Format-version 3
+ * deletion vectors arrive pre-bitmap via {@link PositionDeleteIndex#deserialize} and bypass this
+ * class entirely; this class can retire once V2 position delete files are no longer read.
+ */
+public final class PositionDeleteRangeConsumer {
+
+  /**
+   * Batch size for {@link #forEach}. Sized to fit comfortably in L1 (512 bytes). Smaller buffers
+   * miss the bulk-path branch elision; larger buffers add allocation cost without improving the
+   * inner-loop throughput (the {@code acceptAll} body is the same regardless of slice length).
+   */
+  private static final int FOREACH_BATCH_SIZE = 64;
+
+  /**
+   * Source-cardinality cutoff below which the batched path's setup cost (buffer allocation,
+   * consumer state, {@code Preconditions} checks) outweighs the per-position savings from
+   * coalescing. Sources at or below this size are drained directly via {@code target::delete}.
+   */
+  private static final int SMALL_SOURCE_THRESHOLD = 8;
+
+  /** The number of positions to sniff for boundary density. */
+  private static final int SNIFF_SIZE = 256;
+
+  /** The threshold for boundary density at which to switch to the bulk path, as a percentage. */
+  private static final int BOUNDARY_THRESHOLD_PERCENT = 30;
+
+  private final PositionDeleteIndex target;
+  private boolean hasRun;
+  private long rangeStart;
+  private long lastPosition;
+
+  private int processed;
+  private int boundaries;
+  private boolean escaped;
+
+  /**
+   * Creates a new consumer that writes coalesced ranges into {@code target}. Single-threaded; one
+   * instance per target index.
+   */
+  public PositionDeleteRangeConsumer(PositionDeleteIndex target) {
+    Preconditions.checkArgument(target != null, "Invalid target index: null");
+    this.target = target;
+  }
+
+  /**
+   * Adds the half-open slice {@code positions[from, to)} to the target index, coalescing
+   * consecutive positions into range inserts. Safe to call repeatedly; the consumer keeps the
+   * pending run across calls and only emits it on the next gap or on {@link #flush()}.
+   */
+  public void acceptAll(long[] positions, int from, int to) {
+    Preconditions.checkArgument(positions != null, "Invalid positions array: null");
+    Preconditions.checkPositionIndexes(from, to, positions.length);
+    if (from >= to) {
+      return;
+    }
+
+    int cursor = from;
+
+    if (escaped) {
+      drainEscaped(positions, cursor, to);
+      return;
+    }
+
+    if (!hasRun) {
+      initRun(positions[cursor++]);
+    }
+
+    while (cursor < to && processed < SNIFF_SIZE) {
+      coalesceSniff(positions[cursor++]);
+    }
+
+    if (processed == SNIFF_SIZE && shouldEscape()) {
+      enterEscape();
+      drainEscaped(positions, cursor, to);
+      return;
+    }
+
+    while (cursor < to) {
+      coalesce(positions[cursor++]);
+    }
+  }
+
+  /** Emits the active run, if any. The escape decision is sticky across flushes. */
+  public void flush() {
+    if (hasRun) {
+      emit();
+      hasRun = false;
+    }
+  }
+
+  // Per-element entry used internally by the package-private forEach helpers below and exercised
+  // directly by in-package tests. Not exposed to other modules: callers there should buffer into
+  // a long[] and use acceptAll, which keeps the state-machine dispatch out of the inner loop.
+  void accept(long pos) {
+    if (escaped) {
+      target.delete(pos);
+      return;
+    }
+    if (!hasRun) {
+      initRun(pos);
+      return;
+    }
+    coalesceSniff(pos);
+    if (processed == SNIFF_SIZE && shouldEscape()) {
+      enterEscape();
+    }
+  }
+
+  /**
+   * Drains a boxed {@code Iterable<Long>} into {@code target}. Buffers into a small primitive slice
+   * and hands chunks to {@link #acceptAll(long[], int, int)}; keeps the sniff/escape state machine
+   * out of the inner loop. Package-private: external callers should construct the consumer directly
+   * and feed it via {@code acceptAll}.
+   */
+  public static void forEach(Iterable<Long> positions, PositionDeleteIndex target) {
+    PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
+    long[] buffer = new long[FOREACH_BATCH_SIZE];
+    int filled = 0;
+    for (Long pos : positions) {
+      buffer[filled++] = pos;
+      if (filled == FOREACH_BATCH_SIZE) {
+        consumer.acceptAll(buffer, 0, FOREACH_BATCH_SIZE);
+        filled = 0;
+      }
+    }
+    if (filled > 0) {
+      consumer.acceptAll(buffer, 0, filled);
+    }
+    consumer.flush();
+  }
+
+  /**
+   * Drains all positions from {@code source} into {@code target} via the batched accumulator.
+   * Equivalent to {@code source.forEach(target::delete)} but coalesces consecutive runs into range
+   * inserts. Sources that emit in ascending order (such as {@code BitmapPositionDeleteIndex}, which
+   * iterates a Roaring bitmap) feed straight into the coalescing fast path; out-of-order sources
+   * still produce a correct result via the per-position fallback. Package-private: see the note on
+   * {@link #forEach(Iterable, PositionDeleteIndex)}.
+   */
+  public static void forEach(PositionDeleteIndex source, PositionDeleteIndex target) {
+    if (source.isEmpty()) {
+      return;
+    }
+    if (isSmallSource(source)) {
+      source.forEach(target::delete);
+      return;
+    }
+    PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
+    long[] buffer = new long[FOREACH_BATCH_SIZE];
+    int[] filled = {0};
+    source.forEach(
+        pos -> {
+          buffer[filled[0]++] = pos;
+          if (filled[0] == FOREACH_BATCH_SIZE) {
+            consumer.acceptAll(buffer, 0, FOREACH_BATCH_SIZE);
+            filled[0] = 0;
+          }
+        });
+    if (filled[0] > 0) {
+      consumer.acceptAll(buffer, 0, filled[0]);
+    }
+    consumer.flush();
+  }
+
+  // cardinality() is a default method that throws when the impl does not implement it; treat
+  // "unknown" as "use the batched path" so we never regress on bitmap-backed sources.
+  private static boolean isSmallSource(PositionDeleteIndex source) {
+    try {
+      return source.cardinality() <= SMALL_SOURCE_THRESHOLD;
+    } catch (UnsupportedOperationException ignored) {
+      return false;
+    }
+  }
+
+  /** Starts a new active run anchored at {@code first}. */
+  private void initRun(long first) {
+    rangeStart = first;
+    lastPosition = first;
+    hasRun = true;
+    processed = 1;
+  }
+
+  /** Extends the active run with {@code pos} during sniffing; counts gaps to inform escape. */
+  private void coalesceSniff(long pos) {
+    if (pos - lastPosition != 1) {
+      boundaries++;
+      emit();
+      rangeStart = pos;
+    }
+    lastPosition = pos;
+    processed++;
+  }
+
+  /** Extends the active run with {@code pos} after sniffing has decided not to escape. */
+  private void coalesce(long pos) {
+    if (pos - lastPosition != 1) {
+      emit();
+      rangeStart = pos;
+    }
+    lastPosition = pos;
+  }
+
+  /** True if the sniffed prefix has too many gaps to make coalescing worthwhile. */
+  private boolean shouldEscape() {
+    return boundaries * 100 > (SNIFF_SIZE - 1) * BOUNDARY_THRESHOLD_PERCENT;
+  }
+
+  /** Permanently switches to per-position deletes; flushes any pending run. */
+  private void enterEscape() {
+    emit();
+    hasRun = false;
+    escaped = true;
+  }
+
+  /** Per-position fallback used once the consumer has escaped coalescing. */
+  private void drainEscaped(long[] positions, int from, int to) {
+    for (int cursor = from; cursor < to; cursor++) {
+      target.delete(positions[cursor]);
+    }
+  }
+
+  private void emit() {
+    if (rangeStart == lastPosition) {
+      target.delete(rangeStart);
+    } else {
+      target.delete(rangeStart, lastPosition + 1);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.deletes;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
 /**
  * Coalesces consecutive position deletes into range inserts on a {@link PositionDeleteIndex}.
  *
@@ -30,9 +28,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * produces a correct index via an internal per-position fallback.
  *
  * <p>External callers see three operations: construct with a target index, feed positions via
- * {@link #acceptAll(long[], int, int)} (one or more calls), and {@link #flush()} when done. The
- * sniff/escape state and the buffering policy used by the package-private {@code forEach} helpers
- * are internal and may change.
+ * {@link #acceptAll(long[], int, int)} (one or more calls), and {@link #flush()} when done.
  *
  * <p><b>Note:</b> this class is tied to the V2 position delete file lifecycle. Format-version 3
  * deletion vectors arrive pre-bitmap via {@link PositionDeleteIndex#deserialize} and bypass this
@@ -49,8 +45,8 @@ public final class PositionDeleteRangeConsumer {
 
   /**
    * Source-cardinality cutoff below which the batched path's setup cost (buffer allocation,
-   * consumer state, {@code Preconditions} checks) outweighs the per-position savings from
-   * coalescing. Sources at or below this size are drained directly via {@code target::delete}.
+   * consumer state) outweighs the per-position savings from coalescing. Sources at or below this
+   * size are drained directly via {@code target::delete}.
    */
   private static final int SMALL_SOURCE_THRESHOLD = 8;
 
@@ -74,7 +70,6 @@ public final class PositionDeleteRangeConsumer {
    * instance per target index.
    */
   public PositionDeleteRangeConsumer(PositionDeleteIndex target) {
-    Preconditions.checkArgument(target != null, "Invalid target index: null");
     this.target = target;
   }
 
@@ -84,8 +79,6 @@ public final class PositionDeleteRangeConsumer {
    * pending run across calls and only emits it on the next gap or on {@link #flush()}.
    */
   public void acceptAll(long[] positions, int from, int to) {
-    Preconditions.checkArgument(positions != null, "Invalid positions array: null");
-    Preconditions.checkPositionIndexes(from, to, positions.length);
     if (from >= to) {
       return;
     }
@@ -124,29 +117,9 @@ public final class PositionDeleteRangeConsumer {
     }
   }
 
-  // Per-element entry used internally by the package-private forEach helpers below and exercised
-  // directly by in-package tests. Not exposed to other modules: callers there should buffer into
-  // a long[] and use acceptAll, which keeps the state-machine dispatch out of the inner loop.
-  void accept(long pos) {
-    if (escaped) {
-      target.delete(pos);
-      return;
-    }
-    if (!hasRun) {
-      initRun(pos);
-      return;
-    }
-    coalesceSniff(pos);
-    if (processed == SNIFF_SIZE && shouldEscape()) {
-      enterEscape();
-    }
-  }
-
   /**
-   * Drains a boxed {@code Iterable<Long>} into {@code target}. Buffers into a small primitive slice
-   * and hands chunks to {@link #acceptAll(long[], int, int)}; keeps the sniff/escape state machine
-   * out of the inner loop. Package-private: external callers should construct the consumer directly
-   * and feed it via {@code acceptAll}.
+   * Drains a boxed {@code Iterable<Long>} into {@code target}, buffering into a primitive slice and
+   * forwarding chunks to {@link #acceptAll(long[], int, int)}.
    */
   public static void forEach(Iterable<Long> positions, PositionDeleteIndex target) {
     PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
@@ -166,12 +139,10 @@ public final class PositionDeleteRangeConsumer {
   }
 
   /**
-   * Drains all positions from {@code source} into {@code target} via the batched accumulator.
-   * Equivalent to {@code source.forEach(target::delete)} but coalesces consecutive runs into range
-   * inserts. Sources that emit in ascending order (such as {@code BitmapPositionDeleteIndex}, which
-   * iterates a Roaring bitmap) feed straight into the coalescing fast path; out-of-order sources
-   * still produce a correct result via the per-position fallback. Package-private: see the note on
-   * {@link #forEach(Iterable, PositionDeleteIndex)}.
+   * Drains all positions from {@code source} into {@code target}, coalescing consecutive runs into
+   * range inserts. Equivalent to {@code source.forEach(target::delete)} but cheaper for ascending
+   * sources (such as {@code BitmapPositionDeleteIndex}); out-of-order sources still produce a
+   * correct result via the per-position fallback.
    */
   public static void forEach(PositionDeleteIndex source, PositionDeleteIndex target) {
     if (source.isEmpty()) {

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
@@ -18,14 +18,19 @@
  */
 package org.apache.iceberg.deletes;
 
+import java.util.Objects;
+
 /**
  * Coalesces consecutive position deletes into range inserts on a {@link PositionDeleteIndex}.
  *
- * <p>The consumer is agnostic to input sortedness: callers can stream any {@code Iterable} or
- * {@code long[]} of positions and the API flushes them onto the target {@link PositionDeleteIndex}
- * without requiring a sorted contract. Monotone runs become a single range insert, which touches
- * fewer bitmap pages than a per-position {@code target.delete(pos)} loop; non-monotone input still
- * produces a correct index via an internal per-position fallback.
+ * <p>Position delete files are spec-sorted, but this consumer accepts any input ordering and still
+ * produces a correct index: callers can stream any {@code Iterable} or {@code long[]} of positions
+ * through this API. Out-of-order input is handled by an internal per-position fallback.
+ *
+ * <p>The coalescing benefit scales with monotone runs in the input. Each ascending run is emitted
+ * as a single range insert, which touches fewer bitmap pages than a per-position {@code
+ * target.delete(pos)} loop. A small sniff window measures gap density at the start of the stream
+ * and switches to the per-position path when coalescing would no longer pay for the bookkeeping.
  *
  * <p>External callers see three operations: construct with a target index, feed positions via
  * {@link #acceptAll(long[], int, int)} (one or more calls), and {@link #flush()} when done.
@@ -33,6 +38,11 @@ package org.apache.iceberg.deletes;
  * <p><b>Note:</b> this class is tied to the V2 position delete file lifecycle. Format-version 3
  * deletion vectors arrive pre-bitmap via {@link PositionDeleteIndex#deserialize} and bypass this
  * class entirely; this class can retire once V2 position delete files are no longer read.
+ *
+ * <p><b>API note:</b> cross-module helper used directly by {@code VectorizedPositionDeleteReader}
+ * in the {@code iceberg-arrow} module; the constructor + {@link #acceptAll} + {@link #flush} shape
+ * is not yet a stable public API and may evolve as the Arrow stack lands. The static {@code
+ * forEach} overloads remain package-private since all callers live in this package.
  */
 public final class PositionDeleteRangeConsumer {
 
@@ -53,7 +63,11 @@ public final class PositionDeleteRangeConsumer {
   /** The number of positions to sniff for boundary density. */
   private static final int SNIFF_SIZE = 256;
 
-  /** The threshold for boundary density at which to switch to the bulk path, as a percentage. */
+  /**
+   * Gap-density threshold for the sniff window, as a percentage. If more than this fraction of
+   * adjacent pairs in the first {@link #SNIFF_SIZE} positions are gaps, the consumer escapes
+   * coalescing for the rest of the stream and routes positions through the per-position fallback.
+   */
   private static final int BOUNDARY_THRESHOLD_PERCENT = 30;
 
   private final PositionDeleteIndex target;
@@ -79,7 +93,8 @@ public final class PositionDeleteRangeConsumer {
    * pending run across calls and only emits it on the next gap or on {@link #flush()}.
    */
   public void acceptAll(long[] positions, int from, int to) {
-    if (from >= to) {
+    Objects.checkFromToIndex(from, to, positions.length);
+    if (from == to) {
       return;
     }
 
@@ -169,8 +184,13 @@ public final class PositionDeleteRangeConsumer {
     consumer.flush();
   }
 
-  // cardinality() is a default method that throws when the impl does not implement it; treat
-  // "unknown" as "use the batched path" so we never regress on bitmap-backed sources.
+  /**
+   * Returns {@code true} when {@code source} is small enough that the per-position drain wins over
+   * the batched path's setup cost. {@link UnsupportedOperationException} from {@link
+   * PositionDeleteIndex#cardinality()} is part of the contract here: implementations that don't
+   * report cardinality are treated as "size unknown" and routed through the batched path, so
+   * bitmap-backed sources never regress to per-position dispatch.
+   */
   private static boolean isSmallSource(PositionDeleteIndex source) {
     try {
       return source.cardinality() <= SMALL_SOURCE_THRESHOLD;

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.deletes;
 
 import java.util.Objects;
+import java.util.PrimitiveIterator;
 
 /**
  * Coalesces consecutive position deletes into range inserts on a {@link PositionDeleteIndex}.
@@ -136,7 +137,7 @@ public final class PositionDeleteRangeConsumer {
    * Drains a boxed {@code Iterable<Long>} into {@code target}, buffering into a primitive slice and
    * forwarding chunks to {@link #acceptAll(long[], int, int)}.
    */
-  public static void forEach(Iterable<Long> positions, PositionDeleteIndex target) {
+  static void forEach(Iterable<Long> positions, PositionDeleteIndex target) {
     PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
     long[] buffer = new long[FOREACH_BATCH_SIZE];
     int filled = 0;
@@ -154,12 +155,35 @@ public final class PositionDeleteRangeConsumer {
   }
 
   /**
+   * Drains a {@link PrimitiveIterator.OfLong} into {@code target}, buffering into a primitive slice
+   * and forwarding chunks to {@link #acceptAll(long[], int, int)}. Equivalent to {@link
+   * #forEach(Iterable, PositionDeleteIndex)} but avoids autoboxing each position, which matters
+   * when the caller is itself unboxing from a {@code StructLike} accessor.
+   */
+  static void forEach(PrimitiveIterator.OfLong positions, PositionDeleteIndex target) {
+    PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
+    long[] buffer = new long[FOREACH_BATCH_SIZE];
+    int filled = 0;
+    while (positions.hasNext()) {
+      buffer[filled++] = positions.nextLong();
+      if (filled == FOREACH_BATCH_SIZE) {
+        consumer.acceptAll(buffer, 0, FOREACH_BATCH_SIZE);
+        filled = 0;
+      }
+    }
+    if (filled > 0) {
+      consumer.acceptAll(buffer, 0, filled);
+    }
+    consumer.flush();
+  }
+
+  /**
    * Drains all positions from {@code source} into {@code target}, coalescing consecutive runs into
    * range inserts. Equivalent to {@code source.forEach(target::delete)} but cheaper for ascending
    * sources (such as {@code BitmapPositionDeleteIndex}); out-of-order sources still produce a
    * correct result via the per-position fallback.
    */
-  public static void forEach(PositionDeleteIndex source, PositionDeleteIndex target) {
+  static void forEach(PositionDeleteIndex source, PositionDeleteIndex target) {
     if (source.isEmpty()) {
       return;
     }

--- a/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
@@ -77,6 +77,41 @@ public class TestBitmapPositionDeleteIndex {
   }
 
   @Test
+  public void testCreateReturnsEmptyMutableIndexWithoutProvenance() {
+    PositionDeleteIndex index = PositionDeleteIndex.create();
+    assertThat(index.isEmpty()).isTrue();
+    assertThat(index.cardinality()).isZero();
+    assertThat(index.deleteFiles()).isEmpty();
+
+    index.delete(5L);
+    index.delete(10L, 15L);
+    assertThat(index.isDeleted(5L)).isTrue();
+    assertThat(index.isDeleted(10L)).isTrue();
+    assertThat(index.isDeleted(14L)).isTrue();
+    assertThat(index.isDeleted(15L)).isFalse();
+    assertThat(index.cardinality()).isEqualTo(6L);
+  }
+
+  @Test
+  public void testCreateWithDeleteFileRecordsProvenance() {
+    DeleteFile source = mockDV(/* contentSize */ 0L, /* cardinality */ 0L);
+    PositionDeleteIndex index = PositionDeleteIndex.create(source);
+    assertThat(index.isEmpty()).isTrue();
+    assertThat(index.deleteFiles()).containsExactly(source);
+
+    index.delete(42L);
+    assertThat(index.isDeleted(42L)).isTrue();
+    assertThat(index.deleteFiles()).containsExactly(source);
+  }
+
+  @Test
+  public void testCreateWithNullDeleteFileHasNoProvenance() {
+    PositionDeleteIndex index = PositionDeleteIndex.create(null);
+    assertThat(index.isEmpty()).isTrue();
+    assertThat(index.deleteFiles()).isEmpty();
+  }
+
+  @Test
   public void testMergeBitmapIndexWithNonEmpty() {
     long pos1 = 10L; // Container 0 (high bits = 0)
     long pos2 = 1L << 33; // Container 1 (high bits = 1)

--- a/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
@@ -23,8 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.LongConsumer;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.io.Resources;
 import org.junit.jupiter.api.Test;
@@ -93,6 +96,63 @@ public class TestBitmapPositionDeleteIndex {
     // output must be sorted in ascending order across containers
     List<Long> positions = collect(index1);
     assertThat(positions).containsExactly(pos1, pos2, pos3, pos4);
+  }
+
+  @Test
+  public void testMergeNonBitmapSourcePropagatesPositionsAndDeleteFiles() {
+    DeleteFile sourceFile = Mockito.mock(DeleteFile.class);
+    long pos1 = 10L; // Container 0
+    long pos2 = 1L << 33; // Container 1
+    long pos3 = pos2 + 1; // Container 1, consecutive run with pos2
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    target.delete(5L);
+    PositionDeleteIndex nonBitmapSource =
+        new PositionDeleteIndex() {
+          @Override
+          public void delete(long position) {
+            throw new UnsupportedOperationException("test source is read-only");
+          }
+
+          @Override
+          public void delete(long posStart, long posEnd) {
+            throw new UnsupportedOperationException("test source is read-only");
+          }
+
+          @Override
+          public boolean isDeleted(long position) {
+            return position == pos1 || position == pos2 || position == pos3;
+          }
+
+          @Override
+          public boolean isEmpty() {
+            return false;
+          }
+
+          @Override
+          public void forEach(LongConsumer consumer) {
+            consumer.accept(pos1);
+            consumer.accept(pos2);
+            consumer.accept(pos3);
+          }
+
+          @Override
+          public long cardinality() {
+            return 3L;
+          }
+
+          @Override
+          public Collection<DeleteFile> deleteFiles() {
+            return ImmutableList.of(sourceFile);
+          }
+        };
+
+    target.merge(nonBitmapSource);
+
+    assertThat(collect(target)).containsExactly(5L, pos1, pos2, pos3);
+    assertThat(target.deleteFiles())
+        .as("non-bitmap merge should copy source deleteFiles into target")
+        .containsExactly(sourceFile);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/deletes/TestDeletesToPositionIndexes.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestDeletesToPositionIndexes.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.avro.util.Utf8;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.CharSequenceMap;
+import org.junit.jupiter.api.Test;
+
+public class TestDeletesToPositionIndexes {
+
+  @Test
+  public void emptyInputProducesEmptyMap() {
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(Lists.newArrayList()));
+    assertThat(indexes.keySet()).isEmpty();
+    assertThat(indexes.get("file_a.parquet")).isNull();
+  }
+
+  @Test
+  public void singlePathCoalescesContiguousRun() {
+    List<StructLike> deletes = Lists.newArrayList();
+    for (long pos = 0; pos < 1024; pos++) {
+      deletes.add(Row.of("file_a.parquet", pos));
+    }
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    assertThat(indexes.keySet()).hasSize(1);
+    PositionDeleteIndex index = indexes.get("file_a.parquet");
+    assertThat(index).as("index for file_a.parquet").isNotNull();
+    assertThat(index).isInstanceOf(BitmapPositionDeleteIndex.class);
+    for (long pos = 0; pos < 1024; pos++) {
+      assertThat(index.isDeleted(pos)).as("pos %s should be deleted", pos).isTrue();
+    }
+    assertThat(index.isDeleted(1024L)).isFalse();
+  }
+
+  @Test
+  public void multiplePathsBuildIndependentIndexes() {
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 0L),
+            Row.of("file_a.parquet", 1L),
+            Row.of("file_a.parquet", 5L),
+            Row.of(new Utf8("file_b.parquet"), 7L),
+            Row.of("file_b.parquet", 8L),
+            Row.of("file_b.parquet", 9L),
+            Row.of("file_c.parquet", 42L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    assertThat(indexes.keySet()).hasSize(3);
+
+    PositionDeleteIndex indexA = indexes.get("file_a.parquet");
+    assertThat(indexA).as("index for file_a.parquet").isNotNull();
+    assertThat(indexA.isDeleted(0L)).isTrue();
+    assertThat(indexA.isDeleted(1L)).isTrue();
+    assertThat(indexA.isDeleted(2L)).isFalse();
+    assertThat(indexA.isDeleted(5L)).isTrue();
+    assertThat(indexA.isDeleted(7L)).isFalse();
+
+    PositionDeleteIndex indexB = indexes.get("file_b.parquet");
+    assertThat(indexB).as("index for file_b.parquet").isNotNull();
+    assertThat(indexB.isDeleted(7L)).isTrue();
+    assertThat(indexB.isDeleted(8L)).isTrue();
+    assertThat(indexB.isDeleted(9L)).isTrue();
+    assertThat(indexB.isDeleted(10L)).isFalse();
+
+    PositionDeleteIndex indexC = indexes.get("file_c.parquet");
+    assertThat(indexC).as("index for file_c.parquet").isNotNull();
+    assertThat(indexC.isDeleted(42L)).isTrue();
+    assertThat(indexC.isDeleted(0L)).isFalse();
+  }
+
+  @Test
+  public void outOfOrderPathRevisitMergesIntoExistingIndex() {
+    // Unsorted input: same data file appears on either side of a different path. The implementation
+    // must still produce a single bitmap for file_a containing positions from both runs.
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 1L),
+            Row.of("file_a.parquet", 2L),
+            Row.of("file_b.parquet", 100L),
+            Row.of("file_a.parquet", 50L),
+            Row.of("file_a.parquet", 51L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    assertThat(indexes.keySet()).hasSize(2);
+
+    PositionDeleteIndex indexA = indexes.get("file_a.parquet");
+    assertThat(indexA).as("index for file_a.parquet").isNotNull();
+    assertThat(indexA.isDeleted(1L)).isTrue();
+    assertThat(indexA.isDeleted(2L)).isTrue();
+    assertThat(indexA.isDeleted(50L)).isTrue();
+    assertThat(indexA.isDeleted(51L)).isTrue();
+    assertThat(indexA.isDeleted(3L)).isFalse();
+
+    PositionDeleteIndex indexB = indexes.get("file_b.parquet");
+    assertThat(indexB).as("index for file_b.parquet").isNotNull();
+    assertThat(indexB.isDeleted(100L)).isTrue();
+    assertThat(indexB.isDeleted(1L)).isFalse();
+  }
+
+  @Test
+  public void mixedCharSequenceTypesShareIndex() {
+    // Adjacent records use Utf8 vs String for the same logical path. CharSequenceUtil treats them
+    // as equal, so they must accumulate into a single index without spuriously closing the group.
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 0L),
+            Row.of(new Utf8("file_a.parquet"), 1L),
+            Row.of("file_a.parquet", 2L),
+            Row.of(new Utf8("file_a.parquet"), 3L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    assertThat(indexes.keySet()).hasSize(1);
+    PositionDeleteIndex index = indexes.get("file_a.parquet");
+    assertThat(index.isDeleted(0L)).isTrue();
+    assertThat(index.isDeleted(1L)).isTrue();
+    assertThat(index.isDeleted(2L)).isTrue();
+    assertThat(index.isDeleted(3L)).isTrue();
+    assertThat(index.isDeleted(4L)).isFalse();
+  }
+
+  @Test
+  public void sparseSinglePathRecordsExactPositions() {
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 1L),
+            Row.of("file_a.parquet", 17L),
+            Row.of("file_a.parquet", 256L),
+            Row.of("file_a.parquet", 4096L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    PositionDeleteIndex index = indexes.get("file_a.parquet");
+    assertThat(index.isDeleted(0L)).isFalse();
+    assertThat(index.isDeleted(1L)).isTrue();
+    assertThat(index.isDeleted(2L)).isFalse();
+    assertThat(index.isDeleted(17L)).isTrue();
+    assertThat(index.isDeleted(256L)).isTrue();
+    assertThat(index.isDeleted(4096L)).isTrue();
+    assertThat(index.isDeleted(4097L)).isFalse();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/deletes/TestDeletesToPositionIndexes.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestDeletesToPositionIndexes.java
@@ -19,22 +19,27 @@
 package org.apache.iceberg.deletes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import org.apache.avro.util.Utf8;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.CharSequenceMap;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class TestDeletesToPositionIndexes {
 
   @Test
   public void emptyInputProducesEmptyMap() {
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(Lists.newArrayList()));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(Lists.newArrayList());
     assertThat(indexes.keySet()).isEmpty();
     assertThat(indexes.get("file_a.parquet")).isNull();
   }
@@ -46,8 +51,7 @@ public class TestDeletesToPositionIndexes {
       deletes.add(Row.of("file_a.parquet", pos));
     }
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     assertThat(indexes.keySet()).hasSize(1);
     PositionDeleteIndex index = indexes.get("file_a.parquet");
@@ -71,8 +75,7 @@ public class TestDeletesToPositionIndexes {
             Row.of("file_b.parquet", 9L),
             Row.of("file_c.parquet", 42L));
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     assertThat(indexes.keySet()).hasSize(3);
 
@@ -109,8 +112,7 @@ public class TestDeletesToPositionIndexes {
             Row.of("file_a.parquet", 50L),
             Row.of("file_a.parquet", 51L));
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     assertThat(indexes.keySet()).hasSize(2);
 
@@ -139,8 +141,7 @@ public class TestDeletesToPositionIndexes {
             Row.of("file_a.parquet", 2L),
             Row.of(new Utf8("file_a.parquet"), 3L));
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     assertThat(indexes.keySet()).hasSize(1);
     PositionDeleteIndex index = indexes.get("file_a.parquet");
@@ -160,8 +161,7 @@ public class TestDeletesToPositionIndexes {
             Row.of("file_a.parquet", 256L),
             Row.of("file_a.parquet", 4096L));
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     PositionDeleteIndex index = indexes.get("file_a.parquet");
     assertThat(index.isDeleted(0L)).isFalse();
@@ -171,5 +171,52 @@ public class TestDeletesToPositionIndexes {
     assertThat(index.isDeleted(256L)).isTrue();
     assertThat(index.isDeleted(4096L)).isTrue();
     assertThat(index.isDeleted(4097L)).isFalse();
+  }
+
+  @Test
+  public void deleteFilePropagatesToEachIndex() {
+    DeleteFile file = Mockito.mock(DeleteFile.class);
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 0L),
+            Row.of("file_a.parquet", 1L),
+            Row.of("file_b.parquet", 5L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes), file);
+
+    assertThat(indexes.keySet()).hasSize(2);
+    assertThat(indexes.get("file_a.parquet").deleteFiles())
+        .as("file_a should record its source delete file")
+        .containsExactly(file);
+    assertThat(indexes.get("file_b.parquet").deleteFiles())
+        .as("file_b should record its source delete file")
+        .containsExactly(file);
+  }
+
+  @Test
+  public void closeFailureSurfacesAsUncheckedIOException() {
+    List<StructLike> rows = Lists.newArrayList(Row.of("file_a.parquet", 0L));
+    CloseableIterable<StructLike> throwingOnClose =
+        new CloseableIterable<StructLike>() {
+          @Override
+          public void close() throws IOException {
+            throw new IOException("boom");
+          }
+
+          @Override
+          public CloseableIterator<StructLike> iterator() {
+            return CloseableIterator.withClose(rows.iterator());
+          }
+        };
+
+    assertThatThrownBy(() -> Deletes.toPositionIndexes(throwingOnClose))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessageContaining("Failed to close position delete source")
+        .hasCauseInstanceOf(IOException.class);
+  }
+
+  private static CharSequenceMap<PositionDeleteIndex> toIndexes(Iterable<StructLike> rows) {
+    return Deletes.toPositionIndexes(CloseableIterable.withNoopClose(rows));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionDeleteRangeConsumer.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionDeleteRangeConsumer.java
@@ -1,0 +1,695 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class TestPositionDeleteRangeConsumer {
+
+  @Test
+  void emptyInput() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(Collections.<Long>emptyList(), index);
+    assertThat(index.isEmpty()).isTrue();
+  }
+
+  @Test
+  void singlePosition() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(42L), index);
+
+    assertThat(index.isDeleted(42)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(1);
+  }
+
+  @Test
+  void consecutivePositionsCoalesced() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(10L, 11L, 12L, 13L, 14L), index);
+
+    for (long pos = 10; pos <= 14; pos++) {
+      assertThat(index.isDeleted(pos)).isTrue();
+    }
+
+    assertThat(index.isDeleted(9)).isFalse();
+    assertThat(index.isDeleted(15)).isFalse();
+    assertThat(index.cardinality()).isEqualTo(5);
+  }
+
+  @Test
+  void multipleDisjointRanges() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(3L, 4L, 5L, 10L, 11L, 100L), index);
+
+    assertThat(index.isDeleted(3)).isTrue();
+    assertThat(index.isDeleted(4)).isTrue();
+    assertThat(index.isDeleted(5)).isTrue();
+    assertThat(index.isDeleted(6)).isFalse();
+    assertThat(index.isDeleted(10)).isTrue();
+    assertThat(index.isDeleted(11)).isTrue();
+    assertThat(index.isDeleted(12)).isFalse();
+    assertThat(index.isDeleted(100)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(6);
+  }
+
+  @Test
+  void unsortedInputProducesCorrectResult() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(50L, 10L, 11L, 12L, 1L, 2L, 3L), index);
+
+    assertThat(index.isDeleted(50)).isTrue();
+    assertThat(index.isDeleted(10)).isTrue();
+    assertThat(index.isDeleted(11)).isTrue();
+    assertThat(index.isDeleted(12)).isTrue();
+    assertThat(index.isDeleted(1)).isTrue();
+    assertThat(index.isDeleted(2)).isTrue();
+    assertThat(index.isDeleted(3)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(7);
+  }
+
+  @Test
+  void duplicatePositions() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(5L, 5L, 6L, 6L), index);
+
+    assertThat(index.isDeleted(5)).isTrue();
+    assertThat(index.isDeleted(6)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(2);
+  }
+
+  @Test
+  void largeConsecutiveRange() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    int rangeSize = 100_000;
+    long[] positions = new long[rangeSize];
+    for (int i = 0; i < rangeSize; i++) {
+      positions[i] = i;
+    }
+
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(rangeSize);
+    assertThat(index.isDeleted(0)).isTrue();
+    assertThat(index.isDeleted(rangeSize - 1)).isTrue();
+    assertThat(index.isDeleted(rangeSize)).isFalse();
+  }
+
+  @Test
+  void positionZero() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(0L, 1L, 2L), index);
+
+    assertThat(index.isDeleted(0)).isTrue();
+    assertThat(index.isDeleted(1)).isTrue();
+    assertThat(index.isDeleted(2)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(3);
+  }
+
+  @Test
+  void alternatingPositionsNoCoalescing() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(0L, 2L, 4L, 6L), index);
+
+    assertThat(index.isDeleted(0)).isTrue();
+    assertThat(index.isDeleted(1)).isFalse();
+    assertThat(index.isDeleted(2)).isTrue();
+    assertThat(index.isDeleted(3)).isFalse();
+    assertThat(index.isDeleted(4)).isTrue();
+    assertThat(index.isDeleted(5)).isFalse();
+    assertThat(index.isDeleted(6)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(4);
+  }
+
+  @Test
+  void largeSparseInputTakesNaivePath() {
+    // 4096 alternating positions -- sniff sees 100% boundaries on the 256-long prefix and
+    // dispatches to the naive path. The result must still be identical to coalescing.
+    int count = 4096;
+    long[] positions = new long[count];
+    for (int i = 0; i < count; i++) {
+      positions[i] = i * 2L;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(count);
+    for (int i = 0; i < count; i++) {
+      assertThat(index.isDeleted(positions[i])).isTrue();
+      assertThat(index.isDeleted(positions[i] + 1)).isFalse();
+    }
+  }
+
+  @Test
+  void sparsePrefixWithDenseTail() {
+    // First 512 positions alternate, then 2048 consecutive positions. The sniff sees a sparse
+    // prefix and picks the naive path; the dense tail is still emitted correctly.
+    int prefixCount = 512;
+    int tailCount = 2048;
+    long[] positions = new long[prefixCount + tailCount];
+    for (int i = 0; i < prefixCount; i++) {
+      positions[i] = i * 2L;
+    }
+
+    long tailStart = 10_000L;
+    for (int i = 0; i < tailCount; i++) {
+      positions[prefixCount + i] = tailStart + i;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(prefixCount + tailCount);
+    for (int i = 0; i < prefixCount; i++) {
+      assertThat(index.isDeleted(positions[i])).isTrue();
+    }
+
+    for (int i = 0; i < tailCount; i++) {
+      assertThat(index.isDeleted(tailStart + i)).isTrue();
+    }
+
+    assertThat(index.isDeleted(tailStart + tailCount)).isFalse();
+  }
+
+  @Test
+  void densePrefixWithSparseTail() {
+    // First 512 positions are contiguous, then 2048 alternating. The sniff sees a dense prefix
+    // and picks the coalesce path; the sparse tail is still emitted correctly.
+    int prefixCount = 512;
+    int tailCount = 2048;
+    long[] positions = new long[prefixCount + tailCount];
+    for (int i = 0; i < prefixCount; i++) {
+      positions[i] = i;
+    }
+
+    long tailStart = 10_000L;
+    for (int i = 0; i < tailCount; i++) {
+      positions[prefixCount + i] = tailStart + i * 2L;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(prefixCount + tailCount);
+    for (int i = 0; i < prefixCount; i++) {
+      assertThat(index.isDeleted(i)).isTrue();
+    }
+
+    for (int i = 0; i < tailCount; i++) {
+      assertThat(index.isDeleted(tailStart + i * 2L)).isTrue();
+      assertThat(index.isDeleted(tailStart + i * 2L + 1)).isFalse();
+    }
+  }
+
+  @Test
+  void lengthAtExactSniffBoundary() {
+    // Input length matches the sniff window exactly: the prefix fills, the sniff runs, and the
+    // streaming tail loop never executes. Both dispatch decisions must produce correct output.
+    int count = 256;
+    long[] dense = new long[count];
+    long[] sparse = new long[count];
+    for (int i = 0; i < count; i++) {
+      dense[i] = i;
+      sparse[i] = i * 2L;
+    }
+
+    BitmapPositionDeleteIndex denseIndex = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(dense), denseIndex);
+    assertThat(denseIndex.cardinality()).isEqualTo(count);
+    assertThat(denseIndex.isDeleted(0)).isTrue();
+    assertThat(denseIndex.isDeleted(count - 1)).isTrue();
+
+    BitmapPositionDeleteIndex sparseIndex = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(sparse), sparseIndex);
+    assertThat(sparseIndex.cardinality()).isEqualTo(count);
+    for (int i = 0; i < count; i++) {
+      assertThat(sparseIndex.isDeleted(i * 2L)).isTrue();
+    }
+  }
+
+  @Test
+  void smallAdversarialInputSkipsSniff() {
+    // Alternating input shorter than the sniff window -- the prefix never fills, so the sniff
+    // is skipped and we coalesce directly. Verifies correctness on the small-list fast path.
+    int count = 100;
+    long[] positions = new long[count];
+    for (int i = 0; i < count; i++) {
+      positions[i] = i * 2L;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(count);
+    for (int i = 0; i < count; i++) {
+      assertThat(index.isDeleted(i * 2L)).isTrue();
+      assertThat(index.isDeleted(i * 2L + 1)).isFalse();
+    }
+  }
+
+  @Test
+  void accumulatorRejectsNullTarget() {
+    assertThatThrownBy(() -> new PositionDeleteRangeConsumer(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid target index");
+  }
+
+  @Test
+  void accumulatorEmitsSinglePositionOnFlush() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.accept(42L);
+    acc.flush();
+
+    assertThat(index.isDeleted(42L)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(1);
+  }
+
+  @Test
+  void accumulatorCoalescesConsecutivePositions() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    for (long pos = 10L; pos <= 14L; pos++) {
+      acc.accept(pos);
+    }
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(5);
+    assertThat(index.isDeleted(9L)).isFalse();
+    assertThat(index.isDeleted(15L)).isFalse();
+  }
+
+  @Test
+  void accumulatorBreaksRunOnGap() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.accept(10L);
+    acc.accept(11L);
+    acc.accept(20L);
+    acc.accept(21L);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(4);
+    assertThat(index.isDeleted(12L)).isFalse();
+    assertThat(index.isDeleted(19L)).isFalse();
+  }
+
+  @Test
+  void accumulatorFlushAllowsContinuationWithoutCoalescing() {
+    // Explicit flush mid-stream emulates a logical boundary (e.g. a path change in a multi-file
+    // delete file). The next accept must not be coalesced with the just-emitted run even when
+    // its position is consecutive with the previous one.
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.accept(10L);
+    acc.accept(11L);
+    acc.flush();
+    acc.accept(12L);
+    acc.accept(13L);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(4);
+    assertThat(index.isDeleted(10L)).isTrue();
+    assertThat(index.isDeleted(13L)).isTrue();
+  }
+
+  @Test
+  void doubleFlushIsNoOp() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.accept(7L);
+    acc.flush();
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(1);
+    assertThat(index.isDeleted(7L)).isTrue();
+  }
+
+  @Test
+  void escapedAccumulatorIgnoresFlush() {
+    // Drive the accumulator into escape mode with a fully-alternating prefix, then flush after
+    // every accept. The result must be identical to the per-position path -- no coalescing
+    // across or within flushes.
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    int sniff = 256;
+    for (int i = 0; i < sniff; i++) {
+      acc.accept(i * 2L);
+    }
+
+    // After the sniff window is full and >30% boundaries observed, the accumulator escapes.
+    // Subsequent accepts go through the per-position path, and flush should be a no-op.
+    acc.accept(10_000L);
+    acc.flush();
+    acc.accept(10_001L);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(sniff + 2);
+    for (int i = 0; i < sniff; i++) {
+      assertThat(index.isDeleted(i * 2L)).isTrue();
+    }
+    assertThat(index.isDeleted(10_000L)).isTrue();
+    assertThat(index.isDeleted(10_001L)).isTrue();
+  }
+
+  @Test
+  void acceptAllRejectsNullArray() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    assertThatThrownBy(() -> acc.acceptAll(null, 0, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid positions array");
+  }
+
+  @Test
+  void acceptAllValidatesIndexes() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    long[] positions = {1L, 2L, 3L};
+    assertThatThrownBy(() -> acc.acceptAll(positions, 0, 4))
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessageContaining("end index (4)");
+    assertThatThrownBy(() -> acc.acceptAll(positions, 2, 1))
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessageContaining("end index (1)");
+  }
+
+  @Test
+  void acceptAllEmptyRangeIsNoOp() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.acceptAll(new long[] {1L, 2L, 3L}, 1, 1);
+    acc.flush();
+    assertThat(index.isEmpty()).isTrue();
+  }
+
+  @Test
+  void acceptAllCoalescesContiguousRange() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    long[] positions = {10L, 11L, 12L, 13L, 14L};
+    acc.acceptAll(positions, 0, positions.length);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(5);
+    assertThat(index.isDeleted(9L)).isFalse();
+    assertThat(index.isDeleted(15L)).isFalse();
+  }
+
+  @Test
+  void acceptAllHandlesMultipleDisjointRanges() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    long[] positions = {3L, 4L, 5L, 10L, 11L, 100L};
+    acc.acceptAll(positions, 0, positions.length);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(6);
+    for (long p : positions) {
+      assertThat(index.isDeleted(p)).isTrue();
+    }
+    assertThat(index.isDeleted(6L)).isFalse();
+    assertThat(index.isDeleted(12L)).isFalse();
+  }
+
+  @Test
+  void acceptAllHonoursFromAndTo() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    long[] positions = {1L, 2L, 100L, 101L, 999L};
+    acc.acceptAll(positions, 2, 4);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(2);
+    assertThat(index.isDeleted(100L)).isTrue();
+    assertThat(index.isDeleted(101L)).isTrue();
+    assertThat(index.isDeleted(1L)).isFalse();
+    assertThat(index.isDeleted(999L)).isFalse();
+  }
+
+  @Test
+  void acceptAllChunksProduceSameResultAsSingleCall() {
+    int rangeSize = 10_000;
+    long[] positions = new long[rangeSize];
+    for (int i = 0; i < rangeSize; i++) {
+      positions[i] = i;
+    }
+
+    BitmapPositionDeleteIndex bulkIndex = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer bulk = new PositionDeleteRangeConsumer(bulkIndex);
+    bulk.acceptAll(positions, 0, rangeSize);
+    bulk.flush();
+
+    BitmapPositionDeleteIndex chunkedIndex = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer chunked = new PositionDeleteRangeConsumer(chunkedIndex);
+    int chunk = 137;
+    int cursor = 0;
+    while (cursor < rangeSize) {
+      int end = Math.min(rangeSize, cursor + chunk);
+      chunked.acceptAll(positions, cursor, end);
+      cursor = end;
+    }
+    chunked.flush();
+
+    assertThat(chunkedIndex.cardinality()).isEqualTo(bulkIndex.cardinality());
+    for (long p : positions) {
+      assertThat(chunkedIndex.isDeleted(p)).isTrue();
+    }
+  }
+
+  @Test
+  void acceptAllAndAcceptInterleaveCorrectly() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.acceptAll(new long[] {10L, 11L}, 0, 2);
+    acc.accept(12L);
+    acc.acceptAll(new long[] {13L, 14L, 20L}, 0, 3);
+    acc.accept(21L);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(7);
+    for (long p : new long[] {10L, 11L, 12L, 13L, 14L, 20L, 21L}) {
+      assertThat(index.isDeleted(p)).isTrue();
+    }
+  }
+
+  @Test
+  void acceptAllDispatchesToEscapedPath() {
+    int sniff = 256;
+    int total = 4096;
+    long[] positions = new long[total];
+    for (int i = 0; i < total; i++) {
+      positions[i] = i * 2L;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.acceptAll(positions, 0, total);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(total);
+    for (int i = 0; i < total; i++) {
+      assertThat(index.isDeleted(i * 2L)).isTrue();
+      assertThat(index.isDeleted(i * 2L + 1)).isFalse();
+    }
+    // Unused: silences an unused-variable warning if sniff size assumptions ever change.
+    assertThat(sniff).isLessThan(total);
+  }
+
+  @Test
+  void forEachIndexEmptySourceLeavesTargetUntouched() {
+    BitmapPositionDeleteIndex source = new BitmapPositionDeleteIndex();
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    target.delete(99L);
+
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(1);
+    assertThat(target.isDeleted(99L)).isTrue();
+  }
+
+  @Test
+  void forEachIndexBitmapSourceCoalescesRuns() {
+    BitmapPositionDeleteIndex source = new BitmapPositionDeleteIndex();
+    for (long p = 10; p <= 14; p++) {
+      source.delete(p);
+    }
+    source.delete(100L);
+    source.delete(101L);
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(source.cardinality());
+    for (long p = 10; p <= 14; p++) {
+      assertThat(target.isDeleted(p)).isTrue();
+    }
+    assertThat(target.isDeleted(100L)).isTrue();
+    assertThat(target.isDeleted(101L)).isTrue();
+    assertThat(target.isDeleted(9L)).isFalse();
+    assertThat(target.isDeleted(15L)).isFalse();
+  }
+
+  @Test
+  void forEachIndexSmallSourceShortCircuitsToPerPosition() {
+    BitmapPositionDeleteIndex source = new BitmapPositionDeleteIndex();
+    long[] positions = {1L, 2L, 3L, 5L};
+    for (long p : positions) {
+      source.delete(p);
+    }
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(positions.length);
+    for (long p : positions) {
+      assertThat(target.isDeleted(p)).isTrue();
+    }
+  }
+
+  @Test
+  void forEachIndexCardinalityUnknownStillCorrect() {
+    BitmapPositionDeleteIndex backing = new BitmapPositionDeleteIndex();
+    long[] positions = {7L, 8L, 9L, 100L};
+    for (long p : positions) {
+      backing.delete(p);
+    }
+    // Wrap so cardinality() throws -- forces the batched path even though the source is tiny.
+    PositionDeleteIndex source = forwardingWithoutCardinality(backing);
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(positions.length);
+    for (long p : positions) {
+      assertThat(target.isDeleted(p)).isTrue();
+    }
+  }
+
+  @Test
+  void forEachIndexNonBitmapSourceTakesFallbackPath() {
+    BitmapPositionDeleteIndex backing = new BitmapPositionDeleteIndex();
+    for (long p = 1; p <= 5; p++) {
+      backing.delete(p);
+    }
+    backing.delete(42L);
+    PositionDeleteIndex source = forwarding(backing);
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(6);
+    for (long p = 1; p <= 5; p++) {
+      assertThat(target.isDeleted(p)).isTrue();
+    }
+    assertThat(target.isDeleted(42L)).isTrue();
+  }
+
+  @Test
+  void forEachIndexExceedsBatchSize() {
+    BitmapPositionDeleteIndex source = new BitmapPositionDeleteIndex();
+    int total = 1_024; // > FOREACH_BATCH_SIZE = 64
+    for (long p = 0; p < total; p++) {
+      source.delete(p);
+    }
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(total);
+    assertThat(target.isDeleted(0L)).isTrue();
+    assertThat(target.isDeleted(total - 1L)).isTrue();
+    assertThat(target.isDeleted((long) total)).isFalse();
+  }
+
+  private static PositionDeleteIndex forwarding(PositionDeleteIndex backing) {
+    return new PositionDeleteIndex() {
+      @Override
+      public void delete(long position) {
+        backing.delete(position);
+      }
+
+      @Override
+      public void delete(long posStart, long posEnd) {
+        backing.delete(posStart, posEnd);
+      }
+
+      @Override
+      public boolean isDeleted(long position) {
+        return backing.isDeleted(position);
+      }
+
+      @Override
+      public boolean isEmpty() {
+        return backing.isEmpty();
+      }
+
+      @Override
+      public void forEach(java.util.function.LongConsumer consumer) {
+        backing.forEach(consumer);
+      }
+
+      @Override
+      public long cardinality() {
+        return backing.cardinality();
+      }
+    };
+  }
+
+  private static PositionDeleteIndex forwardingWithoutCardinality(PositionDeleteIndex backing) {
+    return new PositionDeleteIndex() {
+      @Override
+      public void delete(long position) {
+        backing.delete(position);
+      }
+
+      @Override
+      public void delete(long posStart, long posEnd) {
+        backing.delete(posStart, posEnd);
+      }
+
+      @Override
+      public boolean isDeleted(long position) {
+        return backing.isDeleted(position);
+      }
+
+      @Override
+      public boolean isEmpty() {
+        return backing.isEmpty();
+      }
+
+      @Override
+      public void forEach(java.util.function.LongConsumer consumer) {
+        backing.forEach(consumer);
+      }
+      // Intentionally does not override cardinality(); inherits the default that throws.
+    };
+  }
+
+  private static List<Long> asList(long... positions) {
+    return Arrays.stream(positions).boxed().collect(Collectors.toList());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionDeleteRangeConsumer.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionDeleteRangeConsumer.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.deletes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -271,17 +270,10 @@ class TestPositionDeleteRangeConsumer {
   }
 
   @Test
-  void accumulatorRejectsNullTarget() {
-    assertThatThrownBy(() -> new PositionDeleteRangeConsumer(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid target index");
-  }
-
-  @Test
   void accumulatorEmitsSinglePositionOnFlush() {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    acc.accept(42L);
+    feed(acc, 42L);
     acc.flush();
 
     assertThat(index.isDeleted(42L)).isTrue();
@@ -293,7 +285,7 @@ class TestPositionDeleteRangeConsumer {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
     for (long pos = 10L; pos <= 14L; pos++) {
-      acc.accept(pos);
+      feed(acc, pos);
     }
     acc.flush();
 
@@ -306,10 +298,10 @@ class TestPositionDeleteRangeConsumer {
   void accumulatorBreaksRunOnGap() {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    acc.accept(10L);
-    acc.accept(11L);
-    acc.accept(20L);
-    acc.accept(21L);
+    feed(acc, 10L);
+    feed(acc, 11L);
+    feed(acc, 20L);
+    feed(acc, 21L);
     acc.flush();
 
     assertThat(index.cardinality()).isEqualTo(4);
@@ -324,11 +316,11 @@ class TestPositionDeleteRangeConsumer {
     // its position is consecutive with the previous one.
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    acc.accept(10L);
-    acc.accept(11L);
+    feed(acc, 10L);
+    feed(acc, 11L);
     acc.flush();
-    acc.accept(12L);
-    acc.accept(13L);
+    feed(acc, 12L);
+    feed(acc, 13L);
     acc.flush();
 
     assertThat(index.cardinality()).isEqualTo(4);
@@ -340,7 +332,7 @@ class TestPositionDeleteRangeConsumer {
   void doubleFlushIsNoOp() {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    acc.accept(7L);
+    feed(acc, 7L);
     acc.flush();
     acc.flush();
 
@@ -357,14 +349,14 @@ class TestPositionDeleteRangeConsumer {
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
     int sniff = 256;
     for (int i = 0; i < sniff; i++) {
-      acc.accept(i * 2L);
+      feed(acc, i * 2L);
     }
 
     // After the sniff window is full and >30% boundaries observed, the accumulator escapes.
     // Subsequent accepts go through the per-position path, and flush should be a no-op.
-    acc.accept(10_000L);
+    feed(acc, 10_000L);
     acc.flush();
-    acc.accept(10_001L);
+    feed(acc, 10_001L);
     acc.flush();
 
     assertThat(index.cardinality()).isEqualTo(sniff + 2);
@@ -373,28 +365,6 @@ class TestPositionDeleteRangeConsumer {
     }
     assertThat(index.isDeleted(10_000L)).isTrue();
     assertThat(index.isDeleted(10_001L)).isTrue();
-  }
-
-  @Test
-  void acceptAllRejectsNullArray() {
-    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
-    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    assertThatThrownBy(() -> acc.acceptAll(null, 0, 0))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid positions array");
-  }
-
-  @Test
-  void acceptAllValidatesIndexes() {
-    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
-    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    long[] positions = {1L, 2L, 3L};
-    assertThatThrownBy(() -> acc.acceptAll(positions, 0, 4))
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessageContaining("end index (4)");
-    assertThatThrownBy(() -> acc.acceptAll(positions, 2, 1))
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessageContaining("end index (1)");
   }
 
   @Test
@@ -481,13 +451,13 @@ class TestPositionDeleteRangeConsumer {
   }
 
   @Test
-  void acceptAllAndAcceptInterleaveCorrectly() {
+  void acceptAllPersistsStateAcrossMixedSliceSizes() {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
     acc.acceptAll(new long[] {10L, 11L}, 0, 2);
-    acc.accept(12L);
+    acc.acceptAll(new long[] {12L}, 0, 1);
     acc.acceptAll(new long[] {13L, 14L, 20L}, 0, 3);
-    acc.accept(21L);
+    acc.acceptAll(new long[] {21L}, 0, 1);
     acc.flush();
 
     assertThat(index.cardinality()).isEqualTo(7);
@@ -691,5 +661,12 @@ class TestPositionDeleteRangeConsumer {
 
   private static List<Long> asList(long... positions) {
     return Arrays.stream(positions).boxed().collect(Collectors.toList());
+  }
+
+  // Feed one position through the only production entry point. Tests previously called the
+  // removed per-element accept(long); routing through acceptAll keeps the per-position semantics
+  // intact (sniff window, escape decision, run extension) while exercising the real API.
+  private static void feed(PositionDeleteRangeConsumer acc, long pos) {
+    acc.acceptAll(new long[] {pos}, 0, 1);
   }
 }


### PR DESCRIPTION
Add `PositionDeleteRangeConsumer`, a stateless utility that processs consecutive positions into a single `PositionDeleteIndex.delete(start, end)` call instead of one `delete(pos)` per position. 

This primarily benefits Iceberg V2 tables; V3 deletion vectors are loaded as a serialised RoaringBitmap and bypass this path.

To avoid overhead on inputs with no runs, the consumer sniffs the first `SNIFF_SIZE = 256` positions and counts boundaries (pairs where `pos[i] - pos[i-1] != 1`). Above `BOUNDARY_THRESHOLD_PERCENT = 30`, the remaining stream use a per-position loop equivalent to the original behavior.

| Scenario             | Baseline (ms) | Consumer (ms) | Speedup |
|----------------------|--------------:|--------------:|--------:|
| FULL (contiguous)    |         75.83 |         12.15 |   6.24x |
| MEDIUM (~64 + gap)   |         77.44 |         14.88 |   5.20x |
| SHORT (~4 + gap)     |         77.04 |         54.45 |   1.41x |
| SPARSE_95 (95%)      |         76.72 |         25.91 |   2.96x |
| SPARSE_50 (50%)      |         77.75 |         78.93 |   0.98x |
| SPARSE_5 (5%)        |         84.31 |         86.13 |   0.98x |
| NONE (step=2)        |         77.29 |         78.55 |   0.98x |

> Each iteration inserts 5M positions into a fresh BitmapPositionDeleteIndex; 4 back-to-back passes of (30 warmup + 51 measured iterations) in the same JVM; numbers are the average minimum-of-runs across passes 2-4.