### PR TITLE
Schema ids can not be the same in REST Fixture

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
+import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.MetadataUpdate.UpgradeFormatVersion;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RetryableValidationException;
@@ -603,7 +604,7 @@ public class CatalogHandlers {
 
     TableMetadata.Builder builder =
         formatVersion.map(TableMetadata::buildFromEmpty).orElseGet(TableMetadata::buildFromEmpty);
-    request.updates().forEach(update -> update.applyTo(builder));
+    applyUpdates(null, builder, request.updates());
     // create transactions do not retry. if the table exists, retrying is not a solution
     ops.commit(null, builder.build());
 
@@ -637,7 +638,7 @@ public class CatalogHandlers {
                 // apply changes
                 TableMetadata.Builder metadataBuilder = TableMetadata.buildFrom(base);
                 try {
-                  request.updates().forEach(update -> update.applyTo(metadataBuilder));
+                  applyUpdates(base, metadataBuilder, request.updates());
                 } catch (RetryableValidationException e) {
                   // Validation failed because the commit includes stale values (e.g. sequence
                   // number or first-row-id behind the current table state). This is not a conflict.
@@ -798,7 +799,7 @@ public class CatalogHandlers {
 
                 // apply changes
                 ViewMetadata.Builder metadataBuilder = ViewMetadata.buildFrom(base);
-                request.updates().forEach(update -> update.applyTo(metadataBuilder));
+                applyUpdates(base, metadataBuilder, request.updates());
 
                 ViewMetadata updated = metadataBuilder.build();
 
@@ -1037,6 +1038,50 @@ public class CatalogHandlers {
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
+  private static void applyUpdates(
+      TableMetadata base, TableMetadata.Builder builder, List<MetadataUpdate> updates) {
+    updates.forEach(
+        update -> {
+          if (update instanceof MetadataUpdate.AddSchema) {
+            Schema schema = ((MetadataUpdate.AddSchema) update).schema();
+            validateSchemaId(base, schema);
+          }
+          update.applyTo(builder);
+        });
+  }
+
+  private static void applyUpdates(
+      ViewMetadata base, ViewMetadata.Builder builder, List<MetadataUpdate> updates) {
+    updates.forEach(
+        update -> {
+          if (update instanceof MetadataUpdate.AddSchema) {
+            Schema schema = ((MetadataUpdate.AddSchema) update).schema();
+            validateSchemaId(base, schema);
+          }
+          update.applyTo(builder);
+        });
+  }
+
+  private static void validateSchemaId(TableMetadata base, Schema schema) {
+    if (base != null && base.schemasById().containsKey(schema.schemaId())) {
+      Schema existing = base.schemasById().get(schema.schemaId());
+      Preconditions.checkArgument(
+          existing.sameSchema(schema),
+          "Schema ID %s already exists with a different schema",
+          schema.schemaId());
+    }
+  }
+
+  private static void validateSchemaId(ViewMetadata base, Schema schema) {
+    if (base != null && base.schemasById().containsKey(schema.schemaId())) {
+      Schema existing = base.schemasById().get(schema.schemaId());
+      Preconditions.checkArgument(
+          existing.sameSchema(schema),
+          "Schema ID %s already exists with a different schema",
+          schema.schemaId());
+    }
+  }
+
   private static void asyncPlanFiles(
       Scan<?, FileScanTask, ?> scan,
       String asyncPlanId,

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -118,6 +118,7 @@ import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.view.View;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.compression.gzip.GzipCompression;
@@ -3984,6 +3985,112 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         ImmutableMap.of(
             CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.inmemory.InMemoryFileIO"));
     return catalog;
+  }
+
+  @Test
+  public void testAddSchemaWithExistingIdAndDifferentSchema() {
+    TableIdentifier ident = TableIdentifier.of("ns", "table_with_schema_error");
+    if (!catalog().namespaceExists(ident.namespace())) {
+      catalog().createNamespace(ident.namespace());
+    }
+    catalog().createTable(ident, SCHEMA);
+
+    Table table = catalog().loadTable(ident);
+    int existingSchemaId = table.schema().schemaId();
+
+    Schema newSchema =
+        new Schema(
+            existingSchemaId, Types.NestedField.required(100, "new_col", Types.StringType.get()));
+
+    UpdateTableRequest request =
+        new UpdateTableRequest(
+            ImmutableList.of(), ImmutableList.of(new MetadataUpdate.AddSchema(newSchema)));
+
+    assertThatThrownBy(() -> CatalogHandlers.updateTable(backendCatalog, ident, request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("already exists with a different schema");
+  }
+
+  @Test
+  public void testAddSchemaWithExistingIdAndSameSchema() {
+    TableIdentifier ident = TableIdentifier.of("ns", "table_with_schema_idempotent");
+    if (!catalog().namespaceExists(ident.namespace())) {
+      catalog().createNamespace(ident.namespace());
+    }
+    catalog().createTable(ident, SCHEMA);
+
+    Table table = catalog().loadTable(ident);
+    int existingSchemaId = table.schema().schemaId();
+
+    // Use the same schema fields from the loaded table
+    Schema sameSchema =
+        new Schema(existingSchemaId, table.schema().columns(), table.schema().identifierFieldIds());
+
+    UpdateTableRequest request =
+        new UpdateTableRequest(
+            ImmutableList.of(), ImmutableList.of(new MetadataUpdate.AddSchema(sameSchema)));
+
+    // This should succeed (idempotent)
+    CatalogHandlers.updateTable(backendCatalog, ident, request);
+  }
+
+  @Test
+  public void testAddViewSchemaWithExistingIdAndDifferentSchema() {
+    TableIdentifier ident = TableIdentifier.of("ns", "view_with_schema_error");
+    if (!catalog().namespaceExists(ident.namespace())) {
+      catalog().createNamespace(ident.namespace());
+    }
+
+    backendCatalog
+        .buildView(ident)
+        .withSchema(SCHEMA)
+        .withQuery("sql", "select * from table")
+        .withDefaultNamespace(ident.namespace())
+        .create();
+
+    View view = backendCatalog.loadView(ident);
+    int existingSchemaId = view.schema().schemaId();
+
+    Schema newSchema =
+        new Schema(
+            existingSchemaId, Types.NestedField.required(100, "new_col", Types.StringType.get()));
+
+    UpdateTableRequest request =
+        new UpdateTableRequest(
+            ImmutableList.of(), ImmutableList.of(new MetadataUpdate.AddSchema(newSchema)));
+
+    assertThatThrownBy(() -> CatalogHandlers.updateView(backendCatalog, ident, request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("already exists with a different schema");
+  }
+
+  @Test
+  public void testAddViewSchemaWithExistingIdAndSameSchema() {
+    TableIdentifier ident = TableIdentifier.of("ns", "view_with_schema_idempotent");
+    if (!catalog().namespaceExists(ident.namespace())) {
+      catalog().createNamespace(ident.namespace());
+    }
+
+    backendCatalog
+        .buildView(ident)
+        .withSchema(SCHEMA)
+        .withQuery("sql", "select * from table")
+        .withDefaultNamespace(ident.namespace())
+        .create();
+
+    View view = backendCatalog.loadView(ident);
+    int existingSchemaId = view.schema().schemaId();
+
+    // Use the same schema fields from the loaded view
+    Schema sameSchema =
+        new Schema(existingSchemaId, view.schema().columns(), view.schema().identifierFieldIds());
+
+    UpdateTableRequest request =
+        new UpdateTableRequest(
+            ImmutableList.of(), ImmutableList.of(new MetadataUpdate.AddSchema(sameSchema)));
+
+    // This should succeed (idempotent)
+    CatalogHandlers.updateView(backendCatalog, ident, request);
   }
 
   private static List<HTTPRequest> allRequests(RESTCatalogAdapter adapter) {


### PR DESCRIPTION
Right now, the REST Fixture allows you to set multiple schemas with the same schema id. This shouldn't be allowed, since it breaks the idea that each schema has a unique ID.

I've added in a validation into the REST Fixture and added a test.