### PR TITLE
API,REST, DATA,CORE: ReadRestrictions with Iceberg Generics 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/functions/BaseFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/BaseFunction.java
@@ -18,39 +18,41 @@
  */
 package org.apache.iceberg.functions;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.util.SerializableFunction;
+import java.util.Objects;
 
-/** Truncates date or timestamp values to the first instant of their year. */
-public final class TruncateToYear extends BaseFunction<Object, Object> {
-  static final String NAME = "truncate-to-year";
+/** Base for all concrete {@link IcebergFunction} implementations; holds the field id. */
+abstract class BaseFunction<S, T> implements IcebergFunction<S, T> {
+  private final int fieldId;
 
-  TruncateToYear(int fieldId) {
-    super(fieldId);
+  BaseFunction(int fieldId) {
+    this.fieldId = fieldId;
   }
 
   @Override
-  public String name() {
-    return NAME;
+  public final int fieldId() {
+    return fieldId;
   }
 
   @Override
-  public boolean canBind(Type type) {
-    switch (type.typeId()) {
-      case DATE:
-      case TIMESTAMP:
-      case TIMESTAMP_NANO:
-        return true;
-      default:
-        return false;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    IcebergFunction<?, ?> other = (IcebergFunction<?, ?>) o;
+    // name() is a constant per class except in UnknownFunction, whose instances differ by name.
+    return fieldId == other.fieldId() && name().equals(other.name());
   }
 
   @Override
-  public SerializableFunction<Object, Object> bind(Type type) {
-    Preconditions.checkArgument(
-        canBind(type), "truncate-to-year is not supported for type: %s", type);
-    return TruncateTemporal.forType(TruncateTemporal.Unit.YEAR, type);
+  public int hashCode() {
+    return Objects.hash(name(), fieldId);
+  }
+
+  @Override
+  public String toString() {
+    return name() + "(" + fieldId + ")";
   }
 }

--- a/api/src/main/java/org/apache/iceberg/functions/IcebergFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/IcebergFunction.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * A named, type-aware function that can be bound to an Iceberg {@link Type}.
+ *
+ * <p>{@link #bind(Type)} returns a {@link SerializableFunction} that applies this function's logic
+ * to values of the bound type.
+ *
+ * @param <S> input value type
+ * @param <T> output value type
+ */
+public interface IcebergFunction<S, T> extends Serializable {
+
+  String MASK_ALPHANUM = "mask-alphanum";
+  String MASK_TO_FIXED_VALUE = "mask-to-fixed-value";
+  String REPLACE_WITH_NULL = "replace-with-null";
+  String SHOW_FIRST_4 = "show-first-4";
+  String SHOW_LAST_4 = "show-last-4";
+  String TRUNCATE_TO_YEAR = "truncate-to-year";
+  String TRUNCATE_TO_MONTH = "truncate-to-month";
+  String SHA_256_GLOBAL = "sha-256-global";
+  String SHA_256_QUERY_LOCAL = "sha-256-query-local";
+
+  /** The function name as sent on the wire (REST action discriminator). */
+  String name();
+
+  /** The field id of the column this function applies to. */
+  int fieldId();
+
+  /**
+   * Returns a function that applies this projection to values of the given {@link Type}.
+   *
+   * @throws IllegalArgumentException if the type is not supported by this function.
+   */
+  default SerializableFunction<S, T> bind(Type type) {
+    throw new UnsupportedOperationException("bind is not implemented for " + getClass().getName());
+  }
+
+  /** Returns true if this function can be bound to the given {@link Type}. */
+  boolean canBind(Type type);
+
+  /** Base for all concrete functions; holds the field id. */
+  abstract class BaseFunction<S, T> implements IcebergFunction<S, T> {
+    private final int fieldId;
+
+    BaseFunction(int fieldId) {
+      this.fieldId = fieldId;
+    }
+
+    @Override
+    public final int fieldId() {
+      return fieldId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      IcebergFunction<?, ?> other = (IcebergFunction<?, ?>) o;
+      return fieldId == other.fieldId() && name().equals(other.name());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name(), fieldId);
+    }
+
+    @Override
+    public String toString() {
+      return name() + "(" + fieldId + ")";
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/IcebergFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/IcebergFunction.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.functions;
 
 import java.io.Serializable;
-import java.util.Objects;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
@@ -34,17 +33,7 @@ import org.apache.iceberg.util.SerializableFunction;
  */
 public interface IcebergFunction<S, T> extends Serializable {
 
-  String MASK_ALPHANUM = "mask-alphanum";
-  String MASK_TO_FIXED_VALUE = "mask-to-fixed-value";
-  String REPLACE_WITH_NULL = "replace-with-null";
-  String SHOW_FIRST_4 = "show-first-4";
-  String SHOW_LAST_4 = "show-last-4";
-  String TRUNCATE_TO_YEAR = "truncate-to-year";
-  String TRUNCATE_TO_MONTH = "truncate-to-month";
-  String SHA_256_GLOBAL = "sha-256-global";
-  String SHA_256_QUERY_LOCAL = "sha-256-query-local";
-
-  /** The function name as sent on the wire (REST action discriminator). */
+  /** Returns the name of this Iceberg function. */
   String name();
 
   /** The field id of the column this function applies to. */
@@ -61,40 +50,4 @@ public interface IcebergFunction<S, T> extends Serializable {
 
   /** Returns true if this function can be bound to the given {@link Type}. */
   boolean canBind(Type type);
-
-  /** Base for all concrete functions; holds the field id. */
-  abstract class BaseFunction<S, T> implements IcebergFunction<S, T> {
-    private final int fieldId;
-
-    BaseFunction(int fieldId) {
-      this.fieldId = fieldId;
-    }
-
-    @Override
-    public final int fieldId() {
-      return fieldId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      IcebergFunction<?, ?> other = (IcebergFunction<?, ?>) o;
-      return fieldId == other.fieldId() && name().equals(other.name());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(name(), fieldId);
-    }
-
-    @Override
-    public String toString() {
-      return name() + "(" + fieldId + ")";
-    }
-  }
 }

--- a/api/src/main/java/org/apache/iceberg/functions/IcebergFunctions.java
+++ b/api/src/main/java/org/apache/iceberg/functions/IcebergFunctions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Package-private helpers shared by {@link IcebergFunction} implementations. */
+final class IcebergFunctions {
+
+  private IcebergFunctions() {}
+
+  /**
+   * Base for masking functions where null input must pass through as null unchanged (spec: "For all
+   * actions, if the input column value is NULL, the output MUST be NULL."). Subclasses implement
+   * {@link #applyNonNull(Object)} and don't have to repeat the guard.
+   */
+  abstract static class NullSafeFunction<S, T> implements SerializableFunction<S, T> {
+    @Override
+    public final T apply(S value) {
+      return value == null ? null : applyNonNull(value);
+    }
+
+    protected abstract T applyNonNull(S value);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/IcebergFunctions.java
+++ b/api/src/main/java/org/apache/iceberg/functions/IcebergFunctions.java
@@ -18,24 +18,81 @@
  */
 package org.apache.iceberg.functions;
 
-import org.apache.iceberg.util.SerializableFunction;
-
-/** Package-private helpers shared by {@link IcebergFunction} implementations. */
-final class IcebergFunctions {
-
+/** Factory for the {@link IcebergFunction} implementations defined by the REST spec. */
+public class IcebergFunctions {
   private IcebergFunctions() {}
 
   /**
-   * Base for masking functions where null input must pass through as null unchanged (spec: "For all
-   * actions, if the input column value is NULL, the output MUST be NULL."). Subclasses implement
-   * {@link #applyNonNull(Object)} and don't have to repeat the guard.
+   * Returns the function with the given name, or an {@link UnknownFunction} if the name is not
+   * recognized.
    */
-  abstract static class NullSafeFunction<S, T> implements SerializableFunction<S, T> {
-    @Override
-    public final T apply(S value) {
-      return value == null ? null : applyNonNull(value);
+  public static IcebergFunction<?, ?> fromString(String function, int fieldId) {
+    switch (function) {
+      case MaskAlphanum.NAME:
+        return maskAlphanum(fieldId);
+      case MaskToFixedValue.NAME:
+        return maskToFixedValue(fieldId);
+      case ReplaceWithNull.NAME:
+        return replaceWithNull(fieldId);
+      case ShowFirst4.NAME:
+        return showFirst4(fieldId);
+      case ShowLast4.NAME:
+        return showLast4(fieldId);
+      case TruncateToYear.NAME:
+        return truncateToYear(fieldId);
+      case TruncateToMonth.NAME:
+        return truncateToMonth(fieldId);
+      case Sha256Global.NAME:
+        return sha256Global(fieldId);
+      case Sha256QueryLocal.NAME:
+        return sha256QueryLocal(fieldId);
+      default:
+        return new UnknownFunction(fieldId, function);
     }
+  }
 
-    protected abstract T applyNonNull(S value);
+  /** Returns a {@code mask-alphanum} {@link IcebergFunction} for string types. */
+  public static IcebergFunction<String, String> maskAlphanum(int fieldId) {
+    return new MaskAlphanum(fieldId);
+  }
+
+  /** Returns a {@code mask-to-fixed-value} {@link IcebergFunction}. */
+  public static IcebergFunction<Object, Object> maskToFixedValue(int fieldId) {
+    return new MaskToFixedValue(fieldId);
+  }
+
+  /** Returns a {@code replace-with-null} {@link IcebergFunction} for any type. */
+  public static IcebergFunction<Object, Object> replaceWithNull(int fieldId) {
+    return new ReplaceWithNull(fieldId);
+  }
+
+  /** Returns a {@code show-first-4} {@link IcebergFunction} for string types. */
+  public static IcebergFunction<String, String> showFirst4(int fieldId) {
+    return new ShowFirst4(fieldId);
+  }
+
+  /** Returns a {@code show-last-4} {@link IcebergFunction} for string types. */
+  public static IcebergFunction<String, String> showLast4(int fieldId) {
+    return new ShowLast4(fieldId);
+  }
+
+  /** Returns a {@code truncate-to-year} {@link IcebergFunction} for date and timestamp types. */
+  public static IcebergFunction<Object, Object> truncateToYear(int fieldId) {
+    return new TruncateToYear(fieldId);
+  }
+
+  /** Returns a {@code truncate-to-month} {@link IcebergFunction} for date and timestamp types. */
+  public static IcebergFunction<Object, Object> truncateToMonth(int fieldId) {
+    return new TruncateToMonth(fieldId);
+  }
+
+  /** Returns a {@code sha-256-global} {@link IcebergFunction} for string, int, long and binary. */
+  public static IcebergFunction<Object, Object> sha256Global(int fieldId) {
+    return new Sha256Global(fieldId);
+  }
+
+  /** Returns a {@code sha-256-query-local} {@link SaltedFunction}, salted per query. */
+  public static SaltedFunction<Object, Object> sha256QueryLocal(int fieldId) {
+    return new Sha256QueryLocal(fieldId);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/functions/MaskAlphanum.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskAlphanum.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Redacts every Unicode code point in a string per the mask-alphanum rules. */
+public final class MaskAlphanum extends IcebergFunction.BaseFunction<String, String> {
+  public MaskAlphanum(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return MASK_ALPHANUM;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return type.typeId() == Type.TypeID.STRING;
+  }
+
+  @Override
+  public SerializableFunction<String, String> bind(Type type) {
+    Preconditions.checkArgument(canBind(type), "mask-alphanum requires STRING type, got %s", type);
+    return MaskAlphanumFn.INSTANCE;
+  }
+
+  /**
+   * Maps a code point through the mask-alphanum rules; also used by {@link ShowFirst4} and {@link
+   * ShowLast4} on the code points outside their preserved windows:
+   *
+   * <ul>
+   *   <li>ASCII digits (0-9) -&gt; {@code 'n'}
+   *   <li>Structural punctuation kept as-is: {@code ( ) , . - @}
+   *   <li>Everything else -&gt; {@code 'x'}
+   * </ul>
+   */
+  static int maskCodePoint(int cp) {
+    if (cp >= 0x30 && cp <= 0x39) {
+      return 'n';
+    } else if (cp == '(' || cp == ')' || cp == ',' || cp == '.' || cp == '-' || cp == '@') {
+      return cp;
+    } else {
+      return 'x';
+    }
+  }
+
+  private static final class MaskAlphanumFn
+      extends IcebergFunctions.NullSafeFunction<String, String> {
+    static final MaskAlphanumFn INSTANCE = new MaskAlphanumFn();
+
+    @Override
+    protected String applyNonNull(String input) {
+      StringBuilder sb = new StringBuilder(input.length());
+      int offset = 0;
+      while (offset < input.length()) {
+        int cp = input.codePointAt(offset);
+        sb.appendCodePoint(maskCodePoint(cp));
+        offset += Character.charCount(cp);
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/MaskAlphanum.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskAlphanum.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Redacts every Unicode code point in a string per the mask-alphanum rules. */
-public final class MaskAlphanum extends IcebergFunction.BaseFunction<String, String> {
-  public MaskAlphanum(int fieldId) {
+public final class MaskAlphanum extends BaseFunction<String, String> {
+  static final String NAME = "mask-alphanum";
+
+  MaskAlphanum(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return MASK_ALPHANUM;
+    return NAME;
   }
 
   @Override
@@ -64,8 +66,7 @@ public final class MaskAlphanum extends IcebergFunction.BaseFunction<String, Str
     }
   }
 
-  private static final class MaskAlphanumFn
-      extends IcebergFunctions.NullSafeFunction<String, String> {
+  private static final class MaskAlphanumFn extends NullSafeFunction<String, String> {
     static final MaskAlphanumFn INSTANCE = new MaskAlphanumFn();
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.UUID;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.SerializableFunction;
+import org.apache.iceberg.variants.Variant;
+
+/** Returns a spec-defined fixed value for the column's type. */
+public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object, Object> {
+
+  private static final Integer INT_DEFAULT = 0;
+  private static final Long LONG_DEFAULT = 0L;
+  private static final Float FLOAT_DEFAULT = 0.0f;
+  private static final Double DOUBLE_DEFAULT = 0.0d;
+  // Per spec: string uses "XXXXXXXX" (not "") so masked strings stay visually distinct from
+  // legitimately empty strings. All other types use the zero value of their representation.
+  private static final String STRING_DEFAULT = "XXXXXXXX";
+  private static final Integer DATE_DEFAULT = DateTimeUtil.daysFromDate(LocalDate.of(1970, 1, 1));
+  private static final Long TIME_DEFAULT_MICROS = 0L;
+  private static final Long TIMESTAMP_DEFAULT_MICROS =
+      DateTimeUtil.microsFromTimestamp(LocalDateTime.of(1970, 1, 1, 0, 0));
+  private static final Long TIMESTAMP_DEFAULT_NANOS =
+      DateTimeUtil.nanosFromTimestamp(LocalDateTime.of(1970, 1, 1, 0, 0));
+  private static final UUID UUID_DEFAULT = UUID.fromString("00000000-0000-0000-0000-000000000000");
+  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0).asReadOnlyBuffer();
+
+  // Empty Variant: V1 metadata with no entries + empty object value.
+  private static final Variant EMPTY_VARIANT =
+      Variant.from(
+          ByteBuffer.wrap(new byte[] {0x01, 0x00, 0x00, 0x02, 0x00, 0x00})
+              .order(ByteOrder.LITTLE_ENDIAN));
+
+  public MaskToFixedValue(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return MASK_TO_FIXED_VALUE;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+      case INTEGER:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case STRING:
+      case DATE:
+      case TIME:
+      case TIMESTAMP:
+      case TIMESTAMP_NANO:
+      case UUID:
+      case FIXED:
+      case BINARY:
+      case DECIMAL:
+      case VARIANT:
+      case LIST:
+      case MAP:
+        return true;
+        // TODO: support STRUCT (recursive type-specific defaults). Tracked as follow-up.
+        // Per spec, mask-to-fixed-value does not apply to unknown, geometry, or geography.
+      default:
+        return false;
+    }
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    Preconditions.checkArgument(
+        canBind(type), "mask-to-fixed-value is not supported for type: %s", type);
+    Object defaultValue = defaultValueFor(type);
+    return defaultValue instanceof ByteBuffer
+        ? new ConstantByteBufferFn((ByteBuffer) defaultValue)
+        : new ConstantFn(defaultValue);
+  }
+
+  private static Object defaultValueFor(Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+        return Boolean.FALSE;
+      case INTEGER:
+        return INT_DEFAULT;
+      case LONG:
+        return LONG_DEFAULT;
+      case FLOAT:
+        return FLOAT_DEFAULT;
+      case DOUBLE:
+        return DOUBLE_DEFAULT;
+      case STRING:
+        return STRING_DEFAULT;
+      case DATE:
+        return DATE_DEFAULT;
+      case TIME:
+        return TIME_DEFAULT_MICROS;
+      case TIMESTAMP:
+        return TIMESTAMP_DEFAULT_MICROS;
+      case TIMESTAMP_NANO:
+        return TIMESTAMP_DEFAULT_NANOS;
+      case UUID:
+        return UUID_DEFAULT;
+      case FIXED:
+        return ByteBuffer.allocate(((Types.FixedType) type).length()).asReadOnlyBuffer();
+      case BINARY:
+        return EMPTY_BUFFER;
+      case DECIMAL:
+        return new BigDecimal(BigInteger.ZERO, ((Types.DecimalType) type).scale());
+      case VARIANT:
+        return EMPTY_VARIANT;
+      case LIST:
+        return Collections.emptyList();
+      case MAP:
+        return Collections.emptyMap();
+      default:
+        throw new IllegalStateException("unreachable: canBind should have rejected " + type);
+    }
+  }
+
+  private static final class ConstantFn implements SerializableFunction<Object, Object> {
+    private final Object constant;
+
+    ConstantFn(Object constant) {
+      this.constant = constant;
+    }
+
+    @Override
+    public Object apply(Object value) {
+      return constant;
+    }
+  }
+
+  private static final class ConstantByteBufferFn implements SerializableFunction<Object, Object> {
+    private final ByteBuffer constant;
+
+    ConstantByteBufferFn(ByteBuffer constant) {
+      this.constant = constant;
+    }
+
+    @Override
+    public Object apply(Object value) {
+      return constant.duplicate();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.util.SerializableFunction;
 import org.apache.iceberg.variants.Variant;
 
 /** Returns a spec-defined fixed value for the column's type. */
-public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object, Object> {
+public final class MaskToFixedValue extends BaseFunction<Object, Object> {
 
   private static final Integer INT_DEFAULT = 0;
   private static final Long LONG_DEFAULT = 0L;
@@ -61,13 +61,15 @@ public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object,
           ByteBuffer.wrap(new byte[] {0x01, 0x00, 0x00, 0x02, 0x00, 0x00})
               .order(ByteOrder.LITTLE_ENDIAN));
 
-  public MaskToFixedValue(int fieldId) {
+  static final String NAME = "mask-to-fixed-value";
+
+  MaskToFixedValue(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return MASK_TO_FIXED_VALUE;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.functions;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -25,7 +26,9 @@ import java.nio.ByteOrder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -87,9 +90,8 @@ public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object,
       case VARIANT:
       case LIST:
       case MAP:
+      case STRUCT:
         return true;
-        // TODO: support STRUCT (recursive type-specific defaults). Tracked as follow-up.
-        // Per spec, mask-to-fixed-value does not apply to unknown, geometry, or geography.
       default:
         return false;
     }
@@ -141,9 +143,20 @@ public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object,
         return Collections.emptyList();
       case MAP:
         return Collections.emptyMap();
+      case STRUCT:
+        return defaultStruct(type.asStructType());
       default:
         throw new IllegalStateException("unreachable: canBind should have rejected " + type);
     }
+  }
+
+  private static StructLike defaultStruct(Types.StructType structType) {
+    List<Types.NestedField> fields = structType.fields();
+    Object[] values = new Object[fields.size()];
+    for (int i = 0; i < fields.size(); i++) {
+      values[i] = defaultValueFor(fields.get(i).type());
+    }
+    return new DefaultStruct(values);
   }
 
   private static final class ConstantFn implements SerializableFunction<Object, Object> {
@@ -169,6 +182,30 @@ public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object,
     @Override
     public Object apply(Object value) {
       return constant.duplicate();
+    }
+  }
+
+  private static final class DefaultStruct implements StructLike, Serializable {
+    private final Object[] values;
+
+    DefaultStruct(Object[] values) {
+      this.values = values;
+    }
+
+    @Override
+    public int size() {
+      return values.length;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(int pos, Class<T> javaClass) {
+      return (T) values[pos];
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("DefaultStruct is immutable");
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/functions/NullSafeFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/NullSafeFunction.java
@@ -18,39 +18,17 @@
  */
 package org.apache.iceberg.functions;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
-/** Truncates date or timestamp values to the first instant of their year. */
-public final class TruncateToYear extends BaseFunction<Object, Object> {
-  static final String NAME = "truncate-to-year";
-
-  TruncateToYear(int fieldId) {
-    super(fieldId);
-  }
-
+/**
+ * Base for masking functions where null input must pass through as null unchanged (spec: "For all
+ * actions, if the input column value is NULL, the output MUST be NULL.").
+ */
+abstract class NullSafeFunction<S, T> implements SerializableFunction<S, T> {
   @Override
-  public String name() {
-    return NAME;
+  public final T apply(S value) {
+    return value == null ? null : applyNonNull(value);
   }
 
-  @Override
-  public boolean canBind(Type type) {
-    switch (type.typeId()) {
-      case DATE:
-      case TIMESTAMP:
-      case TIMESTAMP_NANO:
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  @Override
-  public SerializableFunction<Object, Object> bind(Type type) {
-    Preconditions.checkArgument(
-        canBind(type), "truncate-to-year is not supported for type: %s", type);
-    return TruncateTemporal.forType(TruncateTemporal.Unit.YEAR, type);
-  }
+  protected abstract T applyNonNull(S value);
 }

--- a/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Returns null for every non-null input. Works for any type. */
+public final class ReplaceWithNull extends IcebergFunction.BaseFunction<Object, Object> {
+  public ReplaceWithNull(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return REPLACE_WITH_NULL;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return true;
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    return ReplaceWithNullFn.INSTANCE;
+  }
+
+  private static final class ReplaceWithNullFn implements SerializableFunction<Object, Object> {
+    static final ReplaceWithNullFn INSTANCE = new ReplaceWithNullFn();
+
+    @Override
+    public Object apply(Object value) {
+      return null;
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
@@ -21,7 +21,13 @@ package org.apache.iceberg.functions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
-/** Returns null for every non-null input. Works for any type. */
+/**
+ * Returns null for every non-null input. Works for any type.
+ *
+ * <p>Per spec, replace-with-null is only valid for optional (nullable) fields. Callers must
+ * validate that the target field is optional before binding; this function cannot check nullability
+ * because {@link org.apache.iceberg.types.Type} does not carry the field's required/optional flag.
+ */
 public final class ReplaceWithNull extends IcebergFunction.BaseFunction<Object, Object> {
   public ReplaceWithNull(int fieldId) {
     super(fieldId);

--- a/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
@@ -28,14 +28,16 @@ import org.apache.iceberg.util.SerializableFunction;
  * validate that the target field is optional before binding; this function cannot check nullability
  * because {@link org.apache.iceberg.types.Type} does not carry the field's required/optional flag.
  */
-public final class ReplaceWithNull extends IcebergFunction.BaseFunction<Object, Object> {
-  public ReplaceWithNull(int fieldId) {
+public final class ReplaceWithNull extends BaseFunction<Object, Object> {
+  static final String NAME = "replace-with-null";
+
+  ReplaceWithNull(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return REPLACE_WITH_NULL;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/SaltedFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/SaltedFunction.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * An {@link IcebergFunction} that requires a per-query salt for binding.
+ *
+ * @param <S> input column value type
+ * @param <T> output column value type
+ */
+public interface SaltedFunction<S, T> extends IcebergFunction<S, T> {
+
+  /**
+   * Returns a function that applies this projection using the given salt.
+   *
+   * @throws IllegalArgumentException if the type is not supported or the salt is invalid.
+   */
+  SerializableFunction<S, T> bind(Type type, byte[] salt);
+}

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
+import org.apache.iceberg.types.Type;
+
+/** Shared SHA-256 masking function. One instance per (type, salt) pair. */
+final class Sha256 extends IcebergFunctions.NullSafeFunction<Object, Object> {
+
+  private static final ThreadLocal<MessageDigest> DIGEST =
+      ThreadLocal.withInitial(
+          () -> {
+            try {
+              return MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException e) {
+              throw new IllegalStateException("SHA-256 not available", e);
+            }
+          });
+
+  enum Codec {
+    STRING {
+      @Override
+      void update(MessageDigest md, Object value) {
+        md.update(((String) value).getBytes(StandardCharsets.UTF_8));
+      }
+
+      @Override
+      Object encode(byte[] digest) {
+        return BaseEncoding.base16().lowerCase().encode(digest);
+      }
+    },
+    INTEGER {
+      @Override
+      void update(MessageDigest md, Object value) {
+        int intVal = (Integer) value;
+        md.update((byte) intVal);
+        md.update((byte) (intVal >>> 8));
+        md.update((byte) (intVal >>> 16));
+        md.update((byte) (intVal >>> 24));
+      }
+
+      @Override
+      Object encode(byte[] digest) {
+        return ByteBuffer.wrap(digest, 0, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+      }
+    },
+    LONG {
+      @Override
+      void update(MessageDigest md, Object value) {
+        long longVal = (Long) value;
+        for (int i = 0; i < 8; i++) {
+          md.update((byte) longVal);
+          longVal >>>= 8;
+        }
+      }
+
+      @Override
+      Object encode(byte[] digest) {
+        return ByteBuffer.wrap(digest, 0, 8).order(ByteOrder.LITTLE_ENDIAN).getLong();
+      }
+    },
+    BINARY {
+      @Override
+      void update(MessageDigest md, Object value) {
+        md.update(((ByteBuffer) value).duplicate());
+      }
+
+      @Override
+      Object encode(byte[] digest) {
+        return ByteBuffer.wrap(digest);
+      }
+    };
+
+    abstract void update(MessageDigest md, Object value);
+
+    abstract Object encode(byte[] digest);
+  }
+
+  static boolean isSupported(Type type) {
+    switch (type.typeId()) {
+      case STRING:
+      case INTEGER:
+      case LONG:
+      case BINARY:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  static Sha256 forType(Type type, byte[] salt) {
+    switch (type.typeId()) {
+      case STRING:
+        return new Sha256(Codec.STRING, salt);
+      case INTEGER:
+        return new Sha256(Codec.INTEGER, salt);
+      case LONG:
+        return new Sha256(Codec.LONG, salt);
+      case BINARY:
+        return new Sha256(Codec.BINARY, salt);
+      default:
+        throw new IllegalArgumentException("sha-256 is not supported for type: " + type);
+    }
+  }
+
+  private final Codec codec;
+  private final byte[] salt;
+
+  private Sha256(Codec codec, byte[] salt) {
+    this.codec = codec;
+    this.salt = salt != null ? salt.clone() : null;
+  }
+
+  @Override
+  protected Object applyNonNull(Object value) {
+    MessageDigest md = DIGEST.get();
+    md.reset();
+    if (salt != null) {
+      md.update(salt);
+    }
+    codec.update(md, value);
+    return codec.encode(md.digest());
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256.java
@@ -27,7 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.types.Type;
 
 /** Shared SHA-256 masking function. One instance per (type, salt) pair. */
-final class Sha256 extends IcebergFunctions.NullSafeFunction<Object, Object> {
+final class Sha256 extends NullSafeFunction<Object, Object> {
 
   private static final ThreadLocal<MessageDigest> DIGEST =
       ThreadLocal.withInitial(

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256Global.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256Global.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Hashes values with SHA-256 using a fixed (unsalted) digest. Output is deterministic. */
+public final class Sha256Global extends IcebergFunction.BaseFunction<Object, Object> {
+  public Sha256Global(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return SHA_256_GLOBAL;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return Sha256.isSupported(type);
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    Preconditions.checkArgument(canBind(type), "sha-256 is not supported for type: %s", type);
+    return Sha256.forType(type, null);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256Global.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256Global.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Hashes values with SHA-256 using a fixed (unsalted) digest. Output is deterministic. */
-public final class Sha256Global extends IcebergFunction.BaseFunction<Object, Object> {
-  public Sha256Global(int fieldId) {
+public final class Sha256Global extends BaseFunction<Object, Object> {
+  static final String NAME = "sha-256-global";
+
+  Sha256Global(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return SHA_256_GLOBAL;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256QueryLocal.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256QueryLocal.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * Hashes values with SHA-256 using a per-query salt. Binding requires the salt via {@link
+ * #bind(Type, byte[])}; the no-salt variant fails fast so callers can't accidentally strip the
+ * query-local randomness.
+ */
+public final class Sha256QueryLocal extends IcebergFunction.BaseFunction<Object, Object>
+    implements SaltedFunction<Object, Object> {
+  public Sha256QueryLocal(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return SHA_256_QUERY_LOCAL;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return Sha256.isSupported(type);
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    throw new IllegalArgumentException(
+        "sha-256-query-local requires a salt; call bind(Type, byte[]) instead");
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type, byte[] salt) {
+    Preconditions.checkArgument(canBind(type), "sha-256 is not supported for type: %s", type);
+    Preconditions.checkArgument(
+        salt != null && salt.length >= 16, "sha-256-query-local salt must be >= 16 bytes");
+    return Sha256.forType(type, salt);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256QueryLocal.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256QueryLocal.java
@@ -27,15 +27,17 @@ import org.apache.iceberg.util.SerializableFunction;
  * #bind(Type, byte[])}; the no-salt variant fails fast so callers can't accidentally strip the
  * query-local randomness.
  */
-public final class Sha256QueryLocal extends IcebergFunction.BaseFunction<Object, Object>
+public final class Sha256QueryLocal extends BaseFunction<Object, Object>
     implements SaltedFunction<Object, Object> {
-  public Sha256QueryLocal(int fieldId) {
+  static final String NAME = "sha-256-query-local";
+
+  Sha256QueryLocal(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return SHA_256_QUERY_LOCAL;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/ShowFirst4.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ShowFirst4.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Preserves the first 4 code points of a string, redacts the rest via mask-alphanum rules. */
+public final class ShowFirst4 extends IcebergFunction.BaseFunction<String, String> {
+  public ShowFirst4(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return SHOW_FIRST_4;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return type.typeId() == Type.TypeID.STRING;
+  }
+
+  @Override
+  public SerializableFunction<String, String> bind(Type type) {
+    Preconditions.checkArgument(canBind(type), "show-first-4 requires STRING type, got %s", type);
+    return ShowFirst4Fn.INSTANCE;
+  }
+
+  private static final class ShowFirst4Fn
+      extends IcebergFunctions.NullSafeFunction<String, String> {
+    static final ShowFirst4Fn INSTANCE = new ShowFirst4Fn();
+
+    @Override
+    protected String applyNonNull(String input) {
+      if (input.codePointCount(0, input.length()) <= 4) {
+        return input;
+      }
+      StringBuilder sb = new StringBuilder(input.length());
+      int cpIndex = 0;
+      int offset = 0;
+      while (offset < input.length()) {
+        int cp = input.codePointAt(offset);
+        sb.appendCodePoint(cpIndex < 4 ? cp : MaskAlphanum.maskCodePoint(cp));
+        offset += Character.charCount(cp);
+        cpIndex++;
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/ShowFirst4.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ShowFirst4.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Preserves the first 4 code points of a string, redacts the rest via mask-alphanum rules. */
-public final class ShowFirst4 extends IcebergFunction.BaseFunction<String, String> {
-  public ShowFirst4(int fieldId) {
+public final class ShowFirst4 extends BaseFunction<String, String> {
+  static final String NAME = "show-first-4";
+
+  ShowFirst4(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return SHOW_FIRST_4;
+    return NAME;
   }
 
   @Override
@@ -44,8 +46,7 @@ public final class ShowFirst4 extends IcebergFunction.BaseFunction<String, Strin
     return ShowFirst4Fn.INSTANCE;
   }
 
-  private static final class ShowFirst4Fn
-      extends IcebergFunctions.NullSafeFunction<String, String> {
+  private static final class ShowFirst4Fn extends NullSafeFunction<String, String> {
     static final ShowFirst4Fn INSTANCE = new ShowFirst4Fn();
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/functions/ShowLast4.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ShowLast4.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Redacts all but the last 4 code points of a string via mask-alphanum rules. */
+public final class ShowLast4 extends IcebergFunction.BaseFunction<String, String> {
+  public ShowLast4(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return SHOW_LAST_4;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return type.typeId() == Type.TypeID.STRING;
+  }
+
+  @Override
+  public SerializableFunction<String, String> bind(Type type) {
+    Preconditions.checkArgument(canBind(type), "show-last-4 requires STRING type, got %s", type);
+    return ShowLast4Fn.INSTANCE;
+  }
+
+  private static final class ShowLast4Fn extends IcebergFunctions.NullSafeFunction<String, String> {
+    static final ShowLast4Fn INSTANCE = new ShowLast4Fn();
+
+    @Override
+    protected String applyNonNull(String input) {
+      // Single pass: walk the string while remembering the last 4 code-point start offsets.
+      // When done, everything before the oldest remembered offset is masked; everything from
+      // that offset onward is kept verbatim.
+      int[] lastFourStarts = new int[4];
+      int count = 0;
+      int offset = 0;
+      while (offset < input.length()) {
+        lastFourStarts[count % 4] = offset;
+        int cp = input.codePointAt(offset);
+        offset += Character.charCount(cp);
+        count++;
+      }
+      if (count <= 4) {
+        return input;
+      }
+      int keepFromOffset = lastFourStarts[count % 4];
+      StringBuilder sb = new StringBuilder(input.length());
+      int maskOffset = 0;
+      while (maskOffset < keepFromOffset) {
+        int cp = input.codePointAt(maskOffset);
+        sb.appendCodePoint(MaskAlphanum.maskCodePoint(cp));
+        maskOffset += Character.charCount(cp);
+      }
+      sb.append(input, keepFromOffset, input.length());
+      return sb.toString();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/ShowLast4.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ShowLast4.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Redacts all but the last 4 code points of a string via mask-alphanum rules. */
-public final class ShowLast4 extends IcebergFunction.BaseFunction<String, String> {
-  public ShowLast4(int fieldId) {
+public final class ShowLast4 extends BaseFunction<String, String> {
+  static final String NAME = "show-last-4";
+
+  ShowLast4(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return SHOW_LAST_4;
+    return NAME;
   }
 
   @Override
@@ -44,7 +46,7 @@ public final class ShowLast4 extends IcebergFunction.BaseFunction<String, String
     return ShowLast4Fn.INSTANCE;
   }
 
-  private static final class ShowLast4Fn extends IcebergFunctions.NullSafeFunction<String, String> {
+  private static final class ShowLast4Fn extends NullSafeFunction<String, String> {
     static final ShowLast4Fn INSTANCE = new ShowLast4Fn();
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateTemporal.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateTemporal.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.DateTimeUtil;
+
+/** Truncates date/timestamp values to the first instant of their year or month. */
+final class TruncateTemporal extends IcebergFunctions.NullSafeFunction<Object, Object> {
+
+  enum Unit {
+    YEAR,
+    MONTH
+  }
+
+  private enum Storage {
+    DATE_DAYS,
+    TIMESTAMP_MICROS,
+    TIMESTAMP_NANOS
+  }
+
+  static final TruncateTemporal DATE_YEAR = new TruncateTemporal(Unit.YEAR, Storage.DATE_DAYS);
+  static final TruncateTemporal DATE_MONTH = new TruncateTemporal(Unit.MONTH, Storage.DATE_DAYS);
+  static final TruncateTemporal TIMESTAMP_YEAR =
+      new TruncateTemporal(Unit.YEAR, Storage.TIMESTAMP_MICROS);
+  static final TruncateTemporal TIMESTAMP_MONTH =
+      new TruncateTemporal(Unit.MONTH, Storage.TIMESTAMP_MICROS);
+  static final TruncateTemporal TIMESTAMP_NANO_YEAR =
+      new TruncateTemporal(Unit.YEAR, Storage.TIMESTAMP_NANOS);
+  static final TruncateTemporal TIMESTAMP_NANO_MONTH =
+      new TruncateTemporal(Unit.MONTH, Storage.TIMESTAMP_NANOS);
+
+  static TruncateTemporal forType(Unit unit, Type type) {
+    switch (type.typeId()) {
+      case DATE:
+        return unit == Unit.YEAR ? DATE_YEAR : DATE_MONTH;
+      case TIMESTAMP:
+        return unit == Unit.YEAR ? TIMESTAMP_YEAR : TIMESTAMP_MONTH;
+      case TIMESTAMP_NANO:
+        return unit == Unit.YEAR ? TIMESTAMP_NANO_YEAR : TIMESTAMP_NANO_MONTH;
+      default:
+        throw new IllegalArgumentException("Unsupported type for truncate: " + type);
+    }
+  }
+
+  private final Unit unit;
+  private final Storage storage;
+
+  private TruncateTemporal(Unit unit, Storage storage) {
+    this.unit = unit;
+    this.storage = storage;
+  }
+
+  @Override
+  protected Object applyNonNull(Object value) {
+    switch (storage) {
+      case DATE_DAYS:
+        LocalDate date = DateTimeUtil.dateFromDays((Integer) value);
+        return DateTimeUtil.daysFromDate(truncateDate(date));
+      case TIMESTAMP_MICROS:
+        LocalDateTime tsMicros = DateTimeUtil.timestampFromMicros((Long) value);
+        return DateTimeUtil.microsFromTimestamp(truncateTimestamp(tsMicros));
+      case TIMESTAMP_NANOS:
+        LocalDateTime tsNanos = DateTimeUtil.timestampFromNanos((Long) value);
+        return DateTimeUtil.nanosFromTimestamp(truncateTimestamp(tsNanos));
+      default:
+        throw new IllegalStateException("unreachable: " + storage);
+    }
+  }
+
+  private LocalDate truncateDate(LocalDate date) {
+    return unit == Unit.YEAR ? date.withMonth(1).withDayOfMonth(1) : date.withDayOfMonth(1);
+  }
+
+  private LocalDateTime truncateTimestamp(LocalDateTime ts) {
+    LocalDateTime truncated =
+        unit == Unit.YEAR ? ts.withMonth(1).withDayOfMonth(1) : ts.withDayOfMonth(1);
+    return truncated.with(LocalTime.MIDNIGHT);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateTemporal.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateTemporal.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.DateTimeUtil;
 
 /** Truncates date/timestamp values to the first instant of their year or month. */
-final class TruncateTemporal extends IcebergFunctions.NullSafeFunction<Object, Object> {
+final class TruncateTemporal extends NullSafeFunction<Object, Object> {
 
   enum Unit {
     YEAR,

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateToMonth.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateToMonth.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Truncates date or timestamp values to the first instant of their month. */
+public final class TruncateToMonth extends IcebergFunction.BaseFunction<Object, Object> {
+  public TruncateToMonth(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return TRUNCATE_TO_MONTH;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    switch (type.typeId()) {
+      case DATE:
+      case TIMESTAMP:
+      case TIMESTAMP_NANO:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    Preconditions.checkArgument(
+        canBind(type), "truncate-to-month is not supported for type: %s", type);
+    return TruncateTemporal.forType(TruncateTemporal.Unit.MONTH, type);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateToMonth.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateToMonth.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Truncates date or timestamp values to the first instant of their month. */
-public final class TruncateToMonth extends IcebergFunction.BaseFunction<Object, Object> {
-  public TruncateToMonth(int fieldId) {
+public final class TruncateToMonth extends BaseFunction<Object, Object> {
+  static final String NAME = "truncate-to-month";
+
+  TruncateToMonth(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return TRUNCATE_TO_MONTH;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateToYear.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateToYear.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Truncates date or timestamp values to the first instant of their year. */
+public final class TruncateToYear extends IcebergFunction.BaseFunction<Object, Object> {
+  public TruncateToYear(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return TRUNCATE_TO_YEAR;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    switch (type.typeId()) {
+      case DATE:
+      case TIMESTAMP:
+      case TIMESTAMP_NANO:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    Preconditions.checkArgument(
+        canBind(type), "truncate-to-year is not supported for type: %s", type);
+    return TruncateTemporal.forType(TruncateTemporal.Unit.YEAR, type);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/UnknownFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/UnknownFunction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * Preserves a function with a discriminator string this client doesn't recognize so that newer
+ * server-side function types don't break parsing. Callers that intend to enforce the function
+ * (engine-side rules) must fail closed when they encounter this — silent skipping would leak
+ * unmasked data.
+ */
+public final class UnknownFunction extends IcebergFunction.BaseFunction<Object, Object> {
+  private final String functionName;
+
+  public UnknownFunction(int fieldId, String functionName) {
+    super(fieldId);
+    Preconditions.checkArgument(functionName != null, "Invalid function name: null");
+    this.functionName = functionName;
+  }
+
+  @Override
+  public String name() {
+    return functionName;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return false;
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    throw new IllegalArgumentException(
+        "Cannot bind unknown function '"
+            + functionName
+            + "': this client does not recognize the function. Upgrade the client or remove the "
+            + "function from the server-side policy.");
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/UnknownFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/UnknownFunction.java
@@ -28,10 +28,10 @@ import org.apache.iceberg.util.SerializableFunction;
  * (engine-side rules) must fail closed when they encounter this — silent skipping would leak
  * unmasked data.
  */
-public final class UnknownFunction extends IcebergFunction.BaseFunction<Object, Object> {
+public final class UnknownFunction extends BaseFunction<Object, Object> {
   private final String functionName;
 
-  public UnknownFunction(int fieldId, String functionName) {
+  UnknownFunction(int fieldId, String functionName) {
     super(fieldId);
     Preconditions.checkArgument(functionName != null, "Invalid function name: null");
     this.functionName = functionName;

--- a/api/src/test/java/org/apache/iceberg/functions/TestIcebergFunctions.java
+++ b/api/src/test/java/org/apache/iceberg/functions/TestIcebergFunctions.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.SerializableFunction;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergFunctions {
+
+  @Test
+  public void maskAlphanumSpecExample() {
+    SerializableFunction<String, String> fn = new MaskAlphanum(1).bind(Types.StringType.get());
+    assertThat(fn.apply("prashant010696@gmail.com")).isEqualTo("xxxxxxxxnnnnnn@xxxxx.xxx");
+  }
+
+  @Test
+  public void maskAlphanumPreservedPunctuation() {
+    SerializableFunction<String, String> fn = new MaskAlphanum(1).bind(Types.StringType.get());
+    assertThat(fn.apply("(555) 123-4567")).isEqualTo("(nnn)xnnn-nnnn");
+    assertThat(fn.apply("a.b,c")).isEqualTo("x.x,x");
+  }
+
+  @Test
+  public void maskAlphanumNullInNullOut() {
+    SerializableFunction<String, String> fn = new MaskAlphanum(1).bind(Types.StringType.get());
+    assertThat(fn.apply(null)).isNull();
+  }
+
+  @Test
+  public void maskAlphanumEmptyString() {
+    SerializableFunction<String, String> fn = new MaskAlphanum(1).bind(Types.StringType.get());
+    assertThat(fn.apply("")).isEqualTo("");
+  }
+
+  @Test
+  public void showFirst4SpecExample() {
+    SerializableFunction<String, String> fn = new ShowFirst4(1).bind(Types.StringType.get());
+    assertThat(fn.apply("prashant010696@gmail.com")).isEqualTo("prasxxxxnnnnnn@xxxxx.xxx");
+  }
+
+  @Test
+  public void showFirst4FourOrFewerReturnedUnchanged() {
+    SerializableFunction<String, String> fn = new ShowFirst4(1).bind(Types.StringType.get());
+    assertThat(fn.apply("abcd")).isEqualTo("abcd");
+    assertThat(fn.apply("ab")).isEqualTo("ab");
+    assertThat(fn.apply("")).isEqualTo("");
+  }
+
+  @Test
+  public void showLast4SpecExample() {
+    SerializableFunction<String, String> fn = new ShowLast4(1).bind(Types.StringType.get());
+    assertThat(fn.apply("4111-1111-1111-4444")).isEqualTo("nnnn-nnnn-nnnn-4444");
+  }
+
+  @Test
+  public void showLast4FourOrFewerReturnedUnchanged() {
+    SerializableFunction<String, String> fn = new ShowLast4(1).bind(Types.StringType.get());
+    assertThat(fn.apply("abcd")).isEqualTo("abcd");
+    assertThat(fn.apply("ab")).isEqualTo("ab");
+  }
+
+  @Test
+  public void replaceWithNullAlwaysReturnsNull() {
+    SerializableFunction<Object, Object> fn = new ReplaceWithNull(1).bind(Types.IntegerType.get());
+    assertThat(fn.apply(42)).isNull();
+    assertThat(fn.apply(null)).isNull();
+
+    SerializableFunction<Object, Object> strFn =
+        new ReplaceWithNull(1).bind(Types.StringType.get());
+    assertThat(strFn.apply("hello")).isNull();
+  }
+
+  @Test
+  public void maskToFixedValueString() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.StringType.get());
+    assertThat(fn.apply("anything")).isEqualTo("XXXXXXXX");
+  }
+
+  @Test
+  public void maskToFixedValueInt() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.IntegerType.get());
+    assertThat(fn.apply(42)).isEqualTo(0);
+  }
+
+  @Test
+  public void maskToFixedValueLong() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.LongType.get());
+    assertThat(fn.apply(42L)).isEqualTo(0L);
+  }
+
+  @Test
+  public void maskToFixedValueDouble() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.DoubleType.get());
+    assertThat(fn.apply(3.14)).isEqualTo(0.0d);
+  }
+
+  @Test
+  public void maskToFixedValueBoolean() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.BooleanType.get());
+    assertThat(fn.apply(true)).isEqualTo(false);
+  }
+
+  @Test
+  public void maskToFixedValueDate() {
+    int input = DateTimeUtil.daysFromDate(LocalDate.of(2024, 7, 15));
+    int expected = DateTimeUtil.daysFromDate(LocalDate.of(1970, 1, 1));
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.DateType.get());
+    assertThat(fn.apply(input)).isEqualTo(expected);
+  }
+
+  @Test
+  public void maskToFixedValueTimestamp() {
+    long input =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    long expected = LocalDateTime.of(1970, 1, 1, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new MaskToFixedValue(1).bind(Types.TimestampType.withZone());
+    assertThat(fn.apply(input)).isEqualTo(expected);
+  }
+
+  @Test
+  public void maskToFixedValueBinary() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.BinaryType.get());
+    ByteBuffer result = (ByteBuffer) fn.apply(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(result.remaining()).isEqualTo(0);
+  }
+
+  @Test
+  public void maskToFixedValueDecimal() {
+    SerializableFunction<Object, Object> fn =
+        new MaskToFixedValue(1).bind(Types.DecimalType.of(10, 2));
+    BigDecimal result = (BigDecimal) fn.apply(new BigDecimal("12.34"));
+    assertThat(result.compareTo(BigDecimal.ZERO)).isEqualTo(0);
+    assertThat(result.scale()).isEqualTo(2);
+  }
+
+  @Test
+  public void maskToFixedValueNullReturnsFixedValue() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.IntegerType.get());
+    assertThat(fn.apply(null)).isEqualTo(0);
+  }
+
+  @Test
+  public void truncateToYearDate() {
+    int input = (int) LocalDate.of(2024, 7, 15).toEpochDay();
+    int expected = (int) LocalDate.of(2024, 1, 1).toEpochDay();
+    SerializableFunction<Object, Object> fn = new TruncateToYear(1).bind(Types.DateType.get());
+    assertThat(fn.apply(input)).isEqualTo(expected);
+  }
+
+  @Test
+  public void truncateToMonthDate() {
+    int input = (int) LocalDate.of(2024, 7, 15).toEpochDay();
+    int expected = (int) LocalDate.of(2024, 7, 1).toEpochDay();
+    SerializableFunction<Object, Object> fn = new TruncateToMonth(1).bind(Types.DateType.get());
+    assertThat(fn.apply(input)).isEqualTo(expected);
+  }
+
+  @Test
+  public void truncateToYearTimestamp() {
+    long inputMicros =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    long expectedMicros =
+        LocalDateTime.of(2024, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new TruncateToYear(1).bind(Types.TimestampType.withZone());
+    assertThat(fn.apply(inputMicros)).isEqualTo(expectedMicros);
+  }
+
+  @Test
+  public void truncateToMonthTimestamp() {
+    long inputMicros =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    long expectedMicros =
+        LocalDateTime.of(2024, 7, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new TruncateToMonth(1).bind(Types.TimestampType.withZone());
+    assertThat(fn.apply(inputMicros)).isEqualTo(expectedMicros);
+  }
+
+  @Test
+  public void truncateToYearTimestampNanoTz() {
+    long inputNanos =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000_000L;
+    long expectedNanos =
+        LocalDateTime.of(2024, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new TruncateToYear(1).bind(Types.TimestampNanoType.withZone());
+    assertThat(fn.apply(inputNanos)).isEqualTo(expectedNanos);
+  }
+
+  @Test
+  public void truncateToMonthTimestampNanoTz() {
+    long inputNanos =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000_000L;
+    long expectedNanos =
+        LocalDateTime.of(2024, 7, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new TruncateToMonth(1).bind(Types.TimestampNanoType.withZone());
+    assertThat(fn.apply(inputNanos)).isEqualTo(expectedNanos);
+  }
+
+  @Test
+  public void sha256GlobalStringIsDeterministic() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.StringType.get());
+    String first = (String) fn.apply("hello");
+    String second = (String) fn.apply("hello");
+    assertThat(first).isEqualTo(second);
+    assertThat(first).isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+  }
+
+  @Test
+  public void sha256GlobalBinaryReturns32Bytes() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.BinaryType.get());
+    ByteBuffer result = (ByteBuffer) fn.apply(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(result.remaining()).isEqualTo(32);
+  }
+
+  @Test
+  public void sha256GlobalIntegerDeterministic() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.IntegerType.get());
+    Object first = fn.apply(42);
+    Object second = fn.apply(42);
+    assertThat(first).isEqualTo(second);
+    assertThat(first).isInstanceOf(Integer.class);
+  }
+
+  @Test
+  public void sha256GlobalLongDeterministic() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.LongType.get());
+    Object first = fn.apply(42L);
+    Object second = fn.apply(42L);
+    assertThat(first).isEqualTo(second);
+    assertThat(first).isInstanceOf(Long.class);
+  }
+
+  @Test
+  public void sha256QueryLocalDiffersWithDifferentSalt() {
+    byte[] saltA = new byte[16];
+    byte[] saltB = new byte[16];
+    Arrays.fill(saltA, (byte) 1);
+    Arrays.fill(saltB, (byte) 2);
+    SerializableFunction<Object, Object> fnA =
+        new Sha256QueryLocal(1).bind(Types.StringType.get(), saltA);
+    SerializableFunction<Object, Object> fnB =
+        new Sha256QueryLocal(1).bind(Types.StringType.get(), saltB);
+    assertThat(fnA.apply("hello")).isNotEqualTo(fnB.apply("hello"));
+  }
+
+  @Test
+  public void sha256QueryLocalSaltMustBeAtLeast16Bytes() {
+    assertThatThrownBy(() -> new Sha256QueryLocal(1).bind(Types.StringType.get(), new byte[15]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("16 bytes");
+  }
+
+  @Test
+  public void bindRejectsMaskAlphanumOnNonString() {
+    assertThatThrownBy(() -> new MaskAlphanum(1).bind(Types.IntegerType.get()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  public void bindRejectsTruncateOnUnsupportedType() {
+    assertThatThrownBy(() -> new TruncateToYear(1).bind(Types.StringType.get()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not supported for type");
+  }
+
+  @Test
+  public void bindFailsClosedOnUnknownFunction() {
+    assertThatThrownBy(() -> new UnknownFunction(1, "future-mask-v2").bind(Types.StringType.get()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("future-mask-v2");
+  }
+
+  @Test
+  public void sha256NullInNullOut() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.StringType.get());
+    assertThat(fn.apply(null)).isNull();
+  }
+
+  @Test
+  public void truncateNullInNullOut() {
+    SerializableFunction<Object, Object> fn = new TruncateToYear(1).bind(Types.DateType.get());
+    assertThat(fn.apply(null)).isNull();
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/functions/TestIcebergFunctions.java
+++ b/api/src/test/java/org/apache/iceberg/functions/TestIcebergFunctions.java
@@ -313,4 +313,88 @@ public class TestIcebergFunctions {
     SerializableFunction<Object, Object> fn = new TruncateToYear(1).bind(Types.DateType.get());
     assertThat(fn.apply(null)).isNull();
   }
+
+  @Test
+  public void factoryMethodsUseSpecWireNames() {
+    assertThat(IcebergFunctions.maskAlphanum(1).name()).isEqualTo("mask-alphanum");
+    assertThat(IcebergFunctions.maskToFixedValue(1).name()).isEqualTo("mask-to-fixed-value");
+    assertThat(IcebergFunctions.replaceWithNull(1).name()).isEqualTo("replace-with-null");
+    assertThat(IcebergFunctions.showFirst4(1).name()).isEqualTo("show-first-4");
+    assertThat(IcebergFunctions.showLast4(1).name()).isEqualTo("show-last-4");
+    assertThat(IcebergFunctions.truncateToYear(1).name()).isEqualTo("truncate-to-year");
+    assertThat(IcebergFunctions.truncateToMonth(1).name()).isEqualTo("truncate-to-month");
+    assertThat(IcebergFunctions.sha256Global(1).name()).isEqualTo("sha-256-global");
+    assertThat(IcebergFunctions.sha256QueryLocal(1).name()).isEqualTo("sha-256-query-local");
+  }
+
+  @Test
+  public void fromStringRoundTripsEveryFunction() {
+    IcebergFunction<?, ?>[] functions =
+        new IcebergFunction<?, ?>[] {
+          IcebergFunctions.maskAlphanum(1),
+          IcebergFunctions.maskToFixedValue(1),
+          IcebergFunctions.replaceWithNull(1),
+          IcebergFunctions.showFirst4(1),
+          IcebergFunctions.showLast4(1),
+          IcebergFunctions.truncateToYear(1),
+          IcebergFunctions.truncateToMonth(1),
+          IcebergFunctions.sha256Global(1),
+          IcebergFunctions.sha256QueryLocal(1)
+        };
+
+    for (IcebergFunction<?, ?> expected : functions) {
+      assertThat(IcebergFunctions.fromString(expected.name(), 1)).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void fromStringPreservesUnknownFunction() {
+    IcebergFunction<?, ?> function = IcebergFunctions.fromString("future-mask-v2", 3);
+    assertThat(function).isInstanceOf(UnknownFunction.class);
+    assertThat(function.name()).isEqualTo("future-mask-v2");
+    assertThat(function.fieldId()).isEqualTo(3);
+    assertThat(function.canBind(Types.StringType.get())).isFalse();
+  }
+
+  @Test
+  public void fromStringReturnsSaltedFunctionForQueryLocalSha256() {
+    assertThat(IcebergFunctions.fromString("sha-256-query-local", 1))
+        .isInstanceOf(SaltedFunction.class);
+    assertThat(IcebergFunctions.fromString("sha-256-global", 1))
+        .isNotInstanceOf(SaltedFunction.class);
+  }
+
+  @Test
+  public void equalIfSameFunctionAndFieldId() {
+    assertThat(IcebergFunctions.maskAlphanum(1))
+        .isEqualTo(IcebergFunctions.maskAlphanum(1))
+        .hasSameHashCodeAs(IcebergFunctions.maskAlphanum(1));
+  }
+
+  @Test
+  public void notEqualIfFieldIdDiffers() {
+    assertThat(IcebergFunctions.maskAlphanum(1)).isNotEqualTo(IcebergFunctions.maskAlphanum(2));
+  }
+
+  @Test
+  public void notEqualIfFunctionDiffers() {
+    assertThat(IcebergFunctions.maskAlphanum(1)).isNotEqualTo(IcebergFunctions.showLast4(1));
+  }
+
+  @Test
+  public void equalsIsSymmetricAcrossFunctionTypes() {
+    // An unknown function reporting a known name must not compare equal to that known function in
+    // either direction: equality is by class, not by the reported name.
+    IcebergFunction<?, ?> known = IcebergFunctions.maskAlphanum(1);
+    IcebergFunction<?, ?> spoofed = new UnknownFunction(1, known.name());
+    assertThat(spoofed.name()).isEqualTo(known.name());
+    assertThat(spoofed).isNotEqualTo(known);
+    assertThat(known).isNotEqualTo(spoofed);
+  }
+
+  @Test
+  public void unknownFunctionsDifferByName() {
+    assertThat(IcebergFunctions.fromString("future-a", 1))
+        .isNotEqualTo(IcebergFunctions.fromString("future-b", 1));
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/SupportsReadRestrictions.java
+++ b/core/src/main/java/org/apache/iceberg/SupportsReadRestrictions.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.Optional;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
+
+/**
+ * Capability interface for table implementations that can carry per-principal {@link
+ * ReadRestrictions}.
+ *
+ * <p>Currently populated only by the REST catalog. Non-REST catalogs either don't implement this or
+ * return {@link Optional#empty()} from {@link #readRestrictions()}. Consumers should route through
+ * {@code TableUtil.readRestrictions(Table)} to handle both cases uniformly.
+ */
+public interface SupportsReadRestrictions {
+  default Optional<ReadRestrictions> readRestrictions() {
+    return Optional.empty();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TableUtil.java
+++ b/core/src/main/java/org/apache/iceberg/TableUtil.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iceberg;
 
+import java.util.Optional;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
 
 public class TableUtil {
   private TableUtil() {}
@@ -68,5 +70,20 @@ public class TableUtil {
     }
 
     return formatVersion(table) >= TableMetadata.MIN_FORMAT_VERSION_ROW_LINEAGE;
+  }
+
+  /**
+   * Returns the server-provided read restrictions carried by the given table, if any. Returns
+   * {@link Optional#empty()} for tables that don't participate in the {@link
+   * SupportsReadRestrictions} contract (most non-REST catalogs) and for wrapper tables
+   * (SerializableTable, metadata tables) — restrictions are a driver-side planning concept and
+   * don't propagate across wrappers.
+   */
+  public static Optional<ReadRestrictions> readRestrictions(Table table) {
+    Preconditions.checkArgument(null != table, "Invalid table: null");
+    if (table instanceof SupportsReadRestrictions) {
+      return ((SupportsReadRestrictions) table).readRestrictions();
+    }
+    return Optional.empty();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/BaseRESTTable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/BaseRESTTable.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import java.util.Optional;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.SupportsReadRestrictions;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
+
+/**
+ * BaseTable specialization for tables loaded via a REST catalog. Carries the per-principal {@link
+ * ReadRestrictions} that the REST server may have attached to the load response and advertises the
+ * capability via {@link SupportsReadRestrictions}.
+ *
+ * <p>Used by {@link RESTSessionCatalog} for REST loadTable paths that do not use server-side scan
+ * planning. {@link RESTTable} extends this class to add scan-planning. Non-REST catalogs (Hadoop,
+ * Hive, Glue, JDBC, Nessie, etc.) construct {@link BaseTable} directly and do not advertise the
+ * capability — they have no pathway to produce a {@link ReadRestrictions}.
+ */
+class BaseRESTTable extends BaseTable implements SupportsReadRestrictions {
+  private final Optional<ReadRestrictions> readRestrictions;
+
+  BaseRESTTable(
+      TableOperations ops,
+      String name,
+      MetricsReporter reporter,
+      ReadRestrictions readRestrictions) {
+    super(ops, name, reporter);
+    this.readRestrictions =
+        readRestrictions != null && !readRestrictions.isEmpty()
+            ? Optional.of(readRestrictions)
+            : Optional.empty();
+  }
+
+  @Override
+  public Optional<ReadRestrictions> readRestrictions() {
+    return readRestrictions;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/BaseRESTTable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/BaseRESTTable.java
@@ -48,6 +48,12 @@ class BaseRESTTable extends BaseTable implements SupportsReadRestrictions {
         readRestrictions != null && !readRestrictions.isEmpty()
             ? Optional.of(readRestrictions)
             : Optional.empty();
+    // Validate here, where server-provided restrictions first meet a table, so every reader
+    // inherits the check rather than re-deriving it per scan. Reads on the loaded table still fail
+    // closed on anything else they cannot apply. Uses ops directly rather than the overridable
+    // schemas() to avoid calling an overridable method from a constructor.
+    this.readRestrictions.ifPresent(
+        restrictions -> restrictions.validate(ops.current().schemasById()));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -99,6 +99,7 @@ import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
 import org.apache.iceberg.util.EnvironmentUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.ThreadPools;
@@ -557,13 +558,22 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
 
     List<Credential> credentials = response.credentials();
+    ReadRestrictions readRestrictions = response.readRestrictions();
     RESTClient tableClient = client.withAuthSession(tableSession);
     Supplier<BaseTable> tableSupplier =
         createTableSupplier(
-            finalIdentifier, tableMetadata, context, tableClient, tableConf, credentials);
+            finalIdentifier,
+            tableMetadata,
+            context,
+            tableClient,
+            tableConf,
+            credentials,
+            readRestrictions);
 
     String eTag = responseHeaders.getOrDefault(HttpHeaders.ETAG, null);
-    if (eTag != null) {
+    if (eTag != null && readRestrictions.isEmpty()) {
+      // per-principal read restrictions are not keyed into ETag; skip cache to avoid serving
+      // stale restrictions on a 304 when the server-side policy has changed
       tableCache.put(context.sessionId(), finalIdentifier, tableSupplier, eTag);
     }
 
@@ -580,7 +590,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       SessionContext context,
       RESTClient tableClient,
       Map<String, String> tableConf,
-      List<Credential> credentials) {
+      List<Credential> credentials,
+      ReadRestrictions readRestrictions) {
     return () -> {
       RESTTableOperations ops =
           newTableOps(
@@ -594,13 +605,17 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
       trackFileIO(ops);
 
-      RESTTable table = restTableForScanPlanning(ops, identifier, tableClient, tableConf);
+      RESTTable table =
+          restTableForScanPlanning(ops, identifier, tableClient, tableConf, readRestrictions);
       if (table != null) {
         return table;
       }
 
-      return new BaseTable(
-          ops, fullTableName(identifier), metricsReporter(paths.metrics(identifier), tableClient));
+      return new BaseRESTTable(
+          ops,
+          fullTableName(identifier),
+          metricsReporter(paths.metrics(identifier), tableClient),
+          readRestrictions);
     };
   }
 
@@ -608,7 +623,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       TableOperations ops,
       TableIdentifier finalIdentifier,
       RESTClient restClient,
-      Map<String, String> tableConf) {
+      Map<String, String> tableConf,
+      ReadRestrictions readRestrictions) {
     String planningModeServerConfig = tableConf.get(RESTCatalogProperties.SCAN_PLANNING_MODE);
     ScanPlanningMode serverScanPlanningMode =
         planningModeServerConfig == null
@@ -653,7 +669,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
           paths,
           endpoints,
           properties(),
-          conf);
+          conf,
+          readRestrictions);
     }
 
     // Default to client-side planning
@@ -740,13 +757,17 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     trackFileIO(ops);
 
-    RESTTable restTable = restTableForScanPlanning(ops, ident, tableClient, tableConf);
+    RESTTable restTable =
+        restTableForScanPlanning(ops, ident, tableClient, tableConf, ReadRestrictions.empty());
     if (restTable != null) {
       return restTable;
     }
 
-    return new BaseTable(
-        ops, fullTableName(ident), metricsReporter(paths.metrics(ident), tableClient));
+    return new BaseRESTTable(
+        ops,
+        fullTableName(ident),
+        metricsReporter(paths.metrics(ident), tableClient),
+        ReadRestrictions.empty());
   }
 
   @Override
@@ -1009,13 +1030,17 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
       trackFileIO(ops);
 
-      RESTTable restTable = restTableForScanPlanning(ops, ident, tableClient, tableConf);
+      RESTTable restTable =
+          restTableForScanPlanning(ops, ident, tableClient, tableConf, ReadRestrictions.empty());
       if (restTable != null) {
         return restTable;
       }
 
-      return new BaseTable(
-          ops, fullTableName(ident), metricsReporter(paths.metrics(ident), tableClient));
+      return new BaseRESTTable(
+          ops,
+          fullTableName(ident),
+          metricsReporter(paths.metrics(ident), tableClient),
+          ReadRestrictions.empty());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTable.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.rest;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BatchScan;
 import org.apache.iceberg.BatchScanAdapter;
 import org.apache.iceberg.ImmutableTableScanContext;
@@ -30,8 +29,9 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
 
-class RESTTable extends BaseTable implements SupportsDistributedScanPlanning {
+class RESTTable extends BaseRESTTable implements SupportsDistributedScanPlanning {
   private final RESTClient client;
   private final Supplier<Map<String, String>> headers;
   private final MetricsReporter reporter;
@@ -51,8 +51,9 @@ class RESTTable extends BaseTable implements SupportsDistributedScanPlanning {
       ResourcePaths resourcePaths,
       Set<Endpoint> supportedEndpoints,
       Map<String, String> catalogProperties,
-      Object hadoopConf) {
-    super(ops, name, reporter);
+      Object hadoopConf,
+      ReadRestrictions readRestrictions) {
+    super(ops, name, reporter, readRestrictions);
     this.reporter = reporter;
     this.client = client;
     this.headers = headers;

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.RESTResponse;
 import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
 
 /**
  * A REST response that is used when a table is successfully loaded.
@@ -45,6 +46,7 @@ public class LoadTableResponse implements RESTResponse {
   private Map<String, String> config;
   private TableMetadata metadataWithLocation;
   private List<Credential> credentials;
+  private ReadRestrictions readRestrictions;
 
   public LoadTableResponse() {
     // Required for Jackson deserialization
@@ -54,11 +56,13 @@ public class LoadTableResponse implements RESTResponse {
       String metadataLocation,
       TableMetadata metadata,
       Map<String, String> config,
-      List<Credential> credentials) {
+      List<Credential> credentials,
+      ReadRestrictions readRestrictions) {
     this.metadataLocation = metadataLocation;
     this.metadata = metadata;
     this.config = config;
     this.credentials = credentials;
+    this.readRestrictions = readRestrictions;
   }
 
   @Override
@@ -87,12 +91,17 @@ public class LoadTableResponse implements RESTResponse {
     return credentials != null ? credentials : ImmutableList.of();
   }
 
+  public ReadRestrictions readRestrictions() {
+    return readRestrictions != null ? readRestrictions : ReadRestrictions.empty();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("metadataLocation", metadataLocation)
         .add("metadata", metadata)
         .add("config", config)
+        .add("readRestrictions", readRestrictions)
         .toString();
   }
 
@@ -105,6 +114,7 @@ public class LoadTableResponse implements RESTResponse {
     private TableMetadata metadata;
     private final Map<String, String> config = Maps.newHashMap();
     private final List<Credential> credentials = Lists.newArrayList();
+    private ReadRestrictions readRestrictions;
 
     private Builder() {}
 
@@ -134,9 +144,15 @@ public class LoadTableResponse implements RESTResponse {
       return this;
     }
 
+    public Builder withReadRestrictions(ReadRestrictions restrictions) {
+      this.readRestrictions = restrictions;
+      return this;
+    }
+
     public LoadTableResponse build() {
       Preconditions.checkNotNull(metadata, "Invalid metadata: null");
-      return new LoadTableResponse(metadataLocation, metadata, config, credentials);
+      return new LoadTableResponse(
+          metadataLocation, metadata, config, credentials, readRestrictions);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponseParser.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.credentials.CredentialParser;
+import org.apache.iceberg.rest.restrictions.ReadRestrictionsParser;
 import org.apache.iceberg.util.JsonUtil;
 
 public class LoadTableResponseParser {
@@ -34,6 +35,7 @@ public class LoadTableResponseParser {
   private static final String METADATA = "metadata";
   private static final String CONFIG = "config";
   private static final String STORAGE_CREDENTIALS = "storage-credentials";
+  private static final String READ_RESTRICTIONS = "read-restrictions";
 
   private LoadTableResponseParser() {}
 
@@ -70,6 +72,11 @@ public class LoadTableResponseParser {
       gen.writeEndArray();
     }
 
+    if (!response.readRestrictions().isEmpty()) {
+      gen.writeFieldName(READ_RESTRICTIONS);
+      ReadRestrictionsParser.toJson(response.readRestrictions(), gen);
+    }
+
     gen.writeEndObject();
   }
 
@@ -99,6 +106,10 @@ public class LoadTableResponseParser {
 
     if (json.hasNonNull(STORAGE_CREDENTIALS)) {
       builder.addAllCredentials(LoadCredentialsResponseParser.fromJson(json).credentials());
+    }
+
+    if (json.hasNonNull(READ_RESTRICTIONS)) {
+      builder.withReadRestrictions(ReadRestrictionsParser.fromJson(json.get(READ_RESTRICTIONS)));
     }
 
     return builder.build();

--- a/core/src/main/java/org/apache/iceberg/rest/restrictions/ActionParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/restrictions/ActionParser.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.restrictions;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.functions.IcebergFunction;
+import org.apache.iceberg.functions.MaskAlphanum;
+import org.apache.iceberg.functions.MaskToFixedValue;
+import org.apache.iceberg.functions.ReplaceWithNull;
+import org.apache.iceberg.functions.Sha256Global;
+import org.apache.iceberg.functions.Sha256QueryLocal;
+import org.apache.iceberg.functions.ShowFirst4;
+import org.apache.iceberg.functions.ShowLast4;
+import org.apache.iceberg.functions.TruncateToMonth;
+import org.apache.iceberg.functions.TruncateToYear;
+import org.apache.iceberg.functions.UnknownFunction;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class ActionParser {
+
+  private ActionParser() {}
+
+  private static final String ACTION = "action";
+  private static final String FIELD_ID = "field-id";
+
+  public static String toJson(IcebergFunction<?, ?> action) {
+    return toJson(action, false);
+  }
+
+  public static String toJson(IcebergFunction<?, ?> action, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(action, gen), pretty);
+  }
+
+  public static void toJson(IcebergFunction<?, ?> action, JsonGenerator generator)
+      throws IOException {
+    Preconditions.checkArgument(action != null, "Invalid action: null");
+
+    generator.writeStartObject();
+    generator.writeStringField(ACTION, action.name());
+    generator.writeNumberField(FIELD_ID, action.fieldId());
+    generator.writeEndObject();
+  }
+
+  public static IcebergFunction<?, ?> fromJson(String json) {
+    return JsonUtil.parse(json, ActionParser::fromJson);
+  }
+
+  public static IcebergFunction<?, ?> fromJson(JsonNode node) {
+    Preconditions.checkArgument(
+        node != null && node.isObject(), "Cannot parse action from non-object value: %s", node);
+    Preconditions.checkArgument(
+        node.hasNonNull(ACTION), "Cannot parse action: missing field: action");
+    Preconditions.checkArgument(
+        node.hasNonNull(FIELD_ID), "Cannot parse action: missing field: field-id");
+
+    String actionType = JsonUtil.getString(ACTION, node);
+    int fieldId = JsonUtil.getInt(FIELD_ID, node);
+    Preconditions.checkArgument(fieldId > 0, "Invalid field id: %s (must be positive)", fieldId);
+
+    switch (actionType) {
+      case IcebergFunction.MASK_ALPHANUM:
+        return new MaskAlphanum(fieldId);
+      case IcebergFunction.MASK_TO_FIXED_VALUE:
+        return new MaskToFixedValue(fieldId);
+      case IcebergFunction.REPLACE_WITH_NULL:
+        return new ReplaceWithNull(fieldId);
+      case IcebergFunction.SHOW_FIRST_4:
+        return new ShowFirst4(fieldId);
+      case IcebergFunction.SHOW_LAST_4:
+        return new ShowLast4(fieldId);
+      case IcebergFunction.TRUNCATE_TO_YEAR:
+        return new TruncateToYear(fieldId);
+      case IcebergFunction.TRUNCATE_TO_MONTH:
+        return new TruncateToMonth(fieldId);
+      case IcebergFunction.SHA_256_GLOBAL:
+        return new Sha256Global(fieldId);
+      case IcebergFunction.SHA_256_QUERY_LOCAL:
+        return new Sha256QueryLocal(fieldId);
+      default:
+        // Preserve unknown action types so older clients don't break when the spec evolves.
+        // Enforcement code (engine rules) must fail closed on UnknownFunction, since silently
+        // skipping an unknown mask would leak unmasked data.
+        return new UnknownFunction(fieldId, actionType);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/restrictions/ReadRestrictions.java
+++ b/core/src/main/java/org/apache/iceberg/rest/restrictions/ReadRestrictions.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.restrictions;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.functions.IcebergFunction;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+
+/**
+ * Server-provided read restrictions for the authenticated principal.
+ *
+ * <p>Applies only to the principal identified by the request's authentication. An empty instance
+ * (no row filter, no column projections) is equivalent to the property being absent from the
+ * response.
+ */
+public class ReadRestrictions implements Serializable {
+
+  private static final ReadRestrictions EMPTY = new ReadRestrictions(null, ImmutableList.of());
+
+  private final Expression rowFilter;
+  private final List<IcebergFunction<?, ?>> columnProjections;
+  private final Set<Integer> maskedFieldIds;
+
+  private ReadRestrictions(Expression rowFilter, List<IcebergFunction<?, ?>> columnProjections) {
+    this.rowFilter = rowFilter;
+    this.columnProjections = ImmutableList.copyOf(columnProjections);
+    this.maskedFieldIds =
+        this.columnProjections.isEmpty()
+            ? ImmutableSet.of()
+            : this.columnProjections.stream()
+                .map(IcebergFunction::fieldId)
+                .collect(ImmutableSet.toImmutableSet());
+  }
+
+  public static ReadRestrictions empty() {
+    return EMPTY;
+  }
+
+  public static ReadRestrictions of(
+      Expression rowFilter, List<IcebergFunction<?, ?>> columnProjections) {
+    List<IcebergFunction<?, ?>> actions =
+        columnProjections == null ? ImmutableList.of() : columnProjections;
+    if (rowFilter == null && actions.isEmpty()) {
+      return EMPTY;
+    }
+    return new ReadRestrictions(rowFilter, actions);
+  }
+
+  public Expression rowFilter() {
+    return rowFilter;
+  }
+
+  public List<IcebergFunction<?, ?>> columnProjections() {
+    return columnProjections;
+  }
+
+  public boolean isEmpty() {
+    return rowFilter == null && columnProjections.isEmpty();
+  }
+
+  /** Field ids covered by a column projection action. */
+  public Set<Integer> maskedFieldIds() {
+    return maskedFieldIds;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/restrictions/ReadRestrictions.java
+++ b/core/src/main/java/org/apache/iceberg/rest/restrictions/ReadRestrictions.java
@@ -20,11 +20,17 @@ package org.apache.iceberg.rest.restrictions;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.functions.IcebergFunction;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 /**
  * Server-provided read restrictions for the authenticated principal.
@@ -44,12 +50,23 @@ public class ReadRestrictions implements Serializable {
   private ReadRestrictions(Expression rowFilter, List<IcebergFunction<?, ?>> columnProjections) {
     this.rowFilter = rowFilter;
     this.columnProjections = ImmutableList.copyOf(columnProjections);
-    this.maskedFieldIds =
-        this.columnProjections.isEmpty()
-            ? ImmutableSet.of()
-            : this.columnProjections.stream()
-                .map(IcebergFunction::fieldId)
-                .collect(ImmutableSet.toImmutableSet());
+
+    Set<Integer> fieldIds = Sets.newLinkedHashSet();
+    List<Integer> duplicates = Lists.newArrayList();
+    for (IcebergFunction<?, ?> projection : this.columnProjections) {
+      if (!fieldIds.add(projection.fieldId())) {
+        duplicates.add(projection.fieldId());
+      }
+    }
+
+    // The spec requires a reader to fail when a field id carries more than one projection: the
+    // actions do not compose and applying either one silently would be a policy decision.
+    Preconditions.checkArgument(
+        duplicates.isEmpty(),
+        "Invalid read restrictions: duplicate column projections for field ids %s",
+        duplicates);
+
+    this.maskedFieldIds = ImmutableSet.copyOf(fieldIds);
   }
 
   public static ReadRestrictions empty() {
@@ -81,5 +98,31 @@ public class ReadRestrictions implements Serializable {
   /** Field ids covered by a column projection action. */
   public Set<Integer> maskedFieldIds() {
     return maskedFieldIds;
+  }
+
+  /**
+   * Validates that every column projection targets a field id the table knows.
+   *
+   * <p>Checked against every schema the table has ever had rather than only the current one: field
+   * ids are never reused, so membership in any schema identifies the column unambiguously, and a
+   * time-travel read may legitimately be restricted on a column that has since been dropped.
+   *
+   * <p>Validating once here, where server-provided restrictions first meet a table, means every
+   * reader inherits the check instead of re-deriving it per scan.
+   *
+   * @param schemas the table's schemas, keyed by schema id
+   * @throws IllegalArgumentException if any projection targets a field id in none of the schemas
+   */
+  public void validate(Map<Integer, Schema> schemas) {
+    List<Integer> unknownFieldIds =
+        maskedFieldIds.stream()
+            .filter(
+                fieldId -> schemas.values().stream().noneMatch(s -> s.findField(fieldId) != null))
+            .collect(Collectors.toList());
+
+    Preconditions.checkArgument(
+        unknownFieldIds.isEmpty(),
+        "Invalid read restrictions: column projections reference unknown field ids %s",
+        unknownFieldIds);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/restrictions/ReadRestrictionsParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/restrictions/ReadRestrictionsParser.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.restrictions;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionParser;
+import org.apache.iceberg.functions.IcebergFunction;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.JsonUtil;
+
+public class ReadRestrictionsParser {
+
+  private ReadRestrictionsParser() {}
+
+  private static final String REQUIRED_ROW_FILTER = "required-row-filter";
+  private static final String REQUIRED_COLUMN_PROJECTIONS = "required-column-projections";
+
+  public static String toJson(ReadRestrictions restrictions) {
+    return toJson(restrictions, false);
+  }
+
+  public static String toJson(ReadRestrictions restrictions, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(restrictions, gen), pretty);
+  }
+
+  public static void toJson(ReadRestrictions restrictions, JsonGenerator generator)
+      throws IOException {
+    Preconditions.checkArgument(restrictions != null, "Invalid read restrictions: null");
+
+    generator.writeStartObject();
+
+    if (restrictions.rowFilter() != null) {
+      generator.writeFieldName(REQUIRED_ROW_FILTER);
+      ExpressionParser.toJson(restrictions.rowFilter(), generator);
+    }
+
+    if (!restrictions.columnProjections().isEmpty()) {
+      generator.writeArrayFieldStart(REQUIRED_COLUMN_PROJECTIONS);
+      for (IcebergFunction<?, ?> action : restrictions.columnProjections()) {
+        ActionParser.toJson(action, generator);
+      }
+      generator.writeEndArray();
+    }
+
+    generator.writeEndObject();
+  }
+
+  public static ReadRestrictions fromJson(String json) {
+    return JsonUtil.parse(json, ReadRestrictionsParser::fromJson);
+  }
+
+  public static ReadRestrictions fromJson(JsonNode node) {
+    if (node == null || node.isNull()) {
+      return ReadRestrictions.empty();
+    }
+    Preconditions.checkArgument(
+        node.isObject(), "Cannot parse read restrictions from non-object value: %s", node);
+
+    Expression rowFilter = null;
+    if (node.hasNonNull(REQUIRED_ROW_FILTER)) {
+      rowFilter = ExpressionParser.fromJson(node.get(REQUIRED_ROW_FILTER));
+    }
+
+    List<IcebergFunction<?, ?>> actions = Lists.newArrayList();
+    if (node.hasNonNull(REQUIRED_COLUMN_PROJECTIONS)) {
+      JsonNode array = node.get(REQUIRED_COLUMN_PROJECTIONS);
+      Preconditions.checkArgument(
+          array.isArray(),
+          "Cannot parse required-column-projections: expected array, got: %s",
+          array);
+      for (JsonNode elem : array) {
+        actions.add(ActionParser.fromJson(elem));
+      }
+    }
+
+    return ReadRestrictions.of(rowFilter, actions);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
@@ -27,8 +27,12 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.functions.Sha256Global;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -477,5 +481,59 @@ public class TestLoadTableResponseParser {
     // can't do an equality comparison because Schema doesn't implement equals/hashCode
     assertThat(LoadTableResponseParser.toJson(LoadTableResponseParser.fromJson(json), true))
         .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void roundTripSerdeWithReadRestrictions() {
+    LoadTableResponse response =
+        LoadTableResponse.builder()
+            .withTableMetadata(metadataWithSingleLongColumn())
+            .withReadRestrictions(
+                ReadRestrictions.of(
+                    Expressions.equal("country", "US"), ImmutableList.of(new Sha256Global(1))))
+            .build();
+
+    // the surrounding metadata document is already pinned by roundTripSerdeV2; assert the node this
+    // response adds, then that a parse/serialize cycle preserves the whole document
+    String json = LoadTableResponseParser.toJson(response, true);
+    assertThat(json)
+        .contains(
+            "  \"read-restrictions\" : {\n"
+                + "    \"required-row-filter\" : {\n"
+                + "      \"type\" : \"eq\",\n"
+                + "      \"term\" : \"country\",\n"
+                + "      \"value\" : \"US\"\n"
+                + "    },\n"
+                + "    \"required-column-projections\" : [ {\n"
+                + "      \"action\" : \"sha-256-global\",\n"
+                + "      \"field-id\" : 1\n"
+                + "    } ]\n"
+                + "  }");
+    assertThat(LoadTableResponseParser.toJson(LoadTableResponseParser.fromJson(json), true))
+        .isEqualTo(json);
+  }
+
+  @Test
+  public void missingReadRestrictionsParsesAsEmpty() {
+    String json =
+        LoadTableResponseParser.toJson(
+            LoadTableResponse.builder().withTableMetadata(metadataWithSingleLongColumn()).build());
+
+    // an absent field must not be serialized, and must read back as "no restrictions" rather than
+    // null, so callers never have to null-check before enforcing
+    assertThat(json).doesNotContain("read-restrictions");
+    assertThat(LoadTableResponseParser.fromJson(json).readRestrictions().isEmpty()).isTrue();
+  }
+
+  private static TableMetadata metadataWithSingleLongColumn() {
+    return TableMetadata.buildFromEmpty()
+        .assignUUID("386b9f01-002b-4d8c-b77f-42c3fd3b7c9b")
+        .setLocation("location")
+        .setCurrentSchema(new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
+        .addPartitionSpec(PartitionSpec.unpartitioned())
+        .addSortOrder(SortOrder.unsorted())
+        .discardChanges()
+        .withMetadataLocation("metadata-location")
+        .build();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/restrictions/TestReadRestrictions.java
+++ b/core/src/test/java/org/apache/iceberg/rest/restrictions/TestReadRestrictions.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.restrictions;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.functions.MaskAlphanum;
+import org.apache.iceberg.functions.ShowLast4;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestReadRestrictions {
+
+  private static final Schema SCHEMA_V0 =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(2, "email", Types.StringType.get()),
+          optional(3, "ssn", Types.StringType.get()));
+
+  // "ssn" (field 3) has been dropped
+  private static final Schema SCHEMA_V1 =
+      new Schema(
+          required(1, "id", Types.LongType.get()), optional(2, "email", Types.StringType.get()));
+
+  private static final Map<Integer, Schema> SCHEMA_HISTORY =
+      ImmutableMap.of(0, SCHEMA_V0, 1, SCHEMA_V1);
+
+  @Test
+  public void validateAcceptsFieldIdsInTheCurrentSchema() {
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(2)));
+
+    assertThatCode(() -> restrictions.validate(SCHEMA_HISTORY)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void validateAcceptsFieldIdsFromAnOlderSchema() {
+    // a time-travel read may legitimately be restricted on a column that has since been dropped, so
+    // membership in any schema is enough
+    ReadRestrictions restrictions = ReadRestrictions.of(null, ImmutableList.of(new ShowLast4(3)));
+
+    assertThatCode(() -> restrictions.validate(SCHEMA_HISTORY)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void validateRejectsFieldIdInNoSchema() {
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(999)));
+
+    assertThatThrownBy(() -> restrictions.validate(SCHEMA_HISTORY))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknown field ids")
+        .hasMessageContaining("999");
+  }
+
+  @Test
+  public void validateReportsEveryUnknownFieldId() {
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(
+            null, ImmutableList.of(new MaskAlphanum(2), new MaskAlphanum(998), new ShowLast4(999)));
+
+    assertThatThrownBy(() -> restrictions.validate(SCHEMA_HISTORY))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("998")
+        .hasMessageContaining("999");
+  }
+
+  @Test
+  public void validateIgnoresTheRowFilter() {
+    // the row filter still serializes column references by name, so it is not field-id validated
+    // here; reads fail closed on a filter that cannot bind
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(Expressions.equal("no-such-column", "x"), ImmutableList.of());
+
+    assertThatCode(() -> restrictions.validate(SCHEMA_HISTORY)).doesNotThrowAnyException();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/restrictions/TestReadRestrictionsParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/restrictions/TestReadRestrictionsParser.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.restrictions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.functions.IcebergFunction;
+import org.apache.iceberg.functions.MaskAlphanum;
+import org.apache.iceberg.functions.MaskToFixedValue;
+import org.apache.iceberg.functions.ReplaceWithNull;
+import org.apache.iceberg.functions.Sha256Global;
+import org.apache.iceberg.functions.Sha256QueryLocal;
+import org.apache.iceberg.functions.ShowFirst4;
+import org.apache.iceberg.functions.ShowLast4;
+import org.apache.iceberg.functions.TruncateToMonth;
+import org.apache.iceberg.functions.TruncateToYear;
+import org.apache.iceberg.functions.UnknownFunction;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+public class TestReadRestrictionsParser {
+
+  @Test
+  public void emptyRestrictionsRoundTrip() {
+    String json = ReadRestrictionsParser.toJson(ReadRestrictions.empty());
+    ReadRestrictions parsed = ReadRestrictionsParser.fromJson(json);
+    assertThat(parsed.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void emptyObjectParsesAsEmpty() {
+    ReadRestrictions parsed = ReadRestrictionsParser.fromJson("{}");
+    assertThat(parsed.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void rowFilterRoundTrip() {
+    Expression filter = Expressions.equal("country", "US");
+    ReadRestrictions restrictions = ReadRestrictions.of(filter, ImmutableList.of());
+    String json = ReadRestrictionsParser.toJson(restrictions);
+
+    assertThat(json).contains("required-row-filter");
+    assertThat(json).doesNotContain("required-column-projections");
+
+    ReadRestrictions parsed = ReadRestrictionsParser.fromJson(json);
+    assertThat(parsed.rowFilter()).isNotNull();
+    assertThat(parsed.columnProjections()).isEmpty();
+  }
+
+  @Test
+  public void allActionTypesRoundTrip() {
+    List<IcebergFunction<?, ?>> actions =
+        ImmutableList.of(
+            new MaskAlphanum(1),
+            new MaskToFixedValue(2),
+            new ReplaceWithNull(3),
+            new ShowFirst4(4),
+            new ShowLast4(5),
+            new TruncateToYear(6),
+            new TruncateToMonth(7),
+            new Sha256Global(8),
+            new Sha256QueryLocal(9));
+
+    ReadRestrictions restrictions = ReadRestrictions.of(null, actions);
+    String json = ReadRestrictionsParser.toJson(restrictions);
+    ReadRestrictions parsed = ReadRestrictionsParser.fromJson(json);
+
+    assertThat(parsed.columnProjections()).hasSize(actions.size());
+    for (int i = 0; i < actions.size(); i++) {
+      assertThat(parsed.columnProjections().get(i).name()).isEqualTo(actions.get(i).name());
+      assertThat(parsed.columnProjections().get(i).fieldId()).isEqualTo(actions.get(i).fieldId());
+    }
+  }
+
+  @Test
+  public void unknownActionTypePreserved() {
+    // Forward-compat: parsing an unrecognized discriminator must not throw, so older clients
+    // keep interoperating with newer servers. Enforcement code is responsible for failing
+    // closed when it encounters UnknownFunction; silently skipping would leak unmasked data.
+    String json =
+        "{\"required-column-projections\":[{\"action\":\"xxx-not-real\",\"field-id\":1}]}";
+    ReadRestrictions restrictions = ReadRestrictionsParser.fromJson(json);
+    assertThat(restrictions.columnProjections()).hasSize(1);
+    IcebergFunction<?, ?> action = restrictions.columnProjections().get(0);
+    assertThat(action).isInstanceOf(UnknownFunction.class);
+    assertThat(action.name()).isEqualTo("xxx-not-real");
+    assertThat(action.fieldId()).isEqualTo(1);
+  }
+
+  @Test
+  public void missingFieldIdRejected() {
+    String json = "{\"required-column-projections\":[{\"action\":\"mask-alphanum\"}]}";
+    assertThatThrownBy(() -> ReadRestrictionsParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("field-id");
+  }
+
+  @Test
+  public void rowFilterAndProjectionsRoundTrip() {
+    Expression filter =
+        Expressions.and(Expressions.equal("country", "US"), Expressions.greaterThan("amount", 100));
+    List<IcebergFunction<?, ?>> actions =
+        ImmutableList.of(new MaskAlphanum(2), new ReplaceWithNull(3));
+    ReadRestrictions restrictions = ReadRestrictions.of(filter, actions);
+
+    String json = ReadRestrictionsParser.toJson(restrictions);
+    ReadRestrictions parsed = ReadRestrictionsParser.fromJson(json);
+
+    assertThat(parsed.rowFilter()).isNotNull();
+    assertThat(parsed.columnProjections()).hasSize(2);
+    assertThat(parsed.maskedFieldIds()).containsExactlyInAnyOrder(2, 3);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/restrictions/TestReadRestrictionsParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/restrictions/TestReadRestrictionsParser.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionParser;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.functions.IcebergFunction;
 import org.apache.iceberg.functions.MaskAlphanum;
@@ -63,7 +64,8 @@ public class TestReadRestrictionsParser {
     assertThat(json).doesNotContain("required-column-projections");
 
     ReadRestrictions parsed = ReadRestrictionsParser.fromJson(json);
-    assertThat(parsed.rowFilter()).isNotNull();
+    assertThat(ExpressionParser.toJson(parsed.rowFilter()))
+        .isEqualTo(ExpressionParser.toJson(filter));
     assertThat(parsed.columnProjections()).isEmpty();
   }
 
@@ -105,6 +107,19 @@ public class TestReadRestrictionsParser {
     assertThat(action).isInstanceOf(UnknownFunction.class);
     assertThat(action.name()).isEqualTo("xxx-not-real");
     assertThat(action.fieldId()).isEqualTo(1);
+  }
+
+  @Test
+  public void duplicateFieldIdRejected() {
+    // The spec requires the reader to fail when a field id carries more than one projection.
+    String json =
+        "{\"required-column-projections\":["
+            + "{\"action\":\"mask-alphanum\",\"field-id\":2},"
+            + "{\"action\":\"show-last-4\",\"field-id\":2}]}";
+    assertThatThrownBy(() -> ReadRestrictionsParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("duplicate column projections")
+        .hasMessageContaining("2");
   }
 
   @Test

--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -19,12 +19,15 @@
 package org.apache.iceberg.data;
 
 import java.util.Collection;
+import java.util.Optional;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.TableUtil;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
 
 public class IcebergGenerics {
   private IcebergGenerics() {}
@@ -40,10 +43,12 @@ public class IcebergGenerics {
   }
 
   public static class ScanBuilder {
+    private final Table table;
     private TableScan tableScan;
     private boolean reuseContainers = false;
 
     public ScanBuilder(Table table) {
+      this.table = table;
       this.tableScan = table.newScan();
     }
 
@@ -103,7 +108,16 @@ public class IcebergGenerics {
     }
 
     public CloseableIterable<Record> build() {
-      return new TableScanIterable(tableScan, reuseContainers);
+      Optional<ReadRestrictions> restrictions = TableUtil.readRestrictions(table);
+      if (restrictions.isPresent() && restrictions.get().rowFilter() != null) {
+        this.tableScan = tableScan.filter(restrictions.get().rowFilter());
+      }
+
+      CloseableIterable<Record> records = new TableScanIterable(tableScan, reuseContainers);
+      if (restrictions.isPresent()) {
+        records = ReadRestrictionsApplier.apply(records, restrictions.get(), tableScan.schema());
+      }
+      return records;
     }
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/ReadRestrictionsApplier.java
+++ b/data/src/main/java/org/apache/iceberg/data/ReadRestrictionsApplier.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.functions.IcebergFunction;
+import org.apache.iceberg.functions.SaltedFunction;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * Applies server-provided {@link ReadRestrictions} (row filter + column masks) to a stream of
+ * {@link Record}s.
+ *
+ * <p>The row filter is evaluated per-record against the original column values before any mask is
+ * applied, as required by the spec:
+ *
+ * <blockquote>
+ *
+ * Row filters MUST be evaluated against the original, untransformed column values. Required
+ * projections MUST be applied only after row filters are applied.
+ *
+ * </blockquote>
+ *
+ * <p>Callers that also push the row filter into {@link org.apache.iceberg.TableScan#filter} get
+ * partition/stats-level pruning for free; this applier re-evaluates the filter at the row level so
+ * correctness does not depend on whether the surrounding reader honors residual evaluation.
+ *
+ * <p>Currently supports top-level fields only. Masks on nested fieldIds fail closed at bind time so
+ * unmasked nested data cannot leak.
+ */
+class ReadRestrictionsApplier {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+  private static final int SALT_LENGTH = 16;
+
+  private ReadRestrictionsApplier() {}
+
+  static CloseableIterable<Record> apply(
+      CloseableIterable<Record> records, ReadRestrictions restrictions, Schema projection) {
+    CloseableIterable<Record> filtered = filterRows(records, restrictions.rowFilter(), projection);
+    return maskColumns(filtered, restrictions.columnProjections(), projection);
+  }
+
+  private static CloseableIterable<Record> filterRows(
+      CloseableIterable<Record> records, Expression rowFilter, Schema projection) {
+    if (rowFilter == null || rowFilter == Expressions.alwaysTrue()) {
+      return records;
+    }
+
+    Types.StructType struct = projection.asStruct();
+    Evaluator evaluator = new Evaluator(struct, rowFilter, true);
+    InternalRecordWrapper wrapper = new InternalRecordWrapper(struct);
+    return CloseableIterable.filter(records, record -> evaluator.eval(wrapper.wrap(record)));
+  }
+
+  private static CloseableIterable<Record> maskColumns(
+      CloseableIterable<Record> records, List<IcebergFunction<?, ?>> actions, Schema projection) {
+    if (actions.isEmpty()) {
+      return records;
+    }
+
+    Map<String, SerializableFunction<Object, Object>> masksByName = bindMasks(actions, projection);
+    return CloseableIterable.transform(records, record -> mask(record, masksByName));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, SerializableFunction<Object, Object>> bindMasks(
+      List<IcebergFunction<?, ?>> actions, Schema projection) {
+    ImmutableMap.Builder<String, SerializableFunction<Object, Object>> builder =
+        ImmutableMap.builder();
+    byte[] querySalt = null;
+    List<Types.NestedField> topLevelFields = projection.asStruct().fields();
+
+    for (IcebergFunction<?, ?> action : actions) {
+      int fieldId = action.fieldId();
+      Types.NestedField field = findTopLevel(topLevelFields, fieldId);
+      if (field == null) {
+        // Fail closed: nested masks, unknown fieldIds, or fields projected away all reach here.
+        // Skipping them silently would either leak unmasked values (nested case) or surprise the
+        // caller (typo case). The latter is acceptable noise since this surfaces at bind time.
+        String path = projection.findColumnName(fieldId);
+        if (path == null) {
+          throw new IllegalStateException(
+              "ReadRestrictions references unknown field id: " + fieldId);
+        }
+        throw new IllegalStateException(
+            "ReadRestrictions on nested fields are not yet supported "
+                + "(fieldId="
+                + fieldId
+                + ", path='"
+                + path
+                + "')");
+      }
+
+      SerializableFunction<Object, Object> bound;
+      if (action instanceof SaltedFunction) {
+        if (querySalt == null) {
+          querySalt = new byte[SALT_LENGTH];
+          RANDOM.nextBytes(querySalt);
+        }
+        bound =
+            (SerializableFunction<Object, Object>)
+                ((SaltedFunction<?, ?>) action).bind(field.type(), querySalt);
+      } else {
+        bound = (SerializableFunction<Object, Object>) action.bind(field.type());
+      }
+      builder.put(field.name(), bound);
+    }
+
+    return builder.build();
+  }
+
+  private static Types.NestedField findTopLevel(List<Types.NestedField> fields, int fieldId) {
+    for (Types.NestedField field : fields) {
+      if (field.fieldId() == fieldId) {
+        return field;
+      }
+    }
+    return null;
+  }
+
+  private static Record mask(
+      Record record, Map<String, SerializableFunction<Object, Object>> masksByName) {
+    GenericRecord out = GenericRecord.create(record.struct());
+    for (int i = 0; i < record.size(); i++) {
+      out.set(i, record.get(i, Object.class));
+    }
+    for (Map.Entry<String, SerializableFunction<Object, Object>> entry : masksByName.entrySet()) {
+      Object original = out.getField(entry.getKey());
+      Object masked = entry.getValue().apply(original);
+      out.setField(entry.getKey(), masked);
+    }
+    return out;
+  }
+}

--- a/data/src/main/java/org/apache/iceberg/data/ReadRestrictionsApplier.java
+++ b/data/src/main/java/org/apache/iceberg/data/ReadRestrictionsApplier.java
@@ -24,10 +24,11 @@ import java.util.Map;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.functions.IcebergFunction;
+import org.apache.iceberg.functions.ReplaceWithNull;
 import org.apache.iceberg.functions.SaltedFunction;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.restrictions.ReadRestrictions;
 import org.apache.iceberg.types.Types;
@@ -53,6 +54,15 @@ import org.apache.iceberg.util.SerializableFunction;
  *
  * <p>Currently supports top-level fields only. Masks on nested fieldIds fail closed at bind time so
  * unmasked nested data cannot leak.
+ *
+ * <p>Projections for columns that are not being read are skipped, as required by the spec:
+ *
+ * <blockquote>
+ *
+ * A reader must enforce projections on the columns it is actually reading. Projections referencing
+ * columns that are not being read do not apply.
+ *
+ * </blockquote>
  */
 class ReadRestrictionsApplier {
 
@@ -69,7 +79,7 @@ class ReadRestrictionsApplier {
 
   private static CloseableIterable<Record> filterRows(
       CloseableIterable<Record> records, Expression rowFilter, Schema projection) {
-    if (rowFilter == null || rowFilter == Expressions.alwaysTrue()) {
+    if (rowFilter == null || rowFilter.op() == Expression.Operation.TRUE) {
       return records;
     }
 
@@ -86,6 +96,10 @@ class ReadRestrictionsApplier {
     }
 
     Map<String, SerializableFunction<Object, Object>> masksByName = bindMasks(actions, projection);
+    if (masksByName.isEmpty()) {
+      return records;
+    }
+
     return CloseableIterable.transform(records, record -> mask(record, masksByName));
   }
 
@@ -95,27 +109,35 @@ class ReadRestrictionsApplier {
     ImmutableMap.Builder<String, SerializableFunction<Object, Object>> builder =
         ImmutableMap.builder();
     byte[] querySalt = null;
-    List<Types.NestedField> topLevelFields = projection.asStruct().fields();
 
     for (IcebergFunction<?, ?> action : actions) {
       int fieldId = action.fieldId();
-      Types.NestedField field = findTopLevel(topLevelFields, fieldId);
+      Types.NestedField field = projection.asStruct().field(fieldId);
       if (field == null) {
-        // Fail closed: nested masks, unknown fieldIds, or fields projected away all reach here.
-        // Skipping them silently would either leak unmasked values (nested case) or surprise the
-        // caller (typo case). The latter is acceptable noise since this surfaces at bind time.
-        String path = projection.findColumnName(fieldId);
-        if (path == null) {
-          throw new IllegalStateException(
-              "ReadRestrictions references unknown field id: " + fieldId);
-        }
-        throw new IllegalStateException(
-            "ReadRestrictions on nested fields are not yet supported "
-                + "(fieldId="
-                + fieldId
-                + ", path='"
-                + path
-                + "')");
+        // A fieldId that resolves inside the projection but is not top-level is nested. Fail
+        // closed so unmasked nested values cannot leak.
+        String nestedPath = projection.findColumnName(fieldId);
+        Preconditions.checkState(
+            nestedPath == null,
+            "ReadRestrictions on nested fields are not yet supported (fieldId=%s, path='%s')",
+            fieldId,
+            nestedPath);
+
+        // The column is not being read. Per spec, projections referencing columns that are not
+        // being read do not apply. Field ids are validated against the table's schemas when the
+        // restrictions are attached to it (ReadRestrictions#validate), so reaching here means the
+        // column exists and was projected away rather than being unknown.
+        continue;
+      }
+
+      // ReplaceWithNull cannot check nullability itself because Type does not carry the field's
+      // required/optional flag, so the caller must reject required fields.
+      if (action instanceof ReplaceWithNull) {
+        Preconditions.checkState(
+            field.isOptional(),
+            "Cannot apply replace-with-null to required field: %s (fieldId=%s)",
+            field.name(),
+            fieldId);
       }
 
       SerializableFunction<Object, Object> bound;
@@ -134,15 +156,6 @@ class ReadRestrictionsApplier {
     }
 
     return builder.build();
-  }
-
-  private static Types.NestedField findTopLevel(List<Types.NestedField> fields, int fieldId) {
-    for (Types.NestedField field : fields) {
-      if (field.fieldId() == fieldId) {
-        return field;
-      }
-    }
-    return null;
   }
 
   private static Record mask(

--- a/data/src/test/java/org/apache/iceberg/data/TestReadRestrictionsApplier.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadRestrictionsApplier.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.functions.MaskAlphanum;
+import org.apache.iceberg.functions.ShowLast4;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestReadRestrictionsApplier {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(2, "email", Types.StringType.get()),
+          optional(3, "ssn", Types.StringType.get()));
+
+  private static final Record TEMPLATE = GenericRecord.create(SCHEMA);
+
+  @Test
+  public void testNoActionsReturnsInputUnchanged() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(
+            ImmutableList.of(TEMPLATE.copy(ImmutableMap.of("id", 1L, "email", "a@b.com"))));
+
+    CloseableIterable<Record> out =
+        ReadRestrictionsApplier.apply(input, ReadRestrictions.empty(), SCHEMA);
+
+    assertThat(out).isSameAs(input);
+  }
+
+  @Test
+  public void testMaskAlphanumRewritesEmailField() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(
+            ImmutableList.of(
+                TEMPLATE.copy(ImmutableMap.of("id", 1L, "email", "alice@example.com")),
+                TEMPLATE.copy(ImmutableMap.of("id", 2L, "email", "bob123@example.com"))));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(2)));
+
+    List<Record> result =
+        Lists.newArrayList(ReadRestrictionsApplier.apply(input, restrictions, SCHEMA));
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getField("id")).isEqualTo(1L);
+    assertThat(result.get(0).getField("email")).isEqualTo("xxxxx@xxxxxxx.xxx");
+    assertThat(result.get(1).getField("email")).isEqualTo("xxxnnn@xxxxxxx.xxx");
+  }
+
+  @Test
+  public void testMultipleMasksApplyIndependently() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(
+            ImmutableList.of(
+                TEMPLATE.copy(
+                    ImmutableMap.of(
+                        "id", 42L, "email", "alice@example.com", "ssn", "123-45-6789"))));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(2), new ShowLast4(3)));
+
+    List<Record> result =
+        Lists.newArrayList(ReadRestrictionsApplier.apply(input, restrictions, SCHEMA));
+
+    assertThat(result.get(0).getField("id")).isEqualTo(42L);
+    assertThat(result.get(0).getField("email")).isEqualTo("xxxxx@xxxxxxx.xxx");
+    assertThat(result.get(0).getField("ssn")).isEqualTo("nnn-nn-6789");
+  }
+
+  @Test
+  public void testNullValuesPassThroughAsNull() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(ImmutableList.of(TEMPLATE.copy(ImmutableMap.of("id", 1L))));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(2)));
+
+    List<Record> result =
+        Lists.newArrayList(ReadRestrictionsApplier.apply(input, restrictions, SCHEMA));
+
+    assertThat(result.get(0).getField("email")).isNull();
+  }
+
+  @Test
+  public void testUnknownFieldIdFailsClosed() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(ImmutableList.of(TEMPLATE.copy()));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(999)));
+
+    assertThatThrownBy(() -> ReadRestrictionsApplier.apply(input, restrictions, SCHEMA))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("unknown field id: 999");
+  }
+
+  @Test
+  public void testNestedFieldIdFailsClosed() {
+    Schema nested =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(
+                2, "contact", Types.StructType.of(optional(3, "email", Types.StringType.get()))));
+
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(ImmutableList.of(GenericRecord.create(nested)));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(3)));
+
+    assertThatThrownBy(() -> ReadRestrictionsApplier.apply(input, restrictions, nested))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("nested fields are not yet supported")
+        .hasMessageContaining("fieldId=3");
+  }
+
+  @Test
+  public void testRowFilterDropsNonMatchingRows() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(
+            ImmutableList.of(
+                TEMPLATE.copy(ImmutableMap.of("id", 1L, "email", "a@b.com")),
+                TEMPLATE.copy(ImmutableMap.of("id", 2L, "email", "c@d.com")),
+                TEMPLATE.copy(ImmutableMap.of("id", 3L, "email", "e@f.com"))));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(Expressions.greaterThan("id", 1L), ImmutableList.of());
+
+    List<Record> result =
+        Lists.newArrayList(ReadRestrictionsApplier.apply(input, restrictions, SCHEMA));
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getField("id")).isEqualTo(2L);
+    assertThat(result.get(1).getField("id")).isEqualTo(3L);
+  }
+
+  @Test
+  public void testRowFilterSeesOriginalValuesBeforeMasks() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(
+            ImmutableList.of(
+                TEMPLATE.copy(ImmutableMap.of("id", 1L, "email", "keep@example.com")),
+                TEMPLATE.copy(ImmutableMap.of("id", 2L, "email", "drop@example.com"))));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(
+            Expressions.equal("email", "keep@example.com"), ImmutableList.of(new MaskAlphanum(2)));
+
+    List<Record> result =
+        Lists.newArrayList(ReadRestrictionsApplier.apply(input, restrictions, SCHEMA));
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getField("id")).isEqualTo(1L);
+    assertThat(result.get(0).getField("email")).isEqualTo("xxxx@xxxxxxx.xxx");
+  }
+
+  @Test
+  public void testNullRowFilterSkipsFilterStep() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(
+            ImmutableList.of(
+                TEMPLATE.copy(ImmutableMap.of("id", 1L)),
+                TEMPLATE.copy(ImmutableMap.of("id", 2L))));
+
+    ReadRestrictions restrictions = ReadRestrictions.of(null, ImmutableList.of());
+
+    List<Record> result =
+        Lists.newArrayList(ReadRestrictionsApplier.apply(input, restrictions, SCHEMA));
+
+    assertThat(result).hasSize(2);
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/data/TestReadRestrictionsApplier.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadRestrictionsApplier.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.functions.MaskAlphanum;
+import org.apache.iceberg.functions.ReplaceWithNull;
 import org.apache.iceberg.functions.ShowLast4;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -113,19 +114,6 @@ public class TestReadRestrictionsApplier {
   }
 
   @Test
-  public void testUnknownFieldIdFailsClosed() {
-    CloseableIterable<Record> input =
-        CloseableIterable.withNoopClose(ImmutableList.of(TEMPLATE.copy()));
-
-    ReadRestrictions restrictions =
-        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(999)));
-
-    assertThatThrownBy(() -> ReadRestrictionsApplier.apply(input, restrictions, SCHEMA))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("unknown field id: 999");
-  }
-
-  @Test
   public void testNestedFieldIdFailsClosed() {
     Schema nested =
         new Schema(
@@ -143,6 +131,39 @@ public class TestReadRestrictionsApplier {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("nested fields are not yet supported")
         .hasMessageContaining("fieldId=3");
+  }
+
+  @Test
+  public void testProjectionForUnreadColumnIsSkipped() {
+    Schema projection = SCHEMA.select("id");
+    Record template = GenericRecord.create(projection);
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(
+            ImmutableList.of(
+                template.copy(ImmutableMap.of("id", 1L)),
+                template.copy(ImmutableMap.of("id", 2L))));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(2)));
+
+    CloseableIterable<Record> out = ReadRestrictionsApplier.apply(input, restrictions, projection);
+
+    // email is not being read, so the projection does not apply and no masking wrapper is added
+    assertThat(out).isSameAs(input);
+  }
+
+  @Test
+  public void testReplaceWithNullOnRequiredFieldFailsClosed() {
+    CloseableIterable<Record> input =
+        CloseableIterable.withNoopClose(ImmutableList.of(TEMPLATE.copy()));
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new ReplaceWithNull(1)));
+
+    assertThatThrownBy(() -> ReadRestrictionsApplier.apply(input, restrictions, SCHEMA))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("replace-with-null")
+        .hasMessageContaining("required field: id");
   }
 
   @Test

--- a/data/src/test/java/org/apache/iceberg/data/TestReadRestrictionsEndToEnd.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadRestrictionsEndToEnd.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.functions.MaskAlphanum;
+import org.apache.iceberg.functions.UnknownFunction;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponseParser;
+import org.apache.iceberg.rest.restrictions.ReadRestrictions;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage for read restrictions: a REST server attaches {@link ReadRestrictions} to
+ * loadTable, the response crosses the wire as JSON, and the generic reader enforces them.
+ *
+ * <p>The unit tests in {@code TestReadRestrictionsApplier} cover the applier in isolation. This
+ * test exists because every failure mode in the surrounding plumbing is fail-open: if restrictions
+ * are dropped anywhere between the response and the reader, queries silently return unmasked rows
+ * rather than failing. Each test below asserts on the records a caller actually receives.
+ */
+public class TestReadRestrictionsEndToEnd {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(2, "email", Types.StringType.get()),
+          optional(3, "country", Types.StringType.get()));
+
+  private static final Namespace NAMESPACE = Namespace.of("restrictions");
+  private static final TableIdentifier TABLE_IDENT = TableIdentifier.of(NAMESPACE, "events");
+
+  private static final Record TEMPLATE = GenericRecord.create(SCHEMA);
+
+  private static final List<Record> ROWS =
+      ImmutableList.of(
+          TEMPLATE.copy(ImmutableMap.of("id", 1L, "email", "alice@example.com", "country", "US")),
+          TEMPLATE.copy(ImmutableMap.of("id", 2L, "email", "bob@example.com", "country", "CA")),
+          TEMPLATE.copy(ImmutableMap.of("id", 3L, "email", "carol@example.com", "country", "US")));
+
+  private static InMemoryCatalog backend;
+
+  @BeforeAll
+  public static void createBackendTable() throws IOException {
+    // read-only tests share one table; only the restrictions attached to loadTable differ. A test
+    // that evolves the schema creates its own table so it cannot disturb the others, since JUnit
+    // does not guarantee execution order.
+    backend = new InMemoryCatalog();
+    backend.initialize(
+        "backend", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, "memory://warehouse"));
+    backend.createNamespace(NAMESPACE);
+    createTableWithRows(TABLE_IDENT);
+  }
+
+  private static Table createTableWithRows(TableIdentifier identifier) throws IOException {
+    Table table = backend.createTable(identifier, SCHEMA);
+    OutputFile out = table.io().newOutputFile(table.location() + "/data/" + UUID.randomUUID());
+    table.newAppend().appendFile(FileHelpers.writeDataFile(table, out, ROWS)).commit();
+    return table;
+  }
+
+  @Test
+  public void masksAreEnforcedThroughTheRestCatalog() throws IOException {
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(2)));
+
+    try (RESTCatalog catalog = restCatalogReturning(restrictions)) {
+      List<Record> records = readAll(catalog.loadTable(TABLE_IDENT));
+
+      assertThat(records)
+          .extracting(record -> record.getField("id"), record -> record.getField("email"))
+          .containsExactlyInAnyOrder(
+              tuple(1L, "xxxxx@xxxxxxx.xxx"),
+              tuple(2L, "xxx@xxxxxxx.xxx"),
+              tuple(3L, "xxxxx@xxxxxxx.xxx"));
+    }
+  }
+
+  @Test
+  public void rowFilterIsEnforcedThroughTheRestCatalog() throws IOException {
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(Expressions.equal("country", "US"), ImmutableList.of());
+
+    try (RESTCatalog catalog = restCatalogReturning(restrictions)) {
+      List<Record> records = readAll(catalog.loadTable(TABLE_IDENT));
+
+      assertThat(records)
+          .extracting(record -> record.getField("id"))
+          .containsExactlyInAnyOrder(1L, 3L);
+    }
+  }
+
+  @Test
+  public void rowFilterIsEvaluatedOnOriginalValuesBeforeMasksApply() throws IOException {
+    // If the mask ran first, "alice@example.com" would already be masked and the filter would
+    // match nothing.
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(
+            Expressions.equal("email", "alice@example.com"), ImmutableList.of(new MaskAlphanum(2)));
+
+    try (RESTCatalog catalog = restCatalogReturning(restrictions)) {
+      List<Record> records = readAll(catalog.loadTable(TABLE_IDENT));
+
+      assertThat(records)
+          .extracting(record -> record.getField("id"), record -> record.getField("email"))
+          .containsExactly(tuple(1L, "xxxxx@xxxxxxx.xxx"));
+    }
+  }
+
+  @Test
+  public void projectionForAColumnThatIsNotReadDoesNotFailTheScan() throws IOException {
+    // Per spec, projections referencing columns that are not being read do not apply, so selecting
+    // only "id" must succeed even though the server masks "email".
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(2)));
+
+    try (RESTCatalog catalog = restCatalogReturning(restrictions)) {
+      List<Record> records =
+          Lists.newArrayList(
+              IcebergGenerics.read(catalog.loadTable(TABLE_IDENT)).select("id").build());
+
+      assertThat(records)
+          .extracting(record -> record.getField("id"))
+          .containsExactlyInAnyOrder(1L, 2L, 3L);
+    }
+  }
+
+  @Test
+  public void unrecognizedActionFailsClosedRatherThanReturningRawValues() throws IOException {
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new UnknownFunction(2, "xxx-not-real")));
+
+    try (RESTCatalog catalog = restCatalogReturning(restrictions)) {
+      Table table = catalog.loadTable(TABLE_IDENT);
+
+      assertThatThrownBy(() -> IcebergGenerics.read(table).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Cannot bind unknown function 'xxx-not-real'");
+    }
+  }
+
+  @Test
+  public void loadTableFailsWhenAProjectionNamesAFieldIdTheTableNeverHad() throws IOException {
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(999)));
+
+    try (RESTCatalog catalog = restCatalogReturning(restrictions)) {
+      // validated where the restrictions are attached to the table, so this fails at load rather
+      // than surfacing later as a skipped projection
+      assertThatThrownBy(() -> catalog.loadTable(TABLE_IDENT))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("unknown field ids")
+          .hasMessageContaining("999");
+    }
+  }
+
+  @Test
+  public void loadTableSucceedsWhenAProjectionNamesASinceDroppedColumn() throws IOException {
+    // own table: dropping a column here must not affect the tests sharing the fixture
+    TableIdentifier evolved = TableIdentifier.of(NAMESPACE, "evolved");
+    createTableWithRows(evolved).updateSchema().deleteColumn("country").commit();
+
+    ReadRestrictions restrictions =
+        ReadRestrictions.of(null, ImmutableList.of(new MaskAlphanum(3)));
+
+    try (RESTCatalog catalog = restCatalogReturning(restrictions)) {
+      // field 3 is real, just absent from the current schema, so the table still loads
+      Table table = catalog.loadTable(evolved);
+
+      assertThat(readAll(table)).hasSize(3);
+    }
+  }
+
+  /**
+   * Builds a REST catalog whose loadTable response carries the given restrictions. The rewritten
+   * response is round-tripped through JSON so the wire format is exercised too, not just the
+   * in-memory objects.
+   */
+  private RESTCatalog restCatalogReturning(ReadRestrictions restrictions) {
+    RESTClient client =
+        new RESTCatalogAdapter(backend) {
+          @Override
+          public <T extends RESTResponse> T execute(
+              HTTPRequest request,
+              Class<T> responseType,
+              Consumer<ErrorResponse> errorHandler,
+              Consumer<Map<String, String>> responseHeaders) {
+            T response = super.execute(request, responseType, errorHandler, responseHeaders);
+            if (!(response instanceof LoadTableResponse)) {
+              return response;
+            }
+
+            LoadTableResponse loaded = (LoadTableResponse) response;
+            LoadTableResponse withRestrictions =
+                LoadTableResponse.builder()
+                    .withTableMetadata(loaded.tableMetadata())
+                    .addAllConfig(loaded.config())
+                    .addAllCredentials(loaded.credentials())
+                    .withReadRestrictions(restrictions)
+                    .build();
+
+            return castResponse(
+                responseType,
+                LoadTableResponseParser.fromJson(LoadTableResponseParser.toJson(withRestrictions)));
+          }
+        };
+
+    RESTCatalog catalog = new RESTCatalog(config -> client);
+    catalog.initialize(
+        "rest", ImmutableMap.of(CatalogProperties.FILE_IO_IMPL, InMemoryFileIO.class.getName()));
+    return catalog;
+  }
+
+  private static List<Record> readAll(Table table) {
+    return Lists.newArrayList(IcebergGenerics.read(table).build());
+  }
+}


### PR DESCRIPTION
**Based on**

- #16198 (feature/add-action-to-core) — direct dependency, its tip is an ancestor of this branch. It contributes the 16 files under api/ (the IcebergFunction masking actions). Review only the 17 files under core/ and data/ here; the api/ files leave this diff once #16198 merges.
- #13879 — the spec this implements. Reference only; no shared code.

**Review order: #13879 → #16198 → this.**

**What this PR does**

Implements client-side enforcement of the ReadRestrictions (per-principal column masking and row filtering) that a REST catalog may attach to a loadTable response.

**core**
- ReadRestrictions plus ReadRestrictionsParser / ActionParser for the wire format.
- read-restrictions field on LoadTableResponse and its parser.
- SupportsReadRestrictions capability interface; RESTSessionCatalog attaches restrictions to BaseRESTTable / RESTTable. Non-REST catalogs don't advertise it. TableUtil.readRestrictions(Table) is the uniform accessor.
- Validates projection field ids when restrictions are attached to a table, against every schema the table has had.

**data**
- ReadRestrictionsApplier applies the row filter and column masks to a Record stream; IcebergGenerics invokes it.
- Row filter is evaluated against original values before masks apply, and re-evaluated per record so correctness doesn't depend on residual handling upstream.
- Fails closed on anything it can't apply: nested-field masks, unrecognized actions, duplicate field ids, replace-with-null on a required field.
- Masks apply only to columns actually being read.

Notes for reviewers

- Field-id validation happens at load, so a policy naming a nonexistent field id makes the table unloadable rather than only failing reads — stricter than the spec's "must fail any read against the loaded table".
- TestReadRestrictionsEndToEnd lives in data but drives RESTSessionCatalog, since the seam under test spans both modules.