### PR TITLE
Core: Add dv_count column to PartitionsTable metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.PartitionUtil;
 import org.apache.iceberg.util.StructLikeMap;
@@ -90,6 +91,9 @@ public class PartitionsTable extends BaseMetadataTable {
           "last_updated_snapshot_id",
           Types.LongType.get(),
           "Id of snapshot that last updated this partition");
+  private static final Types.NestedField DV_COUNT =
+      Types.NestedField.required(
+          12, "dv_count", Types.IntegerType.get(), "Count of deletion vectors");
 
   private final Schema schema;
 
@@ -115,7 +119,8 @@ public class PartitionsTable extends BaseMetadataTable {
             EQUALITY_DELETE_RECORD_COUNT,
             EQUALITY_DELETE_FILE_COUNT,
             LAST_UPDATED_AT,
-            LAST_UPDATED_SNAPSHOT_ID);
+            LAST_UPDATED_SNAPSHOT_ID,
+            DV_COUNT);
     this.unpartitionedTable = Partitioning.partitionType(table).fields().isEmpty();
   }
 
@@ -138,7 +143,8 @@ public class PartitionsTable extends BaseMetadataTable {
               EQUALITY_DELETE_RECORD_COUNT.fieldId(),
               EQUALITY_DELETE_FILE_COUNT.fieldId(),
               LAST_UPDATED_AT.fieldId(),
-              LAST_UPDATED_SNAPSHOT_ID.fieldId()));
+              LAST_UPDATED_SNAPSHOT_ID.fieldId(),
+              DV_COUNT.fieldId()));
     }
     return schema;
   }
@@ -167,7 +173,8 @@ public class PartitionsTable extends BaseMetadataTable {
                   root.eqDeleteRecordCount,
                   root.eqDeleteFileCount,
                   root.lastUpdatedAt,
-                  root.lastUpdatedSnapshotId));
+                  root.lastUpdatedSnapshotId,
+                  root.dvCount));
     } else {
       return StaticDataTask.of(
           io().newInputFile(table().operations().current().metadataFileLocation()),
@@ -190,7 +197,8 @@ public class PartitionsTable extends BaseMetadataTable {
         partition.eqDeleteRecordCount,
         partition.eqDeleteFileCount,
         partition.lastUpdatedAt,
-        partition.lastUpdatedSnapshotId);
+        partition.lastUpdatedSnapshotId,
+        partition.dvCount);
   }
 
   @VisibleForTesting
