### PR TITLE
Core: Add builders for v4 structs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
 
 /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
@@ -39,14 +40,6 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
 
   DeletionVectorStruct(Types.StructType type) {
     super(BASE_TYPE, type);
-  }
-
-  DeletionVectorStruct(String location, long offset, long sizeInBytes, long cardinality) {
-    super(BASE_TYPE.fields().size());
-    this.location = location;
-    this.offset = offset;
-    this.sizeInBytes = sizeInBytes;
-    this.cardinality = cardinality;
   }
 
   private DeletionVectorStruct(DeletionVectorStruct toCopy) {
@@ -131,5 +124,46 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
         .add("size_in_bytes", sizeInBytes)
         .add("cardinality", cardinality)
         .toString();
+  }
+
+  static class Builder {
+    private String location = null;
+    private long offset = -1L;
+    private long sizeInBytes = -1L;
+    private long cardinality = -1L;
+
+    Builder location(String dvLocation) {
+      this.location = dvLocation;
+      return this;
+    }
+
+    Builder offset(long dvOffset) {
+      this.offset = dvOffset;
+      return this;
+    }
+
+    Builder sizeInBytes(long dvSizeInBytes) {
+      this.sizeInBytes = dvSizeInBytes;
+      return this;
+    }
+
+    Builder cardinality(long dvCardinality) {
+      this.cardinality = dvCardinality;
+      return this;
+    }
+
+    DeletionVectorStruct build() {
+      Preconditions.checkArgument(location != null, "Invalid location: null");
+      Preconditions.checkArgument(offset >= 0, "Invalid offset: %s", offset);
+      Preconditions.checkArgument(sizeInBytes >= 0, "Invalid size in bytes: %s", sizeInBytes);
+      Preconditions.checkArgument(cardinality >= 0, "Invalid cardinality: %s", cardinality);
+
+      DeletionVectorStruct struct = new DeletionVectorStruct(BASE_TYPE);
+      struct.location = location;
+      struct.offset = offset;
+      struct.sizeInBytes = sizeInBytes;
+      struct.cardinality = cardinality;
+      return struct;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -49,6 +49,14 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
     this.cardinality = toCopy.cardinality;
   }
 
+  private DeletionVectorStruct(String location, long offset, long sizeInBytes, long cardinality) {
+    super(BASE_TYPE, BASE_TYPE);
+    this.location = location;
+    this.offset = offset;
+    this.sizeInBytes = sizeInBytes;
+    this.cardinality = cardinality;
+  }
+
   @Override
   public String location() {
     return location;
@@ -115,6 +123,10 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
     }
   }
 
+  static Builder builder() {
+    return new Builder();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -152,12 +164,7 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
     }
 
     DeletionVectorStruct build() {
-      DeletionVectorStruct struct = new DeletionVectorStruct(BASE_TYPE);
-      struct.location = location;
-      struct.offset = offset;
-      struct.sizeInBytes = sizeInBytes;
-      struct.cardinality = cardinality;
-      return struct;
+      return new DeletionVectorStruct(location, offset, sizeInBytes, cardinality);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
 
 /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
@@ -153,11 +152,6 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
     }
 
     DeletionVectorStruct build() {
-      Preconditions.checkArgument(location != null, "Invalid location: null");
-      Preconditions.checkArgument(offset >= 0, "Invalid offset: %s", offset);
-      Preconditions.checkArgument(sizeInBytes >= 0, "Invalid size in bytes: %s", sizeInBytes);
-      Preconditions.checkArgument(cardinality >= 0, "Invalid cardinality: %s", cardinality);
-
       DeletionVectorStruct struct = new DeletionVectorStruct(BASE_TYPE);
       struct.location = location;
       struct.offset = offset;

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -41,6 +41,14 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
     super(BASE_TYPE, type);
   }
 
+  DeletionVectorStruct(String location, long offset, long sizeInBytes, long cardinality) {
+    super(BASE_TYPE.fields().size());
+    this.location = location;
+    this.offset = offset;
+    this.sizeInBytes = sizeInBytes;
+    this.cardinality = cardinality;
+  }
+
   private DeletionVectorStruct(DeletionVectorStruct toCopy) {
     super(toCopy);
     this.location = toCopy.location;

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
 
 /** Mutable {@link StructLike} implementation of {@link DeletionVector}. */
@@ -164,6 +165,10 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
     }
 
     DeletionVectorStruct build() {
+      Preconditions.checkArgument(location != null, "Invalid location: null");
+      Preconditions.checkArgument(offset >= 0, "Invalid offset: %s", offset);
+      Preconditions.checkArgument(sizeInBytes >= 0, "Invalid size in bytes: %s", sizeInBytes);
+      Preconditions.checkArgument(cardinality >= 0, "Invalid cardinality: %s", cardinality);
       return new DeletionVectorStruct(location, offset, sizeInBytes, cardinality);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -166,9 +166,11 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
 
     DeletionVectorStruct build() {
       Preconditions.checkArgument(location != null, "Invalid location: null");
-      Preconditions.checkArgument(offset >= 0, "Invalid offset: %s", offset);
-      Preconditions.checkArgument(sizeInBytes >= 0, "Invalid size in bytes: %s", sizeInBytes);
-      Preconditions.checkArgument(cardinality >= 0, "Invalid cardinality: %s", cardinality);
+      Preconditions.checkArgument(offset >= 0, "Invalid offset: %s (must be >= 0)", offset);
+      Preconditions.checkArgument(
+          sizeInBytes >= 0, "Invalid size in bytes: %s (must be >= 0)", sizeInBytes);
+      Preconditions.checkArgument(
+          cardinality >= 0, "Invalid cardinality: %s (must be >= 0)", cardinality);
       return new DeletionVectorStruct(location, offset, sizeInBytes, cardinality);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -73,6 +73,32 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
     this.dvCardinality = toCopy.dvCardinality;
   }
 
+  private ManifestInfoStruct(
+      int addedFilesCount,
+      int existingFilesCount,
+      int deletedFilesCount,
+      int replacedFilesCount,
+      long addedRowsCount,
+      long existingRowsCount,
+      long deletedRowsCount,
+      long replacedRowsCount,
+      long minSequenceNumber,
+      byte[] dv,
+      Long dvCardinality) {
+    super(BASE_TYPE, BASE_TYPE);
+    this.addedFilesCount = addedFilesCount;
+    this.existingFilesCount = existingFilesCount;
+    this.deletedFilesCount = deletedFilesCount;
+    this.replacedFilesCount = replacedFilesCount;
+    this.addedRowsCount = addedRowsCount;
+    this.existingRowsCount = existingRowsCount;
+    this.deletedRowsCount = deletedRowsCount;
+    this.replacedRowsCount = replacedRowsCount;
+    this.minSequenceNumber = minSequenceNumber;
+    this.dv = dv;
+    this.dvCardinality = dvCardinality;
+  }
+
   @Override
   public int addedFilesCount() {
     return addedFilesCount;
@@ -208,6 +234,10 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
     }
   }
 
