### PR TITLE
Flink 2.1: Remove flink-metrics-dropwizard from runtime

### DIFF
--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -169,9 +169,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    // for dropwizard histogram metrics implementation
-    implementation libs.flink21.metrics.dropwizard
-
     // for integration testing with the flink-runtime-jar
     // all of those dependencies are required because the integration test extends FlinkTestBase
     integrationCompileOnly project(':iceberg-api')

--- a/flink/v2.1/flink-runtime/runtime-deps.txt
+++ b/flink/v2.1/flink-runtime/runtime-deps.txt
@@ -6,11 +6,9 @@ com.github.luben:zstd-jni:1.5.7-3
 com.google.errorprone:error_prone_annotations:2.10.0
 dev.failsafe:failsafe:3.3.2
 io.airlift:aircompressor:2.0.3
-io.dropwizard.metrics:metrics-core:3.2.6
 org.apache.avro:avro:1.12.1
 org.apache.datasketches:datasketches-java:6.2.0
 org.apache.datasketches:datasketches-memory:3.0.2
-org.apache.flink:flink-metrics-dropwizard:2.1.0
 org.apache.httpcomponents.client5:httpclient5:5.6
 org.apache.httpcomponents.core5:httpcore5-h2:5.4
 org.apache.httpcomponents.core5:httpcore5:5.4


### PR DESCRIPTION
Flink libraries should be provided by Flink, not by Iceberg's runtime bundle. It would be strange for Iceberg to supply Flink libraries back to Flink.