@@ -310,6 +318,7 @@ public class PartitionsTable extends BaseMetadataTable {
     private int eqDeleteFileCount;
     private Long lastUpdatedAt;
     private Long lastUpdatedSnapshotId;
+    private int dvCount;
 
     Partition(StructLike key, PartitionData partitionDataTemplate) {
       this.partitionData = toPartitionData(key, partitionDataTemplate);
@@ -321,6 +330,7 @@ public class PartitionsTable extends BaseMetadataTable {
       this.posDeleteFileCount = 0;
       this.eqDeleteRecordCount = 0L;
       this.eqDeleteFileCount = 0;
+      this.dvCount = 0;
     }
 
     @VisibleForTesting
@@ -347,7 +357,11 @@ public class PartitionsTable extends BaseMetadataTable {
           break;
         case POSITION_DELETES:
           this.posDeleteRecordCount += file.recordCount();
-          this.posDeleteFileCount += 1;
+          if (ContentFileUtil.isDV((DeleteFile) file)) {
+            this.dvCount += 1;
+          } else {
+            this.posDeleteFileCount += 1;
+          }
           break;
         case EQUALITY_DELETES:
           this.eqDeleteRecordCount += file.recordCount();

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.PartitionUtil;
 import org.apache.iceberg.util.StructLikeMap;
@@ -338,6 +337,16 @@ public class PartitionsTable extends BaseMetadataTable {
       return partitionData;
     }
 
+    @VisibleForTesting
+    int dvCount() {
+      return dvCount;
+    }
+
+    @VisibleForTesting
+    int posDeleteFileCount() {
+      return posDeleteFileCount;
+    }
+
     void update(ContentFile<?> file, Snapshot snapshot) {
       if (snapshot != null) {
         long snapshotCommitTime = snapshot.timestampMillis() * 1000;
@@ -357,7 +366,7 @@ public class PartitionsTable extends BaseMetadataTable {
           break;
         case POSITION_DELETES:
           this.posDeleteRecordCount += file.recordCount();
-          if (ContentFileUtil.isDV((DeleteFile) file)) {
+          if (file.format() == FileFormat.PUFFIN) {
             this.dvCount += 1;
           } else {
             this.posDeleteFileCount += 1;

--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -114,6 +114,17 @@ public class TestBase {
           .withContentOffset(4)
           .withContentSizeInBytes(6)
           .build();
+  static final DeleteFile FILE_A2_DV =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofPositionDeletes()
+          .withPath("/path/to/data-a2-deletes.puffin")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("data_bucket=0")
+          .withRecordCount(5)
+          .withReferencedDataFile(FILE_A2.location())
+          .withContentOffset(4)
+          .withContentSizeInBytes(6)
+          .build();
   // Equality delete files.
   static final DeleteFile FILE_A2_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -685,6 +685,25 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
+  public void testPartitionsTableDvCount() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(FILE_A_DV).addDeletes(FILE_B_DV).commit();
+
+    Table partitionsTable = new PartitionsTable(table);
+    StaticTableScan scan = (StaticTableScan) partitionsTable.newScan();
+    List<PartitionsTable.Partition> partitions =
+        Lists.newArrayList(PartitionsTable.partitions(table, scan));
+
+    assertThat(partitions).hasSize(2);
+    for (PartitionsTable.Partition partition : partitions) {
+      assertThat(partition.dvCount()).isEqualTo(1);
+      assertThat(partition.posDeleteFileCount()).isEqualTo(0);
+    }
+  }
+
+  @TestTemplate
   public void partitionsTableScanNoStats() {
     table.newFastAppend().appendFile(FILE_WITH_STATS).commit();
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -688,19 +688,25 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableDvCount() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
-    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
-    table.newRowDelta().addDeletes(FILE_A_DV).addDeletes(FILE_B_DV).commit();
+    // FILE_A and FILE_A2 are both in data_bucket=0; FILE_B is in data_bucket=1
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_A2).appendFile(FILE_B).commit();
+    // Add two DVs to data_bucket=0 (recordCount=1 and recordCount=5) and one DV to data_bucket=1
+    // to confirm dv_count tracks file count, not record count
+    table.newRowDelta().addDeletes(FILE_A_DV).addDeletes(FILE_A2_DV).addDeletes(FILE_B_DV).commit();
 
     Table partitionsTable = new PartitionsTable(table);
     StaticTableScan scan = (StaticTableScan) partitionsTable.newScan();
     List<PartitionsTable.Partition> partitions =
         Lists.newArrayList(PartitionsTable.partitions(table, scan));
+    partitions.sort(Comparator.comparing(p -> p.partitionData().get(0, Integer.class)));
 
     assertThat(partitions).hasSize(2);
-    for (PartitionsTable.Partition partition : partitions) {
-      assertThat(partition.dvCount()).isEqualTo(1);
-      assertThat(partition.posDeleteFileCount()).isEqualTo(0);
-    }
+    // data_bucket=0 has two DVs (with different record counts) → dv_count=2, not the record sum
+    assertThat(partitions.get(0).dvCount()).isEqualTo(2);
+    assertThat(partitions.get(0).posDeleteFileCount()).isEqualTo(0);
+    // data_bucket=1 has one DV → dv_count=1
+    assertThat(partitions.get(1).dvCount()).isEqualTo(1);
+    assertThat(partitions.get(1).posDeleteFileCount()).isEqualTo(0);
   }
 
   @TestTemplate

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -37,9 +37,12 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.types.Row;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileGenerationUtil;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
@@ -665,6 +668,32 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     for (int i = 0; i < metadataFiles.size(); i++) {
       assertThat(metadataLogWithProjection.get(i).getField("file")).isEqualTo(metadataFiles.get(i));
     }
+  }
+
+  @TestTemplate
+  public void testPartitionsTableDvCount() {
+    String dvTableName = "dv_test_table";
+    sql(
+        "CREATE TABLE %s (id INT, data VARCHAR) PARTITIONED BY (data) WITH ('format-version'='3')",
+        dvTableName);
+    sql("INSERT INTO %s VALUES (1,'a')", dvTableName);
+    sql("INSERT INTO %s VALUES (1,'b')", dvTableName);
+
+    Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, dvTableName));
+    List<DataFile> dataFiles =
+        Lists.newArrayList(
+            CloseableIterable.transform(table.newScan().planFiles(), FileScanTask::file));
+    DeleteFile dv1 = FileGenerationUtil.generateDV(table, dataFiles.get(0));
+    DeleteFile dv2 = FileGenerationUtil.generateDV(table, dataFiles.get(1));
+    table.newRowDelta().addDeletes(dv1).addDeletes(dv2).commit();
+
+    List<Row> actual = sql("SELECT dv_count FROM %s$partitions", dvTableName);
+
+    assertThat(actual).hasSize(2);
+    assertThat((int) actual.get(0).getField(0)).isEqualTo(1);
+    assertThat((int) actual.get(1).getField(0)).isEqualTo(1);
+
+    sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, dvTableName);
   }
 
   @TestTemplate

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -37,9 +37,12 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.types.Row;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileGenerationUtil;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
@@ -665,6 +668,32 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     for (int i = 0; i < metadataFiles.size(); i++) {
       assertThat(metadataLogWithProjection.get(i).getField("file")).isEqualTo(metadataFiles.get(i));
     }
+  }
+
+  @TestTemplate
+  public void testPartitionsTableDvCount() {
+    String dvTableName = "dv_test_table";
+    sql(
+        "CREATE TABLE %s (id INT, data VARCHAR) PARTITIONED BY (data) WITH ('format-version'='3')",
+        dvTableName);
+    sql("INSERT INTO %s VALUES (1,'a')", dvTableName);
+    sql("INSERT INTO %s VALUES (1,'b')", dvTableName);
+
+    Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, dvTableName));
+    List<DataFile> dataFiles =
+        Lists.newArrayList(
+            CloseableIterable.transform(table.newScan().planFiles(), FileScanTask::file));
+    DeleteFile dv1 = FileGenerationUtil.generateDV(table, dataFiles.get(0));
+    DeleteFile dv2 = FileGenerationUtil.generateDV(table, dataFiles.get(1));
+    table.newRowDelta().addDeletes(dv1).addDeletes(dv2).commit();
+
+    List<Row> actual = sql("SELECT dv_count FROM %s$partitions", dvTableName);
+
+    assertThat(actual).hasSize(2);
+    assertThat((int) actual.get(0).getField(0)).isEqualTo(1);
+    assertThat((int) actual.get(1).getField(0)).isEqualTo(1);
+
+    sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, dvTableName);
   }
 
   @TestTemplate

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkMetaDataTable.java
@@ -37,9 +37,12 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.types.Row;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileGenerationUtil;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
@@ -665,6 +668,32 @@ public class TestFlinkMetaDataTable extends CatalogTestBase {
     for (int i = 0; i < metadataFiles.size(); i++) {
       assertThat(metadataLogWithProjection.get(i).getField("file")).isEqualTo(metadataFiles.get(i));
     }
+  }
+
+  @TestTemplate
+  public void testPartitionsTableDvCount() {
+    String dvTableName = "dv_test_table";
+    sql(
+        "CREATE TABLE %s (id INT, data VARCHAR) PARTITIONED BY (data) WITH ('format-version'='3')",
+        dvTableName);
+    sql("INSERT INTO %s VALUES (1,'a')", dvTableName);
+    sql("INSERT INTO %s VALUES (1,'b')", dvTableName);
+
+    Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, dvTableName));
+    List<DataFile> dataFiles =
+        Lists.newArrayList(
+            CloseableIterable.transform(table.newScan().planFiles(), FileScanTask::file));
+    DeleteFile dv1 = FileGenerationUtil.generateDV(table, dataFiles.get(0));
+    DeleteFile dv2 = FileGenerationUtil.generateDV(table, dataFiles.get(1));
+    table.newRowDelta().addDeletes(dv1).addDeletes(dv2).commit();
+
+    List<Row> actual = sql("SELECT dv_count FROM %s$partitions", dvTableName);
+
+    assertThat(actual).hasSize(2);
+    assertThat((int) actual.get(0).getField(0)).isEqualTo(1);
+    assertThat((int) actual.get(1).getField(0)).isEqualTo(1);
+
+    sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, dvTableName);
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -45,6 +45,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
@@ -1303,7 +1304,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
-                "Id of snapshot that last updated this partition"));
+                "Id of snapshot that last updated this partition"),
+            required(12, "dv_count", Types.IntegerType.get(), "Count of deletion vectors"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1326,6 +1328,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .build();
 
     List<Row> actual =
@@ -1399,6 +1402,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1419,6 +1423,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
@@ -1541,6 +1546,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1557,6 +1563,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
@@ -1595,6 +1602,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", null)
             .set("last_updated_snapshot_id", null)
@@ -1689,6 +1697,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1709,6 +1718,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 2) // should be incremented now
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
@@ -1744,6 +1754,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 2L) // should be incremented now
             .set("equality_delete_file_count", 2) // should be incremented now
