### PR TITLE
API, Core: Handle 404 from /v1/config for missing warehouses

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/NoSuchWarehouseException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NoSuchWarehouseException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+
+/** Exception raised when attempting to load a warehouse that does not exist. */
+public class NoSuchWarehouseException extends RuntimeException {
+  @FormatMethod
+  public NoSuchWarehouseException(String message, Object... args) {
+    super(String.format(message, args));
+  }
+
+  @FormatMethod
+  public NoSuchWarehouseException(Throwable cause, String message, Object... args) {
+    super(String.format(message, args), cause);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -1338,7 +1338,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                 queryParams.build(),
                 ConfigResponse.class,
                 RESTUtil.configHeaders(properties),
-                ErrorHandlers.defaultErrorHandler());
+                ErrorHandlers.configErrorHandler());
     configResponse.validate();
     return configResponse;
   }

--- a/core/src/test/java/org/apache/iceberg/rest/TestErrorHandlers.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestErrorHandlers.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.rest;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.iceberg.exceptions.NoSuchWarehouseException;
 import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.junit.jupiter.api.Test;
 
@@ -67,5 +69,39 @@ public class TestErrorHandlers {
     assertThatThrownBy(() -> ErrorHandlers.defaultErrorHandler().accept(error))
         .isInstanceOf(RESTException.class)
         .hasMessage("Unable to process (code: 422, type: ValidationException): null");
+  }
+
+  @Test
+  public void testConfigErrorHandler404ThrowsNoSuchWarehouseException() {
+    ErrorResponse error =
+        ErrorResponse.builder()
+            .responseCode(404)
+            .withType("NotFoundException")
+            .withMessage("Warehouse not found")
+            .build();
+
+    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
+        .isInstanceOf(NoSuchWarehouseException.class)
+        .hasMessage("Warehouse not found");
+  }
+
+  @Test
+  public void testConfigErrorHandler404ForMisconfiguredUri() {
+    ErrorResponse error =
+        ErrorResponse.builder().responseCode(404).withMessage("Not Found").build();
+
+    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
+        .isInstanceOf(RESTException.class)
+        .hasMessageContaining("Not Found");
+  }
+
+  @Test
+  public void testConfigErrorHandlerDelegatesToDefaultForNon404() {
+    ErrorResponse error =
+        ErrorResponse.builder().responseCode(500).withMessage("Internal server error").build();
+
+    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessageContaining("Internal server error");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -50,6 +50,9 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchWarehouseException;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.TLSConfigurer;
@@ -644,5 +647,39 @@ public class TestHTTPClient {
       Item item = (Item) o;
       return Objects.equals(id, item.id) && Objects.equals(data, item.data);
     }
+  }
+
+  @Test
+  public void testConfigErrorHandler404ThrowsNoSuchWarehouseException() {
+    ErrorResponse error =
+        ErrorResponse.builder()
+            .responseCode(404)
+            .withType("NotFoundException")
+            .withMessage("Warehouse not found")
+            .build();
+
+    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
+        .isInstanceOf(NoSuchWarehouseException.class)
+        .hasMessage("Warehouse not found");
+  }
+
+  @Test
+  public void testConfigErrorHandler404ForMisconfiguredUri() {
+    ErrorResponse error =
+        ErrorResponse.builder().responseCode(404).withMessage("Not Found").build();
+
+    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
+        .isInstanceOf(RESTException.class)
+        .hasMessageContaining("Not Found");
+  }
+
+  @Test
+  public void testConfigErrorHandlerDelegatesToDefaultForNon404() {
+    ErrorResponse error =
+        ErrorResponse.builder().responseCode(500).withMessage("Internal server error").build();
+
+    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
+        .isInstanceOf(ServiceFailureException.class)
+        .hasMessageContaining("Internal server error");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -50,9 +50,6 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NoSuchWarehouseException;
-import org.apache.iceberg.exceptions.RESTException;
-import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.TLSConfigurer;
@@ -647,39 +644,5 @@ public class TestHTTPClient {
       Item item = (Item) o;
       return Objects.equals(id, item.id) && Objects.equals(data, item.data);
     }
-  }
-
-  @Test
-  public void testConfigErrorHandler404ThrowsNoSuchWarehouseException() {
-    ErrorResponse error =
-        ErrorResponse.builder()
-            .responseCode(404)
-            .withType("NotFoundException")
-            .withMessage("Warehouse not found")
-            .build();
-
-    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
-        .isInstanceOf(NoSuchWarehouseException.class)
-        .hasMessage("Warehouse not found");
-  }
-
-  @Test
-  public void testConfigErrorHandler404ForMisconfiguredUri() {
-    ErrorResponse error =
-        ErrorResponse.builder().responseCode(404).withMessage("Not Found").build();
-
-    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
-        .isInstanceOf(RESTException.class)
-        .hasMessageContaining("Not Found");
-  }
-
-  @Test
-  public void testConfigErrorHandlerDelegatesToDefaultForNon404() {
-    ErrorResponse error =
-        ErrorResponse.builder().responseCode(500).withMessage("Internal server error").build();
-
-    assertThatThrownBy(() -> ErrorHandlers.configErrorHandler().accept(error))
-        .isInstanceOf(ServiceFailureException.class)
-        .hasMessageContaining("Internal server error");
   }
 }


### PR DESCRIPTION
**Summary**

Add `NoSuchWarehouseException` and `ConfigErrorHandler` to handle 404 responses from the `/v1/config` endpoint when a configured warehouse does not exist.

This is the implementation counterpart to the spec change merged in #15746.

**Handling ambiguous 404s**

As discussed in #14965 , a 404 on `/v1/config` could mean either a missing warehouse or a misconfigured URL pointing to a non-Iceberg server. The handler checks `error.type() != null` to distinguish the two cases: valid Iceberg error responses include a `type` field, a required field per schema `#/components/schemas/ErrorModel`, while non-Iceberg 404s don't.