### PR TITLE
Open API: Remove runtime Jar from build and deploy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1060,6 +1060,9 @@ project(':iceberg-snowflake') {
 
 project(':iceberg-open-api') {
   apply plugin: 'java-test-fixtures'
+  apply plugin: 'com.gradleup.shadow'
+
+  build.dependsOn shadowJar
 
   dependencies {
     testImplementation project(':iceberg-api')
@@ -1143,6 +1146,24 @@ project(':iceberg-open-api') {
     recommend.set(true)
   }
   check.dependsOn('validateRESTCatalogSpec')
+
+  shadowJar {
+    archiveBaseName.set("iceberg-open-api-test-fixtures-runtime")
+    archiveClassifier.set(null)
+    configurations = [project.configurations.testFixturesRuntimeClasspath]
+    from sourceSets.testFixtures.output
+    zip64 true
+
+    // include the LICENSE and NOTICE files for the runtime Jar
+    from(projectDir) {
+      include 'LICENSE'
+      include 'NOTICE'
+    }
+
+    manifest {
+      attributes 'Main-Class': 'org.apache.iceberg.rest.RESTCatalogServer'
+    }
+  }
 
   jar {
     enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -1060,9 +1060,6 @@ project(':iceberg-snowflake') {
 
 project(':iceberg-open-api') {
   apply plugin: 'java-test-fixtures'
-  apply plugin: 'com.gradleup.shadow'
-
-  build.dependsOn shadowJar
 
   dependencies {
     testImplementation project(':iceberg-api')
@@ -1146,24 +1143,6 @@ project(':iceberg-open-api') {
     recommend.set(true)
   }
   check.dependsOn('validateRESTCatalogSpec')
-
-  shadowJar {
-    archiveBaseName.set("iceberg-open-api-test-fixtures-runtime")
-    archiveClassifier.set(null)
-    configurations = [project.configurations.testFixturesRuntimeClasspath]
-    from sourceSets.testFixtures.output
-    zip64 true
-
-    // include the LICENSE and NOTICE files for the runtime Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    manifest {
-      attributes 'Main-Class': 'org.apache.iceberg.rest.RESTCatalogServer'
-    }
-  }
 
   jar {
     enabled = false

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -75,6 +75,7 @@ subprojects {
           } else if (isOpenApi) {
             artifact testJar
             artifact testFixturesJar
+            artifact shadowJar
           } else {
             if (tasks.matching({task -> task.name == 'shadowJar'}).isEmpty()) {
               from components.java

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -75,7 +75,6 @@ subprojects {
           } else if (isOpenApi) {
             artifact testJar
             artifact testFixturesJar
-            artifact shadowJar
           } else {
             if (tasks.matching({task -> task.name == 'shadowJar'}).isEmpty()) {
               from components.java


### PR DESCRIPTION
This removes the Open API runtime Jar from build and deploy. This is an alternative to recent PRs that are attempting to fix the LICENSE and NOTICE documentation, #15872 and #16143.

This Jar was added by #11279. Looking at that PR, the original runtime was about 50 MB, with a 100+ MB version that was rejected for having too much bundled. The Jar is now 4x larger: 200+ MB.

I'm not confident that the original LICENSE and NOTICE were handled correctly; they were auto-generated from license-report, but had to be merged with the root and had a [LGPL dependency](https://github.com/apache/iceberg/pull/11279#issuecomment-2442559693) at some point. I also don't think that the LICENSE was ever thoroughly checked. [One comment](https://github.com/apache/iceberg/pull/11279#issuecomment-2446974737) says "I did some checking and didn't find any red flags" but it doesn't look like there was a thorough review.

Rather than minimizing dependencies and reviewing the LICENSE and NOTICE content, I think that this artifact should be removed from the build.

If I understand correctly, it was created in order to build a Docker image (#11283), but a Docker image doesn't require a runtime Jar. It just needs a `lib/` directory with the necessary dependencies, which is a better way to distribute transitive dependencies with their own license documentation. If there is no need to have a runtime Jar, we should not distribute one.

I also don't think that there is a reasonable use for this runtime Jar. Runtime Jars are a substantial amount of work -- to minimize dependencies and document them -- and we produce runtime Jars when it is a big help to downstream users. For example, adding Iceberg to Spark is much, much easier. We do not distribute runtime Jars for downstream projects that use build systems.

Because this is integration test code, we can reasonably assume that the downstream consumers are using a build system and are able to use that to maintain their own version-managed classpath. This is also test code because we decided not to distribute an example REST service implementation in the project.

I think that this runtime Jar should be removed. Projects using it for testing can use their builds to integrate it and produce the classpath. We still want a Docker image for cross-project testing within the Iceberg community, but that should be built differently.