### PR TITLE
Flink: Add RemoveDanglingDeleteFiles to maintenance API

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RemoveDanglingDeleteFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RemoveDanglingDeleteFiles.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.iceberg.flink.maintenance.operator.RemoveDanglingDeleteFilesProcessor;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Removes dangling delete files from the current snapshot. A delete file is dangling if its deletes
+ * no longer apply to any live data files.
+ */
+public class RemoveDanglingDeleteFiles {
+  private static final String EXECUTOR_OPERATOR_NAME = "Remove Dangling Deletes";
+
+  private RemoveDanglingDeleteFiles() {}
+
+  /** Creates the builder for creating a stream which removes dangling delete files. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder extends MaintenanceTaskBuilder<RemoveDanglingDeleteFiles.Builder> {
+    @Override
+    String maintenanceTaskName() {
+      return "RemoveDanglingDeleteFiles";
+    }
+
+    @Override
+    DataStream<TaskResult> append(DataStream<Trigger> trigger) {
+      Preconditions.checkNotNull(tableLoader(), "TableLoader should not be null");
+
+      return trigger
+          .process(new RemoveDanglingDeleteFilesProcessor(tableLoader()))
+          .name(operatorName(EXECUTOR_OPERATOR_NAME))
+          .uid(EXECUTOR_OPERATOR_NAME + uidSuffix())
+          .slotSharingGroup(slotSharingGroup())
+          .forceNonParallel();
+    }
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/RemoveDanglingDeleteFilesProcessor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/RemoveDanglingDeleteFilesProcessor.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.TaskResult;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.DeleteFileSet;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Removes dangling delete files from the current snapshot. A delete file is dangling if its deletes
+ * no longer apply to any live data files.
+ *
+ * <p>The following dangling delete files are removed:
+ *
+ * <ul>
+ *   <li>Position delete files with a data sequence number less than that of any data file in the
+ *       same partition
+ *   <li>Equality delete files with a data sequence number less than or equal to that of any data
+ *       file in the same partition
+ *   <li>Delete files in partitions with no live data files
+ *   <li>Deletion vectors (Puffin files) referencing non-existent data files
+ * </ul>
+ */
+@Internal
+public class RemoveDanglingDeleteFilesProcessor extends ProcessFunction<Trigger, TaskResult> {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RemoveDanglingDeleteFilesProcessor.class);
+
+  private final TableLoader tableLoader;
+  private transient Table table;
+
+  public RemoveDanglingDeleteFilesProcessor(TableLoader tableLoader) {
+    Preconditions.checkNotNull(tableLoader, "Table loader should not be null");
+    this.tableLoader = tableLoader;
+  }
+
+  @Override
+  public void open(OpenContext parameters) throws Exception {
+    tableLoader.open();
+    this.table = tableLoader.loadTable();
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<TaskResult> out)
+      throws Exception {
+    try {
+      table.refresh();
+
+      if (table.specs().size() == 1 && table.spec().isUnpartitioned()) {
+        LOG.info(
+            "Skipping remove dangling deletes for unpartitioned table {}: "
+                + "ManifestFilterManager handles this case",
+            table.name());
+        out.collect(
+            new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+        return;
+      }
+
+      Snapshot snapshot = table.currentSnapshot();
+      if (snapshot == null) {
+        LOG.info("No current snapshot for table {}, nothing to do", table.name());
+        out.collect(
+            new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+        return;
+      }
+
+      DeleteFileSet danglingDeletes = DeleteFileSet.create();
+      danglingDeletes.addAll(findDanglingDeletes(snapshot));
+      danglingDeletes.addAll(findDanglingDvs(snapshot));
+
+      if (!danglingDeletes.isEmpty()) {
+        RewriteFiles rewriteFiles = table.newRewrite();
+        for (DeleteFile deleteFile : danglingDeletes) {
+          LOG.debug("Removing dangling delete file {}", deleteFile.location());
+          rewriteFiles.deleteFile(deleteFile);
+        }
+
+        rewriteFiles.commit();
+      }
+
+      LOG.info(
+          "Successfully finished removing dangling deletes for {} at {}. Removed {} delete files.",
+          table.name(),
+          ctx.timestamp(),
+          danglingDeletes.size());
+      out.collect(
+          new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+    } catch (Exception e) {
+      LOG.error("Failed to remove dangling deletes for {} at {}", table.name(), ctx.timestamp(), e);
+      out.collect(
+          new TaskResult(trigger.taskId(), trigger.timestamp(), false, Lists.newArrayList(e)));
+    }
+  }
+
+  private DeleteFileSet findDanglingDeletes(Snapshot snapshot) throws Exception {
+    FileIO io = table.io();
+    Map<Integer, PartitionSpec> specsById = table.specs();
+
+    Map<Integer, Map<StructLikeWrapper, Long>> minDataSeqByPartition = Maps.newHashMap();
+    Map<Integer, StructLikeWrapper> wrappersBySpec = Maps.newHashMap();
+
+    for (ManifestFile manifest : snapshot.dataManifests(io)) {
+      try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)) {
+        for (DataFile file : reader) {
+          Long seq = file.dataSequenceNumber();
+          if (seq == null) {
+            continue;
+          }
+
+          int specId = file.specId();
+          StructLikeWrapper template =
+              wrappersBySpec.computeIfAbsent(
+                  specId, id -> StructLikeWrapper.forType(specsById.get(id).partitionType()));
+
+          StructLikeWrapper partitionKey = template.copyFor(file.partition());
+          minDataSeqByPartition
+              .computeIfAbsent(specId, id -> Maps.newHashMap())
+              .merge(partitionKey, seq, Math::min);
+        }
+      }
+    }
+
+    DeleteFileSet danglingDeletes = DeleteFileSet.create();
+
+    for (ManifestFile manifest : snapshot.deleteManifests(io)) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, io, specsById)) {
+        for (DeleteFile file : reader) {
+          if (isDanglingBySequenceNumber(file, minDataSeqByPartition, wrappersBySpec, specsById)) {
+            danglingDeletes.add(file);
+          }
+        }
+      }
+    }
+
+    return danglingDeletes;
+  }
+
+  private DeleteFileSet findDanglingDvs(Snapshot snapshot) throws Exception {
+    FileIO io = table.io();
+    Map<Integer, PartitionSpec> specsById = table.specs();
+
+    Set<String> dvReferencedPaths = Sets.newHashSet();
+    DeleteFileSet dvCandidates = DeleteFileSet.create();
+
+    for (ManifestFile manifest : snapshot.deleteManifests(io)) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, io, specsById)) {
+        for (DeleteFile file : reader) {
+          if (file.format() == FileFormat.PUFFIN && file.referencedDataFile() != null) {
+            dvReferencedPaths.add(file.referencedDataFile());
+            dvCandidates.add(file);
+          }
+        }
+      }
+    }
+
+    if (dvCandidates.isEmpty()) {
+      return dvCandidates;
+    }
+
+    for (ManifestFile manifest : snapshot.dataManifests(io)) {
+      if (dvReferencedPaths.isEmpty()) {
+        break;
+      }
+
+      try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)) {
+        for (DataFile file : reader) {
+          dvReferencedPaths.remove(file.location());
+          if (dvReferencedPaths.isEmpty()) {
+            break;
+          }
+        }
+      }
+    }
+
+    DeleteFileSet danglingDvs = DeleteFileSet.create();
+    for (DeleteFile dv : dvCandidates) {
+      if (dvReferencedPaths.contains(dv.referencedDataFile())) {
+        danglingDvs.add(dv);
+      }
+    }
+
+    return danglingDvs;
+  }
+
+  private static boolean isDanglingBySequenceNumber(
+      DeleteFile file,
+      Map<Integer, Map<StructLikeWrapper, Long>> minDataSeqByPartition,
+      Map<Integer, StructLikeWrapper> wrappersBySpec,
+      Map<Integer, PartitionSpec> specsById) {
+    Long seq = file.dataSequenceNumber();
+    if (seq == null) {
+      return false;
+    }
+
+    int specId = file.specId();
+    StructLikeWrapper template =
+        wrappersBySpec.computeIfAbsent(
+            specId, id -> StructLikeWrapper.forType(specsById.get(id).partitionType()));
+    StructLikeWrapper partitionKey = template.copyFor(file.partition());
+
+    Map<StructLikeWrapper, Long> partitionMap = minDataSeqByPartition.get(specId);
+    Long minDataSeq = partitionMap != null ? partitionMap.get(partitionKey) : null;
+
+    if (minDataSeq == null) {
+      return true;
+    }
+
+    if (file.content() == FileContent.POSITION_DELETES && seq < minDataSeq) {
+      return true;
+    }
+
+    return file.content() == FileContent.EQUALITY_DELETES && seq <= minDataSeq;
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRemoveDanglingDeleteFiles.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRemoveDanglingDeleteFiles.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.StreamSupport;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.operator.MetricsReporterFactoryForTests;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestRemoveDanglingDeleteFiles extends MaintenanceTaskTestBase {
+  private Table table;
+  private PartitionSpec spec;
+
+  @BeforeEach
+  void before() {
+    MetricsReporterFactoryForTests.reset();
+    this.table = createPartitionedTable();
+    this.spec = table.spec();
+    tableLoader().open();
+  }
+
+  @Test
+  void testPartitionedDanglingDeletes() throws Exception {
+    DataFile fileB =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+    DataFile fileC =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-c.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=c")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data files in partitions b, c
+    table.newAppend().appendFile(fileB).appendFile(fileC).commit();
+
+    // Commit 2 (seq=2): Add delete files for partitions a (no data) and b (has data)
+    DeleteFile deleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteA2 =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofPositionDeletes()
+            .withPath("/path/to/delete-a2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteB =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addDeletes(deleteA).addDeletes(deleteA2).addDeletes(deleteB).commit();
+
+    // Commit 3 (seq=3): Add more data to partitions a and b
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DataFile fileB2 =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table.newAppend().appendFile(fileA).appendFile(fileB2).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // Partition a: deleteA (eq, seq=2) and deleteA2 (pos, seq=2) are dangling
+    // because the only data file in partition a (fileA) has seq=3,
+    // meaning min_data_seq=3 > delete_seq=2 for both eq and pos deletes
+    // Partition b: deleteB (eq, seq=2) is NOT dangling
+    // because fileB has seq=1 which is < delete_seq=2
+    assertThat(deleteFilesBefore - deleteFilesAfter)
+        .as("Should have removed 2 dangling delete files from partition a")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void testEqualityDeletesWithEqualSeqNo() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data in partition a
+    table.newAppend().appendFile(fileA).commit();
+
+    // Commit 2 (seq=2): Add data + eq deletes in same commit for partitions a and b
+    DataFile fileA2 =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DataFile fileB =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+    DeleteFile eqDeleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile eqDeleteB =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-delete-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table
+        .newRowDelta()
+        .addRows(fileA2)
+        .addRows(fileB)
+        .addDeletes(eqDeleteA)
+        .addDeletes(eqDeleteB)
+        .commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // Partition a: eqDeleteA (seq=2) is NOT dangling because fileA (seq=1) exists
+    //   and min_data_seq=1 < delete_seq=2
+    // Partition b: eqDeleteB (seq=2) IS dangling because min_data_seq=2 == delete_seq=2
+    //   (equality deletes with seq <= min_data_seq are dangling)
+    assertThat(deleteFilesBefore - deleteFilesAfter)
+        .as("Should have removed 1 dangling eq delete from partition b")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void testUnpartitionedTable() throws Exception {
+    // Drop the partitioned table and create an unpartitioned one
+    dropTable();
+    this.table = createTable();
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteFile =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addRows(dataFile).addDeletes(deleteFile).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    assertThat(deleteFilesAfter)
+        .as("Unpartitioned table should be a no-op")
+        .isEqualTo(deleteFilesBefore);
+  }
+
+  @Test
+  void testNoDanglingDeletes() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data file
+    table.newAppend().appendFile(fileA).commit();
+
+    // Commit 2 (seq=2): Add delete file in same partition
+    DeleteFile deleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addDeletes(deleteA).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // deleteA (seq=2) is not dangling because fileA (seq=1) has min_data_seq=1 < 2
+    assertThat(deleteFilesAfter).as("No deletes should be removed").isEqualTo(deleteFilesBefore);
+  }
+
+  @Test
+  void testNoSnapshot() throws Exception {
+    // Drop and recreate the table so it has no snapshots
+    dropTable();
+    this.table = createPartitionedTable();
+
+    // Should succeed with no changes
+    runRemoveDanglingDeletes();
+  }
+
+  @Test
+  void testFailure() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    table.newAppend().appendFile(fileA).commit();
+
+    RemoveDanglingDeleteFiles.builder()
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    runAndWaitForFailure(infra.env(), infra.source(), infra.sink());
+  }
+
+  private void runRemoveDanglingDeletes() throws Exception {
+    RemoveDanglingDeleteFiles.builder()
+        .parallelism(1)
+        .uidSuffix(UID_SUFFIX)
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            "OTHER",
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+  }
+
+  private int deleteFileCount() {
+    table.refresh();
+    return (int)
+        StreamSupport.stream(
+                table.currentSnapshot().deleteManifests(table.io()).spliterator(), false)
+            .mapToLong(manifest -> manifest.existingFilesCount() + manifest.addedFilesCount())
+            .sum();
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RemoveDanglingDeleteFiles.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RemoveDanglingDeleteFiles.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.iceberg.flink.maintenance.operator.RemoveDanglingDeleteFilesProcessor;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Removes dangling delete files from the current snapshot. A delete file is dangling if its deletes
+ * no longer apply to any live data files.
+ */
+public class RemoveDanglingDeleteFiles {
+  private static final String EXECUTOR_OPERATOR_NAME = "Remove Dangling Deletes";
+
+  private RemoveDanglingDeleteFiles() {}
+
+  /** Creates the builder for creating a stream which removes dangling delete files. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder extends MaintenanceTaskBuilder<RemoveDanglingDeleteFiles.Builder> {
+    @Override
+    String maintenanceTaskName() {
+      return "RemoveDanglingDeleteFiles";
+    }
+
+    @Override
+    DataStream<TaskResult> append(DataStream<Trigger> trigger) {
+      Preconditions.checkNotNull(tableLoader(), "TableLoader should not be null");
+
+      return trigger
+          .process(new RemoveDanglingDeleteFilesProcessor(tableLoader()))
+          .name(operatorName(EXECUTOR_OPERATOR_NAME))
+          .uid(EXECUTOR_OPERATOR_NAME + uidSuffix())
+          .slotSharingGroup(slotSharingGroup())
+          .forceNonParallel();
+    }
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/RemoveDanglingDeleteFilesProcessor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/RemoveDanglingDeleteFilesProcessor.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.TaskResult;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.DeleteFileSet;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Removes dangling delete files from the current snapshot. A delete file is dangling if its deletes
+ * no longer apply to any live data files.
+ *
+ * <p>The following dangling delete files are removed:
+ *
+ * <ul>
+ *   <li>Position delete files with a data sequence number less than that of any data file in the
+ *       same partition
+ *   <li>Equality delete files with a data sequence number less than or equal to that of any data
+ *       file in the same partition
+ *   <li>Delete files in partitions with no live data files
+ *   <li>Deletion vectors (Puffin files) referencing non-existent data files
+ * </ul>
+ */
+@Internal
+public class RemoveDanglingDeleteFilesProcessor extends ProcessFunction<Trigger, TaskResult> {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RemoveDanglingDeleteFilesProcessor.class);
+
+  private final TableLoader tableLoader;
+  private transient Table table;
+
+  public RemoveDanglingDeleteFilesProcessor(TableLoader tableLoader) {
+    Preconditions.checkNotNull(tableLoader, "Table loader should not be null");
+    this.tableLoader = tableLoader;
+  }
+
+  @Override
+  public void open(OpenContext parameters) throws Exception {
+    tableLoader.open();
+    this.table = tableLoader.loadTable();
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<TaskResult> out)
+      throws Exception {
+    try {
+      table.refresh();
+
+      if (table.specs().size() == 1 && table.spec().isUnpartitioned()) {
+        LOG.info(
+            "Skipping remove dangling deletes for unpartitioned table {}: "
+                + "ManifestFilterManager handles this case",
+            table.name());
+        out.collect(
+            new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+        return;
+      }
+
+      Snapshot snapshot = table.currentSnapshot();
+      if (snapshot == null) {
+        LOG.info("No current snapshot for table {}, nothing to do", table.name());
+        out.collect(
+            new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+        return;
+      }
+
+      DeleteFileSet danglingDeletes = DeleteFileSet.create();
+      danglingDeletes.addAll(findDanglingDeletes(snapshot));
+      danglingDeletes.addAll(findDanglingDvs(snapshot));
+
+      if (!danglingDeletes.isEmpty()) {
+        RewriteFiles rewriteFiles = table.newRewrite();
+        for (DeleteFile deleteFile : danglingDeletes) {
+          LOG.debug("Removing dangling delete file {}", deleteFile.location());
+          rewriteFiles.deleteFile(deleteFile);
+        }
+
+        rewriteFiles.commit();
+      }
+
+      LOG.info(
+          "Successfully finished removing dangling deletes for {} at {}. Removed {} delete files.",
+          table.name(),
+          ctx.timestamp(),
+          danglingDeletes.size());
+      out.collect(
+          new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+    } catch (Exception e) {
+      LOG.error("Failed to remove dangling deletes for {} at {}", table.name(), ctx.timestamp(), e);
+      out.collect(
+          new TaskResult(trigger.taskId(), trigger.timestamp(), false, Lists.newArrayList(e)));
+    }
+  }
+
+  private DeleteFileSet findDanglingDeletes(Snapshot snapshot) throws Exception {
+    FileIO io = table.io();
+    Map<Integer, PartitionSpec> specsById = table.specs();
+
+    Map<Integer, Map<StructLikeWrapper, Long>> minDataSeqByPartition = Maps.newHashMap();
+    Map<Integer, StructLikeWrapper> wrappersBySpec = Maps.newHashMap();
+
+    for (ManifestFile manifest : snapshot.dataManifests(io)) {
+      try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)) {
+        for (DataFile file : reader) {
+          Long seq = file.dataSequenceNumber();
+          if (seq == null) {
+            continue;
+          }
+
+          int specId = file.specId();
+          StructLikeWrapper template =
+              wrappersBySpec.computeIfAbsent(
+                  specId, id -> StructLikeWrapper.forType(specsById.get(id).partitionType()));
+
+          StructLikeWrapper partitionKey = template.copyFor(file.partition());
+          minDataSeqByPartition
+              .computeIfAbsent(specId, id -> Maps.newHashMap())
+              .merge(partitionKey, seq, Math::min);
+        }
+      }
+    }
+
+    DeleteFileSet danglingDeletes = DeleteFileSet.create();
+
+    for (ManifestFile manifest : snapshot.deleteManifests(io)) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, io, specsById)) {
+        for (DeleteFile file : reader) {
+          if (isDanglingBySequenceNumber(file, minDataSeqByPartition, wrappersBySpec, specsById)) {
+            danglingDeletes.add(file);
+          }
+        }
+      }
+    }
+
+    return danglingDeletes;
+  }
+
+  private DeleteFileSet findDanglingDvs(Snapshot snapshot) throws Exception {
+    FileIO io = table.io();
+    Map<Integer, PartitionSpec> specsById = table.specs();
+
+    Set<String> dvReferencedPaths = Sets.newHashSet();
+    DeleteFileSet dvCandidates = DeleteFileSet.create();
+
+    for (ManifestFile manifest : snapshot.deleteManifests(io)) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, io, specsById)) {
+        for (DeleteFile file : reader) {
+          if (file.format() == FileFormat.PUFFIN && file.referencedDataFile() != null) {
+            dvReferencedPaths.add(file.referencedDataFile());
+            dvCandidates.add(file);
+          }
+        }
+      }
+    }
+
+    if (dvCandidates.isEmpty()) {
+      return dvCandidates;
+    }
+
+    for (ManifestFile manifest : snapshot.dataManifests(io)) {
+      if (dvReferencedPaths.isEmpty()) {
+        break;
+      }
+
+      try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)) {
+        for (DataFile file : reader) {
+          dvReferencedPaths.remove(file.location());
+          if (dvReferencedPaths.isEmpty()) {
+            break;
+          }
+        }
+      }
+    }
+
+    DeleteFileSet danglingDvs = DeleteFileSet.create();
+    for (DeleteFile dv : dvCandidates) {
+      if (dvReferencedPaths.contains(dv.referencedDataFile())) {
+        danglingDvs.add(dv);
+      }
+    }
+
+    return danglingDvs;
+  }
+
+  private static boolean isDanglingBySequenceNumber(
+      DeleteFile file,
+      Map<Integer, Map<StructLikeWrapper, Long>> minDataSeqByPartition,
+      Map<Integer, StructLikeWrapper> wrappersBySpec,
+      Map<Integer, PartitionSpec> specsById) {
+    Long seq = file.dataSequenceNumber();
+    if (seq == null) {
+      return false;
+    }
+
+    int specId = file.specId();
+    StructLikeWrapper template =
+        wrappersBySpec.computeIfAbsent(
+            specId, id -> StructLikeWrapper.forType(specsById.get(id).partitionType()));
+    StructLikeWrapper partitionKey = template.copyFor(file.partition());
+
+    Map<StructLikeWrapper, Long> partitionMap = minDataSeqByPartition.get(specId);
+    Long minDataSeq = partitionMap != null ? partitionMap.get(partitionKey) : null;
+
+    if (minDataSeq == null) {
+      return true;
+    }
+
+    if (file.content() == FileContent.POSITION_DELETES && seq < minDataSeq) {
+      return true;
+    }
+
+    return file.content() == FileContent.EQUALITY_DELETES && seq <= minDataSeq;
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRemoveDanglingDeleteFiles.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRemoveDanglingDeleteFiles.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.StreamSupport;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.operator.MetricsReporterFactoryForTests;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestRemoveDanglingDeleteFiles extends MaintenanceTaskTestBase {
+  private Table table;
+  private PartitionSpec spec;
+
+  @BeforeEach
+  void before() {
+    MetricsReporterFactoryForTests.reset();
+    this.table = createPartitionedTable();
+    this.spec = table.spec();
+    tableLoader().open();
+  }
+
+  @Test
+  void testPartitionedDanglingDeletes() throws Exception {
+    DataFile fileB =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+    DataFile fileC =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-c.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=c")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data files in partitions b, c
+    table.newAppend().appendFile(fileB).appendFile(fileC).commit();
+
+    // Commit 2 (seq=2): Add delete files for partitions a (no data) and b (has data)
+    DeleteFile deleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteA2 =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofPositionDeletes()
+            .withPath("/path/to/delete-a2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteB =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addDeletes(deleteA).addDeletes(deleteA2).addDeletes(deleteB).commit();
+
+    // Commit 3 (seq=3): Add more data to partitions a and b
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DataFile fileB2 =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table.newAppend().appendFile(fileA).appendFile(fileB2).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // Partition a: deleteA (eq, seq=2) and deleteA2 (pos, seq=2) are dangling
+    // because the only data file in partition a (fileA) has seq=3,
+    // meaning min_data_seq=3 > delete_seq=2 for both eq and pos deletes
+    // Partition b: deleteB (eq, seq=2) is NOT dangling
+    // because fileB has seq=1 which is < delete_seq=2
+    assertThat(deleteFilesBefore - deleteFilesAfter)
+        .as("Should have removed 2 dangling delete files from partition a")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void testEqualityDeletesWithEqualSeqNo() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data in partition a
+    table.newAppend().appendFile(fileA).commit();
+
+    // Commit 2 (seq=2): Add data + eq deletes in same commit for partitions a and b
+    DataFile fileA2 =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DataFile fileB =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+    DeleteFile eqDeleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile eqDeleteB =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-delete-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table
+        .newRowDelta()
+        .addRows(fileA2)
+        .addRows(fileB)
+        .addDeletes(eqDeleteA)
+        .addDeletes(eqDeleteB)
+        .commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // Partition a: eqDeleteA (seq=2) is NOT dangling because fileA (seq=1) exists
+    //   and min_data_seq=1 < delete_seq=2
+    // Partition b: eqDeleteB (seq=2) IS dangling because min_data_seq=2 == delete_seq=2
+    //   (equality deletes with seq <= min_data_seq are dangling)
+    assertThat(deleteFilesBefore - deleteFilesAfter)
+        .as("Should have removed 1 dangling eq delete from partition b")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void testUnpartitionedTable() throws Exception {
+    // Drop the partitioned table and create an unpartitioned one
+    dropTable();
+    this.table = createTable();
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteFile =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addRows(dataFile).addDeletes(deleteFile).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    assertThat(deleteFilesAfter)
+        .as("Unpartitioned table should be a no-op")
+        .isEqualTo(deleteFilesBefore);
+  }
+
+  @Test
+  void testNoDanglingDeletes() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data file
+    table.newAppend().appendFile(fileA).commit();
+
+    // Commit 2 (seq=2): Add delete file in same partition
+    DeleteFile deleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addDeletes(deleteA).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // deleteA (seq=2) is not dangling because fileA (seq=1) has min_data_seq=1 < 2
+    assertThat(deleteFilesAfter).as("No deletes should be removed").isEqualTo(deleteFilesBefore);
+  }
+
+  @Test
+  void testNoSnapshot() throws Exception {
+    // Drop and recreate the table so it has no snapshots
+    dropTable();
+    this.table = createPartitionedTable();
+
+    // Should succeed with no changes
+    runRemoveDanglingDeletes();
+  }
+
+  @Test
+  void testFailure() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    table.newAppend().appendFile(fileA).commit();
+
+    RemoveDanglingDeleteFiles.builder()
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    runAndWaitForFailure(infra.env(), infra.source(), infra.sink());
+  }
+
+  private void runRemoveDanglingDeletes() throws Exception {
+    RemoveDanglingDeleteFiles.builder()
+        .parallelism(1)
+        .uidSuffix(UID_SUFFIX)
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            "OTHER",
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+  }
+
+  private int deleteFileCount() {
+    table.refresh();
+    return (int)
+        StreamSupport.stream(
+                table.currentSnapshot().deleteManifests(table.io()).spliterator(), false)
+            .mapToLong(manifest -> manifest.existingFilesCount() + manifest.addedFilesCount())
+            .sum();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RemoveDanglingDeleteFiles.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RemoveDanglingDeleteFiles.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.iceberg.flink.maintenance.operator.RemoveDanglingDeleteFilesProcessor;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Removes dangling delete files from the current snapshot. A delete file is dangling if its deletes
+ * no longer apply to any live data files.
+ */
+public class RemoveDanglingDeleteFiles {
+  private static final String EXECUTOR_OPERATOR_NAME = "Remove Dangling Deletes";
+
+  private RemoveDanglingDeleteFiles() {}
+
+  /** Creates the builder for creating a stream which removes dangling delete files. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder extends MaintenanceTaskBuilder<RemoveDanglingDeleteFiles.Builder> {
+    @Override
+    String maintenanceTaskName() {
+      return "RemoveDanglingDeleteFiles";
+    }
+
+    @Override
+    DataStream<TaskResult> append(DataStream<Trigger> trigger) {
+      Preconditions.checkNotNull(tableLoader(), "TableLoader should not be null");
+
+      return trigger
+          .process(new RemoveDanglingDeleteFilesProcessor(tableLoader()))
+          .name(operatorName(EXECUTOR_OPERATOR_NAME))
+          .uid(EXECUTOR_OPERATOR_NAME + uidSuffix())
+          .slotSharingGroup(slotSharingGroup())
+          .forceNonParallel();
+    }
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/RemoveDanglingDeleteFilesProcessor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/RemoveDanglingDeleteFilesProcessor.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.TaskResult;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.DeleteFileSet;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Removes dangling delete files from the current snapshot. A delete file is dangling if its deletes
+ * no longer apply to any live data files.
+ *
+ * <p>The following dangling delete files are removed:
+ *
+ * <ul>
+ *   <li>Position delete files with a data sequence number less than that of any data file in the
+ *       same partition
+ *   <li>Equality delete files with a data sequence number less than or equal to that of any data
+ *       file in the same partition
+ *   <li>Delete files in partitions with no live data files
+ *   <li>Deletion vectors (Puffin files) referencing non-existent data files
+ * </ul>
+ */
+@Internal
+public class RemoveDanglingDeleteFilesProcessor extends ProcessFunction<Trigger, TaskResult> {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RemoveDanglingDeleteFilesProcessor.class);
+
+  private final TableLoader tableLoader;
+  private transient Table table;
+
+  public RemoveDanglingDeleteFilesProcessor(TableLoader tableLoader) {
+    Preconditions.checkNotNull(tableLoader, "Table loader should not be null");
+    this.tableLoader = tableLoader;
+  }
+
+  @Override
+  public void open(OpenContext parameters) throws Exception {
+    tableLoader.open();
+    this.table = tableLoader.loadTable();
+  }
+
+  @Override
+  public void processElement(Trigger trigger, Context ctx, Collector<TaskResult> out)
+      throws Exception {
+    try {
+      table.refresh();
+
+      if (table.specs().size() == 1 && table.spec().isUnpartitioned()) {
+        LOG.info(
+            "Skipping remove dangling deletes for unpartitioned table {}: "
+                + "ManifestFilterManager handles this case",
+            table.name());
+        out.collect(
+            new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+        return;
+      }
+
+      Snapshot snapshot = table.currentSnapshot();
+      if (snapshot == null) {
+        LOG.info("No current snapshot for table {}, nothing to do", table.name());
+        out.collect(
+            new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+        return;
+      }
+
+      DeleteFileSet danglingDeletes = DeleteFileSet.create();
+      danglingDeletes.addAll(findDanglingDeletes(snapshot));
+      danglingDeletes.addAll(findDanglingDvs(snapshot));
+
+      if (!danglingDeletes.isEmpty()) {
+        RewriteFiles rewriteFiles = table.newRewrite();
+        for (DeleteFile deleteFile : danglingDeletes) {
+          LOG.debug("Removing dangling delete file {}", deleteFile.location());
+          rewriteFiles.deleteFile(deleteFile);
+        }
+
+        rewriteFiles.commit();
+      }
+
+      LOG.info(
+          "Successfully finished removing dangling deletes for {} at {}. Removed {} delete files.",
+          table.name(),
+          ctx.timestamp(),
+          danglingDeletes.size());
+      out.collect(
+          new TaskResult(trigger.taskId(), trigger.timestamp(), true, Collections.emptyList()));
+    } catch (Exception e) {
+      LOG.error("Failed to remove dangling deletes for {} at {}", table.name(), ctx.timestamp(), e);
+      out.collect(
+          new TaskResult(trigger.taskId(), trigger.timestamp(), false, Lists.newArrayList(e)));
+    }
+  }
+
+  private DeleteFileSet findDanglingDeletes(Snapshot snapshot) throws Exception {
+    FileIO io = table.io();
+    Map<Integer, PartitionSpec> specsById = table.specs();
+
+    Map<Integer, Map<StructLikeWrapper, Long>> minDataSeqByPartition = Maps.newHashMap();
+    Map<Integer, StructLikeWrapper> wrappersBySpec = Maps.newHashMap();
+
+    for (ManifestFile manifest : snapshot.dataManifests(io)) {
+      try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)) {
+        for (DataFile file : reader) {
+          Long seq = file.dataSequenceNumber();
+          if (seq == null) {
+            continue;
+          }
+
+          int specId = file.specId();
+          StructLikeWrapper template =
+              wrappersBySpec.computeIfAbsent(
+                  specId, id -> StructLikeWrapper.forType(specsById.get(id).partitionType()));
+
+          StructLikeWrapper partitionKey = template.copyFor(file.partition());
+          minDataSeqByPartition
+              .computeIfAbsent(specId, id -> Maps.newHashMap())
+              .merge(partitionKey, seq, Math::min);
+        }
+      }
+    }
+
+    DeleteFileSet danglingDeletes = DeleteFileSet.create();
+
+    for (ManifestFile manifest : snapshot.deleteManifests(io)) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, io, specsById)) {
+        for (DeleteFile file : reader) {
+          if (isDanglingBySequenceNumber(file, minDataSeqByPartition, wrappersBySpec, specsById)) {
+            danglingDeletes.add(file);
+          }
+        }
+      }
+    }
+
+    return danglingDeletes;
+  }
+
+  private DeleteFileSet findDanglingDvs(Snapshot snapshot) throws Exception {
+    FileIO io = table.io();
+    Map<Integer, PartitionSpec> specsById = table.specs();
+
+    Set<String> dvReferencedPaths = Sets.newHashSet();
+    DeleteFileSet dvCandidates = DeleteFileSet.create();
+
+    for (ManifestFile manifest : snapshot.deleteManifests(io)) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, io, specsById)) {
+        for (DeleteFile file : reader) {
+          if (file.format() == FileFormat.PUFFIN && file.referencedDataFile() != null) {
+            dvReferencedPaths.add(file.referencedDataFile());
+            dvCandidates.add(file);
+          }
+        }
+      }
+    }
+
+    if (dvCandidates.isEmpty()) {
+      return dvCandidates;
+    }
+
+    for (ManifestFile manifest : snapshot.dataManifests(io)) {
+      if (dvReferencedPaths.isEmpty()) {
+        break;
+      }
+
+      try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)) {
+        for (DataFile file : reader) {
+          dvReferencedPaths.remove(file.location());
+          if (dvReferencedPaths.isEmpty()) {
+            break;
+          }
+        }
+      }
+    }
+
+    DeleteFileSet danglingDvs = DeleteFileSet.create();
+    for (DeleteFile dv : dvCandidates) {
+      if (dvReferencedPaths.contains(dv.referencedDataFile())) {
+        danglingDvs.add(dv);
+      }
+    }
+
+    return danglingDvs;
+  }
+
+  private static boolean isDanglingBySequenceNumber(
+      DeleteFile file,
+      Map<Integer, Map<StructLikeWrapper, Long>> minDataSeqByPartition,
+      Map<Integer, StructLikeWrapper> wrappersBySpec,
+      Map<Integer, PartitionSpec> specsById) {
+    Long seq = file.dataSequenceNumber();
+    if (seq == null) {
+      return false;
+    }
+
+    int specId = file.specId();
+    StructLikeWrapper template =
+        wrappersBySpec.computeIfAbsent(
+            specId, id -> StructLikeWrapper.forType(specsById.get(id).partitionType()));
+    StructLikeWrapper partitionKey = template.copyFor(file.partition());
+
+    Map<StructLikeWrapper, Long> partitionMap = minDataSeqByPartition.get(specId);
+    Long minDataSeq = partitionMap != null ? partitionMap.get(partitionKey) : null;
+
+    if (minDataSeq == null) {
+      return true;
+    }
+
+    if (file.content() == FileContent.POSITION_DELETES && seq < minDataSeq) {
+      return true;
+    }
+
+    return file.content() == FileContent.EQUALITY_DELETES && seq <= minDataSeq;
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRemoveDanglingDeleteFiles.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRemoveDanglingDeleteFiles.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.StreamSupport;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.operator.MetricsReporterFactoryForTests;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestRemoveDanglingDeleteFiles extends MaintenanceTaskTestBase {
+  private Table table;
+  private PartitionSpec spec;
+
+  @BeforeEach
+  void before() {
+    MetricsReporterFactoryForTests.reset();
+    this.table = createPartitionedTable();
+    this.spec = table.spec();
+    tableLoader().open();
+  }
+
+  @Test
+  void testPartitionedDanglingDeletes() throws Exception {
+    DataFile fileB =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+    DataFile fileC =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-c.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=c")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data files in partitions b, c
+    table.newAppend().appendFile(fileB).appendFile(fileC).commit();
+
+    // Commit 2 (seq=2): Add delete files for partitions a (no data) and b (has data)
+    DeleteFile deleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteA2 =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofPositionDeletes()
+            .withPath("/path/to/delete-a2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteB =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addDeletes(deleteA).addDeletes(deleteA2).addDeletes(deleteB).commit();
+
+    // Commit 3 (seq=3): Add more data to partitions a and b
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DataFile fileB2 =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table.newAppend().appendFile(fileA).appendFile(fileB2).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // Partition a: deleteA (eq, seq=2) and deleteA2 (pos, seq=2) are dangling
+    // because the only data file in partition a (fileA) has seq=3,
+    // meaning min_data_seq=3 > delete_seq=2 for both eq and pos deletes
+    // Partition b: deleteB (eq, seq=2) is NOT dangling
+    // because fileB has seq=1 which is < delete_seq=2
+    assertThat(deleteFilesBefore - deleteFilesAfter)
+        .as("Should have removed 2 dangling delete files from partition a")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void testEqualityDeletesWithEqualSeqNo() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data in partition a
+    table.newAppend().appendFile(fileA).commit();
+
+    // Commit 2 (seq=2): Add data + eq deletes in same commit for partitions a and b
+    DataFile fileA2 =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DataFile fileB =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+    DeleteFile eqDeleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+    DeleteFile eqDeleteB =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-delete-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=b")
+            .withRecordCount(1)
+            .build();
+
+    table
+        .newRowDelta()
+        .addRows(fileA2)
+        .addRows(fileB)
+        .addDeletes(eqDeleteA)
+        .addDeletes(eqDeleteB)
+        .commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // Partition a: eqDeleteA (seq=2) is NOT dangling because fileA (seq=1) exists
+    //   and min_data_seq=1 < delete_seq=2
+    // Partition b: eqDeleteB (seq=2) IS dangling because min_data_seq=2 == delete_seq=2
+    //   (equality deletes with seq <= min_data_seq are dangling)
+    assertThat(deleteFilesBefore - deleteFilesAfter)
+        .as("Should have removed 1 dangling eq delete from partition b")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void testUnpartitionedTable() throws Exception {
+    // Drop the partitioned table and create an unpartitioned one
+    dropTable();
+    this.table = createTable();
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteFile =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addRows(dataFile).addDeletes(deleteFile).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    assertThat(deleteFilesAfter)
+        .as("Unpartitioned table should be a no-op")
+        .isEqualTo(deleteFilesBefore);
+  }
+
+  @Test
+  void testNoDanglingDeletes() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    // Commit 1 (seq=1): Add data file
+    table.newAppend().appendFile(fileA).commit();
+
+    // Commit 2 (seq=2): Add delete file in same partition
+    DeleteFile deleteA =
+        FileMetadata.deleteFileBuilder(spec)
+            .ofEqualityDeletes()
+            .withPath("/path/to/delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addDeletes(deleteA).commit();
+
+    int deleteFilesBefore = deleteFileCount();
+
+    runRemoveDanglingDeletes();
+
+    table.refresh();
+    int deleteFilesAfter = deleteFileCount();
+
+    // deleteA (seq=2) is not dangling because fileA (seq=1) has min_data_seq=1 < 2
+    assertThat(deleteFilesAfter).as("No deletes should be removed").isEqualTo(deleteFilesBefore);
+  }
+
+  @Test
+  void testNoSnapshot() throws Exception {
+    // Drop and recreate the table so it has no snapshots
+    dropTable();
+    this.table = createPartitionedTable();
+
+    // Should succeed with no changes
+    runRemoveDanglingDeletes();
+  }
+
+  @Test
+  void testFailure() throws Exception {
+    DataFile fileA =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data=a")
+            .withRecordCount(1)
+            .build();
+
+    table.newAppend().appendFile(fileA).commit();
+
+    RemoveDanglingDeleteFiles.builder()
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            UID_SUFFIX,
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    runAndWaitForFailure(infra.env(), infra.source(), infra.sink());
+  }
+
+  private void runRemoveDanglingDeletes() throws Exception {
+    RemoveDanglingDeleteFiles.builder()
+        .parallelism(1)
+        .uidSuffix(UID_SUFFIX)
+        .append(
+            infra.triggerStream(),
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            0,
+            tableLoader(),
+            "OTHER",
+            StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP,
+            1)
+        .sinkTo(infra.sink());
+
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+  }
+
+  private int deleteFileCount() {
+    table.refresh();
+    return (int)
+        StreamSupport.stream(
+                table.currentSnapshot().deleteManifests(table.io()).spliterator(), false)
+            .mapToLong(manifest -> manifest.existingFilesCount() + manifest.addedFilesCount())
+            .sum();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #16138.

The `RemoveDanglingDeleteFiles` action currently exists only for Spark. Flink users have no equivalent, causing equality delete files to accumulate indefinitely in V2 tables managed by the Flink maintenance pipeline.

This PR adds `RemoveDanglingDeleteFiles` support to the Flink maintenance API across all three Flink versions (v1.20, v2.0, v2.1).

**Approach:**
- Follows the `ExpireSnapshots` pattern (single `ProcessFunction` operator)
- Mirrors `RemoveDanglingDeletesSparkAction`'s two-method structure:
  - `findDanglingDeletes` — sequence-number-based detection using an O(partitions) `minDataSeqByPartition` map (position, equality, and DV deletes)
  - `findDanglingDvs` — reference-based detection for deletion vectors via a targeted data manifest scan with O(DV candidates) memory
- Avoids collecting all live data file paths in memory, preventing OOM on large tables

**New files (identical across all three Flink versions):**
- `RemoveDanglingDeleteFiles.java` — API builder extending `MaintenanceTaskBuilder`
- `RemoveDanglingDeleteFilesProcessor.java` — Core operator with dangling detection logic
- `TestRemoveDanglingDeleteFiles.java` — Tests covering partitioned deletes, equality delete edge cases, unpartitioned tables, and no-op scenarios

## Test plan

- [x] `TestRemoveDanglingDeleteFiles` passes on Flink v1.20, v2.0, v2.1
- [x] All existing maintenance tests pass (no regressions)
- [x] Compilation succeeds across all Flink versions