### PR TITLE
Core: Fix JdbcCatalog & InMemoryCatalog to prevent dropping parent namespaces with children

### DIFF
--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -211,6 +211,13 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
         return false;
       }
 
+      List<Namespace> childNamespaces = listNamespaces(namespace);
+      if (!childNamespaces.isEmpty()) {
+        throw new NamespaceNotEmptyException(
+            "Namespace %s is not empty. Contains %d child namespace(s).",
+            namespace, childNamespaces.size());
+      }
+
       List<TableIdentifier> tableIdentifiers = listTables(namespace);
       if (!tableIdentifiers.isEmpty()) {
         throw new NamespaceNotEmptyException(
@@ -221,13 +228,6 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       if (!viewIdentifiers.isEmpty()) {
         throw new NamespaceNotEmptyException(
             "Namespace %s is not empty. Contains %d view(s).", namespace, viewIdentifiers.size());
-      }
-
-      List<Namespace> childNamespaces = listNamespaces(namespace);
-      if (!childNamespaces.isEmpty()) {
-        throw new NamespaceNotEmptyException(
-            "Namespace %s is not empty. Contains %d child namespace(s).",
-            namespace, childNamespaces.size());
       }
 
       return namespaces.remove(namespace) != null;

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -223,6 +223,13 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
             "Namespace %s is not empty. Contains %d view(s).", namespace, viewIdentifiers.size());
       }
 
+      List<Namespace> childNamespaces = listNamespaces(namespace);
+      if (!childNamespaces.isEmpty()) {
+        throw new NamespaceNotEmptyException(
+            "Namespace %s is not empty. Contains %d child namespace(s).",
+            namespace, childNamespaces.size());
+      }
+
       return namespaces.remove(namespace) != null;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -553,7 +553,8 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     List<Namespace> childNamespaces = listNamespaces(namespace);
     if (childNamespaces != null && !childNamespaces.isEmpty()) {
       throw new NamespaceNotEmptyException(
-          "Namespace %s is not empty. Contains %d child namespace(s).", namespace, childNamespaces.size());
+          "Namespace %s is not empty. Contains %d child namespace(s).",
+          namespace, childNamespaces.size());
     }
 
     int deletedRows =

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -536,6 +536,13 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
       return false;
     }
 
+    List<Namespace> childNamespaces = listNamespaces(namespace);
+    if (childNamespaces != null && !childNamespaces.isEmpty()) {
+      throw new NamespaceNotEmptyException(
+          "Namespace %s is not empty. Contains %d child namespace(s).",
+          namespace, childNamespaces.size());
+    }
+
     List<TableIdentifier> tableIdentifiers = listTables(namespace);
     if (tableIdentifiers != null && !tableIdentifiers.isEmpty()) {
       throw new NamespaceNotEmptyException(
@@ -548,13 +555,6 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
         throw new NamespaceNotEmptyException(
             "Namespace %s is not empty. Contains %d view(s).", namespace, viewIdentifiers.size());
       }
-    }
-
-    List<Namespace> childNamespaces = listNamespaces(namespace);
-    if (childNamespaces != null && !childNamespaces.isEmpty()) {
-      throw new NamespaceNotEmptyException(
-          "Namespace %s is not empty. Contains %d child namespace(s).",
-          namespace, childNamespaces.size());
     }
 
     int deletedRows =

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -550,6 +550,12 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
       }
     }
 
