### PR TITLE
Spark: Fix RoaringBitmap version in runtime-deps.txt

### DIFF
--- a/spark/v4.1/spark-runtime/runtime-deps.txt
+++ b/spark/v4.1/spark-runtime/runtime-deps.txt
@@ -36,5 +36,5 @@ org.eclipse.microprofile.openapi:microprofile-openapi-api:4.1.1
 org.locationtech.jts:jts-core:1.20.0
 org.projectnessie.nessie:nessie-client:0.107.4
 org.projectnessie.nessie:nessie-model:0.107.4
-org.roaringbitmap:RoaringBitmap:1.6.13
+org.roaringbitmap:RoaringBitmap:1.6.14
 org.threeten:threeten-extra:1.7.1


### PR DESCRIPTION
Fixed by this command: 
```
./gradlew :iceberg-spark:iceberg-spark-runtime-4.1_2.13:generateRuntimeDeps
```

https://github.com/apache/iceberg/blob/5dae5fc856e228cd8e1b69ba14909d0067006650/gradle/libs.versions.toml#L84