### PR TITLE
OpenAPI: Add CatalogObjectIdentifier schema

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -108,12 +108,12 @@ class TableIdentifier(BaseModel):
 
 class CatalogObjectIdentifier(RootModel[list[str]]):
     """
-    Reference to a catalog object (table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion type discriminator), not by the identifier structure alone.
+    Reference to a catalog object (for example, table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion type discriminator), not by the identifier structure alone.
     """
 
     root: list[str] = Field(
         ...,
-        description='Reference to a catalog object (table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion type discriminator), not by the identifier structure alone.',
+        description='Reference to a catalog object (for example, table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion type discriminator), not by the identifier structure alone.',
         examples=[['accounting', 'tax', 'paid']],
     )
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -108,19 +108,13 @@ class TableIdentifier(BaseModel):
 
 class CatalogObjectIdentifier(RootModel[list[str]]):
     """
-    Reference to a catalog object (table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion CatalogObjectType discriminator), not by the identifier structure alone.
+    Reference to a catalog object (table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion type discriminator), not by the identifier structure alone.
     """
 
     root: list[str] = Field(
         ...,
-        description='Reference to a catalog object (table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion CatalogObjectType discriminator), not by the identifier structure alone.',
+        description='Reference to a catalog object (table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion type discriminator), not by the identifier structure alone.',
         examples=[['accounting', 'tax', 'paid']],
-    )
-
-
-class CatalogObjectType(RootModel[Literal['table', 'view', 'namespace']]):
-    root: Literal['table', 'view', 'namespace'] = Field(
-        ..., description='The type of a catalog object.\n'
     )
 
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -106,6 +106,24 @@ class TableIdentifier(BaseModel):
     name: str
 
 
+class CatalogObjectIdentifier(RootModel[list[str]]):
+    """
+    Reference to a catalog object (table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion CatalogObjectType discriminator), not by the identifier structure alone.
+    """
+
+    root: list[str] = Field(
+        ...,
+        description='Reference to a catalog object (table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion CatalogObjectType discriminator), not by the identifier structure alone.',
+        examples=[['accounting', 'tax', 'paid']],
+    )
+
+
+class CatalogObjectType(RootModel[Literal['table', 'view', 'namespace']]):
+    root: Literal['table', 'view', 'namespace'] = Field(
+        ..., description='The type of a catalog object.\n'
+    )
+
+
 class PrimitiveType(RootModel[str]):
     root: str = Field(..., examples=[['long', 'string', 'fixed[16]', 'decimal(10,2)']])
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2272,21 +2272,11 @@ components:
         Reference to a catalog object (table, view, or namespace) as an
         ordered list of hierarchical levels.
         The object kind is determined by context (e.g. the endpoint or a
-        companion CatalogObjectType discriminator), not by the identifier
-        structure alone.
+        companion type discriminator), not by the identifier structure alone.
       type: array
       items:
         type: string
       example: [ "accounting", "tax", "paid" ]
-
-    CatalogObjectType:
-      type: string
-      description: |
-        The type of a catalog object.
-      enum:
-        - table
-        - view
-        - namespace
 
     PrimitiveType:
       type: string

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2269,8 +2269,8 @@ components:
 
     CatalogObjectIdentifier:
       description:
-        Reference to a catalog object (table, view, or namespace) as an
-        ordered list of hierarchical levels.
+        Reference to a catalog object (for example, table, view, or namespace) as
+        an ordered list of hierarchical levels.
         The object kind is determined by context (e.g. the endpoint or a
         companion type discriminator), not by the identifier structure alone.
       type: array

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2267,6 +2267,27 @@ components:
           type: string
           nullable: false
 
+    CatalogObjectIdentifier:
+      description:
+        Reference to a catalog object (table, view, or namespace) as an
+        ordered list of hierarchical levels.
+        The object kind is determined by context (e.g. the endpoint or a
+        companion CatalogObjectType discriminator), not by the identifier
+        structure alone.
+      type: array
+      items:
+        type: string
+      example: [ "accounting", "tax", "paid" ]
+
+    CatalogObjectType:
+      type: string
+      description: |
+        The type of a catalog object.
+      enum:
+        - table
+        - view
+        - namespace
+
     PrimitiveType:
       type: string
       example:


### PR DESCRIPTION
## Summary

Adds the `CatalogObjectIdentifier` schema to the REST catalog spec — an ordered list of hierarchical levels (`["accounting", "tax", "paid"]`) that works uniformly for tables, views, materialized views, and namespaces. The kind of object an identifier refers to is determined by context (the endpoint, or a companion type discriminator defined by that endpoint), not by the identifier structure itself.

Structurally the same as `Namespace` (a bare array of strings); the distinct name signals "any catalog object" rather than specifically a namespace path.

## Motivation

Multiple concurrent efforts need a generic catalog-object identifier and would otherwise each introduce their own:

- Events endpoint (#12584)
- Resolve endpoint for relational objects (#15830)
- Functions endpoint (#15180)

Introducing one shared schema avoids identifier proliferation as new object types (functions, materialized views) are added to the spec.

## Scope

Intentionally minimal:

- Add `CatalogObjectIdentifier` alongside the existing `TableIdentifier` and `Namespace`.
- **No changes to existing endpoints.** All current references to `TableIdentifier` and `Namespace` are preserved — no breaking changes.
- No discriminator enum is included. The originally-proposed shared `CatalogObjectType` was dropped during review; the resolve and events endpoints will each define their own narrower closed enums in their respective PRs, since each has a different forward-compat profile.

## Test plan

- [x] `make -C open-api lint` passes (openapi-spec-validator + yamllint --strict)
- [x] `make -C open-api generate` regenerates `rest-catalog-open-api.py` cleanly
- [x] `python3 -m py_compile open-api/rest-catalog-open-api.py` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
