### PR TITLE
Spark: Support aggregate pushdown for identity partition column GROUP BY

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -230,6 +230,11 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
     PartitionSpec currentSpec = table().spec();
     for (org.apache.spark.sql.connector.expressions.Expression groupByExpr :
         aggregation.groupByExpressions()) {
+      if (!(groupByExpr instanceof org.apache.spark.sql.connector.expressions.NamedReference)) {
+        LOG.info("Skipping grouped aggregate pushdown: unsupported group by expression");
+        return false;
+      }
+
       String colName =
           SparkUtil.toColumnName(
               (org.apache.spark.sql.connector.expressions.NamedReference) groupByExpr);
@@ -239,7 +244,6 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
         return false;
       }
 
-      // verify the field is an identity partition in the current spec
       if (findIdentityPartitionPosition(currentSpec, sourceField.fieldId()) < 0) {
         LOG.info(
             "Skipping grouped aggregate pushdown: {} is not an identity partition field", colName);
@@ -354,32 +358,6 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
     return -1;
   }
 
-  private boolean allGroupByAreIdentityPartitionFields(Aggregation aggregation) {
-    PartitionSpec spec = table().spec();
-    Schema tableSchema = table().schema();
-
-    for (org.apache.spark.sql.connector.expressions.Expression groupByExpr :
-        aggregation.groupByExpressions()) {
-      if (!(groupByExpr instanceof org.apache.spark.sql.connector.expressions.NamedReference)) {
-        return false;
-      }
-
-      String colName =
-          SparkUtil.toColumnName(
-              (org.apache.spark.sql.connector.expressions.NamedReference) groupByExpr);
-      Types.NestedField sourceField = tableSchema.findField(colName);
-      if (sourceField == null) {
-        return false;
-      }
-
-      if (findIdentityPartitionPosition(spec, sourceField.fieldId()) < 0) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
   private static class ArrayStructLike implements StructLike {
     private final Object[] values;
 
@@ -411,14 +389,6 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
 
     if (!readConf().aggregatePushDownEnabled()) {
       return false;
-    }
-
-    if (aggregation.groupByExpressions().length > 0) {
-      if (!allGroupByAreIdentityPartitionFields(aggregation)) {
-        LOG.info(
-            "Skipping aggregate pushdown: group by columns must all be identity partition fields");
-        return false;
-      }
     }
 
     return true;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -55,7 +55,6 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
@@ -207,10 +206,29 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
     PartitionSpec spec = table().spec();
     Schema tableSchema = table().schema();
 
-    // resolve GROUP BY columns to partition field positions
     List<Integer> groupByPositions = Lists.newArrayList();
     List<Types.NestedField> groupByFields = Lists.newArrayList();
+    if (!resolveGroupByPartitions(
+        aggregation, spec, tableSchema, groupByPositions, groupByFields)) {
+      return false;
+    }
 
+    Map<List<Object>, AggregateEvaluator> evaluatorsByPartition =
+        groupFilesByPartition(spec, groupByPositions, boundAggregates);
+    if (evaluatorsByPartition == null) {
+      return false;
+    }
+
+    localScan = buildGroupedLocalScan(groupByFields, evaluatorsByPartition);
+    return localScan != null;
+  }
+
+  private boolean resolveGroupByPartitions(
+      Aggregation aggregation,
+      PartitionSpec spec,
+      Schema tableSchema,
+      List<Integer> groupByPositions,
+      List<Types.NestedField> groupByFields) {
     for (org.apache.spark.sql.connector.expressions.Expression groupByExpr :
         aggregation.groupByExpressions()) {
       String colName =
@@ -233,21 +251,27 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
       groupByFields.add(sourceField);
     }
 
-    // group files by partition values and compute per-partition aggregates
+    return true;
+  }
+
+  private Map<List<Object>, AggregateEvaluator> groupFilesByPartition(
+      PartitionSpec spec,
+      List<Integer> groupByPositions,
+      List<BoundAggregate<?, ?>> boundAggregates) {
     Map<List<Object>, AggregateEvaluator> evaluatorsByPartition = Maps.newLinkedHashMap();
 
     try (CloseableIterable<FileScanTask> fileScanTasks = planFilesWithStats()) {
       for (FileScanTask task : fileScanTasks) {
         if (!task.deletes().isEmpty()) {
           LOG.info("Skipping grouped aggregate pushdown: detected row level deletes");
-          return false;
+          return null;
         }
 
         if (task.file().specId() != spec.specId()) {
           LOG.info(
               "Skipping grouped aggregate pushdown: file from different spec {}",
               task.file().specId());
-          return false;
+          return null;
         }
 
         StructLike partition = task.file().partition();
@@ -262,20 +286,25 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
       }
     } catch (IOException e) {
       LOG.info("Skipping grouped aggregate pushdown: ", e);
-      return false;
+      return null;
     }
 
     if (evaluatorsByPartition.isEmpty()) {
-      return false;
+      return null;
     }
 
     for (AggregateEvaluator evaluator : evaluatorsByPartition.values()) {
       if (!evaluator.allAggregatorsValid()) {
-        return false;
+        return null;
       }
     }
 
-    // build result schema: [group_by_col_1, ..., agg_1, agg_2, ...]
+    return evaluatorsByPartition;
+  }
+
+  private SparkLocalScan buildGroupedLocalScan(
+      List<Types.NestedField> groupByFields,
+      Map<List<Object>, AggregateEvaluator> evaluatorsByPartition) {
     AggregateEvaluator firstEvaluator = evaluatorsByPartition.values().iterator().next();
     List<Types.NestedField> resultFields = Lists.newArrayList();
     int fieldId = 0;
@@ -289,9 +318,8 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
     }
 
     Types.StructType resultType = Types.StructType.of(resultFields);
-
-    // build result rows
     List<InternalRow> resultRows = Lists.newArrayList();
+
     for (Map.Entry<List<Object>, AggregateEvaluator> entry : evaluatorsByPartition.entrySet()) {
       List<Object> partitionValues = entry.getKey();
       StructLike aggResult = entry.getValue().result();
@@ -309,10 +337,8 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
     }
 
     StructType pushedSchema = SparkSchemaUtil.convert(new Schema(resultFields));
-    localScan =
-        new SparkLocalScan(
-            table(), pushedSchema, resultRows.toArray(new InternalRow[0]), filters());
-    return true;
+    return new SparkLocalScan(
+        table(), pushedSchema, resultRows.toArray(new InternalRow[0]), filters());
   }
 
   private int findIdentityPartitionPosition(PartitionSpec spec, int sourceFieldId) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -203,18 +203,17 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
    */
   private boolean pushGroupByAggregation(
       Aggregation aggregation, List<BoundAggregate<?, ?>> boundAggregates) {
-    PartitionSpec spec = table().spec();
     Schema tableSchema = table().schema();
 
-    List<Integer> groupByPositions = Lists.newArrayList();
+    // resolve GROUP BY columns to source field IDs (not positions, for spec evolution safety)
+    List<Integer> groupBySourceIds = Lists.newArrayList();
     List<Types.NestedField> groupByFields = Lists.newArrayList();
-    if (!resolveGroupByPartitions(
-        aggregation, spec, tableSchema, groupByPositions, groupByFields)) {
+    if (!resolveGroupByFields(aggregation, tableSchema, groupBySourceIds, groupByFields)) {
       return false;
     }
 
     Map<List<Object>, AggregateEvaluator> evaluatorsByPartition =
-        groupFilesByPartition(spec, groupByPositions, boundAggregates);
+        groupFilesByPartition(groupBySourceIds, boundAggregates);
     if (evaluatorsByPartition == null) {
       return false;
     }
@@ -223,12 +222,12 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
     return localScan != null;
   }
 
-  private boolean resolveGroupByPartitions(
+  private boolean resolveGroupByFields(
       Aggregation aggregation,
-      PartitionSpec spec,
       Schema tableSchema,
-      List<Integer> groupByPositions,
+      List<Integer> groupBySourceIds,
       List<Types.NestedField> groupByFields) {
+    PartitionSpec currentSpec = table().spec();
     for (org.apache.spark.sql.connector.expressions.Expression groupByExpr :
         aggregation.groupByExpressions()) {
       String colName =
@@ -240,14 +239,14 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
         return false;
       }
 
-      int pos = findIdentityPartitionPosition(spec, sourceField.fieldId());
-      if (pos < 0) {
+      // verify the field is an identity partition in the current spec
+      if (findIdentityPartitionPosition(currentSpec, sourceField.fieldId()) < 0) {
         LOG.info(
             "Skipping grouped aggregate pushdown: {} is not an identity partition field", colName);
         return false;
       }
 
-      groupByPositions.add(pos);
+      groupBySourceIds.add(sourceField.fieldId());
       groupByFields.add(sourceField);
     }
 
@@ -255,9 +254,7 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
   }
 
   private Map<List<Object>, AggregateEvaluator> groupFilesByPartition(
-      PartitionSpec spec,
-      List<Integer> groupByPositions,
-      List<BoundAggregate<?, ?>> boundAggregates) {
+      List<Integer> groupBySourceIds, List<BoundAggregate<?, ?>> boundAggregates) {
     Map<List<Object>, AggregateEvaluator> evaluatorsByPartition = Maps.newLinkedHashMap();
 
     try (CloseableIterable<FileScanTask> fileScanTasks = planFilesWithStats()) {
@@ -267,16 +264,20 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
           return null;
         }
 
-        if (task.file().specId() != spec.specId()) {
-          LOG.info(
-              "Skipping grouped aggregate pushdown: file from different spec {}",
-              task.file().specId());
-          return null;
-        }
-
+        // resolve partition values using the file's own spec (handles spec evolution)
+        PartitionSpec fileSpec = table().specs().get(task.file().specId());
         StructLike partition = task.file().partition();
-        List<Object> key = Lists.newArrayListWithCapacity(groupByPositions.size());
-        for (int pos : groupByPositions) {
+        List<Object> key = Lists.newArrayListWithCapacity(groupBySourceIds.size());
+
+        for (int sourceId : groupBySourceIds) {
+          int pos = findIdentityPartitionPosition(fileSpec, sourceId);
+          if (pos < 0) {
+            LOG.info(
+                "Skipping grouped aggregate pushdown: field {} not in spec {}",
+                sourceId,
+                fileSpec.specId());
+            return null;
+          }
           key.add(partition.get(pos, Object.class));
         }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
@@ -28,6 +29,8 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -41,14 +44,18 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkAggregates;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.TimeTravel;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
@@ -157,6 +164,10 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
       return false;
     }
 
+    if (aggregation.groupByExpressions().length > 0) {
+      return pushGroupByAggregation(aggregation, expressions);
+    }
+
     try (CloseableIterable<FileScanTask> fileScanTasks = planFilesWithStats()) {
       for (FileScanTask task : fileScanTasks) {
         if (!task.deletes().isEmpty()) {
@@ -186,6 +197,186 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
     return true;
   }
 
+  /**
+   * Push down aggregation with GROUP BY on identity partition columns. When all GROUP BY columns
+   * are identity partition fields, aggregates can be computed from file metadata grouped by
+   * partition values, avoiding reading any data files.
+   */
+  private boolean pushGroupByAggregation(
+      Aggregation aggregation, List<BoundAggregate<?, ?>> boundAggregates) {
+    PartitionSpec spec = table().spec();
+    Schema tableSchema = table().schema();
+
+    // resolve GROUP BY columns to partition field positions
+    List<Integer> groupByPositions = Lists.newArrayList();
+    List<Types.NestedField> groupByFields = Lists.newArrayList();
+
+    for (org.apache.spark.sql.connector.expressions.Expression groupByExpr :
+        aggregation.groupByExpressions()) {
+      String colName =
+          SparkUtil.toColumnName(
+              (org.apache.spark.sql.connector.expressions.NamedReference) groupByExpr);
+      Types.NestedField sourceField = tableSchema.findField(colName);
+      if (sourceField == null) {
+        LOG.info("Skipping grouped aggregate pushdown: cannot find field {}", colName);
+        return false;
+      }
+
+      int pos = findIdentityPartitionPosition(spec, sourceField.fieldId());
+      if (pos < 0) {
+        LOG.info(
+            "Skipping grouped aggregate pushdown: {} is not an identity partition field", colName);
+        return false;
+      }
+
+      groupByPositions.add(pos);
+      groupByFields.add(sourceField);
+    }
+
+    // group files by partition values and compute per-partition aggregates
+    Map<List<Object>, AggregateEvaluator> evaluatorsByPartition = Maps.newLinkedHashMap();
+
+    try (CloseableIterable<FileScanTask> fileScanTasks = planFilesWithStats()) {
+      for (FileScanTask task : fileScanTasks) {
+        if (!task.deletes().isEmpty()) {
+          LOG.info("Skipping grouped aggregate pushdown: detected row level deletes");
+          return false;
+        }
+
+        if (task.file().specId() != spec.specId()) {
+          LOG.info(
+              "Skipping grouped aggregate pushdown: file from different spec {}",
+              task.file().specId());
+          return false;
+        }
+
+        StructLike partition = task.file().partition();
+        List<Object> key = Lists.newArrayListWithCapacity(groupByPositions.size());
+        for (int pos : groupByPositions) {
+          key.add(partition.get(pos, Object.class));
+        }
+
+        evaluatorsByPartition
+            .computeIfAbsent(key, k -> AggregateEvaluator.create(boundAggregates))
+            .update(task.file());
+      }
+    } catch (IOException e) {
+      LOG.info("Skipping grouped aggregate pushdown: ", e);
+      return false;
+    }
+
+    if (evaluatorsByPartition.isEmpty()) {
+      return false;
+    }
+
+    for (AggregateEvaluator evaluator : evaluatorsByPartition.values()) {
+      if (!evaluator.allAggregatorsValid()) {
+        return false;
+      }
+    }
+
+    // build result schema: [group_by_col_1, ..., agg_1, agg_2, ...]
+    AggregateEvaluator firstEvaluator = evaluatorsByPartition.values().iterator().next();
+    List<Types.NestedField> resultFields = Lists.newArrayList();
+    int fieldId = 0;
+
+    for (Types.NestedField field : groupByFields) {
+      resultFields.add(Types.NestedField.optional(fieldId++, field.name(), field.type()));
+    }
+
+    for (Types.NestedField field : firstEvaluator.resultType().fields()) {
+      resultFields.add(Types.NestedField.optional(fieldId++, field.name(), field.type()));
+    }
+
+    Types.StructType resultType = Types.StructType.of(resultFields);
+
+    // build result rows
+    List<InternalRow> resultRows = Lists.newArrayList();
+    for (Map.Entry<List<Object>, AggregateEvaluator> entry : evaluatorsByPartition.entrySet()) {
+      List<Object> partitionValues = entry.getKey();
+      StructLike aggResult = entry.getValue().result();
+
+      Object[] combined = new Object[resultFields.size()];
+      for (int i = 0; i < partitionValues.size(); i++) {
+        combined[i] = partitionValues.get(i);
+      }
+
+      for (int i = 0; i < aggResult.size(); i++) {
+        combined[partitionValues.size() + i] = aggResult.get(i, Object.class);
+      }
+
+      resultRows.add(new StructInternalRow(resultType).setStruct(new ArrayStructLike(combined)));
+    }
+
+    StructType pushedSchema = SparkSchemaUtil.convert(new Schema(resultFields));
+    localScan =
+        new SparkLocalScan(
+            table(), pushedSchema, resultRows.toArray(new InternalRow[0]), filters());
+    return true;
+  }
+
+  private int findIdentityPartitionPosition(PartitionSpec spec, int sourceFieldId) {
+    List<PartitionField> fields = spec.fields();
+    for (int i = 0; i < fields.size(); i++) {
+      PartitionField field = fields.get(i);
+      if (field.sourceId() == sourceFieldId && field.transform().isIdentity()) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  private boolean allGroupByAreIdentityPartitionFields(Aggregation aggregation) {
+    PartitionSpec spec = table().spec();
+    Schema tableSchema = table().schema();
+
+    for (org.apache.spark.sql.connector.expressions.Expression groupByExpr :
+        aggregation.groupByExpressions()) {
+      if (!(groupByExpr instanceof org.apache.spark.sql.connector.expressions.NamedReference)) {
+        return false;
+      }
+
+      String colName =
+          SparkUtil.toColumnName(
+              (org.apache.spark.sql.connector.expressions.NamedReference) groupByExpr);
+      Types.NestedField sourceField = tableSchema.findField(colName);
+      if (sourceField == null) {
+        return false;
+      }
+
+      if (findIdentityPartitionPosition(spec, sourceField.fieldId()) < 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static class ArrayStructLike implements StructLike {
+    private final Object[] values;
+
+    ArrayStructLike(Object[] values) {
+      this.values = values;
+    }
+
+    @Override
+    public int size() {
+      return values.length;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(int pos, Class<T> javaClass) {
+      return (T) values[pos];
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      values[pos] = value;
+    }
+  }
+
   private boolean canPushDownAggregation(Aggregation aggregation) {
     if (!isMainTable()) {
       return false;
@@ -195,12 +386,12 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
       return false;
     }
 
-    // If group by expression is the same as the partition, the statistics information can still
-    // be used to calculate min/max/count, will enable aggregate push down in next phase.
-    // TODO: enable aggregate push down for partition col group by expression
     if (aggregation.groupByExpressions().length > 0) {
-      LOG.info("Skipping aggregate pushdown: group by aggregation push down is not supported");
-      return false;
+      if (!allGroupByAreIdentityPartitionFields(aggregation)) {
+        LOG.info(
+            "Skipping aggregate pushdown: group by columns must all be identity partition fields");
+        return false;
+      }
     }
 
     return true;

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -922,6 +922,8 @@ public class TestAggregatePushDown extends CatalogTestBase {
 
     String select = "SELECT category, count(*) FROM %s GROUP BY category";
 
+    assertExplainContains(sql("EXPLAIN " + select, tableName), "localtablescan");
+
     List<Object[]> actual = sql(select, tableName);
     assertThat(actual).hasSize(3);
 
@@ -947,6 +949,8 @@ public class TestAggregatePushDown extends CatalogTestBase {
         tableName);
 
     String select = "SELECT region, count(*), max(price), min(price) FROM %s GROUP BY region";
+
+    assertExplainContains(sql("EXPLAIN " + select, tableName), "localtablescan");
 
     List<Object[]> actual = sql(select, tableName);
     assertThat(actual).hasSize(3);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -563,26 +563,6 @@ public class TestAggregatePushDown extends CatalogTestBase {
         "min(struct_with_ts.c1)");
   }
 
-  @TestTemplate
-  public void testAggregationPushdownOnBucketedColumn() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, struct_with_int STRUCT<c1:INT>) USING iceberg PARTITIONED BY (bucket(8, id))",
-        tableName);
-
-    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", NULL))", tableName);
-    sql("INSERT INTO TABLE %s VALUES (null, named_struct(\"c1\", 2))", tableName);
-    sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 3))", tableName);
-
-    String query = "SELECT COUNT(%s), MAX(%s), MIN(%s) FROM %s";
-    String aggField = "id";
-    assertAggregates(sql(query, aggField, aggField, aggField, tableName), 2L, 2L, 1L);
-    assertExplainContains(
-        sql("EXPLAIN " + query, aggField, aggField, aggField, tableName),
-        "count(id)",
-        "max(id)",
-        "min(id)");
-  }
-
   private void assertAggregates(
       List<Object[]> actual, Object expectedCount, Object expectedMax, Object expectedMin) {
     Object actualCount = actual.get(0)[0];
@@ -908,5 +888,111 @@ public class TestAggregatePushDown extends CatalogTestBase {
     expected2.add(new Object[] {-7777, 9999, 6L});
     assertEquals(
         "min/max/count push down", expected2, rowsToJava(unboundedPushdownDs.collectAsList()));
+  }
+
+  @TestTemplate
+  public void testGroupByIdentityPartitionColumnCountPushDown() {
+    sql(
+        "CREATE TABLE %s (id LONG, data STRING, category STRING) USING iceberg PARTITIONED BY (category)",
+        tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES "
+            + "(1, 'a', 'fruit'), (2, 'b', 'fruit'), (3, 'c', 'fruit'),"
+            + "(4, 'd', 'veggie'), (5, 'e', 'veggie'),"
+            + "(6, 'f', 'dairy')",
+        tableName);
+
+    String select = "SELECT category, count(*) FROM %s GROUP BY category";
+
+    List<Object[]> actual = sql(select, tableName);
+    // verify correct results regardless of pushdown
+    assertThat(actual).hasSize(3);
+
+    // sort results for deterministic comparison
+    actual.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
+
+    assertEquals(
+        "group by partition count push down",
+        Lists.newArrayList(
+            new Object[] {"dairy", 1L}, new Object[] {"fruit", 3L}, new Object[] {"veggie", 2L}),
+        actual);
+  }
+
+  @TestTemplate
+  public void testGroupByIdentityPartitionColumnWithMinMax() {
+    sql(
+        "CREATE TABLE %s (id LONG, price DOUBLE, region STRING) USING iceberg PARTITIONED BY (region)",
+        tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES "
+            + "(1, 10.0, 'east'), (2, 20.0, 'east'), (3, 30.0, 'east'),"
+            + "(4, 5.0, 'west'), (5, 50.0, 'west'),"
+            + "(6, 100.0, 'north')",
+        tableName);
+
+    String select = "SELECT region, count(*), max(price), min(price) FROM %s GROUP BY region";
+
+    List<Object[]> actual = sql(select, tableName);
+    assertThat(actual).hasSize(3);
+
+    // sort by region for deterministic comparison
+    actual.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
+
+    assertEquals(
+        "group by partition with min/max push down",
+        Lists.newArrayList(
+            new Object[] {"east", 3L, 30.0, 10.0},
+            new Object[] {"north", 1L, 100.0, 100.0},
+            new Object[] {"west", 2L, 50.0, 5.0}),
+        actual);
+  }
+
+  @TestTemplate
+  public void testGroupByNonPartitionColumnNoPushDown() {
+    sql(
+        "CREATE TABLE %s (id LONG, data STRING, category STRING) USING iceberg PARTITIONED BY (category)",
+        tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a', 'x'), (2, 'b', 'x'), (3, 'a', 'y')", tableName);
+
+    // GROUP BY on non-partition column should NOT be pushed down
+    String select = "SELECT data, count(*) FROM %s GROUP BY data";
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
+
+    // should NOT contain LocalTableScan (pushdown not applied for non-partition GROUP BY)
+    assertThat(explainString)
+        .as("non-partition group by should not be pushed down to LocalTableScan")
+        .doesNotContain("localtablescan");
+
+    // but results should still be correct
+    List<Object[]> actual = sql(select, tableName);
+    assertThat(actual).hasSize(2);
+  }
+
+  @TestTemplate
+  public void testGroupByPartitionColumnMultipleInserts() {
+    sql(
+        "CREATE TABLE %s (id LONG, amount DOUBLE, city STRING) USING iceberg PARTITIONED BY (city)",
+        tableName);
+    // multiple inserts create multiple data files per partition
+    sql("INSERT INTO TABLE %s VALUES (1, 100.0, 'NYC'), (2, 200.0, 'NYC')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, 50.0, 'NYC'), (4, 300.0, 'SF')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (5, 150.0, 'SF'), (6, 75.0, 'LA')", tableName);
+
+    String select = "SELECT city, count(*), max(amount), min(amount) FROM %s GROUP BY city";
+
+    List<Object[]> actual = sql(select, tableName);
+    assertThat(actual).hasSize(3);
+
+    actual.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
+
+    assertEquals(
+        "group by partition with multiple files per partition",
+        Lists.newArrayList(
+            new Object[] {"LA", 1L, 75.0, 75.0},
+            new Object[] {"NYC", 3L, 200.0, 50.0},
+            new Object[] {"SF", 2L, 300.0, 150.0}),
+        actual);
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -1080,8 +1080,12 @@ public class TestAggregatePushDown extends CatalogTestBase {
 
     actual.sort(
         (a, b) -> {
-          if (a[0] == null) return -1;
-          if (b[0] == null) return 1;
+          if (a[0] == null) {
+            return -1;
+          }
+          if (b[0] == null) {
+            return 1;
+          }
           return ((String) a[0]).compareTo((String) b[0]);
         });
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -563,6 +563,24 @@ public class TestAggregatePushDown extends CatalogTestBase {
         "min(struct_with_ts.c1)");
   }
 
+  @TestTemplate
+  public void testAggregationPushdownOnBucketedColumn() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, struct_with_int STRUCT<c1:INT>) USING iceberg PARTITIONED BY (bucket(8, id))",
+        tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", NULL))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (null, named_struct(\"c1\", 2))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 3))", tableName);
+    String query = "SELECT COUNT(%s), MAX(%s), MIN(%s) FROM %s";
+    String aggField = "id";
+    assertAggregates(sql(query, aggField, aggField, aggField, tableName), 2L, 2L, 1L);
+    assertExplainContains(
+        sql("EXPLAIN " + query, aggField, aggField, aggField, tableName),
+        "count(id)",
+        "max(id)",
+        "min(id)");
+  }
+
   private void assertAggregates(
       List<Object[]> actual, Object expectedCount, Object expectedMax, Object expectedMin) {
     Object actualCount = actual.get(0)[0];
@@ -905,10 +923,8 @@ public class TestAggregatePushDown extends CatalogTestBase {
     String select = "SELECT category, count(*) FROM %s GROUP BY category";
 
     List<Object[]> actual = sql(select, tableName);
-    // verify correct results regardless of pushdown
     assertThat(actual).hasSize(3);
 
-    // sort results for deterministic comparison
     actual.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
 
     assertEquals(
@@ -935,7 +951,6 @@ public class TestAggregatePushDown extends CatalogTestBase {
     List<Object[]> actual = sql(select, tableName);
     assertThat(actual).hasSize(3);
 
-    // sort by region for deterministic comparison
     actual.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
 
     assertEquals(
@@ -954,18 +969,15 @@ public class TestAggregatePushDown extends CatalogTestBase {
         tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'a', 'x'), (2, 'b', 'x'), (3, 'a', 'y')", tableName);
 
-    // GROUP BY on non-partition column should NOT be pushed down
     String select = "SELECT data, count(*) FROM %s GROUP BY data";
 
     List<Object[]> explain = sql("EXPLAIN " + select, tableName);
     String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
 
-    // should NOT contain LocalTableScan (pushdown not applied for non-partition GROUP BY)
     assertThat(explainString)
         .as("non-partition group by should not be pushed down to LocalTableScan")
         .doesNotContain("localtablescan");
 
-    // but results should still be correct
     List<Object[]> actual = sql(select, tableName);
     assertThat(actual).hasSize(2);
   }
@@ -975,7 +987,6 @@ public class TestAggregatePushDown extends CatalogTestBase {
     sql(
         "CREATE TABLE %s (id LONG, amount DOUBLE, city STRING) USING iceberg PARTITIONED BY (city)",
         tableName);
-    // multiple inserts create multiple data files per partition
     sql("INSERT INTO TABLE %s VALUES (1, 100.0, 'NYC'), (2, 200.0, 'NYC')", tableName);
     sql("INSERT INTO TABLE %s VALUES (3, 50.0, 'NYC'), (4, 300.0, 'SF')", tableName);
     sql("INSERT INTO TABLE %s VALUES (5, 150.0, 'SF'), (6, 75.0, 'LA')", tableName);
@@ -993,6 +1004,86 @@ public class TestAggregatePushDown extends CatalogTestBase {
             new Object[] {"LA", 1L, 75.0, 75.0},
             new Object[] {"NYC", 3L, 200.0, 50.0},
             new Object[] {"SF", 2L, 300.0, 150.0}),
+        actual);
+  }
+
+  @TestTemplate
+  public void testGroupByPartitionColumnAfterSpecEvolution() {
+    sql(
+        "CREATE TABLE %s (id LONG, amount DOUBLE, region STRING) USING iceberg PARTITIONED BY (region)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 10.0, 'east'), (2, 20.0, 'west')", tableName);
+
+    validationCatalog.loadTable(tableIdent).updateSpec().addField("id").commit();
+
+    sql("INSERT INTO TABLE %s VALUES (3, 30.0, 'east'), (4, 40.0, 'west')", tableName);
+
+    String select = "SELECT region, count(*), max(amount) FROM %s GROUP BY region";
+
+    List<Object[]> actual = sql(select, tableName);
+    assertThat(actual).hasSize(2);
+
+    actual.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
+
+    assertEquals(
+        "group by partition after spec evolution",
+        Lists.newArrayList(new Object[] {"east", 2L, 30.0}, new Object[] {"west", 2L, 40.0}),
+        actual);
+  }
+
+  @TestTemplate
+  public void testGroupByPartitionRemovedInNewSpecFallsBack() {
+    sql(
+        "CREATE TABLE %s (id LONG, amount DOUBLE, region STRING) USING iceberg PARTITIONED BY (region)",
+        tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 10.0, 'east'), (2, 20.0, 'west')", tableName);
+
+    validationCatalog
+        .loadTable(tableIdent)
+        .updateSpec()
+        .removeField("region")
+        .addField("id")
+        .commit();
+
+    sql("INSERT INTO TABLE %s VALUES (3, 30.0, 'east'), (4, 40.0, 'west')", tableName);
+
+    String select = "SELECT region, count(*) FROM %s GROUP BY region";
+
+    List<Object[]> actual = sql(select, tableName);
+    actual.sort((a, b) -> ((String) a[0]).compareTo((String) b[0]));
+    assertEquals(
+        "group by with removed partition field",
+        Lists.newArrayList(new Object[] {"east", 2L}, new Object[] {"west", 2L}),
+        actual);
+  }
+
+  @TestTemplate
+  public void testGroupByPartitionColumnWithNullValues() {
+    sql(
+        "CREATE TABLE %s (id LONG, amount DOUBLE, region STRING) USING iceberg PARTITIONED BY (region)",
+        tableName);
+
+    sql(
+        "INSERT INTO TABLE %s VALUES (1, 10.0, 'east'), (2, 20.0, null), (3, 30.0, 'east'), (4, 40.0, null)",
+        tableName);
+
+    String select = "SELECT region, count(*), max(amount) FROM %s GROUP BY region";
+
+    List<Object[]> actual = sql(select, tableName);
+    assertThat(actual).hasSize(2);
+
+    actual.sort(
+        (a, b) -> {
+          if (a[0] == null) return -1;
+          if (b[0] == null) return 1;
+          return ((String) a[0]).compareTo((String) b[0]);
+        });
+
+    assertEquals(
+        "group by partition with null values",
+        Lists.newArrayList(new Object[] {null, 2L, 40.0}, new Object[] {"east", 2L, 30.0}),
         actual);
   }
 }


### PR DESCRIPTION
This PR enables aggregate pushdown for queries with GROUP BY on identity partition columns. Currently, Iceberg supports pushing down aggregates (COUNT, MIN, MAX) for queries without GROUP BY, computing results from file metadata instead of reading data files. However, when a query includes GROUP BY, the pushdown is disabled even when the GROUP BY columns are identity partition fields.

