### PR TITLE
Spark 4.1: Migrate SparkWriteBuilder to SupportsOverwriteV2

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -27,10 +27,10 @@ import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.spark.SparkFilters;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
+import org.apache.iceberg.spark.SparkV2Filters;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.SparkWriteRequirements;
 import org.apache.iceberg.spark.source.SparkWriteBuilder.Mode.Append;
@@ -39,20 +39,20 @@ import org.apache.iceberg.spark.source.SparkWriteBuilder.Mode.DynamicOverwrite;
 import org.apache.iceberg.spark.source.SparkWriteBuilder.Mode.OverwriteByFilter;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command;
 import org.apache.spark.sql.connector.write.SupportsDynamicOverwrite;
-import org.apache.spark.sql.connector.write.SupportsOverwrite;
+import org.apache.spark.sql.connector.write.SupportsOverwriteV2;
 import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
-import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
-class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, SupportsOverwrite {
+class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, SupportsOverwriteV2 {
   private final SparkSession spark;
   private final Table table;
   private final String branch;
@@ -91,9 +91,9 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
   }
 
   @Override
-  public WriteBuilder overwrite(Filter[] filters) {
+  public WriteBuilder overwrite(Predicate[] predicates) {
     Preconditions.checkState(mode == null, "Cannot use overwrite by filter with other modes");
-    Expression expr = SparkFilters.convert(filters);
+    Expression expr = SparkV2Filters.convert(predicates);
     this.mode = useDynamicOverwrite(expr) ? new DynamicOverwrite() : new OverwriteByFilter(expr);
     return this;
   }


### PR DESCRIPTION
Migrate `SparkWriteBuilder` in Spark 4.1 from  `SupportsOverwrite` (DSv1, `Filter[]`) to `SupportsOverwriteV2` (DSv2, `Predicate[]`)