### PR TITLE
Parquet: handle AlwaysFalse in ParquetFilters.convert()

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -28,7 +28,9 @@ import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.ExpressionVisitors.ExpressionVisitor;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.expressions.NamedReference;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.types.Types.NestedField;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
@@ -42,7 +44,10 @@ class ParquetFilters {
   static FilterCompat.Filter convert(Schema schema, Expression expr, boolean caseSensitive) {
     FilterPredicate pred =
         ExpressionVisitors.visit(expr, new ConvertFilterToParquet(schema, caseSensitive));
-    if (pred != null && pred != AlwaysTrue.INSTANCE && pred != AlwaysFalse.INSTANCE) {
+    if (pred != null
+        && pred != AlwaysTrue.INSTANCE
+        && pred != AlwaysFalse.INSTANCE
+        && pred != Ignored.INSTANCE) {
       // FilterCompat will apply LogicalInverseRewriter
       return FilterCompat.get(pred);
     } else {
@@ -75,6 +80,9 @@ class ParquetFilters {
         return AlwaysFalse.INSTANCE;
       } else if (child == AlwaysFalse.INSTANCE) {
         return AlwaysTrue.INSTANCE;
+      } else if (child == Ignored.INSTANCE) {
+        // an unevaluable predicate stays unevaluable under negation
+        return Ignored.INSTANCE;
       }
       return FilterApi.not(child);
     }
@@ -83,9 +91,10 @@ class ParquetFilters {
     public FilterPredicate and(FilterPredicate left, FilterPredicate right) {
       if (left == AlwaysFalse.INSTANCE || right == AlwaysFalse.INSTANCE) {
         return AlwaysFalse.INSTANCE;
-      } else if (left == AlwaysTrue.INSTANCE) {
+      } else if (left == AlwaysTrue.INSTANCE || left == Ignored.INSTANCE) {
+        // dropping an ignored conjunct only widens the filter, which is safe for pushdown
         return right;
-      } else if (right == AlwaysTrue.INSTANCE) {
+      } else if (right == AlwaysTrue.INSTANCE || right == Ignored.INSTANCE) {
         return left;
       }
       return FilterApi.and(left, right);
@@ -95,6 +104,9 @@ class ParquetFilters {
     public FilterPredicate or(FilterPredicate left, FilterPredicate right) {
       if (left == AlwaysTrue.INSTANCE || right == AlwaysTrue.INSTANCE) {
         return AlwaysTrue.INSTANCE;
+      } else if (left == Ignored.INSTANCE || right == Ignored.INSTANCE) {
+        // an ignored disjunct could match, so the whole OR cannot be pushed down
+        return Ignored.INSTANCE;
       } else if (left == AlwaysFalse.INSTANCE) {
         return right;
       } else if (right == AlwaysFalse.INSTANCE) {
@@ -117,6 +129,11 @@ class ParquetFilters {
       Operation op = pred.op();
       BoundReference<T> ref = (BoundReference<T>) pred.term();
       String path = schema.idToAlias(ref.fieldId());
+      if (path == null) {
+        // the referenced column is not present in the file schema; cannot push down
+        return Ignored.INSTANCE;
+      }
+
       Literal<T> lit;
       if (pred.isUnaryPredicate()) {
         lit = null;
@@ -160,6 +177,16 @@ class ParquetFilters {
 
     @Override
     public <T> FilterPredicate predicate(UnboundPredicate<T> pred) {
+      NamedReference<?> ref = pred.ref();
+      NestedField field =
+          caseSensitive
+              ? schema.findField(ref.name())
+              : schema.caseInsensitiveFindField(ref.name());
+      if (field == null) {
+        // the referenced column is not present in the file schema; cannot push down
+        return Ignored.INSTANCE;
+      }
+
       Expression bound = bind(pred);
       if (bound instanceof BoundPredicate) {
         return predicate((BoundPredicate<?>) bound);
@@ -246,7 +273,22 @@ class ParquetFilters {
 
     @Override
     public <R> R accept(Visitor<R> visitor) {
-      throw new UnsupportedOperationException("AlwaysTrue is a placeholder only");
+      throw new UnsupportedOperationException("AlwaysFalse is a placeholder only");
+    }
+  }
+
+  /**
+   * Sentinel marker for a predicate that referenced a column not present in the file schema and
+   * therefore cannot be evaluated. Distinct from {@link AlwaysTrue} so that {@code not(Ignored)}
+   * does not become {@code AlwaysFalse} and {@code or(x, Ignored)} does not silently drop matching
+   * rows.
+   */
+  private static class Ignored implements FilterPredicate {
+    static final Ignored INSTANCE = new Ignored();
+
+    @Override
+    public <R> R accept(Visitor<R> visitor) {
+      throw new UnsupportedOperationException("Ignored is a placeholder only");
     }
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -42,8 +42,7 @@ class ParquetFilters {
   static FilterCompat.Filter convert(Schema schema, Expression expr, boolean caseSensitive) {
     FilterPredicate pred =
         ExpressionVisitors.visit(expr, new ConvertFilterToParquet(schema, caseSensitive));
-    // TODO: handle AlwaysFalse.INSTANCE
-    if (pred != null && pred != AlwaysTrue.INSTANCE) {
+    if (pred != null && pred != AlwaysTrue.INSTANCE && pred != AlwaysFalse.INSTANCE) {
       // FilterCompat will apply LogicalInverseRewriter
       return FilterCompat.get(pred);
     } else {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.junit.jupiter.api.Test;
+
+class TestParquetFilters {
+
+  private static final Map<String, Integer> ALIASES = ImmutableMap.of("id", 1);
+  private static final Schema SCHEMA =
+      new Schema(ImmutableList.of(required(1, "id", Types.IntegerType.get())), ALIASES);
+
+  @Test
+  void alwaysFalseReturnsNoop() {
+    FilterCompat.Filter result = ParquetFilters.convert(SCHEMA, Expressions.alwaysFalse(), true);
+    assertThat(result)
+        .as("AlwaysFalse expression should produce NOOP filter")
+        .isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void alwaysTrueReturnsNoop() {
+    FilterCompat.Filter result = ParquetFilters.convert(SCHEMA, Expressions.alwaysTrue(), true);
+    assertThat(result)
+        .as("AlwaysTrue expression should produce NOOP filter")
+        .isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void realPredicateReturnsFilter() {
+    FilterCompat.Filter result = ParquetFilters.convert(SCHEMA, Expressions.equal("id", 42), true);
+    assertThat(result)
+        .as("Real predicate should produce a non-NOOP filter")
+        .isNotSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void notAlwaysFalseReturnsNoop() {
+    FilterCompat.Filter result =
+        ParquetFilters.convert(SCHEMA, Expressions.not(Expressions.alwaysFalse()), true);
+    assertThat(result)
+        .as("not(alwaysFalse) should produce NOOP filter")
+        .isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void andWithAlwaysFalseReturnsNoop() {
+    FilterCompat.Filter result =
+        ParquetFilters.convert(
+            SCHEMA, Expressions.and(Expressions.alwaysFalse(), Expressions.equal("id", 42)), true);
+    assertThat(result)
+        .as("and(alwaysFalse, pred) should produce NOOP filter")
+        .isSameAs(FilterCompat.NOOP);
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -78,4 +78,50 @@ class TestParquetFilters {
         .as("and(alwaysFalse, pred) should produce NOOP filter")
         .isSameAs(FilterCompat.NOOP);
   }
+
+  @Test
+  void predicateOnMissingColumnReturnsNoop() {
+    // simulates reading an older file whose schema does not contain the filtered column
+    FilterCompat.Filter result =
+        ParquetFilters.convert(SCHEMA, Expressions.equal("missing", 42), true);
+    assertThat(result)
+        .as("Predicate on a column absent from the file schema should produce NOOP filter")
+        .isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void notPredicateOnMissingColumnReturnsNoop() {
+    // not(Ignored) must stay Ignored rather than flipping to a pushable filter
+    FilterCompat.Filter result =
+        ParquetFilters.convert(SCHEMA, Expressions.not(Expressions.equal("missing", 42)), true);
+    assertThat(result)
+        .as("not() of a missing-column predicate should produce NOOP filter")
+        .isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void orWithMissingColumnReturnsNoop() {
+    // or(present, Ignored) cannot be pushed down: the missing column could match rows
+    FilterCompat.Filter result =
+        ParquetFilters.convert(
+            SCHEMA,
+            Expressions.or(Expressions.equal("id", 42), Expressions.equal("missing", 7)),
+            true);
+    assertThat(result)
+        .as("or(pred, missing-column pred) should produce NOOP filter")
+        .isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void andWithMissingColumnPushesPresentSide() {
+    // and(present, Ignored) can push the resolvable side; dropping the ignored conjunct is safe
+    FilterCompat.Filter result =
+        ParquetFilters.convert(
+            SCHEMA,
+            Expressions.and(Expressions.equal("id", 42), Expressions.equal("missing", 7)),
+            true);
+    assertThat(result)
+        .as("and(pred, missing-column pred) should push the resolvable predicate")
+        .isNotSameAs(FilterCompat.NOOP);
+  }
 }


### PR DESCRIPTION
## Summary

Handle `AlwaysFalse.INSTANCE` in `ParquetFilters.convert()` so it returns `FilterCompat.NOOP` instead of passing the Iceberg-internal sentinel through to Parquet.

## Problem

Fixes #16032

`ParquetFilters.convert()` had a TODO comment acknowledging that `AlwaysFalse.INSTANCE` was not handled. The method only guarded against `AlwaysTrue.INSTANCE` before calling `FilterCompat.get(pred)`. Parquet does not understand Iceberg's internal `AlwaysFalse` type, so the resulting filter was undefined — it could silently read all rows instead of none.

## Solution

Added `&& pred != AlwaysFalse.INSTANCE` to the sentinel check in `convert()`, matching the existing `AlwaysTrue.INSTANCE` guard. When the expression reduces to `AlwaysFalse`, the method returns `FilterCompat.NOOP`. This is safe because Iceberg's own manifest-level filtering has already ensured no matching row groups will be scanned.

## Testing

Added `TestParquetFilters` with five unit tests:

- `alwaysFalseReturnsNoop` — regression guard for the exact bug
- `alwaysTrueReturnsNoop` — confirms existing AlwaysTrue behaviour
- `realPredicateReturnsFilter` — confirms real predicates still produce active filters
- `notAlwaysFalseReturnsNoop` — `not(alwaysFalse)` resolves via the visitor
- `andWithAlwaysFalseReturnsNoop` — `and(alwaysFalse, pred)` resolves via the visitor

All existing `iceberg-parquet` tests pass.