### PR TITLE
Flink: Backport: Dynamic sink options to be configurable in SQL

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
@@ -44,7 +44,7 @@ public class FlinkConfParser {
     this.readableConfig = readableConfig;
   }
 
-  FlinkConfParser(Map<String, String> options, ReadableConfig readableConfig) {
+  public FlinkConfParser(Map<String, String> options, ReadableConfig readableConfig) {
     this.tableProperties = ImmutableMap.of();
     this.options = options;
     this.readableConfig = readableConfig;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -237,12 +237,6 @@ public class DynamicIcebergSink
     private final Map<String, String> snapshotSummary = Maps.newHashMap();
     private ReadableConfig readableConfig = new Configuration();
     private TableCreator tableCreator = TableCreator.DEFAULT;
-    private boolean immediateUpdate = false;
-    private boolean dropUnusedColumns = false;
-    private int cacheMaximumSize = 100;
-    private long cacheRefreshMs = 1_000;
-    private int inputSchemasPerTableCacheMaximumSize = 10;
-    private boolean caseSensitive = true;
 
     Builder() {}
 
@@ -363,7 +357,9 @@ public class DynamicIcebergSink
     }
 
     public Builder<T> immediateTableUpdate(boolean newImmediateUpdate) {
-      this.immediateUpdate = newImmediateUpdate;
+      writeOptions.put(
+          FlinkDynamicSinkOptions.IMMEDIATE_TABLE_UPDATE.key(),
+          Boolean.toString(newImmediateUpdate));
       return this;
     }
 
@@ -379,19 +375,21 @@ public class DynamicIcebergSink
      * will never return data of the old column.
      */
     public Builder<T> dropUnusedColumns(boolean newDropUnusedColumns) {
-      this.dropUnusedColumns = newDropUnusedColumns;
+      writeOptions.put(
+          FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS.key(),
+          Boolean.toString(newDropUnusedColumns));
       return this;
     }
 
     /** Maximum size of the caches used in Dynamic Sink for table data and serializers. */
     public Builder<T> cacheMaxSize(int maxSize) {
-      this.cacheMaximumSize = maxSize;
+      writeOptions.put(FlinkDynamicSinkOptions.CACHE_MAX_SIZE.key(), Integer.toString(maxSize));
       return this;
     }
 
     /** Maximum interval for cache items renewals. */
     public Builder<T> cacheRefreshMs(long refreshMs) {
-      this.cacheRefreshMs = refreshMs;
+      writeOptions.put(FlinkDynamicSinkOptions.CACHE_REFRESH_MS.key(), Long.toString(refreshMs));
       return this;
     }
 
@@ -401,7 +399,9 @@ public class DynamicIcebergSink
      * comparison results.
      */
     public Builder<T> inputSchemasPerTableCacheMaxSize(int inputSchemasPerTableCacheMaxSize) {
-      this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaxSize;
+      writeOptions.put(
+          FlinkDynamicSinkOptions.INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE.key(),
+          Integer.toString(inputSchemasPerTableCacheMaxSize));
       return this;
     }
 
@@ -410,7 +410,8 @@ public class DynamicIcebergSink
      * field names case-sensitive.
      */
     public Builder<T> caseSensitive(boolean newCaseSensitive) {
-      this.caseSensitive = newCaseSensitive;
+      writeOptions.put(
+          FlinkDynamicSinkOptions.CASE_SENSITIVE.key(), Boolean.toString(newCaseSensitive));
       return this;
     }
 
@@ -426,14 +427,14 @@ public class DynamicIcebergSink
           generator != null, "Please use withGenerator() to convert the input DataStream.");
       Preconditions.checkNotNull(catalogLoader, "Catalog loader shouldn't be null");
 
-      Configuration flinkConfig =
-          readableConfig instanceof Configuration
-              ? (Configuration) readableConfig
-              : Configuration.fromMap(readableConfig.toMap());
+      Configuration flinkConfig = fromReadableConfig();
+      FlinkDynamicSinkConf flinkDynamicSinkConf =
+          new FlinkDynamicSinkConf(writeOptions, flinkConfig);
 
       // Forward writer: chained with generator via forward edge, no data shuffle
       ForwardWriterSink forwardWriterSink =
-          new ForwardWriterSink(catalogLoader, writeOptions, flinkConfig, cacheMaximumSize);
+          new ForwardWriterSink(
+              catalogLoader, writeOptions, flinkConfig, flinkDynamicSinkConf.cacheMaxSize());
       TypeInformation<CommittableMessage<DynamicWriteResult>> writeResultTypeInfo =
           CommittableMessageTypeInfo.of(DynamicWriteResultSerializer::new);
 
@@ -457,13 +458,15 @@ public class DynamicIcebergSink
         Map<String, String> writeProperties,
         Configuration flinkWriteConf,
         DataStream<CommittableMessage<DynamicWriteResult>> forwardWriteResults) {
+      FlinkDynamicSinkConf flinkDynamicSinkConf =
+          new FlinkDynamicSinkConf(writeProperties, flinkWriteConf);
       return new DynamicIcebergSink(
           catalogLoader,
           snapshotSummary,
           uidPrefix,
           writeProperties,
           flinkWriteConf,
-          cacheMaximumSize,
+          flinkDynamicSinkConf.cacheMaxSize(),
           forwardWriteResults);
     }
 
@@ -487,10 +490,14 @@ public class DynamicIcebergSink
     public DataStreamSink<DynamicRecordInternal> append() {
       uidPrefix = Optional.ofNullable(uidPrefix).orElse("");
 
+      FlinkDynamicSinkConf flinkDynamicSinkConf =
+          new FlinkDynamicSinkConf(writeOptions, readableConfig);
+      Configuration flinkConfig = fromReadableConfig();
+
       DynamicRecordInternalType type =
-          new DynamicRecordInternalType(catalogLoader, false, cacheMaximumSize);
+          new DynamicRecordInternalType(catalogLoader, false, flinkDynamicSinkConf.cacheMaxSize());
       DynamicRecordInternalType sideOutputType =
-          new DynamicRecordInternalType(catalogLoader, true, cacheMaximumSize);
+          new DynamicRecordInternalType(catalogLoader, true, flinkDynamicSinkConf.cacheMaxSize());
 
       SingleOutputStreamOperator<DynamicRecordInternal> converted =
           input
@@ -498,13 +505,10 @@ public class DynamicIcebergSink
                   new DynamicRecordProcessor<>(
                       generator,
                       catalogLoader,
-                      immediateUpdate,
-                      cacheMaximumSize,
-                      cacheRefreshMs,
-                      inputSchemasPerTableCacheMaximumSize,
                       tableCreator,
-                      caseSensitive,
-                      dropUnusedColumns))
+                      flinkDynamicSinkConf,
+                      writeOptions,
+                      flinkConfig))
               .setParallelism(input.getParallelism())
               .uid(prefixIfNotNull(uidPrefix, "-generator"))
               .name(operatorName("generator"))
@@ -520,14 +524,7 @@ public class DynamicIcebergSink
                       DynamicRecordProcessor.DYNAMIC_TABLE_UPDATE_STREAM, sideOutputType))
               .keyBy((KeySelector<DynamicRecordInternal, String>) DynamicRecordInternal::tableName)
               .map(
-                  new DynamicTableUpdateOperator(
-                      catalogLoader,
-                      cacheMaximumSize,
-                      cacheRefreshMs,
-                      inputSchemasPerTableCacheMaximumSize,
-                      tableCreator,
-                      caseSensitive,
-                      dropUnusedColumns))
+                  new DynamicTableUpdateOperator(catalogLoader, tableCreator, flinkDynamicSinkConf))
               .uid(prefixIfNotNull(uidPrefix, "-updater"))
               .name(operatorName("Updater"))
               .returns(type)
@@ -544,6 +541,12 @@ public class DynamicIcebergSink
       }
 
       return result;