+    List<Namespace> childNamespaces = listNamespaces(namespace);
+    if (childNamespaces != null && !childNamespaces.isEmpty()) {
+      throw new NamespaceNotEmptyException(
+          "Namespace %s is not empty. Contains %d child namespace(s).", namespace, childNamespaces.size());
+    }
+
     int deletedRows =
         execute(
             JdbcUtil.DELETE_ALL_NAMESPACE_PROPERTIES_SQL,

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -430,6 +430,39 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void testDropNamespaceWithNestedNamespace() {
+    assumeThat(supportsNestedNamespaces())
+        .as("Only valid when the catalog supports nested namespaces")
+        .isTrue();
+
+    C catalog = catalog();
+
+    Namespace parent = Namespace.of("parent");
+    Namespace nested = Namespace.of("parent", "child");
+
+    assertThat(catalog.namespaceExists(parent)).as("Parent namespace should not exist").isFalse();
+    assertThat(catalog.namespaceExists(nested)).as("Nested namespace should not exist").isFalse();
+
+    catalog.createNamespace(parent);
+    catalog.createNamespace(nested);
+
+    assertThat(catalog.namespaceExists(parent)).as("Parent namespace should exist").isTrue();
+    assertThat(catalog.namespaceExists(nested)).as("Nested namespace should exist").isTrue();
+
+    assertThatThrownBy(() -> catalog.dropNamespace(parent))
+        .isInstanceOf(NamespaceNotEmptyException.class)
+        .hasMessageContaining("is not empty");
+
+    catalog.dropNamespace(nested);
+    assertThat(catalog.namespaceExists(nested)).as("Nested namespace should not exist").isFalse();
+
+    assertThat(catalog.dropNamespace(parent))
+        .as("Dropping an existing namespace should return true")
+        .isTrue();
+    assertThat(catalog.namespaceExists(parent)).as("Parent namespace should not exist").isFalse();
+  }
+
+  @Test
   public void testListNamespaces() {
     C catalog = catalog();
     // the catalog may automatically create a default namespace

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -453,7 +453,12 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .isInstanceOf(NamespaceNotEmptyException.class)
         .hasMessageContaining("is not empty");
 
-    catalog.dropNamespace(nested);
+    assertThat(catalog.namespaceExists(parent)).as("Parent namespace should still exist").isTrue();
+    assertThat(catalog.namespaceExists(nested)).as("Nested namespace should still exist").isTrue();
+
+    assertThat(catalog.dropNamespace(nested))
+        .as("Dropping an existing nested namespace should return true")
+        .isTrue();
     assertThat(catalog.namespaceExists(nested)).as("Nested namespace should not exist").isFalse();
 
     assertThat(catalog.dropNamespace(parent))

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
@@ -82,6 +82,11 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
     return true;
   }
 
+  @Override
+  protected boolean supportsNestedNamespaces() {
+    return true;
+  }
+
   @Test
   @Override
   public void testLoadTableWithMissingMetadataFile(@TempDir Path tempDir) throws IOException {

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -852,11 +852,11 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
     assertThatThrownBy(() -> catalog.dropNamespace(tbl2.namespace()))
         .isInstanceOf(NamespaceNotEmptyException.class)
-        .hasMessage("Namespace db.ns1 is not empty. Contains 1 table(s).");
+        .hasMessage("Namespace db.ns1 is not empty. Contains 1 child namespace(s).");
 
     assertThatThrownBy(() -> catalog.dropNamespace(tbl4.namespace()))
         .isInstanceOf(NamespaceNotEmptyException.class)
-        .hasMessage("Namespace db is not empty. Contains 1 table(s).");
+        .hasMessage("Namespace db is not empty. Contains 2 child namespace(s).");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -864,16 +864,13 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     Namespace parent = Namespace.of("parent_ns");
     Namespace child = Namespace.of("parent_ns", "child_ns");
 
-    // 1. Create the parent and child namespaces
     catalog.createNamespace(parent);
     catalog.createNamespace(child);
 
-    // 2. Assert that dropping the parent fails because the child exists
     assertThatThrownBy(() -> catalog.dropNamespace(parent))
         .isInstanceOf(NamespaceNotEmptyException.class)
         .hasMessageStartingWith("Namespace parent_ns is not empty. Contains 1 child namespace(s).");
 
-    // 3. Verify the namespaces still safely exist in the catalog
     assertThat(catalog.namespaceExists(parent)).isTrue();
     assertThat(catalog.namespaceExists(child)).isTrue();
   }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -860,22 +860,6 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
   }
 
   @Test
