### PR TITLE
Flink sink fix

### DIFF
--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -486,7 +486,7 @@ We need the following information (DynamicRecord) for every record:
 | `DistributionMode` | The distribution mode for writing the record (NONE, HASH or `null`). When `null`, the record won't be shuffled at all. |
 | `Parallelism`      | The maximum number of parallel writers for a given table/branch/schema/spec (WriteTarget). |
 | `UpsertMode`       | Overrides this table's write.upsert.enabled (optional).                                   |
-| `EqualityFields`   | The equality fields for the table(optional).                                                        |
+| `EqualityFields`   | The equality fields for the table (optional). When unset, the dynamic sink falls back to the schema's identifier fields for both distribution (records sharing a key route to the same writer) and equality-delete inference. Identifier fields do not auto-enable upsert mode — that flag remains opt-in. |
 
 ### Schema Evolution
 

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -555,7 +555,7 @@ The `DistributionMode` set on each `DynamicRecord` controls how that record is r
 |--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `NONE` | Records are distributed across writer subtasks in a round-robin fashion (or by equality fields if set).                                                                                      |
 | `HASH` | Records are distributed by partition key (partitioned tables) or equality fields (unpartitioned tables). Ensures that records for the same partition are handled by the same writer subtask. |
-| `null` | Forward mode: bypasses distribution entirely and sends records directly via a forward edge (see below).                                                                                      |
+| `null` | Forward mode: bypasses distribution entirely and sends records directly via a forward edge (see below). Ignored when the record resolves to non-empty equality fields (see warning below).   |
 
 #### Forward Mode
 
@@ -570,6 +570,7 @@ Forward and regular records can be mixed in the same pipeline. The processor rou
 
 1. In the forward path, schema changes are always applied immediately because records must pass straight through via the forward edge. For the intended high-volume use case, this can cause many conflicting commits to the Iceberg catalog and temporarily delay data processing. Consider either updating the schema externally before publishing records with the new schema, or planning for a temporary disruption in throughput when a new schema is introduced from upstream.
 2. Because the forward path skips distribution entirely, users are responsible for distributing the data correctly in the upstream before the records reach the dynamic Iceberg sink. Otherwise, writes could be unbalanced.
