### PR TITLE
Flink: Throw UnsupportedOperationException for materialized tables

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -423,7 +423,12 @@ public class FlinkCatalog extends AbstractCatalog {
               + "create table without 'connector'='iceberg' related properties in an iceberg table.");
     }
 
-    Preconditions.checkArgument(table instanceof ResolvedCatalogTable, "table should be resolved");
+    Preconditions.checkArgument(
+        table instanceof ResolvedCatalogTable,
+        "Expected a ResolvedCatalogTable but got: %s. "
+            + "Iceberg Flink catalog only supports resolved catalog tables "
+            + "(Materialized tables and other table kinds are not supported).",
+        table == null ? "null" : table.getClass().getName());
     createIcebergTable(tablePath, (ResolvedCatalogTable) table, ignoreIfExists);
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -33,7 +33,9 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema.UnresolvedPrimaryKey;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.iceberg.BaseTable;
@@ -743,6 +745,31 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
             .map(ContentFile::location)
             .collect(Collectors.toSet());
     assertThat(actualFilePaths).as("Files should match").isEqualTo(expectedFilePaths);
+  }
+
+  @TestTemplate
+  public void testCreateMaterializedTableIsUnsupported() {
+    CatalogMaterializedTable materializedTable =
+        CatalogMaterializedTable.newBuilder()
+            .schema(
+                org.apache.flink.table.api.Schema.newBuilder()
+                    .column("id", DataTypes.BIGINT())
+                    .build())
+            .definitionQuery("SELECT id FROM tl")
+            .freshness(IntervalFreshness.ofMinute("5"))
+            .logicalRefreshMode(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC)
+            .refreshMode(CatalogMaterializedTable.RefreshMode.CONTINUOUS)
+            .refreshStatus(CatalogMaterializedTable.RefreshStatus.INITIALIZING)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                getTableEnv()
+                    .getCatalog(catalogName)
+                    .get()
+                    .createTable(new ObjectPath(DATABASE, "mt_table"), materializedTable, false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Materialized tables and other table kinds are not supported");
   }
 
   private Table table(String name) {


### PR DESCRIPTION
## Summary

Creating a materialized table in Flink using an Iceberg catalog currently fails with a
cryptic `IllegalArgumentException: table should be resolved` from a `Preconditions.checkArgument`
deep in `FlinkCatalog.createTable()`. See #15318 for occurrence raised by a user.

This PR adds an explicit `instanceof CatalogMaterializedTable` check before that precondition,
throwing a clear `UnsupportedOperationException` with the message:
*"Materialized tables are not supported by Iceberg's Flink catalog."*

## Before

```
Caused by: java.lang.IllegalArgumentException: table should be resolved
    at org.apache.iceberg.flink.FlinkCatalog.createTable(FlinkCatalog.java:429)
```

## After

```
UnsupportedOperationException: Materialized tables are not supported by Iceberg's Flink catalog.
```

## Test plan

- [x] Added `testCreateMaterializedTableIsUnsupported` in `TestFlinkCatalogTable` (runs across all 3 catalog parametrizations)
- [x] `spotlessCheck` passes
- [x] Existing `TestFlinkCatalogTable` tests unaffected