+            .set("dv_count", 0)
             .set("last_updated_at", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
@@ -1751,6 +1762,64 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
     }
+  }
+
+  @Test
+  public void testPartitionsTableDvCount() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_dv_test");
+    Table table =
+        createTable(
+            tableIdentifier, SCHEMA, SPEC, ImmutableMap.of(TableProperties.FORMAT_VERSION, "3"));
+    Dataset<Row> df =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
+    df.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+    table.refresh();
+    DataFile dataFile = TestHelpers.dataFiles(table).get(0);
+    DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
+    table.newRowDelta().addDeletes(dvFile).commit();
+    table.refresh();
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    assertThat(actual).hasSize(1);
+    assertThat((int) actual.get(0).getAs("dv_count"))
+        .as("dv_count should be 1 after adding a DV")
+        .isEqualTo(1);
+
+    // add a second data file and DV to test dv_count = 2
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class);
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+    table.refresh();
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    DataFile dataFile2 =
+        dataFiles.get(0).location().equals(dataFile.location())
+            ? dataFiles.get(1)
+            : dataFiles.get(0);
+    DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
+    table.newRowDelta().addDeletes(dvFile2).commit();
+    table.refresh();
+    actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    assertThat(actual).hasSize(1);
+    assertThat((int) actual.get(0).getAs("dv_count"))
+        .as("dv_count should be 2 after adding two DVs")
+        .isEqualTo(2);
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1770,48 +1770,28 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     Table table =
         createTable(
             tableIdentifier, SCHEMA, SPEC, ImmutableMap.of(TableProperties.FORMAT_VERSION, "3"));
