### PR TITLE
Spark 4.1: Parameterize TestDeleteFrom with format-version

### DIFF
--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -20,12 +20,20 @@ package org.apache.iceberg.spark.sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.source.SimpleRecord;
@@ -38,14 +46,41 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestDeleteFrom extends CatalogTestBase {
+  @Parameter(index = 3)
+  private int formatVersion;
+
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, formatVersion = {3}")
+  protected static Object[][] parameters() {
+    List<Object[]> parameters = Lists.newArrayList();
+    for (Object[] catalogParams : CatalogTestBase.parameters()) {
+      for (int version : TestHelpers.V2_AND_ABOVE) {
+        parameters.add(
+            new Object[] {catalogParams[0], catalogParams[1], catalogParams[2], version});
+      }
+    }
+
+    return parameters.toArray(new Object[0][]);
+  }
+
   @AfterEach
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 
+  private String tableProperties() {
+    return tableProperties(ImmutableMap.of());
+  }
+
+  private String tableProperties(Map<String, String> additionalProperties) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    builder.putAll(additionalProperties);
+    builder.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    return String.format("TBLPROPERTIES (%s)", tablePropsAsString(builder.buildKeepingLast()));
+  }
+
   @TestTemplate
   public void testDeleteFromUnpartitionedTable() throws NoSuchTableException {
-    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg %s", tableName, tableProperties());
 
     List<SimpleRecord> records =
         Lists.newArrayList(
@@ -75,7 +110,7 @@ public class TestDeleteFrom extends CatalogTestBase {
 
   @TestTemplate
   public void testDeleteFromTableAtSnapshot() throws NoSuchTableException {
-    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg %s", tableName, tableProperties());
 
     List<SimpleRecord> records =
         Lists.newArrayList(
@@ -95,8 +130,9 @@ public class TestDeleteFrom extends CatalogTestBase {
     sql(
         "CREATE TABLE %s (id bigint, data string) "
             + "USING iceberg "
-            + "PARTITIONED BY (truncate(id, 2))",
-        tableName);
+            + "PARTITIONED BY (truncate(id, 2)) "
+            + "%s",
+        tableName, tableProperties());
 
     List<SimpleRecord> records =
         Lists.newArrayList(
@@ -125,7 +161,9 @@ public class TestDeleteFrom extends CatalogTestBase {
 
   @TestTemplate
   public void testDeleteFromWhereFalse() {
-    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg %s",
+        tableName, tableProperties());
     sql("INSERT INTO TABLE %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
 
     assertEquals(
@@ -145,7 +183,9 @@ public class TestDeleteFrom extends CatalogTestBase {
 
   @TestTemplate
   public void testTruncate() {
-    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg %s",
+        tableName, tableProperties());
     sql("INSERT INTO TABLE %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
 
     assertEquals(
@@ -167,8 +207,8 @@ public class TestDeleteFrom extends CatalogTestBase {
   @TestTemplate
   public void testDeleteFromTablePartitionedByVarbinary() {
     sql(
-        "CREATE TABLE %s (id bigint NOT NULL, data binary) USING iceberg PARTITIONED BY (data)",
-        tableName);
+        "CREATE TABLE %s (id bigint NOT NULL, data binary) USING iceberg PARTITIONED BY (data) %s",
+        tableName, tableProperties());
     sql("INSERT INTO TABLE %s VALUES(1, X'e3bcd1'), (2, X'bcd1')", tableName);
 
     assertEquals(
@@ -189,9 +229,14 @@ public class TestDeleteFrom extends CatalogTestBase {
 
   @TestTemplate
   public void truncateWithDVs() throws NoSuchTableException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
     sql(
-        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg TBLPROPERTIES ('format-version'='3','write.delete.mode'='merge-on-read')",
-        tableName);
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg %s",
+        tableName,
+        tableProperties(
+            ImmutableMap.of(
+                TableProperties.DELETE_MODE, RowLevelOperationMode.MERGE_ON_READ.modeName())));
     List<SimpleRecord> records =
         ImmutableList.of(
             new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));


### PR DESCRIPTION
This parameterizes `TestDeleteFrom` and runs all of the existing tests across format versions v2+. This came up in https://github.com/apache/iceberg/pull/16078#discussion_r3124711738