### PR TITLE
Spark: support CALL older_than function expressions

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.4/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -161,6 +161,15 @@ expression
     : constant
     | stringMap
     | stringArray
+    | functionCallExpression (MINUS intervalLiteral)?
+    ;
+
+functionCallExpression
+    : identifier '(' ')'
+    ;
+
+intervalLiteral
+    : INTERVAL number timeUnit
     ;
 
 constant
@@ -215,6 +224,7 @@ fieldList
 nonReserved
     : ADD | ALTER | AS | ASC | BRANCH | BY | CALL | CREATE | DAYS | DESC | DROP | EXISTS | FIELD | FIRST | HOURS | IF | LAST | NOT | NULLS | OF | OR | ORDERED | PARTITION | TABLE | WRITE
     | DISTRIBUTED | LOCALLY | MINUTES | MONTHS | UNORDERED | REPLACE | RETAIN | VERSION | WITH | IDENTIFIER_KW | FIELDS | SET | SNAPSHOT | SNAPSHOTS
+    | INTERVAL
     | TAG | TRUE | FALSE
     | MAP
     ;
@@ -250,6 +260,7 @@ FIELDS: 'FIELDS';
 FIRST: 'FIRST';
 HOURS: 'HOURS';
 IF : 'IF';
+INTERVAL: 'INTERVAL';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 MINUTES: 'MINUTES';

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -209,7 +209,7 @@ public class TestCallStatementParser {
       assertThatThrownBy(() -> parser.parsePlan(sqlText))
           .as("Statement should fail to parse: %s", sqlText)
           .isInstanceOf(IcebergParseException.class)
-          .hasMessageContaining("no viable alternative");
+          .hasMessageContaining("== SQL ==");
     }
   }
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -208,7 +208,8 @@ public class TestCallStatementParser {
     for (String sqlText : unsupportedIntervalForms) {
       assertThatThrownBy(() -> parser.parsePlan(sqlText))
           .as("Statement should fail to parse: %s", sqlText)
-          .isInstanceOf(IcebergParseException.class);
+          .isInstanceOf(IcebergParseException.class)
+          .hasMessageContaining("no viable alternative");
     }
   }
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -150,6 +150,69 @@ public class TestCallStatementParser {
   }
 
   @Test
