### PR TITLE
Kafka: Cleanup LICENSE file

### DIFF
--- a/kafka-connect/kafka-connect-runtime/hive/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/hive/LICENSE
@@ -573,30 +573,9 @@ License: MIT
 
 --------------------------------------------------------------------------------
 
-This product bundles Nimbus Content Type.
-
-Project URL: https://bitbucket.org/connect2id/nimbus-content-type
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Nimbus Lang Tag.
-
-Project URL: https://bitbucket.org/connect2id/nimbus-language-tags
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product bundles Nimbus Jose JWT.
 
 Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Nimbus OIDC SDK.
-
-Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
@@ -932,20 +911,6 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product bundles JNA.
 
 Project URL: https://github.com/java-native-access/jna
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Accessors Smart.
-
-Project URL: https://urielch.github.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Json Smart.
-
-Project URL: https://urielch.github.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/kafka-connect/kafka-connect-runtime/main/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/main/LICENSE
@@ -769,20 +769,6 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Accessors Smart.
-
-Project URL: https://urielch.github.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Json Smart.
-
-Project URL: https://urielch.github.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product bundles Apache Avro.
 
 Project URL: https://avro.apache.org

--- a/kafka-connect/kafka-connect-runtime/main/LICENSE
+++ b/kafka-connect/kafka-connect-runtime/main/LICENSE
@@ -538,34 +538,6 @@ License: MIT
 
 --------------------------------------------------------------------------------
 
-This product bundles Nimbus Content Type.
-
-Project URL: https://bitbucket.org/connect2id/nimbus-content-type
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Nimbus Lang Tag.
-
-Project URL: https://bitbucket.org/connect2id/nimbus-language-tags
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Nimbus Jose JWT.
-
-Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Nimbus OAuth2 OIDC SDK.
-
-Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product bundles JAXB.
 
 Project URL: http://jaxb.java.net/


### PR DESCRIPTION
The `azure-identity` module depends on `msal4j`.

Initially, `msal4j` (<= 1.21.x) depended on Nimbus `oauth2-oidc-sdk` + `json-smart`.

Later on, `msal4j` was upgraded to 1.23.x, which removed `oauth2-oidc-sdk` as a dependency (Microsoft replaced their JWT parsing with `azure-json`).

As a consequence, Nimbus and json-smart are not present anymore in this artifact. Besides, they are not present in `runtime-deps.txt` either.

This PR cleans the LICENSE file accordingly.

\cc @jbonofre 