+    }
+
+    private Configuration fromReadableConfig() {
+      return readableConfig instanceof Configuration
+          ? (Configuration) readableConfig
+          : Configuration.fromMap(readableConfig.toMap());
     }
   }
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.PartitionSpec;
@@ -38,6 +39,9 @@ public class DynamicRecord {
   private int writeParallelism;
   private boolean upsertMode;
   @Nullable private Set<String> equalityFields;
+
+  @Internal
+  DynamicRecord() {}
 
   /**
    * Constructs a new DynamicRecord with forward (no shuffle) writes.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
+import java.util.Map;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Collector;
@@ -30,6 +32,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.flink.CatalogLoader;
+import org.apache.iceberg.flink.FlinkWriteConf;
 
 @Internal
 class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal>
@@ -41,6 +44,8 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
 
   private final DynamicRecordGenerator<T> generator;
   private final CatalogLoader catalogLoader;
+  private final Map<String, String> writeProperties;
+  private final Configuration flinkConfig;
   private final boolean immediateUpdate;
   private final boolean dropUnusedColumns;
   private final int cacheMaximumSize;
@@ -55,27 +60,27 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
   private transient OutputTag<DynamicRecordInternal> updateStream;
   private transient OutputTag<DynamicRecordInternal> forwardStream;
   private transient Collector<DynamicRecordInternal> collector;
+  private transient DynamicRecordWithConfig dynamicRecordWithConfig;
   private transient Context context;
 
   DynamicRecordProcessor(
       DynamicRecordGenerator<T> generator,
       CatalogLoader catalogLoader,
-      boolean immediateUpdate,
-      int cacheMaximumSize,
-      long cacheRefreshMs,
-      int inputSchemasPerTableCacheMaximumSize,
       TableCreator tableCreator,
-      boolean caseSensitive,
-      boolean dropUnusedColumns) {
+      FlinkDynamicSinkConf sinkConfig,
+      Map<String, String> writeProperties,
+      Configuration flinkConfig) {
     this.generator = generator;
     this.catalogLoader = catalogLoader;
-    this.immediateUpdate = immediateUpdate;
-    this.cacheMaximumSize = cacheMaximumSize;
-    this.cacheRefreshMs = cacheRefreshMs;
-    this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
+    this.flinkConfig = flinkConfig;
+    this.writeProperties = writeProperties;
+    this.immediateUpdate = sinkConfig.immediateTableUpdate();
+    this.cacheMaximumSize = sinkConfig.cacheMaxSize();
+    this.cacheRefreshMs = sinkConfig.cacheRefreshMs();
+    this.inputSchemasPerTableCacheMaximumSize = sinkConfig.inputSchemasPerTableCacheMaxSize();
     this.tableCreator = tableCreator;
-    this.caseSensitive = caseSensitive;
-    this.dropUnusedColumns = dropUnusedColumns;
+    this.caseSensitive = sinkConfig.caseSensitive();
+    this.dropUnusedColumns = sinkConfig.dropUnusedColumns();
   }
 
   @Override
@@ -107,6 +112,8 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
               new DynamicRecordInternalType(catalogLoader, true, cacheMaximumSize)) {};
     }
 
+    this.dynamicRecordWithConfig =
+        new DynamicRecordWithConfig(new FlinkWriteConf(writeProperties, flinkConfig));
     generator.open(openContext);
   }
 
@@ -119,9 +126,10 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
   }
 
   @Override
-  public void collect(DynamicRecord data) {
-    boolean isForward = data.distributionMode() == null;
+  public void collect(DynamicRecord inputData) {
+    DynamicRecordWithConfig data = dynamicRecordWithConfig.wrap(inputData);
 
+    boolean isForward = data.distributionMode() == null;
     boolean exists = tableCache.exists(data.tableIdentifier()).f0;
     String foundBranch = exists ? tableCache.branch(data.tableIdentifier(), data.branch()) : null;
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordWithConfig.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordWithConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.Set;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.FlinkWriteConf;
+
+class DynamicRecordWithConfig extends DynamicRecord {
+  private final String defaultBranch;
+  private final Integer defaultWriteParallelism;
+
+  private DynamicRecord wrapped;
+
+  DynamicRecordWithConfig(FlinkWriteConf flinkWriteConf) {
+    this.defaultBranch = flinkWriteConf.branch();
+    this.defaultWriteParallelism = flinkWriteConf.writeParallelism();
+  }
+
+  DynamicRecordWithConfig wrap(DynamicRecord newWrapped) {
+    this.wrapped = newWrapped;
+    return this;
+  }
+
+  @Override
+  public String branch() {
+    return wrapped.branch() != null ? wrapped.branch() : defaultBranch;
+  }
+
+  @Override
+  public DistributionMode distributionMode() {
+    return wrapped.distributionMode();
+  }
+
+  @Override
+  public int writeParallelism() {
+    int originalParallelism = wrapped.writeParallelism();
+    if (originalParallelism > 0 || defaultWriteParallelism == null) {
+      return originalParallelism;
+    }
+
+    return defaultWriteParallelism;
+  }
+
+  @Override
+  public TableIdentifier tableIdentifier() {
+    return wrapped.tableIdentifier();
+  }
+
+  @Override
+  public Schema schema() {
+    return wrapped.schema();
+  }
+
+  @Override
+  public PartitionSpec spec() {
+    return wrapped.spec();
+  }
+
+  @Override
+  public RowData rowData() {
+    return wrapped.rowData();
+  }
+
+  @Override
+  public boolean upsertMode() {
+    return wrapped.upsertMode();
+  }
+
+  @Override
+  public Set<String> equalityFields() {
+    return wrapped.equalityFields();
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
@@ -48,20 +48,15 @@ class DynamicTableUpdateOperator
   private transient TableUpdater updater;
 
   DynamicTableUpdateOperator(
-      CatalogLoader catalogLoader,
-      int cacheMaximumSize,
-      long cacheRefreshMs,
-      int inputSchemasPerTableCacheMaximumSize,
-      TableCreator tableCreator,
-      boolean caseSensitive,
-      boolean dropUnusedColumns) {
+      CatalogLoader catalogLoader, TableCreator tableCreator, FlinkDynamicSinkConf configuration) {
     this.catalogLoader = catalogLoader;
-    this.cacheMaximumSize = cacheMaximumSize;
-    this.cacheRefreshMs = cacheRefreshMs;
-    this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
     this.tableCreator = tableCreator;
-    this.caseSensitive = caseSensitive;
-    this.dropUnusedColumns = dropUnusedColumns;
+
+    this.cacheMaximumSize = configuration.cacheMaxSize();
+    this.cacheRefreshMs = configuration.cacheRefreshMs();
+    this.inputSchemasPerTableCacheMaximumSize = configuration.inputSchemasPerTableCacheMaxSize();
+    this.caseSensitive = configuration.caseSensitive();
+    this.dropUnusedColumns = configuration.dropUnusedColumns();
   }
 
   @Override

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkConf.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkConf.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.Map;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.iceberg.flink.FlinkConfParser;
+
+/**
+ * A class for common Dynamic Iceberg sink configs for Flink writes.
+ *
+ * <p>If a config is set at multiple levels, the following order of precedence is used (top to
+ * bottom):
+ *
+ * <ol>
+ *   <li>Write options
+ *   <li>Flink ReadableConfig
+ *   <li>Default values
+ * </ol>
+ *
+ * The most specific value is set in write options and takes precedence over all other configs. If
+ * no write option is provided, this class checks the flink configuration for any overrides. If no
+ * applicable value is found in the write options, this class uses the default values.
+ */
+class FlinkDynamicSinkConf {
+
+  private final FlinkConfParser confParser;
+
+  FlinkDynamicSinkConf(Map<String, String> writeOptions, ReadableConfig readableConfig) {
+    this.confParser = new FlinkConfParser(writeOptions, readableConfig);
+  }
+
+  int cacheMaxSize() {
+    return confParser
+        .intConf()
+        .option(FlinkDynamicSinkOptions.CACHE_MAX_SIZE.key())
+        .flinkConfig(FlinkDynamicSinkOptions.CACHE_MAX_SIZE)
+        .defaultValue(FlinkDynamicSinkOptions.CACHE_MAX_SIZE.defaultValue())
+        .parse();
+  }
+
+  boolean immediateTableUpdate() {
+    return confParser
+        .booleanConf()
+        .option(FlinkDynamicSinkOptions.IMMEDIATE_TABLE_UPDATE.key())
+        .flinkConfig(FlinkDynamicSinkOptions.IMMEDIATE_TABLE_UPDATE)
+        .defaultValue(FlinkDynamicSinkOptions.IMMEDIATE_TABLE_UPDATE.defaultValue())
+        .parse();
+  }
+
+  boolean dropUnusedColumns() {
+    return confParser
+        .booleanConf()
+        .option(FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS.key())
+        .flinkConfig(FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS)
+        .defaultValue(FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS.defaultValue())
+        .parse();
+  }
+
+  long cacheRefreshMs() {
+    return confParser
+        .longConf()
+        .option(FlinkDynamicSinkOptions.CACHE_REFRESH_MS.key())
+        .flinkConfig(FlinkDynamicSinkOptions.CACHE_REFRESH_MS)
+        .defaultValue(FlinkDynamicSinkOptions.CACHE_REFRESH_MS.defaultValue())
+        .parse();
+  }
+
+  int inputSchemasPerTableCacheMaxSize() {
+    return confParser
+        .intConf()
+        .option(FlinkDynamicSinkOptions.INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE.key())
+        .flinkConfig(FlinkDynamicSinkOptions.INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE)
+        .defaultValue(FlinkDynamicSinkOptions.INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE.defaultValue())
+        .parse();
+  }
+
+  boolean caseSensitive() {
+    return confParser
+        .booleanConf()
+        .option(FlinkDynamicSinkOptions.CASE_SENSITIVE.key())
+        .flinkConfig(FlinkDynamicSinkOptions.CASE_SENSITIVE)
+        .defaultValue(FlinkDynamicSinkOptions.CASE_SENSITIVE.defaultValue())
+        .parse();
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkOptions.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkOptions.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+@Experimental
+public class FlinkDynamicSinkOptions {
+
+  private FlinkDynamicSinkOptions() {}
+
+  public static final ConfigOption<Integer> CACHE_MAX_SIZE =
+      ConfigOptions.key("dynamic-sink.cache-max-size")
+          .intType()
+          .defaultValue(100)
+          .withDescription(
+              "Maximum size of the caches used in Dynamic Sink for table data and serializers.");
+
+  public static final ConfigOption<Boolean> IMMEDIATE_TABLE_UPDATE =
+      ConfigOptions.key("dynamic-sink.immediate-table-update")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription(
+              "Controls whether table schema and partition updates should be applied immediately in Dynamic Sink.");
+
+  public static final ConfigOption<Boolean> DROP_UNUSED_COLUMNS =
+      ConfigOptions.key("dynamic-sink.drop-unused-columns")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription(
+              "Allows dropping unused columns during schema evolution in Dynamic Sink.");
+
+  public static final ConfigOption<Long> CACHE_REFRESH_MS =
+      ConfigOptions.key("dynamic-sink.cache-refresh-ms")
+          .longType()
+          .defaultValue(1_000L)
+          .withDescription(
+              "Cache refresh interval for dynamic table metadata in Dynamic Sink in milliseconds.");
+
+  public static final ConfigOption<Integer> INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE =
+      ConfigOptions.key("dynamic-sink.input-schemas-per-table-cache-max-size")
+          .intType()
+          .defaultValue(10)
+          .withDescription(
+              "Maximum input schema objects to cache per each table in Dynamic Sink for performance.");
+
+  public static final ConfigOption<Boolean> CASE_SENSITIVE =
+      ConfigOptions.key("dynamic-sink.case-sensitive")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription(
+              "Controls whether schema field name matching should be case-sensitive in Dynamic Sink.");
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -88,7 +88,7 @@ class HashKeyGenerator {
             dynamicRecord.schema(),
             dynamicRecord.spec(),
             dynamicRecord.equalityFields(),
-            MoreObjects.firstNonNull(dynamicRecord.distributionMode(), DistributionMode.NONE),
+            dynamicRecord.distributionMode(),
             Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism));
     KeySelector<RowData, Integer> keySelector =
         keySelectorCache.computeIfAbsent(
@@ -98,8 +98,7 @@ class HashKeyGenerator {
                     tableIdent,
                     MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema()),
                     MoreObjects.firstNonNull(tableSpec, dynamicRecord.spec()),
-                    MoreObjects.firstNonNull(
-                        dynamicRecord.distributionMode(), DistributionMode.NONE),
+                    dynamicRecord.distributionMode(),
                     MoreObjects.firstNonNull(
                         dynamicRecord.equalityFields(), Collections.emptySet()),
                     Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism)));

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -77,6 +77,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
 import org.apache.iceberg.flink.MiniFlinkClusterExtension;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TestHelpers;
@@ -85,6 +86,7 @@ import org.apache.iceberg.flink.sink.dynamic.TestDynamicCommitter.CommitHook;
 import org.apache.iceberg.flink.sink.dynamic.TestDynamicCommitter.FailBeforeAndAfterCommit;
 import org.apache.iceberg.inmemory.InMemoryInputFile;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -121,6 +123,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     PartitionSpec partitionSpec;
     boolean upsertMode;
     Set<String> equalityFields;
+    int writeParallelism;
 
     private DynamicIcebergDataImpl(
         Schema schemaProvided, String tableName, String branch, PartitionSpec partitionSpec) {
@@ -132,7 +135,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           partitionSpec,
           false,
           Collections.emptySet(),
-          false);
+          false,
+          10);
     }
 
     private DynamicIcebergDataImpl(
@@ -149,7 +153,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           partitionSpec,
           false,
           Collections.emptySet(),
-          false);
+          false,
+          10);
     }
 
     private DynamicIcebergDataImpl(
@@ -168,7 +173,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           partitionSpec,
           upsertMode,
           equalityFields,
-          isDuplicate);
+          isDuplicate,
+          10);
     }
 
     private DynamicIcebergDataImpl(
@@ -179,7 +185,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
         PartitionSpec partitionSpec,
         boolean upsertMode,
         Set<String> equalityFields,
-        boolean isDuplicate) {
+        boolean isDuplicate,
+        int writeParallelism) {
       this.rowProvided = randomRow(schemaProvided, isDuplicate ? seed : ++seed);
       this.rowExpected = isDuplicate ? null : rowProvided;
       this.schemaProvided = schemaProvided;
@@ -189,6 +196,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
       this.partitionSpec = partitionSpec;
       this.upsertMode = upsertMode;
       this.equalityFields = equalityFields;
+      this.writeParallelism = writeParallelism;
     }
   }
 
