### PR TITLE
OpenAPI: Mark StructField doc as nullable in REST catalog spec

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2293,6 +2293,7 @@ components:
           type: boolean
         doc:
           type: string
+          nullable: true
         initial-default:
           $ref: "#/components/schemas/PrimitiveTypeValue"
         write-default:


### PR DESCRIPTION
## Problem

The `doc` field in the `StructField` schema in `rest-catalog-open-api.yaml` was missing `nullable: true`. However, the Java implementation in `Types.NestedField` has always allowed `doc` to be `null` — it defaults to `null` (see Types.java line 761) and the `doc()` getter can return `null`.

This mismatch means clients that auto-generate code from the OpenAPI spec would incorrectly treat `doc` as a required non-null string, potentially causing deserialization failures when the server returns a `StructField` with no `doc` value.

## Change

Added `nullable: true` to the `doc` field in the `StructField` schema to align the spec with the actual Java behavior.

## References
- `api/src/main/java/org/apache/iceberg/types/Types.java#L761`
- `open-api/rest-catalog-open-api.yaml#L2294`