### PR TITLE
Core: Cache PartitionData template in PartitionsTable to avoid rebuilding Avro schema per partition

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -166,7 +166,8 @@ public class PartitionsTable extends BaseMetadataTable {
         partition.lastUpdatedSnapshotId);
   }
 
-  private static Iterable<Partition> partitions(Table table, StaticTableScan scan) {
+  @VisibleForTesting
+  static Iterable<Partition> partitions(Table table, StaticTableScan scan) {
     Types.StructType partitionType = Partitioning.partitionType(table);
     PartitionData partitionDataTemplate = new PartitionData(partitionType);
 
@@ -293,6 +294,11 @@ public class PartitionsTable extends BaseMetadataTable {
       this.posDeleteFileCount = 0;
       this.eqDeleteRecordCount = 0L;
       this.eqDeleteFileCount = 0;
+    }
+
+    @VisibleForTesting
+    PartitionData partitionData() {
+      return partitionData;
     }
 
     void update(ContentFile<?> file, Snapshot snapshot) {

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -168,6 +168,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private static Iterable<Partition> partitions(Table table, StaticTableScan scan) {
     Types.StructType partitionType = Partitioning.partitionType(table);
+    PartitionData partitionDataTemplate = new PartitionData(partitionType);
 
     StructLikeMap<Partition> partitions =
         StructLikeMap.create(partitionType, new PartitionComparator(partitionType));
@@ -180,7 +181,7 @@ public class PartitionsTable extends BaseMetadataTable {
             PartitionUtil.coercePartition(
                 partitionType, table.specs().get(file.specId()), file.partition());
         partitions
-            .computeIfAbsent(key, () -> new Partition(key, partitionType))
+            .computeIfAbsent(key, () -> new Partition(key, partitionDataTemplate))
             .update(file, snapshot);
       }
     } catch (IOException e) {
@@ -282,8 +283,8 @@ public class PartitionsTable extends BaseMetadataTable {
     private Long lastUpdatedAt;
     private Long lastUpdatedSnapshotId;
 
-    Partition(StructLike key, Types.StructType keyType) {
-      this.partitionData = toPartitionData(key, keyType);
+    Partition(StructLike key, PartitionData partitionDataTemplate) {
+      this.partitionData = toPartitionData(key, partitionDataTemplate);
       this.specId = 0;
       this.dataRecordCount = 0L;
       this.dataFileCount = 0;
@@ -326,9 +327,9 @@ public class PartitionsTable extends BaseMetadataTable {
     }
 
     /** Needed because StructProjection is not serializable */
-    private static PartitionData toPartitionData(StructLike key, Types.StructType keyType) {
-      PartitionData keyTemplate = new PartitionData(keyType);
-      return keyTemplate.copyFor(key);
+    private static PartitionData toPartitionData(
+        StructLike key, PartitionData partitionDataTemplate) {
+      return partitionDataTemplate.copyFor(key);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -25,6 +25,8 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -519,6 +521,34 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     validateSingleFieldPartition(entries, 1);
     validateSingleFieldPartition(entries, 2);
     validateSingleFieldPartition(entries, 3);
+  }
+
+  @TestTemplate
+  public void testPartitionsTableReusesPartitionDataSchema() throws Exception {
+    preparePartitionedTable();
+
+    Table partitionsTable = new PartitionsTable(table);
+    StaticTableScan scan = (StaticTableScan) partitionsTable.newScan();
+    List<org.apache.avro.Schema> partitionSchemas = Lists.newArrayList();
+
+    Method partitionsMethod =
+        PartitionsTable.class.getDeclaredMethod("partitions", Table.class, StaticTableScan.class);
+    partitionsMethod.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Iterable<PartitionsTable.Partition> partitions =
+        (Iterable<PartitionsTable.Partition>) partitionsMethod.invoke(null, table, scan);
+    Field partitionDataField = PartitionsTable.Partition.class.getDeclaredField("partitionData");
+    partitionDataField.setAccessible(true);
+
+    for (PartitionsTable.Partition partition : partitions) {
+      PartitionData partitionData = (PartitionData) partitionDataField.get(partition);
+      partitionSchemas.add(partitionData.getSchema());
+    }
+
+    assertThat(partitionSchemas).hasSize(4);
+    org.apache.avro.Schema expectedSchema = partitionSchemas.get(0);
+    assertThat(partitionSchemas)
+        .allSatisfy(schema -> assertThat(schema).isSameAs(expectedSchema));
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -547,8 +547,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     assertThat(partitionSchemas).hasSize(4);
     org.apache.avro.Schema expectedSchema = partitionSchemas.get(0);
-    assertThat(partitionSchemas)
-        .allSatisfy(schema -> assertThat(schema).isSameAs(expectedSchema));
+    assertThat(partitionSchemas).allSatisfy(schema -> assertThat(schema).isSameAs(expectedSchema));
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -25,8 +25,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -524,28 +522,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
-  public void testPartitionsTableReusesPartitionDataSchema() throws Exception {
+  public void testPartitionsTableReusesPartitionDataSchema() {
     preparePartitionedTable();
 
     Table partitionsTable = new PartitionsTable(table);
     StaticTableScan scan = (StaticTableScan) partitionsTable.newScan();
     List<org.apache.avro.Schema> partitionSchemas = Lists.newArrayList();
 
-    Method partitionsMethod =
-        PartitionsTable.class.getDeclaredMethod("partitions", Table.class, StaticTableScan.class);
-    partitionsMethod.setAccessible(true);
-    @SuppressWarnings("unchecked")
-    Iterable<PartitionsTable.Partition> partitions =
-        (Iterable<PartitionsTable.Partition>) partitionsMethod.invoke(null, table, scan);
-    Field partitionDataField = PartitionsTable.Partition.class.getDeclaredField("partitionData");
-    partitionDataField.setAccessible(true);
-
-    for (PartitionsTable.Partition partition : partitions) {
-      PartitionData partitionData = (PartitionData) partitionDataField.get(partition);
-      partitionSchemas.add(partitionData.getSchema());
+    for (PartitionsTable.Partition partition : PartitionsTable.partitions(table, scan)) {
+      partitionSchemas.add(partition.partitionData().getSchema());
     }
 
-    assertThat(partitionSchemas).hasSize(4);
+    assertThat(partitionSchemas).hasSizeGreaterThanOrEqualTo(2);
     org.apache.avro.Schema expectedSchema = partitionSchemas.get(0);
     assertThat(partitionSchemas).allSatisfy(schema -> assertThat(schema).isSameAs(expectedSchema));
   }


### PR DESCRIPTION
<img width="2830" height="1180" alt="image" src="https://github.com/user-attachments/assets/ca838875-516f-415d-a610-b19dadd2620a" />

## What is changed

  This change avoids rebuilding the same `PartitionData` Avro schema for every partition row when scanning the `partitions` metadata table.

  Instead of creating a fresh `PartitionData(partitionType)` for each partition value, `PartitionsTable` now creates one `PartitionData` template per scan and reuses it through `copyFor(key)`.

  A regression test is also added to verify that partition rows produced within the same scan reuse the same underlying Avro schema instance.

  ## Why


  `PartitionsTable` currently constructs partition rows like this:

  - create `PartitionData(partitionType)`
  - convert partition type to Avro schema
  - copy the partition key into the new object

  When a table has many partition values, this repeats the same schema conversion over and over again, creating heavy allocation pressure in:

  - `PartitionData.partitionDataSchema`
  - `AvroSchemaUtil.convert`
  - `TypeToSchema$WithTypeToName.struct`

  This is especially visible for wide partition specs and large metadata table scans.


### External reproduction

  Used a standalone repro app that scans the Iceberg `partitions` metadata table for a table with:

  - 20,000 partition values
  - 4 partition columns
  - repeated full partitionsTable scans
```
         try (CloseableIterable<FileScanTask> tasks = partitionsTable.newScan().planFiles()) {
                for (FileScanTask task : tasks) {
                    try (CloseableIterable<StructLike> rows = task.asDataTask().rows()) {
                        for (StructLike row : rows) {
                            StructProjection partitionData = row.get(0, StructProjection.class);
                            if (partitionData == null) {
                                throw new IllegalStateException("Partition row returned null partition data");
                            }
                            partitionRows++;
                        }
                    }
                }
            }
```

#### Before fix (origin/main)

  - Average wall clock time: 12.71s
  - Average max RSS: 5,938,604 KB (~5.66 GiB)

  #### After fix

  - Average wall clock time: 5.24s
  - Average max RSS: 1,483,155 KB (~1.41 GiB)
<img width="2820" height="1390" alt="image" src="https://github.com/user-attachments/assets/d7cd1dca-9067-46bb-af49-677df81a739e" />

  #### Improvement

  - Wall clock time reduced by 58.8%
  - Max RSS reduced by 75.0%