-    Dataset<Row> df =
-        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
-    df.select("id", "data")
+    spark
+        .createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class)
+        .select("id", "data")
         .write()
         .format("iceberg")
         .mode("append")
         .save(loadLocation(tableIdentifier));
-    table.refresh();
-    DataFile dataFile = TestHelpers.dataFiles(table).get(0);
-    DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
-    table.newRowDelta().addDeletes(dvFile).commit();
-    table.refresh();
-
-    List<Row> actual =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .collectAsList();
-
-    assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(1);
-
-    // add a second data file and DV to test dv_count = 2
-    Dataset<Row> df2 =
-        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class);
-    df2.select("id", "data")
+    spark
+        .createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class)
+        .select("id", "data")
         .write()
         .format("iceberg")
         .mode("append")
         .save(loadLocation(tableIdentifier));
     table.refresh();
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
-    DataFile dataFile2 =
-        dataFiles.get(0).location().equals(dataFile.location())
-            ? dataFiles.get(1)
-            : dataFiles.get(0);
-    DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
-    table.newRowDelta().addDeletes(dvFile2).commit();
+    DeleteFile dv1 = FileGenerationUtil.generateDV(table, dataFiles.get(0));
+    DeleteFile dv2 = FileGenerationUtil.generateDV(table, dataFiles.get(1));
+    table.newRowDelta().addDeletes(dv1).addDeletes(dv2).commit();
     table.refresh();
 
