### PR TITLE
Flink: Do not ship optional flink-metrics-dropwizard dependency

### DIFF
--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -207,9 +207,9 @@ They should have the following key-value tags.
 | dataFilesSizeHistogram    | Histogram  | Histogram distribution of data file sizes (in bytes).                                               |
 | deleteFilesSizeHistogram  | Histogram  | Histogram distribution of delete file sizes (in bytes).                                             |
 
-The `Histogram` metrics above require `flink-metrics-dropwizard` on the classpath, which is not shipped
-by Flink by default. When using `iceberg-flink-runtime`, this dependency is already bundled. When using
-the `iceberg-flink` artifact directly, add `org.apache.flink:flink-metrics-dropwizard` as a dependency.
+The `Histogram` metrics above require `org.apache.flink:flink-metrics-dropwizard` on the classpath,
+which is not shipped by Flink by default. Please add this artifact to your classpath to see histogram metrics.
+If not present, histogram metrics will be missing. All other metric types will continue to get published.
 
 Committer metrics are added under the sub group of `IcebergFilesCommitter`.
 They should have the following key-value tags.

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -169,9 +169,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    // To support dropwizard histogram metrics (not shipped by Flink by default)
-    implementation libs.flink21.metrics.dropwizard
-
     // for integration testing with the flink-runtime-jar
     // all of those dependencies are required because the integration test extends FlinkTestBase
     integrationCompileOnly project(':iceberg-api')

--- a/flink/v2.1/flink-runtime/LICENSE
+++ b/flink/v2.1/flink-runtime/LICENSE
@@ -460,22 +460,6 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Dropwizard Metrics.
-
-Copyright: (c) 2010-2013 Coda Hale, Yammer.com, 2014-2021 Dropwizard Team
-Project URL: https://github.com/dropwizard/metrics
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Apache Flink's optional support for Dropwizard Metrics.
-
-Copyright: 2014-2026 The Apache Software Foundation
-Project URL: https://flink.apache.org/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product bundles RoaringBitmap.
 
 Copyright: (c) 2013-... the RoaringBitmap authors

--- a/flink/v2.1/flink-runtime/runtime-deps.txt
+++ b/flink/v2.1/flink-runtime/runtime-deps.txt
@@ -6,11 +6,9 @@ com.github.luben:zstd-jni:1.5.7-3
 com.google.errorprone:error_prone_annotations:2.10.0
 dev.failsafe:failsafe:3.3.2
 io.airlift:aircompressor:2.0.3
-io.dropwizard.metrics:metrics-core:3.2.6
 org.apache.avro:avro:1.12.1
 org.apache.datasketches:datasketches-java:6.2.0
 org.apache.datasketches:datasketches-memory:3.0.2
