### PR TITLE
GCP Bundle: Remove JSR 305.

### DIFF
--- a/gcp-bundle/LICENSE
+++ b/gcp-bundle/LICENSE
@@ -380,13 +380,6 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Findbugs jsr305.
-
-Project URL: http://findbugs.sourceforge.net/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product bundles Google Error Prone Annotations.
 
 Project URL: https://github.com/google/error-prone

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -23,6 +23,12 @@ project(":iceberg-gcp-bundle") {
 
   tasks.jar.dependsOn tasks.shadowJar
 
+  configurations {
+    implementation {
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
+  }
+
   dependencies {
     implementation platform(libs.google.libraries.bom)
     implementation "com.google.cloud:google-cloud-storage"

--- a/gcp-bundle/runtime-deps.txt
+++ b/gcp-bundle/runtime-deps.txt
@@ -43,7 +43,6 @@ com.google.cloud:google-cloud-core:2.66.0
 com.google.cloud:google-cloud-kms:2.91.0
 com.google.cloud:google-cloud-monitoring:3.89.0
 com.google.cloud:google-cloud-storage:2.64.1
-com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.12.1
 com.google.errorprone:error_prone_annotations:2.42.0
 com.google.flatbuffers:flatbuffers-java:24.3.25


### PR DESCRIPTION
This removes JSR 305 from the GCP bundle. Annotations do not need to be present in the classpath, so this is a safe change.

JSR 305 is excluded from runtime Jars because of license issues (potential LGPL) that have not been clarified. We used to prefer an alternative project but no longer include these annotations at all. The alternative was: https://github.com/stephenc/findbugs-annotations