### PR TITLE
GCS, S3, ADLS: Handle EOF in inputStreams

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -42,6 +42,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 @Testcontainers
 public class TestS3InputStream {
   @Container private static final MinIOContainer MINIO = MinioUtil.createContainer();
+  private static final int EOF = -1;
 
   private final S3Client s3 = MinioUtil.createS3Client(MINIO);
   private final Random random = new Random(1);
@@ -89,6 +90,41 @@ public class TestS3InputStream {
       // Backseek and read
       readAndCheck(in, 0, readSize, data, true);
       readAndCheck(in, 0, readSize, data, false);
+    }
+  }
+
+  @Test
+  public void testReadSingle() throws Exception {
+    S3URI uri = new S3URI("s3://bucket/path/to/read.dat");
+    int i0 = 1;
+    int i1 = 255;
+    byte[] data = {(byte) i0, (byte) i1};
+
+    writeS3Data(uri, data);
+
+    try (SeekableInputStream in = newInputStream(s3, uri)) {
+      assertThat(in.read()).isEqualTo(i0);
+      assertThat(in.read()).isEqualTo(i1);
+      assertThat(in.read()).isEqualTo(EOF);
+    }
+  }
+
+  @Test
+  public void testReadBufferedEOF() throws Exception {
+    S3URI uri = new S3URI("s3://bucket/path/to/read.dat");
+    int dataSize = 8;
+    byte[] expected = randomData(dataSize);
+    byte[] actual = new byte[dataSize + 1];
+
+    writeS3Data(uri, expected);
+
+    try (SeekableInputStream in = newInputStream(s3, uri)) {
+      int bytesRead = in.read(actual, 0, dataSize + 1);
+      assertThat(bytesRead).isEqualTo(dataSize);
+      assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(expected);
+
+      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF);
+      assertThat(in.getPos()).isEqualTo(dataSize);
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -122,6 +122,10 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
     positionStream();
     try {
       int bytesRead = Failsafe.with(retryPolicy).get(() -> stream.read());
+      if (bytesRead == -1) {
+        return -1;
+      }
+
       pos += 1;
       next += 1;
       readBytes.increment();
@@ -144,6 +148,10 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
 
     try {
       int bytesRead = Failsafe.with(retryPolicy).get(() -> stream.read(b, off, len));
+      if (bytesRead == -1) {
+        return -1;
+      }
+
       pos += bytesRead;
       next += bytesRead;
       readBytes.increment(bytesRead);

--- a/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
+++ b/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
@@ -119,7 +119,8 @@ public class TestADLSInputStream extends AzuriteTestBase {
       assertThat(bytesRead).isEqualTo(dataSize);
       assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(expected);
 
-      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF);
+      // Pos is in the end of data, any read should EOF
+      assertThat(in.read(actual, 0, actual.length)).isEqualTo(EOF);
       assertThat(in.getPos()).isEqualTo(dataSize);
     }
   }

--- a/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
+++ b/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 public class TestADLSInputStream extends AzuriteTestBase {
 
   private static final String FILE_PATH = "path/to/file";
+  private static final int EOF = -1;
 
   private final Random random = new Random(1);
   private final AzureProperties azureProperties = new AzureProperties();
@@ -99,6 +100,27 @@ public class TestADLSInputStream extends AzuriteTestBase {
             location(), fileClient(), null, azureProperties, MetricsContext.nullMetrics())) {
       assertThat(in.read()).isEqualTo(i0);
       assertThat(in.read()).isEqualTo(i1);
+      assertThat(in.read()).isEqualTo(EOF);
+    }
+  }
+
+  @Test
+  public void testReadBufferedEOF() throws Exception {
+    int dataSize = 8;
+    byte[] expected = randomData(dataSize);
+    byte[] actual = new byte[dataSize + 1];
+
+    setupData(expected);
+
+    try (SeekableInputStream in =
+        new ADLSInputStream(
+            location(), fileClient(), null, azureProperties, MetricsContext.nullMetrics())) {
+      int bytesRead = in.read(actual, 0, dataSize + 1);
+      assertThat(bytesRead).isEqualTo(dataSize);
+      assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(expected);
+
+      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF);
+      assertThat(in.getPos()).isEqualTo(dataSize);
     }
   }
 

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSInputStream.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSInputStream.java
@@ -114,12 +114,17 @@ class ADLSInputStream extends SeekableInputStream implements RangeReadable {
     Preconditions.checkState(!closed, "Cannot read: already closed");
     positionStream();
 
+    int bytesRead = stream.read();
+    if (bytesRead == -1) {
+      return -1;
+    }
+
     pos += 1;
     next += 1;
     readBytes.increment();
     readOperations.increment();
 
-    return stream.read();
+    return bytesRead;
   }
 
   @Override