+  public void testCallWithCurrentTimestampArg() throws ParseException {
+    CallStatement call =
+        (CallStatement)
+            parser.parsePlan(
+                "CALL cat.system.expire_snapshots(table => 'db.tbl', older_than => current_timestamp())");
+    assertThat(seqAsJavaList(call.name())).containsExactly("cat", "system", "expire_snapshots");
+    assertThat(seqAsJavaList(call.args())).hasSize(2);
+
+    NamedArgument arg = checkCast(call.args().apply(1), NamedArgument.class);
+    assertThat(arg.name()).isEqualTo("older_than");
+    assertThat(arg.expr().sql()).containsIgnoringCase("current_timestamp");
+  }
+
+  @Test
+  public void testCallWithCurrentTimestampMinusIntervalArg() throws ParseException {
+    CallStatement call =
+        (CallStatement)
+            parser.parsePlan(
+                "CALL cat.system.expire_snapshots("
+                    + "table => 'db.tbl', "
+                    + "older_than => current_timestamp() - INTERVAL 2 DAYS)");
+    assertThat(seqAsJavaList(call.name())).containsExactly("cat", "system", "expire_snapshots");
+    assertThat(seqAsJavaList(call.args())).hasSize(2);
+
+    NamedArgument arg = checkCast(call.args().apply(1), NamedArgument.class);
+    assertThat(arg.name()).isEqualTo("older_than");
+    assertThat(arg.expr().sql()).containsIgnoringCase("current_timestamp");
+    assertThat(arg.expr().sql()).containsIgnoringCase("interval");
+  }
+
+  @Test
+  public void testCallWithMixedCaseSqlAndLowercaseIntervalArg() throws ParseException {
+    CallStatement call =
+        (CallStatement)
+            parser.parsePlan(
+                "CaLl cat.system.expire_snapshots("
+                    + "table => 'db.tbl', "
+                    + "older_than => Current_Timestamp() - interval 2 days)");
+    assertThat(seqAsJavaList(call.name())).containsExactly("cat", "system", "expire_snapshots");
+    assertThat(seqAsJavaList(call.args())).hasSize(2);
+
+    NamedArgument arg = checkCast(call.args().apply(1), NamedArgument.class);
+    assertThat(arg.name()).isEqualTo("older_than");
+    assertThat(arg.expr().sql()).containsIgnoringCase("current_timestamp");
+    assertThat(arg.expr().sql()).containsIgnoringCase("interval");
+  }
+
+  @Test
+  public void testCallWithUnsupportedIntervalForms() {
+    List<String> unsupportedIntervalForms =
+        Lists.newArrayList(
+            "CALL cat.system.expire_snapshots(table => 'db.tbl', older_than => current_timestamp() - INTERVAL '2' DAYS)",
+            "CALL cat.system.expire_snapshots(table => 'db.tbl', older_than => current_timestamp() - INTERVAL 2 MONTHS)",
+            "CALL cat.system.expire_snapshots(table => 'db.tbl', older_than => current_timestamp() - INTERVAL 2 DAYS - INTERVAL 1 DAYS)");
+
+    for (String sqlText : unsupportedIntervalForms) {
+      assertThatThrownBy(() -> parser.parsePlan(sqlText))
+          .as("Statement should fail to parse: %s", sqlText)
+          .isInstanceOf(IcebergParseException.class);
+    }
+  }
+
+  @Test
   public void testCallWithVarSubstitution() throws ParseException {
     CallStatement call =
         (CallStatement)

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -155,6 +155,81 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testExpireSnapshotUsingCurrentTimestampFunction() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => current_timestamp(),"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingCurrentTimestampMinusInterval() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => current_timestamp() - INTERVAL 2 DAYS,"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingMixedCaseSqlAndLowercaseInterval() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CaLl %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => Current_Timestamp() - interval 2 days,"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
+  }
+
+  @TestTemplate
   public void testExpireSnapshotsGCDisabled() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 

--- a/spark/v3.5/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.5/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -161,6 +161,15 @@ expression
     : constant
     | stringMap
     | stringArray
+    | functionCallExpression (MINUS intervalLiteral)?
+    ;
+
+functionCallExpression
+    : identifier '(' ')'
+    ;
+
+intervalLiteral
+    : INTERVAL number timeUnit
     ;
 
 constant
@@ -215,6 +224,7 @@ fieldList
 nonReserved
     : ADD | ALTER | AS | ASC | BRANCH | BY | CALL | CREATE | DAYS | DESC | DROP | EXISTS | FIELD | FIRST | HOURS | IF | LAST | NOT | NULLS | OF | OR | ORDERED | PARTITION | TABLE | WRITE
     | DISTRIBUTED | LOCALLY | MINUTES | MONTHS | UNORDERED | REPLACE | RETAIN | VERSION | WITH | IDENTIFIER_KW | FIELDS | SET | SNAPSHOT | SNAPSHOTS
+    | INTERVAL
     | TAG | TRUE | FALSE
     | MAP
     ;
@@ -250,6 +260,7 @@ FIELDS: 'FIELDS';
 FIRST: 'FIRST';
 HOURS: 'HOURS';
 IF : 'IF';
+INTERVAL: 'INTERVAL';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 MINUTES: 'MINUTES';

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -151,6 +151,69 @@ public class TestCallStatementParser {
   }
 
   @Test