@@ -208,7 +216,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
               converter(schema).toInternal(row.rowProvided),
               spec,
               spec.isPartitioned() ? DistributionMode.HASH : DistributionMode.NONE,
-              10);
+              row.writeParallelism);
       dynamicRecord.setUpsertMode(row.upsertMode);
       dynamicRecord.setEqualityFields(row.equalityFields);
       out.collect(dynamicRecord);
@@ -367,6 +375,19 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     env.execute();
 
     verifyResults(rows);
+  }
+
+  @Test
+  void testWriteWithNullBranch() throws Exception {
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA, "t1", null, PartitionSpec.unpartitioned()),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA, "t1", null, PartitionSpec.unpartitioned()));
+
+    runTest(
+        rows, this.env, false, 1, ImmutableMap.of(FlinkWriteOptions.BRANCH.key(), "test-branch"));
   }
 
   @Test
@@ -1357,6 +1378,35 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     assertThat(generatorParallelism).isEqualTo(source.getParallelism());
   }
 
+  @Test
+  void testFallBackParallelismFromConfig() throws Exception {
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                SnapshotRef.MAIN_BRANCH,
+                PartitionSpec.unpartitioned(),
+                false,
+                Collections.emptySet(),
+                false,
+                -1),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                SnapshotRef.MAIN_BRANCH,
+                PartitionSpec.unpartitioned(),
+                false,
+                Collections.emptySet(),
+                false,
+                0));
+
+    runTest(
+        rows, this.env, true, 2, ImmutableMap.of(FlinkWriteOptions.WRITE_PARALLELISM.key(), "1"));
+  }
+
   private Set<String> createSinkAndReturnUIds(String uidPrefix) {
     StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 
@@ -1465,6 +1515,18 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     verifyResults(dynamicData);
   }
 
+  private void runTest(
+      List<DynamicIcebergDataImpl> dynamicData,
+      StreamExecutionEnvironment env,
+      boolean immediateUpdate,
+      int parallelism,
+      Map<String, String> writeProperties)
+      throws Exception {
+    executeDynamicSink(
+        dynamicData, env, immediateUpdate, parallelism, null, false, writeProperties);
+    verifyResults(dynamicData, writeProperties);
+  }
+
   private void executeDynamicSink(
       List<DynamicIcebergDataImpl> dynamicData,
       StreamExecutionEnvironment env,
@@ -1472,7 +1534,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
       int parallelism,
       @Nullable CommitHook commitHook)
       throws Exception {
-    executeDynamicSink(dynamicData, env, immediateUpdate, parallelism, commitHook, false);
+    executeDynamicSink(
+        dynamicData, env, immediateUpdate, parallelism, commitHook, false, Maps.newHashMap());
   }
 
   private void executeDynamicSink(
@@ -1482,6 +1545,19 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
       int parallelism,
       @Nullable CommitHook commitHook,
       boolean overwrite)
+      throws Exception {
+    executeDynamicSink(
+        dynamicData, env, immediateUpdate, parallelism, commitHook, overwrite, Maps.newHashMap());
+  }
+
+  private void executeDynamicSink(
+      List<DynamicIcebergDataImpl> dynamicData,
+      StreamExecutionEnvironment env,
+      boolean immediateUpdate,
+      int parallelism,
+      @Nullable CommitHook commitHook,
+      boolean overwrite,
+      Map<String, String> writeProperties)
       throws Exception {
     DataStream<DynamicIcebergDataImpl> dataStream =
         env.fromData(dynamicData, TypeInformation.of(new TypeHint<>() {}));
@@ -1496,6 +1572,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           .immediateTableUpdate(immediateUpdate)
           .setSnapshotProperty("commit.retry.num-retries", "0")
           .overwrite(overwrite)
+          .setAll(writeProperties)
           .append();
     } else {
       DynamicIcebergSink.forInput(dataStream)
@@ -1504,6 +1581,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           .writeParallelism(parallelism)
           .immediateTableUpdate(immediateUpdate)
           .overwrite(overwrite)
+          .setAll(writeProperties)
           .append();
     }
 
@@ -1530,7 +1608,6 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           "uidPrefix",
           writeProperties,
           flinkConfig,
-          100,
           forwardWriteResults);
     }
   }
@@ -1547,7 +1624,6 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
         String uidPrefix,
         Map<String, String> writeProperties,
         Configuration flinkConfig,
