### PR TITLE
Core: Refactor: Break down the stored content in RESTTableCache

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -72,7 +72,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
-import org.apache.iceberg.rest.RESTTableCache.TableWithETag;
+import org.apache.iceberg.rest.RESTTableCache.TableCacheEntry;
 import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthManagers;
 import org.apache.iceberg.rest.auth.AuthSession;
@@ -460,7 +460,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     TableIdentifier loadedIdent;
 
     Map<String, String> responseHeaders = Maps.newHashMap();
-    TableWithETag cachedTable = tableCache.getIfPresent(context.sessionId(), identifier);
+    TableCacheEntry cachedTableDetails = tableCache.getIfPresent(context.sessionId(), identifier);
 
     try {
       response =
@@ -468,13 +468,19 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               context,
               identifier,
               snapshotMode,
-              headersForLoadTable(cachedTable),
+              headersForLoadTable(cachedTableDetails),
               responseHeaders::putAll);
 
       if (response == null) {
-        Preconditions.checkNotNull(cachedTable, "Invalid load table response: null");
+        Preconditions.checkNotNull(cachedTableDetails, "Invalid load table response: null");
 
-        return cachedTable.supplier().get();
+        return createTable(
+            identifier,
+            cachedTableDetails.tableMetadata(),
+            context,
+            cachedTableDetails.tableClient(),
+            cachedTableDetails.tableConf(),
+            cachedTableDetails.credentials());
       }
 
       loadedIdent = identifier;
@@ -487,21 +493,28 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         TableIdentifier baseIdent = TableIdentifier.of(identifier.namespace().levels());
         try {
           responseHeaders.clear();
-          cachedTable = tableCache.getIfPresent(context.sessionId(), baseIdent);
+          cachedTableDetails = tableCache.getIfPresent(context.sessionId(), baseIdent);
 
           response =
               loadInternal(
                   context,
                   baseIdent,
                   snapshotMode,
-                  headersForLoadTable(cachedTable),
+                  headersForLoadTable(cachedTableDetails),
                   responseHeaders::putAll);
 
           if (response == null) {
-            Preconditions.checkNotNull(cachedTable, "Invalid load table response: null");
+            Preconditions.checkNotNull(cachedTableDetails, "Invalid load table response: null");
 
             return MetadataTableUtils.createMetadataTableInstance(
-                cachedTable.supplier().get(), metadataType);
+                createTable(
+                    baseIdent,
+                    cachedTableDetails.tableMetadata(),
+                    context,
+                    cachedTableDetails.tableClient(),
+                    cachedTableDetails.tableConf(),
+                    cachedTableDetails.credentials()),
+                metadataType);
           }
 
           loadedIdent = baseIdent;
@@ -542,50 +555,55 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     List<Credential> credentials = response.credentials();
     RESTClient tableClient = client.withAuthSession(tableSession);
-    Supplier<BaseTable> tableSupplier =
-        createTableSupplier(
-            finalIdentifier, tableMetadata, context, tableClient, tableConf, credentials);
 
     String eTag = responseHeaders.getOrDefault(HttpHeaders.ETAG, null);
     if (eTag != null) {
-      tableCache.put(context.sessionId(), finalIdentifier, tableSupplier, eTag);
+      tableCache.put(
+          context.sessionId(),
+          finalIdentifier,
+          tableMetadata,
+          tableClient,
+          tableConf,
+          credentials,
+          eTag);
     }
+
+    BaseTable baseTable =
+        createTable(finalIdentifier, tableMetadata, context, tableClient, tableConf, credentials);
 
     if (metadataType != null) {
-      return MetadataTableUtils.createMetadataTableInstance(tableSupplier.get(), metadataType);
+      return MetadataTableUtils.createMetadataTableInstance(baseTable, metadataType);
     }
 
-    return tableSupplier.get();
+    return baseTable;
   }
 
