### PR TITLE
Build: Add CI check to enforce runtime-deps.gradle coverage across all modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,25 +133,31 @@ tasks.register('verifyRuntimeDepsApplied') {
   description = 'Ensures every subproject either applies runtime-deps.gradle or is explicitly excluded'
   group = 'verification'
 
-  // Modules that do not yet have runtime-deps.gradle applied.
-  // Remove entries from this list as modules are onboarded.
+  // Modules that do not ship bundled/shadow JARs and therefore do not need
+  // runtime-deps.gradle. New modules must either apply runtime-deps.gradle
+  // or be added here with justification.
   def excluded = [
-    // Core / library modules
+    // Aggregate modules — no artifacts produced
     'iceberg-bom',
+    'iceberg-spark',
+    'iceberg-flink',
+    'iceberg-kafka-connect',
+    // Internal shading — not distributed to users
+    'iceberg-bundled-guava',
+    'iceberg-open-api',
+    // Library modules — published as individual JARs to Maven Central
     'iceberg-api',
     'iceberg-common',
     'iceberg-core',
     'iceberg-data',
-    'iceberg-orc',
     'iceberg-arrow',
+    'iceberg-orc',
     'iceberg-parquet',
-    'iceberg-bundled-guava',
     'iceberg-hive-metastore',
     'iceberg-nessie',
     'iceberg-delta-lake',
     'iceberg-mr',
-    'iceberg-open-api',
-    // Cloud modules (non-bundle)
+    // Cloud catalog modules — the corresponding *-bundle carries the shadow JAR
     'iceberg-aliyun',
     'iceberg-aws',
     'iceberg-azure',
@@ -159,28 +165,24 @@ tasks.register('verifyRuntimeDepsApplied') {
     'iceberg-bigquery',
     'iceberg-dell',
     'iceberg-snowflake',
-    // Parent / aggregate modules
-    'iceberg-spark',
-    'iceberg-flink',
-    'iceberg-kafka-connect',
-    // Spark non-runtime (both Scala variants for 3.4/3.5, 2.13 only for 4.0/4.1)
+    // Spark integration modules — the corresponding spark-runtime carries the shadow JAR
     'iceberg-spark-3.4_2.12',
     'iceberg-spark-3.4_2.13',
-    'iceberg-spark-extensions-3.4_2.12',
-    'iceberg-spark-extensions-3.4_2.13',
     'iceberg-spark-3.5_2.12',
     'iceberg-spark-3.5_2.13',
+    'iceberg-spark-4.0_2.13',
+    'iceberg-spark-4.1_2.13',
+    'iceberg-spark-extensions-3.4_2.12',
+    'iceberg-spark-extensions-3.4_2.13',
     'iceberg-spark-extensions-3.5_2.12',
     'iceberg-spark-extensions-3.5_2.13',
-    'iceberg-spark-4.0_2.13',
     'iceberg-spark-extensions-4.0_2.13',
-    'iceberg-spark-4.1_2.13',
     'iceberg-spark-extensions-4.1_2.13',
-    // Flink non-runtime
+    // Flink integration modules — the corresponding flink-runtime carries the shadow JAR
     'iceberg-flink-1.20',
     'iceberg-flink-2.0',
     'iceberg-flink-2.1',
-    // Kafka Connect non-runtime
+    // Kafka Connect integration modules — kafka-connect-runtime carries the distribution
     'iceberg-kafka-connect-events',
     'iceberg-kafka-connect-transforms',
   ] as Set

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,84 @@ tasks.register('checkAllRuntimeDeps') {
   }
 }
 
+tasks.register('verifyRuntimeDepsApplied') {
+  description = 'Ensures every subproject either applies runtime-deps.gradle or is explicitly excluded'
+  group = 'verification'
+
+  // Modules that do not yet have runtime-deps.gradle applied.
+  // Remove entries from this list as modules are onboarded.
+  def excluded = [
+    // Core / library modules
+    'iceberg-bom',
+    'iceberg-api',
+    'iceberg-common',
+    'iceberg-core',
+    'iceberg-data',
+    'iceberg-orc',
+    'iceberg-arrow',
+    'iceberg-parquet',
+    'iceberg-bundled-guava',
+    'iceberg-hive-metastore',
+    'iceberg-nessie',
+    'iceberg-delta-lake',
+    'iceberg-mr',
+    'iceberg-open-api',
+    // Cloud modules (non-bundle)
+    'iceberg-aliyun',
+    'iceberg-aws',
+    'iceberg-azure',
+    'iceberg-gcp',
+    'iceberg-bigquery',
+    'iceberg-dell',
+    'iceberg-snowflake',
+    // Parent / aggregate modules
+    'iceberg-spark',
+    'iceberg-flink',
+    'iceberg-kafka-connect',
+    // Spark non-runtime (both Scala variants for 3.4/3.5, 2.13 only for 4.0/4.1)
+    'iceberg-spark-3.4_2.12',
+    'iceberg-spark-3.4_2.13',
+    'iceberg-spark-extensions-3.4_2.12',
+    'iceberg-spark-extensions-3.4_2.13',
+    'iceberg-spark-3.5_2.12',
+    'iceberg-spark-3.5_2.13',
+    'iceberg-spark-extensions-3.5_2.12',
+    'iceberg-spark-extensions-3.5_2.13',
+    'iceberg-spark-4.0_2.13',
+    'iceberg-spark-extensions-4.0_2.13',
+    'iceberg-spark-4.1_2.13',
+    'iceberg-spark-extensions-4.1_2.13',
+    // Flink non-runtime
+    'iceberg-flink-1.20',
+    'iceberg-flink-2.0',
+    'iceberg-flink-2.1',
+    // Kafka Connect non-runtime
+    'iceberg-kafka-connect-events',
+    'iceberg-kafka-connect-transforms',
+  ] as Set
+
+  doLast {
+    def uncovered = []
+    subprojects.each { subproject ->
+      if (!excluded.contains(subproject.name) &&
+          subproject.tasks.matching { it.name == 'checkRuntimeDeps' }.isEmpty()) {
+        uncovered << subproject.name
+      }
+    }
+    if (uncovered) {
+      throw new GradleException(
+        "The following modules are missing runtime-deps.gradle and are not in the exclusion list:\n" +
+        uncovered.toSorted().collect { "  - ${it}" }.join('\n') + '\n\n' +
+        "Either apply runtime-deps.gradle to the module or add it to the exclusion list in " +
+        "the verifyRuntimeDepsApplied task in build.gradle.")
+    }
+  }
+}
+
+tasks.named('checkAllRuntimeDeps') {
+  dependsOn 'verifyRuntimeDepsApplied'
+}
+
 subprojects {
   if (it.name == 'iceberg-bom') {
     // the BOM does not build anything, the code below expects "source code"

--- a/build.gradle
+++ b/build.gradle
@@ -133,19 +133,16 @@ tasks.register('verifyRuntimeDepsApplied') {
   description = 'Ensures every subproject either applies runtime-deps.gradle or is explicitly excluded'
   group = 'verification'
 
-  // Modules that do not ship bundled/shadow JARs and therefore do not need
-  // runtime-deps.gradle. New modules must either apply runtime-deps.gradle
-  // or be added here with justification.
+  // Every subproject must either apply runtime-deps.gradle or be listed here.
   def excluded = [
     // Aggregate modules — no artifacts produced
     'iceberg-bom',
     'iceberg-spark',
     'iceberg-flink',
     'iceberg-kafka-connect',
-    // Internal shading — not distributed to users
+    // Library and catalog modules — publish normal JARs, not fat JARs
     'iceberg-bundled-guava',
     'iceberg-open-api',
-    // Library modules — published as individual JARs to Maven Central
     'iceberg-api',
     'iceberg-common',
     'iceberg-core',
@@ -157,7 +154,6 @@ tasks.register('verifyRuntimeDepsApplied') {
     'iceberg-nessie',
     'iceberg-delta-lake',
     'iceberg-mr',
-    // Cloud catalog modules — the corresponding *-bundle carries the shadow JAR
     'iceberg-aliyun',
     'iceberg-aws',
     'iceberg-azure',
@@ -165,7 +161,7 @@ tasks.register('verifyRuntimeDepsApplied') {
     'iceberg-bigquery',
     'iceberg-dell',
     'iceberg-snowflake',
-    // Spark integration modules — the corresponding spark-runtime carries the shadow JAR
+    // Integration modules — the corresponding *-runtime carries the shadow JAR
     'iceberg-spark-3.4_2.12',
     'iceberg-spark-3.4_2.13',
     'iceberg-spark-3.5_2.12',
@@ -178,11 +174,9 @@ tasks.register('verifyRuntimeDepsApplied') {
     'iceberg-spark-extensions-3.5_2.13',
     'iceberg-spark-extensions-4.0_2.13',
     'iceberg-spark-extensions-4.1_2.13',
-    // Flink integration modules — the corresponding flink-runtime carries the shadow JAR
     'iceberg-flink-1.20',
     'iceberg-flink-2.0',
     'iceberg-flink-2.1',
-    // Kafka Connect integration modules — kafka-connect-runtime carries the distribution
     'iceberg-kafka-connect-events',
     'iceberg-kafka-connect-transforms',
   ] as Set

--- a/runtime-deps.gradle
+++ b/runtime-deps.gradle
@@ -42,8 +42,8 @@
 //                          lifecycle.
 //
 // Workflow:
-//   1. ./gradlew check                   -- fails if deps changed
-//   2. ./gradlew generateRuntimeDeps     -- auto-updates all baselines
+//   1. ./gradlew checkAllRuntimeDeps -DallModules=true  -- fails if deps changed
+//   2. ./gradlew generateRuntimeDeps -DallModules=true  -- auto-updates all baselines
 //   3. Update LICENSE and NOTICE if dependency licenses changed -- This is a Manual Step
 //   4. Commit
 


### PR DESCRIPTION
This adds a `verifyRuntimeDepsApplied` task that fails CI if a subproject is missing
`runtime-deps.gradle` and is not in an explicit exclusion list. This prevents new
shadow JAR modules from being added without dependency tracking.

### Changes

- Added `verifyRuntimeDepsApplied` task to `build.gradle` with an exclusion list of
  modules that don't ship fat JARs
- Wired it as a dependency of `checkAllRuntimeDeps` so it runs in CI automatically
- Updated workflow comment in `runtime-deps.gradle`

### How it works

Every subproject must either:
1. Apply `runtime-deps.gradle` (produces a `checkRuntimeDeps` task), or
2. Be listed in the exclusion set

If a new module is added without doing either, CI fails with a message naming
the uncovered module and instructions to fix it.

### Testing

- `./gradlew checkAllRuntimeDeps -q -DallModules=true` passes
- Verified the task catches missing modules by temporarily removing
  `runtime-deps.gradle` from `aws-bundle`