-    actual =
+    List<Row> actual =
         spark
             .read()
             .format("iceberg")

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1782,16 +1782,16 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
     table.newRowDelta().addDeletes(dvFile).commit();
     table.refresh();
+
     List<Row> actual =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "partitions"))
             .collectAsList();
+
     assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count"))
-        .as("dv_count should be 1 after adding a DV")
-        .isEqualTo(1);
+    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(1);
 
     // add a second data file and DV to test dv_count = 2
     Dataset<Row> df2 =
@@ -1810,16 +1810,16 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
     table.newRowDelta().addDeletes(dvFile2).commit();
     table.refresh();
+
     actual =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "partitions"))
             .collectAsList();
+
     assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count"))
-        .as("dv_count should be 2 after adding two DVs")
-        .isEqualTo(2);
+    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(2);
   }
 
   @Test

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -45,6 +45,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
@@ -1303,7 +1304,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
-                "Id of snapshot that last updated this partition"));
+                "Id of snapshot that last updated this partition"),
+            required(12, "dv_count", Types.IntegerType.get(), "Count of deletion vectors"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1326,6 +1328,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .build();
 
     List<Row> actual =
@@ -1399,6 +1402,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1419,6 +1423,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
@@ -1541,6 +1546,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1557,6 +1563,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
@@ -1595,6 +1602,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", null)
             .set("last_updated_snapshot_id", null)
@@ -1689,6 +1697,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1709,6 +1718,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 2) // should be incremented now
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
@@ -1744,6 +1754,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 2L) // should be incremented now
             .set("equality_delete_file_count", 2) // should be incremented now
+            .set("dv_count", 0)
             .set("last_updated_at", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
@@ -1751,6 +1762,64 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
     }
+  }
+
+  @Test
+  public void testPartitionsTableDvCount() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_dv_test");
+    Table table =
+        createTable(
+            tableIdentifier, SCHEMA, SPEC, ImmutableMap.of(TableProperties.FORMAT_VERSION, "3"));
+    Dataset<Row> df =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
+    df.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+    table.refresh();
+    DataFile dataFile = TestHelpers.dataFiles(table).get(0);
+    DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
+    table.newRowDelta().addDeletes(dvFile).commit();
+    table.refresh();
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    assertThat(actual).hasSize(1);
+    assertThat((int) actual.get(0).getAs("dv_count"))
+        .as("dv_count should be 1 after adding a DV")
+        .isEqualTo(1);
+
+    // add a second data file and DV to test dv_count = 2
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class);
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+    table.refresh();
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    DataFile dataFile2 =
+        dataFiles.get(0).location().equals(dataFile.location())
+            ? dataFiles.get(1)
+            : dataFiles.get(0);
+    DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
+    table.newRowDelta().addDeletes(dvFile2).commit();
+    table.refresh();
+    actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    assertThat(actual).hasSize(1);
+    assertThat((int) actual.get(0).getAs("dv_count"))
+        .as("dv_count should be 2 after adding two DVs")
+        .isEqualTo(2);
   }
 
   @Test

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1770,48 +1770,28 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     Table table =
         createTable(
             tableIdentifier, SCHEMA, SPEC, ImmutableMap.of(TableProperties.FORMAT_VERSION, "3"));