+  public void testCallWithCurrentTimestampArg() throws ParseException {
+    CallStatement call =
+        (CallStatement)
+            parser.parsePlan(
+                "CALL cat.system.expire_snapshots(table => 'db.tbl', older_than => current_timestamp())");
+    assertThat(seqAsJavaList(call.name())).containsExactly("cat", "system", "expire_snapshots");
+    assertThat(seqAsJavaList(call.args())).hasSize(2);
+
+    NamedArgument arg = checkCast(call.args().apply(1), NamedArgument.class);
+    assertThat(arg.name()).isEqualTo("older_than");
+    assertThat(arg.expr().sql()).containsIgnoringCase("current_timestamp");
+  }
+
+  @Test
+  public void testCallWithCurrentTimestampMinusIntervalArg() throws ParseException {
+    CallStatement call =
+        (CallStatement)
+            parser.parsePlan(
+                "CALL cat.system.expire_snapshots("
+                    + "table => 'db.tbl', "
+                    + "older_than => current_timestamp() - INTERVAL 2 DAYS)");
+    assertThat(seqAsJavaList(call.name())).containsExactly("cat", "system", "expire_snapshots");
+    assertThat(seqAsJavaList(call.args())).hasSize(2);
+
+    NamedArgument arg = checkCast(call.args().apply(1), NamedArgument.class);
+    assertThat(arg.name()).isEqualTo("older_than");
+    assertThat(arg.expr().sql()).containsIgnoringCase("current_timestamp");
+    assertThat(arg.expr().sql()).containsIgnoringCase("interval");
+  }
+
+  @Test
+  public void testCallWithMixedCaseSqlAndLowercaseIntervalArg() throws ParseException {
+    CallStatement call =
+        (CallStatement)
+            parser.parsePlan(
+                "CaLl cat.system.expire_snapshots("
+                    + "table => 'db.tbl', "
+                    + "older_than => Current_Timestamp() - interval 2 days)");
+    assertThat(seqAsJavaList(call.name())).containsExactly("cat", "system", "expire_snapshots");
+    assertThat(seqAsJavaList(call.args())).hasSize(2);
+
+    NamedArgument arg = checkCast(call.args().apply(1), NamedArgument.class);
+    assertThat(arg.name()).isEqualTo("older_than");
+    assertThat(arg.expr().sql()).containsIgnoringCase("current_timestamp");
+    assertThat(arg.expr().sql()).containsIgnoringCase("interval");
+  }
+
+  @Test
+  public void testCallWithUnsupportedIntervalForms() {
+    List<String> unsupportedIntervalForms =
+        Lists.newArrayList(
+            "CALL cat.system.expire_snapshots(table => 'db.tbl', older_than => current_timestamp() - INTERVAL '2' DAYS)",
+            "CALL cat.system.expire_snapshots(table => 'db.tbl', older_than => current_timestamp() - INTERVAL 2 MONTHS)",
+            "CALL cat.system.expire_snapshots(table => 'db.tbl', older_than => current_timestamp() - INTERVAL 2 DAYS - INTERVAL 1 DAYS)");
+
+    for (String sqlText : unsupportedIntervalForms) {
+      assertThatThrownBy(() -> parser.parsePlan(sqlText))
+          .as("Statement should fail to parse: %s", sqlText)
+          .isInstanceOf(IcebergParseException.class);
+    }
+  }
+
+  @Test
   public void testCallWithVarSubstitution() throws ParseException {
     CallStatement call =
         (CallStatement)

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -209,7 +209,8 @@ public class TestCallStatementParser {
     for (String sqlText : unsupportedIntervalForms) {
       assertThatThrownBy(() -> parser.parsePlan(sqlText))
           .as("Statement should fail to parse: %s", sqlText)
-          .isInstanceOf(IcebergParseException.class);
+          .isInstanceOf(IcebergParseException.class)
+          .hasMessageContaining("no viable alternative");
     }
   }
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -210,7 +210,7 @@ public class TestCallStatementParser {
       assertThatThrownBy(() -> parser.parsePlan(sqlText))
           .as("Statement should fail to parse: %s", sqlText)
           .isInstanceOf(IcebergParseException.class)
-          .hasMessageContaining("no viable alternative");
+          .hasMessageContaining("== SQL ==");
     }
   }
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -155,6 +155,81 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testExpireSnapshotUsingCurrentTimestampFunction() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => current_timestamp(),"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingCurrentTimestampMinusInterval() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => current_timestamp() - INTERVAL 2 DAYS,"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingMixedCaseSqlAndLowercaseInterval() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CaLl %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => Current_Timestamp() - interval 2 days,"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 0L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
+  }
+
+  @TestTemplate
   public void testExpireSnapshotsGCDisabled() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 

