### PR TITLE
Core: implement writeManifestsWith executor on SnapshotUpdate

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -61,18 +61,19 @@ public interface SnapshotUpdate<ThisT> extends PendingUpdate<Snapshot> {
   ThisT scanManifestsWith(ExecutorService executorService);
 
   /**
-   * Use a particular executor to write manifests during commit. The default worker pool will be
-   * used by default.
+   * Use a particular executor to write manifests during commit with the specified parallelism. The
+   * default worker pool will be used by default.
    *
-   * <p>Implementations may require a specific executor type (such as {@link
-   * java.util.concurrent.ThreadPoolExecutor}) to derive parallelism for manifest writes.
+   * <p>The parallelism parameter controls how many manifest writers are used, which determines the
+   * number of manifest files produced. The executor provides the threads for parallel execution.
    *
    * @param executorService the provided executor
+   * @param parallelism the number of parallel manifest writers to use
    * @return this for method chaining
    */
-  default ThisT commitManifestsWith(ExecutorService executorService) {
+  default ThisT writeManifestsWith(ExecutorService executorService, int parallelism) {
     throw new UnsupportedOperationException(
-        this.getClass().getName() + " does not support commitManifestsWith");
+        this.getClass().getName() + " does not support writeManifestsWith");
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -61,6 +61,21 @@ public interface SnapshotUpdate<ThisT> extends PendingUpdate<Snapshot> {
   ThisT scanManifestsWith(ExecutorService executorService);
 
   /**
+   * Use a particular executor to write manifests during commit. The default worker pool will be
+   * used by default.
+   *
+   * <p>Implementations may require a specific executor type (such as {@link
+   * java.util.concurrent.ThreadPoolExecutor}) to derive parallelism for manifest writes.
+   *
+   * @param executorService the provided executor
+   * @return this for method chaining
+   */
+  default ThisT commitManifestsWith(ExecutorService executorService) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not support commitManifestsWith");
+  }
+
+  /**
    * Perform operations on a particular branch
    *
    * @param branch which is name of SnapshotRef of type branch.

--- a/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotUpdate.java
@@ -64,7 +64,7 @@ public interface SnapshotUpdate<ThisT> extends PendingUpdate<Snapshot> {
    * Use a particular executor to write manifests during commit with the specified parallelism. The
    * default worker pool will be used by default.
    *
-   * <p>The parallelism parameter controls how many manifest writers are used, which determines the
+   * <p>The parallelism parameter controls how many manifest writers are used, which informs the
    * number of manifest files produced. The executor provides the threads for parallel execution.
    *
    * @param executorService the provided executor

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -125,8 +124,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       SnapshotAncestryValidator.NON_VALIDATING;
 
   private ExecutorService workerPool;
-  private ExecutorService commitPool;
-  private int commitPoolSize = ThreadPools.WORKER_THREAD_POOL_SIZE;
+  private ExecutorService writePool;
+  private int writePoolParallelism = ThreadPools.WORKER_THREAD_POOL_SIZE;
   private String targetBranch = SnapshotRef.MAIN_BRANCH;
   private CommitMetrics commitMetrics;
 
@@ -173,20 +172,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   }
 
   @Override
-  public ThisT commitManifestsWith(ExecutorService executorService) {
-    Preconditions.checkArgument(executorService != null, "Invalid executor service: null");
+  public ThisT writeManifestsWith(ExecutorService executorService, int parallelism) {
+    Preconditions.checkArgument(executorService != null, "Executor service cannot be null");
     Preconditions.checkArgument(
-        executorService instanceof ThreadPoolExecutor,
-        "Unsupported executor type: %s. Expected a fixed-size ThreadPoolExecutor"
-            + " for manifest write with determined parallelism",
-        executorService.getClass().getName());
-    ThreadPoolExecutor pool = (ThreadPoolExecutor) executorService;
-    Preconditions.checkArgument(
-        pool.getMaximumPoolSize() < Integer.MAX_VALUE,
-        "Unbounded executor is not supported."
-            + " Use a fixed-size ThreadPoolExecutor for manifest write with determined parallelism");
-    this.commitPool = executorService;
-    this.commitPoolSize = pool.getMaximumPoolSize();
+        parallelism > 0, "Parallelism must be greater than 0, but was: %s", parallelism);
+    this.writePool = executorService;
+    this.writePoolParallelism = parallelism;
     return self();
   }
 
@@ -248,12 +239,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     return workerPool;
   }
 
-  protected ExecutorService commitPool() {
-    if (commitPool == null) {
-      this.commitPool = ThreadPools.getWorkerPool();
+  protected ExecutorService writePool() {
+    if (writePool == null) {
+      this.writePool = ThreadPools.getWorkerPool();
     }
 
-    return commitPool;
+    return writePool;
   }
 
   @Override
@@ -811,7 +802,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   private <F> List<ManifestFile> writeManifests(
       Collection<F> files, Function<List<F>, List<ManifestFile>> writeFunc) {
-    int parallelism = manifestWriterCount(commitPoolSize, files.size());
+    int parallelism = manifestWriterCount(writePoolParallelism, files.size());
     List<List<F>> groups = divide(files, parallelism);
 
     // Create a new list pairing each group with its index
@@ -825,7 +816,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     Tasks.foreach(groupsWithIndex)
         .stopOnFailure()
         .throwFailureWhenFinished()
-        .executeWith(commitPool())
+        .executeWith(writePool())
         .run(
             indexedGroup -> {
               int index = indexedGroup.first();

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -124,6 +125,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       SnapshotAncestryValidator.NON_VALIDATING;
 
   private ExecutorService workerPool;
+  private ExecutorService commitPool;
+  private int commitPoolSize = ThreadPools.WORKER_THREAD_POOL_SIZE;
   private String targetBranch = SnapshotRef.MAIN_BRANCH;
   private CommitMetrics commitMetrics;
 
@@ -166,6 +169,24 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   @Override
   public ThisT scanManifestsWith(ExecutorService executorService) {
     this.workerPool = executorService;
+    return self();
+  }
+
+  @Override
+  public ThisT commitManifestsWith(ExecutorService executorService) {
+    Preconditions.checkArgument(executorService != null, "Invalid executor service: null");
+    Preconditions.checkArgument(
+        executorService instanceof ThreadPoolExecutor,
+        "Unsupported executor type: %s. Expected a fixed-size ThreadPoolExecutor"
+            + " for manifest write with determined parallelism",
+        executorService.getClass().getName());
+    ThreadPoolExecutor pool = (ThreadPoolExecutor) executorService;
+    Preconditions.checkArgument(
+        pool.getMaximumPoolSize() < Integer.MAX_VALUE,
+        "Unbounded executor is not supported."
+            + " Use a fixed-size ThreadPoolExecutor for manifest write with determined parallelism");
+    this.commitPool = executorService;
+    this.commitPoolSize = pool.getMaximumPoolSize();
     return self();
   }
 
@@ -225,6 +246,14 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     }
 
     return workerPool;
+  }
+
+  protected ExecutorService commitPool() {
+    if (commitPool == null) {
+      this.commitPool = ThreadPools.getWorkerPool();
+    }
+
+    return commitPool;
   }
 
   @Override
@@ -780,9 +809,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     return writer.toManifestFiles();
   }
 
-  private static <F> List<ManifestFile> writeManifests(
+  private <F> List<ManifestFile> writeManifests(
       Collection<F> files, Function<List<F>, List<ManifestFile>> writeFunc) {
-    int parallelism = manifestWriterCount(ThreadPools.WORKER_THREAD_POOL_SIZE, files.size());
+    int parallelism = manifestWriterCount(commitPoolSize, files.size());
     List<List<F>> groups = divide(files, parallelism);
 
     // Create a new list pairing each group with its index
@@ -796,7 +825,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     Tasks.foreach(groupsWithIndex)
         .stopOnFailure()
         .throwFailureWhenFinished()
-        .executeWith(ThreadPools.getWorkerPool())
+        .executeWith(commitPool())
         .run(
             indexedGroup -> {
               int index = indexedGroup.first();

--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -35,6 +35,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.io.FileIO;
@@ -296,6 +299,29 @@ public class TestBase {
 
   public TableMetadata readMetadata() {
     return TestTables.readMetadata("test");
+  }
+
+  protected void assertEmptyTable() {
+    assertThat(listManifestFiles()).isEmpty();
+    TableMetadata base = readMetadata();
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
+  }
+
+  protected static ExecutorService newNamedExecutor(String prefix, AtomicInteger counter) {
+    return newNamedExecutor(prefix, counter, 1);
+  }
+
+  protected static ExecutorService newNamedExecutor(
+      String prefix, AtomicInteger counter, int nThreads) {
+    return Executors.newFixedThreadPool(
+        nThreads,
+        runnable -> {
+          Thread thread = new Thread(runnable);
+          thread.setName(prefix + "-" + counter.getAndIncrement());
+          thread.setDaemon(true);
+          return thread;
+        });
   }
 
   static FileFormat manifestFormat(int version) {

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -382,6 +382,81 @@ public class TestMergeAppend extends TestBase {
   }
 
   @TestTemplate
+  public void testAppendWithCommitManifestsExecutor() {
+    assertThat(listManifestFiles()).isEmpty();
+
+    TableMetadata base = readMetadata();
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
+    AtomicInteger commitThreadsIndex = new AtomicInteger(0);
+    Snapshot snapshot =
+        commit(
+            table,
+            table
+                .newAppend()
+                .appendFile(FILE_A)
+                .appendFile(FILE_B)
+                .commitManifestsWith(
+                    Executors.newFixedThreadPool(
+                        1,
+                        runnable -> {
+                          Thread thread = new Thread(runnable);
+                          thread.setName("commit-" + commitThreadsIndex.getAndIncrement());
+                          thread.setDaemon(true);
+                          return thread;
+                        })),
+            branch);
+    assertThat(commitThreadsIndex.get())
+        .as("Thread should be created in provided commit pool")
+        .isGreaterThan(0);
+    assertThat(snapshot).isNotNull();
+  }
+
+  @TestTemplate
+  public void testAppendWithSeparateScanAndCommitExecutors() {
+    assertThat(listManifestFiles()).isEmpty();
+
+    TableMetadata base = readMetadata();
+    assertThat(base.currentSnapshot()).isNull();
+    assertThat(base.lastSequenceNumber()).isEqualTo(0);
+    AtomicInteger scanThreadsIndex = new AtomicInteger(0);
+    AtomicInteger commitThreadsIndex = new AtomicInteger(0);
+    Snapshot snapshot =
+        commit(
+            table,
+            table
+                .newAppend()
+                .appendFile(FILE_A)
+                .appendFile(FILE_B)
+                .scanManifestsWith(
+                    Executors.newFixedThreadPool(
+                        1,
+                        runnable -> {
+                          Thread thread = new Thread(runnable);
+                          thread.setName("scan-" + scanThreadsIndex.getAndIncrement());
+                          thread.setDaemon(true);
+                          return thread;
+                        }))
+                .commitManifestsWith(
+                    Executors.newFixedThreadPool(
+                        1,
+                        runnable -> {
+                          Thread thread = new Thread(runnable);
+                          thread.setName("commit-" + commitThreadsIndex.getAndIncrement());
+                          thread.setDaemon(true);
+                          return thread;
+                        })),
+            branch);
+    assertThat(scanThreadsIndex.get())
+        .as("Thread should be created in provided scan pool")
+        .isGreaterThan(0);
+    assertThat(commitThreadsIndex.get())
+        .as("Thread should be created in provided commit pool")
+        .isGreaterThan(0);
+    assertThat(snapshot).isNotNull();
+  }
+
+  @TestTemplate
   public void testMergeWithAppendFilesAndManifest() throws IOException {
     // merge all manifests for this test
     table.updateProperties().set("commit.manifest.min-count-to-merge", "1").commit();

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -382,7 +382,7 @@ public class TestMergeAppend extends TestBase {
   }
 
   @TestTemplate
-  public void testAppendWithCommitManifestsExecutor() {
+  public void testAppendWithWriteManifestsExecutor() {
     assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
@@ -396,7 +396,7 @@ public class TestMergeAppend extends TestBase {
                 .newAppend()
                 .appendFile(FILE_A)
                 .appendFile(FILE_B)
-                .commitManifestsWith(
+                .writeManifestsWith(
                     Executors.newFixedThreadPool(
                         1,
                         runnable -> {
@@ -404,7 +404,8 @@ public class TestMergeAppend extends TestBase {
                           thread.setName("commit-" + commitThreadsIndex.getAndIncrement());
                           thread.setDaemon(true);
                           return thread;
-                        })),
+                        }),
+                    1),
             branch);
     assertThat(commitThreadsIndex.get())
         .as("Thread should be created in provided commit pool")
@@ -413,7 +414,7 @@ public class TestMergeAppend extends TestBase {
   }
 
   @TestTemplate
-  public void testAppendWithSeparateScanAndCommitExecutors() {
+  public void testAppendWithSeparateScanAndWriteExecutors() {
     assertThat(listManifestFiles()).isEmpty();
 
     TableMetadata base = readMetadata();
@@ -437,7 +438,7 @@ public class TestMergeAppend extends TestBase {
                           thread.setDaemon(true);
                           return thread;
                         }))
-                .commitManifestsWith(
+                .writeManifestsWith(
                     Executors.newFixedThreadPool(
                         1,
                         runnable -> {
@@ -445,7 +446,8 @@ public class TestMergeAppend extends TestBase {
                           thread.setName("commit-" + commitThreadsIndex.getAndIncrement());
                           thread.setDaemon(true);
                           return thread;
-                        })),
+                        }),
+                    1),
             branch);
     assertThat(scanThreadsIndex.get())
         .as("Thread should be created in provided scan pool")

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -41,7 +41,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.ThreadPools;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -91,11 +90,6 @@ public class TestMergeAppend extends TestBase {
     assertThat(listManifestFiles()).as("Table should start empty").isEmpty();
 
     int multiplier = 3;
-    assumeThat(ThreadPools.WORKER_THREAD_POOL_SIZE)
-        .as(
-            "Worker thread pool size should be at least 3 to test manifest file ordering with multiple threads")
-        .isGreaterThanOrEqualTo(multiplier);
-
     int groupSize = SnapshotProducer.MIN_FILE_GROUP_SIZE;
     List<DataFile> dataFiles = Lists.newArrayList();
 
@@ -107,6 +101,7 @@ public class TestMergeAppend extends TestBase {
 
     AppendFiles append = table.newAppend();
     dataFiles.forEach(append::appendFile);
+    append.writeManifestsWith(Executors.newFixedThreadPool(multiplier), multiplier);
     append.commit();
 
     Snapshot snapshot = table.currentSnapshot();

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -378,11 +378,8 @@ public class TestMergeAppend extends TestBase {
 
   @TestTemplate
   public void testAppendWithWriteManifestsExecutor() {
-    assertThat(listManifestFiles()).isEmpty();
+    assertEmptyTable();
 
-    TableMetadata base = readMetadata();
-    assertThat(base.currentSnapshot()).isNull();
-    assertThat(base.lastSequenceNumber()).isEqualTo(0);
     AtomicInteger commitThreadsIndex = new AtomicInteger(0);
     Snapshot snapshot =
         commit(
@@ -391,30 +388,28 @@ public class TestMergeAppend extends TestBase {
                 .newAppend()
                 .appendFile(FILE_A)
                 .appendFile(FILE_B)
-                .writeManifestsWith(
-                    Executors.newFixedThreadPool(
-                        1,
-                        runnable -> {
-                          Thread thread = new Thread(runnable);
-                          thread.setName("commit-" + commitThreadsIndex.getAndIncrement());
-                          thread.setDaemon(true);
-                          return thread;
-                        }),
-                    1),
+                .writeManifestsWith(newNamedExecutor("commit", commitThreadsIndex), 1),
             branch);
     assertThat(commitThreadsIndex.get())
         .as("Thread should be created in provided commit pool")
         .isGreaterThan(0);
+
     assertThat(snapshot).isNotNull();
+    assertThat(snapshot.allManifests(table.io())).hasSize(1);
+    long snapshotId = snapshot.snapshotId();
+    validateManifest(
+        snapshot.allManifests(table.io()).get(0),
+        dataSeqs(1L, 1L),
+        fileSeqs(1L, 1L),
+        ids(snapshotId, snapshotId),
+        files(FILE_A, FILE_B),
+        statuses(Status.ADDED, Status.ADDED));
   }
 
   @TestTemplate
   public void testAppendWithSeparateScanAndWriteExecutors() {
-    assertThat(listManifestFiles()).isEmpty();
+    assertEmptyTable();
 
-    TableMetadata base = readMetadata();
-    assertThat(base.currentSnapshot()).isNull();
-    assertThat(base.lastSequenceNumber()).isEqualTo(0);
     AtomicInteger scanThreadsIndex = new AtomicInteger(0);
     AtomicInteger commitThreadsIndex = new AtomicInteger(0);
     Snapshot snapshot =
@@ -424,25 +419,8 @@ public class TestMergeAppend extends TestBase {
                 .newAppend()
                 .appendFile(FILE_A)
                 .appendFile(FILE_B)
-                .scanManifestsWith(
-                    Executors.newFixedThreadPool(
-                        1,
-                        runnable -> {
-                          Thread thread = new Thread(runnable);
-                          thread.setName("scan-" + scanThreadsIndex.getAndIncrement());
-                          thread.setDaemon(true);
-                          return thread;
-                        }))
-                .writeManifestsWith(
-                    Executors.newFixedThreadPool(
-                        1,
-                        runnable -> {
-                          Thread thread = new Thread(runnable);
-                          thread.setName("commit-" + commitThreadsIndex.getAndIncrement());
-                          thread.setDaemon(true);
-                          return thread;
-                        }),
-                    1),
+                .scanManifestsWith(newNamedExecutor("scan", scanThreadsIndex))
+                .writeManifestsWith(newNamedExecutor("commit", commitThreadsIndex), 1),
             branch);
     assertThat(scanThreadsIndex.get())
         .as("Thread should be created in provided scan pool")
@@ -450,7 +428,17 @@ public class TestMergeAppend extends TestBase {
     assertThat(commitThreadsIndex.get())
         .as("Thread should be created in provided commit pool")
         .isGreaterThan(0);
+
     assertThat(snapshot).isNotNull();
+    assertThat(snapshot.allManifests(table.io())).hasSize(1);
+    long snapshotId = snapshot.snapshotId();
+    validateManifest(
+        snapshot.allManifests(table.io()).get(0),
+        dataSeqs(1L, 1L),
+        fileSeqs(1L, 1L),
+        ids(snapshotId, snapshotId),
+        files(FILE_A, FILE_B),
+        statuses(Status.ADDED, Status.ADDED));
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
@@ -256,33 +256,24 @@ public class TestSnapshotProducer extends TestBase {
   }
 
   @TestTemplate
-  public void testCommitManifestsWithNullExecutorThrows() {
-    assertThatThrownBy(() -> table.newAppend().commitManifestsWith(null))
+  public void testWriteManifestsWithNullExecutorThrows() {
+    assertThatThrownBy(() -> table.newAppend().writeManifestsWith(null, 4))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid executor service: null");
+        .hasMessage("Executor service cannot be null");
   }
 
   @TestTemplate
-  public void testCommitManifestsWithSingleThreadExecutorThrows() {
-    ExecutorService singleThread = Executors.newSingleThreadExecutor();
+  public void testWriteManifestsWithInvalidParallelismThrows() {
+    ExecutorService executor = Executors.newFixedThreadPool(4);
     try {
-      assertThatThrownBy(() -> table.newAppend().commitManifestsWith(singleThread))
+      assertThatThrownBy(() -> table.newAppend().writeManifestsWith(executor, 0))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("Expected a fixed-size ThreadPoolExecutor");
-    } finally {
-      singleThread.shutdownNow();
-    }
-  }
-
-  @TestTemplate
-  public void testCommitManifestsWithCachedThreadPoolThrows() {
-    ExecutorService cachedPool = Executors.newCachedThreadPool();
-    try {
-      assertThatThrownBy(() -> table.newAppend().commitManifestsWith(cachedPool))
+          .hasMessageContaining("Parallelism must be greater than 0");
+      assertThatThrownBy(() -> table.newAppend().writeManifestsWith(executor, -1))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("Unbounded executor is not supported");
+          .hasMessageContaining("Parallelism must be greater than 0");
     } finally {
-      cachedPool.shutdownNow();
+      executor.shutdownNow();
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
@@ -28,6 +28,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -251,5 +253,36 @@ public class TestSnapshotProducer extends TestBase {
 
     ManifestFile manifest = table.currentSnapshot().dataManifests(table.io()).get(0);
     assertThat(readAvroCodec(new File(manifest.path()))).isEqualTo("snappy");
+  }
+
+  @TestTemplate
+  public void testCommitManifestsWithNullExecutorThrows() {
+    assertThatThrownBy(() -> table.newAppend().commitManifestsWith(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid executor service: null");
+  }
+
+  @TestTemplate
+  public void testCommitManifestsWithSingleThreadExecutorThrows() {
+    ExecutorService singleThread = Executors.newSingleThreadExecutor();
+    try {
+      assertThatThrownBy(() -> table.newAppend().commitManifestsWith(singleThread))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Expected a fixed-size ThreadPoolExecutor");
+    } finally {
+      singleThread.shutdownNow();
+    }
+  }
+
+  @TestTemplate
+  public void testCommitManifestsWithCachedThreadPoolThrows() {
+    ExecutorService cachedPool = Executors.newCachedThreadPool();
+    try {
+      assertThatThrownBy(() -> table.newAppend().commitManifestsWith(cachedPool))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Unbounded executor is not supported");
+    } finally {
+      cachedPool.shutdownNow();
+    }
   }
 }


### PR DESCRIPTION
## Why

The SnapshotUpdate interface today already has scanManifestsWith(ExecutorService) (from #4147) which lets callers control the executor used for reading/scanning manifests. However, writing manifests during snapshot commit still hardcodes `ThreadPools.getWorkerPool()` for parallel manifest writes. 

This means callers cannot control the thread pool used for I/O-heavy manifest writes and coordinate on shutdown behavior (see #15031) also difficult to pass additional contextual information such as tagging/logging/metrics for debug the problem.