-    Dataset<Row> df =
-        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
-    df.select("id", "data")
+    spark
+        .createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class)
+        .select("id", "data")
         .write()
         .format("iceberg")
         .mode("append")
         .save(loadLocation(tableIdentifier));
-    table.refresh();
-    DataFile dataFile = TestHelpers.dataFiles(table).get(0);
-    DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
-    table.newRowDelta().addDeletes(dvFile).commit();
-    table.refresh();
-
-    List<Row> actual =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .collectAsList();
-
-    assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(1);
-
-    // add a second data file and DV to test dv_count = 2
-    Dataset<Row> df2 =
-        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class);
-    df2.select("id", "data")
+    spark
+        .createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class)
+        .select("id", "data")
         .write()
         .format("iceberg")
         .mode("append")
         .save(loadLocation(tableIdentifier));
     table.refresh();
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
-    DataFile dataFile2 =
-        dataFiles.get(0).location().equals(dataFile.location())
-            ? dataFiles.get(1)
-            : dataFiles.get(0);
-    DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
-    table.newRowDelta().addDeletes(dvFile2).commit();
+    DeleteFile dv1 = FileGenerationUtil.generateDV(table, dataFiles.get(0));
+    DeleteFile dv2 = FileGenerationUtil.generateDV(table, dataFiles.get(1));
+    table.newRowDelta().addDeletes(dv1).addDeletes(dv2).commit();
     table.refresh();
 
-    actual =
+    List<Row> actual =
         spark
             .read()
             .format("iceberg")

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1782,16 +1782,16 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
     table.newRowDelta().addDeletes(dvFile).commit();
     table.refresh();
+
     List<Row> actual =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "partitions"))
             .collectAsList();
+
     assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count"))
-        .as("dv_count should be 1 after adding a DV")
-        .isEqualTo(1);
+    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(1);
 
     // add a second data file and DV to test dv_count = 2
     Dataset<Row> df2 =
@@ -1810,16 +1810,16 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
     table.newRowDelta().addDeletes(dvFile2).commit();
     table.refresh();
+
     actual =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "partitions"))
             .collectAsList();
+
     assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count"))
-        .as("dv_count should be 2 after adding two DVs")
-        .isEqualTo(2);
+    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(2);
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -47,6 +47,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
@@ -1308,7 +1309,8 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
-                "Id of snapshot that last updated this partition"));
+                "Id of snapshot that last updated this partition"),
+            required(12, "dv_count", Types.IntegerType.get(), "Count of deletion vectors"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1331,6 +1333,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .build();
 
     List<Row> actual =
@@ -1404,6 +1407,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1424,6 +1428,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
@@ -1546,6 +1551,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1562,6 +1568,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
@@ -1600,6 +1607,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", null)
             .set("last_updated_snapshot_id", null)
@@ -1694,6 +1702,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
@@ -1714,6 +1723,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 2) // should be incremented now
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
+            .set("dv_count", 0)
             .set("spec_id", 0)
             .set("last_updated_at", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
@@ -1749,6 +1759,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 2L) // should be incremented now
             .set("equality_delete_file_count", 2) // should be incremented now
+            .set("dv_count", 0)
             .set("last_updated_at", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
@@ -1756,6 +1767,64 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
     }
