### PR TITLE
Core: Fix ByteBufferInputStream.read() to return -1 at EOF

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/MultiBufferInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/io/MultiBufferInputStream.java
@@ -263,7 +263,7 @@ class MultiBufferInputStream extends ByteBufferInputStream {
   @Override
   public int read() throws IOException {
     if (current == null) {
-      throw new EOFException();
+      return -1;
     }
 
     while (true) {
@@ -272,7 +272,7 @@ class MultiBufferInputStream extends ByteBufferInputStream {
         return current.get() & 0xFF; // as unsigned
       } else if (!nextBuffer()) {
         // there are no more buffers
-        throw new EOFException();
+        return -1;
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
@@ -58,7 +58,7 @@ class SingleBufferInputStream extends ByteBufferInputStream {
   @Override
   public int read() throws IOException {
     if (!buffer.hasRemaining()) {
-      throw new EOFException();
+      return -1;
     }
     return buffer.get() & 0xFF; // as unsigned
   }

--- a/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
@@ -35,6 +35,14 @@ public abstract class TestByteBufferInputStreams {
 
   protected abstract void checkOriginalData();
 
+  private static void assertAtEOF(ByteBufferInputStream stream) throws IOException {
+    long pos = stream.getPos();
+    assertThat(stream.read()).as("read() at EOF").isEqualTo(-1);
+    assertThat(stream.read()).as("read() should keep returning -1 at EOF").isEqualTo(-1);
+    assertThat(stream.getPos()).as("Position should not advance past EOF").isEqualTo(pos);
+    assertThat(stream.available()).as("available() should be 0 at EOF").isEqualTo(0);
+  }
+
   @Test
   public void testRead0() throws Exception {
     byte[] bytes = new byte[0];
@@ -67,7 +75,7 @@ public abstract class TestByteBufferInputStreams {
 
     assertThat(stream.read(bytes)).as("Should return -1 at end of stream").isEqualTo(-1);
 
-    assertThat(stream.available()).as("Should have no more remaining content").isEqualTo(0);
+    assertAtEOF(stream);
 
     checkOriginalData();
   }
@@ -102,7 +110,7 @@ public abstract class TestByteBufferInputStreams {
 
       assertThat(stream.read(bytes)).as("Should return -1 at end of stream").isEqualTo(-1);
 
-      assertThat(stream.available()).as("Should have no more remaining content").isEqualTo(0);
+      assertAtEOF(stream);
     }
 
     checkOriginalData();
@@ -142,7 +150,7 @@ public abstract class TestByteBufferInputStreams {
 
       assertThat(stream.read(bytes)).as("Should return -1 at end of stream").isEqualTo(-1);
 
-      assertThat(stream.available()).as("Should have no more remaining content").isEqualTo(0);
+      assertAtEOF(stream);
     }
 
     checkOriginalData();
@@ -158,7 +166,7 @@ public abstract class TestByteBufferInputStreams {
       assertThat(stream.read()).isEqualTo(i);
     }
 
-    assertThatThrownBy(stream::read).isInstanceOf(EOFException.class).hasMessage(null);
+    assertAtEOF(stream);
 
     checkOriginalData();
   }
@@ -531,5 +539,12 @@ public abstract class TestByteBufferInputStreams {
     assertThatThrownBy(stream::reset)
         .isInstanceOf(IOException.class)
         .hasMessageStartingWith("No mark defined");
+  }
+
+  @Test
+  public void testEmptyStream() throws Exception {
+    assertAtEOF(ByteBufferInputStream.wrap(ByteBuffer.allocate(0)));
+    assertAtEOF(ByteBufferInputStream.wrap(ByteBuffer.allocate(0), ByteBuffer.allocate(0)));
+    assertAtEOF(ByteBufferInputStream.wrap(Collections.emptyList()));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
@@ -39,6 +39,7 @@ public abstract class TestByteBufferInputStreams {
     long pos = stream.getPos();
     assertThat(stream.read()).as("read() at EOF").isEqualTo(-1);
     assertThat(stream.read()).as("read() should keep returning -1 at EOF").isEqualTo(-1);
+    assertThat(stream.read(new byte[1])).as("read(byte[]) at EOF").isEqualTo(-1);
     assertThat(stream.getPos()).as("Position should not advance past EOF").isEqualTo(pos);
     assertThat(stream.available()).as("available() should be 0 at EOF").isEqualTo(0);
   }
@@ -546,5 +547,15 @@ public abstract class TestByteBufferInputStreams {
     assertAtEOF(ByteBufferInputStream.wrap(ByteBuffer.allocate(0)));
     assertAtEOF(ByteBufferInputStream.wrap(ByteBuffer.allocate(0), ByteBuffer.allocate(0)));
     assertAtEOF(ByteBufferInputStream.wrap(Collections.emptyList()));
+  }
+
+  @Test
+  public void testDrainedMultiBufferStream() throws Exception {
+    ByteBufferInputStream stream =
+        ByteBufferInputStream.wrap(
+            ByteBuffer.wrap(new byte[] {1, 2, 3}), ByteBuffer.wrap(new byte[] {4, 5}));
+    byte[] buf = new byte[5];
+    assertThat(stream.read(buf)).as("Should read all bytes").isEqualTo(5);
+    assertAtEOF(stream);
   }
 }


### PR DESCRIPTION
Fixes #16127.

`SingleBufferInputStream.read()` and `MultiBufferInputStream.read()` throw `EOFException` when the stream is exhausted. This violates the `java.io.InputStream` contract, which requires the no-arg `read()` to return `-1` at EOF.

The multi-byte `read(byte[], int, int)` in both classes already correctly returns `-1` at EOF — the two overloads were inconsistent.

**Changes:**
- `SingleBufferInputStream.read()`: return `-1` instead of throwing `EOFException`
- `MultiBufferInputStream.read()`: return `-1` at both EOF entry points instead of throwing `EOFException`
- Update `testReadByte()` to assert `-1` return (including idempotency check)

Other `EOFException`-throwing methods (`slice()`, `sliceBuffers()`, `skipFully()`) are unchanged — they request specific byte counts where `EOFException` is the correct signal.