### PR TITLE
Core: Replace string-based schema projection with selection on field-id

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -26,7 +26,9 @@ import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,14 +80,15 @@ abstract class FileCleanupStrategy {
       ExpireSnapshots.CleanupLevel cleanupLevel);
 
   private static final Schema MANIFEST_PROJECTION =
-      ManifestFile.schema()
-          .select(
-              "manifest_path",
-              "manifest_length",
-              "partition_spec_id",
-              "added_snapshot_id",
-              "added_files_count",
-              "deleted_files_count");
+      TypeUtil.select(
+          ManifestFile.schema(),
+          ImmutableSet.of(
+              ManifestFile.PATH.fieldId(),
+              ManifestFile.LENGTH.fieldId(),
+              ManifestFile.SPEC_ID.fieldId(),
+              ManifestFile.SNAPSHOT_ID.fieldId(),
+              ManifestFile.ADDED_FILES_COUNT.fieldId(),
+              ManifestFile.DELETED_FILES_COUNT.fieldId()));
 
   protected CloseableIterable<ManifestFile> readManifests(Snapshot snapshot) {
     if (snapshot.manifestListLocation() != null) {

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PartitionSet;
 import org.slf4j.Logger;
@@ -67,6 +68,11 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
           "lower_bounds",
           "upper_bounds",
           "record_count");
+
+  private static final Schema STATUS_ONLY_PROJECTION =
+      TypeUtil.select(
+          ManifestEntry.getSchema(Types.StructType.of()),
+          ImmutableSet.of(ManifestEntry.STATUS.fieldId()));
 
   protected enum FileType {
     DATA_FILES(GenericDataFile.class),
@@ -157,9 +163,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
     Map<String, String> metadata;
     try {
       try (CloseableIterable<ManifestEntry<T>> headerReader =
-          InternalData.read(FileFormat.AVRO, inputFile)
-              .project(ManifestEntry.getSchema(Types.StructType.of()).select("status"))
-              .build()) {
+          InternalData.read(FileFormat.AVRO, inputFile).project(STATUS_ONLY_PROJECTION).build()) {
 
         if (headerReader instanceof AvroIterable) {
           metadata = ((AvroIterable<ManifestEntry<T>>) headerReader).getMetadata();

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -39,9 +39,57 @@ import org.apache.iceberg.util.StructProjection;
 /** A {@link Table} implementation that exposes a table's partitions as rows. */
 public class PartitionsTable extends BaseMetadataTable {
 
-  // partition dependent field id
-  private static final int PARTITION_COLUMN_ID = 1;
-  private static final int SPEC_ID_COLUMN_ID = 4;
+  private static final int PARTITION_FIELD_ID = 1;
+
+  private static final Types.NestedField SPEC_ID =
+      Types.NestedField.required(4, "spec_id", Types.IntegerType.get());
+  private static final Types.NestedField RECORD_COUNT =
+      Types.NestedField.required(
+          2, "record_count", Types.LongType.get(), "Count of records in data files");
+  private static final Types.NestedField FILE_COUNT =
+      Types.NestedField.required(3, "file_count", Types.IntegerType.get(), "Count of data files");
+  private static final Types.NestedField TOTAL_DATA_FILE_SIZE_IN_BYTES =
+      Types.NestedField.required(
+          11,
+          "total_data_file_size_in_bytes",
+          Types.LongType.get(),
+          "Total size in bytes of data files");
+  private static final Types.NestedField POSITION_DELETE_RECORD_COUNT =
+      Types.NestedField.required(
+          5,
+          "position_delete_record_count",
+          Types.LongType.get(),
+          "Count of records in position delete files");
+  private static final Types.NestedField POSITION_DELETE_FILE_COUNT =
+      Types.NestedField.required(
+          6,
+          "position_delete_file_count",
+          Types.IntegerType.get(),
+          "Count of position delete files");
+  private static final Types.NestedField EQUALITY_DELETE_RECORD_COUNT =
+      Types.NestedField.required(
+          7,
+          "equality_delete_record_count",
+          Types.LongType.get(),
+          "Count of records in equality delete files");
+  private static final Types.NestedField EQUALITY_DELETE_FILE_COUNT =
+      Types.NestedField.required(
+          8,
+          "equality_delete_file_count",
+          Types.IntegerType.get(),
+          "Count of equality delete files");
+  private static final Types.NestedField LAST_UPDATED_AT =
+      Types.NestedField.optional(
+          9,
+          "last_updated_at",
+          Types.TimestampType.withZone(),
+          "Commit time of snapshot that last updated this partition");
+  private static final Types.NestedField LAST_UPDATED_SNAPSHOT_ID =
+      Types.NestedField.optional(
+          10,
+          "last_updated_snapshot_id",
+          Types.LongType.get(),
+          "Id of snapshot that last updated this partition");
 
   private final Schema schema;
 
@@ -57,47 +105,17 @@ public class PartitionsTable extends BaseMetadataTable {
     this.schema =
         new Schema(
             Types.NestedField.required(
-                PARTITION_COLUMN_ID, "partition", Partitioning.partitionType(table)),
-            Types.NestedField.required(SPEC_ID_COLUMN_ID, "spec_id", Types.IntegerType.get()),
-            Types.NestedField.required(
-                2, "record_count", Types.LongType.get(), "Count of records in data files"),
-            Types.NestedField.required(
-                3, "file_count", Types.IntegerType.get(), "Count of data files"),
-            Types.NestedField.required(
-                11,
-                "total_data_file_size_in_bytes",
-                Types.LongType.get(),
-                "Total size in bytes of data files"),
-            Types.NestedField.required(
-                5,
-                "position_delete_record_count",
-                Types.LongType.get(),
-                "Count of records in position delete files"),
-            Types.NestedField.required(
-                6,
-                "position_delete_file_count",
-                Types.IntegerType.get(),
-                "Count of position delete files"),
-            Types.NestedField.required(
-                7,
-                "equality_delete_record_count",
-                Types.LongType.get(),
-                "Count of records in equality delete files"),
-            Types.NestedField.required(
-                8,
-                "equality_delete_file_count",
-                Types.IntegerType.get(),
-                "Count of equality delete files"),
-            Types.NestedField.optional(
-                9,
-                "last_updated_at",
-                Types.TimestampType.withZone(),
-                "Commit time of snapshot that last updated this partition"),
-            Types.NestedField.optional(
-                10,
-                "last_updated_snapshot_id",
-                Types.LongType.get(),
-                "Id of snapshot that last updated this partition"));
+                PARTITION_FIELD_ID, "partition", Partitioning.partitionType(table)),
+            SPEC_ID,
+            RECORD_COUNT,
+            FILE_COUNT,
+            TOTAL_DATA_FILE_SIZE_IN_BYTES,
+            POSITION_DELETE_RECORD_COUNT,
+            POSITION_DELETE_FILE_COUNT,
+            EQUALITY_DELETE_RECORD_COUNT,
+            EQUALITY_DELETE_FILE_COUNT,
+            LAST_UPDATED_AT,
+            LAST_UPDATED_SNAPSHOT_ID);
     this.unpartitionedTable = Partitioning.partitionType(table).fields().isEmpty();
   }
 
@@ -109,7 +127,18 @@ public class PartitionsTable extends BaseMetadataTable {
   @Override
   public Schema schema() {
     if (unpartitionedTable) {
-      return TypeUtil.selectNot(schema, ImmutableSet.of(PARTITION_COLUMN_ID, SPEC_ID_COLUMN_ID));
+      return TypeUtil.select(
+          schema,
+          ImmutableSet.of(
+              RECORD_COUNT.fieldId(),
+              FILE_COUNT.fieldId(),
+              TOTAL_DATA_FILE_SIZE_IN_BYTES.fieldId(),
+              POSITION_DELETE_RECORD_COUNT.fieldId(),
+              POSITION_DELETE_FILE_COUNT.fieldId(),
+              EQUALITY_DELETE_RECORD_COUNT.fieldId(),
+              EQUALITY_DELETE_FILE_COUNT.fieldId(),
+              LAST_UPDATED_AT.fieldId(),
+              LAST_UPDATED_SNAPSHOT_ID.fieldId()));
     }
     return schema;
   }

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -27,7 +27,9 @@ import java.util.List;
 import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.PartitionUtil;
@@ -36,6 +38,10 @@ import org.apache.iceberg.util.StructProjection;
 
 /** A {@link Table} implementation that exposes a table's partitions as rows. */
 public class PartitionsTable extends BaseMetadataTable {
+
+  // partition dependent field id
+  private static final int PARTITION_COLUMN_ID = 1;
+  private static final int SPEC_ID_COLUMN_ID = 4;
 
   private final Schema schema;
 
@@ -50,8 +56,9 @@ public class PartitionsTable extends BaseMetadataTable {
 
     this.schema =
         new Schema(
-            Types.NestedField.required(1, "partition", Partitioning.partitionType(table)),
-            Types.NestedField.required(4, "spec_id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                PARTITION_COLUMN_ID, "partition", Partitioning.partitionType(table)),
+            Types.NestedField.required(SPEC_ID_COLUMN_ID, "spec_id", Types.IntegerType.get()),
             Types.NestedField.required(
                 2, "record_count", Types.LongType.get(), "Count of records in data files"),
             Types.NestedField.required(
@@ -102,16 +109,7 @@ public class PartitionsTable extends BaseMetadataTable {
   @Override
   public Schema schema() {
     if (unpartitionedTable) {
-      return schema.select(
-          "record_count",
-          "file_count",
-          "total_data_file_size_in_bytes",
-          "position_delete_record_count",
-          "position_delete_file_count",
-          "equality_delete_record_count",
-          "equality_delete_file_count",
-          "last_updated_at",
-          "last_updated_snapshot_id");
+      return TypeUtil.selectNot(schema, ImmutableSet.of(PARTITION_COLUMN_ID, SPEC_ID_COLUMN_ID));
     }
     return schema;
   }


### PR DESCRIPTION
Inspired by https://github.com/apache/iceberg/pull/16077#discussion_r3170215745

Use `TypeUtil.select/selectNot` with field IDs instead of `Schema.select` with string names in FileCleanupStrategy and PartitionsTable. With pure mechanical change, I think existing UT coverage is sufficient.

FYI @RussellSpitzer @amogh-jahagirdar 