@@ -128,6 +133,10 @@ class ADLSInputStream extends SeekableInputStream implements RangeReadable {
     positionStream();
 
     int bytesRead = stream.read(b, off, len);
+    if (bytesRead == -1) {
+      return -1;
+    }
+
     pos += bytesRead;
     next += bytesRead;
     readBytes.increment(bytesRead);

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.azure.adlsv2;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -25,8 +26,11 @@ import static org.mockito.Mockito.when;
 
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.implementation.models.InternalDataLakeFileOpenInputStreamResult;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TestADLSInputStream {
+  private static final int EOF = -1;
 
   @Mock private DataLakeFileClient fileClient;
   @Mock private InputStream inputStream;
@@ -52,7 +57,57 @@ class TestADLSInputStream {
             fileClient,
             0L,
             mock(),
-            mock());
+            MetricsContext.nullMetrics());
+  }
+
+  @Test
+  void testReadSingle() throws IOException {
+    int i0 = 1;
+    int i1 = 255;
+    byte[] data = {(byte) i0, (byte) i1};
+    InputStream byteStream = new ByteArrayInputStream(data);
+    InternalDataLakeFileOpenInputStreamResult openInputStreamResult =
+        new InternalDataLakeFileOpenInputStreamResult(byteStream, mock());
+    when(fileClient.openInputStream(any())).thenReturn(openInputStreamResult);
+
+    try (ADLSInputStream in =
+        new ADLSInputStream(
+            "abfs://container@account.dfs.core.windows.net/path/to/file",
+            fileClient,
+            2L,
+            mock(),
+            MetricsContext.nullMetrics())) {
+
+      assertThat(in.read()).isEqualTo(i0);
+      assertThat(in.read()).isEqualTo(i1);
+      assertThat(in.read()).isEqualTo(EOF);
+    }
+  }
+
+  @Test
+  void testReadBufferedEOF() throws IOException {
+    byte[] data = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+    InputStream byteStream = new ByteArrayInputStream(data);
+    InternalDataLakeFileOpenInputStreamResult openInputStreamResult =
+        new InternalDataLakeFileOpenInputStreamResult(byteStream, mock());
+    when(fileClient.openInputStream(any())).thenReturn(openInputStreamResult);
+
+    try (ADLSInputStream in =
+        new ADLSInputStream(
+            "abfs://container@account.dfs.core.windows.net/path/to/file",
+            fileClient,
+            8L,
+            mock(),
+            MetricsContext.nullMetrics())) {
+
+      byte[] actual = new byte[10];
+      int bytesRead = in.read(actual, 0, 10);
+      assertThat(bytesRead).isEqualTo(8);
+      assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(data);
+
+      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF);
+      assertThat(in.getPos()).isEqualTo(8);
+    }
   }
 
   @Test

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -126,13 +126,19 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
     Preconditions.checkState(!closed, "Cannot read: already closed");
     singleByteBuffer.position(0);
 
-    pos += 1;
+    int bytesRead;
     try {
-      channel.read(singleByteBuffer);
+      bytesRead = channel.read(singleByteBuffer);
     } catch (IOException e) {
       GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
       throw e;
     }
+
+    if (bytesRead == -1) {
+      return -1;
+    }
+
+    pos += 1;
     readBytes.increment();
     readOperations.increment();
 
@@ -144,6 +150,10 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
     Preconditions.checkState(!closed, "Cannot read: already closed");
     byteBuffer = byteBuffer != null && byteBuffer.array() == b ? byteBuffer : ByteBuffer.wrap(b);
     int bytesRead = read(channel, byteBuffer, off, len);
+    if (bytesRead == -1) {
+      return -1;
+    }
+
     pos += bytesRead;
     readBytes.increment(bytesRead);
     readOperations.increment();

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -126,23 +126,21 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
     Preconditions.checkState(!closed, "Cannot read: already closed");
     singleByteBuffer.position(0);
 