-        int cacheMaximumSize,
         DataStream<CommittableMessage<DynamicWriteResult>> forwardWritten) {
       super(
           catalogLoader,
@@ -1555,7 +1631,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           uidPrefix,
           writeProperties,
           flinkConfig,
-          cacheMaximumSize,
+          100,
           forwardWritten);
       this.commitHook = commitHook;
       this.overwriteMode = new FlinkWriteConf(writeProperties, flinkConfig).overwriteMode();
@@ -1575,6 +1651,12 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
   }
 
   private void verifyResults(List<DynamicIcebergDataImpl> dynamicData) throws IOException {
+    verifyResults(dynamicData, Maps.newHashMap());
+  }
+
+  private void verifyResults(
+      List<DynamicIcebergDataImpl> dynamicData, Map<String, String> writeProperties)
+      throws IOException {
     // Calculate the expected result
     Map<Tuple2<String, String>, List<RowData>> expectedData = Maps.newHashMap();
     Map<String, Schema> expectedSchema = Maps.newHashMap();
@@ -1588,9 +1670,12 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
 
     dynamicData.forEach(
         r -> {
+          String branch =
+              MoreObjects.firstNonNull(
+                  r.branch, writeProperties.get(FlinkWriteOptions.BRANCH.key()));
           List<RowData> data =
               expectedData.computeIfAbsent(
-                  Tuple2.of(r.tableName, r.branch), unused -> Lists.newArrayList());
+                  Tuple2.of(r.tableName, branch), unused -> Lists.newArrayList());
           data.addAll(
               convertToRowData(expectedSchema.get(r.tableName), ImmutableList.of(r.rowExpected)));
         });

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicRecordWithConfig.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicRecordWithConfig.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Set;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestDynamicRecordWithConfig {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.required(2, "data", Types.StringType.get()));
+
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of("db", "table");
+  private static final PartitionSpec UNPARTITIONED = PartitionSpec.unpartitioned();
+  private static final RowData ROW_DATA = GenericRowData.of(1, StringData.fromString("test"));
+
+  @Test
+  void testBranchFallBack() {
+    String defaultBranch = "default-branch";
+    FlinkWriteConf conf =
+        new FlinkWriteConf(
+            ImmutableMap.of(FlinkWriteOptions.BRANCH.key(), defaultBranch), new Configuration());
+    DynamicRecordWithConfig dynamicRecordWithConfig = new DynamicRecordWithConfig(conf);
+
+    DynamicRecord dynamicRecord =
+        new DynamicRecord(TABLE_IDENTIFIER, null, SCHEMA, ROW_DATA, UNPARTITIONED);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).branch()).isEqualTo(defaultBranch);
+
+    String customBranch = "custom-branch";
+    dynamicRecord.setBranch(customBranch);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).branch()).isEqualTo(customBranch);
+  }
+
+  @Test
+  void testWriteParallelismFallBack() {
+    int defaultParallelism = 4;
+    FlinkWriteConf conf =
+        new FlinkWriteConf(
+            ImmutableMap.of(
+                FlinkWriteOptions.WRITE_PARALLELISM.key(), String.valueOf(defaultParallelism)),
+            new Configuration());
+    DynamicRecordWithConfig dynamicRecordWithConfig = new DynamicRecordWithConfig(conf);
+
+    DynamicRecord dynamicRecord =
+        new DynamicRecord(TABLE_IDENTIFIER, null, SCHEMA, ROW_DATA, UNPARTITIONED, null, -1);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).writeParallelism())
+        .isEqualTo(defaultParallelism);
+
+    dynamicRecord.writeParallelism(0);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).writeParallelism())
+        .isEqualTo(defaultParallelism);
+
+    dynamicRecord.writeParallelism(8);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).writeParallelism()).isEqualTo(8);
+  }
+
+  @Test
+  void testDelegatesToWrappedRecord() {
+    FlinkWriteConf conf = new FlinkWriteConf(Collections.emptyMap(), new Configuration());
+    PartitionSpec partitioned = PartitionSpec.builderFor(SCHEMA).identity("id").build();
+    Set<String> equalityFields = ImmutableSet.of("id", "data");
+
+    DynamicRecord dynamicRecord =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            SnapshotRef.MAIN_BRANCH,
+            SCHEMA,
+            ROW_DATA,
+            partitioned,
+            DistributionMode.HASH,
+            2);
+    dynamicRecord.setUpsertMode(true);
+    dynamicRecord.setEqualityFields(equalityFields);
+
+    DynamicRecordWithConfig record = new DynamicRecordWithConfig(conf).wrap(dynamicRecord);
+
+    assertThat(record.tableIdentifier()).isEqualTo(TABLE_IDENTIFIER);
+    assertThat(record.schema()).isEqualTo(SCHEMA);
+    assertThat(record.spec()).isEqualTo(partitioned);
+    assertThat(record.rowData()).isSameAs(ROW_DATA);
+    assertThat(record.distributionMode()).isEqualTo(DistributionMode.HASH);
+    assertThat(record.upsertMode()).isTrue();
+    assertThat(record.equalityFields()).isEqualTo(equalityFields);
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -58,9 +59,6 @@ class TestDynamicTableUpdateOperator {
 
   @Test
   void testDynamicTableUpdateOperatorNewTable() throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
@@ -68,12 +66,8 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            CASE_SENSITIVE,
-            PRESERVE_COLUMNS);
+            flinkDynamicSinkConfiguration(CASE_SENSITIVE, PRESERVE_COLUMNS));
     operator.open((OpenContext) null);
 
     DynamicRecordInternal input =
@@ -94,21 +88,14 @@ class TestDynamicTableUpdateOperator {
 
   @Test
   void testDynamicTableUpdateOperatorSchemaChange() throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            CASE_SENSITIVE,
-            PRESERVE_COLUMNS);
+            flinkDynamicSinkConfiguration(CASE_SENSITIVE, PRESERVE_COLUMNS));
     operator.open((OpenContext) null);
 
     catalog.createTable(table, SCHEMA1);
@@ -136,9 +123,6 @@ class TestDynamicTableUpdateOperator {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testCaseInSensitivity(boolean caseSensitive) throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
@@ -149,12 +133,8 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            caseSensitive,
-            PRESERVE_COLUMNS);
+            flinkDynamicSinkConfiguration(caseSensitive, PRESERVE_COLUMNS));
     operator.open((OpenContext) null);
 
     catalog.createTable(table, initialSchema);
@@ -188,21 +168,14 @@ class TestDynamicTableUpdateOperator {
 
   @Test
   void testDynamicTableUpdateOperatorPreserveUnusedColumns() throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            CASE_SENSITIVE,
-            PRESERVE_COLUMNS);
+            flinkDynamicSinkConfiguration(CASE_SENSITIVE, PRESERVE_COLUMNS));
     operator.open((OpenContext) null);
 
     catalog.createTable(table, SCHEMA2);
@@ -229,21 +202,14 @@ class TestDynamicTableUpdateOperator {
 
   @Test
   void testDynamicTableUpdateOperatorDropUnusedColumns() throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            CASE_INSENSITIVE,
-            DROP_COLUMNS);
+            flinkDynamicSinkConfiguration(CASE_INSENSITIVE, DROP_COLUMNS));
     operator.open((OpenContext) null);
 
     catalog.createTable(table, SCHEMA2);
@@ -265,5 +231,14 @@ class TestDynamicTableUpdateOperator {
     assertThat(tableSchema.findField("id")).isNotNull();
     assertThat(tableSchema.findField("data")).isNull();
     assertThat(input).isEqualTo(output);
+  }
+
+  private static FlinkDynamicSinkConf flinkDynamicSinkConfiguration(
+      boolean caseSensitive, boolean dropUnusedColumns) {
+    return new FlinkDynamicSinkConf(
+        ImmutableMap.of(
+            FlinkDynamicSinkOptions.CASE_SENSITIVE.key(), String.valueOf(caseSensitive),
+            FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS.key(), String.valueOf(dropUnusedColumns)),
+        new Configuration());
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -34,6 +35,9 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -227,6 +231,38 @@ class TestHashKeyGenerator {
               Collections.emptySet(),
               GenericRowData.of());
         });
+  }
+
+  @Test
+  void testNonPositiveWriteParallelismConfigFallback() throws Exception {
+    int maxWriteParallelism = 5;
+    HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+    FlinkWriteConf flinkWriteConf =
+        new FlinkWriteConf(
+            ImmutableMap.of(FlinkWriteOptions.WRITE_PARALLELISM.key(), "2"), new Configuration());
+
+    Set<Integer> writeKeys = Sets.newHashSet();
+    for (int i = 0; i < 20; i++) {
+      GenericRowData row = GenericRowData.of(i, StringData.fromString("z"));
+      writeKeys.add(
+          getWriteKey(
+              generator,
+              unpartitioned,
+              DistributionMode.NONE,
+              i % 2 == 0 ? 0 : -1,
+              Collections.emptySet(),
+              row,
+              flinkWriteConf));
+    }
+
+    assertThat(writeKeys).hasSize(2);
+    assertThat(
+            writeKeys.stream()
+                .map(key -> getSubTaskId(key, 2, maxWriteParallelism))
+                .distinct()
+                .count())
+        .isEqualTo(2);
   }
 
   @Test
@@ -477,10 +513,31 @@ class TestHashKeyGenerator {
       Set<String> equalityFields,
       GenericRowData row)
       throws Exception {
-    DynamicRecord record =
+    return getWriteKey(
+        generator,
+        spec,
+        mode,
+        writeParallelism,
+        equalityFields,
+        row,
+        new FlinkWriteConf(Collections.emptyMap(), new Configuration()));
+  }
+
+  private static int getWriteKey(
+      HashKeyGenerator generator,
+      PartitionSpec spec,
+      DistributionMode mode,
+      int writeParallelism,
+      Set<String> equalityFields,
+      GenericRowData row,
+      FlinkWriteConf flinkWriteConf)
+      throws Exception {
+    DynamicRecord inputRecord =
         new DynamicRecord(TABLE_IDENTIFIER, BRANCH, SCHEMA, row, spec, mode, writeParallelism);
-    record.setEqualityFields(equalityFields);
-    return generator.generateKey(record);
+    inputRecord.setEqualityFields(equalityFields);
+
+    DynamicRecordWithConfig dynamicRecordWithConfig = new DynamicRecordWithConfig(flinkWriteConf);
+    return generator.generateKey(dynamicRecordWithConfig.wrap(inputRecord));
   }
 
   private static int getSubTaskId(int writeKey1, int writeParallelism, int maxWriteParallelism) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
@@ -44,7 +44,7 @@ public class FlinkConfParser {
     this.readableConfig = readableConfig;
   }
 
