### PR TITLE
AWS, GCP: Use CopyOnWriteArrayList for FileIO storage credentials

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -109,8 +110,9 @@ public class S3FileIO
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
   private transient StackTraceElement[] createStack;
-  // use modifiable collection for Kryo serde
-  private volatile List<StorageCredential> storageCredentials = Lists.newArrayList();
+  // CopyOnWriteArrayList gives a safe snapshot view for readers iterating outside
+  // the synchronized block in clientByPrefix() and is Kryo-serialisable
+  private volatile List<StorageCredential> storageCredentials = new CopyOnWriteArrayList<>();
   private transient volatile Map<String, PrefixedS3Client> clientByPrefix;
   private transient volatile ScheduledFuture<?> refreshFuture;
 
@@ -469,7 +471,7 @@ public class S3FileIO
               .collect(Collectors.toList());
 
       if (!refreshed.isEmpty() && !isResourceClosed.get()) {
-        this.storageCredentials = Lists.newArrayList(refreshed);
+        this.storageCredentials = new CopyOnWriteArrayList<>(refreshed);
         scheduleCredentialRefresh();
       }
     } catch (Exception e) {
@@ -619,8 +621,8 @@ public class S3FileIO
       refreshFuture.cancel(true);
     }
 
-    // copy credentials into a modifiable collection for Kryo serde
-    this.storageCredentials = Lists.newArrayList(credentials);
+    // use a thread-safe list so concurrent readers observe a consistent snapshot
+    this.storageCredentials = new CopyOnWriteArrayList<>(credentials);
 
     // if the clients are already initialized, we need to close and allow them to be recreated
     synchronized (this) {

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOCredentialRefresh.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOCredentialRefresh.java
@@ -23,10 +23,13 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.AwsProperties;
@@ -263,6 +266,25 @@ public class TestS3FileIOCredentialRefresh {
                     .containsEntry(
                         S3FileIOProperties.SESSION_TOKEN_EXPIRES_AT_MS, refreshedExpiryMs);
               });
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void setCredentialsPublishesThreadSafeSnapshot() throws Exception {
+    StorageCredential credential =
+        StorageCredential.create(
+            "s3://bucket/path", ImmutableMap.of(S3FileIOProperties.ACCESS_KEY_ID, "key"));
+
+    try (S3FileIO fileIO = new S3FileIO()) {
+      List<StorageCredential> input = new ArrayList<>();
+      input.add(credential);
+      fileIO.setCredentials(input);
+
+      Field field = S3FileIO.class.getDeclaredField("storageCredentials");
+      field.setAccessible(true);
+      List<StorageCredential> stored = (List<StorageCredential>) field.get(fileIO);
+      assertThat(stored).isInstanceOf(CopyOnWriteArrayList.class).containsExactly(credential);
     }
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOCredentialRefresh.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOCredentialRefresh.java
@@ -26,7 +26,6 @@ import static org.mockserver.model.HttpResponse.response;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -35,6 +34,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.HttpMethod;
 import org.apache.iceberg.rest.credentials.ImmutableCredential;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
@@ -277,7 +277,7 @@ public class TestS3FileIOCredentialRefresh {
             "s3://bucket/path", ImmutableMap.of(S3FileIOProperties.ACCESS_KEY_ID, "key"));
 
     try (S3FileIO fileIO = new S3FileIO()) {
-      List<StorageCredential> input = new ArrayList<>();
+      List<StorageCredential> input = Lists.newArrayList();
       input.add(credential);
       fileIO.setCredentials(input);
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.gcp.gcs;
 
-import com.google.api.client.util.Lists;
 import com.google.api.client.util.Maps;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -30,6 +29,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -80,8 +80,9 @@ public class GCSFileIO implements DelegateFileIO, SupportsStorageCredentials {
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
   private SerializableMap<String, String> properties = null;
-  // use modifiable collection for Kryo serde
-  private volatile List<StorageCredential> storageCredentials = Lists.newArrayList();
+  // CopyOnWriteArrayList gives a safe snapshot view for readers iterating outside
+  // the synchronized block in storageByPrefix() and is Kryo-serialisable
+  private volatile List<StorageCredential> storageCredentials = new CopyOnWriteArrayList<>();
   private transient volatile Map<String, PrefixedStorage> storageByPrefix;
   private transient volatile ScheduledFuture<?> refreshFuture;
 
@@ -251,7 +252,7 @@ public class GCSFileIO implements DelegateFileIO, SupportsStorageCredentials {
               .toList();
 
       if (!refreshed.isEmpty() && !isResourceClosed.get()) {
-        this.storageCredentials = Lists.newArrayList(refreshed);
+        this.storageCredentials = new CopyOnWriteArrayList<>(refreshed);
         scheduleCredentialRefresh();
       }
     } catch (Exception e) {
@@ -347,8 +348,8 @@ public class GCSFileIO implements DelegateFileIO, SupportsStorageCredentials {
       refreshFuture.cancel(true);
     }
 
-    // copy credentials into a modifiable collection for Kryo serde
-    this.storageCredentials = Lists.newArrayList(credentials);
+    // use a thread-safe list so concurrent readers observe a consistent snapshot
+    this.storageCredentials = new CopyOnWriteArrayList<>(credentials);
 
     // if the clients are already initialized, we need to close and allow them to be recreated
     synchronized (this) {

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSFileIO.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSFileIO.java
@@ -42,7 +42,6 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -586,7 +585,7 @@ public class TestGCSFileIO {
         StorageCredential.create("gs://bucket/path", ImmutableMap.of("key1", "val1"));
 
     try (GCSFileIO fileIO = new GCSFileIO()) {
-      List<StorageCredential> input = new ArrayList<>();
+      List<StorageCredential> input = Lists.newArrayList();
       input.add(credential);
       fileIO.setCredentials(input);
 

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSFileIO.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSFileIO.java
@@ -38,13 +38,16 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.StreamSupport;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
@@ -574,5 +577,23 @@ public class TestGCSFileIO {
         .asInstanceOf(InstanceOfAssertFactories.type(GCSFileIO.class))
         .extracting(GCSFileIO::credentials)
         .isEqualTo(storageCredentials);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void setCredentialsPublishesThreadSafeSnapshot() throws Exception {
+    StorageCredential credential =
+        StorageCredential.create("gs://bucket/path", ImmutableMap.of("key1", "val1"));
+
+    try (GCSFileIO fileIO = new GCSFileIO()) {
+      List<StorageCredential> input = new ArrayList<>();
+      input.add(credential);
+      fileIO.setCredentials(input);
+
+      Field field = GCSFileIO.class.getDeclaredField("storageCredentials");
+      field.setAccessible(true);
+      List<StorageCredential> stored = (List<StorageCredential>) field.get(fileIO);
+      assertThat(stored).isInstanceOf(CopyOnWriteArrayList.class).containsExactly(credential);
+    }
   }
 }


### PR DESCRIPTION
Closes #16034.

`S3FileIO.storageCredentials` and `GCSFileIO.storageCredentials` are declared `volatile` but back the reference with a plain `ArrayList`. The reference is read from `clientByPrefix()` / `storageByPrefix()` outside of the synchronized block that publishes the client map, and is replaced wholesale during a scheduled credential refresh. `volatile` covers visibility of the reference, but it does not cover the list contents if the backing `ArrayList` is ever modified in place. Readers iterating outside synchronization rely on the refresh path publishing a stable snapshot.

This switches the backing list to `CopyOnWriteArrayList`, which gives readers a consistent snapshot view even when the reference is replaced or the list is mutated, and is still compatible with the Kryo round-trip serialization that the existing FileIO tests exercise.

### Before
```java
// use modifiable collection for Kryo serde
private volatile List<StorageCredential> storageCredentials = Lists.newArrayList();
```

### After
```java
// CopyOnWriteArrayList gives a safe snapshot view for readers iterating outside
// the synchronized block in clientByPrefix() and is Kryo-serialisable
private volatile List<StorageCredential> storageCredentials = new CopyOnWriteArrayList<>();
```

I considered the alternatives called out in the issue (`List.copyOf`, `Collections.unmodifiableList`, `ImmutableList.copyOf`) but Kryo's default `CollectionSerializer` rebuilds collections via `add()` during deserialization, which throws `UnsupportedOperationException` on any of those wrapper types and broke the existing `fileIOWithStorageCredentialsSerialization` / `resolvingFileIOLoadWithStorageCredentials` tests. `CopyOnWriteArrayList` supports `add()` and round-trips cleanly.

### Tests
- Added `setCredentialsPublishesThreadSafeSnapshot` in `TestS3FileIOCredentialRefresh` and `TestGCSFileIO` to verify the field type after `setCredentials`.
- Re-ran `./gradlew :iceberg-aws:test --tests "*S3FileIO*"` and `./gradlew :iceberg-gcp:test --tests "*GCSFileIO*"`; both green, including the Kryo / Java serialization round trips.
- `./gradlew :iceberg-aws:spotlessCheck :iceberg-gcp:spotlessCheck` passes.