### PR TITLE
Build: Check runtime deps baseline for all engine versions in CI

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -138,4 +138,4 @@ jobs:
         distribution: zulu
         java-version: 17
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
-    - run: ./gradlew checkAllRuntimeDeps -q
+    - run: ./gradlew checkAllRuntimeDeps -q -DallModules=true


### PR DESCRIPTION
The check-runtime-deps job only validated default engine versions (Spark 4.1, Flink 2.1) because it did not enable all modules. Pass -DallModules=true so settings.gradle activates all known Spark, Flink, and Kafka versions from gradle.properties.