-  FlinkConfParser(Map<String, String> options, ReadableConfig readableConfig) {
+  public FlinkConfParser(Map<String, String> options, ReadableConfig readableConfig) {
     this.tableProperties = ImmutableMap.of();
     this.options = options;
     this.readableConfig = readableConfig;

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicIcebergSink.java
@@ -235,12 +235,6 @@ public class DynamicIcebergSink
     private final Map<String, String> snapshotSummary = Maps.newHashMap();
     private ReadableConfig readableConfig = new Configuration();
     private TableCreator tableCreator = TableCreator.DEFAULT;
-    private boolean immediateUpdate = false;
-    private boolean dropUnusedColumns = false;
-    private int cacheMaximumSize = 100;
-    private long cacheRefreshMs = 1_000;
-    private int inputSchemasPerTableCacheMaximumSize = 10;
-    private boolean caseSensitive = true;
 
     Builder() {}
 
@@ -361,7 +355,9 @@ public class DynamicIcebergSink
     }
 
     public Builder<T> immediateTableUpdate(boolean newImmediateUpdate) {
-      this.immediateUpdate = newImmediateUpdate;
+      writeOptions.put(
+          FlinkDynamicSinkOptions.IMMEDIATE_TABLE_UPDATE.key(),
+          Boolean.toString(newImmediateUpdate));
       return this;
     }
 
@@ -377,19 +373,21 @@ public class DynamicIcebergSink
      * will never return data of the old column.
      */
     public Builder<T> dropUnusedColumns(boolean newDropUnusedColumns) {
-      this.dropUnusedColumns = newDropUnusedColumns;
+      writeOptions.put(
+          FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS.key(),
+          Boolean.toString(newDropUnusedColumns));
       return this;
     }
 
     /** Maximum size of the caches used in Dynamic Sink for table data and serializers. */
     public Builder<T> cacheMaxSize(int maxSize) {
-      this.cacheMaximumSize = maxSize;
+      writeOptions.put(FlinkDynamicSinkOptions.CACHE_MAX_SIZE.key(), Integer.toString(maxSize));
       return this;
     }
 
     /** Maximum interval for cache items renewals. */
     public Builder<T> cacheRefreshMs(long refreshMs) {
-      this.cacheRefreshMs = refreshMs;
+      writeOptions.put(FlinkDynamicSinkOptions.CACHE_REFRESH_MS.key(), Long.toString(refreshMs));
       return this;
     }
 
@@ -399,7 +397,9 @@ public class DynamicIcebergSink
      * comparison results.
      */
     public Builder<T> inputSchemasPerTableCacheMaxSize(int inputSchemasPerTableCacheMaxSize) {
-      this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaxSize;
+      writeOptions.put(
+          FlinkDynamicSinkOptions.INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE.key(),
+          Integer.toString(inputSchemasPerTableCacheMaxSize));
       return this;
     }
 
@@ -408,7 +408,8 @@ public class DynamicIcebergSink
      * field names case-sensitive.
      */
     public Builder<T> caseSensitive(boolean newCaseSensitive) {
-      this.caseSensitive = newCaseSensitive;
+      writeOptions.put(
+          FlinkDynamicSinkOptions.CASE_SENSITIVE.key(), Boolean.toString(newCaseSensitive));
       return this;
     }
 
@@ -424,14 +425,14 @@ public class DynamicIcebergSink
           generator != null, "Please use withGenerator() to convert the input DataStream.");
       Preconditions.checkNotNull(catalogLoader, "Catalog loader shouldn't be null");
 
-      Configuration flinkConfig =
-          readableConfig instanceof Configuration
-              ? (Configuration) readableConfig
-              : Configuration.fromMap(readableConfig.toMap());
+      Configuration flinkConfig = fromReadableConfig();
+      FlinkDynamicSinkConf flinkDynamicSinkConf =
+          new FlinkDynamicSinkConf(writeOptions, flinkConfig);
 
       // Forward writer: chained with generator via forward edge, no data shuffle
       ForwardWriterSink forwardWriterSink =
-          new ForwardWriterSink(catalogLoader, writeOptions, flinkConfig, cacheMaximumSize);
+          new ForwardWriterSink(
+              catalogLoader, writeOptions, flinkConfig, flinkDynamicSinkConf.cacheMaxSize());
       TypeInformation<CommittableMessage<DynamicWriteResult>> writeResultTypeInfo =
           CommittableMessageTypeInfo.of(DynamicWriteResultSerializer::new);
 
@@ -455,13 +456,15 @@ public class DynamicIcebergSink
         Map<String, String> writeProperties,
         Configuration flinkWriteConf,
         DataStream<CommittableMessage<DynamicWriteResult>> forwardWriteResults) {
+      FlinkDynamicSinkConf flinkDynamicSinkConf =
+          new FlinkDynamicSinkConf(writeProperties, flinkWriteConf);
       return new DynamicIcebergSink(
           catalogLoader,
           snapshotSummary,
           uidPrefix,
           writeProperties,
           flinkWriteConf,
-          cacheMaximumSize,
+          flinkDynamicSinkConf.cacheMaxSize(),
           forwardWriteResults);
     }
 
@@ -485,10 +488,14 @@ public class DynamicIcebergSink
     public DataStreamSink<DynamicRecordInternal> append() {
       uidPrefix = Optional.ofNullable(uidPrefix).orElse("");
 
+      FlinkDynamicSinkConf flinkDynamicSinkConf =
+          new FlinkDynamicSinkConf(writeOptions, readableConfig);
+      Configuration flinkConfig = fromReadableConfig();
+
       DynamicRecordInternalType type =
-          new DynamicRecordInternalType(catalogLoader, false, cacheMaximumSize);
+          new DynamicRecordInternalType(catalogLoader, false, flinkDynamicSinkConf.cacheMaxSize());
       DynamicRecordInternalType sideOutputType =
-          new DynamicRecordInternalType(catalogLoader, true, cacheMaximumSize);
+          new DynamicRecordInternalType(catalogLoader, true, flinkDynamicSinkConf.cacheMaxSize());
 
       SingleOutputStreamOperator<DynamicRecordInternal> converted =
           input
@@ -496,13 +503,10 @@ public class DynamicIcebergSink
                   new DynamicRecordProcessor<>(
                       generator,
                       catalogLoader,
-                      immediateUpdate,
-                      cacheMaximumSize,
-                      cacheRefreshMs,
-                      inputSchemasPerTableCacheMaximumSize,
                       tableCreator,
-                      caseSensitive,
-                      dropUnusedColumns))
+                      flinkDynamicSinkConf,
+                      writeOptions,
+                      flinkConfig))
               .setParallelism(input.getParallelism())
               .uid(prefixIfNotNull(uidPrefix, "-generator"))
               .name(operatorName("generator"))
@@ -518,14 +522,7 @@ public class DynamicIcebergSink
                       DynamicRecordProcessor.DYNAMIC_TABLE_UPDATE_STREAM, sideOutputType))
               .keyBy((KeySelector<DynamicRecordInternal, String>) DynamicRecordInternal::tableName)
               .map(
-                  new DynamicTableUpdateOperator(
-                      catalogLoader,
-                      cacheMaximumSize,
-                      cacheRefreshMs,
-                      inputSchemasPerTableCacheMaximumSize,
-                      tableCreator,
-                      caseSensitive,
-                      dropUnusedColumns))
+                  new DynamicTableUpdateOperator(catalogLoader, tableCreator, flinkDynamicSinkConf))
               .uid(prefixIfNotNull(uidPrefix, "-updater"))
               .name(operatorName("Updater"))
               .returns(type)
@@ -542,6 +539,12 @@ public class DynamicIcebergSink
       }
 
       return result;
