### PR TITLE
AWS Bundle: Exclude logging dependencies

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -23,6 +23,14 @@ project(":iceberg-aws-bundle") {
 
   tasks.jar.dependsOn tasks.shadowJar
 
+  configurations {
+    implementation {
+      exclude group: 'org.slf4j'
+      exclude group: 'org.apache.logging.slf4j'
+      exclude group: 'org.apache.logging.log4j'
+    }
+  }
+
   dependencies {
     implementation platform(libs.awssdk.bom)
     implementation libs.awssdk.s3accessgrants
@@ -50,12 +58,6 @@ project(":iceberg-aws-bundle") {
     from(projectDir) {
       include 'LICENSE'
       include 'NOTICE'
-    }
-
-    dependencies {
-      exclude(dependency('org.slf4j:.*'))
-      exclude(dependency('org.apache.logging.log4j:.*'))
-      exclude(dependency('org.apache.logging.slf4j:.*'))
     }
 
     // relocate AWS-specific versions

--- a/aws-bundle/runtime-deps.txt
+++ b/aws-bundle/runtime-deps.txt
@@ -14,12 +14,8 @@ io.netty:netty-transport-native-unix-common:4.1.132.Final
 io.netty:netty-transport:4.1.132.Final
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.16
-org.apache.logging.log4j:log4j-api:2.20.0
-org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.checkerframework:checker-qual:3.19.0
 org.reactivestreams:reactive-streams:1.0.4
-org.slf4j:slf4j-api:2.0.17
 software.amazon.awssdk.crt:aws-crt:0.43.9
 software.amazon.awssdk:annotations:2.42.33
 software.amazon.awssdk:apache-client:2.42.33


### PR DESCRIPTION
This removes log4j from iceberg-aws-bundle dependencies.

The classes were already removed from the runtime Jar by an exclusion in the `shadowJar` configuration, but excluding them when the Jar is created leaves the dependency listed in runtime-deps.txt, which is how I found this. The solution is to add an exclusion from the `implementation` configuration so that the deps match.

This produces the following dependency changes to the `runtimeClasspath` configuration:

```diff
10d10
< +--- org.slf4j:slf4j-api:2.0.17
66,67c66
< |    |    |    |    |    |    |    |    +--- software.amazon.awssdk:annotations:2.42.33
< |    |    |    |    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
---
> |    |    |    |    |    |    |    |    \--- software.amazon.awssdk:annotations:2.42.33
110d108
< |    |    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
122,126c120,123
< |    |    |    |    |    |    +--- software.amazon.awssdk:json-utils:2.42.33
< |    |    |    |    |    |    |    +--- software.amazon.awssdk:utils:2.42.33 (*)
< |    |    |    |    |    |    |    +--- software.amazon.awssdk:annotations:2.42.33
< |    |    |    |    |    |    |    \--- software.amazon.awssdk:third-party-jackson-core:2.42.33
< |    |    |    |    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
---
> |    |    |    |    |    |    \--- software.amazon.awssdk:json-utils:2.42.33
> |    |    |    |    |    |         +--- software.amazon.awssdk:utils:2.42.33 (*)
> |    |    |    |    |    |         +--- software.amazon.awssdk:annotations:2.42.33
> |    |    |    |    |    |         \--- software.amazon.awssdk:third-party-jackson-core:2.42.33
255,256c252
< |    |         +--- org.reactivestreams:reactive-streams:1.0.4
< |    |         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.17
---
> |    |         \--- org.reactivestreams:reactive-streams:1.0.4
262,266d257
< |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
< |    |    +--- org.apache.logging.log4j:log4j-api:2.20.0
< |    |    +--- org.slf4j:slf4j-api:1.7.25 -> 2.0.17
< |    |    \--- org.apache.logging.log4j:log4j-core:2.20.0
< |    |         \--- org.apache.logging.log4j:log4j-api:2.20.0
```