### PR TITLE
Detect contradictory predicates in Expressions.and() to enable scan p…

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.apache.iceberg.expressions.Expression.Operation;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -39,6 +41,8 @@ public class Expressions {
       return right;
     } else if (right == alwaysTrue()) {
       return left;
+    } else if (isContradiction(left, right)) {
+      return alwaysFalse();
     }
     return new And(left, right);
   }
@@ -278,6 +282,150 @@ public class Expressions {
 
   public static <T> UnboundPredicate<T> predicate(Operation op, UnboundTerm<T> expr) {
     return new UnboundPredicate<>(op, expr);
+  }
+
+  /**
+   * Checks whether two expressions form a logical contradiction (always false when ANDed).
+   *
+   * <p>Detects patterns like {@code col == 'a' AND col != 'a'} or {@code col == 'a' AND col ==
+   * 'b'} that can never be satisfied. This enables early pruning of scans that would otherwise plan
+   * file tasks only to discard every row.
+   */
+  private static boolean isContradiction(Expression left, Expression right) {
+    // Both are simple predicates
+    if (left instanceof Predicate && right instanceof Predicate) {
+      return arePredicatesContradictory(left, right);
+    }
+
+    // Left is And, right is a predicate: contradiction if right contradicts any leaf of left
+    if (left instanceof And && right instanceof Predicate) {
+      And and = (And) left;
+      return isContradiction(and.left(), right) || isContradiction(and.right(), right);
+    }
+
+    // Right is And, left is a predicate: symmetric case
+    if (right instanceof And && left instanceof Predicate) {
+      And and = (And) right;
+      return isContradiction(left, and.left()) || isContradiction(left, and.right());
+    }
+
+    return false;
+  }
+
+  private static boolean arePredicatesContradictory(Expression left, Expression right) {
+    // Bound literal vs bound literal (post-binding path)
+    if (left instanceof BoundLiteralPredicate && right instanceof BoundLiteralPredicate) {
+      return areBoundLiteralsContradictory(
+          (BoundLiteralPredicate<?>) left, (BoundLiteralPredicate<?>) right);
+    }
+
+    // Bound literal vs bound set (e.g., EQ vs NOT_IN)
+    if (left instanceof BoundLiteralPredicate && right instanceof BoundSetPredicate) {
+      return isBoundLiteralSetContradiction(
+          (BoundLiteralPredicate<?>) left, (BoundSetPredicate<?>) right);
+    }
+
+    if (left instanceof BoundSetPredicate && right instanceof BoundLiteralPredicate) {
+      return isBoundLiteralSetContradiction(
+          (BoundLiteralPredicate<?>) right, (BoundSetPredicate<?>) left);
+    }
+
+    // Unbound predicates (pre-binding path, used by SparkScanBuilder)
+    if (left instanceof UnboundPredicate && right instanceof UnboundPredicate) {
+      return areUnboundContradictory(
+          (UnboundPredicate<?>) left, (UnboundPredicate<?>) right);
+    }
+
+    return false;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static boolean areBoundLiteralsContradictory(
+      BoundLiteralPredicate<?> left, BoundLiteralPredicate<?> right) {
+    if (left.ref().fieldId() != right.ref().fieldId()) {
+      return false;
+    }
+
+    Comparator<Object> cmp = (Comparator<Object>) left.literal().comparator();
+    int comparison = cmp.compare(left.literal().value(), right.literal().value());
+
+    Operation leftOp = left.op();
+    Operation rightOp = right.op();
+
+    // EQ(col, a) AND NOT_EQ(col, a) with same value
+    if (comparison == 0) {
+      return (leftOp == Operation.EQ && rightOp == Operation.NOT_EQ)
+          || (leftOp == Operation.NOT_EQ && rightOp == Operation.EQ);
+    }
+
+    // EQ(col, a) AND EQ(col, b) with different values
+    return leftOp == Operation.EQ && rightOp == Operation.EQ;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static boolean isBoundLiteralSetContradiction(
+      BoundLiteralPredicate<?> literal, BoundSetPredicate<?> set) {
+    if (literal.ref().fieldId() != set.ref().fieldId()) {
+      return false;
+    }
+
+    Object value = literal.literal().value();
+
+    // EQ(col, val) AND NOT_IN(col, {val, ...}) => false
+    if (literal.op() == Operation.EQ && set.op() == Operation.NOT_IN) {
+      return set.literalSet().contains(value);
+    }
+
+    // EQ(col, val) AND IN(col, set) where val not in set => false
+    if (literal.op() == Operation.EQ && set.op() == Operation.IN) {
+      return !set.literalSet().contains(value);
+    }
+
+    return false;
+  }
+
+  private static boolean areUnboundContradictory(
+      UnboundPredicate<?> left, UnboundPredicate<?> right) {
+    // Only handle simple column references, not transforms
+    if (!(left.term() instanceof NamedReference) || !(right.term() instanceof NamedReference)) {
+      return false;
+    }
+
+    String leftName = ((NamedReference<?>) left.term()).name();
+    String rightName = ((NamedReference<?>) right.term()).name();
+    if (!leftName.equals(rightName)) {
+      return false;
+    }
+
+    // Both must have literals
+    if (left.literals() == null || right.literals() == null) {
+      return false;
+    }
+
+    Operation leftOp = left.op();
+    Operation rightOp = right.op();
+    boolean leftIsSingle = leftOp != Operation.IN && leftOp != Operation.NOT_IN;
+    boolean rightIsSingle = rightOp != Operation.IN && rightOp != Operation.NOT_IN;
+
+    if (leftIsSingle && rightIsSingle) {
+      Object leftVal = left.literal().value();
+      Object rightVal = right.literal().value();
+      boolean sameValue = Objects.equals(leftVal, rightVal);
+
+      // EQ AND NOT_EQ with same value
+      if (sameValue
+          && ((leftOp == Operation.EQ && rightOp == Operation.NOT_EQ)
+              || (leftOp == Operation.NOT_EQ && rightOp == Operation.EQ))) {
+        return true;
+      }
+
+      // EQ AND EQ with different values
+      if (!sameValue && leftOp == Operation.EQ && rightOp == Operation.EQ) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   public static True alwaysTrue() {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -279,6 +279,125 @@ public class TestExpressionHelpers {
         .hasMessage("Cannot create expression literal from NaN");
   }
 
+  @Test
+  public void testContradictionUnboundEqAndNotEq() {
+    // col == 'a' AND col != 'a' => alwaysFalse
+    assertThat(and(equal("x", 5), notEqual("x", 5)))
+        .as("EQ and NOT_EQ on same column with same value should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+
+    // symmetric
+    assertThat(and(notEqual("x", 5), equal("x", 5)))
+        .as("NOT_EQ and EQ on same column with same value should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+  }
+
+  @Test
+  public void testContradictionUnboundEqAndEqDifferentValues() {
+    // col == 5 AND col == 10 => alwaysFalse
+    assertThat(and(equal("x", 5), equal("x", 10)))
+        .as("EQ and EQ on same column with different values should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+  }
+
+  @Test
+  public void testContradictionUnboundStringValues() {
+    // col == 'desktop' AND col != 'desktop' => alwaysFalse
+    assertThat(and(equal("service_name", "desktop"), notEqual("service_name", "desktop")))
+        .as("EQ and NOT_EQ on same string column with same value should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+
+    // col == 'desktop' AND col == 'webapp' => alwaysFalse
+    assertThat(and(equal("service_name", "desktop"), equal("service_name", "webapp")))
+        .as("EQ and EQ on same string column with different values should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+  }
+
+  @Test
+  public void testNoContradictionDifferentColumns() {
+    // Different columns should not be detected as contradiction
+    Expression result = and(equal("x", 5), notEqual("y", 5));
+    assertThat(result).as("Different columns should not be a contradiction").isInstanceOf(And.class);
+  }
+
+  @Test
+  public void testNoContradictionSameColumnCompatible() {
+    // col == 5 AND col != 10 is satisfiable
+    Expression result = and(equal("x", 5), notEqual("x", 10));
+    assertThat(result).as("EQ and NOT_EQ with different values is satisfiable").isInstanceOf(And.class);
+
+    // col == 5 AND col == 5 is satisfiable (redundant but not contradictory)
+    result = and(equal("x", 5), equal("x", 5));
+    assertThat(result).as("EQ and EQ with same value is not a contradiction").isInstanceOf(And.class);
+  }
+
+  @Test
+  public void testContradictionNestedAnd() {
+    // (col == 5 AND col > 0) AND col != 5 => alwaysFalse
+    // because col == 5 AND col != 5 is a contradiction
+    Expression nested = and(equal("x", 5), greaterThan("x", 0));
+    assertThat(and(nested, notEqual("x", 5)))
+        .as("Contradiction should be detected through nested AND")
+        .isEqualTo(alwaysFalse());
+  }
+
+  @Test
+  public void testContradictionBoundPredicates() {
+    StructType struct = StructType.of(
+        NestedField.required(1, "x", Types.IntegerType.get()),
+        NestedField.required(2, "s", Types.StringType.get()));
+
+    // Bind predicates first, then AND them
+    Expression boundEq = Binder.bind(struct, equal("x", 5));
+    Expression boundNotEq = Binder.bind(struct, notEqual("x", 5));
+    assertThat(and(boundEq, boundNotEq))
+        .as("Bound EQ and NOT_EQ on same field should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+
+    // Different values
+    Expression boundEq5 = Binder.bind(struct, equal("x", 5));
+    Expression boundEq10 = Binder.bind(struct, equal("x", 10));
+    assertThat(and(boundEq5, boundEq10))
+        .as("Bound EQ and EQ with different values should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+  }
+
+  @Test
+  public void testContradictionBoundEqAndNotIn() {
+    StructType struct = StructType.of(
+        NestedField.required(1, "x", Types.IntegerType.get()));
+
+    Expression boundEq = Binder.bind(struct, equal("x", 5));
+    Expression boundNotIn = Binder.bind(struct, notIn("x", 5, 10, 15));
+    assertThat(and(boundEq, boundNotIn))
+        .as("Bound EQ(5) and NOT_IN({5, 10, 15}) should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+  }
+
+  @Test
+  public void testContradictionBoundEqAndInWithoutValue() {
+    StructType struct = StructType.of(
+        NestedField.required(1, "x", Types.IntegerType.get()));
+
+    Expression boundEq = Binder.bind(struct, equal("x", 5));
+    Expression boundIn = Binder.bind(struct, in("x", 10, 15, 20));
+    assertThat(and(boundEq, boundIn))
+        .as("Bound EQ(5) and IN({10, 15, 20}) should be alwaysFalse")
+        .isEqualTo(alwaysFalse());
+  }
+
+  @Test
+  public void testNoContradictionBoundEqAndInWithValue() {
+    StructType struct = StructType.of(
+        NestedField.required(1, "x", Types.IntegerType.get()));
+
+    Expression boundEq = Binder.bind(struct, equal("x", 5));
+    Expression boundIn = Binder.bind(struct, in("x", 5, 10, 15));
+    assertThat(and(boundEq, boundIn))
+        .as("Bound EQ(5) and IN({5, 10, 15}) is satisfiable")
+        .isInstanceOf(And.class);
+  }
+
   private <T> UnboundTerm<T> self(String name) {
     return new UnboundTransform<>(ref(name), Transforms.identity());
   }


### PR DESCRIPTION
…runing

When Spark pushes predicates through UNION ALL views to Iceberg, contradictory filters like `col = 'a' AND col != 'a'` can end up combined in a single scan. Neither Spark's Catalyst optimizer nor Iceberg's expression system detected these contradictions, causing Iceberg to plan tens of thousands of file tasks that would return zero rows.

This adds contradiction detection to Expressions.and() for:
- EQ(col, a) AND NOT_EQ(col, a) with same value
- EQ(col, a) AND EQ(col, b) with different values
- EQ(col, val) AND NOT_IN(col, {val, ...})
- EQ(col, val) AND IN(col, set) where val not in set
- Contradictions through nested AND expressions

Handles both bound predicates (post-binding) and unbound predicates (pre-binding, as used by SparkScanBuilder).