+    }
+
+    private Configuration fromReadableConfig() {
+      return readableConfig instanceof Configuration
+          ? (Configuration) readableConfig
+          : Configuration.fromMap(readableConfig.toMap());
     }
   }
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecord.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.PartitionSpec;
@@ -38,6 +39,9 @@ public class DynamicRecord {
   private int writeParallelism;
   private boolean upsertMode;
   @Nullable private Set<String> equalityFields;
+
+  @Internal
+  DynamicRecord() {}
 
   /**
    * Constructs a new DynamicRecord with forward (no shuffle) writes.

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordProcessor.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
+import java.util.Map;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Collector;
@@ -30,6 +32,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.flink.CatalogLoader;
+import org.apache.iceberg.flink.FlinkWriteConf;
 
 @Internal
 class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal>
@@ -41,6 +44,8 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
 
   private final DynamicRecordGenerator<T> generator;
   private final CatalogLoader catalogLoader;
+  private final Map<String, String> writeProperties;
+  private final Configuration flinkConfig;
   private final boolean immediateUpdate;
   private final boolean dropUnusedColumns;
   private final int cacheMaximumSize;
@@ -55,27 +60,27 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
   private transient OutputTag<DynamicRecordInternal> updateStream;
   private transient OutputTag<DynamicRecordInternal> forwardStream;
   private transient Collector<DynamicRecordInternal> collector;
+  private transient DynamicRecordWithConfig dynamicRecordWithConfig;
   private transient Context context;
 
   DynamicRecordProcessor(
       DynamicRecordGenerator<T> generator,
       CatalogLoader catalogLoader,
-      boolean immediateUpdate,
-      int cacheMaximumSize,
-      long cacheRefreshMs,
-      int inputSchemasPerTableCacheMaximumSize,
       TableCreator tableCreator,
-      boolean caseSensitive,
-      boolean dropUnusedColumns) {
+      FlinkDynamicSinkConf sinkConfig,
+      Map<String, String> writeProperties,
+      Configuration flinkConfig) {
     this.generator = generator;
     this.catalogLoader = catalogLoader;
-    this.immediateUpdate = immediateUpdate;
-    this.cacheMaximumSize = cacheMaximumSize;
-    this.cacheRefreshMs = cacheRefreshMs;
-    this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
+    this.flinkConfig = flinkConfig;
+    this.writeProperties = writeProperties;
+    this.immediateUpdate = sinkConfig.immediateTableUpdate();
+    this.cacheMaximumSize = sinkConfig.cacheMaxSize();
+    this.cacheRefreshMs = sinkConfig.cacheRefreshMs();
+    this.inputSchemasPerTableCacheMaximumSize = sinkConfig.inputSchemasPerTableCacheMaxSize();
     this.tableCreator = tableCreator;
-    this.caseSensitive = caseSensitive;
-    this.dropUnusedColumns = dropUnusedColumns;
+    this.caseSensitive = sinkConfig.caseSensitive();
+    this.dropUnusedColumns = sinkConfig.dropUnusedColumns();
   }
 
   @Override
@@ -107,6 +112,8 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
               new DynamicRecordInternalType(catalogLoader, true, cacheMaximumSize)) {};
     }
 
+    this.dynamicRecordWithConfig =
+        new DynamicRecordWithConfig(new FlinkWriteConf(writeProperties, flinkConfig));
     generator.open(openContext);
   }
 
@@ -119,9 +126,10 @@ class DynamicRecordProcessor<T> extends ProcessFunction<T, DynamicRecordInternal
   }
 
   @Override
-  public void collect(DynamicRecord data) {
-    boolean isForward = data.distributionMode() == null;
+  public void collect(DynamicRecord inputData) {
+    DynamicRecordWithConfig data = dynamicRecordWithConfig.wrap(inputData);
 
+    boolean isForward = data.distributionMode() == null;
     boolean exists = tableCache.exists(data.tableIdentifier()).f0;
     String foundBranch = exists ? tableCache.branch(data.tableIdentifier(), data.branch()) : null;
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordWithConfig.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicRecordWithConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.Set;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.FlinkWriteConf;
+
+class DynamicRecordWithConfig extends DynamicRecord {
+  private final String defaultBranch;
+  private final Integer defaultWriteParallelism;
+
+  private DynamicRecord wrapped;
+
+  DynamicRecordWithConfig(FlinkWriteConf flinkWriteConf) {
+    this.defaultBranch = flinkWriteConf.branch();
+    this.defaultWriteParallelism = flinkWriteConf.writeParallelism();
+  }
+
+  DynamicRecordWithConfig wrap(DynamicRecord newWrapped) {
+    this.wrapped = newWrapped;
+    return this;
+  }
+
+  @Override
+  public String branch() {
+    return wrapped.branch() != null ? wrapped.branch() : defaultBranch;
+  }
+
+  @Override
+  public DistributionMode distributionMode() {
+    return wrapped.distributionMode();
+  }
+
+  @Override
+  public int writeParallelism() {
+    int originalParallelism = wrapped.writeParallelism();
+    if (originalParallelism > 0 || defaultWriteParallelism == null) {
+      return originalParallelism;
+    }
+
+    return defaultWriteParallelism;
+  }
+
+  @Override
+  public TableIdentifier tableIdentifier() {
+    return wrapped.tableIdentifier();
+  }
+
+  @Override
+  public Schema schema() {
+    return wrapped.schema();
+  }
+
+  @Override
+  public PartitionSpec spec() {
+    return wrapped.spec();
+  }
+
+  @Override
+  public RowData rowData() {
+    return wrapped.rowData();
+  }
+
+  @Override
+  public boolean upsertMode() {
+    return wrapped.upsertMode();
+  }
+
+  @Override
+  public Set<String> equalityFields() {
+    return wrapped.equalityFields();
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableUpdateOperator.java
@@ -48,20 +48,15 @@ class DynamicTableUpdateOperator
   private transient TableUpdater updater;
 
   DynamicTableUpdateOperator(
-      CatalogLoader catalogLoader,
-      int cacheMaximumSize,
-      long cacheRefreshMs,
-      int inputSchemasPerTableCacheMaximumSize,
-      TableCreator tableCreator,
-      boolean caseSensitive,
-      boolean dropUnusedColumns) {
+      CatalogLoader catalogLoader, TableCreator tableCreator, FlinkDynamicSinkConf configuration) {
     this.catalogLoader = catalogLoader;
-    this.cacheMaximumSize = cacheMaximumSize;
-    this.cacheRefreshMs = cacheRefreshMs;
-    this.inputSchemasPerTableCacheMaximumSize = inputSchemasPerTableCacheMaximumSize;
     this.tableCreator = tableCreator;
-    this.caseSensitive = caseSensitive;
-    this.dropUnusedColumns = dropUnusedColumns;
+
+    this.cacheMaximumSize = configuration.cacheMaxSize();
+    this.cacheRefreshMs = configuration.cacheRefreshMs();
+    this.inputSchemasPerTableCacheMaximumSize = configuration.inputSchemasPerTableCacheMaxSize();
+    this.caseSensitive = configuration.caseSensitive();
+    this.dropUnusedColumns = configuration.dropUnusedColumns();
   }
 
   @Override

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkConf.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkConf.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.Map;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.iceberg.flink.FlinkConfParser;
+
+/**
+ * A class for common Dynamic Iceberg sink configs for Flink writes.
+ *
+ * <p>If a config is set at multiple levels, the following order of precedence is used (top to
+ * bottom):
+ *
+ * <ol>
+ *   <li>Write options
+ *   <li>Flink ReadableConfig
+ *   <li>Default values
+ * </ol>
+ *
+ * The most specific value is set in write options and takes precedence over all other configs. If
+ * no write option is provided, this class checks the flink configuration for any overrides. If no
+ * applicable value is found in the write options, this class uses the default values.
+ */
+class FlinkDynamicSinkConf {
+
+  private final FlinkConfParser confParser;
+
+  FlinkDynamicSinkConf(Map<String, String> writeOptions, ReadableConfig readableConfig) {
+    this.confParser = new FlinkConfParser(writeOptions, readableConfig);
+  }
+
+  int cacheMaxSize() {
+    return confParser
+        .intConf()
+        .option(FlinkDynamicSinkOptions.CACHE_MAX_SIZE.key())
+        .flinkConfig(FlinkDynamicSinkOptions.CACHE_MAX_SIZE)
+        .defaultValue(FlinkDynamicSinkOptions.CACHE_MAX_SIZE.defaultValue())
+        .parse();
+  }
+
+  boolean immediateTableUpdate() {
+    return confParser
+        .booleanConf()
+        .option(FlinkDynamicSinkOptions.IMMEDIATE_TABLE_UPDATE.key())
+        .flinkConfig(FlinkDynamicSinkOptions.IMMEDIATE_TABLE_UPDATE)
+        .defaultValue(FlinkDynamicSinkOptions.IMMEDIATE_TABLE_UPDATE.defaultValue())
+        .parse();
+  }
+
+  boolean dropUnusedColumns() {
+    return confParser
+        .booleanConf()
+        .option(FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS.key())
+        .flinkConfig(FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS)
+        .defaultValue(FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS.defaultValue())
+        .parse();
+  }
+
+  long cacheRefreshMs() {
+    return confParser
+        .longConf()
+        .option(FlinkDynamicSinkOptions.CACHE_REFRESH_MS.key())
+        .flinkConfig(FlinkDynamicSinkOptions.CACHE_REFRESH_MS)
+        .defaultValue(FlinkDynamicSinkOptions.CACHE_REFRESH_MS.defaultValue())
+        .parse();
+  }
+
+  int inputSchemasPerTableCacheMaxSize() {
+    return confParser
+        .intConf()
+        .option(FlinkDynamicSinkOptions.INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE.key())
+        .flinkConfig(FlinkDynamicSinkOptions.INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE)
+        .defaultValue(FlinkDynamicSinkOptions.INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE.defaultValue())
+        .parse();
+  }
+
+  boolean caseSensitive() {
+    return confParser
+        .booleanConf()
+        .option(FlinkDynamicSinkOptions.CASE_SENSITIVE.key())
+        .flinkConfig(FlinkDynamicSinkOptions.CASE_SENSITIVE)
+        .defaultValue(FlinkDynamicSinkOptions.CASE_SENSITIVE.defaultValue())
+        .parse();
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkOptions.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkOptions.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+@Experimental
+public class FlinkDynamicSinkOptions {
+
+  private FlinkDynamicSinkOptions() {}
+
+  public static final ConfigOption<Integer> CACHE_MAX_SIZE =
+      ConfigOptions.key("dynamic-sink.cache-max-size")
+          .intType()
+          .defaultValue(100)
+          .withDescription(
+              "Maximum size of the caches used in Dynamic Sink for table data and serializers.");
+
+  public static final ConfigOption<Boolean> IMMEDIATE_TABLE_UPDATE =
+      ConfigOptions.key("dynamic-sink.immediate-table-update")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription(
+              "Controls whether table schema and partition updates should be applied immediately in Dynamic Sink.");
+
+  public static final ConfigOption<Boolean> DROP_UNUSED_COLUMNS =
+      ConfigOptions.key("dynamic-sink.drop-unused-columns")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription(
+              "Allows dropping unused columns during schema evolution in Dynamic Sink.");
+
+  public static final ConfigOption<Long> CACHE_REFRESH_MS =
+      ConfigOptions.key("dynamic-sink.cache-refresh-ms")
+          .longType()
+          .defaultValue(1_000L)
+          .withDescription(
+              "Cache refresh interval for dynamic table metadata in Dynamic Sink in milliseconds.");
+
+  public static final ConfigOption<Integer> INPUT_SCHEMAS_PER_TABLE_CACHE_MAX_SIZE =
+      ConfigOptions.key("dynamic-sink.input-schemas-per-table-cache-max-size")
+          .intType()
+          .defaultValue(10)
+          .withDescription(
+              "Maximum input schema objects to cache per each table in Dynamic Sink for performance.");
+
+  public static final ConfigOption<Boolean> CASE_SENSITIVE =
+      ConfigOptions.key("dynamic-sink.case-sensitive")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription(
+              "Controls whether schema field name matching should be case-sensitive in Dynamic Sink.");
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -88,7 +88,7 @@ class HashKeyGenerator {
             dynamicRecord.schema(),
             dynamicRecord.spec(),
             dynamicRecord.equalityFields(),
-            MoreObjects.firstNonNull(dynamicRecord.distributionMode(), DistributionMode.NONE),
+            dynamicRecord.distributionMode(),
             Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism));
     KeySelector<RowData, Integer> keySelector =
         keySelectorCache.computeIfAbsent(
@@ -98,8 +98,7 @@ class HashKeyGenerator {
                     tableIdent,
                     MoreObjects.firstNonNull(tableSchema, dynamicRecord.schema()),
                     MoreObjects.firstNonNull(tableSpec, dynamicRecord.spec()),
-                    MoreObjects.firstNonNull(
-                        dynamicRecord.distributionMode(), DistributionMode.NONE),
+                    dynamicRecord.distributionMode(),
                     MoreObjects.firstNonNull(
                         dynamicRecord.equalityFields(), Collections.emptySet()),
                     Math.min(dynamicRecord.writeParallelism(), maxWriteParallelism)));

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -78,6 +78,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
 import org.apache.iceberg.flink.MiniFlinkClusterExtension;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TestHelpers;
@@ -86,6 +87,7 @@ import org.apache.iceberg.flink.sink.dynamic.TestDynamicCommitter.CommitHook;
 import org.apache.iceberg.flink.sink.dynamic.TestDynamicCommitter.FailBeforeAndAfterCommit;
 import org.apache.iceberg.inmemory.InMemoryInputFile;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -122,6 +124,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     PartitionSpec partitionSpec;
     boolean upsertMode;
     Set<String> equalityFields;
+    int writeParallelism;
 
     private DynamicIcebergDataImpl(
         Schema schemaProvided, String tableName, String branch, PartitionSpec partitionSpec) {
@@ -133,7 +136,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           partitionSpec,
           false,
           Collections.emptySet(),
-          false);
+          false,
+          10);
     }
 
     private DynamicIcebergDataImpl(
@@ -150,7 +154,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           partitionSpec,
           false,
           Collections.emptySet(),
-          false);
+          false,
+          10);
     }
 
     private DynamicIcebergDataImpl(
@@ -169,7 +174,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           partitionSpec,
           upsertMode,
           equalityFields,
-          isDuplicate);
+          isDuplicate,
+          10);
     }
 
     private DynamicIcebergDataImpl(
@@ -180,7 +186,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
         PartitionSpec partitionSpec,
         boolean upsertMode,
         Set<String> equalityFields,
-        boolean isDuplicate) {
+        boolean isDuplicate,
+        int writeParallelism) {
       this.rowProvided = randomRow(schemaProvided, isDuplicate ? seed : ++seed);
       this.rowExpected = isDuplicate ? null : rowProvided;
       this.schemaProvided = schemaProvided;
@@ -190,6 +197,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
       this.partitionSpec = partitionSpec;
       this.upsertMode = upsertMode;
       this.equalityFields = equalityFields;
+      this.writeParallelism = writeParallelism;
     }
   }
 
