### PR TITLE
Hive: add HiveCatalog(Configuration, Map<String, String>) convenience constructor

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -100,6 +100,19 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
 
   public HiveCatalog() {}
 
+  /**
+   * Convenience constructor that uses the passed configuration and properties to initialize the
+   * catalog under the name {@code "hive"}, equivalent to calling {@link #setConf(Configuration)}
+   * followed by {@link #initialize(String, Map)}.
+   *
+   * @param conf The Hadoop configuration
+   * @param properties The catalog properties
+   */
+  public HiveCatalog(Configuration conf, Map<String, String> properties) {
+    setConf(conf);
+    initialize("hive", properties);
+  }
+
   @Override
   public void initialize(String inputName, Map<String, String> properties) {
     this.catalogProperties = ImmutableMap.copyOf(properties);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -113,6 +113,12 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
     initialize("hive", properties);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When instantiating {@code HiveCatalog} directly, prefer {@link #HiveCatalog(Configuration,
+   * Map)}, which combines {@code setConf(...)} and this call.
+   */
   @Override
   public void initialize(String inputName, Map<String, String> properties) {
     this.catalogProperties = ImmutableMap.copyOf(properties);
@@ -829,6 +835,12 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
         .toString();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When instantiating {@code HiveCatalog} directly, prefer {@link #HiveCatalog(Configuration,
+   * Map)}, which combines this call and {@code initialize(...)}.
+   */
   @Override
   public void setConf(Configuration conf) {
     this.conf = new Configuration(conf);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -287,6 +287,23 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
   }
 
   @Test
+  public void testConstructorWithConfAndProperties() {
+    Configuration conf = new Configuration();
+    conf.set("custom.caller.key", "custom-value");
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("uri", "thrift://examplehost:9083");
+    properties.put("warehouse", "/user/hive/testwarehouse");
+
+    HiveCatalog hiveCatalog = new HiveCatalog(conf, properties);
+
+    assertThat(hiveCatalog.getConf().get("hive.metastore.uris"))
+        .isEqualTo("thrift://examplehost:9083");
+    assertThat(hiveCatalog.getConf().get("hive.metastore.warehouse.dir"))
+        .isEqualTo("/user/hive/testwarehouse");
+    assertThat(hiveCatalog.getConf().get("custom.caller.key")).isEqualTo("custom-value");
+  }
+
+  @Test
   public void testCreateTableTxnBuilder() throws Exception {
     Schema schema = getTestSchema();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");


### PR DESCRIPTION
Closes #16134.

`HiveCatalog.initialize(name, properties)` reads URI/warehouse from the property map and HMS/Hadoop settings from the `Configuration`. Callers that have both populated currently need the two-step `setConf(conf); initialize(name, properties)` dance.

This adds a convenience constructor mirroring [`HadoopCatalog(Configuration, String)`](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java#L137-L140), accepting a property map since `HiveCatalog` reads more than one key:

```java
public HiveCatalog(Configuration conf, Map<String, String> properties) {
  setConf(conf);
  initialize("hive", properties);
}
```

`testConstructorWithConfAndProperties` in `TestHiveCatalog` covers the property-to-conf propagation and verifies caller-provided Configuration entries are preserved.

Surfaced in apache/hive#6454.