### PR TITLE
Azure: Fix LICENSE, NOTICE, and runtime-deps for azure-bundle

### DIFF
--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -238,6 +238,94 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product bundles FastDoubleParser (via Jackson JSON Processor).
+
+Copyright: 2023 Werner Randelshofer, Switzerland
+Project URL: https://github.com/wrandelshofer/FastDoubleParser
+License: MIT
+| MIT License
+|
+| Copyright (c) 2023 Werner Randelshofer, Switzerland
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+This product bundles fast_float (bundled by FastDoubleParser).
+
+Copyright: 2021 The fast_float authors
+Project URL: https://github.com/fastfloat/fast_float
+License: MIT
+| MIT License
+|
+| Copyright (c) 2021 The fast_float authors
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+This product bundles bigint (bundled by FastDoubleParser).
+
+Copyright: 2022 Tim Buktu
+Project URL: https://github.com/tbuktu/bigint
+License: BSD 2-Clause
+| 2-clause BSD License
+|
+| Copyright 2022 Tim Buktu
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions
+| are met:
+|
+| 1. Redistributions of source code must retain the above copyright notice, this
+|    list of conditions and the following disclaimer.
+|
+| 2. Redistributions in binary form must reproduce the above copyright notice,
+|    this list of conditions and the following disclaimer in the documentation
+|    and/or other materials provided with the distribution.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+| ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+| WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+| FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+| DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+| SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+| CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+| OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
@@ -269,9 +357,44 @@ License: MIT
 
 --------------------------------------------------------------------------------
 
+This product bundles MSAL4J Persistence Extension.
+
+Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
+License: MIT
+|     MIT License
+|
+|     Copyright (c) Microsoft Corporation. All rights reserved.
+|
+|     Permission is hereby granted, free of charge, to any person obtaining a copy
+|     of this software and associated documentation files (the "Software"), to deal
+|     in the Software without restriction, including without limitation the rights
+|     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+|     copies of the Software, and to permit persons to whom the Software is
+|     furnished to do so, subject to the following conditions:
+|
+|     The above copyright notice and this permission notice shall be included in all
+|     copies or substantial portions of the Software.
+|
+|     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+|     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+|     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+|     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+|     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+|     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+|     SOFTWARE
+
+--------------------------------------------------------------------------------
+
 This product bundles Netty.
 
 Project URL: https://netty.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache Tomcat Native (netty-tcnative-classes and netty-tcnative-boringssl-static, bundled by Reactor Netty).
+
+Project URL: https://tomcat.apache.org/native-doc/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
@@ -290,9 +413,16 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Reactor AddOns.
+This product bundles Reactor Pool (bundled by Reactor Netty).
 
-Project URL: https://github.com/reactor/reactor-addons
+Project URL: https://github.com/reactor/reactor-pool
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Aalto XML (bundled by Azure SDK for Java).
+
+Project URL: https://github.com/FasterXML/aalto-xml
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
@@ -301,6 +431,11 @@ This product bundles JNA.
 
 Project URL: https://github.com/java-native-access/jna
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+| Java Native Access (JNA) is dual-licensed under the Apache License, Version 2.0
+| (from JNA 4.0 onward) or the LGPL, version 2.1 or later. This product
+| redistributes JNA under the terms of the Apache License, Version 2.0.
+| The shaded JAR retains JNA's upstream META-INF/LGPL2.1 and META-INF/AL2.0
+| copies of both license texts as published by the JNA project.
 
 --------------------------------------------------------------------------------
 

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -426,12 +426,6 @@ This product bundles JNA.
 Project URL: https://github.com/java-native-access/jna
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
-| Java Native Access (JNA) is dual-licensed under the Apache License, Version 2.0
-| (from JNA 4.0 onward) or the LGPL, version 2.1 or later. This product
-| redistributes JNA under the terms of the Apache License, Version 2.0.
-| The shaded JAR retains JNA's upstream META-INF/LGPL2.1 and META-INF/AL2.0
-| copies of both license texts as published by the JNA project.
-
 --------------------------------------------------------------------------------
 
 This product bundles Reactive Streams.

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -207,8 +207,7 @@ This product bundles Azure SDK for Java.
 
 Project URL: https://github.com/Azure/azure-sdk-for-java
 License: MIT
-| The MIT License (MIT)
-| 
+
 | Copyright (c) 2015 Microsoft
 | 
 | Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -243,8 +242,7 @@ This product bundles FastDoubleParser (via Jackson JSON Processor).
 Copyright: 2023 Werner Randelshofer, Switzerland
 Project URL: https://github.com/wrandelshofer/FastDoubleParser
 License: MIT
-| MIT License
-|
+
 | Copyright (c) 2023 Werner Randelshofer, Switzerland
 |
 | Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -272,8 +270,7 @@ This product bundles fast_float (bundled by FastDoubleParser).
 Copyright: 2021 The fast_float authors
 Project URL: https://github.com/fastfloat/fast_float
 License: MIT