@@ -209,7 +217,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
               converter(schema).toInternal(row.rowProvided),
               spec,
               spec.isPartitioned() ? DistributionMode.HASH : DistributionMode.NONE,
-              10);
+              row.writeParallelism);
       dynamicRecord.setUpsertMode(row.upsertMode);
       dynamicRecord.setEqualityFields(row.equalityFields);
       out.collect(dynamicRecord);
@@ -379,6 +387,19 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     env.execute();
 
     verifyResults(rows);
+  }
+
+  @Test
+  void testWriteWithNullBranch() throws Exception {
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA, "t1", null, PartitionSpec.unpartitioned()),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA, "t1", null, PartitionSpec.unpartitioned()));
+
+    runTest(
+        rows, this.env, false, 1, ImmutableMap.of(FlinkWriteOptions.BRANCH.key(), "test-branch"));
   }
 
   @Test
@@ -1369,6 +1390,35 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     assertThat(generatorParallelism).isEqualTo(source.getParallelism());
   }
 
+  @Test
+  void testFallBackParallelismFromConfig() throws Exception {
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                SnapshotRef.MAIN_BRANCH,
+                PartitionSpec.unpartitioned(),
+                false,
+                Collections.emptySet(),
+                false,
+                -1),
+            new DynamicIcebergDataImpl(
+                SimpleDataUtil.SCHEMA,
+                SimpleDataUtil.SCHEMA,
+                "t1",
+                SnapshotRef.MAIN_BRANCH,
+                PartitionSpec.unpartitioned(),
+                false,
+                Collections.emptySet(),
+                false,
+                0));
+
+    runTest(
+        rows, this.env, true, 2, ImmutableMap.of(FlinkWriteOptions.WRITE_PARALLELISM.key(), "1"));
+  }
+
   private Set<String> createSinkAndReturnUIds(String uidPrefix) {
     StreamExecutionEnvironment streamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 
@@ -1477,6 +1527,18 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     verifyResults(dynamicData);
   }
 
+  private void runTest(
+      List<DynamicIcebergDataImpl> dynamicData,
+      StreamExecutionEnvironment env,
+      boolean immediateUpdate,
+      int parallelism,
+      Map<String, String> writeProperties)
+      throws Exception {
+    executeDynamicSink(
+        dynamicData, env, immediateUpdate, parallelism, null, false, writeProperties);
+    verifyResults(dynamicData, writeProperties);
+  }
+
   private void executeDynamicSink(
       List<DynamicIcebergDataImpl> dynamicData,
       StreamExecutionEnvironment env,
@@ -1484,7 +1546,8 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
       int parallelism,
       @Nullable CommitHook commitHook)
       throws Exception {
-    executeDynamicSink(dynamicData, env, immediateUpdate, parallelism, commitHook, false);
+    executeDynamicSink(
+        dynamicData, env, immediateUpdate, parallelism, commitHook, false, Maps.newHashMap());
   }
 
   private void executeDynamicSink(
@@ -1494,6 +1557,19 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
       int parallelism,
       @Nullable CommitHook commitHook,
       boolean overwrite)
+      throws Exception {
+    executeDynamicSink(
+        dynamicData, env, immediateUpdate, parallelism, commitHook, overwrite, Maps.newHashMap());
+  }
+
+  private void executeDynamicSink(
+      List<DynamicIcebergDataImpl> dynamicData,
+      StreamExecutionEnvironment env,
+      boolean immediateUpdate,
+      int parallelism,
+      @Nullable CommitHook commitHook,
+      boolean overwrite,
+      Map<String, String> writeProperties)
       throws Exception {
     DataStream<DynamicIcebergDataImpl> dataStream =
         env.fromData(dynamicData, TypeInformation.of(new TypeHint<>() {}));
@@ -1508,6 +1584,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           .immediateTableUpdate(immediateUpdate)
           .setSnapshotProperty("commit.retry.num-retries", "0")
           .overwrite(overwrite)
+          .setAll(writeProperties)
           .append();
     } else {
       DynamicIcebergSink.forInput(dataStream)
@@ -1516,6 +1593,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           .writeParallelism(parallelism)
           .immediateTableUpdate(immediateUpdate)
           .overwrite(overwrite)
+          .setAll(writeProperties)
           .append();
     }
 
@@ -1542,7 +1620,6 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           "uidPrefix",
           writeProperties,
           flinkConfig,
-          100,
           forwardWriteResults);
     }
   }
@@ -1559,7 +1636,6 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
         String uidPrefix,
         Map<String, String> writeProperties,
         Configuration flinkConfig,
