### PR TITLE
Docker: Quiet noisy per-request loggers in iceberg-rest-fixture image

### DIFF
--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -33,6 +33,12 @@ WORKDIR /usr/lib/iceberg-rest
 # Copy the JAR file directly to the target location
 COPY --chown=iceberg:iceberg open-api/build/libs/iceberg-open-api-test-fixtures-runtime-*.jar /usr/lib/iceberg-rest/iceberg-rest-adapter.jar
 
+# Default slf4j-simple configuration. Lives next to the jar so users can mount
+# their own simplelogger.properties at /usr/lib/iceberg-rest/simplelogger.properties
+# or override individual loggers via -D system properties without rebuilding.
+# See https://github.com/apache/iceberg/issues/14227
+COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/simplelogger.properties /usr/lib/iceberg-rest/simplelogger.properties
+
 ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
 ENV CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db
 ENV CATALOG_JDBC_USER=user
@@ -47,4 +53,6 @@ HEALTHCHECK --retries=10 --interval=1s \
 EXPOSE $REST_PORT
 USER iceberg:iceberg
 ENV LANG=en_US.UTF-8
-CMD ["java", "-jar", "iceberg-rest-adapter.jar"]
+# Add the working directory to the classpath so simplelogger.properties is
+# discovered by slf4j-simple. Main class is set in the runtime jar manifest.
+CMD ["java", "-cp", "/usr/lib/iceberg-rest:/usr/lib/iceberg-rest/iceberg-rest-adapter.jar", "org.apache.iceberg.rest.RESTCatalogServer"]

--- a/docker/iceberg-rest-fixture/README.md
+++ b/docker/iceberg-rest-fixture/README.md
@@ -35,6 +35,31 @@ When making changes to the local files and test them out, you can build the imag
 docker image rm -f apache/iceberg-rest-fixture && docker build -t apache/iceberg-rest-fixture -f docker/iceberg-rest-fixture/Dockerfile .
 ```
 
+## Logging
+
+The image uses [slf4j-simple](https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html)
+and ships with `simplelogger.properties` at `/usr/lib/iceberg-rest/`. The
+defaults keep the root level at `INFO` and quiet a couple of per-request
+loggers (`BaseMetastoreCatalog`, `BaseMetastoreTableOperations`) that would
+otherwise log on every table load and commit.
+
+Override individual loggers at runtime via `-D` system properties — no rebuild
+needed:
+
+```bash
+docker run apache/iceberg-rest-fixture \
+  java -Dorg.slf4j.simpleLogger.defaultLogLevel=debug \
+       -cp /usr/lib/iceberg-rest:/usr/lib/iceberg-rest/iceberg-rest-adapter.jar \
+       org.apache.iceberg.rest.RESTCatalogServer
+```
+
+To replace the file entirely, mount your own:
+
+```bash
+docker run -v /path/to/simplelogger.properties:/usr/lib/iceberg-rest/simplelogger.properties \
+  apache/iceberg-rest-fixture
+```
+
 ## Browse
 
 To browse the catalog, you can use `pyiceberg`:

--- a/docker/iceberg-rest-fixture/simplelogger.properties
+++ b/docker/iceberg-rest-fixture/simplelogger.properties
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Default logging configuration for the iceberg-rest-fixture Docker image.
+# Picked up by slf4j-simple from the working directory, which the Dockerfile
+# adds to the classpath ahead of the runtime jar.
+#
+# Override at runtime via system properties without rebuilding the image,
+# for example:
+#   docker run apache/iceberg-rest-fixture \
+#     java -Dorg.slf4j.simpleLogger.defaultLogLevel=debug \
+#          -cp /usr/lib/iceberg-rest:/usr/lib/iceberg-rest/iceberg-rest-adapter.jar \
+#          org.apache.iceberg.rest.RESTCatalogServer
+#
+# Reference: https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html
+
+# Root level. Iceberg's own INFO logs remain visible by default.
+org.slf4j.simpleLogger.defaultLogLevel=info
+
+# Quiet the per-request loggers that flood the container output on every
+# table load/commit/refresh. See https://github.com/apache/iceberg/issues/14227
+org.slf4j.simpleLogger.log.org.apache.iceberg.BaseMetastoreCatalog=warn
+org.slf4j.simpleLogger.log.org.apache.iceberg.BaseMetastoreTableOperations=warn
+
+# Show timestamps so logs are useful in long-running fixtures.
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS


### PR DESCRIPTION
### Summary

The `iceberg-rest-fixture` Docker image uses `slf4j-simple` (the
`testFixturesImplementation` binding in `build.gradle`) and ships with no
logging configuration on the classpath. Two iceberg loggers fire on every
REST API call and drown out warnings and errors:

```
[qtp...] INFO  org.apache.iceberg.BaseMetastoreCatalog - Table loaded by catalog: ...
[qtp...] INFO  org.apache.iceberg.BaseMetastoreTableOperations - Successfully committed to table ... in 12 ms
[qtp...] INFO  org.apache.iceberg.BaseMetastoreTableOperations - Refreshing table metadata from new version: ...
```

The user reported that `CATALOG_LOG4J_LOGLEVEL=WARN` had no effect — the
runtime is `slf4j-simple`, not log4j, and the `CATALOG_*` prefix is for
catalog config, so there was no override knob at all.

### Change

Config-only:

- Add `docker/iceberg-rest-fixture/simplelogger.properties` with the root
  level kept at `INFO` (so iceberg's own startup and lifecycle logs stay
  visible) and `BaseMetastoreCatalog` / `BaseMetastoreTableOperations`
  bumped to `WARN`. Includes a timestamp pattern.
- `Dockerfile`: `COPY` the properties file to `/usr/lib/iceberg-rest/` and
  switch `CMD` from `java -jar iceberg-rest-adapter.jar` to
  `java -cp /usr/lib/iceberg-rest:/usr/lib/iceberg-rest/iceberg-rest-adapter.jar org.apache.iceberg.rest.RESTCatalogServer`
  so slf4j-simple picks up the file from the working directory. Main class
  is the same one already declared in the shadowJar manifest.
- `README.md`: short Logging section showing how to override individual
  loggers via `-D` props or replace the file via a bind mount.

No Java code changes. No build script changes. No new dependencies.

### How users override

```bash
# bump to debug for everything
docker run apache/iceberg-rest-fixture \
  java -Dorg.slf4j.simpleLogger.defaultLogLevel=debug \
       -cp /usr/lib/iceberg-rest:/usr/lib/iceberg-rest/iceberg-rest-adapter.jar \
       org.apache.iceberg.rest.RESTCatalogServer

# replace the file entirely
docker run -v /path/to/simplelogger.properties:/usr/lib/iceberg-rest/simplelogger.properties \
  apache/iceberg-rest-fixture
```

### Test plan

- [ ] `./gradlew :iceberg-open-api:shadowJar`
- [ ] `docker build -t apache/iceberg-rest-fixture -f docker/iceberg-rest-fixture/Dockerfile .`
- [ ] Run image, hit `/v1/config` and `/v1/namespaces`, confirm the
      `BaseMetastoreCatalog` / `BaseMetastoreTableOperations` INFO lines
      no longer appear.
- [ ] Run image with `-Dorg.slf4j.simpleLogger.defaultLogLevel=debug`
      override and confirm DEBUG lines appear.
- [ ] Healthcheck still passes (it shells `curl`, not Java, so unaffected).

I don't have docker available to run the build locally, so the rebuild and
runtime verification above are pending. The change is mechanical (file +
classpath) and the slf4j-simple property names are from the
[upstream docs](https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html).

Closes #14227