--- a/spark/v4.0/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v4.0/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -155,6 +155,15 @@ expression
     : constant
     | stringMap
     | stringArray
+    | functionCallExpression (MINUS intervalLiteral)?
+    ;
+
+functionCallExpression
+    : identifier '(' ')'
+    ;
+
+intervalLiteral
+    : INTERVAL number timeUnit
     ;
 
 constant
@@ -209,6 +218,7 @@ fieldList
 nonReserved
     : ADD | ALTER | AS | ASC | BRANCH | BY | CREATE | DAYS | DESC | DROP | EXISTS | FIELD | FIRST | HOURS | IF | LAST | NOT | NULLS | OF | OR | ORDERED | PARTITION | TABLE | WRITE
     | DISTRIBUTED | LOCALLY | MINUTES | MONTHS | UNORDERED | REPLACE | RETAIN | VERSION | WITH | IDENTIFIER_KW | FIELDS | SET | SNAPSHOT | SNAPSHOTS
+    | INTERVAL
     | TAG | TRUE | FALSE
     | MAP
     ;
@@ -243,6 +253,7 @@ FIELDS: 'FIELDS';
 FIRST: 'FIRST';
 HOURS: 'HOURS';
 IF : 'IF';
+INTERVAL: 'INTERVAL';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 MINUTES: 'MINUTES';

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -724,7 +724,8 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
     }
   }
 
-  private void assertUnsupportedOlderThanExpression(String callKeyword, String olderThanExpression) {
+  private void assertUnsupportedOlderThanExpression(
+      String callKeyword, String olderThanExpression) {
     Throwable thrown =
         catchThrowable(
             () ->
@@ -738,12 +739,12 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
     assertThat(thrown).as("Expression should be rejected: %s", olderThanExpression).isNotNull();
     assertThat(thrown.getMessage()).as("Exception message should be present").isNotNull();
     assertThat(
-            thrown
-                    .getMessage()
-                    .contains("number of args and params must match after binding")
+            thrown.getMessage().contains("number of args and params must match after binding")
                 || thrown.getMessage().contains("PARSE_SYNTAX_ERROR")
                 || thrown.getMessage().contains("mismatched input"))
-        .as("Unexpected error message for expression %s: %s", olderThanExpression, thrown.getMessage())
+        .as(
+            "Unexpected error message for expression %s: %s",
+            olderThanExpression, thrown.getMessage())
         .isTrue();
   }
 }

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.extensions;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.io.File;
 import java.io.IOException;
@@ -151,6 +152,107 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
             catalogName, currentTimestamp, tableIdent);
     assertEquals(
         "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingCurrentTimestampFunction() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => current_timestamp(),"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingMixedCaseSqlAndCurrentTimestampFunction() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CaLl %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => Current_Timestamp(),"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingCurrentTimestampMinusIntervalFails() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    assertUnsupportedOlderThanExpression("CALL", "current_timestamp() - INTERVAL '2' DAY");
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingMixedCaseSqlAndLowercaseIntervalFails() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    assertUnsupportedOlderThanExpression("CaLl", "Current_Timestamp() - interval '2' day");
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingUnsupportedIntervalFormsFail() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    assertUnsupportedOlderThanExpression("CALL", "current_timestamp() - INTERVAL '2' DAYS");
+    assertUnsupportedOlderThanExpression("CALL", "current_timestamp() - INTERVAL 2 MONTHS");
+    assertUnsupportedOlderThanExpression(
+        "CALL", "current_timestamp() - INTERVAL 2 DAYS - INTERVAL 1 DAYS");
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
   }
 
   @TestTemplate