-        int cacheMaximumSize,
         DataStream<CommittableMessage<DynamicWriteResult>> forwardWritten) {
       super(
           catalogLoader,
@@ -1567,7 +1643,7 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
           uidPrefix,
           writeProperties,
           flinkConfig,
-          cacheMaximumSize,
+          100,
           forwardWritten);
       this.commitHook = commitHook;
       this.overwriteMode = new FlinkWriteConf(writeProperties, flinkConfig).overwriteMode();
@@ -1587,6 +1663,12 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
   }
 
   private void verifyResults(List<DynamicIcebergDataImpl> dynamicData) throws IOException {
+    verifyResults(dynamicData, Maps.newHashMap());
+  }
+
+  private void verifyResults(
+      List<DynamicIcebergDataImpl> dynamicData, Map<String, String> writeProperties)
+      throws IOException {
     // Calculate the expected result
     Map<Tuple2<String, String>, List<RowData>> expectedData = Maps.newHashMap();
     Map<String, Schema> expectedSchema = Maps.newHashMap();
@@ -1600,9 +1682,12 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
 
     dynamicData.forEach(
         r -> {
+          String branch =
+              MoreObjects.firstNonNull(
+                  r.branch, writeProperties.get(FlinkWriteOptions.BRANCH.key()));
           List<RowData> data =
               expectedData.computeIfAbsent(
-                  Tuple2.of(r.tableName, r.branch), unused -> Lists.newArrayList());
+                  Tuple2.of(r.tableName, branch), unused -> Lists.newArrayList());
           data.addAll(
               convertToRowData(expectedSchema.get(r.tableName), ImmutableList.of(r.rowExpected)));
         });

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicRecordWithConfig.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicRecordWithConfig.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Set;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestDynamicRecordWithConfig {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.required(2, "data", Types.StringType.get()));
+
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of("db", "table");
+  private static final PartitionSpec UNPARTITIONED = PartitionSpec.unpartitioned();
+  private static final RowData ROW_DATA = GenericRowData.of(1, StringData.fromString("test"));
+
+  @Test
+  void testBranchFallBack() {
+    String defaultBranch = "default-branch";
+    FlinkWriteConf conf =
+        new FlinkWriteConf(
+            ImmutableMap.of(FlinkWriteOptions.BRANCH.key(), defaultBranch), new Configuration());
+    DynamicRecordWithConfig dynamicRecordWithConfig = new DynamicRecordWithConfig(conf);
+
+    DynamicRecord dynamicRecord =
+        new DynamicRecord(TABLE_IDENTIFIER, null, SCHEMA, ROW_DATA, UNPARTITIONED);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).branch()).isEqualTo(defaultBranch);
+
+    String customBranch = "custom-branch";
+    dynamicRecord.setBranch(customBranch);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).branch()).isEqualTo(customBranch);
+  }
+
+  @Test
+  void testWriteParallelismFallBack() {
+    int defaultParallelism = 4;
+    FlinkWriteConf conf =
+        new FlinkWriteConf(
+            ImmutableMap.of(
+                FlinkWriteOptions.WRITE_PARALLELISM.key(), String.valueOf(defaultParallelism)),
+            new Configuration());
+    DynamicRecordWithConfig dynamicRecordWithConfig = new DynamicRecordWithConfig(conf);
+
+    DynamicRecord dynamicRecord =
+        new DynamicRecord(TABLE_IDENTIFIER, null, SCHEMA, ROW_DATA, UNPARTITIONED, null, -1);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).writeParallelism())
+        .isEqualTo(defaultParallelism);
+
+    dynamicRecord.writeParallelism(0);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).writeParallelism())
+        .isEqualTo(defaultParallelism);
+
+    dynamicRecord.writeParallelism(8);
+    assertThat(dynamicRecordWithConfig.wrap(dynamicRecord).writeParallelism()).isEqualTo(8);
+  }
+
+  @Test
+  void testDelegatesToWrappedRecord() {
+    FlinkWriteConf conf = new FlinkWriteConf(Collections.emptyMap(), new Configuration());
+    PartitionSpec partitioned = PartitionSpec.builderFor(SCHEMA).identity("id").build();
+    Set<String> equalityFields = ImmutableSet.of("id", "data");
+
+    DynamicRecord dynamicRecord =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            SnapshotRef.MAIN_BRANCH,
+            SCHEMA,
+            ROW_DATA,
+            partitioned,
+            DistributionMode.HASH,
+            2);
+    dynamicRecord.setUpsertMode(true);
+    dynamicRecord.setEqualityFields(equalityFields);
+
+    DynamicRecordWithConfig record = new DynamicRecordWithConfig(conf).wrap(dynamicRecord);
+
+    assertThat(record.tableIdentifier()).isEqualTo(TABLE_IDENTIFIER);
+    assertThat(record.schema()).isEqualTo(SCHEMA);
+    assertThat(record.spec()).isEqualTo(partitioned);
+    assertThat(record.rowData()).isSameAs(ROW_DATA);
+    assertThat(record.distributionMode()).isEqualTo(DistributionMode.HASH);
+    assertThat(record.upsertMode()).isTrue();
+    assertThat(record.equalityFields()).isEqualTo(equalityFields);
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
@@ -23,12 +23,14 @@ import static org.apache.iceberg.flink.TestFixtures.TABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -57,9 +59,6 @@ class TestDynamicTableUpdateOperator {
 
   @Test
   void testDynamicTableUpdateOperatorNewTable() throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
@@ -67,12 +66,8 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            CASE_SENSITIVE,
-            PRESERVE_COLUMNS);
+            flinkDynamicSinkConfiguration(CASE_SENSITIVE, PRESERVE_COLUMNS));
     operator.open(null);
 
     DynamicRecordInternal input =
@@ -93,21 +88,14 @@ class TestDynamicTableUpdateOperator {
 
   @Test
   void testDynamicTableUpdateOperatorSchemaChange() throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            CASE_SENSITIVE,
-            PRESERVE_COLUMNS);
+            flinkDynamicSinkConfiguration(CASE_SENSITIVE, PRESERVE_COLUMNS));
     operator.open(null);
 
     catalog.createTable(table, SCHEMA1);
@@ -135,9 +123,6 @@ class TestDynamicTableUpdateOperator {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testCaseInSensitivity(boolean caseSensitive) throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
@@ -148,12 +133,8 @@ class TestDynamicTableUpdateOperator {
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            caseSensitive,
-            PRESERVE_COLUMNS);
+            flinkDynamicSinkConfiguration(caseSensitive, PRESERVE_COLUMNS));
     operator.open(null);
 
     catalog.createTable(table, initialSchema);
@@ -187,21 +168,14 @@ class TestDynamicTableUpdateOperator {
 
   @Test
   void testDynamicTableUpdateOperatorPreserveUnusedColumns() throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            CASE_SENSITIVE,
-            PRESERVE_COLUMNS);
+            flinkDynamicSinkConfiguration(CASE_SENSITIVE, PRESERVE_COLUMNS));
     operator.open(null);
 
     catalog.createTable(table, SCHEMA2);
@@ -228,21 +202,14 @@ class TestDynamicTableUpdateOperator {
 
   @Test
   void testDynamicTableUpdateOperatorDropUnusedColumns() throws Exception {
-    int cacheMaximumSize = 10;
-    int cacheRefreshMs = 1000;
-    int inputSchemaCacheMaximumSize = 10;
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier table = TableIdentifier.of(TABLE);
 
     DynamicTableUpdateOperator operator =
         new DynamicTableUpdateOperator(
             CATALOG_EXTENSION.catalogLoader(),
-            cacheMaximumSize,
-            cacheRefreshMs,
-            inputSchemaCacheMaximumSize,
             TableCreator.DEFAULT,
-            CASE_INSENSITIVE,
-            DROP_COLUMNS);
+            flinkDynamicSinkConfiguration(CASE_INSENSITIVE, DROP_COLUMNS));
     operator.open(null);
 
     catalog.createTable(table, SCHEMA2);
@@ -264,5 +231,14 @@ class TestDynamicTableUpdateOperator {
     assertThat(tableSchema.findField("id")).isNotNull();
     assertThat(tableSchema.findField("data")).isNull();
     assertThat(input).isEqualTo(output);
+  }
+
+  private static FlinkDynamicSinkConf flinkDynamicSinkConfiguration(
+      boolean caseSensitive, boolean dropUnusedColumns) {
+    return new FlinkDynamicSinkConf(
+        ImmutableMap.of(
+            FlinkDynamicSinkOptions.CASE_SENSITIVE.key(), String.valueOf(caseSensitive),
+            FlinkDynamicSinkOptions.DROP_UNUSED_COLUMNS.key(), String.valueOf(dropUnusedColumns)),
+        new Configuration());
   }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -34,6 +35,9 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -227,6 +231,38 @@ class TestHashKeyGenerator {
               Collections.emptySet(),
               GenericRowData.of());
         });
+  }
+
+  @Test
+  void testNonPositiveWriteParallelismConfigFallback() throws Exception {
+    int maxWriteParallelism = 5;
+    HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+    FlinkWriteConf flinkWriteConf =
+        new FlinkWriteConf(
+            ImmutableMap.of(FlinkWriteOptions.WRITE_PARALLELISM.key(), "2"), new Configuration());
+
+    Set<Integer> writeKeys = Sets.newHashSet();
+    for (int i = 0; i < 20; i++) {
+      GenericRowData row = GenericRowData.of(i, StringData.fromString("z"));
+      writeKeys.add(
+          getWriteKey(
+              generator,
+              unpartitioned,
+              DistributionMode.NONE,
+              i % 2 == 0 ? 0 : -1,
+              Collections.emptySet(),
+              row,
+              flinkWriteConf));
+    }
+
+    assertThat(writeKeys).hasSize(2);
+    assertThat(
+            writeKeys.stream()
+                .map(key -> getSubTaskId(key, 2, maxWriteParallelism))
+                .distinct()
+                .count())
+        .isEqualTo(2);
   }
 
   @Test
@@ -477,10 +513,31 @@ class TestHashKeyGenerator {
       Set<String> equalityFields,
       GenericRowData row)
       throws Exception {
-    DynamicRecord record =
+    return getWriteKey(
+        generator,
+        spec,
+        mode,
+        writeParallelism,
+        equalityFields,
+        row,
+        new FlinkWriteConf(Collections.emptyMap(), new Configuration()));
+  }
+
+  private static int getWriteKey(
+      HashKeyGenerator generator,
+      PartitionSpec spec,
+      DistributionMode mode,
+      int writeParallelism,
+      Set<String> equalityFields,
+      GenericRowData row,
+      FlinkWriteConf flinkWriteConf)
+      throws Exception {
+    DynamicRecord inputRecord =
         new DynamicRecord(TABLE_IDENTIFIER, BRANCH, SCHEMA, row, spec, mode, writeParallelism);
-    record.setEqualityFields(equalityFields);
-    return generator.generateKey(record);
+    inputRecord.setEqualityFields(equalityFields);
+
+    DynamicRecordWithConfig dynamicRecordWithConfig = new DynamicRecordWithConfig(flinkWriteConf);
+    return generator.generateKey(dynamicRecordWithConfig.wrap(inputRecord));
   }
 
   private static int getSubTaskId(int writeKey1, int writeParallelism, int maxWriteParallelism) {


### PR DESCRIPTION
Backport of https://github.com/apache/iceberg/pull/15780 

Clean backport except class,
flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicTableUpdateOperator.java
  

```
Conflict 1 (line 26) — import:
  <<<<<<< ours
  import org.apache.flink.api.common.functions.OpenContext;
  =======
  import org.apache.flink.configuration.Configuration;
  >>>>>>> theirs

  Conflicts 2–6 (lines 74, 108, 153, 200, 240) — all identical pattern:
  <<<<<<< ours
              CASE_SENSITIVE,       // (or caseSensitive / CASE_INSENSITIVE)
              PRESERVE_COLUMNS);    // (or DROP_COLUMNS)
      operator.open((OpenContext) null);
  =======
              flinkDynamicSinkConfiguration(CASE_SENSITIVE, PRESERVE_COLUMNS));  // (or corresponding args)
      operator.open(null);
  >>>>>>> theirs
```