+  static Builder builder() {
+    return new Builder();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -294,19 +324,18 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
     }
 
     ManifestInfoStruct build() {
-      ManifestInfoStruct struct = new ManifestInfoStruct(BASE_TYPE);
-      struct.addedFilesCount = addedFilesCount;
-      struct.existingFilesCount = existingFilesCount;
-      struct.deletedFilesCount = deletedFilesCount;
-      struct.replacedFilesCount = replacedFilesCount;
-      struct.addedRowsCount = addedRowsCount;
-      struct.existingRowsCount = existingRowsCount;
-      struct.deletedRowsCount = deletedRowsCount;
-      struct.replacedRowsCount = replacedRowsCount;
-      struct.minSequenceNumber = minSequenceNumber;
-      struct.dv = dv;
-      struct.dvCardinality = dvCardinality;
-      return struct;
+      return new ManifestInfoStruct(
+          addedFilesCount,
+          existingFilesCount,
+          deletedFilesCount,
+          replacedFilesCount,
+          addedRowsCount,
+          existingRowsCount,
+          deletedRowsCount,
+          replacedRowsCount,
+          minSequenceNumber,
+          dv,
+          dvCardinality);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -362,7 +362,7 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
           minSequenceNumber);
       Preconditions.checkArgument(
           (dv == null) == (dvCardinality == null),
-          "dv and dvCardinality must both be null or both be non-null");
+          "Invalid DV and cardinality: must both be null or non-null");
       return new ManifestInfoStruct(
           addedFilesCount,
           existingFilesCount,

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
@@ -295,25 +294,6 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
     }
 
     ManifestInfoStruct build() {
-      Preconditions.checkArgument(
-          addedFilesCount >= 0, "Invalid added files count: %s", addedFilesCount);
-      Preconditions.checkArgument(
-          existingFilesCount >= 0, "Invalid existing files count: %s", existingFilesCount);
-      Preconditions.checkArgument(
-          deletedFilesCount >= 0, "Invalid deleted files count: %s", deletedFilesCount);
-      Preconditions.checkArgument(
-          replacedFilesCount >= 0, "Invalid replaced files count: %s", replacedFilesCount);
-      Preconditions.checkArgument(
-          addedRowsCount >= 0, "Invalid added rows count: %s", addedRowsCount);
-      Preconditions.checkArgument(
-          existingRowsCount >= 0, "Invalid existing rows count: %s", existingRowsCount);
-      Preconditions.checkArgument(
-          deletedRowsCount >= 0, "Invalid deleted rows count: %s", deletedRowsCount);
-      Preconditions.checkArgument(
-          replacedRowsCount >= 0, "Invalid replaced rows count: %s", replacedRowsCount);
-      Preconditions.checkArgument(
-          minSequenceNumber >= 0, "Invalid min sequence number: %s", minSequenceNumber);
-
       ManifestInfoStruct struct = new ManifestInfoStruct(BASE_TYPE);
       struct.addedFilesCount = addedFilesCount;
       struct.existingFilesCount = existingFilesCount;

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -360,6 +360,9 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
           minSequenceNumber >= 0,
           "Invalid min sequence number: %s (must be >= 0)",
           minSequenceNumber);
