### PR TITLE
Spark: Replace deprecated registerTempTable with createOrReplaceTempView

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -667,7 +667,7 @@ public class TestCreateActions extends CatalogTestBase {
             "CAST(id AS FLOAT) col1",
             "CAST(id AS STRING) col2",
             "CAST(id AS INT) col3")
-        .registerTempTable("tempdata");
+        .createOrReplaceTempView("tempdata");
     sql("INSERT INTO TABLE %s SELECT * FROM tempdata", tblName);
     List<Object[]> expectedBeforeAddColumn = sql("SELECT * FROM %s ORDER BY col0", tblName);
     List<Object[]> expectedAfterAddColumn =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -662,7 +662,7 @@ public class TestCreateActions extends CatalogTestBase {
             "CAST(id AS FLOAT) col1",
             "CAST(id AS STRING) col2",
             "CAST(id AS INT) col3")
-        .registerTempTable("tempdata");
+        .createOrReplaceTempView("tempdata");
     sql("INSERT INTO TABLE %s SELECT * FROM tempdata", tblName);
     List<Object[]> expectedBeforeAddColumn = sql("SELECT * FROM %s ORDER BY col0", tblName);
     List<Object[]> expectedAfterAddColumn =

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -662,7 +662,7 @@ public class TestCreateActions extends CatalogTestBase {
             "CAST(id AS FLOAT) col1",
             "CAST(id AS STRING) col2",
             "CAST(id AS INT) col3")
-        .registerTempTable("tempdata");
+        .createOrReplaceTempView("tempdata");
     sql("INSERT INTO TABLE %s SELECT * FROM tempdata", tblName);
     List<Object[]> expectedBeforeAddColumn = sql("SELECT * FROM %s ORDER BY col0", tblName);
     List<Object[]> expectedAfterAddColumn =

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -662,7 +662,7 @@ public class TestCreateActions extends CatalogTestBase {
             "CAST(id AS FLOAT) col1",
             "CAST(id AS STRING) col2",
             "CAST(id AS INT) col3")
-        .registerTempTable("tempdata");
+        .createOrReplaceTempView("tempdata");
     sql("INSERT INTO TABLE %s SELECT * FROM tempdata", tblName);
     List<Object[]> expectedBeforeAddColumn = sql("SELECT * FROM %s ORDER BY col0", tblName);
     List<Object[]> expectedAfterAddColumn =


### PR DESCRIPTION
`DataSet.registerTempTable` has been deprecated in Spark since 2.0 in favor of `createOrReplaceTempView`. Update `TestCreateActions` to use the non-deprecated API.