### PR TITLE
Open API: Backport 1.10 Remove runtime Jar from build and deploy (#16163)

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -75,7 +75,6 @@ subprojects {
           } else if (isOpenApi) {
             artifact testJar
             artifact testFixturesJar
-            artifact shadowJar
           } else {
             if (tasks.matching({task -> task.name == 'shadowJar'}).isEmpty()) {
               from components.java


### PR DESCRIPTION
Backport @rdblue change from #16163 to stop publishing open API runtime jar 