### PR TITLE
Core: Accept null for new sortOrderId in DataFiles builder

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -321,7 +321,7 @@ public class DataFiles {
       return this;
     }
 
-    public Builder withSortOrderId(int newSortOrderId) {
+    public Builder withSortOrderId(Integer newSortOrderId) {
       this.sortOrderId = newSortOrderId;
       return this;
     }


### PR DESCRIPTION
Trino currently uses reflection to set the sortOrderId field to null.

https://github.com/trinodb/trino/blob/077486894ae2eef79be3db88f9be0710fc30f6bd/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java#L920-L925

Since the sort order ID is optional in the specification, it would be preferable for this method to allow null values.