+      Preconditions.checkArgument(
+          (dv == null) == (dvCardinality == null),
+          "dv and dvCardinality must both be null or both be non-null");
       return new ManifestInfoStruct(
           addedFilesCount,
           existingFilesCount,

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
@@ -324,6 +325,24 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
     }
 
     ManifestInfoStruct build() {
+      Preconditions.checkArgument(
+          addedFilesCount >= 0, "Invalid added files count: %s", addedFilesCount);
+      Preconditions.checkArgument(
+          existingFilesCount >= 0, "Invalid existing files count: %s", existingFilesCount);
+      Preconditions.checkArgument(
+          deletedFilesCount >= 0, "Invalid deleted files count: %s", deletedFilesCount);
+      Preconditions.checkArgument(
+          replacedFilesCount >= 0, "Invalid replaced files count: %s", replacedFilesCount);
+      Preconditions.checkArgument(
+          addedRowsCount >= 0, "Invalid added rows count: %s", addedRowsCount);
+      Preconditions.checkArgument(
+          existingRowsCount >= 0, "Invalid existing rows count: %s", existingRowsCount);
+      Preconditions.checkArgument(
+          deletedRowsCount >= 0, "Invalid deleted rows count: %s", deletedRowsCount);
+      Preconditions.checkArgument(
+          replacedRowsCount >= 0, "Invalid replaced rows count: %s", replacedRowsCount);
+      Preconditions.checkArgument(
+          minSequenceNumber >= 0, "Invalid min sequence number: %s", minSequenceNumber);
       return new ManifestInfoStruct(
           addedFilesCount,
           existingFilesCount,

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -319,6 +319,11 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
       return this;
     }
 
+    Builder dv(byte[] buffer) {
+      this.dv = buffer;
+      return this;
+    }
+
     Builder dvCardinality(Long cardinality) {
       this.dvCardinality = cardinality;
       return this;
@@ -326,23 +331,35 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
 
     ManifestInfoStruct build() {
       Preconditions.checkArgument(
-          addedFilesCount >= 0, "Invalid added files count: %s", addedFilesCount);
+          addedFilesCount >= 0, "Invalid added files count: %s (must be >= 0)", addedFilesCount);
       Preconditions.checkArgument(
-          existingFilesCount >= 0, "Invalid existing files count: %s", existingFilesCount);
+          existingFilesCount >= 0,
+          "Invalid existing files count: %s (must be >= 0)",
+          existingFilesCount);
       Preconditions.checkArgument(
-          deletedFilesCount >= 0, "Invalid deleted files count: %s", deletedFilesCount);
+          deletedFilesCount >= 0,
+          "Invalid deleted files count: %s (must be >= 0)",
+          deletedFilesCount);
       Preconditions.checkArgument(
-          replacedFilesCount >= 0, "Invalid replaced files count: %s", replacedFilesCount);
+          replacedFilesCount >= 0,
+          "Invalid replaced files count: %s (must be >= 0)",
+          replacedFilesCount);
       Preconditions.checkArgument(
-          addedRowsCount >= 0, "Invalid added rows count: %s", addedRowsCount);
+          addedRowsCount >= 0, "Invalid added rows count: %s (must be >= 0)", addedRowsCount);
       Preconditions.checkArgument(
-          existingRowsCount >= 0, "Invalid existing rows count: %s", existingRowsCount);
+          existingRowsCount >= 0,
+          "Invalid existing rows count: %s (must be >= 0)",
+          existingRowsCount);
       Preconditions.checkArgument(
-          deletedRowsCount >= 0, "Invalid deleted rows count: %s", deletedRowsCount);
+          deletedRowsCount >= 0, "Invalid deleted rows count: %s (must be >= 0)", deletedRowsCount);
       Preconditions.checkArgument(
-          replacedRowsCount >= 0, "Invalid replaced rows count: %s", replacedRowsCount);
+          replacedRowsCount >= 0,
+          "Invalid replaced rows count: %s (must be >= 0)",
+          replacedRowsCount);
       Preconditions.checkArgument(
-          minSequenceNumber >= 0, "Invalid min sequence number: %s", minSequenceNumber);
+          minSequenceNumber >= 0,
+          "Invalid min sequence number: %s (must be >= 0)",
+          minSequenceNumber);
       return new ManifestInfoStruct(
           addedFilesCount,
           existingFilesCount,

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -363,6 +363,10 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
       Preconditions.checkArgument(
           (dv == null) == (dvCardinality == null),
           "Invalid DV and cardinality: must both be null or non-null");
+      Preconditions.checkArgument(
+          dvCardinality == null || dvCardinality > 0,
+          "Invalid DV cardinality: %s (must be positive)",
+          dvCardinality);
       return new ManifestInfoStruct(
           addedFilesCount,
           existingFilesCount,

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 
@@ -223,5 +224,109 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
         .add("dv", dv == null ? "null" : "(binary)")
         .add("dv_cardinality", dvCardinality == null ? "null" : dvCardinality)
         .toString();
+  }
+
+  static class Builder {
+    private int addedFilesCount = -1;
+    private int existingFilesCount = -1;
+    private int deletedFilesCount = -1;
+    private int replacedFilesCount = -1;
+    private long addedRowsCount = -1L;
+    private long existingRowsCount = -1L;
+    private long deletedRowsCount = -1L;
+    private long replacedRowsCount = -1L;
+    private long minSequenceNumber = -1L;
+    private byte[] dv = null;
+    private Long dvCardinality = null;
+
+    Builder addedFilesCount(int count) {
+      this.addedFilesCount = count;
+      return this;
+    }
+
+    Builder existingFilesCount(int count) {
+      this.existingFilesCount = count;
+      return this;
+    }
+
+    Builder deletedFilesCount(int count) {
+      this.deletedFilesCount = count;
+      return this;
+    }
+
+    Builder replacedFilesCount(int count) {
+      this.replacedFilesCount = count;
+      return this;
+    }
+
+    Builder addedRowsCount(long count) {
+      this.addedRowsCount = count;
+      return this;
+    }
+
+    Builder existingRowsCount(long count) {
+      this.existingRowsCount = count;
+      return this;
+    }
+
+    Builder deletedRowsCount(long count) {
+      this.deletedRowsCount = count;
+      return this;
+    }
+
+    Builder replacedRowsCount(long count) {
+      this.replacedRowsCount = count;
+      return this;
+    }
+
+    Builder minSequenceNumber(long sequenceNumber) {
+      this.minSequenceNumber = sequenceNumber;
+      return this;
+    }
+
+    Builder dv(ByteBuffer buffer) {
+      this.dv = buffer != null ? ByteBuffers.toByteArray(buffer) : null;
+      return this;
+    }
+
+    Builder dvCardinality(Long cardinality) {
+      this.dvCardinality = cardinality;
+      return this;
+    }
+
+    ManifestInfoStruct build() {
+      Preconditions.checkArgument(
+          addedFilesCount >= 0, "Invalid added files count: %s", addedFilesCount);
+      Preconditions.checkArgument(
+          existingFilesCount >= 0, "Invalid existing files count: %s", existingFilesCount);
+      Preconditions.checkArgument(
+          deletedFilesCount >= 0, "Invalid deleted files count: %s", deletedFilesCount);
+      Preconditions.checkArgument(
+          replacedFilesCount >= 0, "Invalid replaced files count: %s", replacedFilesCount);
+      Preconditions.checkArgument(
+          addedRowsCount >= 0, "Invalid added rows count: %s", addedRowsCount);
+      Preconditions.checkArgument(
+          existingRowsCount >= 0, "Invalid existing rows count: %s", existingRowsCount);
+      Preconditions.checkArgument(
+          deletedRowsCount >= 0, "Invalid deleted rows count: %s", deletedRowsCount);
+      Preconditions.checkArgument(
+          replacedRowsCount >= 0, "Invalid replaced rows count: %s", replacedRowsCount);
+      Preconditions.checkArgument(
+          minSequenceNumber >= 0, "Invalid min sequence number: %s", minSequenceNumber);
+
+      ManifestInfoStruct struct = new ManifestInfoStruct(BASE_TYPE);
+      struct.addedFilesCount = addedFilesCount;
+      struct.existingFilesCount = existingFilesCount;
+      struct.deletedFilesCount = deletedFilesCount;
+      struct.replacedFilesCount = replacedFilesCount;
+      struct.addedRowsCount = addedRowsCount;
+      struct.existingRowsCount = existingRowsCount;
+      struct.deletedRowsCount = deletedRowsCount;
+      struct.replacedRowsCount = replacedRowsCount;
+      struct.minSequenceNumber = minSequenceNumber;
+      struct.dv = dv;
+      struct.dvCardinality = dvCardinality;
+      return struct;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -79,6 +79,26 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     this.manifestPos = toCopy.manifestPos;
   }
 
+  private TrackingStruct(
+      EntryStatus status,
+      Long snapshotId,
+      Long dataSequenceNumber,
+      Long fileSequenceNumber,
+      Long dvSnapshotId,
+      Long firstRowId,
+      byte[] deletedPositions,
+      byte[] replacedPositions) {
+    super(BASE_TYPE, BASE_TYPE);
+    this.status = status;
+    this.snapshotId = snapshotId;
+    this.dataSequenceNumber = dataSequenceNumber;
+    this.fileSequenceNumber = fileSequenceNumber;
+    this.dvSnapshotId = dvSnapshotId;
+    this.firstRowId = firstRowId;
+    this.deletedPositions = deletedPositions;
+    this.replacedPositions = replacedPositions;
+  }
+
   void inheritFrom(Tracking manifestTracking) {
     if (manifestTracking != null) {
       if (snapshotId == null) {
@@ -229,6 +249,10 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     }
   }
 
+  static Builder builder() {
+    return new Builder();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -294,16 +318,15 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     }
 
     TrackingStruct build() {
-      TrackingStruct struct = new TrackingStruct(BASE_TYPE);
-      struct.status = status;
-      struct.snapshotId = snapshotId;
-      struct.dataSequenceNumber = dataSequenceNumber;
-      struct.fileSequenceNumber = fileSequenceNumber;
-      struct.dvSnapshotId = dvSnapshotId;
-      struct.firstRowId = firstRowId;
-      struct.deletedPositions = deletedPositions;
-      struct.replacedPositions = replacedPositions;
-      return struct;
+      return new TrackingStruct(
+          status,
+          snapshotId,
+          dataSequenceNumber,
+          fileSequenceNumber,
+          dvSnapshotId,
+          firstRowId,
+          deletedPositions,
+          replacedPositions);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -312,8 +312,18 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
       return this;
     }
 
+    Builder deletedPositions(byte[] positions) {
+      this.deletedPositions = positions;
+      return this;
+    }
+
     Builder replacedPositions(ByteBuffer positions) {
       this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
+      return this;
+    }
+
+    Builder replacedPositions(byte[] positions) {
+      this.replacedPositions = positions;
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -63,6 +63,12 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     super(BASE_TYPE.fields().size());
   }
 
+  TrackingStruct(EntryStatus status, Long snapshotId) {
+    super(BASE_TYPE.fields().size());
+    this.status = status;
+    this.snapshotId = snapshotId;
+  }
+
   private TrackingStruct(TrackingStruct toCopy) {
     super(toCopy);
     this.status = toCopy.status;

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -318,6 +318,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     }
 
     TrackingStruct build() {
+      Preconditions.checkArgument(status != null, "Invalid status: null");
       return new TrackingStruct(
           status,
           snapshotId,

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -59,16 +59,6 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     super(BASE_TYPE, type);
   }
 
-  TrackingStruct() {
-    super(BASE_TYPE.fields().size());
-  }
-
-  TrackingStruct(EntryStatus status, Long snapshotId) {
-    super(BASE_TYPE.fields().size());
-    this.status = status;
-    this.snapshotId = snapshotId;
-  }
-
   private TrackingStruct(TrackingStruct toCopy) {
     super(toCopy);
     this.status = toCopy.status;
@@ -251,5 +241,71 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
         .add("deleted_positions", deletedPositions == null ? "null" : "(binary)")
         .add("replaced_positions", replacedPositions == null ? "null" : "(binary)")
         .toString();
+  }
+
+  static class Builder {
+    private EntryStatus status = null;
+    private Long snapshotId = null;
+    private Long dataSequenceNumber = null;
+    private Long fileSequenceNumber = null;
+    private Long dvSnapshotId = null;
+    private Long firstRowId = null;
+    private byte[] deletedPositions = null;
+    private byte[] replacedPositions = null;
+
+    Builder status(EntryStatus entryStatus) {
+      this.status = entryStatus;
+      return this;
+    }
+
+    Builder snapshotId(Long id) {
+      this.snapshotId = id;
+      return this;
+    }
+
+    Builder dataSequenceNumber(Long sequenceNumber) {
+      this.dataSequenceNumber = sequenceNumber;
+      return this;
+    }
+
+    Builder fileSequenceNumber(Long sequenceNumber) {
+      this.fileSequenceNumber = sequenceNumber;
+      return this;
+    }
+
+    Builder dvSnapshotId(Long id) {
+      this.dvSnapshotId = id;
+      return this;
+    }
+
+    Builder firstRowId(Long rowId) {
+      this.firstRowId = rowId;
+      return this;
+    }
+
+    Builder deletedPositions(ByteBuffer positions) {
+      this.deletedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
+      return this;
+    }
+
+    Builder replacedPositions(ByteBuffer positions) {
+      this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
+      return this;
+    }
+
+    TrackingStruct build() {
+      Preconditions.checkArgument(status != null, "Invalid status: null");
+
+      TrackingStruct struct = new TrackingStruct(BASE_TYPE);
+      struct.status = status;
+      struct.snapshotId = snapshotId;
+      struct.dataSequenceNumber = dataSequenceNumber;
+      struct.fileSequenceNumber = fileSequenceNumber;
+      struct.dvSnapshotId = dvSnapshotId;
+      struct.firstRowId = firstRowId;
+      struct.deletedPositions = deletedPositions;
+      struct.replacedPositions = replacedPositions;
+      return struct;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -294,8 +294,6 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     }
 
     TrackingStruct build() {
-      Preconditions.checkArgument(status != null, "Invalid status: null");
-
       TrackingStruct struct = new TrackingStruct(BASE_TYPE);
       struct.status = status;
       struct.snapshotId = snapshotId;

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -28,12 +28,8 @@ class TestDeletionVectorStruct {
 
   @Test
   void testFieldAccess() {
-    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
-
-    dv.set(0, "s3://bucket/data/dv.puffin");
-    dv.set(1, 256L);
-    dv.set(2, 128L);
-    dv.set(3, 42L);
+    DeletionVectorStruct dv =
+        new DeletionVectorStruct("s3://bucket/data/dv.puffin", 256L, 128L, 42L);
 
     assertThat(dv.location()).isEqualTo("s3://bucket/data/dv.puffin");
     assertThat(dv.offset()).isEqualTo(256L);
@@ -43,12 +39,8 @@ class TestDeletionVectorStruct {
 
   @Test
   void testCopy() {
-    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
-
-    dv.set(0, "s3://bucket/data/dv.puffin");
-    dv.set(1, 256L);
-    dv.set(2, 128L);
-    dv.set(3, 42L);
+    DeletionVectorStruct dv =
+        new DeletionVectorStruct("s3://bucket/data/dv.puffin", 256L, 128L, 42L);
 
     DeletionVectorStruct copy = dv.copy();
 
@@ -86,11 +78,8 @@ class TestDeletionVectorStruct {
 
   @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
-    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
-    dv.set(0, "s3://bucket/data/dv.puffin");
-    dv.set(1, 256L);
-    dv.set(2, 128L);
-    dv.set(3, 42L);
+    DeletionVectorStruct dv =
+        new DeletionVectorStruct("s3://bucket/data/dv.puffin", 256L, 128L, 42L);
 
     DeletionVectorStruct deserialized = TestHelpers.roundTripSerialize(dv);
 
@@ -102,11 +91,8 @@ class TestDeletionVectorStruct {
 
   @Test
   void testKryoSerializationRoundTrip() throws IOException {
-    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
-    dv.set(0, "s3://bucket/data/dv.puffin");
-    dv.set(1, 256L);
-    dv.set(2, 128L);
-    dv.set(3, 42L);
+    DeletionVectorStruct dv =
+        new DeletionVectorStruct("s3://bucket/data/dv.puffin", 256L, 128L, 42L);
 
     DeletionVectorStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(dv);
 

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -120,7 +120,7 @@ class TestDeletionVectorStruct {
                     .cardinality(1)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid offset: -1");
+        .hasMessage("Invalid offset: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -130,7 +130,7 @@ class TestDeletionVectorStruct {
                     .cardinality(1)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid size in bytes: -1");
+        .hasMessage("Invalid size in bytes: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -140,7 +140,7 @@ class TestDeletionVectorStruct {
                     .sizeInBytes(1)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid cardinality: -1");
+        .hasMessage("Invalid cardinality: -1 (must be >= 0)");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import org.apache.iceberg.types.Types;
@@ -121,17 +120,5 @@ class TestDeletionVectorStruct {
     assertThat(deserialized.offset()).isEqualTo(256L);
     assertThat(deserialized.sizeInBytes()).isEqualTo(128L);
     assertThat(deserialized.cardinality()).isEqualTo(42L);
-  }
-
-  @Test
-  void testBuildValidatesRequiredFields() {
-    assertThatThrownBy(() -> new DeletionVectorStruct.Builder().build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid location: null");
-
-    assertThatThrownBy(
-            () -> new DeletionVectorStruct.Builder().location("s3://bucket/dv.puffin").build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid offset: -1");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -29,7 +29,7 @@ class TestDeletionVectorStruct {
   @Test
   void testFieldAccess() {
     DeletionVectorStruct dv =
-        new DeletionVectorStruct.Builder()
+        DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
             .offset(256L)
             .sizeInBytes(128L)
@@ -45,7 +45,7 @@ class TestDeletionVectorStruct {
   @Test
   void testCopy() {
     DeletionVectorStruct dv =
-        new DeletionVectorStruct.Builder()
+        DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
             .offset(256L)
             .sizeInBytes(128L)
@@ -89,7 +89,7 @@ class TestDeletionVectorStruct {
   @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     DeletionVectorStruct dv =
-        new DeletionVectorStruct.Builder()
+        DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
             .offset(256L)
             .sizeInBytes(128L)
@@ -107,7 +107,7 @@ class TestDeletionVectorStruct {
   @Test
   void testKryoSerializationRoundTrip() throws IOException {
     DeletionVectorStruct dv =
-        new DeletionVectorStruct.Builder()
+        DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
             .offset(256L)
             .sizeInBytes(128L)

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import org.apache.iceberg.types.Types;
@@ -29,7 +30,12 @@ class TestDeletionVectorStruct {
   @Test
   void testFieldAccess() {
     DeletionVectorStruct dv =
-        new DeletionVectorStruct("s3://bucket/data/dv.puffin", 256L, 128L, 42L);
+        new DeletionVectorStruct.Builder()
+            .location("s3://bucket/data/dv.puffin")
+            .offset(256L)
+            .sizeInBytes(128L)
+            .cardinality(42L)
+            .build();
 
     assertThat(dv.location()).isEqualTo("s3://bucket/data/dv.puffin");
     assertThat(dv.offset()).isEqualTo(256L);
@@ -40,7 +46,12 @@ class TestDeletionVectorStruct {
   @Test
   void testCopy() {
     DeletionVectorStruct dv =
-        new DeletionVectorStruct("s3://bucket/data/dv.puffin", 256L, 128L, 42L);
+        new DeletionVectorStruct.Builder()
+            .location("s3://bucket/data/dv.puffin")
+            .offset(256L)
+            .sizeInBytes(128L)
+            .cardinality(42L)
+            .build();
 
     DeletionVectorStruct copy = dv.copy();
 
@@ -79,7 +90,12 @@ class TestDeletionVectorStruct {
   @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     DeletionVectorStruct dv =
-        new DeletionVectorStruct("s3://bucket/data/dv.puffin", 256L, 128L, 42L);
+        new DeletionVectorStruct.Builder()
+            .location("s3://bucket/data/dv.puffin")
+            .offset(256L)
+            .sizeInBytes(128L)
+            .cardinality(42L)
+            .build();
 
     DeletionVectorStruct deserialized = TestHelpers.roundTripSerialize(dv);
 
@@ -92,7 +108,12 @@ class TestDeletionVectorStruct {
   @Test
   void testKryoSerializationRoundTrip() throws IOException {
     DeletionVectorStruct dv =
-        new DeletionVectorStruct("s3://bucket/data/dv.puffin", 256L, 128L, 42L);
+        new DeletionVectorStruct.Builder()
+            .location("s3://bucket/data/dv.puffin")
+            .offset(256L)
+            .sizeInBytes(128L)
+            .cardinality(42L)
+            .build();
 
     DeletionVectorStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(dv);
 
@@ -100,5 +121,17 @@ class TestDeletionVectorStruct {
     assertThat(deserialized.offset()).isEqualTo(256L);
     assertThat(deserialized.sizeInBytes()).isEqualTo(128L);
     assertThat(deserialized.cardinality()).isEqualTo(42L);
+  }
+
+  @Test
+  void testBuildValidatesRequiredFields() {
+    assertThatThrownBy(() -> new DeletionVectorStruct.Builder().build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid location: null");
+
+    assertThatThrownBy(
+            () -> new DeletionVectorStruct.Builder().location("s3://bucket/dv.puffin").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid offset: -1");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import org.apache.iceberg.types.Types;
@@ -102,6 +103,44 @@ class TestDeletionVectorStruct {
     assertThat(deserialized.offset()).isEqualTo(256L);
     assertThat(deserialized.sizeInBytes()).isEqualTo(128L);
     assertThat(deserialized.cardinality()).isEqualTo(42L);
+  }
+
+  @Test
+  void testBuilderValidation() {
+    assertThatThrownBy(
+            () -> DeletionVectorStruct.builder().offset(0).sizeInBytes(1).cardinality(1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid location: null");
+
+    assertThatThrownBy(
+            () ->
+                DeletionVectorStruct.builder()
+                    .location("s3://bucket/dv.puffin")
+                    .sizeInBytes(1)
+                    .cardinality(1)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid offset: -1");
+
+    assertThatThrownBy(
+            () ->
+                DeletionVectorStruct.builder()
+                    .location("s3://bucket/dv.puffin")
+                    .offset(0)
+                    .cardinality(1)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid size in bytes: -1");
+
+    assertThatThrownBy(
+            () ->
+                DeletionVectorStruct.builder()
+                    .location("s3://bucket/dv.puffin")
+                    .offset(0)
+                    .sizeInBytes(1)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid cardinality: -1");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -301,6 +301,43 @@ class TestManifestInfoStruct {
   }
 
   @Test
+  void testBuilderDvPairingValidation() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .dv(new byte[] {0xF})
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("dv and dvCardinality must both be null or both be non-null");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .dvCardinality(1L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("dv and dvCardinality must both be null or both be non-null");
+  }
+
+  @Test
   void testKryoSerializationRoundTrip() throws IOException {
     ManifestInfoStruct info =
         ManifestInfoStruct.builder()

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -335,6 +335,24 @@ class TestManifestInfoStruct {
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid DV and cardinality: must both be null or non-null");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .dv(new byte[] {0xF})
+                    .dvCardinality(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid DV cardinality: 0 (must be positive)");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -317,7 +317,7 @@ class TestManifestInfoStruct {
                     .dv(new byte[] {0xF})
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("dv and dvCardinality must both be null or both be non-null");
+        .hasMessage("Invalid DV and cardinality: must both be null or non-null");
 
     assertThatThrownBy(
             () ->
@@ -334,7 +334,7 @@ class TestManifestInfoStruct {
                     .dvCardinality(1L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("dv and dvCardinality must both be null or both be non-null");
+        .hasMessage("Invalid DV and cardinality: must both be null or non-null");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -59,7 +59,7 @@ class TestManifestInfoStruct {
   @Test
   void testCopy() {
     ManifestInfoStruct info =
-        new ManifestInfoStruct.Builder()
+        ManifestInfoStruct.builder()
             .addedFilesCount(10)
             .existingFilesCount(20)
             .deletedFilesCount(3)
@@ -93,7 +93,7 @@ class TestManifestInfoStruct {
   @Test
   void testNullableFields() {
     ManifestInfoStruct info =
-        new ManifestInfoStruct.Builder()
+        ManifestInfoStruct.builder()
             .addedFilesCount(0)
             .existingFilesCount(0)
             .deletedFilesCount(0)
@@ -132,7 +132,7 @@ class TestManifestInfoStruct {
   @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     ManifestInfoStruct info =
-        new ManifestInfoStruct.Builder()
+        ManifestInfoStruct.builder()
             .addedFilesCount(10)
             .existingFilesCount(20)
             .deletedFilesCount(3)
@@ -164,7 +164,7 @@ class TestManifestInfoStruct {
   @Test
   void testKryoSerializationRoundTrip() throws IOException {
     ManifestInfoStruct info =
-        new ManifestInfoStruct.Builder()
+        ManifestInfoStruct.builder()
             .addedFilesCount(10)
             .existingFilesCount(20)
             .deletedFilesCount(3)

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -70,7 +70,7 @@ class TestManifestInfoStruct {
             .deletedRowsCount(300L)
             .replacedRowsCount(200L)
             .minSequenceNumber(5L)
-            .dv(ByteBuffer.wrap(new byte[] {0xF}))
+            .dv(new byte[] {0xF})
             .dvCardinality(1L)
             .build();
 
@@ -143,7 +143,7 @@ class TestManifestInfoStruct {
             .deletedRowsCount(300L)
             .replacedRowsCount(200L)
             .minSequenceNumber(5L)
-            .dv(ByteBuffer.wrap(new byte[] {0xF}))
+            .dv(new byte[] {0xF})
             .dvCardinality(1L)
             .build();
 
@@ -177,7 +177,7 @@ class TestManifestInfoStruct {
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid added files count: -1");
+        .hasMessage("Invalid added files count: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -192,7 +192,7 @@ class TestManifestInfoStruct {
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid existing files count: -1");
+        .hasMessage("Invalid existing files count: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -207,7 +207,7 @@ class TestManifestInfoStruct {
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid deleted files count: -1");
+        .hasMessage("Invalid deleted files count: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -222,7 +222,7 @@ class TestManifestInfoStruct {
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid replaced files count: -1");
+        .hasMessage("Invalid replaced files count: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -237,7 +237,7 @@ class TestManifestInfoStruct {
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid added rows count: -1");
+        .hasMessage("Invalid added rows count: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -252,7 +252,7 @@ class TestManifestInfoStruct {
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid existing rows count: -1");
+        .hasMessage("Invalid existing rows count: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -267,7 +267,7 @@ class TestManifestInfoStruct {
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid deleted rows count: -1");
+        .hasMessage("Invalid deleted rows count: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -282,7 +282,7 @@ class TestManifestInfoStruct {
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid replaced rows count: -1");
+        .hasMessage("Invalid replaced rows count: -1 (must be >= 0)");
 
     assertThatThrownBy(
             () ->
@@ -297,7 +297,7 @@ class TestManifestInfoStruct {
                     .replacedRowsCount(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid min sequence number: -1");
+        .hasMessage("Invalid min sequence number: -1 (must be >= 0)");
   }
 
   @Test
@@ -313,7 +313,7 @@ class TestManifestInfoStruct {
             .deletedRowsCount(300L)
             .replacedRowsCount(200L)
             .minSequenceNumber(5L)
-            .dv(ByteBuffer.wrap(new byte[] {0xF}))
+            .dv(new byte[] {0xF})
             .dvCardinality(1L)
             .build();
 

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -192,27 +191,5 @@ class TestManifestInfoStruct {
     assertThat(deserialized.minSequenceNumber()).isEqualTo(5L);
     assertThat(deserialized.dv()).isEqualTo(ByteBuffer.wrap(new byte[] {0xF}));
     assertThat(deserialized.dvCardinality()).isEqualTo(1L);
-  }
-
-  @Test
-  void testBuildValidatesRequiredFields() {
-    assertThatThrownBy(() -> new ManifestInfoStruct.Builder().build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid added files count: -1");
-
-    assertThatThrownBy(
-            () ->
-                new ManifestInfoStruct.Builder()
-                    .addedFilesCount(0)
-                    .existingFilesCount(0)
-                    .deletedFilesCount(0)
-                    .replacedFilesCount(0)
-                    .addedRowsCount(0L)
-                    .existingRowsCount(0L)
-                    .deletedRowsCount(0L)
-                    .replacedRowsCount(0L)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid min sequence number: -1");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -159,6 +160,144 @@ class TestManifestInfoStruct {
     assertThat(deserialized.minSequenceNumber()).isEqualTo(5L);
     assertThat(deserialized.dv()).isEqualTo(ByteBuffer.wrap(new byte[] {0xF}));
     assertThat(deserialized.dvCardinality()).isEqualTo(1L);
+  }
+
+  @Test
+  void testBuilderValidation() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid added files count: -1");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid existing files count: -1");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid deleted files count: -1");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid replaced files count: -1");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid added rows count: -1");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid existing rows count: -1");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid deleted rows count: -1");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid replaced rows count: -1");
+
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid min sequence number: -1");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -58,19 +59,20 @@ class TestManifestInfoStruct {
 
   @Test
   void testCopy() {
-    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
-
-    info.set(0, 10);
-    info.set(1, 20);
-    info.set(2, 3);
-    info.set(3, 2);
-    info.set(4, 1000L);
-    info.set(5, 2000L);
-    info.set(6, 300L);
-    info.set(7, 200L);
-    info.set(8, 5L);
-    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
-    info.set(10, 1L);
+    ManifestInfoStruct info =
+        new ManifestInfoStruct.Builder()
+            .addedFilesCount(10)
+            .existingFilesCount(20)
+            .deletedFilesCount(3)
+            .replacedFilesCount(2)
+            .addedRowsCount(1000L)
+            .existingRowsCount(2000L)
+            .deletedRowsCount(300L)
+            .replacedRowsCount(200L)
+            .minSequenceNumber(5L)
+            .dv(ByteBuffer.wrap(new byte[] {0xF}))
+            .dvCardinality(1L)
+            .build();
 
     ManifestInfoStruct copy = info.copy();
 
@@ -91,17 +93,18 @@ class TestManifestInfoStruct {
 
   @Test
   void testNullableFields() {
-    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
-
-    info.set(0, 0);
-    info.set(1, 0);
-    info.set(2, 0);
-    info.set(3, 0);
-    info.set(4, 0L);
-    info.set(5, 0L);
-    info.set(6, 0L);
-    info.set(7, 0L);
-    info.set(8, 0L);
+    ManifestInfoStruct info =
+        new ManifestInfoStruct.Builder()
+            .addedFilesCount(0)
+            .existingFilesCount(0)
+            .deletedFilesCount(0)
+            .replacedFilesCount(0)
+            .addedRowsCount(0L)
+            .existingRowsCount(0L)
+            .deletedRowsCount(0L)
+            .replacedRowsCount(0L)
+            .minSequenceNumber(0L)
+            .build();
 
     assertThat(info.dv()).isNull();
     assertThat(info.dvCardinality()).isNull();
@@ -129,18 +132,20 @@ class TestManifestInfoStruct {
 
   @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
-    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
-    info.set(0, 10);
-    info.set(1, 20);
-    info.set(2, 3);
-    info.set(3, 2);
-    info.set(4, 1000L);
-    info.set(5, 2000L);
-    info.set(6, 300L);
-    info.set(7, 200L);
-    info.set(8, 5L);
-    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
-    info.set(10, 1L);
+    ManifestInfoStruct info =
+        new ManifestInfoStruct.Builder()
+            .addedFilesCount(10)
+            .existingFilesCount(20)
+            .deletedFilesCount(3)
+            .replacedFilesCount(2)
+            .addedRowsCount(1000L)
+            .existingRowsCount(2000L)
+            .deletedRowsCount(300L)
+            .replacedRowsCount(200L)
+            .minSequenceNumber(5L)
+            .dv(ByteBuffer.wrap(new byte[] {0xF}))
+            .dvCardinality(1L)
+            .build();
 
     ManifestInfoStruct deserialized = TestHelpers.roundTripSerialize(info);
 
@@ -159,18 +164,20 @@ class TestManifestInfoStruct {
 
   @Test
   void testKryoSerializationRoundTrip() throws IOException {
-    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
-    info.set(0, 10);
-    info.set(1, 20);
-    info.set(2, 3);
-    info.set(3, 2);
-    info.set(4, 1000L);
-    info.set(5, 2000L);
-    info.set(6, 300L);
-    info.set(7, 200L);
-    info.set(8, 5L);
-    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
-    info.set(10, 1L);
+    ManifestInfoStruct info =
+        new ManifestInfoStruct.Builder()
+            .addedFilesCount(10)
+            .existingFilesCount(20)
+            .deletedFilesCount(3)
+            .replacedFilesCount(2)
+            .addedRowsCount(1000L)
+            .existingRowsCount(2000L)
+            .deletedRowsCount(300L)
+            .replacedRowsCount(200L)
+            .minSequenceNumber(5L)
+            .dv(ByteBuffer.wrap(new byte[] {0xF}))
+            .dvCardinality(1L)
+            .build();
 
     ManifestInfoStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(info);
 
@@ -185,5 +192,27 @@ class TestManifestInfoStruct {
     assertThat(deserialized.minSequenceNumber()).isEqualTo(5L);
     assertThat(deserialized.dv()).isEqualTo(ByteBuffer.wrap(new byte[] {0xF}));
     assertThat(deserialized.dvCardinality()).isEqualTo(1L);
+  }
+
+  @Test
+  void testBuildValidatesRequiredFields() {
+    assertThatThrownBy(() -> new ManifestInfoStruct.Builder().build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid added files count: -1");
+
+    assertThatThrownBy(
+            () ->
+                new ManifestInfoStruct.Builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid min sequence number: -1");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -33,19 +33,27 @@ class TestTrackedFileStruct {
   @Test
   void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, 42L);
-    DeletionVectorStruct dv = new DeletionVectorStruct("s3://bucket/dv.puffin", 100L, 50L, 5L);
-    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
-
-    info.set(0, 10);
-    info.set(1, 20);
-    info.set(2, 3);
-    info.set(3, 2);
-    info.set(4, 1000L);
-    info.set(5, 2000L);
-    info.set(6, 300L);
-    info.set(7, 200L);
-    info.set(8, 5L);
+    TrackingStruct tracking =
+        new TrackingStruct.Builder().status(EntryStatus.ADDED).snapshotId(42L).build();
+    DeletionVectorStruct dv =
+        new DeletionVectorStruct.Builder()
+            .location("s3://bucket/dv.puffin")
+            .offset(100L)
+            .sizeInBytes(50L)
+            .cardinality(5L)
+            .build();
+    ManifestInfoStruct info =
+        new ManifestInfoStruct.Builder()
+            .addedFilesCount(10)
+            .existingFilesCount(20)
+            .deletedFilesCount(3)
+            .replacedFilesCount(2)
+            .addedRowsCount(1000L)
+            .existingRowsCount(2000L)
+            .deletedRowsCount(300L)
+            .replacedRowsCount(200L)
+            .minSequenceNumber(5L)
+            .build();
 
     file.set(0, tracking);
     file.set(1, FileContent.EQUALITY_DELETES.id());
@@ -82,7 +90,7 @@ class TestTrackedFileStruct {
   void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, null);
+    TrackingStruct tracking = new TrackingStruct.Builder().status(EntryStatus.ADDED).build();
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
     tracking.set(8, 7L);
 
@@ -270,12 +278,22 @@ class TestTrackedFileStruct {
   }
 
   static TrackedFileStruct createFullTrackedFile() {
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, 42L);
-    tracking.set(2, 10L);
+    TrackingStruct tracking =
+        new TrackingStruct.Builder()
+            .status(EntryStatus.ADDED)
+            .snapshotId(42L)
+            .dataSequenceNumber(10L)
+            .build();
     tracking.setManifestLocation("s3://bucket/manifest.avro");
     tracking.set(8, 3L);
 
-    DeletionVectorStruct dv = new DeletionVectorStruct("s3://bucket/dv.puffin", 100L, 50L, 5L);
+    DeletionVectorStruct dv =
+        new DeletionVectorStruct.Builder()
+            .location("s3://bucket/dv.puffin")
+            .offset(100L)
+            .sizeInBytes(50L)
+            .cardinality(5L)
+            .build();
 
     TrackedFileStruct file =
         new TrackedFileStruct(

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -33,17 +33,9 @@ class TestTrackedFileStruct {
   @Test
   void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = new TrackingStruct();
-    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, 42L);
+    DeletionVectorStruct dv = new DeletionVectorStruct("s3://bucket/dv.puffin", 100L, 50L, 5L);
     ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
-
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-
-    dv.set(0, "s3://bucket/dv.puffin");
-    dv.set(1, 100L);
-    dv.set(2, 50L);
-    dv.set(3, 5L);
 
     info.set(0, 10);
     info.set(1, 20);
@@ -90,8 +82,7 @@ class TestTrackedFileStruct {
   void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = new TrackingStruct();
-    tracking.set(0, EntryStatus.ADDED.id());
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, null);
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
     tracking.set(8, 7L);
 
@@ -279,18 +270,12 @@ class TestTrackedFileStruct {
   }
 
   static TrackedFileStruct createFullTrackedFile() {
-    TrackingStruct tracking = new TrackingStruct();
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, 42L);
     tracking.set(2, 10L);
     tracking.setManifestLocation("s3://bucket/manifest.avro");
     tracking.set(8, 3L);
 
-    DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
-    dv.set(0, "s3://bucket/dv.puffin");
-    dv.set(1, 100L);
-    dv.set(2, 50L);
-    dv.set(3, 5L);
+    DeletionVectorStruct dv = new DeletionVectorStruct("s3://bucket/dv.puffin", 100L, 50L, 5L);
 
     TrackedFileStruct file =
         new TrackedFileStruct(

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -34,16 +34,16 @@ class TestTrackedFileStruct {
   void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
     TrackingStruct tracking =
-        new TrackingStruct.Builder().status(EntryStatus.ADDED).snapshotId(42L).build();
+        TrackingStruct.builder().status(EntryStatus.ADDED).snapshotId(42L).build();
     DeletionVectorStruct dv =
-        new DeletionVectorStruct.Builder()
+        DeletionVectorStruct.builder()
             .location("s3://bucket/dv.puffin")
             .offset(100L)
             .sizeInBytes(50L)
             .cardinality(5L)
             .build();
     ManifestInfoStruct info =
-        new ManifestInfoStruct.Builder()
+        ManifestInfoStruct.builder()
             .addedFilesCount(10)
             .existingFilesCount(20)
             .deletedFilesCount(3)
@@ -90,7 +90,7 @@ class TestTrackedFileStruct {
   void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = new TrackingStruct.Builder().status(EntryStatus.ADDED).build();
+    TrackingStruct tracking = TrackingStruct.builder().status(EntryStatus.ADDED).build();
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
     tracking.set(8, 7L);
 
@@ -279,7 +279,7 @@ class TestTrackedFileStruct {
 
   static TrackedFileStruct createFullTrackedFile() {
     TrackingStruct tracking =
-        new TrackingStruct.Builder()
+        TrackingStruct.builder()
             .status(EntryStatus.ADDED)
             .snapshotId(42L)
             .dataSequenceNumber(10L)
@@ -288,7 +288,7 @@ class TestTrackedFileStruct {
     tracking.set(8, 3L);
 
     DeletionVectorStruct dv =
-        new DeletionVectorStruct.Builder()
+        DeletionVectorStruct.builder()
             .location("s3://bucket/dv.puffin")
             .offset(100L)
             .sizeInBytes(50L)

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -174,13 +174,6 @@ class TestTrackingStruct {
     assertThat(tracking.fileSequenceNumber()).isNull();
   }
 
-  @Test
-  void testBuildValidatesRequiredFields() {
-    assertThatThrownBy(() -> new TrackingStruct.Builder().build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid status: null");
-  }
-
   private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
     return new TrackingStruct.Builder()
         .status(EntryStatus.ADDED)

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -54,7 +54,7 @@ class TestTrackingStruct {
   @Test
   void testCopy() {
     TrackingStruct tracking =
-        new TrackingStruct.Builder()
+        TrackingStruct.builder()
             .status(EntryStatus.ADDED)
             .snapshotId(42L)
             .dataSequenceNumber(10L)
@@ -99,7 +99,7 @@ class TestTrackingStruct {
 
   @Test
   void testInheritSnapshotId() {
-    TrackingStruct tracking = new TrackingStruct.Builder().status(EntryStatus.ADDED).build();
+    TrackingStruct tracking = TrackingStruct.builder().status(EntryStatus.ADDED).build();
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // snapshotId is null, should inherit from manifest
@@ -108,7 +108,7 @@ class TestTrackingStruct {
 
   @Test
   void testInheritSequenceNumberForAddedEntries() {
-    TrackingStruct tracking = new TrackingStruct.Builder().status(EntryStatus.ADDED).build();
+    TrackingStruct tracking = TrackingStruct.builder().status(EntryStatus.ADDED).build();
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // sequence numbers are null and status is ADDED, should inherit
@@ -119,7 +119,7 @@ class TestTrackingStruct {
   @Test
   void testDoNotInheritSequenceNumberForExistingEntries() {
     TrackingStruct tracking =
-        new TrackingStruct.Builder()
+        TrackingStruct.builder()
             .status(EntryStatus.EXISTING)
             .dataSequenceNumber(5L)
             .fileSequenceNumber(6L)
@@ -134,7 +134,7 @@ class TestTrackingStruct {
   @Test
   void testExplicitValuesOverrideInheritance() {
     TrackingStruct tracking =
-        new TrackingStruct.Builder()
+        TrackingStruct.builder()
             .status(EntryStatus.ADDED)
             .snapshotId(200L)
             .dataSequenceNumber(75L)
@@ -166,7 +166,7 @@ class TestTrackingStruct {
 
   @Test
   void testNoDefaultingWithoutInheritance() {
-    TrackingStruct tracking = new TrackingStruct.Builder().status(EntryStatus.ADDED).build();
+    TrackingStruct tracking = TrackingStruct.builder().status(EntryStatus.ADDED).build();
 
     // no inheritance, nulls stay null
     assertThat(tracking.snapshotId()).isNull();
@@ -175,7 +175,7 @@ class TestTrackingStruct {
   }
 
   private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
-    return new TrackingStruct.Builder()
+    return TrackingStruct.builder()
         .status(EntryStatus.ADDED)
         .snapshotId(snapshotId)
         .dataSequenceNumber(sequenceNumber)
@@ -205,7 +205,7 @@ class TestTrackingStruct {
   @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     TrackingStruct tracking =
-        new TrackingStruct.Builder()
+        TrackingStruct.builder()
             .status(EntryStatus.ADDED)
             .snapshotId(42L)
             .dataSequenceNumber(10L)
@@ -223,7 +223,7 @@ class TestTrackingStruct {
   @Test
   void testKryoSerializationRoundTrip() throws IOException {
     TrackingStruct tracking =
-        new TrackingStruct.Builder()
+        TrackingStruct.builder()
             .status(EntryStatus.ADDED)
             .snapshotId(42L)
             .dataSequenceNumber(10L)

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -53,12 +53,13 @@ class TestTrackingStruct {
 
   @Test
   void testCopy() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-    tracking.set(2, 10L);
-    tracking.set(6, ByteBuffer.wrap(new byte[] {1, 2}));
+    TrackingStruct tracking =
+        new TrackingStruct.Builder()
+            .status(EntryStatus.ADDED)
+            .snapshotId(42L)
+            .dataSequenceNumber(10L)
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .build();
 
     TrackingStruct copy = tracking.copy();
 
@@ -98,7 +99,7 @@ class TestTrackingStruct {
 
   @Test
   void testInheritSnapshotId() {
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, null);
+    TrackingStruct tracking = new TrackingStruct.Builder().status(EntryStatus.ADDED).build();
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // snapshotId is null, should inherit from manifest
@@ -107,7 +108,7 @@ class TestTrackingStruct {
 
   @Test
   void testInheritSequenceNumberForAddedEntries() {
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, null);
+    TrackingStruct tracking = new TrackingStruct.Builder().status(EntryStatus.ADDED).build();
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // sequence numbers are null and status is ADDED, should inherit
@@ -117,9 +118,12 @@ class TestTrackingStruct {
 
   @Test
   void testDoNotInheritSequenceNumberForExistingEntries() {
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.EXISTING, null);
-    tracking.set(2, 5L);
-    tracking.set(3, 6L);
+    TrackingStruct tracking =
+        new TrackingStruct.Builder()
+            .status(EntryStatus.EXISTING)
+            .dataSequenceNumber(5L)
+            .fileSequenceNumber(6L)
+            .build();
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // sequence numbers are not inherited for EXISTING entries
@@ -129,9 +133,13 @@ class TestTrackingStruct {
 
   @Test
   void testExplicitValuesOverrideInheritance() {
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, 200L);
-    tracking.set(2, 75L);
-    tracking.set(3, 76L);
+    TrackingStruct tracking =
+        new TrackingStruct.Builder()
+            .status(EntryStatus.ADDED)
+            .snapshotId(200L)
+            .dataSequenceNumber(75L)
+            .fileSequenceNumber(76L)
+            .build();
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // explicit values should take precedence
@@ -158,7 +166,7 @@ class TestTrackingStruct {
 
   @Test
   void testNoDefaultingWithoutInheritance() {
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, null);
+    TrackingStruct tracking = new TrackingStruct.Builder().status(EntryStatus.ADDED).build();
 
     // no inheritance, nulls stay null
     assertThat(tracking.snapshotId()).isNull();
@@ -166,11 +174,20 @@ class TestTrackingStruct {
     assertThat(tracking.fileSequenceNumber()).isNull();
   }
 
+  @Test
+  void testBuildValidatesRequiredFields() {
+    assertThatThrownBy(() -> new TrackingStruct.Builder().build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid status: null");
+  }
+
   private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
-    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, snapshotId);
-    tracking.set(2, sequenceNumber);
-    tracking.set(3, sequenceNumber);
-    return tracking;
+    return new TrackingStruct.Builder()
+        .status(EntryStatus.ADDED)
+        .snapshotId(snapshotId)
+        .dataSequenceNumber(sequenceNumber)
+        .fileSequenceNumber(sequenceNumber)
+        .build();
   }
 
   @Test
@@ -194,11 +211,13 @@ class TestTrackingStruct {
 
   @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-    tracking.set(2, 10L);
-    tracking.set(6, ByteBuffer.wrap(new byte[] {1, 2}));
+    TrackingStruct tracking =
+        new TrackingStruct.Builder()
+            .status(EntryStatus.ADDED)
+            .snapshotId(42L)
+            .dataSequenceNumber(10L)
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .build();
 
     TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
 
@@ -210,11 +229,13 @@ class TestTrackingStruct {
 
   @Test
   void testKryoSerializationRoundTrip() throws IOException {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-    tracking.set(2, 10L);
-    tracking.set(6, ByteBuffer.wrap(new byte[] {1, 2}));
+    TrackingStruct tracking =
+        new TrackingStruct.Builder()
+            .status(EntryStatus.ADDED)
+            .snapshotId(42L)
+            .dataSequenceNumber(10L)
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .build();
 
     TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -58,7 +58,7 @@ class TestTrackingStruct {
             .status(EntryStatus.ADDED)
             .snapshotId(42L)
             .dataSequenceNumber(10L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .deletedPositions(new byte[] {1, 2})
             .build();
 
     TrackingStruct copy = tracking.copy();
@@ -216,7 +216,7 @@ class TestTrackingStruct {
             .status(EntryStatus.ADDED)
             .snapshotId(42L)
             .dataSequenceNumber(10L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .deletedPositions(new byte[] {1, 2})
             .build();
 
     TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
@@ -234,7 +234,7 @@ class TestTrackingStruct {
             .status(EntryStatus.ADDED)
             .snapshotId(42L)
             .dataSequenceNumber(10L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .deletedPositions(new byte[] {1, 2})
             .build();
 
     TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -184,6 +184,13 @@ class TestTrackingStruct {
   }
 
   @Test
+  void testBuilderValidation() {
+    assertThatThrownBy(() -> TrackingStruct.builder().build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid status: null");
+  }
+
+  @Test
   void testProjectedStructLike() {
     // project only snapshot_id (field ID 1) and first_row_id (field ID 142)
     Types.StructType projection = Types.StructType.of(Tracking.SNAPSHOT_ID, Tracking.FIRST_ROW_ID);

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -98,8 +98,7 @@ class TestTrackingStruct {
 
   @Test
   void testInheritSnapshotId() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, null);
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // snapshotId is null, should inherit from manifest
@@ -108,8 +107,7 @@ class TestTrackingStruct {
 
   @Test
   void testInheritSequenceNumberForAddedEntries() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, null);
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // sequence numbers are null and status is ADDED, should inherit
@@ -119,8 +117,7 @@ class TestTrackingStruct {
 
   @Test
   void testDoNotInheritSequenceNumberForExistingEntries() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.EXISTING.id());
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.EXISTING, null);
     tracking.set(2, 5L);
     tracking.set(3, 6L);
     tracking.inheritFrom(createManifestTracking(100L, 60L));
@@ -132,9 +129,7 @@ class TestTrackingStruct {
 
   @Test
   void testExplicitValuesOverrideInheritance() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 200L);
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, 200L);
     tracking.set(2, 75L);
     tracking.set(3, 76L);
     tracking.inheritFrom(createManifestTracking(100L, 60L));
@@ -163,8 +158,7 @@ class TestTrackingStruct {
 
   @Test
   void testNoDefaultingWithoutInheritance() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, null);
 
     // no inheritance, nulls stay null
     assertThat(tracking.snapshotId()).isNull();
@@ -173,9 +167,7 @@ class TestTrackingStruct {
   }
 
   private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, snapshotId);
+    TrackingStruct tracking = new TrackingStruct(EntryStatus.ADDED, snapshotId);
     tracking.set(2, sequenceNumber);
     tracking.set(3, sequenceNumber);
     return tracking;


### PR DESCRIPTION
Use builders for v4 structs so that we don't need to do positional set() calls in tests.

this is a followup from https://github.com/apache/iceberg/pull/15854