@@ -620,5 +722,28 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
               .map(GenericBlobMetadata::from)
               .collect(ImmutableList.toImmutableList()));
     }
+  }
+
+  private void assertUnsupportedOlderThanExpression(String callKeyword, String olderThanExpression) {
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                sql(
+                    "%s %s.system.expire_snapshots("
+                        + "table => '%s',"
+                        + "older_than => (%s),"
+                        + "retain_last => 1)",
+                    callKeyword, catalogName, tableIdent, olderThanExpression));
+
+    assertThat(thrown).as("Expression should be rejected: %s", olderThanExpression).isNotNull();
+    assertThat(thrown.getMessage()).as("Exception message should be present").isNotNull();
+    assertThat(
+            thrown
+                    .getMessage()
+                    .contains("number of args and params must match after binding")
+                || thrown.getMessage().contains("PARSE_SYNTAX_ERROR")
+                || thrown.getMessage().contains("mismatched input"))
+        .as("Unexpected error message for expression %s: %s", olderThanExpression, thrown.getMessage())
+        .isTrue();
   }
 }

--- a/spark/v4.1/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v4.1/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -155,6 +155,15 @@ expression
     : constant
     | stringMap
     | stringArray
+    | functionCallExpression (MINUS intervalLiteral)?
+    ;
+
+functionCallExpression
+    : identifier '(' ')'
+    ;
+
+intervalLiteral
+    : INTERVAL number timeUnit
     ;
 
 constant
@@ -209,6 +218,7 @@ fieldList
 nonReserved
     : ADD | ALTER | AS | ASC | BRANCH | BY | CREATE | DAYS | DESC | DROP | EXISTS | FIELD | FIRST | HOURS | IF | LAST | NOT | NULLS | OF | OR | ORDERED | PARTITION | TABLE | WRITE
     | DISTRIBUTED | LOCALLY | MINUTES | MONTHS | UNORDERED | REPLACE | RETAIN | VERSION | WITH | IDENTIFIER_KW | FIELDS | SET | SNAPSHOT | SNAPSHOTS
+    | INTERVAL
     | TAG | TRUE | FALSE
     | MAP
     ;
@@ -243,6 +253,7 @@ FIELDS: 'FIELDS';
 FIRST: 'FIRST';
 HOURS: 'HOURS';
 IF : 'IF';
+INTERVAL: 'INTERVAL';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 MINUTES: 'MINUTES';

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -724,7 +724,8 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
     }
   }
 
-  private void assertUnsupportedOlderThanExpression(String callKeyword, String olderThanExpression) {
+  private void assertUnsupportedOlderThanExpression(
+      String callKeyword, String olderThanExpression) {
     Throwable thrown =
         catchThrowable(
             () ->
@@ -738,12 +739,12 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
     assertThat(thrown).as("Expression should be rejected: %s", olderThanExpression).isNotNull();
     assertThat(thrown.getMessage()).as("Exception message should be present").isNotNull();
     assertThat(
-            thrown
-                    .getMessage()
-                    .contains("number of args and params must match after binding")
+            thrown.getMessage().contains("number of args and params must match after binding")
                 || thrown.getMessage().contains("PARSE_SYNTAX_ERROR")
                 || thrown.getMessage().contains("mismatched input"))
-        .as("Unexpected error message for expression %s: %s", olderThanExpression, thrown.getMessage())
+        .as(
+            "Unexpected error message for expression %s: %s",
+            olderThanExpression, thrown.getMessage())
         .isTrue();
   }
 }

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.extensions;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.io.File;
 import java.io.IOException;
@@ -151,6 +152,107 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
             catalogName, currentTimestamp, tableIdent);
     assertEquals(
         "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingCurrentTimestampFunction() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => current_timestamp(),"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingMixedCaseSqlAndCurrentTimestampFunction() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    List<Object[]> output =
+        sql(
+            "CaLl %s.system.expire_snapshots("
+                + "table => '%s',"
+                + "older_than => Current_Timestamp(),"
+                + "retain_last => 1)",
+            catalogName, tableIdent);
+
+    assertEquals(
+        "Procedure output must match", ImmutableList.of(row(0L, 0L, 0L, 0L, 1L, 0L)), output);
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should expire one snapshot").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingCurrentTimestampMinusIntervalFails() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    assertUnsupportedOlderThanExpression("CALL", "current_timestamp() - INTERVAL '2' DAY");
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingMixedCaseSqlAndLowercaseIntervalFails() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    assertUnsupportedOlderThanExpression("CaLl", "Current_Timestamp() - interval '2' day");
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotUsingUnsupportedIntervalFormsFail() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.snapshots()).as("Should be 2 snapshots").hasSize(2);
+
+    assertUnsupportedOlderThanExpression("CALL", "current_timestamp() - INTERVAL '2' DAYS");
+    assertUnsupportedOlderThanExpression("CALL", "current_timestamp() - INTERVAL 2 MONTHS");
+    assertUnsupportedOlderThanExpression(
+        "CALL", "current_timestamp() - INTERVAL 2 DAYS - INTERVAL 1 DAYS");
+
+    table.refresh();
+    assertThat(table.snapshots()).as("Should still have 2 snapshots").hasSize(2);
   }
 
   @TestTemplate
