### PR TITLE
API: Fix Identity projection for mismatched transform types

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.transforms;
 import java.io.ObjectStreamException;
 import java.util.Set;
 import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.BoundReference;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -146,6 +147,10 @@ class Identity<T> implements Transform<T, T> {
 
   @Override
   public UnboundPredicate<T> projectStrict(String name, BoundPredicate<T> predicate) {
+    if (!(predicate.term() instanceof BoundReference)) {
+      return null;
+    }
+
     if (predicate.isUnaryPredicate()) {
       return Expressions.predicate(predicate.op(), name);
     } else if (predicate.isLiteralPredicate()) {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
@@ -394,4 +394,34 @@ public class TestProjection {
             Projections.inclusive(partitionSpec).project(equal(truncate("string", 10), "abc"));
     assertThat(predicate.ref().name()).isEqualTo("string_trunc");
   }
+
+  @Test
+  public void testIdentityProjectionWithTransformPredicate() {
+    // Regression test for https://github.com/apache/iceberg/issues/15502
+    // When an identity-partitioned timestamptz field is filtered with hours(), the
+    // projection must return alwaysTrue (inclusive) or alwaysFalse (strict) because
+    // the identity transform cannot project a transform-based predicate.
+    //
+    // Without the fix, projectStrict() returns an invalid UnboundPredicate with an
+    // integer literal (490674) for a timestamptz field. This test fails because the
+    // result is neither alwaysTrue nor alwaysFalse -- it is the invalid predicate
+    // "ts == 490674" which causes a downstream ValidationException when evaluated.
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "ts", Types.TimestampType.withZone()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("ts").build();
+
+    // hours(ts) = 490674 produces an integer literal that cannot bind to timestamptz.
+    Expression hourFilter = equal(hour("ts"), 490674);
+
+    // Inclusive projection: cannot project, falls back to alwaysTrue
+    Expression projected = Projections.inclusive(spec).project(hourFilter);
+    assertThat(projected).isEqualTo(Expressions.alwaysTrue());
+
+    // Strict projection: cannot project, falls back to alwaysFalse
+    Expression strictProjected = Projections.strict(spec).project(hourFilter);
+    assertThat(strictProjected).isEqualTo(Expressions.alwaysFalse());
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/15502

## Problem

When an Iceberg table has manifests written using a partition spec with `identity`-transformed timestamp field, queries that filter on that field using a temporal transform like `hours()` fail with:

```
ValidationException: Invalid value for conversion to type timestamptz: 490674 (java.lang.Integer)
```

`Identity.projectStrict()` creates an unbound predicate with the literal from the input predicate. When the predicate term is a transform (e.g. `hours(ts) = 490674`), the literal type (integer) does not match the partition field type (timestamptz), causing a `ValidationException` when the unbound predicate is later bound to the partition schema.

## Fix

Return `null` from `projectStrict()` when the predicate term is not a `BoundReference`, indicating the identity transform cannot project transform-based predicates. This causes the projection to fall back to `alwaysTrue` (inclusive) or `alwaysFalse` (strict), which is the correct behavior.

The fix is a 4-line guard clause at the top of `projectStrict()`. Since `project()` delegates to `projectStrict()`, both paths are covered.

## Testing

Added a regression test in `TestProjection` that reproduces the exact scenario from the issue: identity-partitioned `timestamptz` field filtered with `hours()` transform, verifying both inclusive and strict projections.