### PR TITLE
Spark: Add session configs for adaptive split sizing and read parallelism

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -293,7 +293,10 @@ public class SparkReadConf {
 
   public int splitParallelism() {
     Integer parallelism =
-        confParser.intConf().sessionConf(SparkSQLProperties.READ_SPLIT_PARALLELISM).parseOptional();
+        confParser
+            .intConf()
+            .sessionConf(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_PARALLELISM)
+            .parseOptional();
     Preconditions.checkArgument(
         parallelism == null || parallelism > 0, "Split parallelism must be > 0: %s", parallelism);
     return parallelism != null ? parallelism : parallelism();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -292,14 +292,14 @@ public class SparkReadConf {
   }
 
   public int splitParallelism() {
-    Integer parallelism =
+    int parallelism =
         confParser
             .intConf()
             .sessionConf(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_PARALLELISM)
-            .parseOptional();
-    Preconditions.checkArgument(
-        parallelism == null || parallelism > 0, "Split parallelism must be > 0: %s", parallelism);
-    return parallelism != null ? parallelism : parallelism();
+            .defaultValue(parallelism())
+            .parse();
+    Preconditions.checkArgument(parallelism > 0, "Split parallelism must be > 0: %s", parallelism);
+    return parallelism;
   }
 
   public boolean distributedPlanningEnabled() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -291,12 +291,12 @@ public class SparkReadConf {
     return Math.max(defaultParallelism, numShufflePartitions);
   }
 
-  public Integer splitParallelism() {
+  public int splitParallelism() {
     Integer parallelism =
         confParser.intConf().sessionConf(SparkSQLProperties.READ_SPLIT_PARALLELISM).parseOptional();
     Preconditions.checkArgument(
         parallelism == null || parallelism > 0, "Split parallelism must be > 0: %s", parallelism);
-    return parallelism;
+    return parallelism != null ? parallelism : parallelism();
   }
 
   public boolean distributedPlanningEnabled() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -279,6 +279,7 @@ public class SparkReadConf {
   public boolean adaptiveSplitSizeEnabled() {
     return confParser
         .booleanConf()
+        .sessionConf(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_ENABLED)
         .tableProperty(TableProperties.ADAPTIVE_SPLIT_SIZE_ENABLED)
         .defaultValue(TableProperties.ADAPTIVE_SPLIT_SIZE_ENABLED_DEFAULT)
         .parse();
@@ -288,6 +289,14 @@ public class SparkReadConf {
     int defaultParallelism = spark.sparkContext().defaultParallelism();
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
     return Math.max(defaultParallelism, numShufflePartitions);
+  }
+
+  public Integer splitParallelism() {
+    Integer parallelism =
+        confParser.intConf().sessionConf(SparkSQLProperties.READ_SPLIT_PARALLELISM).parseOptional();
+    Preconditions.checkArgument(
+        parallelism == null || parallelism > 0, "Split parallelism must be > 0: %s", parallelism);
+    return parallelism;
   }
 
   public boolean distributedPlanningEnabled() {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -116,7 +116,8 @@ public class SparkSQLProperties {
 
   // Overrides the parallelism used for adaptive split sizing. When unset, the parallelism
   // defaults to max(spark.default.parallelism, spark.sql.shuffle.partitions).
-  public static final String READ_SPLIT_PARALLELISM = "spark.sql.iceberg.read.split-parallelism";
+  public static final String READ_ADAPTIVE_SPLIT_SIZE_PARALLELISM =
+      "spark.sql.iceberg.read.adaptive-split-size.parallelism";
 
   // Controls whether to enable async micro batch planning for session
   public static final String ASYNC_MICRO_BATCH_PLANNING_ENABLED =

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -110,6 +110,13 @@ public class SparkSQLProperties {
   // Prefix for custom snapshot properties
   public static final String SNAPSHOT_PROPERTY_PREFIX = "spark.sql.iceberg.snapshot-property.";
 
+  // Controls whether adaptive split sizing is enabled
+  public static final String READ_ADAPTIVE_SPLIT_SIZE_ENABLED =
+      "spark.sql.iceberg.read.adaptive-split-size.enabled";
+
+  // Controls the parallelism used for adaptive split sizing
+  public static final String READ_SPLIT_PARALLELISM = "spark.sql.iceberg.read.split.parallelism";
+
   // Controls whether to enable async micro batch planning for session
   public static final String ASYNC_MICRO_BATCH_PLANNING_ENABLED =
       "spark.sql.iceberg.async-micro-batch-planning-enabled";

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -114,8 +114,9 @@ public class SparkSQLProperties {
   public static final String READ_ADAPTIVE_SPLIT_SIZE_ENABLED =
       "spark.sql.iceberg.read.adaptive-split-size.enabled";
 
-  // Controls the parallelism used for adaptive split sizing
-  public static final String READ_SPLIT_PARALLELISM = "spark.sql.iceberg.read.split.parallelism";
+  // Overrides the parallelism used for adaptive split sizing. When unset, the parallelism
+  // defaults to max(spark.default.parallelism, spark.sql.shuffle.partitions).
+  public static final String READ_SPLIT_PARALLELISM = "spark.sql.iceberg.read.split-parallelism";
 
   // Controls whether to enable async micro batch planning for session
   public static final String ASYNC_MICRO_BATCH_PLANNING_ENABLED =

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -369,8 +369,19 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   protected long adjustSplitSize(List<? extends ScanTask> tasks, long splitSize) {
     if (readConf.splitSizeOption() == null && readConf.adaptiveSplitSizeEnabled()) {
       long scanSize = tasks.stream().mapToLong(ScanTask::sizeBytes).sum();
-      int parallelism = readConf.parallelism();
-      return TableScanUtil.adjustSplitSize(scanSize, parallelism, splitSize);
+      Integer configuredParallelism = readConf.splitParallelism();
+      int parallelism =
+          configuredParallelism != null ? configuredParallelism : readConf.parallelism();
+      long adjustedSplitSize = TableScanUtil.adjustSplitSize(scanSize, parallelism, splitSize);
+      if (adjustedSplitSize != splitSize) {
+        LOG.debug(
+            "Adjusted split size from {} to {} for table {} with parallelism {}",
+            splitSize,
+            adjustedSplitSize,
+            table().name(),
+            parallelism);
+      }
+      return adjustedSplitSize;
     } else {
       return splitSize;
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -369,9 +369,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   protected long adjustSplitSize(List<? extends ScanTask> tasks, long splitSize) {
     if (readConf.splitSizeOption() == null && readConf.adaptiveSplitSizeEnabled()) {
       long scanSize = tasks.stream().mapToLong(ScanTask::sizeBytes).sum();
-      Integer configuredParallelism = readConf.splitParallelism();
-      int parallelism =
-          configuredParallelism != null ? configuredParallelism : readConf.parallelism();
+      int parallelism = readConf.splitParallelism();
       long adjustedSplitSize = TableScanUtil.adjustSplitSize(scanSize, parallelism, splitSize);
       if (adjustedSplitSize != splitSize) {
         LOG.debug(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestSparkReadConf extends TestBaseWithCatalog {
+
+  @BeforeEach
+  public void before() {
+    super.before();
+    sql("CREATE TABLE %s (id BIGINT, data STRING) USING iceberg", tableName);
+  }
+
+  @AfterEach
+  public void after() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testAdaptiveSplitSizeSessionConf() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_ENABLED, "false"),
+        () -> {
+          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+          assertThat(conf.adaptiveSplitSizeEnabled()).isFalse();
+        });
+  }
+
+  @TestTemplate
+  public void testSplitParallelismDefault() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    withSQLConf(
+        ImmutableMap.of(SQLConf.SHUFFLE_PARTITIONS().key(), "999"),
+        () -> {
+          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+          assertThat(conf.splitParallelism()).isEqualTo(999);
+        });
+  }
+
+  @TestTemplate
+  public void testSplitParallelismSessionConf() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.READ_SPLIT_PARALLELISM, "42"),
+        () -> {
+          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+          assertThat(conf.splitParallelism()).isEqualTo(42);
+        });
+  }
+
+  @TestTemplate
+  public void testSplitParallelismRejectsZero() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.READ_SPLIT_PARALLELISM, "0"),
+        () -> {
+          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+          assertThatIllegalArgumentException()
+              .isThrownBy(conf::splitParallelism)
+              .withMessageContaining("Split parallelism must be > 0");
+        });
+  }
+
+  @TestTemplate
+  public void testSplitParallelismRejectsNegative() {
+    Table table = validationCatalog.loadTable(tableIdent);
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.READ_SPLIT_PARALLELISM, "-5"),
+        () -> {
+          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+          assertThatIllegalArgumentException()
+              .isThrownBy(conf::splitParallelism)
+              .withMessageContaining("Split parallelism must be > 0");
+        });
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
@@ -46,32 +46,21 @@ public class TestSparkReadConf extends TestBaseWithCatalog {
   }
 
   @TestTemplate
-  public void testAdaptiveSplitSizeSessionConf() {
-    Table table = validationCatalog.loadTable(tableIdent);
-    withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_ENABLED, "false"),
-        () -> {
-          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
-          assertThat(conf.adaptiveSplitSizeEnabled()).isFalse();
-        });
-  }
-
-  @TestTemplate
   public void testSplitParallelismDefault() {
     Table table = validationCatalog.loadTable(tableIdent);
-    withSQLConf(
-        ImmutableMap.of(SQLConf.SHUFFLE_PARTITIONS().key(), "999"),
-        () -> {
-          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
-          assertThat(conf.splitParallelism()).isEqualTo(999);
-        });
+    SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+    assertThat(conf.splitParallelism()).isEqualTo(conf.parallelism());
   }
 
   @TestTemplate
   public void testSplitParallelismSessionConf() {
     Table table = validationCatalog.loadTable(tableIdent);
     withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.READ_SPLIT_PARALLELISM, "42"),
+        ImmutableMap.of(
+            SQLConf.SHUFFLE_PARTITIONS().key(),
+            "999",
+            SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_PARALLELISM,
+            "42"),
         () -> {
           SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
           assertThat(conf.splitParallelism()).isEqualTo(42);
@@ -82,7 +71,7 @@ public class TestSparkReadConf extends TestBaseWithCatalog {
   public void testSplitParallelismRejectsZero() {
     Table table = validationCatalog.loadTable(tableIdent);
     withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.READ_SPLIT_PARALLELISM, "0"),
+        ImmutableMap.of(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_PARALLELISM, "0"),
         () -> {
           SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
           assertThatIllegalArgumentException()
@@ -95,7 +84,7 @@ public class TestSparkReadConf extends TestBaseWithCatalog {
   public void testSplitParallelismRejectsNegative() {
     Table table = validationCatalog.loadTable(tableIdent);
     withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.READ_SPLIT_PARALLELISM, "-5"),
+        ImmutableMap.of(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_PARALLELISM, "-5"),
         () -> {
           SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
           assertThatIllegalArgumentException()

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
@@ -44,7 +44,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalogConfig;
-import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
@@ -1104,53 +1103,6 @@ public class TestSparkScan extends TestBaseWithCatalog {
           assertThat(description).contains(tableName);
           assertThat(description).contains("startSnapshotId=" + startSnapshotId);
           assertThat(description).contains("endSnapshotId=" + endSnapshotId);
-        });
-  }
-
-  @TestTemplate
-  public void testAdaptiveSplitSizeSessionConfig() throws Exception {
-    sql(
-        "CREATE TABLE %s (id BIGINT, date DATE) USING iceberg TBLPROPERTIES('%s' = '%s')",
-        tableName, TableProperties.DEFAULT_FILE_FORMAT, format);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-    SparkReadConf readConf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
-    assertThat(readConf.adaptiveSplitSizeEnabled()).isTrue();
-
-    withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_ENABLED, "false"),
-        () -> {
-          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
-          assertThat(conf.adaptiveSplitSizeEnabled()).isFalse();
-        });
-
-    table.updateProperties().set(TableProperties.ADAPTIVE_SPLIT_SIZE_ENABLED, "true").commit();
-
-    withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_ENABLED, "false"),
-        () -> {
-          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
-          assertThat(conf.adaptiveSplitSizeEnabled()).isFalse();
-        });
-  }
-
-  @TestTemplate
-  public void testSplitParallelismSessionConfig() throws Exception {
-    sql(
-        "CREATE TABLE %s (id BIGINT, date DATE) USING iceberg TBLPROPERTIES('%s' = '%s')",
-        tableName, TableProperties.DEFAULT_FILE_FORMAT, format);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    SparkReadConf readConf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
-    assertThat(readConf.splitParallelism()).isNull();
-
-    withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.READ_SPLIT_PARALLELISM, "42"),
-        () -> {
-          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
-          assertThat(conf.splitParallelism()).isEqualTo(42);
-          assertThat(conf.parallelism()).isEqualTo(readConf.parallelism());
         });
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
@@ -1103,6 +1104,53 @@ public class TestSparkScan extends TestBaseWithCatalog {
           assertThat(description).contains(tableName);
           assertThat(description).contains("startSnapshotId=" + startSnapshotId);
           assertThat(description).contains("endSnapshotId=" + endSnapshotId);
+        });
+  }
+
+  @TestTemplate
+  public void testAdaptiveSplitSizeSessionConfig() throws Exception {
+    sql(
+        "CREATE TABLE %s (id BIGINT, date DATE) USING iceberg TBLPROPERTIES('%s' = '%s')",
+        tableName, TableProperties.DEFAULT_FILE_FORMAT, format);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    SparkReadConf readConf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+    assertThat(readConf.adaptiveSplitSizeEnabled()).isTrue();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_ENABLED, "false"),
+        () -> {
+          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+          assertThat(conf.adaptiveSplitSizeEnabled()).isFalse();
+        });
+
+    table.updateProperties().set(TableProperties.ADAPTIVE_SPLIT_SIZE_ENABLED, "true").commit();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.READ_ADAPTIVE_SPLIT_SIZE_ENABLED, "false"),
+        () -> {
+          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+          assertThat(conf.adaptiveSplitSizeEnabled()).isFalse();
+        });
+  }
+
+  @TestTemplate
+  public void testSplitParallelismSessionConfig() throws Exception {
+    sql(
+        "CREATE TABLE %s (id BIGINT, date DATE) USING iceberg TBLPROPERTIES('%s' = '%s')",
+        tableName, TableProperties.DEFAULT_FILE_FORMAT, format);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+    assertThat(readConf.splitParallelism()).isNull();
+
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.READ_SPLIT_PARALLELISM, "42"),
+        () -> {
+          SparkReadConf conf = new SparkReadConf(spark, table, CaseInsensitiveStringMap.empty());
+          assertThat(conf.splitParallelism()).isEqualTo(42);
+          assertThat(conf.parallelism()).isEqualTo(readConf.parallelism());
         });
   }
 


### PR DESCRIPTION
###   Summary
  - Add session configs to control adaptive split sizing and allow configurable read parallelism
  - Resolves [ICEBERG-15988](https://github.com/apache/iceberg/issues/15988)

### Changes

 - Added configs to enable/disable adaptive split sizing at session level
 - Added config to config read split parallelism count

 ###  Test plan
  - Unit tests added