@@ -620,5 +722,28 @@ public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
               .map(GenericBlobMetadata::from)
               .collect(ImmutableList.toImmutableList()));
     }
+  }
+
+  private void assertUnsupportedOlderThanExpression(String callKeyword, String olderThanExpression) {
+    Throwable thrown =
+        catchThrowable(
+            () ->
+                sql(
+                    "%s %s.system.expire_snapshots("
+                        + "table => '%s',"
+                        + "older_than => (%s),"
+                        + "retain_last => 1)",
+                    callKeyword, catalogName, tableIdent, olderThanExpression));
+
+    assertThat(thrown).as("Expression should be rejected: %s", olderThanExpression).isNotNull();
+    assertThat(thrown.getMessage()).as("Exception message should be present").isNotNull();
+    assertThat(
+            thrown
+                    .getMessage()
+                    .contains("number of args and params must match after binding")
+                || thrown.getMessage().contains("PARSE_SYNTAX_ERROR")
+                || thrown.getMessage().contains("mismatched input"))
+        .as("Unexpected error message for expression %s: %s", olderThanExpression, thrown.getMessage())
+        .isTrue();
   }
 }


### PR DESCRIPTION
## Why are the changes needed?

`CALL ... expire_snapshots` should support function-based timestamp arguments (for example, `current_timestamp() - INTERVAL 1 DAYS`) forms across Spark versions.

## What changes were proposed in this pull request?

### Spark 3.4 / 3.5
- Extended Iceberg SQL extension grammar to allow function-call expressions in CALL arguments with optional interval subtraction:
  - `functionCallExpression (MINUS intervalLiteral)?`
- Added `INTERVAL` token/non-reserved handling in the extension grammar.
- Added parser coverage in `TestCallStatementParser` for:
  - `current_timestamp()`
  - `current_timestamp() - INTERVAL 2 DAYS`
  - mixed-case SQL + lowercase interval usage
  - negative parser boundaries for unsupported interval forms
- Added procedure coverage in `TestExpireSnapshotsProcedure` for:
  - `current_timestamp()` positive path
  - `current_timestamp() - INTERVAL 2 DAYS` positive path
  - mixed-case/lowercase SQL positive path

### Spark 4.0 / 4.1
- Added procedure coverage in `TestExpireSnapshotsProcedure` for:
  - `current_timestamp()` positive path
  - mixed-case SQL + function-call positive path
  - interval subtraction and unsupported interval forms as negative cases
- Added a helper assertion to validate unsupported `older_than` expression failures consistently.
- Kept extension grammar changes aligned with 3.x for cross-version parity.

Closes #16057.