### PR TITLE
Flink: Backport: Bundle flink-metrics-dropwizard in runtime jar (#16126)

### DIFF
--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -33,7 +33,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation project(':iceberg-hive-metastore')
 
     compileOnly libs.flink120.avro
-    // for dropwizard histogram metrics implementation
+    // dropwizard histogram metrics (optional in Flink)
     compileOnly libs.flink120.metrics.dropwizard
     compileOnly libs.flink120.streaming.java
     compileOnly "${libs.flink120.streaming.java.get().module}:${libs.flink120.streaming.java.get().getVersion()}:tests"
@@ -169,7 +169,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    // for dropwizard histogram metrics implementation
+    // To support dropwizard histogram metrics (not shipped by Flink by default)
     implementation libs.flink120.metrics.dropwizard
 
     // for integration testing with the flink-runtime-jar

--- a/flink/v1.20/flink-runtime/LICENSE
+++ b/flink/v1.20/flink-runtime/LICENSE
@@ -556,10 +556,18 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Codahale Metrics.
+This product bundles Dropwizard Metrics.
 
 Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
 Project URL: https://github.com/dropwizard/metrics
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Flink's optional support for Dropwizard Metrics.
+
+Copyright: 2014-2026 The Apache Software Foundation
+Project URL: https://flink.apache.org/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -33,7 +33,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation project(':iceberg-hive-metastore')
 
     compileOnly libs.flink20.avro
-    // for dropwizard histogram metrics implementation
+    // dropwizard histogram metrics (optional in Flink)
     compileOnly libs.flink20.metrics.dropwizard
     compileOnly libs.flink20.streaming.java
     compileOnly "${libs.flink20.streaming.java.get().module}:${libs.flink20.streaming.java.get().getVersion()}:tests"
@@ -169,7 +169,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    // for dropwizard histogram metrics implementation
+    // To support dropwizard histogram metrics (not shipped by Flink by default)
     implementation libs.flink20.metrics.dropwizard
 
     // for integration testing with the flink-runtime-jar

--- a/flink/v2.0/flink-runtime/LICENSE
+++ b/flink/v2.0/flink-runtime/LICENSE
@@ -556,10 +556,18 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Codahale Metrics.
+This product bundles Dropwizard Metrics.
 
 Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
 Project URL: https://github.com/dropwizard/metrics
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Flink's optional support for Dropwizard Metrics.
+
+Copyright: 2014-2026 The Apache Software Foundation
+Project URL: https://flink.apache.org/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Backport of #16126 for Flink versions 1.20 and 2.0.