+  }
+
+  @Test
+  public void testPartitionsTableDvCount() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_dv_test");
+    Table table =
+        createTable(
+            tableIdentifier, SCHEMA, SPEC, ImmutableMap.of(TableProperties.FORMAT_VERSION, "3"));
+    Dataset<Row> df =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
+    df.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+    table.refresh();
+    DataFile dataFile = TestHelpers.dataFiles(table).get(0);
+    DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
+    table.newRowDelta().addDeletes(dvFile).commit();
+    table.refresh();
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    assertThat(actual).hasSize(1);
+    assertThat((int) actual.get(0).getAs("dv_count"))
+        .as("dv_count should be 1 after adding a DV")
+        .isEqualTo(1);
+
+    // add a second data file and DV to test dv_count = 2
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class);
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+    table.refresh();
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    DataFile dataFile2 =
+        dataFiles.get(0).location().equals(dataFile.location())
+            ? dataFiles.get(1)
+            : dataFiles.get(0);
+    DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
+    table.newRowDelta().addDeletes(dvFile2).commit();
+    table.refresh();
+    actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    assertThat(actual).hasSize(1);
+    assertThat((int) actual.get(0).getAs("dv_count"))
+        .as("dv_count should be 2 after adding two DVs")
+        .isEqualTo(2);
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1787,16 +1787,16 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
     table.newRowDelta().addDeletes(dvFile).commit();
     table.refresh();
+
     List<Row> actual =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "partitions"))
             .collectAsList();
+
     assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count"))
-        .as("dv_count should be 1 after adding a DV")
-        .isEqualTo(1);
+    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(1);
 
     // add a second data file and DV to test dv_count = 2
     Dataset<Row> df2 =
@@ -1815,16 +1815,16 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
     table.newRowDelta().addDeletes(dvFile2).commit();
     table.refresh();
+
     actual =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "partitions"))
             .collectAsList();
+
     assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count"))
-        .as("dv_count should be 2 after adding two DVs")
-        .isEqualTo(2);
+    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(2);
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1775,48 +1775,28 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
     Table table =
         createTable(
             tableIdentifier, SCHEMA, SPEC, ImmutableMap.of(TableProperties.FORMAT_VERSION, "3"));
-    Dataset<Row> df =
-        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
-    df.select("id", "data")
+    spark
+        .createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class)
+        .select("id", "data")
         .write()
         .format("iceberg")
         .mode("append")
         .save(loadLocation(tableIdentifier));
-    table.refresh();
-    DataFile dataFile = TestHelpers.dataFiles(table).get(0);
-    DeleteFile dvFile = FileGenerationUtil.generateDV(table, dataFile);
-    table.newRowDelta().addDeletes(dvFile).commit();
-    table.refresh();
-
-    List<Row> actual =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .collectAsList();
-
-    assertThat(actual).hasSize(1);
-    assertThat((int) actual.get(0).getAs("dv_count")).isEqualTo(1);
-
-    // add a second data file and DV to test dv_count = 2
-    Dataset<Row> df2 =
-        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class);
-    df2.select("id", "data")
+    spark
+        .createDataFrame(Lists.newArrayList(new SimpleRecord(1, "b")), SimpleRecord.class)
+        .select("id", "data")
         .write()
         .format("iceberg")
         .mode("append")
         .save(loadLocation(tableIdentifier));
     table.refresh();
     List<DataFile> dataFiles = TestHelpers.dataFiles(table);
-    DataFile dataFile2 =
-        dataFiles.get(0).location().equals(dataFile.location())
-            ? dataFiles.get(1)
-            : dataFiles.get(0);
-    DeleteFile dvFile2 = FileGenerationUtil.generateDV(table, dataFile2);
-    table.newRowDelta().addDeletes(dvFile2).commit();
+    DeleteFile dv1 = FileGenerationUtil.generateDV(table, dataFiles.get(0));
+    DeleteFile dv2 = FileGenerationUtil.generateDV(table, dataFiles.get(1));
+    table.newRowDelta().addDeletes(dv1).addDeletes(dv2).commit();
     table.refresh();
 
-    actual =
+    List<Row> actual =
         spark
             .read()
             .format("iceberg")


### PR DESCRIPTION
Add a dv_count column to the partitions metadata table to expose deletion vector counts per partition. Users querying from table.partitions can now see DV density per partition, which is useful for understanding which partitions have accumulated row-level deletes.