### PR TITLE
AWS: Fix stale LICENSE entry for Parquet, clarify failsafe attribution

### DIFF
--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -217,13 +217,6 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
-
-Project URL: https://parquet.apache.org
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product bundles Netty.
 
 Project URL: https://netty.io/
@@ -291,14 +284,6 @@ This product bundles Caffeine by Ben Manes.
 
 Copyright: 2014-2020 Ben Manes and contributors
 Project URL: https://github.com/ben-manes/caffeine
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles failsafe.
-
-Copyright: Jonathan Halterman and friends
-Project URL: https://failsafe.dev/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -217,7 +217,7 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet (shaded by AWS Analytics Accelerator S3).
+This product bundles Apache Parquet (bundled by AWS Analytics Accelerator S3).
 
 Copyright: 2014-2024 The Apache Software Foundation
 Project URL: https://parquet.apache.org/
@@ -327,7 +327,7 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles failsafe (shaded by AWS Analytics Accelerator S3).
+This product bundles failsafe (bundled by AWS Analytics Accelerator S3).
 
 Copyright: Jonathan Halterman and friends
 Project URL: https://failsafe.dev/

--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -288,6 +288,14 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product bundles failsafe (shaded by AWS Analytics Accelerator S3).
+
+Copyright: Jonathan Halterman and friends
+Project URL: https://failsafe.dev/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
 This product bundles Jackson JSON Processor.
 
 Copyright: 2007-2020 Tatu Saloranta and other contributors

--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -217,8 +217,6 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
---------------------------------------------------------------------------------
-
 This product bundles Apache Parquet (shaded by AWS Analytics Accelerator S3).
 
 Project URL: https://parquet.apache.org/

--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -219,15 +219,42 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 This product bundles Apache Parquet (shaded by AWS Analytics Accelerator S3).
 
+Copyright: 2014-2024 The Apache Software Foundation
 Project URL: https://parquet.apache.org/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Thrift (bundled by Parquet, shaded by AWS Analytics Accelerator S3).
+This product bundles Apache Thrift (bundled by Parquet).
 
+Copyright: 2006-2017 The Apache Software Foundation.
 Project URL: https://thrift.apache.org/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Daniel Lemire's JavaFastPFOR project (bundled by Parquet).
+
+Copyright: 2013 Daniel Lemire
+Project URL: https://github.com/lemire/JavaFastPFOR
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles fastutil (bundled by Parquet).
+
+Copyright: 2002-2014 Sebastiano Vigna
+Project URL: http://fastutil.di.unimi.it/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Zero-Allocation Hashing (bundled by Parquet).
+
+Project URL: https://github.com/OpenHFT/Zero-Allocation-Hashing
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
 
 This product bundles Netty.
 

--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -351,3 +351,17 @@ This product bundles JCTools (via Netty).
 
 Project URL: https://github.com/JCTools/JCTools
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Parquet (shaded by AWS Analytics Accelerator S3).
+
+Project URL: https://parquet.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Thrift (bundled by Parquet, shaded by AWS Analytics Accelerator S3).
+
+Project URL: https://thrift.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0

--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -217,6 +217,20 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+--------------------------------------------------------------------------------
+
+This product bundles Apache Parquet (shaded by AWS Analytics Accelerator S3).
+
+Project URL: https://parquet.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Thrift (bundled by Parquet, shaded by AWS Analytics Accelerator S3).
+
+Project URL: https://thrift.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
 This product bundles Netty.
 
 Project URL: https://netty.io/
@@ -350,18 +364,4 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product bundles JCTools (via Netty).
 
 Project URL: https://github.com/JCTools/JCTools
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Apache Parquet (shaded by AWS Analytics Accelerator S3).
-
-Project URL: https://parquet.apache.org/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Apache Thrift (bundled by Parquet, shaded by AWS Analytics Accelerator S3).
-
-Project URL: https://thrift.apache.org/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
- Remove "Apache Parquet" from `aws-bundle/LICENSE` — no Parquet classes exist in the shadow JAR
- Clarify failsafe entry with "(shaded by AWS Analytics Accelerator S3)" qualifier

**Verification:**
- `jar tf` on the shadow JAR shows zero `org/apache/parquet/` classes
- failsafe IS present as `software/amazon/s3/shaded/dev/failsafe/` (124 classes, pre-shaded by analytics-accelerator-s3)
- Parquet was mistakenly added in #15449 (multi-module LICENSE cleanup)