-| MIT License
-|
+
 | Copyright (c) 2021 The fast_float authors
 |
 | Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -301,8 +298,7 @@ This product bundles bigint (bundled by FastDoubleParser).
 Copyright: 2022 Tim Buktu
 Project URL: https://github.com/tbuktu/bigint
 License: BSD 2-Clause
-| 2-clause BSD License
-|
+
 | Copyright 2022 Tim Buktu
 |
 | Redistribution and use in source and binary forms, with or without
@@ -333,27 +329,26 @@ This product bundles Microsoft Authentication Library for Java.
 
 Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
 License: MIT
-|     MIT License
-| 
-|     Copyright (c) Microsoft Corporation. All rights reserved.
-| 
-|     Permission is hereby granted, free of charge, to any person obtaining a copy
-|     of this software and associated documentation files (the "Software"), to deal
-|     in the Software without restriction, including without limitation the rights
-|     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-|     copies of the Software, and to permit persons to whom the Software is
-|     furnished to do so, subject to the following conditions:
-| 
-|     The above copyright notice and this permission notice shall be included in all
-|     copies or substantial portions of the Software.
-| 
-|     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-|     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-|     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-|     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-|     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-|     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-|     SOFTWARE
+
+| Copyright (c) Microsoft Corporation. All rights reserved.
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE
 
 --------------------------------------------------------------------------------
 
@@ -361,27 +356,26 @@ This product bundles MSAL4J Persistence Extension.
 
 Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
 License: MIT
-|     MIT License
+
+| Copyright (c) Microsoft Corporation. All rights reserved.
 |
-|     Copyright (c) Microsoft Corporation. All rights reserved.
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
 |
-|     Permission is hereby granted, free of charge, to any person obtaining a copy
-|     of this software and associated documentation files (the "Software"), to deal
-|     in the Software without restriction, including without limitation the rights
-|     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-|     copies of the Software, and to permit persons to whom the Software is
-|     furnished to do so, subject to the following conditions:
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
 |
-|     The above copyright notice and this permission notice shall be included in all
-|     copies or substantial portions of the Software.
-|
-|     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-|     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-|     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-|     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-|     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-|     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-|     SOFTWARE
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE
 
 --------------------------------------------------------------------------------
 
@@ -431,6 +425,7 @@ This product bundles JNA.
 
 Project URL: https://github.com/java-native-access/jna
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
 | Java Native Access (JNA) is dual-licensed under the Apache License, Version 2.0
 | (from JNA 4.0 onward) or the LGPL, version 2.1 or later. This product
 | redistributes JNA under the terms of the Apache License, Version 2.0.
@@ -442,9 +437,8 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product bundles Reactive Streams.
 
 Project URL: http://www.reactive-streams.org/
-License: MIT
-| MIT No Attribution
-| 
+License: MIT-0
+
 | Copyright 2014 Reactive Streams
 | 
 | Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.

--- a/azure-bundle/NOTICE
+++ b/azure-bundle/NOTICE
@@ -16,6 +16,10 @@ This product bundles Jackson JSON Processor with the following in its NOTICE fil
 | been in development since 2007.
 | It is currently developed by a community of developers.
 | 
+| ## Copyright
+| 
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+| 
 | ## Licensing
 | 
 | Jackson 2.x core and extension components are licensed under Apache License 2.0
@@ -26,7 +30,17 @@ This product bundles Jackson JSON Processor with the following in its NOTICE fil
 | A list of contributors may be found from CREDITS(-2.x) file, which is included
 | in some artifacts (usually source distributions); but is always available
 | from the source code management (SCM) system project uses.
-|
+| 
+| ## FastDoubleParser
+| 
+| jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+| That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+| under the following copyright.
+| 
+| Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+| 
+| See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+| and the licenses and copyrights that apply to that code.
 
 --------------------------------------------------------------------------------
 

