### PR TITLE
Spark: Add support for CASCADE option in DROP NAMESPACE

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -55,6 +55,7 @@ import org.apache.iceberg.view.ViewVersion;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -317,6 +318,8 @@ public class TestViews extends ExtensionsTestBase {
     assertThat(sql("SELECT * FROM %s", viewName))
         .hasSize(5)
         .containsExactlyInAnyOrderElementsOf(expected);
+
+    sql("DROP VIEW %s", viewName);
   }
 
   @TestTemplate
@@ -1309,6 +1312,8 @@ public class TestViews extends ExtensionsTestBase {
         .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("that references temporary view:")
         .hasMessageContaining(tempView);
+
+    sql("DROP VIEW %s", tempView);
   }
 
   @TestTemplate
@@ -1511,6 +1516,20 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void dropNamespaceCascade() {
+    sql("DROP NAMESPACE IF EXISTS ns CASCADE");
+    sql("CREATE NAMESPACE ns");
+    sql("CREATE VIEW ns.view AS SELECT id FROM %s", tableName);
+    sql("DESCRIBE NAMESPACE ns");
+
+    sql("DROP NAMESPACE ns CASCADE");
+
+    assertThatThrownBy(() -> sql("DESCRIBE NAMESPACE ns"))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessageContaining("cannot be found");
+  }
+
+  @TestTemplate
   public void showViewProperties() {
     String viewName = viewName("showViewProps");
 
@@ -1594,6 +1613,8 @@ public class TestViews extends ExtensionsTestBase {
     assertThat(sql("SHOW VIEWS")).contains(tempView);
 
     assertThat(sql("SHOW VIEWS IN default")).contains(tempView);
+
+    sql("DROP VIEW %s", tempViewForListing);
   }
 
   @TestTemplate

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.view.ViewVersion;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
 import org.apache.spark.sql.types.DataTypes;
@@ -319,6 +320,8 @@ public class TestViews extends ExtensionsTestBase {
     assertThat(sql("SELECT * FROM %s", viewName))
         .hasSize(5)
         .containsExactlyInAnyOrderElementsOf(expected);
+
+    sql("DROP VIEW %s", viewName);
   }
 
   @TestTemplate
@@ -1311,6 +1314,8 @@ public class TestViews extends ExtensionsTestBase {
         .hasMessageContaining("Cannot create view %s.%s.%s", catalogName, NAMESPACE, viewName)
         .hasMessageContaining("that references temporary view:")
         .hasMessageContaining(tempView);
+
+    sql("DROP VIEW %s", tempView);
   }
 
   @TestTemplate
@@ -1513,6 +1518,20 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void dropNamespaceCascade() {
+    sql("DROP NAMESPACE IF EXISTS ns CASCADE");
+    sql("CREATE NAMESPACE ns");
+    sql("CREATE VIEW ns.view AS SELECT id FROM %s", tableName);
+    sql("DESCRIBE NAMESPACE ns");
+
+    sql("DROP NAMESPACE ns CASCADE");
+
+    assertThatThrownBy(() -> sql("DESCRIBE NAMESPACE ns"))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessageContaining("cannot be found");
+  }
+
+  @TestTemplate
   public void showViewProperties() {
     String viewName = viewName("showViewProps");
 
@@ -1596,6 +1615,8 @@ public class TestViews extends ExtensionsTestBase {
     assertThat(sql("SHOW VIEWS")).contains(tempView);
 
     assertThat(sql("SHOW VIEWS IN default")).contains(tempView);
+
+    sql("DROP VIEW %s", tempViewForListing);
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -530,12 +530,8 @@ public class SparkCatalog extends BaseCatalog {
       for (String[] ns : listNamespaces(namespace)) {
         dropNamespace(ns, true);
       }
-      for (Identifier view : listViews(namespace)) {
-        dropView(view);
-      }
-      for (Identifier table : listTables(namespace)) {
-        dropTable(table);
-      }
+      Arrays.stream(listViews(namespace)).forEach(this::dropView);
+      Arrays.stream(listTables(namespace)).forEach(this::dropTable);
     }
 
     if (asNamespaceCatalog != null) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -526,6 +526,18 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public boolean dropNamespace(String[] namespace, boolean cascade)
       throws NoSuchNamespaceException {
+    if (cascade) {
+      for (String[] ns : listNamespaces(namespace)) {
+        dropNamespace(ns, true);
+      }
+      for (Identifier view : listViews(namespace)) {
+        dropView(view);
+      }
+      for (Identifier table : listTables(namespace)) {
+        dropTable(table);
+      }
+    }
+
     if (asNamespaceCatalog != null) {
       try {
         return asNamespaceCatalog.dropNamespace(Namespace.of(namespace));

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -132,6 +132,17 @@ public class SparkSessionCatalog<
   @Override
   public boolean dropNamespace(String[] namespace, boolean cascade)
       throws NoSuchNamespaceException, NonEmptyNamespaceException {
+    if (cascade) {
+      for (String[] ns : listNamespaces(namespace)) {
+        dropNamespace(ns, true);
+      }
+      for (Identifier view : listViews(namespace)) {
+        dropView(view);
+      }
+      for (Identifier table : listTables(namespace)) {
+        dropTable(table);
+      }
+    }
     return getSessionCatalog().dropNamespace(namespace, cascade);
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -156,6 +156,35 @@ public class TestNamespaceSQL extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testDropNamespaceCascade() {
+    assumeThat(catalogName).as("Session catalog has flaky behavior").isNotEqualTo("spark_catalog");
+    assumeThat(catalogName).as("Multi part namespace is unsupported").isNotEqualTo("testhive");
+
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+    sql("CREATE NAMESPACE %s.nested", fullNamespace);
+    sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullNamespace);
+    sql("CREATE TABLE %s.nested.table (id bigint) USING iceberg", fullNamespace);
+
+    Namespace nestedNs = Namespace.of("db", "nested");
+
+    assertThat(validationNamespaceCatalog.namespaceExists(NS)).isTrue();
+    assertThat(validationNamespaceCatalog.namespaceExists(nestedNs)).isTrue();
+    assertThat(validationCatalog.tableExists(TableIdentifier.of(NS, "table"))).isTrue();
+    assertThat(validationCatalog.tableExists(TableIdentifier.of(nestedNs, "table"))).isTrue();
+
+    sql("DROP NAMESPACE %s CASCADE", fullNamespace);
+
+    assertThat(validationNamespaceCatalog.namespaceExists(NS)).isFalse();
+    assertThat(validationNamespaceCatalog.namespaceExists(nestedNs)).isFalse();
+    assertThat(validationCatalog.tableExists(TableIdentifier.of(NS, "table"))).isFalse();
+    assertThat(validationCatalog.tableExists(TableIdentifier.of(nestedNs, "table"))).isFalse();
+  }
+
+  @TestTemplate
   public void testListTables() {
     assertThat(validationNamespaceCatalog.namespaceExists(NS))
         .as("Namespace should not already exist")

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -158,6 +158,28 @@ public class TestNamespaceSQL extends CatalogTestBase {
   @TestTemplate
   public void testDropNamespaceCascade() {
     assumeThat(catalogName).as("Session catalog has flaky behavior").isNotEqualTo("spark_catalog");
+
+    assertThat(validationNamespaceCatalog.namespaceExists(NS))
+        .as("Namespace should not already exist")
+        .isFalse();
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+    sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullNamespace);
+    // Views are not tested here because Hadoop catalog does not support them.
+    // See TestViews for view drop behavior with CASCADE.
+
+    assertThat(validationNamespaceCatalog.namespaceExists(NS)).isTrue();
+    assertThat(validationCatalog.tableExists(TableIdentifier.of(NS, "table"))).isTrue();
+
+    sql("DROP NAMESPACE %s CASCADE", fullNamespace);
+
+    assertThat(validationNamespaceCatalog.namespaceExists(NS)).isFalse();
+    assertThat(validationCatalog.tableExists(TableIdentifier.of(NS, "table"))).isFalse();
+  }
+
+  @TestTemplate
+  public void testDropNestedNamespaceCascade() {
+    assumeThat(catalogName).as("Session catalog has flaky behavior").isNotEqualTo("spark_catalog");
     assumeThat(catalogName).as("Multi part namespace is unsupported").isNotEqualTo("testhive");
 
     assertThat(validationNamespaceCatalog.namespaceExists(NS))


### PR DESCRIPTION
# Summary

Add support for the CASCADE option in DROP NAMESPACE statements in Spark 4.1.
When CASCADE is specified, the operation recursively drops all nested namespaces, tables, 
and views within the target namespace before dropping the namespace itself.

# Implementation

- Modified SparkCatalog and SparkSessionCatalog to handle the cascade parameter
- When cascade=true, the implementation:
  - Recursively drops all nested namespaces
  - Drops all tables in the namespace
  - Drops all views in the namespace
  - Finally drops the namespace itself