-org.apache.flink:flink-metrics-dropwizard:2.1.0
 org.apache.httpcomponents.client5:httpclient5:5.6
 org.apache.httpcomponents.core5:httpcore5-h2:5.4
 org.apache.httpcomponents.core5:httpcore5:5.4

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -25,7 +25,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.util.ScanTaskUtil;
@@ -41,6 +40,48 @@ public class IcebergStreamWriterMetrics {
   // It should also produce good accuracy for histogram distribution (like percentiles).
   private static final int HISTOGRAM_RESERVOIR_SIZE = 1024;
 
+  // Histogram metrics loaded through Flink's optional flink-metrics-dropwizard dependency
+  private static final boolean DROPWIZARD_AVAILABLE;
+  private static final DynConstructors.Ctor<?> RESERVOIR_CTOR;
+  private static final DynConstructors.Ctor<?> CODAHALE_HISTOGRAM_CTOR;
+  private static final DynConstructors.Ctor<Histogram> WRAPPER_CTOR;
+
+  static {
+    DynConstructors.Ctor<?> reservoirCtor = null;
+    DynConstructors.Ctor<?> codahaleHistogramCtor = null;
+    DynConstructors.Ctor<Histogram> wrapperCtor = null;
+    boolean available = false;
+
+    try {
+      Class<?> reservoirInterface = Class.forName("com.codahale.metrics.Reservoir");
+      Class<?> codahaleHistogramClass = Class.forName("com.codahale.metrics.Histogram");
+      reservoirCtor =
+          DynConstructors.builder()
+              .impl("com.codahale.metrics.SlidingWindowReservoir", int.class)
+              .buildChecked();
+      codahaleHistogramCtor =
+          DynConstructors.builder()
+              .impl("com.codahale.metrics.Histogram", reservoirInterface)
+              .buildChecked();
+      wrapperCtor =
+          DynConstructors.builder(Histogram.class)
+              .impl(
+                  "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper",
+                  codahaleHistogramClass)
+              .buildChecked();
+      available = true;
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      LOG.warn(
+          "flink-metrics-dropwizard is not on the classpath. Histogram metrics will be disabled. Add org.apache.flink:flink-metrics-dropwizard to enable them.",
+          e);
+    }
+
+    RESERVOIR_CTOR = reservoirCtor;
+    CODAHALE_HISTOGRAM_CTOR = codahaleHistogramCtor;
+    WRAPPER_CTOR = wrapperCtor;
+    DROPWIZARD_AVAILABLE = available;
+  }
+
   private final Counter flushedDataFiles;
   private final Counter flushedDeleteFiles;
   private final Counter flushedReferencedDataFiles;
@@ -49,11 +90,6 @@ public class IcebergStreamWriterMetrics {
   private final Histogram deleteFilesSizeHistogram;
 
   public IcebergStreamWriterMetrics(MetricGroup metrics, String fullTableName) {
-    this(metrics, fullTableName, IcebergStreamWriterMetrics.class.getClassLoader());
-  }
-
-  @VisibleForTesting
-  IcebergStreamWriterMetrics(MetricGroup metrics, String fullTableName, ClassLoader classLoader) {
     MetricGroup writerMetrics =
         metrics.addGroup("IcebergStreamWriter").addGroup("table", fullTableName);
     this.flushedDataFiles = writerMetrics.counter("flushedDataFiles");
@@ -63,11 +99,10 @@ public class IcebergStreamWriterMetrics {
     writerMetrics.gauge("lastFlushDurationMs", lastFlushDurationMs::get);
 
     this.dataFilesSizeHistogram =
-        loadHistogramIfAvailable(
-            writerMetrics, "dataFilesSizeHistogram", HISTOGRAM_RESERVOIR_SIZE, classLoader);
+        loadHistogramIfAvailable(writerMetrics, "dataFilesSizeHistogram", HISTOGRAM_RESERVOIR_SIZE);
     this.deleteFilesSizeHistogram =
         loadHistogramIfAvailable(
-            writerMetrics, "deleteFilesSizeHistogram", HISTOGRAM_RESERVOIR_SIZE, classLoader);
+            writerMetrics, "deleteFilesSizeHistogram", HISTOGRAM_RESERVOIR_SIZE);
   }
 
   public void updateFlushResult(WriteResult result) {
@@ -122,48 +157,16 @@ public class IcebergStreamWriterMetrics {
    * Checks whether the Dropwizard-based histogram wrapper provided through Flink's optional
    * flink-metrics-dropwizard dependency is available.
    */
-  @SuppressWarnings("CatchBlockLogException")
   private static Histogram loadHistogramIfAvailable(
-      MetricGroup group, String name, int reservoirSize, ClassLoader classLoader) {
+      MetricGroup group, String name, int reservoirSize) {
 
-    try {
-      Class<?> reservoirInterface =
-          DynClasses.builder()
-              .loader(classLoader)
-              .impl("com.codahale.metrics.Reservoir")
-              .buildChecked();
-      Class<?> codahaleHistogramClass =
-          DynClasses.builder()
-              .loader(classLoader)
-              .impl("com.codahale.metrics.Histogram")
-              .buildChecked();
-
-      Object reservoir =
-          DynConstructors.builder()
-              .loader(classLoader)
-              .impl("com.codahale.metrics.SlidingWindowReservoir", int.class)
-              .buildChecked()
-              .newInstance(reservoirSize);
-      Object codahaleHistogram =
-          DynConstructors.builder()
-              .impl(codahaleHistogramClass, reservoirInterface)
-              .buildChecked()
-              .newInstance(reservoir);
-      Histogram wrapper =
-          DynConstructors.builder(Histogram.class)
-              .loader(classLoader)
-              .impl(
-                  "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper",
-                  codahaleHistogramClass)
-              .<Histogram>buildChecked()
-              .newInstance(codahaleHistogram);
-
-      return group.histogram(name, wrapper);
-    } catch (ClassNotFoundException | NoSuchMethodException e) {
-      LOG.warn(
-          "flink-metrics-dropwizard is not on the classpath. '{}' histogram metrics will be disabled. Add org.apache.flink:flink-metrics-dropwizard to enable them.",
-          name);
+    if (!DROPWIZARD_AVAILABLE) {
       return null;
     }
+
+    Object reservoir = RESERVOIR_CTOR.newInstance(reservoirSize);
+    Object codahaleHistogram = CODAHALE_HISTOGRAM_CTOR.newInstance(reservoir);
+    Histogram wrapper = WRAPPER_CTOR.newInstance(codahaleHistogram);
+    return group.histogram(name, wrapper);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -27,6 +27,7 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.iceberg.common.DynClasses;
+import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.util.ScanTaskUtil;
 import org.slf4j.Logger;
@@ -128,33 +129,51 @@ public class IcebergStreamWriterMetrics {
   private static Histogram loadHistogramIfAvailable(
       MetricGroup group, String name, int reservoirSize, ClassLoader classLoader) {
 
-    Class<?> wrapperClass =
-        DynClasses.builder()
-            .loader(classLoader)
-            .impl("org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper")
-            .orNull()
-            .build();
-    if (wrapperClass == null) {
+    try {
+      Class<?> reservoirInterface =
+          DynClasses.builder()
+              .loader(classLoader)
+              .impl("com.codahale.metrics.Reservoir")
+              .buildChecked();
+      Class<?> slidingWindowReservoirClass =
+          DynClasses.builder()
+              .loader(classLoader)
+              .impl("com.codahale.metrics.SlidingWindowReservoir")
+              .buildChecked();
+      Class<?> codahaleHistogramClass =
+          DynClasses.builder()
+              .loader(classLoader)
+              .impl("com.codahale.metrics.Histogram")
+              .buildChecked();
+      Class<?> wrapperClass =
+          DynClasses.builder()
+              .loader(classLoader)
+              .impl("org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper")
+              .buildChecked();
+
+      Object reservoir =
+          DynConstructors.builder()
+              .impl(slidingWindowReservoirClass, int.class)
+              .buildChecked()
+              .newInstance(reservoirSize);
+      Object codahaleHistogram =
+          DynConstructors.builder()
+              .impl(codahaleHistogramClass, reservoirInterface)
+              .buildChecked()
+              .newInstance(reservoir);
+      Histogram wrapper =
+          (Histogram)
+              DynConstructors.builder()
+                  .impl(wrapperClass, codahaleHistogramClass)
+                  .buildChecked()
+                  .newInstance(codahaleHistogram);
+
+      return group.histogram(name, wrapper);
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
       LOG.warn(
           "flink-metrics-dropwizard is not on the classpath. '{}' histogram metrics will be disabled. Add org.apache.flink:flink-metrics-dropwizard to enable them.",
           name);
       return null;
-    }
-
-    return HistogramLoader.load(name, group, reservoirSize);
-  }
-
-  /**
-   * Must be encapsulated into a separate class to avoid the JVM eagerly loading any non-existing
-   * referenced classes. This has been manually verified.
-   */
-  private static final class HistogramLoader {
-
-    static Histogram load(String name, MetricGroup group, int reservoirSize) {
-      com.codahale.metrics.Histogram codahaleHistogram =
-          new com.codahale.metrics.Histogram(
-              new com.codahale.metrics.SlidingWindowReservoir(reservoirSize));
-      return group.histogram(name, new DropwizardHistogramWrapper(codahaleHistogram));
     }
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -132,25 +132,16 @@ public class IcebergStreamWriterMetrics {
               .loader(classLoader)
               .impl("com.codahale.metrics.Reservoir")
               .buildChecked();
-      Class<?> slidingWindowReservoirClass =
-          DynClasses.builder()
-              .loader(classLoader)
-              .impl("com.codahale.metrics.SlidingWindowReservoir")
-              .buildChecked();
       Class<?> codahaleHistogramClass =
           DynClasses.builder()
               .loader(classLoader)
               .impl("com.codahale.metrics.Histogram")
               .buildChecked();
-      Class<?> wrapperClass =
-          DynClasses.builder()
-              .loader(classLoader)
-              .impl("org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper")
-              .buildChecked();
 
       Object reservoir =
           DynConstructors.builder()
-              .impl(slidingWindowReservoirClass, int.class)
+              .loader(classLoader)
+              .impl("com.codahale.metrics.SlidingWindowReservoir", int.class)
               .buildChecked()
               .newInstance(reservoirSize);
       Object codahaleHistogram =
@@ -161,7 +152,10 @@ public class IcebergStreamWriterMetrics {
       Histogram wrapper =
           (Histogram)
               DynConstructors.builder()
-                  .impl(wrapperClass, codahaleHistogramClass)
+                  .loader(classLoader)
+                  .impl(
+                      "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper",
+                      codahaleHistogramClass)
                   .buildChecked()
                   .newInstance(codahaleHistogram);
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -123,7 +123,7 @@ public class IcebergStreamWriterMetrics {
    * flink-metrics-dropwizard dependency is available.
    */
   @SuppressWarnings("CatchBlockLogException")
-  static Histogram loadHistogramIfAvailable(
+  private static Histogram loadHistogramIfAvailable(
       MetricGroup group, String name, int reservoirSize, ClassLoader classLoader) {
 
     try {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -23,10 +23,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.util.ScanTaskUtil;
 import org.slf4j.Logger;
@@ -128,16 +128,20 @@ public class IcebergStreamWriterMetrics {
   private static Histogram loadHistogramIfAvailable(
       MetricGroup group, String name, int reservoirSize, ClassLoader classLoader) {
 
-    try {
-      Class.forName(
-          "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper", false, classLoader);
-      return HistogramLoader.load(name, group, reservoirSize);
-    } catch (ClassNotFoundException e) {
+    Class<?> wrapperClass =
+        DynClasses.builder()
+            .loader(classLoader)
+            .impl("org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper")
+            .orNull()
+            .build();
+    if (wrapperClass == null) {
       LOG.warn(
           "flink-metrics-dropwizard is not on the classpath. '{}' histogram metrics will be disabled. Add org.apache.flink:flink-metrics-dropwizard to enable them.",
           name);
       return null;
     }
+
+    return HistogramLoader.load(name, group, reservoirSize);
   }
 
   /**

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -40,47 +40,9 @@ public class IcebergStreamWriterMetrics {
   // It should also produce good accuracy for histogram distribution (like percentiles).
   private static final int HISTOGRAM_RESERVOIR_SIZE = 1024;
 
-  // Histogram metrics loaded through Flink's optional flink-metrics-dropwizard dependency
-  private static final boolean DROPWIZARD_AVAILABLE;
-  private static final DynConstructors.Ctor<?> RESERVOIR_CTOR;
-  private static final DynConstructors.Ctor<?> CODAHALE_HISTOGRAM_CTOR;
-  private static final DynConstructors.Ctor<Histogram> WRAPPER_CTOR;
-
-  static {
-    DynConstructors.Ctor<?> reservoirCtor = null;
-    DynConstructors.Ctor<?> codahaleHistogramCtor = null;
-    DynConstructors.Ctor<Histogram> wrapperCtor = null;
-    boolean available = false;
-
-    try {
-      Class<?> reservoirInterface = Class.forName("com.codahale.metrics.Reservoir");
-      Class<?> codahaleHistogramClass = Class.forName("com.codahale.metrics.Histogram");
-      reservoirCtor =
-          DynConstructors.builder()
-              .impl("com.codahale.metrics.SlidingWindowReservoir", int.class)
-              .buildChecked();
-      codahaleHistogramCtor =
-          DynConstructors.builder()
-              .impl("com.codahale.metrics.Histogram", reservoirInterface)
-              .buildChecked();
-      wrapperCtor =
-          DynConstructors.builder(Histogram.class)
-              .impl(
-                  "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper",
-                  codahaleHistogramClass)
-              .buildChecked();
-      available = true;
-    } catch (ClassNotFoundException | NoSuchMethodException e) {
-      LOG.warn(
-          "Cannot load Dropwizard metrics; is org.apache.flink:flink-metrics-dropwizard on the classpath?",
-          e);
-    }
-
-    RESERVOIR_CTOR = reservoirCtor;
-    CODAHALE_HISTOGRAM_CTOR = codahaleHistogramCtor;
-    WRAPPER_CTOR = wrapperCtor;
-    DROPWIZARD_AVAILABLE = available;
-  }
+  // Histogram metrics loaded through Flink's optional flink-metrics-dropwizard dependency.
+  // Will be null if not available.
+  private static final DropwizardCtors DROPWIZARD = loadDropwizardCtors();
 
   private final Counter flushedDataFiles;
   private final Counter flushedDeleteFiles;
@@ -156,12 +118,41 @@ public class IcebergStreamWriterMetrics {
   }
 
   private static Histogram newDropwizardHistogram() {
-    if (!DROPWIZARD_AVAILABLE) {
+    if (DROPWIZARD == null) {
       return null;
     }
 
-    Object reservoir = RESERVOIR_CTOR.newInstance(HISTOGRAM_RESERVOIR_SIZE);
-    Object codahaleHistogram = CODAHALE_HISTOGRAM_CTOR.newInstance(reservoir);
-    return WRAPPER_CTOR.newInstance(codahaleHistogram);
+    Object reservoir = DROPWIZARD.reservoirCtor.newInstance(HISTOGRAM_RESERVOIR_SIZE);
+    Object codahaleHistogram = DROPWIZARD.histogramCtor.newInstance(reservoir);
+    return DROPWIZARD.wrapperCtor.newInstance(codahaleHistogram);
   }
+
+  private static DropwizardCtors loadDropwizardCtors() {
+    try {
+      Class<?> reservoirInterface = Class.forName("com.codahale.metrics.Reservoir");
+      Class<?> codahaleHistogramClass = Class.forName("com.codahale.metrics.Histogram");
+      return new DropwizardCtors(
+          DynConstructors.builder()
+              .impl("com.codahale.metrics.SlidingWindowReservoir", int.class)
+              .buildChecked(),
+          DynConstructors.builder()
+              .impl("com.codahale.metrics.Histogram", reservoirInterface)
+              .buildChecked(),
+          DynConstructors.builder(Histogram.class)
+              .impl(
+                  "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper",
+                  codahaleHistogramClass)
+              .buildChecked());
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      LOG.warn(
+          "Cannot load Dropwizard metrics; is org.apache.flink:flink-metrics-dropwizard on the classpath?",
+          e);
+      return null;
+    }
+  }
+
+  private record DropwizardCtors(
+      DynConstructors.Ctor<?> reservoirCtor,
+      DynConstructors.Ctor<?> histogramCtor,
+      DynConstructors.Ctor<Histogram> wrapperCtor) {}
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -150,14 +150,13 @@ public class IcebergStreamWriterMetrics {
               .buildChecked()
               .newInstance(reservoir);
       Histogram wrapper =
-          (Histogram)
-              DynConstructors.builder()
-                  .loader(classLoader)
-                  .impl(
-                      "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper",
-                      codahaleHistogramClass)
-                  .buildChecked()
-                  .newInstance(codahaleHistogram);
+          DynConstructors.builder(Histogram.class)
+              .loader(classLoader)
+              .impl(
+                  "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper",
+                  codahaleHistogramClass)
+              .<Histogram>buildChecked()
+              .newInstance(codahaleHistogram);
 
       return group.histogram(name, wrapper);
     } catch (ClassNotFoundException | NoSuchMethodException e) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -108,11 +108,13 @@ public class IcebergStreamWriterMetrics {
     return flushedDeleteFiles;
   }
 
+  @VisibleForTesting
   @Nullable
   Histogram dataFilesSizeHistogram() {
     return dataFilesSizeHistogram;
   }
 
+  @VisibleForTesting
   @Nullable
   Histogram deleteFilesSizeHistogram() {
     return deleteFilesSizeHistogram;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -98,11 +98,8 @@ public class IcebergStreamWriterMetrics {
     this.lastFlushDurationMs = new AtomicLong();
     writerMetrics.gauge("lastFlushDurationMs", lastFlushDurationMs::get);
 
-    this.dataFilesSizeHistogram =
-        loadHistogramIfAvailable(writerMetrics, "dataFilesSizeHistogram", HISTOGRAM_RESERVOIR_SIZE);
-    this.deleteFilesSizeHistogram =
-        loadHistogramIfAvailable(
-            writerMetrics, "deleteFilesSizeHistogram", HISTOGRAM_RESERVOIR_SIZE);
+    this.dataFilesSizeHistogram = registerHistogram(writerMetrics, "dataFilesSizeHistogram");
+    this.deleteFilesSizeHistogram = registerHistogram(writerMetrics, "deleteFilesSizeHistogram");
   }
 
   public void updateFlushResult(WriteResult result) {
@@ -153,20 +150,18 @@ public class IcebergStreamWriterMetrics {
     return deleteFilesSizeHistogram;
   }
 
-  /**
-   * Checks whether the Dropwizard-based histogram wrapper provided through Flink's optional
-   * flink-metrics-dropwizard dependency is available.
-   */
-  private static Histogram loadHistogramIfAvailable(
-      MetricGroup group, String name, int reservoirSize) {
+  private static Histogram registerHistogram(MetricGroup group, String name) {
+    Histogram histogram = newDropwizardHistogram();
+    return histogram != null ? group.histogram(name, histogram) : null;
+  }
 
+  private static Histogram newDropwizardHistogram() {
     if (!DROPWIZARD_AVAILABLE) {
       return null;
     }
 
-    Object reservoir = RESERVOIR_CTOR.newInstance(reservoirSize);
+    Object reservoir = RESERVOIR_CTOR.newInstance(HISTOGRAM_RESERVOIR_SIZE);
     Object codahaleHistogram = CODAHALE_HISTOGRAM_CTOR.newInstance(reservoir);
-    Histogram wrapper = WRAPPER_CTOR.newInstance(codahaleHistogram);
-    return group.histogram(name, wrapper);
+    return WRAPPER_CTOR.newInstance(codahaleHistogram);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -25,6 +25,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.util.ScanTaskUtil;
@@ -129,8 +130,10 @@ public class IcebergStreamWriterMetrics {
 
   private static DropwizardCtors loadDropwizardCtors() {
     try {
-      Class<?> reservoirInterface = Class.forName("com.codahale.metrics.Reservoir");
-      Class<?> codahaleHistogramClass = Class.forName("com.codahale.metrics.Histogram");
+      Class<?> reservoirInterface =
+          DynClasses.builder().impl("com.codahale.metrics.Reservoir").buildChecked();
+      Class<?> codahaleHistogramClass =
+          DynClasses.builder().impl("com.codahale.metrics.Histogram").buildChecked();
       return new DropwizardCtors(
           DynConstructors.builder()
               .impl("com.codahale.metrics.SlidingWindowReservoir", int.class)

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -118,30 +118,23 @@ public class IcebergStreamWriterMetrics {
     return deleteFilesSizeHistogram;
   }
 
-  static Histogram loadHistogramIfAvailable(
-      MetricGroup group, String name, int reservoirSize, ClassLoader classLoader) {
-
-    if (isFlinkDropwizardAvailable(classLoader)) {
-      return HistogramLoader.load(name, group, reservoirSize);
-    } else {
-      LOG.warn(
-          "flink-metrics-dropwizard is not on the classpath. '{}' histogram metrics will be disabled. Add org.apache.flink:flink-metrics-dropwizard to enable them.",
-          name);
-      return null;
-    }
-  }
-
   /**
    * Checks whether the Dropwizard-based histogram wrapper provided through Flink's optional
    * flink-metrics-dropwizard dependency is available.
    */
-  private static boolean isFlinkDropwizardAvailable(ClassLoader classLoader) {
+  @SuppressWarnings("CatchBlockLogException")
+  static Histogram loadHistogramIfAvailable(
+      MetricGroup group, String name, int reservoirSize, ClassLoader classLoader) {
+
     try {
       Class.forName(
           "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper", false, classLoader);
-      return true;
+      return HistogramLoader.load(name, group, reservoirSize);
     } catch (ClassNotFoundException e) {
-      return false;
+      LOG.warn(
+          "flink-metrics-dropwizard is not on the classpath. '{}' histogram metrics will be disabled. Add org.apache.flink:flink-metrics-dropwizard to enable them.",
+          name);
+      return null;
     }
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -109,12 +109,12 @@ public class IcebergStreamWriterMetrics {
   }
 
   @Nullable
-  Histogram getDataFilesSizeHistogram() {
+  Histogram dataFilesSizeHistogram() {
     return dataFilesSizeHistogram;
   }
 
   @Nullable
-  Histogram getDeleteFilesSizeHistogram() {
+  Histogram deleteFilesSizeHistogram() {
     return deleteFilesSizeHistogram;
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -72,7 +72,7 @@ public class IcebergStreamWriterMetrics {
       available = true;
     } catch (ClassNotFoundException | NoSuchMethodException e) {
       LOG.warn(
-          "flink-metrics-dropwizard is not on the classpath. Histogram metrics will be disabled. Add org.apache.flink:flink-metrics-dropwizard to enable them.",
+          "Cannot load Dropwizard metrics; is org.apache.flink:flink-metrics-dropwizard on the classpath?",
           e);
     }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.flink.sink;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
@@ -110,13 +109,11 @@ public class IcebergStreamWriterMetrics {
   }
 
   @VisibleForTesting
-  @Nullable
   Histogram dataFilesSizeHistogram() {
     return dataFilesSizeHistogram;
   }
 
   @VisibleForTesting
-  @Nullable
   Histogram deleteFilesSizeHistogram() {
     return deleteFilesSizeHistogram;
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriterMetrics.java
@@ -18,19 +18,25 @@
  */
 package org.apache.iceberg.flink.sink;
 
-import com.codahale.metrics.SlidingWindowReservoir;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.util.ScanTaskUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Internal
 public class IcebergStreamWriterMetrics {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergStreamWriterMetrics.class);
+
   // 1,024 reservoir size should cost about 8KB, which is quite small.
   // It should also produce good accuracy for histogram distribution (like percentiles).
   private static final int HISTOGRAM_RESERVOIR_SIZE = 1024;
@@ -43,6 +49,11 @@ public class IcebergStreamWriterMetrics {
   private final Histogram deleteFilesSizeHistogram;
 
   public IcebergStreamWriterMetrics(MetricGroup metrics, String fullTableName) {
+    this(metrics, fullTableName, IcebergStreamWriterMetrics.class.getClassLoader());
+  }
+
+  @VisibleForTesting
+  IcebergStreamWriterMetrics(MetricGroup metrics, String fullTableName, ClassLoader classLoader) {
     MetricGroup writerMetrics =
         metrics.addGroup("IcebergStreamWriter").addGroup("table", fullTableName);
     this.flushedDataFiles = writerMetrics.counter("flushedDataFiles");
@@ -51,18 +62,12 @@ public class IcebergStreamWriterMetrics {
     this.lastFlushDurationMs = new AtomicLong();
     writerMetrics.gauge("lastFlushDurationMs", lastFlushDurationMs::get);
 
-    com.codahale.metrics.Histogram dropwizardDataFilesSizeHistogram =
-        new com.codahale.metrics.Histogram(new SlidingWindowReservoir(HISTOGRAM_RESERVOIR_SIZE));
     this.dataFilesSizeHistogram =
-        writerMetrics.histogram(
-            "dataFilesSizeHistogram",
-            new DropwizardHistogramWrapper(dropwizardDataFilesSizeHistogram));
-    com.codahale.metrics.Histogram dropwizardDeleteFilesSizeHistogram =
-        new com.codahale.metrics.Histogram(new SlidingWindowReservoir(HISTOGRAM_RESERVOIR_SIZE));
+        loadHistogramIfAvailable(
+            writerMetrics, "dataFilesSizeHistogram", HISTOGRAM_RESERVOIR_SIZE, classLoader);
     this.deleteFilesSizeHistogram =
-        writerMetrics.histogram(
-            "deleteFilesSizeHistogram",
-            new DropwizardHistogramWrapper(dropwizardDeleteFilesSizeHistogram));
+        loadHistogramIfAvailable(
+            writerMetrics, "deleteFilesSizeHistogram", HISTOGRAM_RESERVOIR_SIZE, classLoader);
   }
 
   public void updateFlushResult(WriteResult result) {
@@ -74,16 +79,21 @@ public class IcebergStreamWriterMetrics {
     // This should works equally well and we avoided the overhead of tracking the list of file sizes
     // in the {@link CommitSummary}, which currently stores simple stats for counters and gauges
     // metrics.
-    Arrays.stream(result.dataFiles())
-        .forEach(
-            dataFile -> {
-              dataFilesSizeHistogram.update(dataFile.fileSizeInBytes());
-            });
-    Arrays.stream(result.deleteFiles())
-        .forEach(
-            deleteFile -> {
-              deleteFilesSizeHistogram.update(ScanTaskUtil.contentSizeInBytes(deleteFile));
-            });
+    if (dataFilesSizeHistogram != null) {
+      Arrays.stream(result.dataFiles())
+          .forEach(
+              dataFile -> {
+                dataFilesSizeHistogram.update(dataFile.fileSizeInBytes());
+              });
+    }
+
+    if (deleteFilesSizeHistogram != null) {
+      Arrays.stream(result.deleteFiles())
+          .forEach(
+              deleteFile -> {
+                deleteFilesSizeHistogram.update(ScanTaskUtil.contentSizeInBytes(deleteFile));
+              });
+    }
   }
 
   public void flushDuration(long flushDurationMs) {
@@ -96,5 +106,56 @@ public class IcebergStreamWriterMetrics {
 
   public Counter getFlushedDeleteFiles() {
     return flushedDeleteFiles;
+  }
+
+  @Nullable
+  Histogram getDataFilesSizeHistogram() {
+    return dataFilesSizeHistogram;
+  }
+
+  @Nullable
+  Histogram getDeleteFilesSizeHistogram() {
+    return deleteFilesSizeHistogram;
+  }
+
+  static Histogram loadHistogramIfAvailable(
+      MetricGroup group, String name, int reservoirSize, ClassLoader classLoader) {
+
+    if (isFlinkDropwizardAvailable(classLoader)) {
+      return HistogramLoader.load(name, group, reservoirSize);
+    } else {
+      LOG.warn(
+          "flink-metrics-dropwizard is not on the classpath. '{}' histogram metrics will be disabled. Add org.apache.flink:flink-metrics-dropwizard to enable them.",
+          name);
+      return null;
+    }
+  }
+
+  /**
+   * Checks whether the Dropwizard-based histogram wrapper provided through Flink's optional
+   * flink-metrics-dropwizard dependency is available.
+   */
+  private static boolean isFlinkDropwizardAvailable(ClassLoader classLoader) {
+    try {
+      Class.forName(
+          "org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper", false, classLoader);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Must be encapsulated into a separate class to avoid the JVM eagerly loading any non-existing
+   * referenced classes. This has been manually verified.
+   */
+  private static final class HistogramLoader {
+
+    static Histogram load(String name, MetricGroup group, int reservoirSize) {
+      com.codahale.metrics.Histogram codahaleHistogram =
+          new com.codahale.metrics.Histogram(
+              new com.codahale.metrics.SlidingWindowReservoir(reservoirSize));
+      return group.histogram(name, new DropwizardHistogramWrapper(codahaleHistogram));
+    }
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriterMetrics.java
@@ -35,8 +35,8 @@ public class TestIcebergStreamWriterMetrics {
         new IcebergStreamWriterMetrics(
             UnregisteredMetricsGroup.createSinkWriterMetricGroup(), "db.table");
 
-    assertThat(metrics.getDataFilesSizeHistogram()).isNotNull();
-    assertThat(metrics.getDeleteFilesSizeHistogram()).isNotNull();
+    assertThat(metrics.dataFilesSizeHistogram()).isNotNull();
+    assertThat(metrics.deleteFilesSizeHistogram()).isNotNull();
 
     assertThatNoException()
         .isThrownBy(() -> metrics.updateFlushResult(WriteResult.builder().build()));
@@ -50,8 +50,8 @@ public class TestIcebergStreamWriterMetrics {
           new IcebergStreamWriterMetrics(
               UnregisteredMetricsGroup.createSinkWriterMetricGroup(), "db.table", loader);
 
-      assertThat(metrics.getDataFilesSizeHistogram()).isNull();
-      assertThat(metrics.getDeleteFilesSizeHistogram()).isNull();
+      assertThat(metrics.dataFilesSizeHistogram()).isNull();
+      assertThat(metrics.deleteFilesSizeHistogram()).isNull();
 
       assertThatNoException()
           .isThrownBy(() -> metrics.updateFlushResult(WriteResult.builder().build()));

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriterMetrics.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.iceberg.io.WriteResult;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergStreamWriterMetrics {
+
+  @Test
+  void histogramsCreatedWhenDropwizardAvailable() {
+    IcebergStreamWriterMetrics metrics =
+        new IcebergStreamWriterMetrics(
+            UnregisteredMetricsGroup.createSinkWriterMetricGroup(), "db.table");
+
+    assertThat(metrics.getDataFilesSizeHistogram()).isNotNull();
+    assertThat(metrics.getDeleteFilesSizeHistogram()).isNotNull();
+
+    assertThatNoException()
+        .isThrownBy(() -> metrics.updateFlushResult(WriteResult.builder().build()));
+  }
+
+  @Test
+  void histogramsSkippedWhenDropwizardMissing() throws Exception {
+    try (EmptyClassloader loader = new EmptyClassloader()) {
+
+      IcebergStreamWriterMetrics metrics =
+          new IcebergStreamWriterMetrics(
+              UnregisteredMetricsGroup.createSinkWriterMetricGroup(), "db.table", loader);
+
+      assertThat(metrics.getDataFilesSizeHistogram()).isNull();
+      assertThat(metrics.getDeleteFilesSizeHistogram()).isNull();
+
+      assertThatNoException()
+          .isThrownBy(() -> metrics.updateFlushResult(WriteResult.builder().build()));
+    }
+  }
+
+  private static final class EmptyClassloader extends URLClassLoader {
+
+    EmptyClassloader() {
+      super(new URL[0]);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+      throw new ClassNotFoundException(name);
+    }
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriterMetrics.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriterMetrics.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.flink.sink;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-import java.net.URL;
-import java.net.URLClassLoader;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.iceberg.io.WriteResult;
 import org.junit.jupiter.api.Test;
@@ -40,33 +38,5 @@ public class TestIcebergStreamWriterMetrics {
 
     assertThatNoException()
         .isThrownBy(() -> metrics.updateFlushResult(WriteResult.builder().build()));
-  }
-
-  @Test
-  void histogramsSkippedWhenDropwizardMissing() throws Exception {
-    try (EmptyClassloader loader = new EmptyClassloader()) {
-
-      IcebergStreamWriterMetrics metrics =
-          new IcebergStreamWriterMetrics(
-              UnregisteredMetricsGroup.createSinkWriterMetricGroup(), "db.table", loader);
-
-      assertThat(metrics.dataFilesSizeHistogram()).isNull();
-      assertThat(metrics.deleteFilesSizeHistogram()).isNull();
-
-      assertThatNoException()
-          .isThrownBy(() -> metrics.updateFlushResult(WriteResult.builder().build()));
-    }
-  }
-
-  private static final class EmptyClassloader extends URLClassLoader {
-
-    EmptyClassloader() {
-      super(new URL[0]);
-    }
-
-    @Override
-    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-      throw new ClassNotFoundException(name);
-    }
   }
 }

--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -67,11 +67,6 @@ To add a dependency on Iceberg in Maven, add the following to your `pom.xml`:
 </dependencies>
 ```
 
-### 1.11.0 release
-
-* Flink
-    - Flink's optional `flink-metrics-dropwizard` dependency is no longer shipped in the `iceberg-flink-runtime` fat jar. Without this dependency, the histogram metrics "dataFilesSizeHistogram" and "deleteFilesSizeHistogram" will no longer be published. Users can add manually add back the dependency for the metrics to continue to get published.
-
 ### 1.10.1 release
 
 Apache Iceberg 1.10.1 was released on Dec 22, 2025.

--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -67,6 +67,11 @@ To add a dependency on Iceberg in Maven, add the following to your `pom.xml`:
 </dependencies>
 ```
 
+### 1.11.0 release
+
+* Flink
+    - Flink's optional `flink-metrics-dropwizard` dependency is no longer shipped in the `iceberg-flink-runtime` fat jar. Without this dependency, the histogram metrics "dataFilesSizeHistogram" and "deleteFilesSizeHistogram" will no longer be published. Users can add manually add back the dependency for the metrics to continue to get published.
+
 ### 1.10.1 release
 
 Apache Iceberg 1.10.1 was released on Dec 22, 2025.


### PR DESCRIPTION
Flink does not bundle `flink-metrics-dropwizard` [1][2], which enables histogram metrics. Users need to manually include the dependency for histograms to work.

In Iceberg, we used to include the dependency in the flink-runtime jar. Ryan had removed the dependency in #16093 to avoid LICENSE issues, but we added it back in #16126 with the corresponding LICENSE changes, to avoid breaking changes for users.

After discussing with Peter, we decided to remove the bundling going forward (`1.11.0` and later). This PR makes sure there are no regressions removing the dependency. I've updated the docs and the changelog to inform users of the change.

References:
1. https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/metrics/#histogram
2. https://github.com/apache/flink/blob/ccf45727eeb2e920f7939f453db67a411e3cb109/flink-dist/pom.xml#L284