### PR TITLE
Azure: Avoid depending on KeyWrapAlgorithm in AzureProperties

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.azure;
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
-import com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
 import java.io.Serializable;
@@ -135,9 +134,7 @@ public class AzureProperties implements Serializable {
     }
 
     this.keyWrapAlgorithm =
-        properties.getOrDefault(
-            AzureProperties.AZURE_KEYVAULT_KEY_WRAP_ALGORITHM,
-            KeyWrapAlgorithm.RSA_OAEP_256.getValue());
+        properties.getOrDefault(AzureProperties.AZURE_KEYVAULT_KEY_WRAP_ALGORITHM, "RSA-OAEP-256");
   }
 
   public Optional<Integer> adlsReadBlockSize() {
@@ -204,8 +201,8 @@ public class AzureProperties implements Serializable {
     }
   }
 
-  public KeyWrapAlgorithm keyWrapAlgorithm() {
-    return KeyWrapAlgorithm.fromString(this.keyWrapAlgorithm);
+  public String keyWrapAlgorithm() {
+    return this.keyWrapAlgorithm;
   }
 
   public Optional<String> keyVaultUrl() {

--- a/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java
@@ -52,6 +52,9 @@ public class AzureProperties implements Serializable {
   public static final String AZURE_KEYVAULT_KEY_WRAP_ALGORITHM =
       "azure.keyvault.key-wrap-algorithm";
 
+  // Must match KeyWrapAlgorithm.RSA_OAEP_256.getValue() from azure-security-keyvault-keys
+  private static final String DEFAULT_KEY_WRAP_ALGORITHM = "RSA-OAEP-256";
+
   /**
    * Configure the ADLS token credential provider used to get {@link TokenCredential}. A fully
    * qualified concrete class with package that implements the {@link AdlsTokenCredentialProvider}
@@ -134,7 +137,8 @@ public class AzureProperties implements Serializable {
     }
 
     this.keyWrapAlgorithm =
-        properties.getOrDefault(AzureProperties.AZURE_KEYVAULT_KEY_WRAP_ALGORITHM, "RSA-OAEP-256");
+        properties.getOrDefault(
+            AzureProperties.AZURE_KEYVAULT_KEY_WRAP_ALGORITHM, DEFAULT_KEY_WRAP_ALGORITHM);
   }
 
   public Optional<Integer> adlsReadBlockSize() {

--- a/azure/src/main/java/org/apache/iceberg/azure/keymanagement/AzureKeyManagementClient.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/keymanagement/AzureKeyManagementClient.java
@@ -80,7 +80,8 @@ public class AzureKeyManagementClient implements KeyManagementClient {
               keyClientBuilder
                   .credential(AdlsTokenCredentialProviders.from(allProperties).credential())
                   .buildClient();
-          KeyWrapAlgorithm keyWrapAlgorithm = azureProperties.keyWrapAlgorithm();
+          KeyWrapAlgorithm keyWrapAlgorithm =
+              KeyWrapAlgorithm.fromString(azureProperties.keyWrapAlgorithm());
           state = new ClientState(keyClient, keyWrapAlgorithm);
         }
       }


### PR DESCRIPTION
Without this change, any downstream application that uses AzureProperties will encounter a NoClassDefFound error even if table encryption is unused. 

Changing the return type is safe because Iceberg 1.10.x does not include [#13186](https://github.com/apache/iceberg/pull/13186)

- Relates to https://github.com/trinodb/trino/pull/26640