### PR TITLE
[1.10.x] Flink: Add LICENSE entries for bundled flink-metrics-dropwizard

### DIFF
--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -210,6 +210,10 @@ They should have the following key-value tags.
 | dataFilesSizeHistogram    | Histogram  | Histogram distribution of data file sizes (in bytes).                                               |
 | deleteFilesSizeHistogram  | Histogram  | Histogram distribution of delete file sizes (in bytes).                                             |
 
+The `Histogram` metrics above require `flink-metrics-dropwizard` on the classpath, which is not shipped
+by Flink by default. When using `iceberg-flink-runtime`, this dependency is already bundled. When using
+the `iceberg-flink` artifact directly, add `org.apache.flink:flink-metrics-dropwizard` as a dependency.
+
 Committer metrics are added under the sub group of `IcebergFilesCommitter`.
 They should have the following key-value tags.
 

--- a/flink/v1.19/build.gradle
+++ b/flink/v1.19/build.gradle
@@ -33,7 +33,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation project(':iceberg-hive-metastore')
 
     compileOnly libs.flink119.avro
-    // for dropwizard histogram metrics implementation
+    // dropwizard histogram metrics (optional in Flink)
     compileOnly libs.flink119.metrics.dropwizard
     compileOnly libs.flink119.streaming.java
     compileOnly "${libs.flink119.streaming.java.get().module}:${libs.flink119.streaming.java.get().getVersion()}:tests"
@@ -168,7 +168,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    // for dropwizard histogram metrics implementation
+    // To support dropwizard histogram metrics (not shipped by Flink by default)
     implementation libs.flink119.metrics.dropwizard
 
     // for integration testing with the flink-runtime-jar

--- a/flink/v1.19/flink-runtime/LICENSE
+++ b/flink/v1.19/flink-runtime/LICENSE
@@ -461,11 +461,18 @@ License: https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Codehale Metrics.
+This product bundles Dropwizard Metrics.
 
 Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
 Home page: https://github.com/dropwizard/metrics
-License: https://www.apache.org/licenses/LICENSE-2.0.html
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Flink's optional support for Dropwizard Metrics.
+
+Copyright: 2014-2026 The Apache Software Foundation
+Project URL: https://flink.apache.org/
 
 --------------------------------------------------------------------------------
 

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -33,7 +33,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation project(':iceberg-hive-metastore')
 
     compileOnly libs.flink120.avro
-    // for dropwizard histogram metrics implementation
+    // dropwizard histogram metrics (optional in Flink)
     compileOnly libs.flink120.metrics.dropwizard
     compileOnly libs.flink120.streaming.java
     compileOnly "${libs.flink120.streaming.java.get().module}:${libs.flink120.streaming.java.get().getVersion()}:tests"
@@ -168,7 +168,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    // for dropwizard histogram metrics implementation
+    // To support dropwizard histogram metrics (not shipped by Flink by default)
     implementation libs.flink120.metrics.dropwizard
 
     // for integration testing with the flink-runtime-jar

--- a/flink/v1.20/flink-runtime/LICENSE
+++ b/flink/v1.20/flink-runtime/LICENSE
@@ -461,11 +461,18 @@ License: https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Codehale Metrics.
+This product bundles Dropwizard Metrics.
 
 Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
 Home page: https://github.com/dropwizard/metrics
-License: https://www.apache.org/licenses/LICENSE-2.0.html
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Flink's optional support for Dropwizard Metrics.
+
+Copyright: 2014-2026 The Apache Software Foundation
+Project URL: https://flink.apache.org/
 
 --------------------------------------------------------------------------------
 

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -33,7 +33,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation project(':iceberg-hive-metastore')
 
     compileOnly libs.flink20.avro
-    // for dropwizard histogram metrics implementation
+    // dropwizard histogram metrics (optional in Flink)
     compileOnly libs.flink20.metrics.dropwizard
     compileOnly libs.flink20.streaming.java
     compileOnly "${libs.flink20.streaming.java.get().module}:${libs.flink20.streaming.java.get().getVersion()}:tests"
@@ -168,7 +168,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    // for dropwizard histogram metrics implementation
+    // To support dropwizard histogram metrics (not shipped by Flink by default)
     implementation libs.flink20.metrics.dropwizard
 
     // for integration testing with the flink-runtime-jar

--- a/flink/v2.0/flink-runtime/LICENSE
+++ b/flink/v2.0/flink-runtime/LICENSE
@@ -461,11 +461,18 @@ License: https://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains Codehale Metrics.
+This product bundles Dropwizard Metrics.
 
 Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
 Home page: https://github.com/dropwizard/metrics
-License: https://www.apache.org/licenses/LICENSE-2.0.html
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Flink's optional support for Dropwizard Metrics.
+
+Copyright: 2014-2026 The Apache Software Foundation
+Project URL: https://flink.apache.org/
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
The flink-metrics-dropwizard jar is bundled into the iceberg-flink-runtime artifacts via the build.gradle implementation dependency, but was missing the corresponding bundled-product entries in LICENSE that the Apache release policy requires for redistributed binaries.

Backport of #16126 for 1.10x.