-  public void testDropNamespaceWithChildNamespace() {
-    Namespace parent = Namespace.of("parent_ns");
-    Namespace child = Namespace.of("parent_ns", "child_ns");
-
-    catalog.createNamespace(parent);
-    catalog.createNamespace(child);
-
-    assertThatThrownBy(() -> catalog.dropNamespace(parent))
-        .isInstanceOf(NamespaceNotEmptyException.class)
-        .hasMessageStartingWith("Namespace parent_ns is not empty. Contains 1 child namespace(s).");
-
-    assertThat(catalog.namespaceExists(parent)).isTrue();
-    assertThat(catalog.namespaceExists(child)).isTrue();
-  }
-
-  @Test
   public void testCreateNamespace() {
     Namespace testNamespace = Namespace.of("testDb", "ns1", "ns2");
     assertThat(catalog.namespaceExists(testNamespace)).isFalse();

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -860,6 +860,25 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
   }
 
   @Test
+  public void testDropNamespaceWithChildNamespace() {
+    Namespace parent = Namespace.of("parent_ns");
+    Namespace child = Namespace.of("parent_ns", "child_ns");
+
+    // 1. Create the parent and child namespaces
+    catalog.createNamespace(parent);
+    catalog.createNamespace(child);
+
+    // 2. Assert that dropping the parent fails because the child exists
+    assertThatThrownBy(() -> catalog.dropNamespace(parent))
+        .isInstanceOf(NamespaceNotEmptyException.class)
+        .hasMessageStartingWith("Namespace parent_ns is not empty. Contains 1 child namespace(s).");
+
+    // 3. Verify the namespaces still safely exist in the catalog
+    assertThat(catalog.namespaceExists(parent)).isTrue();
+    assertThat(catalog.namespaceExists(child)).isTrue();
+  }
+
+  @Test
   public void testCreateNamespace() {
     Namespace testNamespace = Namespace.of("testDb", "ns1", "ns2");
     assertThat(catalog.namespaceExists(testNamespace)).isFalse();


### PR DESCRIPTION
### Summary
Solution for [#16060](https://github.com/apache/iceberg/issues/16060)
This PR fixes a bug in JdbcCatalog where a parent namespace could be dropped even if it contained child namespaces, provided the parent had no direct tables or views. This behavior violates the Iceberg REST OpenAPI specification, which requires that a namespace must be empty of both tables and child namespaces before deletion.

Without this fix, dropping a parent namespace results in "orphaned" metadata: the child namespaces and their associated tables remain in the database but become unreachable through standard catalog traversal, leading to metadata inconsistency.

### Changes
Modified `JdbcCatalog#dropNamespace` to include a validation check using `listNamespaces(namespace)`.

Ensured `NamespaceNotEmptyException` is thrown if the list of child namespaces is not empty.

### Verifying this change
This change is a code fix and includes a new unit test in `TestJdbcCatalog`.

### Added Tests
`TestJdbcCatalog#testDropNamespaceWithChildNamespace`: Verifies that `dropNamespace` throws `NamespaceNotEmptyException` when a child namespace exists and that the catalog state remains unchanged.

### Manual Verification
Reproduced the issue using a local REST Catalog fixture and verified that the fix correctly blocks the operation:

```
CREATE NAMESPACE n1;
CREATE NAMESPACE n1.n2;
CREATE TABLE n1.n2.t2 (id INT) USING iceberg;

-- Prior to fix: Succeeded and orphaned n1.n2
-- After fix: Throws NamespaceNotEmptyException
DROP NAMESPACE n1;
```

### Documentation
Does this pull request introduce a new feature? **No**

Does this pull request introduce a breaking change? **No** (It enforces an existing specification contract that was being bypassed).

Is any documentation update required? **No**