### PR TITLE
API: Add ReadRestrictions Actions 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/functions/BaseFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/BaseFunction.java
@@ -18,39 +18,41 @@
  */
 package org.apache.iceberg.functions;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.util.SerializableFunction;
+import java.util.Objects;
 
-/** Truncates date or timestamp values to the first instant of their year. */
-public final class TruncateToYear extends BaseFunction<Object, Object> {
-  static final String NAME = "truncate-to-year";
+/** Base for all concrete {@link IcebergFunction} implementations; holds the field id. */
+abstract class BaseFunction<S, T> implements IcebergFunction<S, T> {
+  private final int fieldId;
 
-  TruncateToYear(int fieldId) {
-    super(fieldId);
+  BaseFunction(int fieldId) {
+    this.fieldId = fieldId;
   }
 
   @Override
-  public String name() {
-    return NAME;
+  public final int fieldId() {
+    return fieldId;
   }
 
   @Override
-  public boolean canBind(Type type) {
-    switch (type.typeId()) {
-      case DATE:
-      case TIMESTAMP:
-      case TIMESTAMP_NANO:
-        return true;
-      default:
-        return false;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    IcebergFunction<?, ?> other = (IcebergFunction<?, ?>) o;
+    // name() is a constant per class except in UnknownFunction, whose instances differ by name.
+    return fieldId == other.fieldId() && name().equals(other.name());
   }
 
   @Override
-  public SerializableFunction<Object, Object> bind(Type type) {
-    Preconditions.checkArgument(
-        canBind(type), "truncate-to-year is not supported for type: %s", type);
-    return TruncateTemporal.forType(TruncateTemporal.Unit.YEAR, type);
+  public int hashCode() {
+    return Objects.hash(name(), fieldId);
+  }
+
+  @Override
+  public String toString() {
+    return name() + "(" + fieldId + ")";
   }
 }

--- a/api/src/main/java/org/apache/iceberg/functions/IcebergFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/IcebergFunction.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * A named, type-aware function that can be bound to an Iceberg {@link Type}.
+ *
+ * <p>{@link #bind(Type)} returns a {@link SerializableFunction} that applies this function's logic
+ * to values of the bound type.
+ *
+ * @param <S> input value type
+ * @param <T> output value type
+ */
+public interface IcebergFunction<S, T> extends Serializable {
+
+  String MASK_ALPHANUM = "mask-alphanum";
+  String MASK_TO_FIXED_VALUE = "mask-to-fixed-value";
+  String REPLACE_WITH_NULL = "replace-with-null";
+  String SHOW_FIRST_4 = "show-first-4";
+  String SHOW_LAST_4 = "show-last-4";
+  String TRUNCATE_TO_YEAR = "truncate-to-year";
+  String TRUNCATE_TO_MONTH = "truncate-to-month";
+  String SHA_256_GLOBAL = "sha-256-global";
+  String SHA_256_QUERY_LOCAL = "sha-256-query-local";
+
+  /** The function name as sent on the wire (REST action discriminator). */
+  String name();
+
+  /** The field id of the column this function applies to. */
+  int fieldId();
+
+  /**
+   * Returns a function that applies this projection to values of the given {@link Type}.
+   *
+   * @throws IllegalArgumentException if the type is not supported by this function.
+   */
+  default SerializableFunction<S, T> bind(Type type) {
+    throw new UnsupportedOperationException("bind is not implemented for " + getClass().getName());
+  }
+
+  /** Returns true if this function can be bound to the given {@link Type}. */
+  boolean canBind(Type type);
+
+  /** Base for all concrete functions; holds the field id. */
+  abstract class BaseFunction<S, T> implements IcebergFunction<S, T> {
+    private final int fieldId;
+
+    BaseFunction(int fieldId) {
+      this.fieldId = fieldId;
+    }
+
+    @Override
+    public final int fieldId() {
+      return fieldId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      IcebergFunction<?, ?> other = (IcebergFunction<?, ?>) o;
+      return fieldId == other.fieldId() && name().equals(other.name());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name(), fieldId);
+    }
+
+    @Override
+    public String toString() {
+      return name() + "(" + fieldId + ")";
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/IcebergFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/IcebergFunction.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.functions;
 
 import java.io.Serializable;
-import java.util.Objects;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
@@ -34,17 +33,7 @@ import org.apache.iceberg.util.SerializableFunction;
  */
 public interface IcebergFunction<S, T> extends Serializable {
 
-  String MASK_ALPHANUM = "mask-alphanum";
-  String MASK_TO_FIXED_VALUE = "mask-to-fixed-value";
-  String REPLACE_WITH_NULL = "replace-with-null";
-  String SHOW_FIRST_4 = "show-first-4";
-  String SHOW_LAST_4 = "show-last-4";
-  String TRUNCATE_TO_YEAR = "truncate-to-year";
-  String TRUNCATE_TO_MONTH = "truncate-to-month";
-  String SHA_256_GLOBAL = "sha-256-global";
-  String SHA_256_QUERY_LOCAL = "sha-256-query-local";
-
-  /** The function name as sent on the wire (REST action discriminator). */
+  /** Returns the name of this Iceberg function. */
   String name();
 
   /** The field id of the column this function applies to. */
@@ -61,40 +50,4 @@ public interface IcebergFunction<S, T> extends Serializable {
 
   /** Returns true if this function can be bound to the given {@link Type}. */
   boolean canBind(Type type);
-
-  /** Base for all concrete functions; holds the field id. */
-  abstract class BaseFunction<S, T> implements IcebergFunction<S, T> {
-    private final int fieldId;
-
-    BaseFunction(int fieldId) {
-      this.fieldId = fieldId;
-    }
-
-    @Override
-    public final int fieldId() {
-      return fieldId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      IcebergFunction<?, ?> other = (IcebergFunction<?, ?>) o;
-      return fieldId == other.fieldId() && name().equals(other.name());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(name(), fieldId);
-    }
-
-    @Override
-    public String toString() {
-      return name() + "(" + fieldId + ")";
-    }
-  }
 }

--- a/api/src/main/java/org/apache/iceberg/functions/IcebergFunctions.java
+++ b/api/src/main/java/org/apache/iceberg/functions/IcebergFunctions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Package-private helpers shared by {@link IcebergFunction} implementations. */
+final class IcebergFunctions {
+
+  private IcebergFunctions() {}
+
+  /**
+   * Base for masking functions where null input must pass through as null unchanged (spec: "For all
+   * actions, if the input column value is NULL, the output MUST be NULL."). Subclasses implement
+   * {@link #applyNonNull(Object)} and don't have to repeat the guard.
+   */
+  abstract static class NullSafeFunction<S, T> implements SerializableFunction<S, T> {
+    @Override
+    public final T apply(S value) {
+      return value == null ? null : applyNonNull(value);
+    }
+
+    protected abstract T applyNonNull(S value);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/IcebergFunctions.java
+++ b/api/src/main/java/org/apache/iceberg/functions/IcebergFunctions.java
@@ -18,24 +18,81 @@
  */
 package org.apache.iceberg.functions;
 
-import org.apache.iceberg.util.SerializableFunction;
-
-/** Package-private helpers shared by {@link IcebergFunction} implementations. */
-final class IcebergFunctions {
-
+/** Factory for the {@link IcebergFunction} implementations defined by the REST spec. */
+public class IcebergFunctions {
   private IcebergFunctions() {}
 
   /**
-   * Base for masking functions where null input must pass through as null unchanged (spec: "For all
-   * actions, if the input column value is NULL, the output MUST be NULL."). Subclasses implement
-   * {@link #applyNonNull(Object)} and don't have to repeat the guard.
+   * Returns the function with the given name, or an {@link UnknownFunction} if the name is not
+   * recognized.
    */
-  abstract static class NullSafeFunction<S, T> implements SerializableFunction<S, T> {
-    @Override
-    public final T apply(S value) {
-      return value == null ? null : applyNonNull(value);
+  public static IcebergFunction<?, ?> fromString(String function, int fieldId) {
+    switch (function) {
+      case MaskAlphanum.NAME:
+        return maskAlphanum(fieldId);
+      case MaskToFixedValue.NAME:
+        return maskToFixedValue(fieldId);
+      case ReplaceWithNull.NAME:
+        return replaceWithNull(fieldId);
+      case ShowFirst4.NAME:
+        return showFirst4(fieldId);
+      case ShowLast4.NAME:
+        return showLast4(fieldId);
+      case TruncateToYear.NAME:
+        return truncateToYear(fieldId);
+      case TruncateToMonth.NAME:
+        return truncateToMonth(fieldId);
+      case Sha256Global.NAME:
+        return sha256Global(fieldId);
+      case Sha256QueryLocal.NAME:
+        return sha256QueryLocal(fieldId);
+      default:
+        return new UnknownFunction(fieldId, function);
     }
+  }
 
-    protected abstract T applyNonNull(S value);
+  /** Returns a {@code mask-alphanum} {@link IcebergFunction} for string types. */
+  public static IcebergFunction<String, String> maskAlphanum(int fieldId) {
+    return new MaskAlphanum(fieldId);
+  }
+
+  /** Returns a {@code mask-to-fixed-value} {@link IcebergFunction}. */
+  public static IcebergFunction<Object, Object> maskToFixedValue(int fieldId) {
+    return new MaskToFixedValue(fieldId);
+  }
+
+  /** Returns a {@code replace-with-null} {@link IcebergFunction} for any type. */
+  public static IcebergFunction<Object, Object> replaceWithNull(int fieldId) {
+    return new ReplaceWithNull(fieldId);
+  }
+
+  /** Returns a {@code show-first-4} {@link IcebergFunction} for string types. */
+  public static IcebergFunction<String, String> showFirst4(int fieldId) {
+    return new ShowFirst4(fieldId);
+  }
+
+  /** Returns a {@code show-last-4} {@link IcebergFunction} for string types. */
+  public static IcebergFunction<String, String> showLast4(int fieldId) {
+    return new ShowLast4(fieldId);
+  }
+
+  /** Returns a {@code truncate-to-year} {@link IcebergFunction} for date and timestamp types. */
+  public static IcebergFunction<Object, Object> truncateToYear(int fieldId) {
+    return new TruncateToYear(fieldId);
+  }
+
+  /** Returns a {@code truncate-to-month} {@link IcebergFunction} for date and timestamp types. */
+  public static IcebergFunction<Object, Object> truncateToMonth(int fieldId) {
+    return new TruncateToMonth(fieldId);
+  }
+
+  /** Returns a {@code sha-256-global} {@link IcebergFunction} for string, int, long and binary. */
+  public static IcebergFunction<Object, Object> sha256Global(int fieldId) {
+    return new Sha256Global(fieldId);
+  }
+
+  /** Returns a {@code sha-256-query-local} {@link SaltedFunction}, salted per query. */
+  public static SaltedFunction<Object, Object> sha256QueryLocal(int fieldId) {
+    return new Sha256QueryLocal(fieldId);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/functions/MaskAlphanum.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskAlphanum.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Redacts every Unicode code point in a string per the mask-alphanum rules. */
+public final class MaskAlphanum extends IcebergFunction.BaseFunction<String, String> {
+  public MaskAlphanum(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return MASK_ALPHANUM;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return type.typeId() == Type.TypeID.STRING;
+  }
+
+  @Override
+  public SerializableFunction<String, String> bind(Type type) {
+    Preconditions.checkArgument(canBind(type), "mask-alphanum requires STRING type, got %s", type);
+    return MaskAlphanumFn.INSTANCE;
+  }
+
+  /**
+   * Maps a code point through the mask-alphanum rules; also used by {@link ShowFirst4} and {@link
+   * ShowLast4} on the code points outside their preserved windows:
+   *
+   * <ul>
+   *   <li>ASCII digits (0-9) -&gt; {@code 'n'}
+   *   <li>Structural punctuation kept as-is: {@code ( ) , . - @}
+   *   <li>Everything else -&gt; {@code 'x'}
+   * </ul>
+   */
+  static int maskCodePoint(int cp) {
+    if (cp >= 0x30 && cp <= 0x39) {
+      return 'n';
+    } else if (cp == '(' || cp == ')' || cp == ',' || cp == '.' || cp == '-' || cp == '@') {
+      return cp;
+    } else {
+      return 'x';
+    }
+  }
+
+  private static final class MaskAlphanumFn
+      extends IcebergFunctions.NullSafeFunction<String, String> {
+    static final MaskAlphanumFn INSTANCE = new MaskAlphanumFn();
+
+    @Override
+    protected String applyNonNull(String input) {
+      StringBuilder sb = new StringBuilder(input.length());
+      int offset = 0;
+      while (offset < input.length()) {
+        int cp = input.codePointAt(offset);
+        sb.appendCodePoint(maskCodePoint(cp));
+        offset += Character.charCount(cp);
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/MaskAlphanum.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskAlphanum.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Redacts every Unicode code point in a string per the mask-alphanum rules. */
-public final class MaskAlphanum extends IcebergFunction.BaseFunction<String, String> {
-  public MaskAlphanum(int fieldId) {
+public final class MaskAlphanum extends BaseFunction<String, String> {
+  static final String NAME = "mask-alphanum";
+
+  MaskAlphanum(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return MASK_ALPHANUM;
+    return NAME;
   }
 
   @Override
@@ -64,8 +66,7 @@ public final class MaskAlphanum extends IcebergFunction.BaseFunction<String, Str
     }
   }
 
-  private static final class MaskAlphanumFn
-      extends IcebergFunctions.NullSafeFunction<String, String> {
+  private static final class MaskAlphanumFn extends NullSafeFunction<String, String> {
     static final MaskAlphanumFn INSTANCE = new MaskAlphanumFn();
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.UUID;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.SerializableFunction;
+import org.apache.iceberg.variants.Variant;
+
+/** Returns a spec-defined fixed value for the column's type. */
+public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object, Object> {
+
+  private static final Integer INT_DEFAULT = 0;
+  private static final Long LONG_DEFAULT = 0L;
+  private static final Float FLOAT_DEFAULT = 0.0f;
+  private static final Double DOUBLE_DEFAULT = 0.0d;
+  // Per spec: string uses "XXXXXXXX" (not "") so masked strings stay visually distinct from
+  // legitimately empty strings. All other types use the zero value of their representation.
+  private static final String STRING_DEFAULT = "XXXXXXXX";
+  private static final Integer DATE_DEFAULT = DateTimeUtil.daysFromDate(LocalDate.of(1970, 1, 1));
+  private static final Long TIME_DEFAULT_MICROS = 0L;
+  private static final Long TIMESTAMP_DEFAULT_MICROS =
+      DateTimeUtil.microsFromTimestamp(LocalDateTime.of(1970, 1, 1, 0, 0));
+  private static final Long TIMESTAMP_DEFAULT_NANOS =
+      DateTimeUtil.nanosFromTimestamp(LocalDateTime.of(1970, 1, 1, 0, 0));
+  private static final UUID UUID_DEFAULT = UUID.fromString("00000000-0000-0000-0000-000000000000");
+  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0).asReadOnlyBuffer();
+
+  // Empty Variant: V1 metadata with no entries + empty object value.
+  private static final Variant EMPTY_VARIANT =
+      Variant.from(
+          ByteBuffer.wrap(new byte[] {0x01, 0x00, 0x00, 0x02, 0x00, 0x00})
+              .order(ByteOrder.LITTLE_ENDIAN));
+
+  public MaskToFixedValue(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return MASK_TO_FIXED_VALUE;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+      case INTEGER:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case STRING:
+      case DATE:
+      case TIME:
+      case TIMESTAMP:
+      case TIMESTAMP_NANO:
+      case UUID:
+      case FIXED:
+      case BINARY:
+      case DECIMAL:
+      case VARIANT:
+      case LIST:
+      case MAP:
+        return true;
+        // TODO: support STRUCT (recursive type-specific defaults). Tracked as follow-up.
+        // Per spec, mask-to-fixed-value does not apply to unknown, geometry, or geography.
+      default:
+        return false;
+    }
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    Preconditions.checkArgument(
+        canBind(type), "mask-to-fixed-value is not supported for type: %s", type);
+    Object defaultValue = defaultValueFor(type);
+    return defaultValue instanceof ByteBuffer
+        ? new ConstantByteBufferFn((ByteBuffer) defaultValue)
+        : new ConstantFn(defaultValue);
+  }
+
+  private static Object defaultValueFor(Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+        return Boolean.FALSE;
+      case INTEGER:
+        return INT_DEFAULT;
+      case LONG:
+        return LONG_DEFAULT;
+      case FLOAT:
+        return FLOAT_DEFAULT;
+      case DOUBLE:
+        return DOUBLE_DEFAULT;
+      case STRING:
+        return STRING_DEFAULT;
+      case DATE:
+        return DATE_DEFAULT;
+      case TIME:
+        return TIME_DEFAULT_MICROS;
+      case TIMESTAMP:
+        return TIMESTAMP_DEFAULT_MICROS;
+      case TIMESTAMP_NANO:
+        return TIMESTAMP_DEFAULT_NANOS;
+      case UUID:
+        return UUID_DEFAULT;
+      case FIXED:
+        return ByteBuffer.allocate(((Types.FixedType) type).length()).asReadOnlyBuffer();
+      case BINARY:
+        return EMPTY_BUFFER;
+      case DECIMAL:
+        return new BigDecimal(BigInteger.ZERO, ((Types.DecimalType) type).scale());
+      case VARIANT:
+        return EMPTY_VARIANT;
+      case LIST:
+        return Collections.emptyList();
+      case MAP:
+        return Collections.emptyMap();
+      default:
+        throw new IllegalStateException("unreachable: canBind should have rejected " + type);
+    }
+  }
+
+  private static final class ConstantFn implements SerializableFunction<Object, Object> {
+    private final Object constant;
+
+    ConstantFn(Object constant) {
+      this.constant = constant;
+    }
+
+    @Override
+    public Object apply(Object value) {
+      return constant;
+    }
+  }
+
+  private static final class ConstantByteBufferFn implements SerializableFunction<Object, Object> {
+    private final ByteBuffer constant;
+
+    ConstantByteBufferFn(ByteBuffer constant) {
+      this.constant = constant;
+    }
+
+    @Override
+    public Object apply(Object value) {
+      return constant.duplicate();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.util.SerializableFunction;
 import org.apache.iceberg.variants.Variant;
 
 /** Returns a spec-defined fixed value for the column's type. */
-public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object, Object> {
+public final class MaskToFixedValue extends BaseFunction<Object, Object> {
 
   private static final Integer INT_DEFAULT = 0;
   private static final Long LONG_DEFAULT = 0L;
@@ -61,13 +61,15 @@ public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object,
           ByteBuffer.wrap(new byte[] {0x01, 0x00, 0x00, 0x02, 0x00, 0x00})
               .order(ByteOrder.LITTLE_ENDIAN));
 
-  public MaskToFixedValue(int fieldId) {
+  static final String NAME = "mask-to-fixed-value";
+
+  MaskToFixedValue(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return MASK_TO_FIXED_VALUE;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
+++ b/api/src/main/java/org/apache/iceberg/functions/MaskToFixedValue.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.functions;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -25,7 +26,9 @@ import java.nio.ByteOrder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -87,9 +90,8 @@ public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object,
       case VARIANT:
       case LIST:
       case MAP:
+      case STRUCT:
         return true;
-        // TODO: support STRUCT (recursive type-specific defaults). Tracked as follow-up.
-        // Per spec, mask-to-fixed-value does not apply to unknown, geometry, or geography.
       default:
         return false;
     }
@@ -141,9 +143,20 @@ public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object,
         return Collections.emptyList();
       case MAP:
         return Collections.emptyMap();
+      case STRUCT:
+        return defaultStruct(type.asStructType());
       default:
         throw new IllegalStateException("unreachable: canBind should have rejected " + type);
     }
+  }
+
+  private static StructLike defaultStruct(Types.StructType structType) {
+    List<Types.NestedField> fields = structType.fields();
+    Object[] values = new Object[fields.size()];
+    for (int i = 0; i < fields.size(); i++) {
+      values[i] = defaultValueFor(fields.get(i).type());
+    }
+    return new DefaultStruct(values);
   }
 
   private static final class ConstantFn implements SerializableFunction<Object, Object> {
@@ -169,6 +182,30 @@ public final class MaskToFixedValue extends IcebergFunction.BaseFunction<Object,
     @Override
     public Object apply(Object value) {
       return constant.duplicate();
+    }
+  }
+
+  private static final class DefaultStruct implements StructLike, Serializable {
+    private final Object[] values;
+
+    DefaultStruct(Object[] values) {
+      this.values = values;
+    }
+
+    @Override
+    public int size() {
+      return values.length;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(int pos, Class<T> javaClass) {
+      return (T) values[pos];
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("DefaultStruct is immutable");
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/functions/NullSafeFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/NullSafeFunction.java
@@ -18,39 +18,17 @@
  */
 package org.apache.iceberg.functions;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
-/** Truncates date or timestamp values to the first instant of their year. */
-public final class TruncateToYear extends BaseFunction<Object, Object> {
-  static final String NAME = "truncate-to-year";
-
-  TruncateToYear(int fieldId) {
-    super(fieldId);
-  }
-
+/**
+ * Base for masking functions where null input must pass through as null unchanged (spec: "For all
+ * actions, if the input column value is NULL, the output MUST be NULL.").
+ */
+abstract class NullSafeFunction<S, T> implements SerializableFunction<S, T> {
   @Override
-  public String name() {
-    return NAME;
+  public final T apply(S value) {
+    return value == null ? null : applyNonNull(value);
   }
 
-  @Override
-  public boolean canBind(Type type) {
-    switch (type.typeId()) {
-      case DATE:
-      case TIMESTAMP:
-      case TIMESTAMP_NANO:
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  @Override
-  public SerializableFunction<Object, Object> bind(Type type) {
-    Preconditions.checkArgument(
-        canBind(type), "truncate-to-year is not supported for type: %s", type);
-    return TruncateTemporal.forType(TruncateTemporal.Unit.YEAR, type);
-  }
+  protected abstract T applyNonNull(S value);
 }

--- a/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Returns null for every non-null input. Works for any type. */
+public final class ReplaceWithNull extends IcebergFunction.BaseFunction<Object, Object> {
+  public ReplaceWithNull(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return REPLACE_WITH_NULL;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return true;
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    return ReplaceWithNullFn.INSTANCE;
+  }
+
+  private static final class ReplaceWithNullFn implements SerializableFunction<Object, Object> {
+    static final ReplaceWithNullFn INSTANCE = new ReplaceWithNullFn();
+
+    @Override
+    public Object apply(Object value) {
+      return null;
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
@@ -21,7 +21,13 @@ package org.apache.iceberg.functions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
-/** Returns null for every non-null input. Works for any type. */
+/**
+ * Returns null for every non-null input. Works for any type.
+ *
+ * <p>Per spec, replace-with-null is only valid for optional (nullable) fields. Callers must
+ * validate that the target field is optional before binding; this function cannot check nullability
+ * because {@link org.apache.iceberg.types.Type} does not carry the field's required/optional flag.
+ */
 public final class ReplaceWithNull extends IcebergFunction.BaseFunction<Object, Object> {
   public ReplaceWithNull(int fieldId) {
     super(fieldId);

--- a/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ReplaceWithNull.java
@@ -28,14 +28,16 @@ import org.apache.iceberg.util.SerializableFunction;
  * validate that the target field is optional before binding; this function cannot check nullability
  * because {@link org.apache.iceberg.types.Type} does not carry the field's required/optional flag.
  */
-public final class ReplaceWithNull extends IcebergFunction.BaseFunction<Object, Object> {
-  public ReplaceWithNull(int fieldId) {
+public final class ReplaceWithNull extends BaseFunction<Object, Object> {
+  static final String NAME = "replace-with-null";
+
+  ReplaceWithNull(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return REPLACE_WITH_NULL;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/SaltedFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/SaltedFunction.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * An {@link IcebergFunction} that requires a per-query salt for binding.
+ *
+ * @param <S> input column value type
+ * @param <T> output column value type
+ */
+public interface SaltedFunction<S, T> extends IcebergFunction<S, T> {
+
+  /**
+   * Returns a function that applies this projection using the given salt.
+   *
+   * @throws IllegalArgumentException if the type is not supported or the salt is invalid.
+   */
+  SerializableFunction<S, T> bind(Type type, byte[] salt);
+}

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
+import org.apache.iceberg.types.Type;
+
+/** Shared SHA-256 masking function. One instance per (type, salt) pair. */
+final class Sha256 extends IcebergFunctions.NullSafeFunction<Object, Object> {
+
+  private static final ThreadLocal<MessageDigest> DIGEST =
+      ThreadLocal.withInitial(
+          () -> {
+            try {
+              return MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException e) {
+              throw new IllegalStateException("SHA-256 not available", e);
+            }
+          });
+
+  enum Codec {
+    STRING {
+      @Override
+      void update(MessageDigest md, Object value) {
+        md.update(((String) value).getBytes(StandardCharsets.UTF_8));
+      }
+
+      @Override
+      Object encode(byte[] digest) {
+        return BaseEncoding.base16().lowerCase().encode(digest);
+      }
+    },
+    INTEGER {
+      @Override
+      void update(MessageDigest md, Object value) {
+        int intVal = (Integer) value;
+        md.update((byte) intVal);
+        md.update((byte) (intVal >>> 8));
+        md.update((byte) (intVal >>> 16));
+        md.update((byte) (intVal >>> 24));
+      }
+
+      @Override
+      Object encode(byte[] digest) {
+        return ByteBuffer.wrap(digest, 0, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
+      }
+    },
+    LONG {
+      @Override
+      void update(MessageDigest md, Object value) {
+        long longVal = (Long) value;
+        for (int i = 0; i < 8; i++) {
+          md.update((byte) longVal);
+          longVal >>>= 8;
+        }
+      }
+
+      @Override
+      Object encode(byte[] digest) {
+        return ByteBuffer.wrap(digest, 0, 8).order(ByteOrder.LITTLE_ENDIAN).getLong();
+      }
+    },
+    BINARY {
+      @Override
+      void update(MessageDigest md, Object value) {
+        md.update(((ByteBuffer) value).duplicate());
+      }
+
+      @Override
+      Object encode(byte[] digest) {
+        return ByteBuffer.wrap(digest);
+      }
+    };
+
+    abstract void update(MessageDigest md, Object value);
+
+    abstract Object encode(byte[] digest);
+  }
+
+  static boolean isSupported(Type type) {
+    switch (type.typeId()) {
+      case STRING:
+      case INTEGER:
+      case LONG:
+      case BINARY:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  static Sha256 forType(Type type, byte[] salt) {
+    switch (type.typeId()) {
+      case STRING:
+        return new Sha256(Codec.STRING, salt);
+      case INTEGER:
+        return new Sha256(Codec.INTEGER, salt);
+      case LONG:
+        return new Sha256(Codec.LONG, salt);
+      case BINARY:
+        return new Sha256(Codec.BINARY, salt);
+      default:
+        throw new IllegalArgumentException("sha-256 is not supported for type: " + type);
+    }
+  }
+
+  private final Codec codec;
+  private final byte[] salt;
+
+  private Sha256(Codec codec, byte[] salt) {
+    this.codec = codec;
+    this.salt = salt != null ? salt.clone() : null;
+  }
+
+  @Override
+  protected Object applyNonNull(Object value) {
+    MessageDigest md = DIGEST.get();
+    md.reset();
+    if (salt != null) {
+      md.update(salt);
+    }
+    codec.update(md, value);
+    return codec.encode(md.digest());
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256.java
@@ -27,7 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.types.Type;
 
 /** Shared SHA-256 masking function. One instance per (type, salt) pair. */
-final class Sha256 extends IcebergFunctions.NullSafeFunction<Object, Object> {
+final class Sha256 extends NullSafeFunction<Object, Object> {
 
   private static final ThreadLocal<MessageDigest> DIGEST =
       ThreadLocal.withInitial(

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256Global.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256Global.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Hashes values with SHA-256 using a fixed (unsalted) digest. Output is deterministic. */
+public final class Sha256Global extends IcebergFunction.BaseFunction<Object, Object> {
+  public Sha256Global(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return SHA_256_GLOBAL;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return Sha256.isSupported(type);
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    Preconditions.checkArgument(canBind(type), "sha-256 is not supported for type: %s", type);
+    return Sha256.forType(type, null);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256Global.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256Global.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Hashes values with SHA-256 using a fixed (unsalted) digest. Output is deterministic. */
-public final class Sha256Global extends IcebergFunction.BaseFunction<Object, Object> {
-  public Sha256Global(int fieldId) {
+public final class Sha256Global extends BaseFunction<Object, Object> {
+  static final String NAME = "sha-256-global";
+
+  Sha256Global(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return SHA_256_GLOBAL;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256QueryLocal.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256QueryLocal.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * Hashes values with SHA-256 using a per-query salt. Binding requires the salt via {@link
+ * #bind(Type, byte[])}; the no-salt variant fails fast so callers can't accidentally strip the
+ * query-local randomness.
+ */
+public final class Sha256QueryLocal extends IcebergFunction.BaseFunction<Object, Object>
+    implements SaltedFunction<Object, Object> {
+  public Sha256QueryLocal(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return SHA_256_QUERY_LOCAL;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return Sha256.isSupported(type);
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    throw new IllegalArgumentException(
+        "sha-256-query-local requires a salt; call bind(Type, byte[]) instead");
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type, byte[] salt) {
+    Preconditions.checkArgument(canBind(type), "sha-256 is not supported for type: %s", type);
+    Preconditions.checkArgument(
+        salt != null && salt.length >= 16, "sha-256-query-local salt must be >= 16 bytes");
+    return Sha256.forType(type, salt);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/Sha256QueryLocal.java
+++ b/api/src/main/java/org/apache/iceberg/functions/Sha256QueryLocal.java
@@ -27,15 +27,17 @@ import org.apache.iceberg.util.SerializableFunction;
  * #bind(Type, byte[])}; the no-salt variant fails fast so callers can't accidentally strip the
  * query-local randomness.
  */
-public final class Sha256QueryLocal extends IcebergFunction.BaseFunction<Object, Object>
+public final class Sha256QueryLocal extends BaseFunction<Object, Object>
     implements SaltedFunction<Object, Object> {
-  public Sha256QueryLocal(int fieldId) {
+  static final String NAME = "sha-256-query-local";
+
+  Sha256QueryLocal(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return SHA_256_QUERY_LOCAL;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/ShowFirst4.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ShowFirst4.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Preserves the first 4 code points of a string, redacts the rest via mask-alphanum rules. */
+public final class ShowFirst4 extends IcebergFunction.BaseFunction<String, String> {
+  public ShowFirst4(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return SHOW_FIRST_4;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return type.typeId() == Type.TypeID.STRING;
+  }
+
+  @Override
+  public SerializableFunction<String, String> bind(Type type) {
+    Preconditions.checkArgument(canBind(type), "show-first-4 requires STRING type, got %s", type);
+    return ShowFirst4Fn.INSTANCE;
+  }
+
+  private static final class ShowFirst4Fn
+      extends IcebergFunctions.NullSafeFunction<String, String> {
+    static final ShowFirst4Fn INSTANCE = new ShowFirst4Fn();
+
+    @Override
+    protected String applyNonNull(String input) {
+      if (input.codePointCount(0, input.length()) <= 4) {
+        return input;
+      }
+      StringBuilder sb = new StringBuilder(input.length());
+      int cpIndex = 0;
+      int offset = 0;
+      while (offset < input.length()) {
+        int cp = input.codePointAt(offset);
+        sb.appendCodePoint(cpIndex < 4 ? cp : MaskAlphanum.maskCodePoint(cp));
+        offset += Character.charCount(cp);
+        cpIndex++;
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/ShowFirst4.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ShowFirst4.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Preserves the first 4 code points of a string, redacts the rest via mask-alphanum rules. */
-public final class ShowFirst4 extends IcebergFunction.BaseFunction<String, String> {
-  public ShowFirst4(int fieldId) {
+public final class ShowFirst4 extends BaseFunction<String, String> {
+  static final String NAME = "show-first-4";
+
+  ShowFirst4(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return SHOW_FIRST_4;
+    return NAME;
   }
 
   @Override
@@ -44,8 +46,7 @@ public final class ShowFirst4 extends IcebergFunction.BaseFunction<String, Strin
     return ShowFirst4Fn.INSTANCE;
   }
 
-  private static final class ShowFirst4Fn
-      extends IcebergFunctions.NullSafeFunction<String, String> {
+  private static final class ShowFirst4Fn extends NullSafeFunction<String, String> {
     static final ShowFirst4Fn INSTANCE = new ShowFirst4Fn();
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/functions/ShowLast4.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ShowLast4.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Redacts all but the last 4 code points of a string via mask-alphanum rules. */
+public final class ShowLast4 extends IcebergFunction.BaseFunction<String, String> {
+  public ShowLast4(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return SHOW_LAST_4;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return type.typeId() == Type.TypeID.STRING;
+  }
+
+  @Override
+  public SerializableFunction<String, String> bind(Type type) {
+    Preconditions.checkArgument(canBind(type), "show-last-4 requires STRING type, got %s", type);
+    return ShowLast4Fn.INSTANCE;
+  }
+
+  private static final class ShowLast4Fn extends IcebergFunctions.NullSafeFunction<String, String> {
+    static final ShowLast4Fn INSTANCE = new ShowLast4Fn();
+
+    @Override
+    protected String applyNonNull(String input) {
+      // Single pass: walk the string while remembering the last 4 code-point start offsets.
+      // When done, everything before the oldest remembered offset is masked; everything from
+      // that offset onward is kept verbatim.
+      int[] lastFourStarts = new int[4];
+      int count = 0;
+      int offset = 0;
+      while (offset < input.length()) {
+        lastFourStarts[count % 4] = offset;
+        int cp = input.codePointAt(offset);
+        offset += Character.charCount(cp);
+        count++;
+      }
+      if (count <= 4) {
+        return input;
+      }
+      int keepFromOffset = lastFourStarts[count % 4];
+      StringBuilder sb = new StringBuilder(input.length());
+      int maskOffset = 0;
+      while (maskOffset < keepFromOffset) {
+        int cp = input.codePointAt(maskOffset);
+        sb.appendCodePoint(MaskAlphanum.maskCodePoint(cp));
+        maskOffset += Character.charCount(cp);
+      }
+      sb.append(input, keepFromOffset, input.length());
+      return sb.toString();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/ShowLast4.java
+++ b/api/src/main/java/org/apache/iceberg/functions/ShowLast4.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Redacts all but the last 4 code points of a string via mask-alphanum rules. */
-public final class ShowLast4 extends IcebergFunction.BaseFunction<String, String> {
-  public ShowLast4(int fieldId) {
+public final class ShowLast4 extends BaseFunction<String, String> {
+  static final String NAME = "show-last-4";
+
+  ShowLast4(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return SHOW_LAST_4;
+    return NAME;
   }
 
   @Override
@@ -44,7 +46,7 @@ public final class ShowLast4 extends IcebergFunction.BaseFunction<String, String
     return ShowLast4Fn.INSTANCE;
   }
 
-  private static final class ShowLast4Fn extends IcebergFunctions.NullSafeFunction<String, String> {
+  private static final class ShowLast4Fn extends NullSafeFunction<String, String> {
     static final ShowLast4Fn INSTANCE = new ShowLast4Fn();
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateTemporal.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateTemporal.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.DateTimeUtil;
+
+/** Truncates date/timestamp values to the first instant of their year or month. */
+final class TruncateTemporal extends IcebergFunctions.NullSafeFunction<Object, Object> {
+
+  enum Unit {
+    YEAR,
+    MONTH
+  }
+
+  private enum Storage {
+    DATE_DAYS,
+    TIMESTAMP_MICROS,
+    TIMESTAMP_NANOS
+  }
+
+  static final TruncateTemporal DATE_YEAR = new TruncateTemporal(Unit.YEAR, Storage.DATE_DAYS);
+  static final TruncateTemporal DATE_MONTH = new TruncateTemporal(Unit.MONTH, Storage.DATE_DAYS);
+  static final TruncateTemporal TIMESTAMP_YEAR =
+      new TruncateTemporal(Unit.YEAR, Storage.TIMESTAMP_MICROS);
+  static final TruncateTemporal TIMESTAMP_MONTH =
+      new TruncateTemporal(Unit.MONTH, Storage.TIMESTAMP_MICROS);
+  static final TruncateTemporal TIMESTAMP_NANO_YEAR =
+      new TruncateTemporal(Unit.YEAR, Storage.TIMESTAMP_NANOS);
+  static final TruncateTemporal TIMESTAMP_NANO_MONTH =
+      new TruncateTemporal(Unit.MONTH, Storage.TIMESTAMP_NANOS);
+
+  static TruncateTemporal forType(Unit unit, Type type) {
+    switch (type.typeId()) {
+      case DATE:
+        return unit == Unit.YEAR ? DATE_YEAR : DATE_MONTH;
+      case TIMESTAMP:
+        return unit == Unit.YEAR ? TIMESTAMP_YEAR : TIMESTAMP_MONTH;
+      case TIMESTAMP_NANO:
+        return unit == Unit.YEAR ? TIMESTAMP_NANO_YEAR : TIMESTAMP_NANO_MONTH;
+      default:
+        throw new IllegalArgumentException("Unsupported type for truncate: " + type);
+    }
+  }
+
+  private final Unit unit;
+  private final Storage storage;
+
+  private TruncateTemporal(Unit unit, Storage storage) {
+    this.unit = unit;
+    this.storage = storage;
+  }
+
+  @Override
+  protected Object applyNonNull(Object value) {
+    switch (storage) {
+      case DATE_DAYS:
+        LocalDate date = DateTimeUtil.dateFromDays((Integer) value);
+        return DateTimeUtil.daysFromDate(truncateDate(date));
+      case TIMESTAMP_MICROS:
+        LocalDateTime tsMicros = DateTimeUtil.timestampFromMicros((Long) value);
+        return DateTimeUtil.microsFromTimestamp(truncateTimestamp(tsMicros));
+      case TIMESTAMP_NANOS:
+        LocalDateTime tsNanos = DateTimeUtil.timestampFromNanos((Long) value);
+        return DateTimeUtil.nanosFromTimestamp(truncateTimestamp(tsNanos));
+      default:
+        throw new IllegalStateException("unreachable: " + storage);
+    }
+  }
+
+  private LocalDate truncateDate(LocalDate date) {
+    return unit == Unit.YEAR ? date.withMonth(1).withDayOfMonth(1) : date.withDayOfMonth(1);
+  }
+
+  private LocalDateTime truncateTimestamp(LocalDateTime ts) {
+    LocalDateTime truncated =
+        unit == Unit.YEAR ? ts.withMonth(1).withDayOfMonth(1) : ts.withDayOfMonth(1);
+    return truncated.with(LocalTime.MIDNIGHT);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateTemporal.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateTemporal.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.DateTimeUtil;
 
 /** Truncates date/timestamp values to the first instant of their year or month. */
-final class TruncateTemporal extends IcebergFunctions.NullSafeFunction<Object, Object> {
+final class TruncateTemporal extends NullSafeFunction<Object, Object> {
 
   enum Unit {
     YEAR,

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateToMonth.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateToMonth.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Truncates date or timestamp values to the first instant of their month. */
+public final class TruncateToMonth extends IcebergFunction.BaseFunction<Object, Object> {
+  public TruncateToMonth(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return TRUNCATE_TO_MONTH;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    switch (type.typeId()) {
+      case DATE:
+      case TIMESTAMP:
+      case TIMESTAMP_NANO:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    Preconditions.checkArgument(
+        canBind(type), "truncate-to-month is not supported for type: %s", type);
+    return TruncateTemporal.forType(TruncateTemporal.Unit.MONTH, type);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateToMonth.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateToMonth.java
@@ -23,14 +23,16 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.SerializableFunction;
 
 /** Truncates date or timestamp values to the first instant of their month. */
-public final class TruncateToMonth extends IcebergFunction.BaseFunction<Object, Object> {
-  public TruncateToMonth(int fieldId) {
+public final class TruncateToMonth extends BaseFunction<Object, Object> {
+  static final String NAME = "truncate-to-month";
+
+  TruncateToMonth(int fieldId) {
     super(fieldId);
   }
 
   @Override
   public String name() {
-    return TRUNCATE_TO_MONTH;
+    return NAME;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/functions/TruncateToYear.java
+++ b/api/src/main/java/org/apache/iceberg/functions/TruncateToYear.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/** Truncates date or timestamp values to the first instant of their year. */
+public final class TruncateToYear extends IcebergFunction.BaseFunction<Object, Object> {
+  public TruncateToYear(int fieldId) {
+    super(fieldId);
+  }
+
+  @Override
+  public String name() {
+    return TRUNCATE_TO_YEAR;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    switch (type.typeId()) {
+      case DATE:
+      case TIMESTAMP:
+      case TIMESTAMP_NANO:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    Preconditions.checkArgument(
+        canBind(type), "truncate-to-year is not supported for type: %s", type);
+    return TruncateTemporal.forType(TruncateTemporal.Unit.YEAR, type);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/UnknownFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/UnknownFunction.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
+
+/**
+ * Preserves a function with a discriminator string this client doesn't recognize so that newer
+ * server-side function types don't break parsing. Callers that intend to enforce the function
+ * (engine-side rules) must fail closed when they encounter this — silent skipping would leak
+ * unmasked data.
+ */
+public final class UnknownFunction extends IcebergFunction.BaseFunction<Object, Object> {
+  private final String functionName;
+
+  public UnknownFunction(int fieldId, String functionName) {
+    super(fieldId);
+    Preconditions.checkArgument(functionName != null, "Invalid function name: null");
+    this.functionName = functionName;
+  }
+
+  @Override
+  public String name() {
+    return functionName;
+  }
+
+  @Override
+  public boolean canBind(Type type) {
+    return false;
+  }
+
+  @Override
+  public SerializableFunction<Object, Object> bind(Type type) {
+    throw new IllegalArgumentException(
+        "Cannot bind unknown function '"
+            + functionName
+            + "': this client does not recognize the function. Upgrade the client or remove the "
+            + "function from the server-side policy.");
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/functions/UnknownFunction.java
+++ b/api/src/main/java/org/apache/iceberg/functions/UnknownFunction.java
@@ -28,10 +28,10 @@ import org.apache.iceberg.util.SerializableFunction;
  * (engine-side rules) must fail closed when they encounter this — silent skipping would leak
  * unmasked data.
  */
-public final class UnknownFunction extends IcebergFunction.BaseFunction<Object, Object> {
+public final class UnknownFunction extends BaseFunction<Object, Object> {
   private final String functionName;
 
-  public UnknownFunction(int fieldId, String functionName) {
+  UnknownFunction(int fieldId, String functionName) {
     super(fieldId);
     Preconditions.checkArgument(functionName != null, "Invalid function name: null");
     this.functionName = functionName;

--- a/api/src/test/java/org/apache/iceberg/functions/TestIcebergFunctions.java
+++ b/api/src/test/java/org/apache/iceberg/functions/TestIcebergFunctions.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.functions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.SerializableFunction;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergFunctions {
+
+  @Test
+  public void maskAlphanumSpecExample() {
+    SerializableFunction<String, String> fn = new MaskAlphanum(1).bind(Types.StringType.get());
+    assertThat(fn.apply("prashant010696@gmail.com")).isEqualTo("xxxxxxxxnnnnnn@xxxxx.xxx");
+  }
+
+  @Test
+  public void maskAlphanumPreservedPunctuation() {
+    SerializableFunction<String, String> fn = new MaskAlphanum(1).bind(Types.StringType.get());
+    assertThat(fn.apply("(555) 123-4567")).isEqualTo("(nnn)xnnn-nnnn");
+    assertThat(fn.apply("a.b,c")).isEqualTo("x.x,x");
+  }
+
+  @Test
+  public void maskAlphanumNullInNullOut() {
+    SerializableFunction<String, String> fn = new MaskAlphanum(1).bind(Types.StringType.get());
+    assertThat(fn.apply(null)).isNull();
+  }
+
+  @Test
+  public void maskAlphanumEmptyString() {
+    SerializableFunction<String, String> fn = new MaskAlphanum(1).bind(Types.StringType.get());
+    assertThat(fn.apply("")).isEqualTo("");
+  }
+
+  @Test
+  public void showFirst4SpecExample() {
+    SerializableFunction<String, String> fn = new ShowFirst4(1).bind(Types.StringType.get());
+    assertThat(fn.apply("prashant010696@gmail.com")).isEqualTo("prasxxxxnnnnnn@xxxxx.xxx");
+  }
+
+  @Test
+  public void showFirst4FourOrFewerReturnedUnchanged() {
+    SerializableFunction<String, String> fn = new ShowFirst4(1).bind(Types.StringType.get());
+    assertThat(fn.apply("abcd")).isEqualTo("abcd");
+    assertThat(fn.apply("ab")).isEqualTo("ab");
+    assertThat(fn.apply("")).isEqualTo("");
+  }
+
+  @Test
+  public void showLast4SpecExample() {
+    SerializableFunction<String, String> fn = new ShowLast4(1).bind(Types.StringType.get());
+    assertThat(fn.apply("4111-1111-1111-4444")).isEqualTo("nnnn-nnnn-nnnn-4444");
+  }
+
+  @Test
+  public void showLast4FourOrFewerReturnedUnchanged() {
+    SerializableFunction<String, String> fn = new ShowLast4(1).bind(Types.StringType.get());
+    assertThat(fn.apply("abcd")).isEqualTo("abcd");
+    assertThat(fn.apply("ab")).isEqualTo("ab");
+  }
+
+  @Test
+  public void replaceWithNullAlwaysReturnsNull() {
+    SerializableFunction<Object, Object> fn = new ReplaceWithNull(1).bind(Types.IntegerType.get());
+    assertThat(fn.apply(42)).isNull();
+    assertThat(fn.apply(null)).isNull();
+
+    SerializableFunction<Object, Object> strFn =
+        new ReplaceWithNull(1).bind(Types.StringType.get());
+    assertThat(strFn.apply("hello")).isNull();
+  }
+
+  @Test
+  public void maskToFixedValueString() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.StringType.get());
+    assertThat(fn.apply("anything")).isEqualTo("XXXXXXXX");
+  }
+
+  @Test
+  public void maskToFixedValueInt() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.IntegerType.get());
+    assertThat(fn.apply(42)).isEqualTo(0);
+  }
+
+  @Test
+  public void maskToFixedValueLong() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.LongType.get());
+    assertThat(fn.apply(42L)).isEqualTo(0L);
+  }
+
+  @Test
+  public void maskToFixedValueDouble() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.DoubleType.get());
+    assertThat(fn.apply(3.14)).isEqualTo(0.0d);
+  }
+
+  @Test
+  public void maskToFixedValueBoolean() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.BooleanType.get());
+    assertThat(fn.apply(true)).isEqualTo(false);
+  }
+
+  @Test
+  public void maskToFixedValueDate() {
+    int input = DateTimeUtil.daysFromDate(LocalDate.of(2024, 7, 15));
+    int expected = DateTimeUtil.daysFromDate(LocalDate.of(1970, 1, 1));
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.DateType.get());
+    assertThat(fn.apply(input)).isEqualTo(expected);
+  }
+
+  @Test
+  public void maskToFixedValueTimestamp() {
+    long input =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    long expected = LocalDateTime.of(1970, 1, 1, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new MaskToFixedValue(1).bind(Types.TimestampType.withZone());
+    assertThat(fn.apply(input)).isEqualTo(expected);
+  }
+
+  @Test
+  public void maskToFixedValueBinary() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.BinaryType.get());
+    ByteBuffer result = (ByteBuffer) fn.apply(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(result.remaining()).isEqualTo(0);
+  }
+
+  @Test
+  public void maskToFixedValueDecimal() {
+    SerializableFunction<Object, Object> fn =
+        new MaskToFixedValue(1).bind(Types.DecimalType.of(10, 2));
+    BigDecimal result = (BigDecimal) fn.apply(new BigDecimal("12.34"));
+    assertThat(result.compareTo(BigDecimal.ZERO)).isEqualTo(0);
+    assertThat(result.scale()).isEqualTo(2);
+  }
+
+  @Test
+  public void maskToFixedValueNullReturnsFixedValue() {
+    SerializableFunction<Object, Object> fn = new MaskToFixedValue(1).bind(Types.IntegerType.get());
+    assertThat(fn.apply(null)).isEqualTo(0);
+  }
+
+  @Test
+  public void truncateToYearDate() {
+    int input = (int) LocalDate.of(2024, 7, 15).toEpochDay();
+    int expected = (int) LocalDate.of(2024, 1, 1).toEpochDay();
+    SerializableFunction<Object, Object> fn = new TruncateToYear(1).bind(Types.DateType.get());
+    assertThat(fn.apply(input)).isEqualTo(expected);
+  }
+
+  @Test
+  public void truncateToMonthDate() {
+    int input = (int) LocalDate.of(2024, 7, 15).toEpochDay();
+    int expected = (int) LocalDate.of(2024, 7, 1).toEpochDay();
+    SerializableFunction<Object, Object> fn = new TruncateToMonth(1).bind(Types.DateType.get());
+    assertThat(fn.apply(input)).isEqualTo(expected);
+  }
+
+  @Test
+  public void truncateToYearTimestamp() {
+    long inputMicros =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    long expectedMicros =
+        LocalDateTime.of(2024, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new TruncateToYear(1).bind(Types.TimestampType.withZone());
+    assertThat(fn.apply(inputMicros)).isEqualTo(expectedMicros);
+  }
+
+  @Test
+  public void truncateToMonthTimestamp() {
+    long inputMicros =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    long expectedMicros =
+        LocalDateTime.of(2024, 7, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new TruncateToMonth(1).bind(Types.TimestampType.withZone());
+    assertThat(fn.apply(inputMicros)).isEqualTo(expectedMicros);
+  }
+
+  @Test
+  public void truncateToYearTimestampNanoTz() {
+    long inputNanos =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000_000L;
+    long expectedNanos =
+        LocalDateTime.of(2024, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new TruncateToYear(1).bind(Types.TimestampNanoType.withZone());
+    assertThat(fn.apply(inputNanos)).isEqualTo(expectedNanos);
+  }
+
+  @Test
+  public void truncateToMonthTimestampNanoTz() {
+    long inputNanos =
+        LocalDateTime.of(2024, 7, 15, 13, 45, 30).toEpochSecond(ZoneOffset.UTC) * 1_000_000_000L;
+    long expectedNanos =
+        LocalDateTime.of(2024, 7, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000_000L;
+    SerializableFunction<Object, Object> fn =
+        new TruncateToMonth(1).bind(Types.TimestampNanoType.withZone());
+    assertThat(fn.apply(inputNanos)).isEqualTo(expectedNanos);
+  }
+
+  @Test
+  public void sha256GlobalStringIsDeterministic() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.StringType.get());
+    String first = (String) fn.apply("hello");
+    String second = (String) fn.apply("hello");
+    assertThat(first).isEqualTo(second);
+    assertThat(first).isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+  }
+
+  @Test
+  public void sha256GlobalBinaryReturns32Bytes() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.BinaryType.get());
+    ByteBuffer result = (ByteBuffer) fn.apply(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(result.remaining()).isEqualTo(32);
+  }
+
+  @Test
+  public void sha256GlobalIntegerDeterministic() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.IntegerType.get());
+    Object first = fn.apply(42);
+    Object second = fn.apply(42);
+    assertThat(first).isEqualTo(second);
+    assertThat(first).isInstanceOf(Integer.class);
+  }
+
+  @Test
+  public void sha256GlobalLongDeterministic() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.LongType.get());
+    Object first = fn.apply(42L);
+    Object second = fn.apply(42L);
+    assertThat(first).isEqualTo(second);
+    assertThat(first).isInstanceOf(Long.class);
+  }
+
+  @Test
+  public void sha256QueryLocalDiffersWithDifferentSalt() {
+    byte[] saltA = new byte[16];
+    byte[] saltB = new byte[16];
+    Arrays.fill(saltA, (byte) 1);
+    Arrays.fill(saltB, (byte) 2);
+    SerializableFunction<Object, Object> fnA =
+        new Sha256QueryLocal(1).bind(Types.StringType.get(), saltA);
+    SerializableFunction<Object, Object> fnB =
+        new Sha256QueryLocal(1).bind(Types.StringType.get(), saltB);
+    assertThat(fnA.apply("hello")).isNotEqualTo(fnB.apply("hello"));
+  }
+
+  @Test
+  public void sha256QueryLocalSaltMustBeAtLeast16Bytes() {
+    assertThatThrownBy(() -> new Sha256QueryLocal(1).bind(Types.StringType.get(), new byte[15]))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("16 bytes");
+  }
+
+  @Test
+  public void bindRejectsMaskAlphanumOnNonString() {
+    assertThatThrownBy(() -> new MaskAlphanum(1).bind(Types.IntegerType.get()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("STRING");
+  }
+
+  @Test
+  public void bindRejectsTruncateOnUnsupportedType() {
+    assertThatThrownBy(() -> new TruncateToYear(1).bind(Types.StringType.get()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not supported for type");
+  }
+
+  @Test
+  public void bindFailsClosedOnUnknownFunction() {
+    assertThatThrownBy(() -> new UnknownFunction(1, "future-mask-v2").bind(Types.StringType.get()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("future-mask-v2");
+  }
+
+  @Test
+  public void sha256NullInNullOut() {
+    SerializableFunction<Object, Object> fn = new Sha256Global(1).bind(Types.StringType.get());
+    assertThat(fn.apply(null)).isNull();
+  }
+
+  @Test
+  public void truncateNullInNullOut() {
+    SerializableFunction<Object, Object> fn = new TruncateToYear(1).bind(Types.DateType.get());
+    assertThat(fn.apply(null)).isNull();
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/functions/TestIcebergFunctions.java
+++ b/api/src/test/java/org/apache/iceberg/functions/TestIcebergFunctions.java
@@ -313,4 +313,88 @@ public class TestIcebergFunctions {
     SerializableFunction<Object, Object> fn = new TruncateToYear(1).bind(Types.DateType.get());
     assertThat(fn.apply(null)).isNull();
   }
+
+  @Test
+  public void factoryMethodsUseSpecWireNames() {
+    assertThat(IcebergFunctions.maskAlphanum(1).name()).isEqualTo("mask-alphanum");
+    assertThat(IcebergFunctions.maskToFixedValue(1).name()).isEqualTo("mask-to-fixed-value");
+    assertThat(IcebergFunctions.replaceWithNull(1).name()).isEqualTo("replace-with-null");
+    assertThat(IcebergFunctions.showFirst4(1).name()).isEqualTo("show-first-4");
+    assertThat(IcebergFunctions.showLast4(1).name()).isEqualTo("show-last-4");
+    assertThat(IcebergFunctions.truncateToYear(1).name()).isEqualTo("truncate-to-year");
+    assertThat(IcebergFunctions.truncateToMonth(1).name()).isEqualTo("truncate-to-month");
+    assertThat(IcebergFunctions.sha256Global(1).name()).isEqualTo("sha-256-global");
+    assertThat(IcebergFunctions.sha256QueryLocal(1).name()).isEqualTo("sha-256-query-local");
+  }
+
+  @Test
+  public void fromStringRoundTripsEveryFunction() {
+    IcebergFunction<?, ?>[] functions =
+        new IcebergFunction<?, ?>[] {
+          IcebergFunctions.maskAlphanum(1),
+          IcebergFunctions.maskToFixedValue(1),
+          IcebergFunctions.replaceWithNull(1),
+          IcebergFunctions.showFirst4(1),
+          IcebergFunctions.showLast4(1),
+          IcebergFunctions.truncateToYear(1),
+          IcebergFunctions.truncateToMonth(1),
+          IcebergFunctions.sha256Global(1),
+          IcebergFunctions.sha256QueryLocal(1)
+        };
+
+    for (IcebergFunction<?, ?> expected : functions) {
+      assertThat(IcebergFunctions.fromString(expected.name(), 1)).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void fromStringPreservesUnknownFunction() {
+    IcebergFunction<?, ?> function = IcebergFunctions.fromString("future-mask-v2", 3);
+    assertThat(function).isInstanceOf(UnknownFunction.class);
+    assertThat(function.name()).isEqualTo("future-mask-v2");
+    assertThat(function.fieldId()).isEqualTo(3);
+    assertThat(function.canBind(Types.StringType.get())).isFalse();
+  }
+
+  @Test
+  public void fromStringReturnsSaltedFunctionForQueryLocalSha256() {
+    assertThat(IcebergFunctions.fromString("sha-256-query-local", 1))
+        .isInstanceOf(SaltedFunction.class);
+    assertThat(IcebergFunctions.fromString("sha-256-global", 1))
+        .isNotInstanceOf(SaltedFunction.class);
+  }
+
+  @Test
+  public void equalIfSameFunctionAndFieldId() {
+    assertThat(IcebergFunctions.maskAlphanum(1))
+        .isEqualTo(IcebergFunctions.maskAlphanum(1))
+        .hasSameHashCodeAs(IcebergFunctions.maskAlphanum(1));
+  }
+
+  @Test
+  public void notEqualIfFieldIdDiffers() {
+    assertThat(IcebergFunctions.maskAlphanum(1)).isNotEqualTo(IcebergFunctions.maskAlphanum(2));
+  }
+
+  @Test
+  public void notEqualIfFunctionDiffers() {
+    assertThat(IcebergFunctions.maskAlphanum(1)).isNotEqualTo(IcebergFunctions.showLast4(1));
+  }
+
+  @Test
+  public void equalsIsSymmetricAcrossFunctionTypes() {
+    // An unknown function reporting a known name must not compare equal to that known function in
+    // either direction: equality is by class, not by the reported name.
+    IcebergFunction<?, ?> known = IcebergFunctions.maskAlphanum(1);
+    IcebergFunction<?, ?> spoofed = new UnknownFunction(1, known.name());
+    assertThat(spoofed.name()).isEqualTo(known.name());
+    assertThat(spoofed).isNotEqualTo(known);
+    assertThat(known).isNotEqualTo(spoofed);
+  }
+
+  @Test
+  public void unknownFunctionsDifferByName() {
+    assertThat(IcebergFunctions.fromString("future-a", 1))
+        .isNotEqualTo(IcebergFunctions.fromString("future-b", 1));
+  }
 }


### PR DESCRIPTION
  ## About the change
 Adds the org.apache.iceberg.functions package - the engine-side Java API for
  column projection functions defined by the [ReadRestrictions spec](https://github.com/apache/iceberg/pull/13879). Each
  function takes a column value, applies a masking or transformation operation,
   and returns the result. The REST spec uses "action" as the wire-format
  discriminator; this package uses IcebergFunction at the Java layer to avoid
  collision with org.apache.iceberg.actions.Action.

 ## Design

  - IcebergFunction<S, T> — base interface with name(), fieldId(), bind(Type),
  canBind(Type). Generic over input (S) and output (T) types to support future
  type-changing functions.
  - SaltedFunction<S, T> — sub-interface adding bind(Type, byte[] salt) for
  per-query salted operations. Only Sha256QueryLocal implements this.
  - BaseFunction<S, T> — abstract inner class holding field-id, with strict
  getClass() equals.
  - UnknownFunction — forward-compatibility: parses unrecognized function names
   without crashing, fails closed at bind time to prevent data leaks.
  - All functions are Serializable for distributed engine use (Spark, Flink)
