### PR TITLE
Core: Surface failed scan planning even when server omits error payload

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -323,9 +323,8 @@ class RESTTableScan extends DataTableScan {
   }
 
   private static String failureMessage(String planId, ErrorResponse error) {
-    // Be lenient when reading: the spec requires an error payload with a FAILED status, but
-    // if a server violates that, still surface a meaningful message rather than throwing on
-    // top of an already-broken response.
+    // If a FAILED response lacks the expected error payload, still return a useful error
+    // message instead of throwing.
     String type = error != null ? error.type() : "unknown";
     int code = error != null ? error.code() : 0;
     String message = error != null ? error.message() : "unknown";

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -323,14 +323,19 @@ class RESTTableScan extends DataTableScan {
   }
 
   private static String failureMessage(String planId, ErrorResponse error) {
-    Preconditions.checkArgument(error != null, "Error must be present for failed status");
+    // Be lenient when reading: the spec requires an error payload with a FAILED status, but
+    // if a server violates that, still surface a meaningful message rather than throwing on
+    // top of an already-broken response.
+    String type = error != null ? error.type() : "unknown";
+    int code = error != null ? error.code() : 0;
+    String message = error != null ? error.message() : "unknown";
     return String.format(
         Locale.ROOT,
         "Remote scan planning failed for planId: %s: %s (code=%d): %s",
         planId,
-        error.type(),
-        error.code(),
-        error.message());
+        type,
+        code,
+        message);
   }
 
   private CloseableIterable<FileScanTask> scanTasksIterable(

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -1311,6 +1311,27 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
         .hasMessageContaining(serverError.message());
   }
 
+  @ParameterizedTest
+  @EnumSource(PlanningMode.class)
+  public void planningFailsWithoutServerErrorIsStillSurfaced(
+      Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> planMode) {
+    // Spec requires an error payload with a FAILED status; if a server violates that,
+    // the client must still surface a meaningful failure rather than throw on top of it.
+    TestPlanningBehavior behavior = planMode.apply(TestPlanningBehavior.builder()).build();
+    CatalogWithAdapter catalogWithAdapter =
+        catalogThatFailsPlanning(null, behavior, "test-planning-failed-no-error");
+
+    RESTTable table = restTableFor(catalogWithAdapter.catalog, "planning_failed_no_error_test");
+    setParserContext(table);
+    RESTTableScan scan = restTableScanFor(table);
+
+    assertThatThrownBy(scan::planFiles)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Remote scan planning failed")
+        .hasMessageContaining("unknown")
+        .hasMessageContaining("code=0");
+  }
+
   private CatalogWithAdapter catalogThatFailsPlanning(
       ErrorResponse serverError, TestPlanningBehavior behavior, String catalogName) {
     List<Endpoint> endpoints =


### PR DESCRIPTION
Follow-up to #16024. The spec requires an ErrorResponse with a FAILED plan status, but if a server violates that, the client should still give the user a meaningful failure message rather than throw an IllegalArgumentException on top of an already-broken response.

Replace the precondition check with per-field fallbacks ("unknown" / code 0), preserving the full message when the server conforms and degrading gracefully otherwise.

Addresses https://github.com/apache/iceberg/pull/16024#discussion_r3177313116