### PR TITLE
AWS: remove extra/staled LICENSE entry bundled by Parquet

### DIFF
--- a/aws-bundle/LICENSE
+++ b/aws-bundle/LICENSE
@@ -233,29 +233,6 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product includes code from Daniel Lemire's JavaFastPFOR project (bundled by Parquet).
-
-Copyright: 2013 Daniel Lemire
-Project URL: https://github.com/lemire/JavaFastPFOR
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles fastutil (bundled by Parquet).
-
-Copyright: 2002-2014 Sebastiano Vigna
-Project URL: http://fastutil.di.unimi.it/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product bundles Zero-Allocation Hashing (bundled by Parquet).
-
-Project URL: https://github.com/OpenHFT/Zero-Allocation-Hashing
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product bundles Netty.
 
 Project URL: https://netty.io/


### PR DESCRIPTION
Follow up to #16179

We dont need JavaFastPFOR/fastutil/Zero-Allocation Hashing since [AAL only bundles `parquet-format`](https://github.com/awslabs/analytics-accelerator-s3/blob/6a7346734a0c8cf43b97cf22611a79fa8e395b4d/gradle/libs.versions.toml#L30) (the Thrift-generated metadata classes), NOT the full `parquet-mr` with JavaFastPFOR, fastutil, and Zero-Allocation Hashing.

Context: https://github.com/apache/iceberg/pull/16179/files#r3171006878