-    int bytesRead;
     try {
-      bytesRead = channel.read(singleByteBuffer);
+      int bytesRead = channel.read(singleByteBuffer);
+      if (bytesRead == -1) {
+        return -1;
+      }
+
+      pos += 1;
+      readBytes.increment();
+      readOperations.increment();
+
+      return singleByteBuffer.array()[0] & 0xFF;
     } catch (IOException e) {
       GCSExceptionUtil.throwNotFoundIfNotPresent(e, blobId);
       throw e;
     }
-
-    if (bytesRead == -1) {
-      return -1;
-    }
-
-    pos += 1;
-    readBytes.increment();
-    readOperations.increment();
-
-    return singleByteBuffer.array()[0] & 0xFF;
   }
 
   @Override

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
@@ -98,7 +98,7 @@ public class TestGCSInputStream {
 
   @Test
   public void testReadBufferedEOF() throws Exception {
-    BlobId uri = BlobId.fromGsUtilUri("gs://bucket/path/to/read_buffered_eof.dat");
+    BlobId uri = BlobId.fromGsUtilUri("gs://bucket/path/to/read.dat");
     int dataSize = 8;
     byte[] expected = randomData(dataSize);
     byte[] actual = new byte[dataSize + 1];

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.Test;
 
 public class TestGCSInputStream {
+  private static final int EOF_FLAG = -1;
 
   private final Random random = new Random(1);
 
@@ -54,7 +55,6 @@ public class TestGCSInputStream {
     try (SeekableInputStream in =
         new GCSInputStream(storage, uri, null, gcpProperties, MetricsContext.nullMetrics())) {
       int readSize = 1024;
-      byte[] actual = new byte[readSize];
 
       readAndCheck(in, in.getPos(), readSize, data, false);
       readAndCheck(in, in.getPos(), readSize, data, true);
@@ -92,6 +92,27 @@ public class TestGCSInputStream {
         new GCSInputStream(storage, uri, null, gcpProperties, MetricsContext.nullMetrics())) {
       assertThat(in.read()).isEqualTo(i0);
       assertThat(in.read()).isEqualTo(i1);
+      assertThat(in.read()).isEqualTo(EOF_FLAG);
+    }
+  }
+
+  @Test
+  public void testReadBufferedEOF() throws Exception {
+    BlobId uri = BlobId.fromGsUtilUri("gs://bucket/path/to/read_buffered_eof.dat");
+    int dataSize = 8;
+    byte[] expected = randomData(dataSize);
+    byte[] actual = new byte[dataSize + 1];
+
+    writeGCSData(uri, expected);
+
+    try (SeekableInputStream in =
+        new GCSInputStream(storage, uri, null, gcpProperties, MetricsContext.nullMetrics())) {
+      int bytesRead = in.read(actual, 0, dataSize + 1);
+      assertThat(bytesRead).isEqualTo(dataSize);
+      assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(expected);
+
+      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF_FLAG);
+      assertThat(in.getPos()).isEqualTo(dataSize);
     }
   }
 

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.Test;
 
 public class TestGCSInputStream {
-  private static final int EOF_FLAG = -1;
+  private static final int EOF = -1;
 
   private final Random random = new Random(1);
 
@@ -92,7 +92,7 @@ public class TestGCSInputStream {
         new GCSInputStream(storage, uri, null, gcpProperties, MetricsContext.nullMetrics())) {
       assertThat(in.read()).isEqualTo(i0);
       assertThat(in.read()).isEqualTo(i1);
-      assertThat(in.read()).isEqualTo(EOF_FLAG);
+      assertThat(in.read()).isEqualTo(EOF);
     }
   }
 
@@ -111,7 +111,7 @@ public class TestGCSInputStream {
       assertThat(bytesRead).isEqualTo(dataSize);
       assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(expected);
 
-      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF_FLAG);
+      assertThat(in.read(actual, 0, 10)).isEqualTo(EOF);
       assertThat(in.getPos()).isEqualTo(dataSize);
     }
   }


### PR DESCRIPTION
Returned `EOF` value was ignored and stale byte from `singleByteBuffer` was retuned in `read()`. 

In `read(byte[] b, int off, int len)` behavior was correct, only metrics and `pos` were affected. 