+3. Forward mode does not apply to records that resolve to a non-empty equality-field set — either because `EqualityFields` is set or because the schema declares identifier fields. Such records are always hash-distributed by those fields (as in `HASH` mode) so that rows sharing a key reach the same writer subtask; without that guarantee, data and equality deletes can be emitted by multiple writers at once without cancelling each other out, leading to duplicated data.
 
 ### Notes
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
@@ -67,7 +67,10 @@ public class DynamicRecord {
    * @param rowData The data matching the provided schema.
    * @param partitionSpec The target table {@link PartitionSpec}.
    * @param distributionMode The {@link DistributionMode}. {@code null} indicates forward (no
-   *     shuffle) writes.
+   *     shuffle) writes. Ignored when the record resolves to a non-empty equality-field set (either
+   *     {@code equalityFields} is set, or the schema declares identifier fields): such records are
+   *     always hash-distributed by those fields so that rows sharing a key reach the same writer
+   *     subtask, which is required for equality-delete correctness.
    * @param writeParallelism The number of parallel writers. Can be set to any value {@literal > 0},
    *     but will always be automatically capped by the maximum write parallelism, which is the
    *     parallelism of the sink. Set to Integer.MAX_VALUE for always using the maximum available

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -120,14 +120,7 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
 
   @Override
   public void collect(DynamicRecord data) {
-    // Forward mode is incompatible with equality fields: records sharing the same equality key must
-    // land on the same writer subtask to preserve equality-delete semantics. Fall back to hash
-    // distribution by equality fields whenever the record resolves to a non-empty equality-field
-    // set (user-supplied or inferred from the schema's identifier fields).
-    boolean isForward =
-        data.distributionMode() == null
-            && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
-                .isEmpty();
+    boolean isForward = isForwardEligible(data);
 
     boolean exists = tableCache.exists(data.tableIdentifier()).f0;
     String foundBranch = exists ? tableCache.branch(data.tableIdentifier(), data.branch()) : null;
@@ -222,5 +215,17 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Forward mode is incompatible with equality fields: records sharing the same equality key must
+   * land on the same writer subtask to preserve equality-delete semantics. A record can only take
+   * the forward path when the user requested it (null distribution mode) and the record resolves to
+   * an empty equality-field set (no user-supplied set and no schema identifier fields).
+   */
+  private static boolean isForwardEligible(DynamicRecord data) {
+    return data.distributionMode() == null
+        && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
+            .isEmpty();
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -120,7 +120,14 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
 
   @Override
   public void collect(DynamicRecord data) {
-    boolean isForward = data.distributionMode() == null;
+    // Forward mode is incompatible with equality fields: records sharing the same equality key must
+    // land on the same writer subtask to preserve equality-delete semantics. Fall back to hash
+    // distribution by equality fields whenever the record resolves to a non-empty equality-field
+    // set (user-supplied or inferred from the schema's identifier fields).
+    boolean isForward =
+        data.distributionMode() == null
+            && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
+                .isEmpty();
 
     boolean exists = tableCache.exists(data.tableIdentifier()).f0;
     String foundBranch = exists ? tableCache.branch(data.tableIdentifier(), data.branch()) : null;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.Collections;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -47,6 +48,20 @@ class DynamicSinkUtil {
     }
 
     return equalityFieldIds;
+  }
+
+  /**
+   * Resolves the effective equality field names. Returns the user-supplied set when non-empty,
+   * otherwise falls back to the names of {@link Schema#identifierFieldIds()}. Mirrors {@link
+   * #getEqualityFieldIds} so distribution and write-side equality-field inference stay aligned.
+   */
+  static Set<String> resolveEqualityFieldNames(
+      @Nullable Set<String> equalityFields, Schema schema) {
+    if (equalityFields != null && !equalityFields.isEmpty()) {
+      return equalityFields;
+    }
+
+    return schema.identifierFieldNames();
   }
 
   static int safeAbs(int input) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -79,6 +78,9 @@ class HashKeyGenerator {
       @Nullable PartitionSpec tableSpec,
       @Nullable RowData overrideRowData) {
     String tableIdent = dynamicRecord.tableIdentifier().toString();
+    Schema effectiveSchema = MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema());
+    Set<String> effectiveEqualityFields =
+        DynamicSinkUtil.resolveEqualityFieldNames(dynamicRecord.equalityFields(), effectiveSchema);
     SelectorKey cacheKey =
         new SelectorKey(
             tableIdent,
@@ -87,7 +89,7 @@ class HashKeyGenerator {
             tableSpec != null ? tableSpec.specId() : null,
             dynamicRecord.schema(),
             dynamicRecord.spec(),
-            dynamicRecord.equalityFields(),
+            effectiveEqualityFields,
             MoreObjects.firstNonNull(dynamicRecord.distributionMode(), DistributionMode.NONE),
             Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism));
     KeySelector<RowData, Integer> keySelector =
@@ -96,12 +98,11 @@ class HashKeyGenerator {
             k ->
                 getKeySelector(
                     tableIdent,
-                    MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema()),
+                    effectiveSchema,
                     MoreObjects.firstNonNull(tableSpec, dynamicRecord.spec()),
                     MoreObjects.firstNonNull(
                         dynamicRecord.distributionMode(), DistributionMode.NONE),
-                    MoreObjects.firstNonNull(
-                        dynamicRecord.equalityFields(), Collections.emptySet()),
+                    effectiveEqualityFields,
                     Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism)));
     try {
       return keySelector.getKey(

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -256,6 +257,60 @@ class TestHashKeyGenerator {
                 .distinct()
                 .count())
         .isEqualTo(maxWriteParallelism);
+  }
+
+  @Test
+  void testIdentifierFieldsResolvedAsEqualityFields() throws Exception {
+    int writeParallelism = 2;
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
+
+    Schema schemaWithIdentifier =
+        new Schema(
+            Lists.newArrayList(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                Types.NestedField.required(2, "data", Types.StringType.get())),
+            Sets.newHashSet(1));
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    GenericRowData row1 = GenericRowData.of(1, StringData.fromString("foo"));
+    GenericRowData row2 = GenericRowData.of(1, StringData.fromString("bar"));
+    GenericRowData row3 = GenericRowData.of(2, StringData.fromString("baz"));
+
+    DynamicRecord record1 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row1,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+    DynamicRecord record2 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row2,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+    DynamicRecord record3 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row3,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+
+    int writeKey1 = generator.generateKey(record1);
+    int writeKey2 = generator.generateKey(record2);
+    int writeKey3 = generator.generateKey(record3);
+
+    assertThat(writeKey1).isEqualTo(writeKey2);
+    assertThat(writeKey3).isNotEqualTo(writeKey1);
   }
 
   @Test

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
@@ -67,7 +67,10 @@ public class DynamicRecord {
    * @param rowData The data matching the provided schema.
    * @param partitionSpec The target table {@link PartitionSpec}.
    * @param distributionMode The {@link DistributionMode}. {@code null} indicates forward (no
-   *     shuffle) writes.
+   *     shuffle) writes. Ignored when the record resolves to a non-empty equality-field set (either
+   *     {@code equalityFields} is set, or the schema declares identifier fields): such records are
+   *     always hash-distributed by those fields so that rows sharing a key reach the same writer
+   *     subtask, which is required for equality-delete correctness.
    * @param writeParallelism The number of parallel writers. Can be set to any value {@literal > 0},
    *     but will always be automatically capped by the maximum write parallelism, which is the
    *     parallelism of the sink. Set to Integer.MAX_VALUE for always using the maximum available

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -120,14 +120,7 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
 
   @Override
   public void collect(DynamicRecord data) {
-    // Forward mode is incompatible with equality fields: records sharing the same equality key must
-    // land on the same writer subtask to preserve equality-delete semantics. Fall back to hash
-    // distribution by equality fields whenever the record resolves to a non-empty equality-field
-    // set (user-supplied or inferred from the schema's identifier fields).
-    boolean isForward =
-        data.distributionMode() == null
-            && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
-                .isEmpty();
+    boolean isForward = isForwardEligible(data);
 
     boolean exists = tableCache.exists(data.tableIdentifier()).f0;
     String foundBranch = exists ? tableCache.branch(data.tableIdentifier(), data.branch()) : null;
@@ -222,5 +215,17 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Forward mode is incompatible with equality fields: records sharing the same equality key must
+   * land on the same writer subtask to preserve equality-delete semantics. A record can only take
+   * the forward path when the user requested it (null distribution mode) and the record resolves to
+   * an empty equality-field set (no user-supplied set and no schema identifier fields).
+   */
+  private static boolean isForwardEligible(DynamicRecord data) {
+    return data.distributionMode() == null
+        && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
+            .isEmpty();
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -120,7 +120,14 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
 
   @Override
   public void collect(DynamicRecord data) {
-    boolean isForward = data.distributionMode() == null;
+    // Forward mode is incompatible with equality fields: records sharing the same equality key must
+    // land on the same writer subtask to preserve equality-delete semantics. Fall back to hash
+    // distribution by equality fields whenever the record resolves to a non-empty equality-field
+    // set (user-supplied or inferred from the schema's identifier fields).
+    boolean isForward =
+        data.distributionMode() == null
+            && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
+                .isEmpty();
 
     boolean exists = tableCache.exists(data.tableIdentifier()).f0;
     String foundBranch = exists ? tableCache.branch(data.tableIdentifier(), data.branch()) : null;

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.Collections;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -47,6 +48,20 @@ class DynamicSinkUtil {
     }
 
     return equalityFieldIds;
+  }
+
+  /**
+   * Resolves the effective equality field names. Returns the user-supplied set when non-empty,
+   * otherwise falls back to the names of {@link Schema#identifierFieldIds()}. Mirrors {@link
+   * #getEqualityFieldIds} so distribution and write-side equality-field inference stay aligned.
+   */
+  static Set<String> resolveEqualityFieldNames(
+      @Nullable Set<String> equalityFields, Schema schema) {
+    if (equalityFields != null && !equalityFields.isEmpty()) {
+      return equalityFields;
+    }
+
+    return schema.identifierFieldNames();
   }
 
   static int safeAbs(int input) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -79,6 +78,9 @@ class HashKeyGenerator {
       @Nullable PartitionSpec tableSpec,
       @Nullable RowData overrideRowData) {
     String tableIdent = dynamicRecord.tableIdentifier().toString();
+    Schema effectiveSchema = MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema());
+    Set<String> effectiveEqualityFields =
+        DynamicSinkUtil.resolveEqualityFieldNames(dynamicRecord.equalityFields(), effectiveSchema);
     SelectorKey cacheKey =
         new SelectorKey(
             tableIdent,
@@ -87,7 +89,7 @@ class HashKeyGenerator {
             tableSpec != null ? tableSpec.specId() : null,
             dynamicRecord.schema(),
             dynamicRecord.spec(),
-            dynamicRecord.equalityFields(),
+            effectiveEqualityFields,
             MoreObjects.firstNonNull(dynamicRecord.distributionMode(), DistributionMode.NONE),
             Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism));
     KeySelector<RowData, Integer> keySelector =
@@ -96,12 +98,11 @@ class HashKeyGenerator {
             k ->
                 getKeySelector(
                     tableIdent,
-                    MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema()),
+                    effectiveSchema,
                     MoreObjects.firstNonNull(tableSpec, dynamicRecord.spec()),
                     MoreObjects.firstNonNull(
                         dynamicRecord.distributionMode(), DistributionMode.NONE),
-                    MoreObjects.firstNonNull(
-                        dynamicRecord.equalityFields(), Collections.emptySet()),
+                    effectiveEqualityFields,
                     Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism)));
     try {
       return keySelector.getKey(

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -256,6 +257,60 @@ class TestHashKeyGenerator {
                 .distinct()
                 .count())
         .isEqualTo(maxWriteParallelism);
+  }
+
+  @Test
+  void testIdentifierFieldsResolvedAsEqualityFields() throws Exception {
+    int writeParallelism = 2;
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
+
+    Schema schemaWithIdentifier =
+        new Schema(
+            Lists.newArrayList(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                Types.NestedField.required(2, "data", Types.StringType.get())),
+            Sets.newHashSet(1));
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    GenericRowData row1 = GenericRowData.of(1, StringData.fromString("foo"));
+    GenericRowData row2 = GenericRowData.of(1, StringData.fromString("bar"));
+    GenericRowData row3 = GenericRowData.of(2, StringData.fromString("baz"));
+
+    DynamicRecord record1 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row1,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+    DynamicRecord record2 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row2,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+    DynamicRecord record3 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row3,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+
+    int writeKey1 = generator.generateKey(record1);
+    int writeKey2 = generator.generateKey(record2);
+    int writeKey3 = generator.generateKey(record3);
+
+    assertThat(writeKey1).isEqualTo(writeKey2);
+    assertThat(writeKey3).isNotEqualTo(writeKey1);
   }
 
   @Test

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
@@ -67,7 +67,10 @@ public class DynamicRecord {
    * @param rowData The data matching the provided schema.
    * @param partitionSpec The target table {@link PartitionSpec}.
    * @param distributionMode The {@link DistributionMode}. {@code null} indicates forward (no
-   *     shuffle) writes.
+   *     shuffle) writes. Ignored when the record resolves to a non-empty equality-field set (either
+   *     {@code equalityFields} is set, or the schema declares identifier fields): such records are
+   *     always hash-distributed by those fields so that rows sharing a key reach the same writer
+   *     subtask, which is required for equality-delete correctness.
    * @param writeParallelism The number of parallel writers. Can be set to any value {@literal > 0},
    *     but will always be automatically capped by the maximum write parallelism, which is the
    *     parallelism of the sink. Set to Integer.MAX_VALUE for always using the maximum available

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -120,14 +120,7 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
 
   @Override
   public void collect(DynamicRecord data) {
-    // Forward mode is incompatible with equality fields: records sharing the same equality key must
-    // land on the same writer subtask to preserve equality-delete semantics. Fall back to hash
-    // distribution by equality fields whenever the record resolves to a non-empty equality-field
-    // set (user-supplied or inferred from the schema's identifier fields).
-    boolean isForward =
-        data.distributionMode() == null
-            && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
-                .isEmpty();
+    boolean isForward = isForwardEligible(data);
 
     boolean exists = tableCache.exists(data.tableIdentifier()).f0;
     String foundBranch = exists ? tableCache.branch(data.tableIdentifier(), data.branch()) : null;
@@ -222,5 +215,17 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Forward mode is incompatible with equality fields: records sharing the same equality key must
+   * land on the same writer subtask to preserve equality-delete semantics. A record can only take
+   * the forward path when the user requested it (null distribution mode) and the record resolves to
+   * an empty equality-field set (no user-supplied set and no schema identifier fields).
+   */
+  private static boolean isForwardEligible(DynamicRecord data) {
+    return data.distributionMode() == null
+        && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
+            .isEmpty();
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -120,7 +120,14 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
 
   @Override
   public void collect(DynamicRecord data) {
-    boolean isForward = data.distributionMode() == null;
+    // Forward mode is incompatible with equality fields: records sharing the same equality key must
+    // land on the same writer subtask to preserve equality-delete semantics. Fall back to hash
+    // distribution by equality fields whenever the record resolves to a non-empty equality-field
+    // set (user-supplied or inferred from the schema's identifier fields).
+    boolean isForward =
+        data.distributionMode() == null
+            && DynamicSinkUtil.resolveEqualityFieldNames(data.equalityFields(), data.schema())
+                .isEmpty();
 
     boolean exists = tableCache.exists(data.tableIdentifier()).f0;
     String foundBranch = exists ? tableCache.branch(data.tableIdentifier(), data.branch()) : null;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicSinkUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.Collections;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -47,6 +48,20 @@ class DynamicSinkUtil {
     }
 
     return equalityFieldIds;
+  }
+
+  /**
+   * Resolves the effective equality field names. Returns the user-supplied set when non-empty,
+   * otherwise falls back to the names of {@link Schema#identifierFieldIds()}. Mirrors {@link
+   * #getEqualityFieldIds} so distribution and write-side equality-field inference stay aligned.
+   */
+  static Set<String> resolveEqualityFieldNames(
+      @Nullable Set<String> equalityFields, Schema schema) {
+    if (equalityFields != null && !equalityFields.isEmpty()) {
+      return equalityFields;
+    }
+
+    return schema.identifierFieldNames();
   }
 
   static int safeAbs(int input) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -79,6 +78,9 @@ class HashKeyGenerator {
       @Nullable PartitionSpec tableSpec,
       @Nullable RowData overrideRowData) {
     String tableIdent = dynamicRecord.tableIdentifier().toString();
+    Schema effectiveSchema = MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema());
+    Set<String> effectiveEqualityFields =
+        DynamicSinkUtil.resolveEqualityFieldNames(dynamicRecord.equalityFields(), effectiveSchema);
     SelectorKey cacheKey =
         new SelectorKey(
             tableIdent,
@@ -87,7 +89,7 @@ class HashKeyGenerator {
             tableSpec != null ? tableSpec.specId() : null,
             dynamicRecord.schema(),
             dynamicRecord.spec(),
-            dynamicRecord.equalityFields(),
+            effectiveEqualityFields,
             MoreObjects.firstNonNull(dynamicRecord.distributionMode(), DistributionMode.NONE),
             Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism));
     KeySelector<RowData, Integer> keySelector =
@@ -96,12 +98,11 @@ class HashKeyGenerator {
             k ->
                 getKeySelector(
                     tableIdent,
-                    MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema()),
+                    effectiveSchema,
                     MoreObjects.firstNonNull(tableSpec, dynamicRecord.spec()),
                     MoreObjects.firstNonNull(
                         dynamicRecord.distributionMode(), DistributionMode.NONE),
-                    MoreObjects.firstNonNull(
-                        dynamicRecord.equalityFields(), Collections.emptySet()),
+                    effectiveEqualityFields,
                     Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism)));
     try {
       return keySelector.getKey(

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -256,6 +257,60 @@ class TestHashKeyGenerator {
                 .distinct()
                 .count())
         .isEqualTo(maxWriteParallelism);
+  }
+
+  @Test
+  void testIdentifierFieldsResolvedAsEqualityFields() throws Exception {
+    int writeParallelism = 2;
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
+
+    Schema schemaWithIdentifier =
+        new Schema(
+            Lists.newArrayList(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                Types.NestedField.required(2, "data", Types.StringType.get())),
+            Sets.newHashSet(1));
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    GenericRowData row1 = GenericRowData.of(1, StringData.fromString("foo"));
+    GenericRowData row2 = GenericRowData.of(1, StringData.fromString("bar"));
+    GenericRowData row3 = GenericRowData.of(2, StringData.fromString("baz"));
+
+    DynamicRecord record1 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row1,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+    DynamicRecord record2 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row2,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+    DynamicRecord record3 =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            schemaWithIdentifier,
+            row3,
+            unpartitioned,
+            DistributionMode.NONE,
+            writeParallelism);
+
+    int writeKey1 = generator.generateKey(record1);
+    int writeKey2 = generator.generateKey(record2);
+    int writeKey3 = generator.generateKey(record3);
+
+    assertThat(writeKey1).isEqualTo(writeKey2);
+    assertThat(writeKey3).isNotEqualTo(writeKey1);
   }
 
   @Test


### PR DESCRIPTION
1) Use identifier fields on dynamic record to determine which type of distribution mode should be used
2) Use equality/identifier fields on dynamic record to avoid using forward sink