### PR TITLE
Spec: Fix reserved field ID limit

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -375,7 +375,7 @@ Identifier fields may be nested in structs but cannot be nested within maps or l
 
 #### Reserved Field IDs
 
-Iceberg tables must not use field ids greater than 2147483447 (`Integer.MAX_VALUE - 200`). This id range is reserved for metadata columns that can be used in user data schemas, like the `_file` column that holds the file path in which a row was stored.
+Iceberg tables must not use field ids greater than or equal to 2147483447 (`Integer.MAX_VALUE - 200`). This id range is reserved for metadata columns that can be used in user data schemas, like the `_file` column that holds the file path in which a row was stored.
 
 The set of metadata columns is:
 


### PR DESCRIPTION
According to the Java implementation, this requirement is inclusive or "greater than or equal" to this value. https://github.com/apache/iceberg/blob/3d4c6e00d1864746d99791f160a64b70dbaaa6af/core/src/main/java/org/apache/iceberg/StatsUtil.java#L54-L58

I am proposing to update the spec to clarify this. This appears to change the spec itself though, so I'm open to looking instead at changing this in the Java implementation to accommodate the difference with the spec.