### PR TITLE
Core: validate buffered v2 deletes against concurrent format upgrade

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -963,8 +963,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     return summaryBuilder.build();
   }
 
-  // guard buffered v2 deletes against concurrent format upgrade
-  private void validateV2DeleteFilesForVersion(int currentFormatVersion) {
+  // guard buffered deletes against concurrent format upgrade
+  private void validateDeleteFilesForVersion(int currentFormatVersion) {
     for (DeleteFile file : v2Deletes) {
       validateDeleteFileForVersion(file, currentFormatVersion);
     }
@@ -972,7 +972,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   @Override
   public List<ManifestFile> apply(TableMetadata base, Snapshot snapshot) {
-    validateV2DeleteFilesForVersion(base.formatVersion());
+    validateDeleteFilesForVersion(base.formatVersion());
     // filter any existing manifests
     List<ManifestFile> filtered =
         filterManager.filterManifests(

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -289,7 +289,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   protected void validateNewDeleteFile(DeleteFile file) {
     Preconditions.checkNotNull(file, "Invalid delete file: null");
-    switch (formatVersion()) {
+    validateDeleteFileForVersion(file, formatVersion());
+  }
+
+  private static void validateDeleteFileForVersion(DeleteFile file, int formatVersion) {
+    switch (formatVersion) {
       case 1:
         throw new IllegalArgumentException("Deletes are supported in V2 and above");
       case 2:
@@ -303,11 +307,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         Preconditions.checkArgument(
             file.content() == FileContent.EQUALITY_DELETES || ContentFileUtil.isDV(file),
             "Must use DVs for position deletes in V%s: %s",
-            formatVersion(),
+            formatVersion,
             file.location());
         break;
       default:
-        throw new IllegalArgumentException("Unsupported format version: " + formatVersion());
+        throw new IllegalArgumentException("Unsupported format version: " + formatVersion);
     }
   }
 
@@ -959,8 +963,16 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     return summaryBuilder.build();
   }
 
+  // guard buffered v2 deletes against concurrent format upgrade
+  private void validateV2DeleteFilesForVersion(int currentFormatVersion) {
+    for (DeleteFile file : v2Deletes) {
+      validateDeleteFileForVersion(file, currentFormatVersion);
+    }
+  }
+
   @Override
   public List<ManifestFile> apply(TableMetadata base, Snapshot snapshot) {
+    validateV2DeleteFilesForVersion(base.formatVersion());
     // filter any existing manifests
     List<ManifestFile> filtered =
         filterManager.filterManifests(

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -2420,6 +2420,27 @@ public class TestRowDelta extends TestBase {
   }
 
   @TestTemplate
+  public void testV2StagedPositionDeleteCannotCommitToV3() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    Snapshot initial = commit(table, table.newAppend().appendFile(FILE_A), branch);
+
+    // Stage RowDelta at v2: position delete for FILE_A + add new data FILE_B.
+    RowDelta rowDelta = table.newRowDelta().addDeletes(FILE_A_DELETES).addRows(FILE_B);
+
+    // upgrade the table
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "3").commit();
+
+    assertThatThrownBy(rowDelta::commit)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Must use DVs for position deletes in V3");
+
+    table.refresh();
+    assertThat(table.operations().current().formatVersion()).isEqualTo(3);
+    assertThat(table.snapshot(branch)).isEqualTo(initial);
+  }
+
+  @TestTemplate
   public void testInabilityToAddPositionDeleteFilesInTablesWithDVs() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     DeleteFile deleteFile = newDeleteFile(table.spec().specId(), "data_bucket=0");


### PR DESCRIPTION
We recently discovered TOCTOU upgrade concurrency problem, where commit of V2 position delete happens after the table has been upgraded to format version 3. The existing validation is applied at the time of add delete files instead of commit rebase. 

With this change, the position delete shall be rejected after table has been upgraded to V3 like https://github.com/apache/iceberg/blob/9b139c99d8ee1bb4991025ab95539eb2274952d0/core/src/test/java/org/apache/iceberg/TestRowDelta.java#L2423-L2429