-  private Supplier<BaseTable> createTableSupplier(
+  private BaseTable createTable(
       TableIdentifier identifier,
       TableMetadata tableMetadata,
       SessionContext context,
       RESTClient tableClient,
       Map<String, String> tableConf,
       List<Credential> credentials) {
-    return () -> {
-      RESTTableOperations ops =
-          newTableOps(
-              tableClient,
-              paths.table(identifier),
-              Map::of,
-              mutationHeaders,
-              tableFileIO(context, tableConf, credentials),
-              tableMetadata,
-              endpoints);
+    RESTTableOperations ops =
+        newTableOps(
+            tableClient,
+            paths.table(identifier),
+            Map::of,
+            mutationHeaders,
+            tableFileIO(context, tableConf, credentials),
+            tableMetadata,
+            endpoints);
 
-      trackFileIO(ops);
+    trackFileIO(ops);
 
-      RESTTable table = restTableForScanPlanning(ops, identifier, tableClient, tableConf);
-      if (table != null) {
-        return table;
-      }
+    RESTTable table = restTableForScanPlanning(ops, identifier, tableClient, tableConf);
+    if (table != null) {
+      return table;
+    }
 
-      return new BaseTable(
-          ops, fullTableName(identifier), metricsReporter(paths.metrics(identifier), tableClient));
-    };
+    return new BaseTable(
+        ops, fullTableName(identifier), metricsReporter(paths.metrics(identifier), tableClient));
   }
 
   private RESTTable restTableForScanPlanning(
@@ -1549,12 +1567,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     return new BaseView(ops, ViewUtil.fullViewName(name(), ident));
   }
 
-  private static Map<String, String> headersForLoadTable(TableWithETag tableWithETag) {
-    if (tableWithETag == null) {
+  private static Map<String, String> headersForLoadTable(TableCacheEntry tableDetails) {
+    if (tableDetails == null) {
       return Map.of();
     }
 
-    String eTag = tableWithETag.eTag();
+    String eTag = tableDetails.eTag();
     Preconditions.checkArgument(eTag != null, "Invalid ETag: null");
 
     return Map.of(HttpHeaders.IF_NONE_MATCH, eTag);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableCache.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableCache.java
@@ -23,12 +23,13 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
 import java.io.Closeable;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
-import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.util.PropertyUtil;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -37,7 +38,7 @@ import org.slf4j.LoggerFactory;
 class RESTTableCache implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(RESTTableCache.class);
 
-  private final Cache<SessionIdTableId, TableWithETag> tableCache;
+  private final Cache<SessionIdTableId, TableCacheEntry> tableCache;
 
   RESTTableCache(Map<String, String> props) {
     this(props, Ticker.systemTicker());
@@ -72,7 +73,7 @@ class RESTTableCache implements Closeable {
             .build();
   }
 
-  public TableWithETag getIfPresent(String sessionId, TableIdentifier identifier) {
+  public TableCacheEntry getIfPresent(String sessionId, TableIdentifier identifier) {
     SessionIdTableId cacheKey = SessionIdTableId.of(sessionId, identifier);
     return tableCache.getIfPresent(cacheKey);
   }
@@ -80,10 +81,14 @@ class RESTTableCache implements Closeable {
   public void put(
       String sessionId,
       TableIdentifier identifier,
-      Supplier<BaseTable> tableSupplier,
+      TableMetadata tableMetadata,
+      RESTClient tableClient,
+      Map<String, String> tableConf,
+      List<Credential> credentials,
       String eTag) {
     tableCache.put(
-        SessionIdTableId.of(sessionId, identifier), TableWithETag.of(tableSupplier, eTag));
+        SessionIdTableId.of(sessionId, identifier),
+        TableCacheEntry.of(tableMetadata, tableClient, tableConf, credentials, eTag));
   }
 
   public void invalidate(String sessionId, TableIdentifier identifier) {
@@ -92,7 +97,7 @@ class RESTTableCache implements Closeable {
   }
 
   @VisibleForTesting
-  Cache<SessionIdTableId, TableWithETag> cache() {
+  Cache<SessionIdTableId, TableCacheEntry> cache() {
     return tableCache;
   }
 
@@ -117,13 +122,30 @@ class RESTTableCache implements Closeable {
   }
 
   @Value.Immutable
-  interface TableWithETag {
-    Supplier<BaseTable> supplier();
+  interface TableCacheEntry {
+    TableMetadata tableMetadata();
+
+    RESTClient tableClient();
+
+    Map<String, String> tableConf();
+
+    List<Credential> credentials();
 
     String eTag();
 
-    static TableWithETag of(Supplier<BaseTable> tableSupplier, String eTag) {
-      return ImmutableTableWithETag.builder().supplier(tableSupplier).eTag(eTag).build();
+    static TableCacheEntry of(
+        TableMetadata tableMetadata,
+        RESTClient tableClient,
+        Map<String, String> tableConf,
+        List<Credential> credentials,
+        String eTag) {
+      return ImmutableTableCacheEntry.builder()
+          .tableMetadata(tableMetadata)
+          .tableClient(tableClient)
+          .tableConf(tableConf)
+          .credentials(credentials)
+          .eTag(eTag)
+          .build();
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -22,7 +22,7 @@ import static org.apache.iceberg.TestBase.FILE_A;
 import static org.apache.iceberg.TestBase.FILE_B;
 import static org.apache.iceberg.TestBase.SCHEMA;
 import static org.apache.iceberg.rest.RESTTableCache.SessionIdTableId;
-import static org.apache.iceberg.rest.RESTTableCache.TableWithETag;
+import static org.apache.iceberg.rest.RESTTableCache.TableCacheEntry;
 import static org.apache.iceberg.rest.RequestMatcher.matches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -294,7 +294,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
     restCatalog.createNamespace(TABLE.namespace());
     restCatalog.createTable(TABLE, SCHEMA);
 
-    Cache<SessionIdTableId, TableWithETag> tableCache =
+    Cache<SessionIdTableId, TableCacheEntry> tableCache =
         restCatalog.sessionCatalog().tableCache().cache();
     assertThat(tableCache.estimatedSize()).isZero();
 
@@ -315,10 +315,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
             tableCache
                 .asMap()
                 .get(SessionIdTableId.of(DEFAULT_SESSION_CONTEXT.sessionId(), TABLE))
-                .supplier()
-                .get()
-                .operations()
-                .current()
+                .tableMetadata()
                 .metadataFileLocation())
         .isEqualTo(tableAfterFirstLoad.operations().current().metadataFileLocation());
 
@@ -332,7 +329,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
     restCatalog.createNamespace(TABLE.namespace());
     restCatalog.createTable(TABLE, SCHEMA);
 
-    Cache<SessionIdTableId, TableWithETag> tableCache =
+    Cache<SessionIdTableId, TableCacheEntry> tableCache =
         restCatalog.sessionCatalog().tableCache().cache();
     assertThat(tableCache.estimatedSize()).isZero();
 
@@ -511,7 +508,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
     catalog.createTable(TABLE, SCHEMA);
     BaseTable originalTable = (BaseTable) catalog.loadTable(TABLE);
 
-    Cache<SessionIdTableId, TableWithETag> tableCache =
+    Cache<SessionIdTableId, TableCacheEntry> tableCache =
         catalog.sessionCatalog().tableCache().cache();
     assertThat(tableCache.stats().hitCount()).isZero();
     assertThat(tableCache.asMap())
@@ -559,7 +556,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
     expectFullTableLoadForLoadTable(TABLE, adapter);
     BaseTable tableSession1 = (BaseTable) sessionCatalog.loadTable(DEFAULT_SESSION_CONTEXT, TABLE);
 
-    Cache<SessionIdTableId, TableWithETag> tableCache = sessionCatalog.tableCache().cache();
+    Cache<SessionIdTableId, TableCacheEntry> tableCache = sessionCatalog.tableCache().cache();
     assertThat(tableCache.stats().hitCount()).isZero();
     assertThat(tableCache.asMap())
         .containsOnlyKeys(SessionIdTableId.of(DEFAULT_SESSION_CONTEXT.sessionId(), TABLE));
@@ -672,7 +669,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
     catalog.createTable(TABLE, SCHEMA);
     catalog.loadTable(TABLE);
 
-    Cache<SessionIdTableId, TableWithETag> tableCache =
+    Cache<SessionIdTableId, TableCacheEntry> tableCache =
         catalog.sessionCatalog().tableCache().cache();
     SessionIdTableId tableCacheKey =
         SessionIdTableId.of(DEFAULT_SESSION_CONTEXT.sessionId(), TABLE);
@@ -721,7 +718,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
 
     ticker.advance(HALF_OF_TABLE_EXPIRATION);
 
-    Cache<SessionIdTableId, TableWithETag> tableCache =
+    Cache<SessionIdTableId, TableCacheEntry> tableCache =
         catalog.sessionCatalog().tableCache().cache();
     SessionIdTableId tableCacheKey =
         SessionIdTableId.of(DEFAULT_SESSION_CONTEXT.sessionId(), TABLE);
@@ -820,11 +817,11 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
         .asInstanceOf(InstanceOfAssertFactories.list(Snapshot.class))
         .hasSize(1);
 
-    Cache<SessionIdTableId, TableWithETag> tableCache =
+    Cache<SessionIdTableId, TableCacheEntry> tableCache =
         catalog.sessionCatalog().tableCache().cache();
     assertThat(tableCache.estimatedSize()).isEqualTo(1);
     SessionIdTableId tableCacheKey = SessionIdTableId.of(sessionContext.sessionId(), TABLE);
-    TableWithETag tableWithEtag = tableCache.asMap().get(tableCacheKey);
+    TableCacheEntry tableWithEtag = tableCache.asMap().get(tableCacheKey);
     assertThat(tableWithEtag).isNotNull();
 
     // Trigger loading all snapshots via the lazy loading mechanism

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTTableCache.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTTableCache.java
@@ -19,35 +19,47 @@
 package org.apache.iceberg.rest;
 
 import static org.apache.iceberg.rest.RESTTableCache.SessionIdTableId;
-import static org.apache.iceberg.rest.RESTTableCache.TableWithETag;
+import static org.apache.iceberg.rest.RESTTableCache.TableCacheEntry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
-import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.TestTables;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.credentials.Credential;
+import org.apache.iceberg.rest.credentials.ImmutableCredential;
 import org.apache.iceberg.util.FakeTicker;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 public class TestRESTTableCache {
-  @TempDir private static Path temp;
 
   private static final String SESSION_ID = SessionCatalog.SessionContext.createEmpty().sessionId();
   private static final String TABLE_NAME = "tbl";
   private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of("ns", TABLE_NAME);
-  private static final Supplier<BaseTable> TABLE_SUPPLIER =
-      () ->
-          new BaseTable(new TestTables.TestTableOperations(TABLE_NAME, temp.toFile()), TABLE_NAME);
+  private static final TableMetadata TABLE_METADATA =
+      TableMetadata.newTableMetadata(
+          new Schema(), PartitionSpec.unpartitioned(), "file:///tmp/test", ImmutableMap.of());
+  private static final Map<String, String> TABLE_CONF = ImmutableMap.of("conf1", "abcd");
+  private static final Credential CREDENTIAL =
+      ImmutableCredential.builder().prefix("pre").putConfig("conf2", "xyz").build();
+  private static final List<Credential> CREDENTIALS = ImmutableList.of(CREDENTIAL);
+  private static final RESTClient TABLE_CLIENT = Mockito.mock(RESTClient.class);
   private static final String ETAG = "d7sa6das";
   private static final Duration HALF_OF_TABLE_EXPIRATION =
       Duration.ofMillis(RESTCatalogProperties.TABLE_CACHE_EXPIRE_AFTER_WRITE_MS_DEFAULT)
           .dividedBy(2);
+
+  private void putEntry(RESTTableCache cache, String sessionId, TableIdentifier identifier) {
+    cache.put(sessionId, identifier, TABLE_METADATA, TABLE_CLIENT, TABLE_CONF, CREDENTIALS, ETAG);
+  }
 
   @Test
   public void invalidProperties() {
@@ -74,22 +86,25 @@ public class TestRESTTableCache {
   @Test
   public void basicPutAndGet() {
     RESTTableCache cache = new RESTTableCache(Map.of());
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    putEntry(cache, SESSION_ID, TABLE_IDENTIFIER);
 
     assertThat(cache.cache().asMap()).hasSize(1);
     assertThat(cache.cache().asMap())
         .containsKeys(SessionIdTableId.of(SESSION_ID, TABLE_IDENTIFIER));
 
-    TableWithETag tableWithETag = cache.getIfPresent(SESSION_ID, TABLE_IDENTIFIER);
+    TableCacheEntry entry = cache.getIfPresent(SESSION_ID, TABLE_IDENTIFIER);
 
-    assertThat(tableWithETag.supplier()).isSameAs(TABLE_SUPPLIER);
-    assertThat(tableWithETag.eTag()).isSameAs(ETAG);
+    assertThat(entry.tableMetadata()).isSameAs(TABLE_METADATA);
+    assertThat(entry.tableClient()).isSameAs(TABLE_CLIENT);
+    assertThat(entry.tableConf()).isEqualTo(TABLE_CONF);
+    assertThat(entry.credentials()).isEqualTo(CREDENTIALS);
+    assertThat(entry.eTag()).isSameAs(ETAG);
   }
 
   @Test
   public void notFoundInCache() {
     RESTTableCache cache = new RESTTableCache(Map.of());
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    putEntry(cache, SESSION_ID, TABLE_IDENTIFIER);
 
     assertThat(cache.getIfPresent("some_id", TABLE_IDENTIFIER)).isNull();
     assertThat(cache.getIfPresent(SESSION_ID, TableIdentifier.of("ns", "other_table"))).isNull();
@@ -99,19 +114,20 @@ public class TestRESTTableCache {
   public void tableInMultipleSessions() {
     RESTTableCache cache = new RESTTableCache(Map.of());
     String otherSessionId = "sessionID2";
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
-    cache.put(otherSessionId, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    putEntry(cache, SESSION_ID, TABLE_IDENTIFIER);
+    putEntry(cache, otherSessionId, TABLE_IDENTIFIER);
 
     assertThat(cache.cache().asMap()).hasSize(2);
 
     cache.invalidate(SESSION_ID, TABLE_IDENTIFIER);
-    TableWithETag tableWithETag = cache.getIfPresent(otherSessionId, TABLE_IDENTIFIER);
+    TableCacheEntry entry = cache.getIfPresent(otherSessionId, TABLE_IDENTIFIER);
     cache.cache().cleanUp();
 
     assertThat(cache.cache().asMap()).hasSize(1);
     assertThat(cache.getIfPresent(SESSION_ID, TABLE_IDENTIFIER)).isNull();
-    assertThat(tableWithETag.supplier()).isSameAs(TABLE_SUPPLIER);
-    assertThat(tableWithETag.eTag()).isSameAs(ETAG);
+    assertThat(entry.tableMetadata()).isSameAs(TABLE_METADATA);
+    assertThat(entry.tableClient()).isSameAs(TABLE_CLIENT);
+    assertThat(entry.eTag()).isSameAs(ETAG);
   }
 
   @Test
@@ -119,7 +135,7 @@ public class TestRESTTableCache {
     RESTTableCache cache = new RESTTableCache(Map.of());
     // Add more items than the max limit
     for (int i = 0; i < RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES_DEFAULT + 10; ++i) {
-      cache.put(SESSION_ID, TableIdentifier.of("ns", "tbl" + i), TABLE_SUPPLIER, ETAG);
+      putEntry(cache, SESSION_ID, TableIdentifier.of("ns", "tbl" + i));
     }
     cache.cache().cleanUp();
 
@@ -132,8 +148,8 @@ public class TestRESTTableCache {
     RESTTableCache cache =
         new RESTTableCache(Map.of(RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES, "1"));
     TableIdentifier otherTableIdentifier = TableIdentifier.of("ns", "other_table");
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
-    cache.put(SESSION_ID, otherTableIdentifier, TABLE_SUPPLIER, ETAG);
+    putEntry(cache, SESSION_ID, TABLE_IDENTIFIER);
+    putEntry(cache, SESSION_ID, otherTableIdentifier);
     cache.cache().cleanUp();
 
     assertThat(cache.cache().asMap()).hasSize(1);
@@ -145,7 +161,7 @@ public class TestRESTTableCache {
   public void cacheTurnedOff() {
     RESTTableCache cache =
         new RESTTableCache(Map.of(RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES, "0"));
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    putEntry(cache, SESSION_ID, TABLE_IDENTIFIER);
     cache.cache().cleanUp();
 
     assertThat(cache.cache().asMap()).isEmpty();
@@ -155,7 +171,7 @@ public class TestRESTTableCache {
   public void entryExpires() {
     FakeTicker ticker = new FakeTicker();
     RESTTableCache cache = new RESTTableCache(Map.of(), ticker);
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    putEntry(cache, SESSION_ID, TABLE_IDENTIFIER);
 
     SessionIdTableId cacheKey = SessionIdTableId.of(SESSION_ID, TABLE_IDENTIFIER);
     assertThat(cache.cache().policy().expireAfterAccess()).isNotPresent();
@@ -188,7 +204,7 @@ public class TestRESTTableCache {
                 RESTCatalogProperties.TABLE_CACHE_EXPIRE_AFTER_WRITE_MS,
                 String.valueOf(expirationInterval.toMillis())),
             ticker);
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    putEntry(cache, SESSION_ID, TABLE_IDENTIFIER);
 
     assertThat(cache.getIfPresent(SESSION_ID, TABLE_IDENTIFIER)).isNotNull();
 


### PR DESCRIPTION
Currently, the RESTTableCache stores a Supplier<BaseTable>. This is somewhat rigid and doesn't leave much room for further changes. This PR breaks this down and stores relevant information needed for table creation instead of the Supplier. With this, it's the user's responsibility to hold the logic to create the table.

Motivation for this refactor is to split the internal representation of the table cache between table-level details and user/session-level details. Currently, if multiple users query the same table, the table metadata itself is cached multiple times that is wasteful and also adds up for the maximum numbr of entries config. With the refactor we could improve this.