--- a/azure-bundle/NOTICE
+++ b/azure-bundle/NOTICE
@@ -8,7 +8,6 @@ The Apache Software Foundation (http://www.apache.org/).
 --------------------------------------------------------------------------------
 
 This product bundles Jackson JSON Processor with the following in its NOTICE file:
-|
 | # Jackson JSON processor
 | 
 | Jackson is a high-performance, Free/Open Source JSON processing library.

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -23,6 +23,12 @@ project(":iceberg-azure-bundle") {
 
   tasks.jar.dependsOn tasks.shadowJar
 
+  configurations {
+    implementation {
+      exclude group: 'org.slf4j'
+    }
+  }
+
   dependencies {
     implementation platform(libs.azuresdk.bom)
     implementation "com.azure:azure-storage-file-datalake"
@@ -38,10 +44,6 @@ project(":iceberg-azure-bundle") {
     from(projectDir) {
       include 'LICENSE'
       include 'NOTICE'
-    }
-
-    dependencies {
-      exclude(dependency('org.slf4j:slf4j-api'))
     }
 
     // relocate Azure-specific versions

--- a/azure-bundle/runtime-deps.txt
+++ b/azure-bundle/runtime-deps.txt
@@ -41,4 +41,3 @@ io.projectreactor:reactor-core:3.7.14
 net.java.dev.jna:jna-platform:5.17.0
 net.java.dev.jna:jna:5.17.0
 org.reactivestreams:reactive-streams:1.0.4
-org.slf4j:slf4j-api:2.0.17


### PR DESCRIPTION
Fixes license compliance gaps in `azure-bundle` found by auditing the shadow JAR contents against LICENSE/NOTICE declarations.
Exclude logging dependencies, following same pattern in #16105

## Build and verify

```bash
./gradlew :iceberg-azure-bundle:shadowJar -x test
./gradlew :iceberg-azure-bundle:checkRuntimeDeps
```

## LICENSE changes

- **Added FastDoubleParser (MIT)** — **Required** per [Category B](https://www.apache.org/legal/resolved.html). Shaded into Jackson Core at `org/apache/iceberg/azure/shaded/com/fasterxml/jackson/core/internal/shaded/fdp/` (52 class files). Full MIT text added.
  ```bash
  jar tf azure-bundle/build/libs/iceberg-azure-bundle-*.jar | grep -c "shaded/fdp"
  unzip -p azure-bundle/build/libs/iceberg-azure-bundle-*.jar META-INF/FastDoubleParser-NOTICE
  ```
  Upstream: https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE

- **Added fast_float (MIT)** — **Required** per Category B. Bundled transitively by FastDoubleParser.
  Upstream: https://github.com/fastfloat/fast_float/blob/main/LICENSE-MIT

- **Added bigint (BSD 2-Clause)** — **Required** per Category B. Bundled transitively by FastDoubleParser.
  Upstream: https://github.com/tbuktu/bigint/blob/master/LICENSE

- **Added MSAL4J Persistence Extension (MIT)** — **Required** per Category B. 61 classes at `com/microsoft/aad/msal4jextensions/`.
  ```bash
  jar tf azure-bundle/build/libs/iceberg-azure-bundle-*.jar | grep -c "msal4jextensions"
  ```
  Upstream: https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/dev/LICENSE

- **Added Apache Tomcat Native / netty-tcnative (Apache 2.0)** — Not strictly required (Apache-licensed) but consistent with existing convention of declaring all bundled components. 37 tcnative resources in JAR.
  ```bash
  jar tf azure-bundle/build/libs/iceberg-azure-bundle-*.jar | grep "tcnative"
  ```
  Upstream: https://tomcat.apache.org/native-doc/

- **Added Reactor Pool (Apache 2.0)** — Consistent with convention. 35 classes at `reactor/netty/internal/shaded/reactor/pool/`.
  ```bash
  jar tf azure-bundle/build/libs/iceberg-azure-bundle-*.jar | grep -c "reactor/pool"
  ```

- **Replaced "Reactor AddOns" with "Aalto XML" (Apache 2.0)** — Reactor AddOns (reactor-extra) is not present in the JAR (0 classes). Aalto XML is bundled by Azure SDK at `com/azure/xml/implementation/aalto/` (72 classes).
  ```bash
  jar tf azure-bundle/build/libs/iceberg-azure-bundle-*.jar | grep -c "reactor/extra"
  jar tf azure-bundle/build/libs/iceberg-azure-bundle-*.jar | grep -c "aalto"
  ```
  Upstream: https://github.com/FasterXML/aalto-xml

- **Reactive Streams (MIT-0)** — Corrected license label from `MIT` to `MIT-0`. The upstream POM declares `<name>MIT-0</name>` and source headers state "Licensed under MIT No Attribution (SPDX: MIT-0)". The license text already reflected MIT-0 (no attribution clause), but the `License:` label was inaccurate. Also removed redundant `| MIT No Attribution` header line from the quoted block since the license name is already conveyed by the `License: MIT-0` label.
  Upstream POM: https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.4/reactive-streams-1.0.4.pom
  Upstream source: https://github.com/reactive-streams/reactive-streams-jvm/blob/master/LICENSE


## NOTICE changes

- **Jackson** — Added missing FastDoubleParser attribution section and missing copyright section. The upstream `jackson-core` NOTICE references the shaded FastDoubleParser copy and its MIT copyright and includes `Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)` but the old gcp-bundle NOTICE omitted it. **Required**: ASF policy mandates propagating upstream NOTICE contents.
  ```bash
  jar tf azure-bundle/build/libs/iceberg-azure-bundle-*.jar | grep FastDoubleParser
  # Upstream NOTICE from Maven Central jackson-core-2.18.3.jar:
  curl -sL "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.3/jackson-core-2.18.3.jar" -o /tmp/jc.jar && unzip -p /tmp/jc.jar META-INF/NOTICE
  ```
