### PR TITLE
Core: Do not pass parent Bearer header in client_credentials token request

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -658,7 +658,7 @@ public class OAuth2Util {
       OAuthTokenResponse response =
           fetchToken(
               client,
-              parent.headers(),
+              Map.of(),
               credential,
               parent.scope(),
               parent.oauth2ServerUri(),

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -665,10 +665,10 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             eq(ConfigResponse.class),
             any(),
             any());
-    // use the bearer token to fetch the context token
+    // fetch the context token via client_credentials with no extra headers
     Mockito.verify(adapter)
         .execute(
-            matches(HTTPMethod.POST, oauth2ServerUri, catalogHeaders),
+            matches(HTTPMethod.POST, oauth2ServerUri, ImmutableMap.of()),
             eq(OAuthTokenResponse.class),
             any(),
             any());
@@ -712,8 +712,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     assertThat(catalog.tableExists(TBL)).isFalse();
 
-    // call client credentials with no initial auth
-    Mockito.verify(adapter)
+    // both client_credentials token fetches (catalog and context) use empty headers
+    Mockito.verify(adapter, Mockito.times(2))
         .execute(
             matches(HTTPMethod.POST, oauth2ServerUri, emptyHeaders),
             eq(OAuthTokenResponse.class),
@@ -724,13 +724,6 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         .execute(
             matches(HTTPMethod.GET, ResourcePaths.config(), catalogHeaders),
             eq(ConfigResponse.class),
-            any(),
-            any());
-    // use the client credential to fetch the context token
-    Mockito.verify(adapter)
-        .execute(
-            matches(HTTPMethod.POST, oauth2ServerUri, catalogHeaders),
-            eq(OAuthTokenResponse.class),
             any(),
             any());
     // use the context token for table existence check
@@ -789,10 +782,10 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             eq(ConfigResponse.class),
             any(),
             any());
-    // use the client credential to fetch the context token
+    // fetch the context token via client_credentials with no extra headers
     Mockito.verify(adapter)
         .execute(
-            matches(HTTPMethod.POST, oauth2ServerUri, catalogHeaders),
+            matches(HTTPMethod.POST, oauth2ServerUri, ImmutableMap.of()),
             eq(OAuthTokenResponse.class),
             any(),
             any());
@@ -969,9 +962,12 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     // token passes a static token. otherwise, validate a client credentials or token exchange
     // request
     if (!credentials.containsKey("token")) {
+      // client_credentials uses no extra headers; token exchange uses catalog headers
+      Map<String, String> tokenRequestHeaders =
+          credentials.containsKey("credential") ? ImmutableMap.of() : catalogHeaders;
       Mockito.verify(adapter)
           .execute(
-              matches(HTTPMethod.POST, oauth2ServerUri, catalogHeaders),
+              matches(HTTPMethod.POST, oauth2ServerUri, tokenRequestHeaders),
               eq(OAuthTokenResponse.class),
               any(),
               any());

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -25,9 +25,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.io.IOException;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.junit.jupiter.api.Test;
@@ -132,6 +134,46 @@ public class TestOAuth2Util {
                           && formData.get(GRANT_TYPE).equals(CLIENT_CREDENTIALS)),
               Mockito.eq(OAuthTokenResponse.class),
               anyMap(),
+              any());
+    }
+  }
+
+  @Test
+  void fromCredentialShouldNotPassParentBearerTokenToTokenEndpoint() throws IOException {
+    String parentToken = "parent_bearer_token";
+    AuthConfig parentConfig =
+        ImmutableAuthConfig.builder()
+            .token(parentToken)
+            .scope("catalog")
+            .oauth2ServerUri("/v1/token")
+            .build();
+    OAuth2Util.AuthSession parent =
+        new OAuth2Util.AuthSession(OAuth2Util.authHeaders(parentToken), parentConfig);
+
+    OAuthTokenResponse response =
+        OAuthTokenResponse.builder()
+            .withToken("child_token")
+            .withTokenType(BEARER)
+            .setExpirationInSeconds(3600)
+            .build();
+
+    try (RESTClient client = Mockito.mock(RESTClient.class)) {
+      Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any())).thenReturn(response);
+
+      OAuth2Util.AuthSession.fromCredential(client, null, "clientId:clientSecret", parent);
+
+      // Verify that the token endpoint request does NOT include the parent's Bearer header.
+      // The headers map passed to postForm must be empty.
+      Mockito.verify(client)
+          .postForm(
+              eq("/v1/token"),
+              argThat(
+                  formData ->
+                      CLIENT_CREDENTIALS.equals(formData.get(GRANT_TYPE))
+                          && "clientId".equals(formData.get("client_id"))
+                          && "clientSecret".equals(formData.get("client_secret"))),
+              eq(OAuthTokenResponse.class),
+              eq(ImmutableMap.of()),
               any());
     }
   }


### PR DESCRIPTION
fromCredential() was passing parent.headers() (containing the parent session's Bearer token) to fetchToken when making a client_credentials grant request. This violates RFC 6749 Section 2.3 which states the client MUST NOT use more than one authentication method per request.

IDPs like CAS and AWS Cognito reject the request due to the extra Authorization header, while lenient IDPs silently ignore it.

All other fetchToken call sites correctly pass Map.of(). This change aligns fromCredential() with that pattern.

Closes #13337